### PR TITLE
Specify character set as UTF8 in survey.php

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -15,6 +15,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+ini_set('default_charset', 'utf-8');
 require_once 'NDB_Config.class.inc';
 require_once 'Smarty_hook.class.inc';
 require_once 'NDB_Caller.class.inc';


### PR DESCRIPTION
The survey module was not specifying the character encoding as utf8, which was causing the review page to break as the default before PHP 5.6 was iso-8859-1
