### PR TITLE
Add missing columns to users table

### DIFF
--- a/SQL/2012-06-28-User_preferences.sql
+++ b/SQL/2012-06-28-User_preferences.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users add column  `Degree` varchar(255) default NULL;
+ALTER TABLE users add column  `Position_title` varchar(255) default NULL;
+ALTER TABLE users add column  `Institution` varchar(255) default NULL;
+ALTER TABLE users add column  `Department` varchar(255) default NULL;
+ALTER TABLE users add column  `City` varchar(255) default NULL;
+ALTER TABLE users add column  `State` varchar(255) default NULL;
+ALTER TABLE users add column  `Zip_code` varchar(255) default NULL;
+ALTER TABLE users add column  `Country` varchar(255) default NULL;
+ALTER TABLE users add column  `Fax` varchar(255) default NULL;


### PR DESCRIPTION
This patch will add the missing user preference columns to users table (for the existing database). These columns already exist in the dummy schema.
