### PR TITLE
Fix Conflict resolver

### DIFF
--- a/php/libraries/NDB_Form_conflicts_resolve.class.inc
+++ b/php/libraries/NDB_Form_conflicts_resolve.class.inc
@@ -129,8 +129,8 @@ class NDB_Form_conflicts_resolve extends NDB_Form
         // which can be used by quickforms for the dropdown. The array_merge
         // call after that just adds an Any/All Instruments option.
 
-        $in = array_map(array('Utility', 'Flatten'), $instruments_q); 
-        $instruments = array_combine($in, $in);
+        
+        $instruments = Utility::getAllInstruments();
         $instruments = array_merge(array('' => 'All Instruments'), $instruments);
         
         // Filter selection elements


### PR DESCRIPTION
Currently conflict_resolver is calling the function Flatten (in utility.class.inc) which doesn't exist causing error messages. To resolve the issue, the function getAllInstruments(from utility.class.inc) is called instead.
