### PR TITLE
Fixed a couple annoying warnings from DB wrapper

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -60,7 +60,8 @@ class Database extends PEAR
         if(is_null($database) && is_null($username) && is_null($password) && is_null($host)) {
             if(!empty($connections)) {
                 reset($connections);
-                return current($connections);
+                $connection = current($connections);
+                return $connection;
             } else {
                 return PEAR::raiseError('No database connection exists');
             }
@@ -395,7 +396,10 @@ class Database extends PEAR
 
     function pselectRow($query, $params) {
         $rows = $this->pselect($query . " LIMIT 1", $params);
-        return $rows[0];
+        if(isset($rows[0])) {
+            return $rows[0];
+        }
+        return $rows;
     }
     function pselectOne($query, $params) {
         $result = $this->pselectRow($query, $params);


### PR DESCRIPTION
The DB->pselectRow call was returning $rows[0] without checking if it exists. This caused a log of "PHP Notice" messages to be printed (especially from scripts or loops that use pselectRow) that are distracting. This pull request just adds a check before returning.

It also fixes a notice about how only variables can be returned by reference by assigning current($connections) to a variable before returning it in Database::Singleton();
