### PR TITLE
Fixes that add the SeriesUID and EchoTime in the files, files_qcstatus a...

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -318,6 +318,8 @@ CREATE TABLE `feedback_mri_comments` (
   `CommentID` int(11) unsigned NOT NULL auto_increment,
   `MRIID` int(11) unsigned default NULL,
   `FileID` int(10) unsigned default NULL,
+  `SeriesUID` varchar(64) default NULL,
+  `EchoTime` double default NULL,
   `SessionID` int(10) unsigned default NULL,
   `PatientName` varchar(255) default NULL,
   `CandID` varchar(6) default NULL,
@@ -382,6 +384,8 @@ CREATE TABLE `files` (
   `FileID` int(10) unsigned NOT NULL auto_increment,
   `SessionID` int(10) unsigned NOT NULL default '0',
   `File` varchar(255) NOT NULL default '',
+  `SeriesUID` varchar(64) DEFAULT NULL,
+  `EchoTime` double DEFAULT NULL,
   `CoordinateSpace` varchar(255) default NULL,
   `Algorithm` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
@@ -405,7 +409,8 @@ DROP TABLE IF EXISTS `files_qcstatus`;
 CREATE TABLE `files_qcstatus` (
     FileQCID int(11) PRIMARY KEY auto_increment,
     FileID int(11) UNIQUE NULL,
-    SeriesUID varchar(64) UNIQUE NULL,
+    SeriesUID varchar(64) DEFAULT NULL,
+    EchoTime double DEFAULT NULL,
     QCStatus enum('Pass', 'Fail'),
     QCFirstChangeTime int(10) unsigned,
     QCLastChangeTime int(10) unsigned

--- a/SQL/2013-01-21-SeriesUID-fix.sql
+++ b/SQL/2013-01-21-SeriesUID-fix.sql
@@ -1,0 +1,25 @@
+/* Add SeriesUID and EchoTime to the files table */
+alter table files add SeriesUID varchar(64) NULL after FileID;
+alter table files add EchoTime double NULL after SeriesUID;
+
+/* Add SeriesUID and EchoTime to the files_qcstatus table */
+alter table files_qcstatus drop index SeriesUID;
+alter table files_qcstatus add EchoTime double NULL after SeriesUID;
+
+/* Add SeriesUID and EchoTime to the feedback_mri_comments table */
+alter table feedback_mri_comments add SeriesUID varchar(64) NULL after FileID;
+alter table feedback_mri_comments add EchoTime double NULL after SeriesUID;
+
+
+/* Populate SeriesUID and EchoTime in files, files_qcstatus and feedback_mri_comments tables*/
+CREATE TEMPORARY TABLE SeriesUIDs AS select pf.FileID, pf.Value AS SeriesUID from parameter_file AS pf LEFT JOIN parameter_type AS pt ON pf.ParameterTypeID=pt.ParameterTypeID where pt.Name="series_instance_uid";
+CREATE TEMPORARY TABLE EchoTime AS select pf.FileID, pf.Value AS EchoTime from parameter_file AS pf LEFT JOIN parameter_type AS pt ON pf.ParameterTypeID=pt.ParameterTypeID where pt.Name="echo_time";
+/* feedback_mri_comments */
+UPDATE feedback_mri_comments AS fmc, SeriesUIDs AS S SET fmc.SeriesUID=S.SeriesUID where fmc.FileID=S.FileID;
+UPDATE feedback_mri_comments AS fmc, EchoTime AS et SET fmc.EchoTime=et.EchoTime where fmc.FileID=et.FileID;
+/* files */
+UPDATE files AS f, SeriesUIDs AS S SET f.SeriesUID=S.SeriesUID where f.FileID=S.FileID;
+UPDATE files AS f, EchoTime AS et SET f.EchoTime=et.EchoTime where f.FileID=et.FileID;
+/* files_qcstatus */
+UPDATE files_qcstatus AS fqc, SeriesUIDs AS S SET fqc.SeriesUID=S.SeriesUID where fqc.FileID=S.FileID;
+UPDATE files_qcstatus AS fqc, EchoTime AS et SET fqc.EchoTime=et.EchoTime where fqc.FileID=et.FileID;


### PR DESCRIPTION
Fixes that: 
- add the SeriesUID and EchoTime in the files, files_qcstatus and feedback_mri_comments tables 
- populate the fields based on the parameter_file table (only when using 2013-01-21-SeriesUID-fix.sql).
  modified:   0000-00-00-schema.sql
  new file:   2013-01-21-SeriesUID-fix.sql
