### PR TITLE
Fixed instrument control panel

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1850,8 +1850,11 @@ class NDB_BVL_Instrument extends NDB_Page
             if (Utility::isErrorX($success)) {
                 $tpl_data['error_message'][] = $success->getMessage();
             } else {
+                $config = NDB_Config::singleton();
+                $paths = $config->getSetting('paths');
                 if (empty($subtest)) {
                     // check if the file/class exists
+                    $TestName = $this->testName;
                     if (file_exists($paths['base']."project/instruments/NDB_BVL_Instrument_$TestName.class.inc") || file_exists($paths['base']."project/instruments/$TestName.linst")) {
                         // save possible changes from the control panel...
                         $success = $controlPanel->save();


### PR DESCRIPTION
The file_exists check in the Instrument getControlPanel was referring to some variables that hadn't been initialized, so this adds them to fix the actions.
