### PR TITLE
Makes first select dropdown on each page required for instrument builder instruments

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1440,9 +1440,10 @@ class NDB_BVL_Instrument extends NDB_Page
             }
 
             $parsingPage = 'top';
+            $firstSelectOfPage = true;
 
             while(($line = fgets($fp, 4096)) !== false) {
-                $pieces = split("{@}", $line);
+                $pieces = preg_split("/{@}/", $line);
 
                 $type = $pieces[0];
                 if(strpos($pieces[1], "_status") !== FALSE) {
@@ -1464,6 +1465,7 @@ class NDB_BVL_Instrument extends NDB_Page
                         } else {
                             $addElements = false;
                         }
+                        $firstSelectOfPage = true;
                         break;
                     case 'table':
                         $this->testName = trim($pieces[1]);
@@ -1517,7 +1519,7 @@ class NDB_BVL_Instrument extends NDB_Page
                         // fall through and also execute select code below
                     case 'select':
 
-                        $options = split("{-}", trim($pieces[3]));
+                        $options = preg_split("/{-}/", trim($pieces[3]));
                         $opt = array();
                         foreach($options as $o) {
                             $arr = explode("=>", $o);
@@ -1540,6 +1542,10 @@ class NDB_BVL_Instrument extends NDB_Page
                             } else {
                                 $this->form->addElement('select', $pieces[1], $pieces[2], $opt);
                             }
+                        }
+                        if ($firstSelectOfPage) {
+                            $this->_requiredElements[] = $pieces[1];
+                            $firstSelectOfPage = false;
                         }
                         break;
                     case 'header':


### PR DESCRIPTION
Prior to this, there were no required pages for administration all.

Now all pages (that have a select dropdown) are required. This is how it behaved(/behaves) for PHP instruments that use XINRules.
