### PR TITLE
Add Check of VisitLabel to create Time point

### DIFF
--- a/php/libraries/NDB_Form_create_timepoint.class.inc
+++ b/php/libraries/NDB_Form_create_timepoint.class.inc
@@ -121,6 +121,12 @@ class NDB_Form_create_timepoint extends NDB_Form
         
         $errors = array();
         
+        // This can happen if the user quickly clicks "Create Time Point" before the page has loaded
+        // and the Visit Label dropdown hasn't been selected yet. The page will create "V1" when this
+        // is the case without this check.
+        if(empty($values['visitLabel'])) {
+            $errors['visitLabel'] = 'A visit label is required for creating a timepoint.';
+        }
         // make sure the user entered a valid visit label
         if ($visitLabelSettings['generation'] == 'user') {
             if (!preg_match($visitLabelSettings['regex'], $values['visitLabel'])) {


### PR DESCRIPTION
The validate function in create_timepoint doesn't check if a visit label is entered, it expects the addFormRule to do that. But since the Quickform element is dynamically added to the page, this won't be invoked unless the element is on the page. If the user quickly selects a subproject, and then clicks Create Timepoint before the page has re-loaded with the dropdown, the visit "V1" (or V2, V3, etc) will be created, even if this violates the project's visit naming scheme.

This patch adds a check to the _validate function to make sure a visit was also entered.
