### PR TITLE
Login Security

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -262,22 +262,6 @@ class SinglePointLogin extends PEAR
                 $this->_username = $_POST['username'];
                 return true;
             }
-            // !!! DELETE ONCE ALL PASSWORDS HAVE BEEN SET TO MD5 SALTS
-            else {
-                // check users table to see if we have a valid user
-                $query = "SELECT COUNT(*) AS User_count FROM users WHERE UserID = '".$_POST['username']."' AND Password = PASSWORD('".$_POST['password']."')";
-                $DB->selectRow($query, $row2);
-                if (PEAR::isError($row2)) {
-                    return PEAR::raiseError("DB Error: ".$row2->getMessage());
-                }
-
-                // user is logged in
-                if ($row2['User_count'] == 1) {
-                    // force password expiry screen
-                    $this->showPasswordExpiryScreen();
-                }
-            }
-            // !!! END DELETE
             // bad usename or password
         }
 


### PR DESCRIPTION
This patch fixes a security vulnerability in Loris caused by the fact that the login page uses string concatenation instead of prepared statements to select from the users table.

It also deletes a legacy section of code that says "!!! DELETE ONCE ALL PASSWORDS HAVE BEEN SET TO MD5 SALTS", because as far as I can tell all passwords have been set to MD5 salts.
