### PR TITLE
Cancelled visits show up in number of visits

### DIFF
--- a/php/libraries/NDB_Menu_Filter_candidate_list.class.inc
+++ b/php/libraries/NDB_Menu_Filter_candidate_list.class.inc
@@ -41,7 +41,7 @@ class NDB_Menu_Filter_candidate_list extends NDB_Menu_Filter
         	$this->validFilters[]='candidate.EDC';
         }
 
-        $this->columns=array_merge($this->columns,array('max(session.VisitNo) as Visit_count', 'max(session.Current_stage) as Latest_visit_status', 'min(feedback_bvl_thread.Status+0) as Feedback'));
+        $this->columns=array_merge($this->columns,array('count(DISTINCT session.Visit_label) as Visit_count', 'max(session.Current_stage) as Latest_visit_status', 'min(feedback_bvl_thread.Status+0) as Feedback'));
 
         
         $this->query = " FROM psc, candidate LEFT JOIN session ON candidate.CandID = session.CandID AND session.Cancelled = 'N' AND session.Active = 'Y'
@@ -54,8 +54,8 @@ class NDB_Menu_Filter_candidate_list extends NDB_Menu_Filter
         
         $this->group_by = 'candidate.CandID';
         $this->order_by = 'psc.Name, candidate.CandID DESC, session.VisitNo';
-        $this->validFilters = array('candidate.CenterID', 'candidate.CandID', 'candidate.PSCID', 'candidate.Gender', 'session.SubprojectID', 'candidate.DoB', 'max(session.VisitNo)', 'max(session.Current_stage)', 'coalesce(min(feedback_bvl_thread.Status+1), 1)');
-        $this->validHavingFilters = array('max(session.VisitNo)','max(session.Current_stage)', 'coalesce(min(feedback_bvl_thread.Status+1), 1)');
+        $this->validFilters = array('candidate.CenterID', 'candidate.CandID', 'candidate.PSCID', 'candidate.Gender', 'session.SubprojectID', 'candidate.DoB', 'count(DISTINCT session.Visit_label)', 'max(session.Current_stage)', 'coalesce(min(feedback_bvl_thread.Status+1), 1)');
+        $this->validHavingFilters = array('count(DISTINCT session.Visit_label)','max(session.Current_stage)', 'coalesce(min(feedback_bvl_thread.Status+1), 1)');
 		
         $this->formToFilter = array(
                                     'centerID' => 'candidate.CenterID',
@@ -64,7 +64,7 @@ class NDB_Menu_Filter_candidate_list extends NDB_Menu_Filter
                                     'gender' => 'candidate.Gender',
                                     'SubprojectID' => 'session.SubprojectID',
                                     'dob' => 'candidate.DoB',
-                                    'Visit_Count' => 'max(session.VisitNo)',
+                                    'Visit_Count' => 'count(DISTINCT session.Visit_label)', // Need distinct because of joining with feedback_bvl_thread
                                     'Latest_Visit_Status' => 'max(session.Current_stage)',
                                     'Feedback' => 'coalesce(min(feedback_bvl_thread.Status+1), 1)'
 


### PR DESCRIPTION
Pull request for small code change to use count(Visit_label) instead of max(VisitNo), on candidate_list page since 
max(visitNo) doesn't change if an earlier session is cancelled.
