### PR TITLE
Add dde commentid

### DIFF
--- a/tools/dde_comment_ID_corrrector.php
+++ b/tools/dde_comment_ID_corrrector.php
@@ -7,38 +7,59 @@ require_once "Utility.class.inc";
 $instruments = Utility::getAllInstruments();
 $result = array();
 
+//make sure that the instrument is dde-enable (in the config.xml)
+// Get the list of DDE instruments
+$config =& NDB_Config::singleton();
+$ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 foreach ($instruments as $instrument) {
 
-	$query = "SELECT f.CommentID FROM flag f JOIN $instrument t on (t.CommentID = f.CommentID) WHERE f.commentid NOT LIKE '%DDE%'";
-	$result = $DB->pselect($query, array());
+    $query = "SELECT f.CommentID,s.UserID,s.ID FROM flag f
+        JOIN $instrument t ON (t.CommentID = f.CommentID) 
+        JOIN session s ON (s.ID = f.SessionID) 
+        WHERE f.commentid NOT LIKE '%DDE%'";
+    $result = $DB->pselect($query, array());
 
-	if(PEAR::isError($result)) {
-		print "Cannot pull instrument table data ".$result->getMessage()."<br>\n";
-		die();
-	}
-	//for each row of the given table , concat DDE to the comment id
-	foreach ($result as $record) {
-		// Concat DDE to the comment_d
-		$comment_id = $record['CommentID'];
-		$pattern = '/^DDE_/';
-		$dde_commentid = "DDE_" . $comment_id;
+    if(PEAR::isError($result)) {
+        print "Cannot pull instrument table data ".$result->getMessage()."<br>\n";
+        die();
+    }
 
-		//Doesn't exist
-		if (($DB->pselectOne("SELECT COUNT(*) FROM flag WHERE CommentID =:cf",array('cf'=>$dde_commentid)))==0){
-			print "hello";
-			$success=$DB->insert('flag',array("CommentID" => $dde_commentid)); //create the dde for instrument
-			if (PEAR::isError($success)) {
-				print "DB Error: ".$success->getMessage();
-			}
-		}
 
-		if (($DB->pselectOne("SELECT COUNT(*) FROM $instrument WHERE CommentID =:ci",array('ci'=>$dde_commentid)))==0){
-			$success=$DB->insert($instrument,array("CommentID" => $dde_commentid)); //create the dde for instrument
-			if (PEAR::isError($success)) {
-				print "DB Error: ".$success->getMessage();
-			}
-		}
+    if(in_array($instrument, $ddeInstruments)) {
+        //for each row of the given table , concat DDE to the comment id
+        foreach ($result as $record) {
+            // Concat DDE to the comment_d
+            $comment_id = $record['CommentID'];
+            $userid = $record['UserID'];
+            $session_id = $record['ID'];
+            $pattern = '/^DDE_/';
+            $dde_commentid = "DDE_" . $comment_id;
 
-	}
+
+
+            //if the comment-id doesn't exist in the flag table insert it
+            if (($DB->pselectOne("SELECT COUNT(*) FROM flag WHERE CommentID =:cf",array('cf'=>$dde_commentid)))==0) {
+
+                $success=$DB->insert('flag',array("CommentID" => $dde_commentid,
+                            'Test_name'=>$instrument,
+                            'UserID'=>$userid,
+                            'SessionID'=>$session_id,
+                            'Testdate'=>null));
+                //create the dde for instrument
+                if (PEAR::isError($success)) {
+                    print "DB Error: ".$success->getMessage();
+                }
+            }
+
+            //if the comment-id doesn't exist in the instrument table insert it
+            if (($DB->pselectOne("SELECT COUNT(*) FROM $instrument WHERE CommentID =:ci",array('ci'=>$dde_commentid)))==0) {
+
+                $success = $DB->insert($instrument, array('CommentID'=>$dde_commentid));
+                if (PEAR::isError($success)) {
+                    print "DB Error: ".$success->getMessage();
+                }
+            }
+        }
+    }
 }
 ?>


### PR DESCRIPTION
For those instruments which were added to the test_battery before the double-data-entry option was added, the comment-id needed to be added manually. The following script will add the dde commentid to both the instrument and flag table.
