### PR TITLE
Remove useless dde config options causing the instrument to not show err...

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -90,7 +90,6 @@
 	<objectives>1</objectives>
 	<!-- max number of timepoints per subject (integer)-->
 	<visits>1</visits>
-        <doubleDataEntry>0</doubleDataEntry>
 	<useScreening>false</useScreening>
 	<subprojects>
 	    <subproject>

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -283,17 +283,7 @@ class NDB_BVL_Instrument extends PEAR
             $this->form->addGroup($buttons, null, null, "&nbsp;");
         }
         
-        // if double data is in play, only show data after the second save
-        $config =& NDB_Config::singleton();
-        $doubleDataEntry = $config->getSetting('doubleDataEntry');
-        if($doubleDataEntry) {
-            // check for first save in session
-            $stateProperty = 'savedData'.$this->getCommentID().$this->page;
-            $showData = $_SESSION['State']->getProperty($stateProperty."_showData");
-        } else {
-            $showData = true;
-        }
-        
+ 
         // get saved data to pre-populate form
         $db =& Database::singleton();
         $db->select("SELECT * FROM $this->table WHERE CommentID='".$this->getCommentID()."'", $defaults);
@@ -311,20 +301,7 @@ class NDB_BVL_Instrument extends PEAR
         
         // actually set the quickform object defaults
         $this->form->setDefaults($defaults);
-        
-        // clear all if double data is in play and this is the second display
-        if(!$showData) {
-            $submittedData = $this->form->getSubmitValues();
-            unset($submittedData['commentID'], $submittedData['candID'], $submittedData['sessionID'], $submittedData['test_name'], $submittedData['page'], $submittedData['subtest'], $submittedData['fire_away']);
-            foreach(array_keys($submittedData) AS $elname) {
-                $constants[$elname] = null;
-                //$element = $this->form->getElement($elname);
-            }
-            //$this->form->setConstants($constants);
-            $this->form->_submitValues = $constants;
-            $this->form->setConstants($constants);
-            print "<!--\nSETTING CONSTANTS\n"; print_r($constants); print_r($this->form); print "\n-->\n";
-        }
+
         
         // display the HTML_Quickform object
         // return $this->form->toHTML();
@@ -401,17 +378,8 @@ class NDB_BVL_Instrument extends PEAR
         } else {
             $submittedData = $this->form->getSubmitValues();
             
-            $config =& NDB_Config::singleton();
-            $doubleDataEntry = $config->getSetting('doubleDataEntry');
-            if($doubleDataEntry) {
-                // check for first save in session
-                $stateProperty = 'savedData'.$this->getCommentID().$this->page;
-                $showData = $_SESSION['State']->getProperty($stateProperty."_showData");
-            } else {
-                $showData = true;
-            }
-            
-            if(count($submittedData) && $showData) {
+           
+            if(count($submittedData)) {
                 
                 // the form WAS submitted but validate() failed...
                 // main error message


### PR DESCRIPTION
Useless dde config options have , which were causing the given instrument to not display the validation errors, have been removed by making the following changes:

 1) Removed the  <doubleDataEntry> flag from the config.xml
 2) Removed the blocks of code ( from the NDB_BVL_Instrument.class.inc) where the doubledataentry flag was utilized.
