### PR TITLE
Fixed "can not redeclare flatten" error in Utility::getAllInstruments()

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -518,13 +518,13 @@ class Utility extends PEAR
 	    return false;
 	}
    
-        function Flatten($Arr) {
-            return $Arr['Test_name'];
-        }
+    function Flatten($Arr) {
+        return $Arr['Test_name'];
+    }
 
-        function FlattenFull($Arr) {
-            return $Arr['Full_name'];
-        }
+    function FlattenFull($Arr) {
+        return $Arr['Full_name'];
+    }
 
     function getAllInstruments() {
         $DB =& Database::singleton();
@@ -535,10 +535,7 @@ class Utility extends PEAR
         // trick to get an array of the form array( 'test_name' => 'test_name')
         // which can be used by quickforms for the dropdown. The array_merge
         // call after that just adds an Any/All Instruments option.
-        function Flatten($Arr) {
-            return $Arr['Test_name'];
-        }
-        $in = array_map('Flatten', $instruments_q);
+        $in = array_map(array('Utility', 'Flatten'), $instruments_q);
         $instruments = array_combine($in, $in);
         return $instruments;
 


### PR DESCRIPTION
Utility::GetAllInstruments() was redeclaring Flatten inline, while
it was already defined as Utility::Flatten. This removes the duplicated
function definition and changes the code to use the Utility::Flatten
that is already there.

(It also fixes the indentation of those functions to be consistent with the rest of the file)
