### PR TITLE
Fixed bug where conflict resolver was doing error checking meant for timepoint_list

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -152,8 +152,18 @@ class Candidate
             $this->candidateInfo['DisplayParameters'] = $params;
         }
 
-        // checK PSCID - only if it's passed by the open profile form
-        if (isset($_REQUEST['PSCID'])) {
+        // check that PSCID matches CandID when entered into the boxes
+        // on the candidate_list form (and is therefore trying to open
+        // the timepoint_list page, which is why the if statement checks
+        // for timepoint_list instead of candidate_list)
+        //
+        // Since other pages (ie. the filter in the conflicts_resolve page)
+        // might include an element named PSCID, we also need to check that
+        // the test_name matches before throwing the error.
+        if (isset($_REQUEST['PSCID'])
+            && (isset($_REQUEST['test_name'])
+            && $_REQUEST['test_name']=='timepoint_list')
+        ) {
             if (strtolower(
                 trim($_REQUEST['PSCID'])
             ) != strtolower($this->getPSCID())


### PR DESCRIPTION
I found this bugfix on IBIS that wasn't pushed to Loris-Trunk.

The code meant to check that PSCID/DCCID match on the candidate_list page can be accidentally triggered from the conflict resolver, because the conflict resolver has a field named "PSCID" too. It would come up with an "IDs do not match" error if the instrument that has the conflicts uses Candidate.class.inc anywhere.

This adds a test_name check to make sure it's only invoked from the correct page.
