### PR TITLE
Improving the Error_Raising Functionality

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -226,7 +226,7 @@ class NDB_Caller extends PEAR
         // make an instance of the instrument's object
         $instrument =& NDB_BVL_Instrument::factory($instrument, $commentID, $page);
         if (Utility::isErrorX($instrument)) {
-            return PEAR::raiseError("NDB_BVL_Caller::loadInstrument instrument factory: " . $instrument->getMessage());
+            return $instrument;
         }
 
         // save instrument form data


### PR DESCRIPTION
Modified the loadInstrument error messsage ( in NDB_Caller.class.inc) to return the error object instead of calling PEAR::raiseError. The same improvement can be made to all  php files.
