### PR TITLE
Added check for dateTimeFields in addDate wrapper

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1326,21 +1326,30 @@ class NDB_BVL_Instrument extends NDB_Page
 
     /**
     * Adds a date group with a status box and appropriate rule
-    * Note: $this->dateOptions must be defined by the subclass calling this wrapper function
-    * @param $name   Name prepended to the HTMLQuickform element
-    * @param $label Element label
+    * Note: $this->dateOptions must be defined by the subclass calling this 
+    * wrapper function
+    *
+    * @param string $name    Name prepended to the HTMLQuickform element
+    * @param string $label   Element label
+    * @param array  $options optional override of class's dateOptions
+    *
+    * @return none
     */
-    function addDateElement($name, $label, $options = null){
-        if($options === null) {
+    function addDateElement($name, $label, $options = null)
+    {
+        if ($options === null) {
             $options = $this->dateOptions;
         }
-        $group [] = $this->createDate($name . "_date", null, $this->dateOptions);
-        $this->dateTimeFields[] = $name . "_date"; //add to array of dates and times.
+
+        $group [] = $this->createDate($name . "_date", null, $options);
+        if (!in_array($name . "_date", $this->dateTimeFields)) {
+            $this->dateTimeFields[] = $name . "_date"; 
+        }
+
         $group [] = $this->createSelect($name . "_date_status", null, array(NULL=>"", 'not_answered'=>"Not Answered"));
         $this->addGroup($group, $name . "_date_group", $label, $this->_GUIDelimiter, FALSE);
         unset($group);
         $this->XINRegisterRule($name . "_date", array($name . "_date_status{@}=={@}"), "A Date, or Not Answered is required.", $name . "_date_group");
-        
     }
 
     /** 


### PR DESCRIPTION
The addDateElement wrapper "helpfully" adds the date to the instrument's dateTimeFields array. However, if the user has already done this (ie. in the setup function), the field will not save correctly.

This adds a check so that it only adds the element if it's not already present and makes it a little more robust.
