### PR TITLE
Fix some warnings

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -20,6 +20,8 @@ require_once 'Instrument_List_ControlPanel.class.inc';
 require_once 'NDB_BVL_InstrumentStatus_ControlPanel.class.inc';
 require_once 'NDB_Breadcrumb.class.inc';
 
+$TestName = isset($_REQUEST['test_name']) ? $_REQUEST['test_name'] : '';
+$subtest = isset($_REQUEST['subtest']) ? $_REQUEST['subtest'] : '';
 // make local instances of objects
 $config =& NDB_Config::singleton();
 
@@ -28,11 +30,20 @@ $timer->setMarker('Loaded client');
 //--------------------------------------------------
 
 // set URL params
-$tpl_data['test_name'] = $_REQUEST['test_name']; 
-$tpl_data['subtest']   = $_REQUEST['subtest'];
-$tpl_data['candID']    = $_REQUEST['candID'];
-$tpl_data['sessionID'] = $_REQUEST['sessionID'];
-$tpl_data['commentID'] = $_REQUEST['commentID'];
+function tplFromRequest($param) {
+    global $tpl_data;
+    if(isset($_REQUEST[$param])) {
+        $tpl_data[$param] = $_REQUEST[$param];
+    } else {
+        $tpl_data[$param] = '';
+    }
+}
+
+tplFromRequest('test_name');
+tplFromRequest('subtest');
+tplFromRequest('candID');
+tplFromRequest('sessionID');
+tplFromRequest('commentID');
 
 // study title
 $tpl_data['study_title'] = $config->getSetting('title');
@@ -104,6 +115,7 @@ $timer->setMarker('Drew user information');
 
 // configure browser args for the mri browser
 // !!! array URL args -- need to correct query in mri_browser to accept candidate data
+$argstring = '';
 if (!empty($_REQUEST['candID'])) {
     $argstring .= "filter%5BcandID%5D=".$_REQUEST['candID']."&";
 }
@@ -116,6 +128,7 @@ if (!empty($_REQUEST['sessionID'])) {
         $argstring .= "filter%5Bm.VisitNo%5D=".$timePoint->getVisitNo()."&";
     }
 }
+
 $link_args['MRIBrowser'] = $argstring;
 
 $timer->setMarker('Configured browser arguments for the MRI browser');
@@ -127,9 +140,9 @@ $timer->setMarker('Configured browser arguments for the MRI browser');
  */
 $paths = $config->getSetting('paths');
 
