### PR TITLE
Special characters are now displayed correctly in help section

### DIFF
--- a/smarty/templates/help/help.tpl
+++ b/smarty/templates/help/help.tpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+<meta charset="utf-8"/>
 <link rel="stylesheet" href="main.css" type="text/css" />
 <!-- shortcut icon that displays on the browser window -->
 <link rel="shortcut icon" href="images/mni_icon.ico" type="image/ico" />

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" style="height:100%">
 <head>
+<meta charset="utf-8"/>
 <link rel="stylesheet" href="{$css}" type="text/css" />
 {if $test_name_css}
 <link rel="stylesheet" href="css/instruments/{$test_name_css}" type="text/css" />


### PR DESCRIPTION
Special characters are now displayed correctly in help section (redmine ticket #5756)
