### PR TITLE
Config regex for livingphantom and legophantom

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -47,6 +47,8 @@
 <dicom_archive>
     <patientIDRegex>/./</patientIDRegex>
     <patientNameRegex>/./i</patientNameRegex>
+    <LegoPhantomRegex>/./i</LegoPhantomRegex>
+    <LivingPhantomRegex>/./i</LivingPhantomRegex>
     <showTransferStatus>false</showTransferStatus>
 </dicom_archive>
 <!-- Following links will appear on the footer of the home page of loris installation -->

--- a/htdocs/dicom_archive.php
+++ b/htdocs/dicom_archive.php
@@ -108,7 +108,10 @@ if(!empty($_REQUEST['TarchiveID'])) {
     if(Utility::isErrorX($detail_tpl_data['archive'])) print $detail_tpl_data['archive']->getMessage()."<br>\n";
 
     // determine if the patient name is valid
-    if(preg_match($dicom_archive_settings['patientNameRegex'], $detail_tpl_data['archive']['PatientName']))
+    if ((preg_match($dicom_archive_settings['patientNameRegex'], $detail_tpl_data['archive']['PatientName'])) 
+      || (preg_match($dicom_archive_settings['LegoPhantomRegex'], $detail_tpl_data['archive']['PatientName'])) 
+      || (preg_match($dicom_archive_settings['LivingPhantomRegex'], $detail_tpl_data['archive']['PatientName']))) 
+    
        $detail_tpl_data['archive']['patientNameValid']=1;
     else {
        $detail_tpl_data['archive']['patientNameValid']=0;


### PR DESCRIPTION
Two new dicom_archive regex are available (for both Livingphantom and legophantom) in config.xml and extracted/used by dicom_archive.php. This refers to the following redmine task:
https://redmine.cbrain.mcgill.ca/issues/5877

This pull request has been tested on the testing VM and the following regex are currently used in the testing vm:
    <LegoPhantomRegex>/lego_phantom_[a-zA-Z]{3}[A-Z0-9]_/i</LegoPhantomRegex>
    <LivingPhantomRegex>/living_phantom_[a-zA-Z]{3}[A-Z0-9]_/i</LivingPhantomRegex>
