### PR TITLE
Fixed bug where instrument builder multiselects saved as "Array"

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1591,6 +1591,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
                     case 'selectmultiple':
                         $type = 'multiple';
+                        $this->_selectMultipleElements[] = $pieces[1];
                         // fall through and also execute select code below
                     case 'select':
 


### PR DESCRIPTION
Instrument builder instruments weren't adding questions to the list of multiselect questions used by save, result in the data being saved as "Array". This fixes that error.

We should probably add a test suite before merging this.
