### PR TITLE
Cleanup Final Radiological Review Tests

### DIFF
--- a/test/tests/CoreFunctionality.php
+++ b/test/tests/CoreFunctionality.php
@@ -108,14 +108,14 @@ class TestOfLoris extends LorisTest {
     function testIntruments() {
         $DDE_instruments = $this->config->getSetting("DoubleDataEntryInstruments");
         if($this->CandID) {
-            $this->DB->selectRow("SELECT *, s.ID as SessionID FROM session s JOIN candidate c using (CandID) WHERE c.CandID=" . $this->CandID, &$Candidate);
+            $this->DB->selectRow("SELECT *, s.ID as SessionID FROM session s JOIN candidate c using (CandID) WHERE c.CandID=" . $this->CandID, $Candidate);
 
         } else {
-            $this->DB->selectRow("select *, s.ID as SessionID from session s join candidate c using (CandID) where c.pscid not like 'dcc%' and c.pscid <> 'scanner' and s.Active='Y' and s.Visit_label='v06' AND s.CenterID = 1 order by s.ID desc limit 1 ", &$Candidate);
+            $this->DB->selectRow("select *, s.ID as SessionID from session s join candidate c using (CandID) where c.pscid not like 'dcc%' and c.pscid <> 'scanner' and s.Active='Y' and s.Visit_label='v06' AND s.CenterID = 1 order by s.ID desc limit 1 ", $Candidate);
         }
-        $this->DB->select("select * from test_battery where AgeMinDays <=180 and SubprojectID=" . $Candidate['SubprojectID'], &$Battery);
+        $this->DB->select("select * from test_battery where AgeMinDays <=180 and SubprojectID=" . $Candidate['SubprojectID'], $Battery);
 
-        $this->DB->select("select * from flag where SessionID=$Candidate[SessionID] AND CommentID NOT LIKE 'DDE%'", &$CommentIDs);
+        $this->DB->select("select * from flag where SessionID=$Candidate[SessionID] AND CommentID NOT LIKE 'DDE%'", $CommentIDs);
         
         //$this->assertEqual(count($Battery), count($CommentIDs), "Missing CommentIDs for $Candidate[CandID]");
 

--- a/test/tests/FinalRadiologicalReview.php
+++ b/test/tests/FinalRadiologicalReview.php
@@ -101,6 +101,19 @@ class TestOfFinalRadiologicalReview extends LorisTest
     {
         $this->login("UnitTester", "4test4");
 
+        $this->DB->insert("flag",
+            array('CommentID' => 'TestCommentID',
+            'Data_entry' => 'Complete',
+            'Administration' => 'Partial',
+            'Test_name' => 'radiology_review',
+            'SessionID' => $this->SessionID
+        ));
+        $this->DB->insert("radiology_review",
+            array(
+                'CommentID' => 'TestCommentID'
+            )
+        );
+
         $this->get($this->url . "/main.php?test_name=final_radiological_review");
         $PostArray = array(
             'test_name'            => 'final_radiological_review',
@@ -163,6 +176,8 @@ class TestOfFinalRadiologicalReview extends LorisTest
             . "for review done and CandID"
         );
 
+        $this->DB->delete("radiology_review", array('CommentID' => 'TestCommentID'));
+        $this->DB->delete("flag", array('CommentID' => 'TestCommentID'));
     }
 
 }


### PR DESCRIPTION
This fixes an assumption made by the final radiological review tests which assume the radiology_review commentID already exists. It now creates a temporary one, and then deletes it after the test is run.

At the same time, it fixes some errors that stopped the tests from running in PHP 5.4.
