### PR TITLE
Fixed some errors with HTML that was causing help to not save

### DIFF
--- a/smarty/templates/help/help.tpl
+++ b/smarty/templates/help/help.tpl
@@ -6,6 +6,7 @@
 <link rel="shortcut icon" href="images/mni_icon.ico" type="image/ico" />
 
 <link type="text/css" href="css/jqueryslidemenu.css" rel="Stylesheet" />
+<script src="js/jquery/jquery-1.4.2.min.js" type="text/javascript"></script>
 <script type="text/javascript" src="js/jquery/jquery-ui-1.8.2.custom.min.js"></script>
 <script type="text/javascript" src="js/jquery/jqueryslidemenu.js"></script>
 
@@ -63,6 +64,7 @@ function mailThisPage()
 <!-- end page header -->
 </head>
 <body>
+<form action="context_help_popup.php" method="get">
 <table width="100%" class="header">
 <tr>
 <th align="left" id="jsheader">
@@ -80,7 +82,6 @@ function mailThisPage()
 </li>
 <div class="Account">
 <li align="right">
-<form action="context_help_popup.php" action="post">
 <input type="text" name="search" /><br />
 </li>
 <li>
@@ -92,6 +93,7 @@ function mailThisPage()
 </th>
 </tr>
 </table>
+</form>
 
 <!-- top table -->
 {if not $is_popup}

--- a/smarty/templates/help/help_edit.tpl
+++ b/smarty/templates/help/help_edit.tpl
@@ -1,70 +1,73 @@
-	    <h1>You are now editing.</h1>
-            
-            <h2>First time? Read the <a href="context_help_popup.php?helpID={$guide.helpID}" target="instructions">instructions</a>.</h2>
+<form action="context_help_popup.php" name="edit" method="post">
+    <h1>You are now editing.</h1>
 
-            <form action="context_help_popup.php" name="edit" method="post">
-	    <input type="hidden" name="helpID" value="{$help_file.helpID}" />
-	    <input type="hidden" name="parentID" value="{$help_file.parentID}" />
+    <h2>First time? Read the <a href="context_help_popup.php?helpID={$guide.helpID}" target="instructions">instructions</a>.</h2>
 
-            <p>Topic: <br />
-            <input type="text" name="topic" size="45" maxlength="100" value="{$help_file.topic}" /></p>
+    <input type="hidden" name="helpID" value="{$help_file.helpID}" />
+    <input type="hidden" name="parentID" value="{$help_file.parentID}" />
 
-            <p>Content:<br />
-            <textarea name="content" rows="20" cols="75">{$help_file.content}</textarea></p>
-            
-            <hr />
+    <p>
+        Topic: <br />
+        <input type="text" name="topic" size="45" maxlength="100" value="{$help_file.topic}" />
+    </p>
 
-            <table border="0" cellpadding="5" cellspacing="0" width="100%" class="std">
-                <tr>
-		    <td>
-                        Related links: 
-{section name=links loop=$related_links}
-                        <a href="context_help_popup.php?helpID={$related_links[links].helpID}">{$related_links[links].topic}</a>{if not $smarty.section.links.last}, {/if}
-{sectionelse}
-                        None
-{/section}
-                        <input type="button" name="addlinks" value="Add Links" onclick="doEdit(this.form, 'Add Links')" class="button" />
-{if $related_links}
-                        <input type="button" name="removelinks" value="Remove Links" onclick="doEdit(this.form, 'Remove Links')" class="button" />
-{/if}
-		    </td>
-		</tr>
-                <tr>
-		    <td>
-                        Subtopics: 
-{section name=child loop=$subtopics}
-                        <a href="context_help_popup.php?helpID={$subtopics[child].helpID}">{$subtopics[child].topic}</a>{if not $smarty.section.child.last}, {/if}
-{sectionelse}
-                        None
-{/section}
-		    </td>
-		</tr>
-                <tr>
-		    <td>
-                        Parent:
-{if $help_file.parentID and $help_file.parentID != -1}
-                        <a href="context_help_popup.php?helpID={$parent.helpID}">{$parent.topic}</a>
-{else}
-                        None
-{/if}
-                        <input type="button" name="changeparent" value="Change Parent" onclick="doEdit(this.form, 'Change Parent')" class="button" /></p>
-		    </td>
-                </tr>
-	    </table>
+    <p>Content: <br />
+        <textarea name="content" rows="20" cols="75">{$help_file.content}</textarea>
+    </p>
 
-            <hr />
-	    
-	    <table border="0" cellpadding="0" cellspacing="0" width="100%">
-                <tr>
-                    <td valign="top">
-                        Created: {$help_file.created|date_format:"%A, %B %e, %Y"|default:"Never"}<br />
-                        Last Update: {$help_file.updated|date_format:"%A, %B %e, %Y"|default:"Never"}<br />
-                    </td>
-                    <td valign="top" align="right">
-                        <input type="submit" name="mode" value="Cancel" class="button" />
-                        <input type="submit" name="mode" value="Save" class="button" />
-                        <input type="submit" name="mode" value="Finish" class="button" />
-                    </td>
-                </tr>
-	    </table>
-            </form>
+    <hr />
+
+    <table border="0" cellpadding="5" cellspacing="0" width="100%" class="std">
+        <tr>
+            <td>
+            Related links: 
+            {section name=links loop=$related_links}
+            <a href="context_help_popup.php?helpID={$related_links[links].helpID}">{$related_links[links].topic}</a>{if not $smarty.section.links.last}, {/if}
+            {sectionelse}
+            None
+            {/section}
+            <input type="button" name="addlinks" value="Add Links" onclick="doEdit(this.form, 'Add Links')" class="button" />
+            {if $related_links}
+            <input type="button" name="removelinks" value="Remove Links" onclick="doEdit(this.form, 'Remove Links')" class="button" />
+            {/if}
+            </td>
+        </tr>
+        <tr>
+            <td>
+            Subtopics: 
+            {section name=child loop=$subtopics}
+            <a href="context_help_popup.php?helpID={$subtopics[child].helpID}">{$subtopics[child].topic}</a>{if not $smarty.section.child.last}, {/if}
+            {sectionelse}
+            None
+            {/section}
+            </td>
+        </tr>
+        <tr>
+            <td>
+            Parent:
+            {if $help_file.parentID and $help_file.parentID != -1}
+            <a href="context_help_popup.php?helpID={$parent.helpID}">{$parent.topic}</a>
+            {else}
+            None
+            {/if}
+            <input type="button" name="changeparent" value="Change Parent" onclick="doEdit(this.form, 'Change Parent')" class="button" />
+            </td>
+        </tr>
+    </table>
+
+    <hr />
+
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+            <td valign="top">
+            Created: {$help_file.created|date_format:"%A, %B %e, %Y"|default:"Never"}<br />
+            Last Update: {$help_file.updated|date_format:"%A, %B %e, %Y"|default:"Never"}<br />
+            </td>
+            <td valign="top" align="right">
+                <input type="submit" name="mode" value="Cancel" class="button" />
+                <input type="submit" name="mode" value="Save" class="button" />
+                <input type="submit" name="mode" value="Finish" class="button" />
+            </td>
+        </tr>
+    </table>
+</form>


### PR DESCRIPTION
There were some bugs in the HTML of the help page with the new GUI. The DOM was not being parsed properly because of an invalid form tag for the Search box, and  jquery wasn't included.

The indentation of the help_edit.tpl file was also wrong.
