### PR TITLE
Added an extra validation for dob

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -73,7 +73,7 @@ class NDB_BVL_Battery extends PEAR
         }
 
         // compute subject age
-        if(!is_null($testDate)) {
+        if((!is_null($testDate)) && (!is_null($dob))) {
             $ageArray = Utility::calculateAge($dob, $testDate);
             $age = ($ageArray['year'] * 12 + $ageArray['mon']) * 30 + $ageArray['day'];
             //echo "age is:".$age."<BR>\n";


### PR DESCRIPTION
Currently ndb_bvl_battery.class.inc doesn't check to see if the dob is not null before calculating the age. This change makes the code more robust.
