### PR TITLE
Fixed a bug where reverse send to dcc doesn't work if battery modified

### DIFF
--- a/php/libraries/Instrument_List_ControlPanel.class.inc
+++ b/php/libraries/Instrument_List_ControlPanel.class.inc
@@ -510,6 +510,9 @@ Class Instrument_List_ControlPanel extends TimePoint
             }
         }
         
+        if ($this->getData('Submitted')=='Y') {
+            return $hasAccess;
+        }
         return ($hasAccess && $allDataEntryComplete);
     }
     


### PR DESCRIPTION
The reverse send to dcc was checking if all data was entered before
allowing the link for reverse send to DCC to be clickable. This causes
problems if, for instance, the battery was modified and assign missing
instruments was run after the candidate was sent to the Recycling Bin. 

This bug fix changes it so that send to dcc requires all data to be
entered, but reverse send to dcc only requires the permission and doesn't depend on the data entry status of the instruments.
