### PR TITLE
Set the default charset to utf8 for Loris

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -3,6 +3,7 @@
  * @package main
  */
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+ini_set('default_charset', 'utf-8');
 ob_start('ob_gzhandler');
 // start benchmarking
 require_once 'Benchmark/Timer.php';


### PR DESCRIPTION
This sets the default character set to UTF8, so that we can use accents and other language characters in Loris.
