### PR TITLE
removing path before testname.css as its part of main.tpl

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -142,8 +142,8 @@ if (!empty($TestName)) {
     if(file_exists($paths['base'] . "htdocs/js/modules/$TestName.js")) {
         $tpl_data['test_name_js'] = "js/modules/$TestName.js";
     }
-    if(file_exists("css/instruments/$TestName.css")) {
-       $tpl_data['test_name_css'] = "css/instruments/$TestName.css";
+    if(file_exists("css/instruments/$TestName.css")) { 
+       $tpl_data['test_name_css'] = "$TestName.css";
     }
 }
 


### PR DESCRIPTION
In my over excitement to push instrument template changes I added the path to the css file in both main.tpl and main.php. We need it only in one place
