### PR TITLE
convert the visit_label to an array

### DIFF
--- a/php/libraries/NDB_Form_create_timepoint.class.inc
+++ b/php/libraries/NDB_Form_create_timepoint.class.inc
@@ -120,7 +120,7 @@ class NDB_Form_create_timepoint extends NDB_Form
     {
         $config =& NDB_Config::singleton();
         $visitLabelSettings = $config->getSetting('visitLabel');
-        foreach($visitLabelSettings AS $visitLabel){
+        foreach(Utility::toArray($visitLabelSettings) AS $visitLabel){
             if($visitLabel['@']['subprojectID']==$values['subprojectID']){
                 $visitLabelSettings=$visitLabel;
                 break;


### PR DESCRIPTION
The visit_labels will not be generated properly in the front-end when there is only one subprojectID. This pull request will fix the issue.

It however needs to be tested on the testing VM before been merged.
