### PR TITLE
Instrument builder groups

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1378,7 +1378,11 @@ class NDB_BVL_Instrument extends NDB_Page
      * @return none
     */
     function addMonthYear($field, $label, $options=array()) {
+        if(is_array($options)) {
+            $options['format'] = 'YM';
+        }
         $this->form->addElement('date', $field, $label, $options);
+        $this->monthYearFields[] = $field;
     }
 
 
@@ -1674,7 +1678,12 @@ class NDB_BVL_Instrument extends NDB_Page
                                 );
                             }
 
-                            $this->addDateElement($pieces[1], $pieces[2], $dateOptions);
+                            $pieces[5] = trim($pieces[5]);
+                            if($pieces[5] === 'MonthYear') {
+                                $this->addMonthYear($pieces[1], $pieces[2], $dateOptions);
+                            } else {
+                                $this->addDateElement($pieces[1], $pieces[2], $dateOptions);
+                            }
                         }
                         $this->LinstQuestions[$pieces[1]] = array('type' => 'date');
                         break;


### PR DESCRIPTION
This adds support for groups/tables in the backend of the instrument builder by adding support for a begintable, endtable, and begingroup and endgroup tag to designate a table or row.

The frontend does not yet have a UI to add these tags, but a poweruser can use them to markup an instrument which requires a table without resorting to converting to PHP by directly adding them to the .linst file.
