### PR TITLE
Fixed some warnings from the error logs in PHP 5.4

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -185,7 +185,7 @@ Class NDB_BVL_Feedback
     * @static
     * @return string color hex code (format #xxxxxx)
     */
-    function getThreadColor($status)
+    static function getThreadColor($status)
     {
         if(empty($status)) return '';
 
@@ -791,7 +791,7 @@ Class NDB_BVL_Feedback
     * @throws PEAR error
     * @access static
     */
-    function getFeedbackStatusVerbose($statusID) 
+    static function getFeedbackStatusVerbose($statusID)
     {
         if (empty($statusID)) return PEAR::raiseError("NDB_BVL_Feedback::getFeedbackStatusVerbose  Error, empty status ID\n");
         // new DB Object

--- a/php/libraries/NDB_Menu_Filter_candidate_list.class.inc
+++ b/php/libraries/NDB_Menu_Filter_candidate_list.class.inc
@@ -207,8 +207,7 @@ class NDB_Menu_Filter_candidate_list extends NDB_Menu_Filter
                     } else {
                         $this->tpl_data['items'][$x][$i]['value'] = '';
                     }
-                } else if ($key == 'Participant_Status') {
-                   
+                } else if ($key == 'Participant_Status' && !empty($val)) {
                 	$this->tpl_data['items'][$x][$i]['value'] = $participantOptions[$val];
                 }
                   else if ($key=='scan_done'){

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -351,7 +351,7 @@ class Utility extends PEAR
      * @access public
      * @static
      */
-    function getCleanString($string)
+    static function getCleanString($string)
     {
         $string = trim($string);
         $string = str_replace('  ', ' ', $string);
@@ -511,7 +511,7 @@ class Utility extends PEAR
     //toArray ensures that $var is a collection of $var elements, not just a single element
     //If this makes no sense to you, examine the way the xml parser deals with multiple elements of the same name.
     //Note: This does not change a string into an array with one string element
-    function toArray($var){
+    static function toArray($var){
         if(!isset($var[0])) {
             $var = array($var);
         }


### PR DESCRIPTION
There are a few static function missing the static keyword, which causes warning messages to fill the logs in PHP 5.4+.

Some of these functions are called often or from loops, causing them to show up many times per request.
