### PR TITLE
Feedback mri fixes

### DIFF
--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * @package mri
  */


### PR DESCRIPTION
The MRI feedback comment module was broken because it did not set_include_path and had the wrong PHP opening tag. This fixes it.
