### PR TITLE
Removed the absolute path for the get_file.php

### DIFF
--- a/php/libraries/MRIViewScansPage.class.inc
+++ b/php/libraries/MRIViewScansPage.class.inc
@@ -255,7 +255,7 @@ class MRIViewScansPage {
             $fileData[$fIdx]['Pipeline'] = $file->getParameter('Pipeline');
             $fileData[$fIdx]['Comment'] = $file->getParameter('Comment');
             // this has been changed for more security
-            $fileData[$fIdx]['checkpicFilename'] = "/mri/jiv/get_file.php?file=" .'pic/'. $file->getParameter('check_pic_filename');
+            $fileData[$fIdx]['checkpicFilename'] = "mri/jiv/get_file.php?file=" .'pic/'. $file->getParameter('check_pic_filename');
             // the jivs
             $fileData[$fIdx]['jivFilename'] = basename($file->getParameter('File'));
             $fileData[$fIdx]['jivAddress'] = str_replace('_check.jpg', '', $file->getParameter('check_pic_filename'));


### PR DESCRIPTION
https://redmine.cbrain.mcgill.ca/issues/3574

The  path for get_file in MRIViewScansPage.class.inc is now modified not to use the absolute path
