### PR TITLE
Fix feedback in new gui

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -217,6 +217,7 @@
         <showTiming>0</showTiming>
         <showPearErrors>0</showPearErrors>
         <showDatabaseQueries>0</showDatabaseQueries>
+        <PopUpFeedbackBVL>1</PopUpFeedbackBVL>
     </gui>
 
 <main_menu_tabs>


### PR DESCRIPTION
Changed the Feedback popup to 1 in the default config file. If this isn't set, then the popup no longer follows the current page in the new GUI. Since it's not actually a popup anymore, it makes sense to just enable it.
