### PR TITLE
Customizable header table

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -108,6 +108,12 @@
             </project>
         </Projects>
 
+<!-- Add items to display in the header table for a candidate/session.
+     Until a project has been going on for a while, this is most likely
+     unnecessary. -->
+<!--HeaderTable>
+     <parameter_candidate>candidate_comment</parameter_candidate>
+</HeaderTable-->
 	<!-- number of subprojects in the project - corresponds to the list of subpojects below -->
 	<objectives>1</objectives>
 	<!-- max number of timepoints per subject (integer)-->

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -41,6 +41,7 @@ class Candidate
     
     function select($candID)
     {
+        $config = NDB_Config::singleton();
         // right off, set the candID
         $candID = trim($candID);
         $CandArray = array('Candidate' => $candID);
@@ -72,6 +73,23 @@ class Candidate
         if($config->getSetting('useProjects') === 'true') {
             $this->candidateInfo['ProjectTitle'] = $this->getProjectTitle();
         }
+
+        $headerSetting = $config->getSetting('HeaderTable');
+        if(!empty($headerSetting)) {
+            $params = array();
+            $parameterCandSettings = $headerSetting['parameter_candidate'];
+            if(!is_array($parameterCandSettings)) {
+                $parameterCandSettings= array($parameterCandSettings);
+            }
+            foreach($parameterCandSettings as $parameter_type) {
+                $row = $db->pselectRow("SELECT Value, pt.Description FROM candidate c JOIN parameter_candidate pc ON (pc.CandID=c.CandID) LEFT JOIN parameter_type pt ON (pc.ParameterTypeID=pt.ParameterTypeID) WHERE c.CandID=:Candidate AND pt.Name=:PTName", array('Candidate' => $candID, 'PTName' => $parameter_type));
+                if(!empty($row['Value'])) {
+                    $params[$row['Description']] = $row['Value'];
+                }
+            }
+            $this->candidateInfo['DisplayParameters'] = $params;
+        }
+
         // checK PSCID - only if it's passed by the open profile form
         if (isset($_REQUEST['PSCID'])) {
             if (strtolower(trim($_REQUEST['PSCID'])) != strtolower($this->getPSCID())) {

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -154,6 +154,9 @@ function open_help_section(){
         {if $candidate.ProjectTitle != ""}
                     <th nowrap="nowrap">Project</th>
         {/if}
+        {foreach from=$candidate.DisplayParameters item=value key=name}
+                    <th nowrap="nowrap">{$name}</th>
+        {/foreach}
         {if $sessionID != ""}
                     <th nowrap="nowrap">Visit Label</th>
                     <th nowrap="nowrap">Visit to Site</th>
@@ -179,6 +182,9 @@ function open_help_section(){
         {if $candidate.ProjectTitle != ""}
                     <td nowrap="nowrap">{$candidate.ProjectTitle}</td>
         {/if}
+        {foreach from=$candidate.DisplayParameters item=value key=name}
+                    <td nowrap="nowrap">{$value}</td>
+        {/foreach}
 
         {if $sessionID != ""}
                     <!-- timepoint data -->


### PR DESCRIPTION
This pull request makes the header table that's automatically shown for candidates a little more flexible. In particular:
1. If useProjects is enabled, it adds the project to the table beside the subproject
2. It allows you to display custom entries from parameter_candidate to the header table, based on the config file.
