### PR TITLE
Fixes the bug with the site list

### DIFF
--- a/php/libraries/NDB_Form_conflicts_resolve.class.inc
+++ b/php/libraries/NDB_Form_conflicts_resolve.class.inc
@@ -140,9 +140,10 @@ class NDB_Form_conflicts_resolve extends NDB_Form
         $instruments = Utility::getAllInstruments();
         $instruments = array_merge(array('' => 'All Instruments'), $instruments);
 
-        $sites = Utility::getSiteList();
-        $sites = array_merge(array('All'=>''), array_flip($sites));
-        $sites= array_flip($sites);
+        
+        
+        
+        $sites = array_flip(array_merge(array('All'=>''), array_flip(Utility::getSiteList())));
         
         // Filter selection elements
         $this->form->addElement('select', 'site', 'Site:', $sites);
@@ -151,7 +152,8 @@ class NDB_Form_conflicts_resolve extends NDB_Form
         $this->form->addElement('text', 'CandID', 'DCCID:', '');
         $this->form->addElement('text', 'PSCID', 'PSCID:', '');
 
-        if(!empty($_REQUEST['site'])) {
+        //This condition is commmented out because the $_REQUEST['site'] will always be empty (All) by default (which will show all the sites)
+        //if(!empty($_REQUEST['site'])) {
             $extra_where = '';
             function AddWhere($Column, $Filter) {
                 if(!empty($_REQUEST[$Filter]) && $_REQUEST[$Filter] != 'all') {
@@ -178,10 +180,11 @@ class NDB_Form_conflicts_resolve extends NDB_Form
                 $DB->selectRow("SELECT COUNT(*) as total FROM conflicts_unresolved c LEFT JOIN flag f ON (c.CommentId1=f.CommentID) LEFT JOIN session s ON (f.SessionID=s.ID) LEFT JOIN candidate ca ON (ca.CandID=s.CandID) WHERE 1=1 $extra_where", $conflicts_num);
                 $this->form->addElement('static', 'total', 'Total number of results:', $conflicts_num['total']);
             }
-        } else {
+       /* } else {
             $this->form->addElement('static', 'status', 'Please select a filter criteria first.');
                 return;
         }
+        */
 
 
         /*        $DB->select("SELECT TableName, ExtraKeyColumn, ExtraKey1, ExtraKey2, FieldName, CommentId1, CommentId2, Value1, Value2, MD5(CONCAT_WS(':',TableName, ExtraKeyColumn, ExtraKey1, ExtraKey2, FieldName, CommentId1, CommentId2)) AS hash FROM conflicts_unresolved", $conflicts);


### PR DESCRIPTION
The site list was not showing due to the fact that array_merge was putting values starting index 0. To resolve this issue, 
1) array_flip is used to mapp properly the values
2) Also the if(!empty($_REQUEST['site'])) was preventing the 'all' sites to show up. This condition is now commented out to resolve the issue.
