### PR TITLE
Add missing columns to tarchive table

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1245,6 +1245,8 @@ CREATE TABLE `tarchive` (
   `CreateInfo` text,
   `AcquisitionMetadata` longtext NOT NULL,
   `TarchiveID` int(11) NOT NULL auto_increment,
+  `DateSent` datetime DEFAULT NULL,
+  `PendingTransfer` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY  (`TarchiveID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
There are currently two columns ( DateSent and PendingTransfer) missing from tarchive table. The dummy schema is modified to include these two columns.
