### PR TITLE
Made searching for Review Done "No" include empty rows

### DIFF
--- a/php/libraries/NDB_Menu_Filter_final_radiological_review.class.inc
+++ b/php/libraries/NDB_Menu_Filter_final_radiological_review.class.inc
@@ -177,7 +177,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
             's.visit_label',
             'c.PSCID',
             'r.Final_Review_Results',
-            'r.Review_Done',
+            "COALESCE(r.Review_Done, 'no')",
             'r.sas',
             'r.pvs',
             'r.Final_Exclusionary',
@@ -194,7 +194,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
                                     'Visit_label' => 's.visit_label',
                                     'Project'   => 'c.ProjectID',
                                     'pscid'       => 'c.PSCID',
-                                    'Review_done' => 'r.Review_Done',
+                                    'Review_done' => "COALESCE(r.Review_Done, 'no')",
                                     'Results'     => 'r.Final_Review_Results',
                                     'Final_Review_Results' 
                                                   => 'r.Final_Review_Results',
@@ -206,7 +206,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
                                     'Conflict2'   => $conflict_condition2,
                                     'Finalized'   => 'r.Finalized'
         );
-        $this->EqualityFilters = array($conflict_condition1, $conflict_condition2,'r.Final_Exclusionary','r.Finalized','r.Review_Done');
+        $this->EqualityFilters = array($conflict_condition1, $conflict_condition2,'r.Final_Exclusionary','r.Finalized',"COALESCE(r.Review_Done, 'no')");
     }
 
     /**

--- a/test/tests/FinalRadiologicalReview.php
+++ b/test/tests/FinalRadiologicalReview.php
@@ -153,7 +153,7 @@ class TestOfFinalRadiologicalReview extends LorisTest
             "Could not find $this->CandID with filter"
         );
 
-        $PostArray['Review_done'] = '0';
+        $PostArray['Review_done'] = 'no';
         $this->post($this->url . '/main.php', $PostArray);
         $this->assertBasicConditions();
         $this->assertNoPattern(


### PR DESCRIPTION
The final radiological review module was only searching for reviews that were explicitly set to Review Done = 'No' when the filter was set. It was not including cases where the data was null (ie the data hadn't been entered yet, and therefore there was no review done, so it should be included in the query.)

Also updated the test suite to change from 1/0 to yes/no for the boolean fields in the radiological review module, which was changed a couple weeks ago but didn't have the test updated.
