### PR TITLE
Fix generated sql by generate_table_sql.php

### DIFF
--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -79,7 +79,7 @@ foreach($instruments AS $instrument){
                 $output.="`CommentID` varchar(255) NOT NULL default '',\n
                           `UserID` varchar(255) default NULL,\n
                           `Examiner` varchar(255) default NULL,\n
-                          `Testdate` timestamp(14) NOT NULL,\n
+                          `Testdate` timestamp NOT NULL,\n
                           `Data_entry_completion_status` enum('Incomplete','Complete') NOT NULL default 'Incomplete',\n";
             break;
 
@@ -111,7 +111,7 @@ foreach($instruments AS $instrument){
 
     }
     $output.="PRIMARY KEY  (`CommentID`)\n
-              ) TYPE=MyISAM;\n";
+              );\n";
     $fp=fopen($filename, "w");
     fwrite($fp, $output);
     fclose($fp);


### PR DESCRIPTION
The generate_tables_sql.php script generates an SQL script which doesn't work in the most recent version of MySQL.

In the older version that we used, it was generating warnings, but on the most recent version it appears to no longer work at all. This patch removes the (14) from the "timestamp" column which is no longer valid, and removes the Type=MyISAM, which is also no longer valid in a create table statement.
