### PR TITLE
Added check to ensure Date_taken is not in the future

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1245,14 +1245,18 @@ function _checkDateTaken($dateElement) {
     // else, check the date
     else {
         $checked = checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
-        if($checked === false) {
-            return false;
+        if(version_compare(phpversion(), '5.3.0', '>=')) {
+            if($checked === false) {
+                return false;
+            }
+            $formatted = date_create();
+            $formatted->setDate($dateElement['Y'], $dateElement['M'], $dateElement['d']);
+            $now = date_create(); #getdate(); #date("Y-m-d", getdate());
+            $diff = date_diff($formatted, $now);
+            return ($diff->format("%r") === '');
+        } else {
+            return $checked;
         }
-        $formatted = date_create();
-        $formatted->setDate($dateElement['Y'], $dateElement['M'], $dateElement['d']);
-        $now = date_create(); #getdate(); #date("Y-m-d", getdate());
-        $diff = date_diff($formatted, $now);
-        return ($diff->format("%r") === '');
     }
 }
 


### PR DESCRIPTION
This pull request adds a feature to Loris where it will ensure that the "Date_taken" field entered in an instrument can not be in the future, since that's obviously a data input error.
