### PR TITLE
Module Specific Javascript

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -127,6 +127,9 @@ $timer->setMarker('Configured browser arguments for the MRI browser');
 $paths = $config->getSetting('paths');
 
 if (!empty($_REQUEST['test_name'])) {
+    if(file_exists($paths['base'] . "htdocs/js/modules/" . $_REQUEST['test_name'] . ".js")) {
+        $tpl_data['test_name_js'] = "js/modules/" . $_REQUEST['test_name'] . ".js";
+    }
     if (!empty($_REQUEST['commentID'])) {
         // make the control panel object for the current instrument
         $controlPanel = new NDB_BVL_InstrumentStatus_ControlPanel;

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -5,11 +5,15 @@
 <link rel="shortcut icon" href="images/mni_icon.ico" type="image/ico" />
 <title>{$study_title}</title>
 
-{literal}
 <link type="text/css" href="JS/JQeggplant/css/eggplant/jquery-ui-1.8.2.custom.css" rel="Stylesheet" />	
 <script src="js/jquery/jquery-1.4.2.min.js" type="text/javascript"></script>
 <script type="text/javascript" src="js/jquery/jquery-ui-1.8.2.custom.min.js"></script>
 
+{if $test_name_js}
+<script type="text/javascript" src="{$test_name_js}"></script>
+{/if}
+
+{literal}
 <script language="javascript" type="text/javascript"> 
 <!--
 function feedback_bvl_popup(features) { 


### PR DESCRIPTION
I've made a small change which should make it easier to use javascript  in Loris.

This patch makes it so that if there's a file under htdocs/js/modules/ with the same name as the current $test_name, Loris will load that javascript file. If it doesn't exist, nothing will be loaded. Combined with jQuery, this should let us make fancy modules that do fancy javascript things without needing to hardcode all the javascript into the template. It also, should the need arise, makes it possible for us to create instrument-specific javascript for things like validating user input client-side.
