### PR TITLE
Update reference to tables_sql to point to project directory

### DIFF
--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -67,7 +67,7 @@ foreach($instruments AS $instrument){
             case "table":
                 $tablename = $bits[1];
 
-                $filename="tables_sql/".$bits[1].".super_sql";
+                $filename="../project/tables_sql/".$bits[1].".super_sql";
                 $output="CREATE TABLE `$bits[1]` (\n";
                 $output.="`CommentID` varchar(255) NOT NULL default '',
                           `UserID` varchar(255) default NULL,


### PR DESCRIPTION
This updates the tables_sql references in the tools/ directory to point to project/tables_sql. (generate_tables.sql was already pointing there, generate_tables_and_testNames had to be updated)
