### PR TITLE
Added IsFile column to parameter_type

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -922,6 +922,7 @@ CREATE TABLE `parameter_type` (
   `SourceCondition` text,
   `CurrentGUITable` varchar(255) default NULL,
   `Queryable` tinyint(1) default '1',
+  `IsFile` tinyint(1) default '0',
   PRIMARY KEY  (`ParameterTypeID`),
   KEY `name` (`Name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8 COMMENT='dictionary of all the variables in the project';

--- a/SQL/2014-01-21-AddIsFile.sql
+++ b/SQL/2014-01-21-AddIsFile.sql
@@ -1,0 +1,1 @@
+ALTER TABLE parameter_type ADD COLUMN IsFile tinyint(1) default '0';


### PR DESCRIPTION
This adds the IsFile column to the parameter_type table. This was used by the old DQG to check if the data in the column points to a file (so that it would know if it could be downloaded and is also useful for ie. cbrain hooks.) At some point the new querying tool will probably also use this column to determine if a column should be uploaded to CouchDB.
