### PR TITLE
Added some missing require_once for Utility and NDB_Page

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -4,6 +4,7 @@
  * @version $Id: NDB_Client.class.inc,v 1.7 2006/04/05 17:07:42 sebas Exp $
  * @package main
  */
+require_once 'Utility.class.inc';
 class NDB_Client
 {
     /**

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -1,5 +1,6 @@
 <?php
-require_once("PEAR.php");
+require_once "PEAR.php";
+require_once "Utility.class.inc";
 /**
  * provides an interface to the NeuroDB configuration
  * @access public

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -1,5 +1,6 @@
 <?php
 require_once 'PEAR.php';
+require_once 'NDB_Page.class.inc';
 
 /**
  * Base Menu class


### PR DESCRIPTION
These were required by main.php, but could cause some scripts to fail when calling Utility::isErrorX or extending NDB_Page if they weren't already required by an earlier requirement.
