### PR TITLE
HTML was not properly closed in MRI Browser, breaking scrolling on menu

### DIFF
--- a/php/libraries/MRIViewScansPage.class.inc
+++ b/php/libraries/MRIViewScansPage.class.inc
@@ -237,7 +237,7 @@ class MRIViewScansPage {
             }
             $fileData[$fIdx]['fileInsertDate'] = $file->getParameter('InsertTime');
             $fileData[$fIdx]['filename'] = basename($file->getParameter('File'));
-            $fileData[$fIDx]['fullFilename'] = $file->getParameter('File');
+            $fileData[$fIdx]['fullFilename'] = $file->getParameter('File');
             $fileData[$fIdx]['seriesDescription'] = $file->getParameter('series_description');
             $fileData[$fIdx]['seriesNumber'] = $file->getParameter('series_number');
             $fileData[$fIdx]['echoTime'] = number_format($file->getParameter('echo_time')*1000, 2);

--- a/smarty/templates/mri_browser_main.tpl
+++ b/smarty/templates/mri_browser_main.tpl
@@ -157,9 +157,9 @@ function FeedbackButtonClicked() {
 </p>
 {if $has_permission}<input class="button" type="submit" accesskey="s" value="Save" name="save_changes">{/if}            
 </div>
-</div>
 
 {/if}
+</div>
 <BODY>
 <!-- start main table -->
 <table width="100%" border="0" class="mainlayout" cellpadding="3" cellspacing="2">


### PR DESCRIPTION
One of the DIV tags in the MRI browser wasn't properly closed. This was causing scrolling to break, because the web browser interpreted the whole page as being part of the (unscrollable) control panel on the sidebar instead of being part of the main section of the page.

This puts the closing tag in the proper place so that you can scroll on the mri browser menu
