### PR TITLE
Fixed error in test module caused by static keyword being missing

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -199,7 +199,7 @@ class User extends UserPermissions
      * @access public
      * @static
      */
-    function md5_salt($word)
+    static function md5_salt($word)
     {
         // get a two-character hexadecimal salt from 10 to ff
         $salt = dechex(rand(16, 255));


### PR DESCRIPTION
This fixes an error in the test suite caused by the fact that a static function isn't labelled as static in the User class. As a result, newer versions of PHP complaint when the function is called as User::function because it isn't explicitly labeled as static.

Just added the static keyword.
