### PR TITLE
Update to CouchDB demographics import script

### DIFF
--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -125,7 +125,6 @@ class CouchDBDemographicsImporter {
             $fieldsInQuery .= $EDCFields;
         }
         $concatQuery = $fieldsInQuery . $tablesToJoin . " WHERE s.Active='Y' AND c.Active='Y' AND ps.study_consent='yes' AND ps.study_consent_withdrawal IS NULL AND c.PSCID <> 'scanner'";
-        print($concatQuery);
         return $concatQuery;
     }
 


### PR DESCRIPTION
- Added several fields (caveat emptor and related fields, participant status, etc.)
- Only imported if candidate has consented and not withdrawn (based on information in the participant_status table)
- Other information such as proband fields, sibling fields are only imported if they are specified as being used in the config file

Other:
- I would like to grab all candidate parameters that are queryable and import them, but I have yet to incorporate this into the currently used query
