### PR TITLE
Fixed bug where conflicts resolver was showing all sites for all users

### DIFF
--- a/php/libraries/NDB_Form_conflicts_resolve.class.inc
+++ b/php/libraries/NDB_Form_conflicts_resolve.class.inc
@@ -171,7 +171,7 @@ class NDB_Form_conflicts_resolve extends NDB_Form
             // Only show current site in the filter
             $sites = array('' => '', $user->getCenterID() => $user->getSiteName());
             // And update the query to only select the current site
-            $extra_where .= "AND s.CenterID = " . $DB->quote($user->getcenterID());
+            $extra_where .= "AND s.CenterID = " . $DB->quote($user->getCenterID());
         }
         // Filter selection elements
         $this->addSelect('site', 'Site:', $sites);


### PR DESCRIPTION
Now cross-site conflict resolution depends on having the (already existing) cross site access permission.
