### PR TITLE
Made insert and update statements raise PEAR errors on error

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -161,9 +161,13 @@ class Database extends PEAR
 
         $this->_printQuery($query);
         $prep = $this->_PDO->prepare($prepQ);
-        $prep->execute($exec_params);
+        $result = $prep->execute($exec_params);
+        if($result === FALSE) {
+            return $this->raiseError("Insert statement did not execute successfully.");
+        }
         $this->affected = $prep->rowCount(); 
         $this->lastInsertID = $this->_PDO->lastInsertId();
+        return true;
     }
 
     /**
@@ -232,8 +236,12 @@ class Database extends PEAR
         $this->_printQuery($query.$where);
 
         $prep = $this->_PDO->prepare($prepQ);
-        $prep->execute($exec_params);
+        $result = $prep->execute($exec_params);
+        if($result === FALSE) {
+            return $this->raiseError("Update statement did not execute successfully.");
+        }
         $this->affected = $prep->rowCount(); 
+        return true;
     }
 
     /**


### PR DESCRIPTION
When the PDO execute() method fails, it returns false. This differs from the old mysql_query function which would throw a PEAR exception.

This branch restores the old behaviour of raising an exception if the query fails in our Database wrapper.
