### PR TITLE
Changed referenced from ENV superglobal to getenv()

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -491,7 +491,7 @@ class Database extends PEAR
         }
 
         if(empty($userID)) {
-            $userID = $_ENV['USER'];
+            $userID = getenv('USER');
         }
 	    if(empty($userID)) {
 	        $userID = 'unknown';

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -117,7 +117,7 @@ Class TimePoint
             $userID = $_SESSION['State']->getUsername();
         } else {
             // not a web hit, so use the unix username from the environment
-            $userID = $_ENV['USER'];
+            $userID = getenv('USER');
         }
 
         // generate today's date for the Date registered field


### PR DESCRIPTION
This branch fixes some of the PHP notices that people are getting with newer versions of PHP. In particular, it changes references of the _ENV superglobal (which is no longer registered in the default php.ini) to the function getenv(), which the PHP documentation suggests using instead.
