### PR TITLE
Fixed PHP short tag and converted to <?php

### DIFF
--- a/php/libraries/smarty/plugins/resource.neurodb.php
+++ b/php/libraries/smarty/plugins/resource.neurodb.php
@@ -1,4 +1,4 @@
-<?
+<?php
 function smarty_resource_neurodb_source($rsrc_name, &$source, &$smarty){
     if(strpos($rsrc_name, '/')===0) $filename = $rsrc_name;
     else {


### PR DESCRIPTION
The short_open_tag php.ini in newer versions of Ubuntu and PHP default to "Off". This is one straggler in our code that causes loris to not work on a new clean install with Ubuntu 13.10.