-if (!empty($_REQUEST['test_name'])) {
-    if(file_exists($paths['base'] . "htdocs/js/modules/" . $_REQUEST['test_name'] . ".js")) {
-        $tpl_data['test_name_js'] = "js/modules/" . $_REQUEST['test_name'] . ".js";
+if (!empty($TestName)) {
+    if(file_exists($paths['base'] . "htdocs/js/modules/$TestName.js")) {
+        $tpl_data['test_name_js'] = "js/modules/$TestName.js";
     }
     if (!empty($_REQUEST['commentID'])) {
         // make the control panel object for the current instrument
@@ -138,9 +151,9 @@ if (!empty($_REQUEST['test_name'])) {
         if (Utility::isErrorX($success)) {
               $tpl_data['error_message'][] = $success->getMessage();
         } else {
-            if (empty($_REQUEST['subtest'])) {
+            if (empty($subtest)) {
                 // check if the file/class exists
-                if (file_exists($paths['base']."project/instruments/NDB_BVL_Instrument_".$_REQUEST['test_name'].".class.inc") || file_exists($paths['base']."project/instruments/" . $_REQUEST['test_name'].".linst")) {
+                if (file_exists($paths['base']."project/instruments/NDB_BVL_Instrument_$TestName.class.inc") || file_exists($paths['base']."project/instruments/$TestName.linst")) {
                     // save possible changes from the control panel...
                     $success = $controlPanel->save();
                     if (Utility::isErrorX($success)) {
@@ -234,7 +247,7 @@ function HandleError($error) {
     }
 }
 $caller->setErrorHandling(PEAR_ERROR_CALLBACK, 'HandleError');
-$workspace = $caller->load($_REQUEST['test_name'], $_REQUEST['subtest']);
+$workspace = $caller->load($TestName, $subtest);
 if (Utility::isErrorX($workspace)) {
     $tpl_data['error_message'][] = $workspace->getMessage();
 } else {
@@ -253,7 +266,11 @@ if (Utility::isErrorX($crumbs)) {
 } else {
     $tpl_data['crumbs'] = $crumbs;
     parse_str($crumbs[0]['query'], $parsed);
-    $tpl_data['top_level'] = $parsed['test_name'];
+    if(isset($parsed['test_name'])) {
+        $tpl_data['top_level'] = $parsed['test_name'];
+    } else {
+        $tpl_data['top_level'] = '';
+    }
 }
 
 $timer->setMarker('Drew breadcrumbs');
@@ -267,7 +284,7 @@ $tpl_data['lastURL'] = $_SESSION['State']->getLastURL();
 //Display the links, as specified in the config file
 $links=$config->getSetting('links');
 foreach(Utility::toArray($links['link']) AS $link){
-    $BaseURL = 'url'=>$link['@']['url'];
+    $BaseURL = $link['@']['url'];
     if(isset($link['@']['args'])) {
         $LinkArgs = $link_args[$link['@']['args']];
     }

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -58,7 +58,9 @@ class NDB_Caller extends PEAR
                              || $this->existsAndRequire($base."php/libraries/NDB_Menu_Filter_$test_name.class.inc"))
             ) {
 
-            $html = $this->loadMenu($test_name, $_REQUEST['mode']);
+
+                $mode = isset($_REQUEST['mode']) ? $_REQUEST['mode'] : '';
+                    $html = $this->loadMenu($test_name, $mode);
             if (Utility::isErrorX($html)) {
                 return PEAR::raiseError($html->getMessage());
             }

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -74,7 +74,7 @@ class NDB_Client
         session_start();
 
         // if exiting, destroy the php session
-        if($_REQUEST['logout']) {
+        if(isset($_REQUEST['logout']) && $_REQUEST['logout']) {
             session_destroy();
             session_start();
         }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -209,6 +209,13 @@ class NDB_Menu_Filter extends NDB_Menu
 
         $filter = $_SESSION['State']->getProperty('filter');
 
+        /**
+         * TODO: I don't know why this is written this way.
+         *       It should be rewritten both to fix references
+         *       to undefined indexes and because it definitely
+         *       shouldn't be using eval for security reasons.
+         *       - Dave
+         */
         // build the array of defaults
         foreach ($this->formToFilter as $key => $val) {
             if (is_array($filter) && count($filter) > 0) {
@@ -219,7 +226,11 @@ class NDB_Menu_Filter extends NDB_Menu
                     $defaults[] = "'$key' => array(".implode(', ', $sub).")";
                     unset($sub);
                 } else {
-                    $defaults[] = "'$key' => '".$filter[$val]."'";
+                    if(isset($filter[$val])) {
+                        $defaults[] = "'$key' => '".$filter[$val]."'";
+                    } else {
+                        $defaults[] = "'$key' => ''";
+                    }
                 }
             } else {
                 if (strtolower(substr($val, -8)) == 'centerid') {
@@ -239,10 +250,12 @@ class NDB_Menu_Filter extends NDB_Menu
             if (is_array($filter) && count($filter) > 0) {
                 // If it's an aggregate, don't add it to the where clause filters. Add it to the
                 // having clause filters
-                if(in_array($value, $this->validHavingFilters)) {
-                    $this->having[$value] = $filter[$value];
-                } else {
-                    $this->filter[$value] = $filter[$value];
+                if(isset($filter[$value])) {
+                    if( in_array($value, $this->validHavingFilters)) {
+                        $this->having[$value] = $filter[$value];
+                    } else {
+                        $this->filter[$value] = $filter[$value];
+                    }
                 }
             } else {
                 if (strtolower(substr($value, -8)) == 'centerid') {
@@ -252,7 +265,7 @@ class NDB_Menu_Filter extends NDB_Menu
         }
 
         // set the ordering
-        if (in_array($filter['order']['field'], $this->headers)) {
+        if (isset($filter['order']) && in_array($filter['order']['field'], $this->headers)) {
             $this->filter['order'] = $filter['order'];
         }
     }
@@ -424,7 +437,9 @@ class NDB_Menu_Filter extends NDB_Menu
             // format header
             $this->tpl_data['headers'][$i]['displayName'] = ucwords(str_replace('_', ' ', $header));
             // set field ordering
-            $this->tpl_data['headers'][$i]['fieldOrder'] = ($this->filter['order']['fieldOrder'] == 'ASC') ? 'DESC' : 'ASC';
+            if(isset($this->filter['order'])) {
+                $this->tpl_data['headers'][$i]['fieldOrder'] = ($this->filter['order']['fieldOrder'] == 'ASC') ? 'DESC' : 'ASC';
+            }
             $i++;
         }
 

--- a/php/libraries/NDB_Menu_Filter_final_radiological_review.class.inc
+++ b/php/libraries/NDB_Menu_Filter_final_radiological_review.class.inc
@@ -322,9 +322,15 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
 
                 $this->tpl_data['items'][$x][$i]['value'] = _makePretty($key, $val);
                 $this->tpl_data['items'][$x][$i]['name'] = $key;
-                $this->tpl_data['items'][$x][$i]['CandID'] = $item['CandID'];
-                $this->tpl_data['items'][$x][$i]['CommentID'] = $item['CommentID'];
-                $this->tpl_data['items'][$x][$i]['SessionID'] = $item['SessionID'];
+                if(isset($item['CandID'])) {
+                    $this->tpl_data['items'][$x][$i]['CandID'] = $item['CandID'];
+                }
+                if(isset($item['CommentID'])) {
+                    $this->tpl_data['items'][$x][$i]['CommentID'] = $item['CommentID'];
+                }
+                if(isset($item['SessionID'])) {
+                    $this->tpl_data['items'][$x][$i]['SessionID'] = $item['SessionID'];
+                }
                 $i++;
             }
             $x++;

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -121,7 +121,7 @@ class NDB_Page extends PEAR
 
         // display the HTML_Quickform object
         $smarty = new Smarty_neurodb;
-        $renderer =& new HTML_QuickForm_Renderer_ArraySmarty($smarty);
+        $renderer = new HTML_QuickForm_Renderer_ArraySmarty($smarty);
         $this->form->accept($renderer);
         $smarty->assign('form', $renderer->toArray());
         $smarty->assign($this->tpl_data);

--- a/php/libraries/State.class.inc
+++ b/php/libraries/State.class.inc
@@ -76,7 +76,10 @@ class State
      */
     function getProperty($property)
     {
-        return $this->_stateData[$property];
+        if(isset($this->_stateData[$property])) {
+            return $this->_stateData[$property];
+        }
+        return null;
     }
 
 
@@ -89,11 +92,11 @@ class State
         'mri_safety'
         );
         $caller =& NDB_Caller::singleton();
-        if ($_REQUEST['test_name'] == 'timepoint_list') {
+        if (isset($_REQUEST['test_name']) && $_REQUEST['test_name'] == 'timepoint_list') {
             return 'main.php?test_name=candidate_list';
         } elseif (!empty($_REQUEST['candID']) && in_array($_REQUEST['test_name'], $timepointSubMenus)) {
             return 'main.php?test_name=timepoint_list&candID='.$_REQUEST['candID'];
-        } elseif ($caller->type == 'instrument' || $_REQUEST['test_name'] == 'next_stage') {
+        } elseif ($caller->type == 'instrument' || (isset($_REQUEST['test_name']) && $_REQUEST['test_name'] == 'next_stage')) {
             return 'main.php?test_name=instrument_list&candID='.$_REQUEST['candID'].'&sessionID='.$_REQUEST['sessionID'];
         }
 


### PR DESCRIPTION
There's a number of places in the code where arrays or variables are accessed without making sure they exist first, causing PHP to print warnings.

This fixes some of the more common ones that come up on multiple pages.
