### PR TITLE
Modified mri_protocol_violated_scan table

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1503,7 +1503,7 @@ CREATE TABLE `mri_protocol_violated_scans` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `CandID` int(6),
   `PSCID` varchar(255),
-  `Last_inserted` datetime,
+  `time_run` datetime,
   `series_description` varchar(255) DEFAULT NULL,
    minc_location varchar(255),
    PatientName varchar(255) DEFAULT NULL,
@@ -1517,6 +1517,7 @@ CREATE TABLE `mri_protocol_violated_scans` (
   `xstep_range` varchar(255) DEFAULT NULL,
   `ystep_range` varchar(255) DEFAULT NULL,
   `zstep_range` varchar(255) DEFAULT NULL,
+  `time_range` varchar(255)  DEFAULT NULL,
   PRIMARY KEY (`ID`));
 
 CREATE TABLE `conflicts_unresolved` (

--- a/SQL/2012-08-21-MRI-scan_violated_modified.sql
+++ b/SQL/2012-08-21-MRI-scan_violated_modified.sql
@@ -1,1 +1,2 @@
-ALTER TABLE mri_protocol_violated_scans CHANGE Last_inserted Last_inserted datetime;
+ALTER TABLE mri_protocol_violated_scans CHANGE Last_inserted time_run datetime;
+ALTER TABLE mri_protocol_violated_scans ADD COLUMN time_range varchar(255) AFTER zstep_range;


### PR DESCRIPTION
- The mysql type date (for column Last_inserted in mri_protocol_violated_scan table) is now changed to datetime in order to store the value of function now() which contains both date and time. 
- changed the column name 'Last_inserted' to 'time_run'
- Included the 'time_range' column
