### PR TITLE
Modified DB schema and patch for pull request register_processed_data.pl...

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -392,10 +392,13 @@ CREATE TABLE `files` (
   `ClassifyAlgorithm` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
   `AcquisitionProtocolID` int(10) unsigned default NULL,
-  `FileType` enum('mnc','obj','xfm','xfmmnc','imp','vertstat') default NULL,
+  `FileType` enum('mnc','obj','xfm','xfmmnc','imp','vertstat','xml','txt') default NULL,
   `PendingStaging` tinyint(1) NOT NULL default '0',
   `InsertedByUserID` varchar(255) NOT NULL default '',
   `InsertTime` int(10) unsigned NOT NULL default '0',
+  `SourcePipeline` varchar(255),
+  `PipelineDate` date,
+  `SourceFileID` int(10) unsigned DEFAULT '0',
   PRIMARY KEY  (`FileID`),
   KEY `file` (`File`),
   KEY `sessionid` (`SessionID`),
@@ -404,7 +407,8 @@ CREATE TABLE `files` (
   KEY `staging_filetype_outputtype` (`PendingStaging`,`FileType`,`OutputType`),
   KEY `AcquiIndex` (`AcquisitionProtocolID`,`SessionID`),
   CONSTRAINT `FK_files_2` FOREIGN KEY (`AcquisitionProtocolID`) REFERENCES `mri_scan_type` (`ID`),
-  CONSTRAINT `FK_files_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`)
+  CONSTRAINT `FK_files_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_files_3` FOREIGN KEY (`SourceFileID`) REFERENCES `files` (`FileID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `files_qcstatus`;

--- a/SQL/2013-05-01-Processed_files_update.sql
+++ b/SQL/2013-05-01-Processed_files_update.sql
@@ -1,0 +1,4 @@
+ALTER TABLE files ADD COLUMN SourcePipeline varchar(255);
+ALTER TABLE files ADD COLUMN PipelineDate date;
+ALTER TABLE files ADD COLUMN SourceFileID int(10) unsigned REFERENCES files(FileID);
+ALTER TABLE files CHANGE FileType FileType  enum('mnc','obj','xfm','xfmmnc','imp','vertstat','xml','txt');


### PR DESCRIPTION
This modifies the DB schema and add a patch to add SourcePipeline, PipelineDate and SourceFileID fields to the files table.

These fields are required to register processed MRI data to the DB.
