### PR TITLE
Added helper function to replace empty string with null in arrays

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -494,6 +494,19 @@ class Utility extends PEAR
 	   return $Zoo;
 	}
 
+    // Replace the empty string with null in specified field
+    // in an array passed in as an argument. This undoes the
+    // damaged that Smarty causes by making nulls in a dropdown
+    // the empty string.
+    // This is needed before calling $db->insert() on any integer
+    // fields, because mysql considers '' to be 0, not null if
+    // the database column is of type integer.
+    function nullifyEmpty(&$arr, $field) {
+        if($arr[$field] === '') {
+            $arr[$field] = null;
+        }
+        return $arr;
+    }
 	// from php.net comments
 	function in_array_insensitive($item, $array) {
 	    $item = &strtoupper($item);


### PR DESCRIPTION
There's a bug in Loris/Smarty where a field is empty, smarty passes the value as  '' (the empty string) instead of null. As a result, you can't use Smarty to save into integer database columns using templates, because MySQL treats '' as 0.

This patch adds a helper Utility function called Utility::nullifyEmpty() which takes as parameters an array and a fieldname. The function checks if the field is  the string '' , and if it is it replaces the value with null. This should be called on any integer columns in an array before $db->insert or $db->update is called with those arrays, otherwise the columns are likely to be incorrectly populated as "0" instead of null when the user leaves the field blank.

It can also be called on other column types if you want to ensure that MySQL is storing the values as null when the user chooses a blank option in a dropdown or leaves a textbox empty.
