### PR TITLE
Validation for new user

### DIFF
--- a/php/libraries/NDB_Form_user_accounts.class.inc
+++ b/php/libraries/NDB_Form_user_accounts.class.inc
@@ -443,7 +443,7 @@ class NDB_Form_user_accounts extends NDB_Form
         $errors = array();
 
         // if username is user-defined, and it is a new user
-	if (!empty($values['NA_UserID']) || !empty($values['UserID']) && empty($this->identifier)) {
+	if ((!empty($values['NA_UserID']) || !empty($values['UserID'])) && empty($this->identifier)) {
             // check username's uniqueness
             $result = $DB->selectOne("SELECT COUNT(*) FROM users WHERE UserID = '" . $values['UserID'] . "'");
             if (PEAR::isError($result)) {


### PR DESCRIPTION
A bug has been detected in the NDB_Form_user_accounts.class.inc as follows:

If a UserID "ABC" belonging to "Freddie Mercury" exists, 
and someone creates a new account "ABC" for "Michael Meaney",
the system does not prompt an error message.
The new account is not saved in the database, but the email continues to be send to account "ABC" telling the person a new account was created.

Issues:
1) error message not shown when ID is already in use
2) system continues to send out email when ID is already in use, although new account is not saved nor overwrites existing data

The corresponding change will resolve the issue.
