### PR TITLE
Make the default URL/hostname localhost

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -67,8 +67,8 @@
 
     <!-- www settings -->
     <www>
-        <host>HOSTNAME</host>
-        <url>https://HOSTNAME/main.php</url>
+        <host>localhost</host>
+        <url>https://localhost/</url>
         <mantis_url></mantis_url>
     </www>
 


### PR DESCRIPTION
Made the default hostname/URL localhost to simplify the installation process.
