### PR TITLE
Commented out rules portion of instrument builder for release

### DIFF
--- a/smarty/templates/form_instrument_builder.tpl
+++ b/smarty/templates/form_instrument_builder.tpl
@@ -111,7 +111,7 @@
         <input type="submit" value="Save" />
         </form>
     </div>
-    <h2>Rules (Optional)</h2>
+    <!--h2>Rules (Optional)</h2>
     <div>
         <dl>
             <dt>Question</dt>
@@ -139,7 +139,7 @@
         </table>
         <input type="button" onclick="Rules.save()" value="Save Rules" />
 
-    </div>
+    </div-->
 </div>
 </body>
 </html>


### PR DESCRIPTION
This removes the "Rules" portion of the instrument builder from the front end for the release to avoid confusion because the rules section isn't stable enough for public release.
