### PR TITLE
Made MRI browser side panel use CSS instead of javascript

### DIFF
--- a/smarty/templates/mri_browser_main.tpl
+++ b/smarty/templates/mri_browser_main.tpl
@@ -100,7 +100,8 @@ function FeedbackButtonClicked() {
 </tr>
 </table>
 
-<div id="divTopLeft" style="position:absolute">
+<div class="controlPanel" style="position:fixed">
+<div id="divTopLeft">
 <!-- back button and other navigation buttons -->
     {if $backURL!=""}
 <!-- Back Button -  -->
@@ -118,14 +119,14 @@ function FeedbackButtonClicked() {
     {if $prevTimepoint.URL!="" && $nextTimepoint.URL!=""}<br><br>{/if}
 </div>
 {if $showFloatJIV}
-<div id="divTopRight" style="position:absolute">
+<div id="divTopRight">
 <h3>3D Panel Viewing<br><br>
 <input type="button" accesskey="c" class="button" value="3D+Overlay" onClick="javascript:show_jiv(jivNames, jivData, true);"><br>
 <input type="button" accesskey="d" class="button" value="3D Only" onClick="javascript:show_jiv(jivNames, jivData, false);">
 </h3>
 </h3>
 </div>
-<div id="divBottomRight" style="position:absolute">
+<div id="divBottomRight">
 <h3>Links</h3><br>
 <a href="main.php?test_name=mri_parameter_form&candID={$subject.candid}&sessionID={$subject.sessionID}&commentID={$subject.ParameterFormCommentID}">MRI Parameter Form</a>
 <br>
@@ -134,13 +135,13 @@ function FeedbackButtonClicked() {
 <br>
 {foreach from=$subject.tarchiveids item=tarchive}
 <!--td nowrap="nowrap"><input type="button" name="button" value="DICOM Archive" class="button" style = "background-color: #08245b" onclick="window.open('dicom_archive.php?TarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}')" /></td-->
-<a href="dicom_archive.php?TarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive</a>
+<a href="dicom_archive.php?TarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive.TarchiveID}</a>
 <br>
 {/foreach}
 <a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a>
 
 </div>
-<div id="divBottomLeft" style="position:absolute">
+<div id="divBottomLeft">
 <h3>Visit Controls</h3>
 <br>
  <a href="#" onClick="javascript:open_popup('feedback_mri_popup.php?sessionID={$subject.sessionID}')">Visit-level feedback</a>
@@ -156,51 +157,9 @@ function FeedbackButtonClicked() {
 </p>
 {if $has_permission}<input class="button" type="submit" accesskey="s" value="Save" name="save_changes">{/if}            
 </div>
+</div>
 
 {/if}
-<!-- *********************************************************
-     * You may use this code for free on any web page provided that 
-     * these comment lines and the following credit remain in the code.
-     * Floating Div from http://www.javascript-fx.com
-     ********************************************************  -->
-
-{literal}
-<script type="text/javascript">
-var ns = (navigator.appName.indexOf("Netscape") != -1);
-var d = document;
-var px = document.layers ? "" : "px";
-function JSFX_FloatDiv(id, sx, sy)
-{
-	var el=d.getElementById?d.getElementById(id):d.all?d.all[id]:d.layers[id];
-	window[id + "_obj"] = el;
-	if(d.layers)el.style=el;
-	el.cx = el.sx = sx;el.cy = el.sy = sy;
-	el.sP=function(x,y){this.style.left=x+px;this.style.top=y+px;};
-	el.flt=function()
-	{
-		var pX, pY;
-		pX = (this.sx >= 0) ? 0 : ns ? innerWidth : 
-		document.documentElement && document.documentElement.clientWidth ? 
-		document.documentElement.clientWidth : document.body.clientWidth;
-		pY = ns ? pageYOffset : document.documentElement && document.documentElement.scrollTop ? 
-		document.documentElement.scrollTop : document.body.scrollTop;
-		if(this.sy<0) 
-		pY += ns ? innerHeight : document.documentElement && document.documentElement.clientHeight ? 
-		document.documentElement.clientHeight : document.body.clientHeight;
-		this.cx += (pX + this.sx - this.cx)/8;this.cy += (pY + this.sy - this.cy)/8;
-		this.sP(this.cx, this.cy);
-		setTimeout(this.id + "_obj.flt()", 40);
-	}
-	return el;
-}
-JSFX_FloatDiv("divTopLeft",       10, 46).flt();
-JSFX_FloatDiv("divTopRight", 	  10, 180).flt();
-JSFX_FloatDiv("divBottomLeft",    10, 400).flt();
-JSFX_FloatDiv("divBottomRight",   10, 300).flt();
-
-</script>
-{/literal}
-
 <BODY>
 <!-- start main table -->
 <table width="100%" border="0" class="mainlayout" cellpadding="3" cellspacing="2">
@@ -258,9 +217,3 @@ JSFX_FloatDiv("divBottomRight",   10, 300).flt();
 <br>
 </div>
 </HTML>
-
-
-
-
-
-


### PR DESCRIPTION
Scrolling is really chopped in the MRI browser because of some antiquated javascript to make the sidebar scroll up/down. This can be done more easily and efficiently with CSS position:fixed. This implements that change (which also eliminates a problem of some links not being clickable because of the way the javascript hack was implemented.)
