### PR TITLE
Added wrappers for instruments.

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1142,6 +1142,37 @@ class NDB_BVL_Instrument extends PEAR
         $this->XINRegisterRule($field, array($field . '_status{@}=={@}'), 'This field is required', $field . '_group');
     }
 
+    /**
+    * Wrapper to create a header
+    */
+
+    function addHeader($header) {
+        $this->form->addElement('header', null, $header); 
+    }
+
+    /**
+    * Wrapper to create a select drop-down list
+    */
+    
+    function addSelect($name, $label, $options=array()) {
+        $this->form->addElement('select', $name, $label, $options);
+    }
+
+    /**
+    * Wrapper to create a static label
+    */
+    
+    function addLabel($label) {
+        $this->form->addElement('static', null, $label);
+    }
+
+    /**
+    * Wrapper to create a static score column
+    */
+   
+    function addScoreColumn($name, $label) {
+        $this->form->addElement('static', $name, $label);
+     }
 
     /**
     * nulls all scores for the record identified by CommentID
@@ -1271,5 +1302,4 @@ function _checkDate($dateElement) {
     }
     return checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
 }
-
 ?>


### PR DESCRIPTION
I added several wrappers to the file NDB_BVL_Instrument.class.inc that can be called instead of the addElement method. For example, instead of writing $this->form->addElement("header", null, "My Header");
you would write this with the wrapper as $this->addHeader("My Header");  
Please review.

Kevin
