### PR TITLE
Added the SeriesUID and EchoTime entries in the feedback_mri_comments.

### DIFF
--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -4,6 +4,8 @@
  * @package mri
  * @access public
  */
+require_once "MRIFile.class.inc";
+
 class FeedbackMRI {
     /**
      * FileID from files table
@@ -384,6 +386,9 @@ class FeedbackMRI {
         if ($this->objectType == 'volume') {
             // per-volume
             $set['FileID'] = $this->fileID;
+            $file = new MRIFile($this->fileID);
+            $set['SeriesUID'] = $file->getParameter('series_instance_uid');
+            $set['EchoTime'] = $file->getParameter('echo_time');
         } else {
             // per-visit
             $set['SessionID'] = $this->sessionID;

--- a/php/libraries/MRIViewScansPage.class.inc
+++ b/php/libraries/MRIViewScansPage.class.inc
@@ -41,6 +41,7 @@ class MRIViewScansPage {
                 } else {
                     $file = new MRIFile($curFileID);
                     $updateSet['SeriesUID'] = $file->getParameter('series_instance_uid');
+                    $updateSet['EchoTime'] = $file->getParameter('echo_time');
                     $updateSet['FileID'] = $curFileID;
                     $this->DB->insert("files_qcstatus", $updateSet);
                 }


### PR DESCRIPTION
This fix inserts the SeriesUID and the EchoTime in the files_qcstatus and feedback_mri_comments tables to be able to change the FileID after a re-run of the MRI pipeline.

```
modified:   FeedbackMRI.class.inc
modified:   MRIViewScansPage.class.inc
```
