### PR TITLE
Added tests for timepoint_list page.

### DIFF
--- a/test/TestRunner.php
+++ b/test/TestRunner.php
@@ -26,6 +26,8 @@ $test->addFile('tests/CoreFunctionality.php');
 $test->addFile('tests/NewProfile.php');
 $test->addFile('tests/FinalRadiologicalReview.php');
 $test->addFile('tests/CandidateList.php');
+$test->addFile('tests/TimePointList.php');
+
 // Project specific tests..
 //$test->addFile('tests/SiteSpecific.php');
 exit ($test->run($Reporter) ? 0 : 1);

--- a/test/tests/TimePointList.php
+++ b/test/tests/TimePointList.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Test the functionality of the timepoint_list menu filter in Loris
+ *
+ * PHP Version 5
+ *
+ *  @category Testing
+ *  @package  Test
+ *  @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ *  @license  Loris license
+ *  @link     http://www.loris.ca
+ *
+ */
+
+require_once 'LorisTest.php';
+
+/**
+ * Class which implements testing of timepoint_list page in Loris
+ *
+ *  @category Testing
+ *  @package  Test
+ *  @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ *  @license  Loris license
+ *  @link     http://www.loris.ca
+ */
+class TestOfTimepointList extends LorisTest
+{
+    /**
+     * Test that the timepoint_list page is not accessible if
+     * the user is not logged in
+     *
+     * @return null
+     */
+    function testTPLLoggedOut()
+    {
+        $this->get(
+            $this->url . "/main.php?test_name=timepoint_list&candID="
+            . $this->CandID
+        );
+        $this->assertPattern("/Password/", "Could access candidate_list logged out");
+    }
+
+    /**
+     * Test the timepoint_list page. This checks that the timepoint_list
+     * page is accessible, and that it contains all the visits for the
+     * candidate specified for testing in the config.xml.
+     *
+     * It also checks that there's at least 1 session for that candidate,
+     * since otherwise it's a useless test.
+     *
+     * @return null
+     */
+    function testTPLGetPage()
+    {
+        $this->login("UnitTester", "4test4");
+        $this->get(
+            $this->url . "/main.php?test_name=timepoint_list&candID="
+            . $this->CandID
+        );
+        $this->assertBasicConditions();
+        $this->assertResponse(200, "Could not access timepoint_list as UnitTester");
+        $this->assertPattern(
+            "/Candidate Profile/", 
+            "Page does not appear to have header"
+        );
+        $this->assertNoPattern("/Password/", "Unexpectedly got login page");
+
+        $this->assertNoPattern(
+            "/Visit Label \(Click to Open\)/",
+            "Table appears to be missing"
+        );
+        $sessions = $this->DB->pselect(
+            "SELECT Visit_label, ID FROM session
+             WHERE CandID=:CaID AND Active='Y'",
+            array('CaID' => $this->CandID)
+        );
+        $this->assertTrue(
+            count($sessions) > 0, 
+            "Candidate does not have any sessions"
+        );
+        foreach ($sessions as $row) {
+            $vl = $row['Visit_label'];
+            $sid = $row['ID'];
+            $this->assertLink(
+                $vl,
+                $this->url . "/main.php?test_name=instrument_list&candID="
+                . $this->CandID . "&sessionID=" . $sid,
+                "Missing link for Visit Label $vl"
+            );
+        }
+    }
+}
+?>


### PR DESCRIPTION
This adds test cases for the timepoint_list page, that are more explicit than the generic "access all pages" core test.

This one makes sure that the page lists all the sessions in the session table for the test candid
