### PR TITLE
Configurable permission categories

### DIFF
--- a/SQL/2011-12-12-PermissionCategory.sql
+++ b/SQL/2011-12-12-PermissionCategory.sql
@@ -1,0 +1,17 @@
+CREATE TABLE permissions_category (
+    ID int(10) not null AUTO_INCREMENT,
+    Description varchar(255) not null,
+    PRIMARY KEY(`ID`)
+);
+
+REPLACE INTO permissions_category VALUES (1, 'Roles');
+REPLACE INTO permissions_category VALUES (2, 'Permission');
+
+
+ALTER TABLE permissions ADD COLUMN categoryID int(10) REFERENCES permissions_category(ID);
+
+UPDATE permissions SET categoryID=1 WHERE type='role';
+UPDATE permissions SET categoryID=2 WHERE type='permission';
+
+-- You should run this once you're sure everything works.
+-- ALTER TABLE permissions DROP COLUMN type;

--- a/php/libraries/NDB_Form_user_accounts.class.inc
+++ b/php/libraries/NDB_Form_user_accounts.class.inc
@@ -347,9 +347,11 @@ class NDB_Form_user_accounts extends NDB_Form
         foreach ($perms as $row) {
             if($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
-                $group[] = $this->form->createElement('static', null, null, '<b>'.ucwords($row['type']).'</b>');
+                $group[] = $this->form->createElement('static', null, null, '</div>' . 
+                        "<h3 id=\"header_$lastRole\" class=\"perm_header button\" style=\"text-align: center; margin-top: 5px;\">".ucwords($row['type']).'</h3>' 
+                        . "<div id=\"perms_$lastRole\" style=\"margin-top: 5px;\">");
             }
-            $group[] = $this->form->createElement('advcheckbox', 'permID['.$row['permID'].']', null, $row['description']);
+            $group[] = $this->form->createElement('advcheckbox', 'permID['.$row['permID'].']', null, $row['description'], "class=\"perm_$lastRole\"");
         }
         $this->form->addGroup($group, 'PermID_Group', 'Permissions', "<br />\n", FALSE);
         unset($group);

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -239,7 +239,7 @@ class UserPermissions
             return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
         }
 
-        $query = "SELECT permissions.permID, code, description, type FROM permissions, user_perm_rel WHERE permissions.permID = user_perm_rel.permID AND userID = '$this->userID' ORDER BY type, description";
+        $query = "SELECT p.permID, p.code, p.description, pc.Description as type FROM permissions p JOIN user_perm_rel up ON (p.permID=up.PermID) LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID) WHERE up.userID = '$this->userID' ORDER BY p.categoryID, p.description";
         $DB->select($query, $results);
         if (PEAR::isError($results)) {
             return PEAR::raiseError("DB Error: ".$results->getMessage());

--- a/smarty/templates/form_edit_user.tpl
+++ b/smarty/templates/form_edit_user.tpl
@@ -1,4 +1,32 @@
 <br />
+{literal}
+<script>
+$(document).ready(function() {
+    function toggleGroup(group) {
+        if(group) {
+            // id is the header that was clicked
+            id = group.target.id;
+
+            // chop off header_ to get section name
+            section = id.substring(7);
+            
+            // hide (or show) the appropriate div for that section
+            section_el = $("#perms_" + section);
+            section_el.toggle();
+        }
+    }
+    // define event handler for all the header sections
+    $(".perm_header").click(toggleGroup);
+    // Get rid of the extra <br /> tag that Quickform element adds at the top of each <div>
+    $(".perm_header").each(function(idx, el) {
+        id = el.id;
+        section = id.substring(7);
+        section_el = $("#perms_" + section + " br:nth-child(1)").hide();
+    });
+    
+});
+</script>
+{/literal}
 <form method="post" name="edit_user" id="edit_user">
 <table class="std">
     <!-- table title -->
@@ -121,7 +149,7 @@
 
 	<tr>
 		<td nowrap="nowrap" valign="top">Permissions</td>
-		<td nowrap="nowrap">{$form.PermID_Group.html}</td>
+		<td nowrap="nowrap"><div>{$form.PermID_Group.html}</div></td>
     </tr>
 
 	<tr>


### PR DESCRIPTION
This pull request addresses Redmine ticket #2020. It makes the sections of permissions in the user management module customizable instead of being hardcoded to the (meaningless) "role" and "permission" categories.

A new table called permissions_category is created, and a column added to the permissions table which is a foreign key to the category for that permission. This replaces the 'type' column, which can be dropped (the SQL to do so is commented out in the SQL script, and needs to be done manually to make sure no data is lost)

By default the permission categories are "role" and "permission", so that everything should work identically with this patch unless you manually customize your categories to something more appropriate for your project.

(jQuery is also added to make the headings clickable to collapse/expand the sections)
