### PR TITLE
Ignore score columns and TextAreas in DDE From IB instruments

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1481,6 +1481,7 @@ class NDB_BVL_Instrument extends NDB_Page
                         }
                         break;
                     case 'textarea':
+                        $this->_doubleDataEntryDiffIgnoreColumns[] = $pieces[1];
                         if($addElements) {
                             $this->addTextAreaElement($pieces[1], $pieces[2]);
                         }
@@ -1548,6 +1549,7 @@ class NDB_BVL_Instrument extends NDB_Page
                         }
                         break;
                     case 'static':
+                        $this->_doubleDataEntryDiffIgnoreColumns[] = $pieces[1];
                         if($addElements) {
                             $this->form->addElement('static', $pieces[1], $pieces[2]);
                         }


### PR DESCRIPTION
This adds both score columns and open text (textarea, mostly used for comments) fields to the doubleDataEntryDiffIgnoreColumns array for instrument builder style instruments automatically.
