### PR TITLE
Fixed deprecation warning DB function

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -428,8 +428,8 @@ class Database extends PEAR
             if($item===null || $item==='') {
                 $output[] = "`$key`=NULL";
             } else {
-                $item = mysql_escape_string($item);
-                $output[] = "`$key`='$item'";
+                $item = $this->quote($item);
+                $output[] = "`$key`=$item";
             }
         
         return implode($glue, $output);


### PR DESCRIPTION
This fixes a bug in the database class that generates a lot of warnings in PHP 5.4 (and will probably completely break in PHP 5.5) about mysql_escape_string being deprecated. It now uses the PDO.
