### PR TITLE
Fixed patch for data dict edit perm

### DIFF
--- a/SQL/2014-01-27-data_dict_edit.sql
+++ b/SQL/2014-01-27-data_dict_edit.sql
@@ -1,1 +1,1 @@
-INSERT INTO permissions VALUES ('','data_dict_edit','Edit permissions for Data Dictionary',2);
+INSERT INTO permissions (code, description, categoryID) VALUES ('data_dict_edit','Edit permissions for Data Dictionary',2);


### PR DESCRIPTION
The patch for data_dict_edit permission didn't apply cleanly on IBIS because it doesn't specify the field names and make assumptions about their order. This fixes the insert statement to be more versatile to schema changes by being explicit about the columns.
