### PR TITLE
Includes the functionality to insert login_info into user_login_history ...

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1742,3 +1742,18 @@ CREATE TABLE `consent_info_history` (
         PRIMARY KEY (`ID`),
         UNIQUE KEY `ID` (`ID`)
         ) ;
+
+CREATE TABLE `user_login_history` (
+  `loginhistoryID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `userID` varchar(255) NOT NULL DEFAULT '',
+  `Success` enum('Y','N') NOT NULL DEFAULT 'Y',
+  `Failcode` varchar(2) DEFAULT NULL,
+  `Fail_detail` varchar(255) DEFAULT NULL,
+  `Login_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `IP_address` varchar(255) DEFAULT NULL,
+  `Page_requested` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`loginhistoryID`),
+  KEY `FK_user_login_history_1` (`userID`),
+  CONSTRAINT `FK_user_login_history_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
+)  ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/SQL/2014-07-10_user_login_history_tracker.sql
+++ b/SQL/2014-07-10_user_login_history_tracker.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `user_login_history` (
+  `loginhistoryID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `userID` varchar(255) NOT NULL DEFAULT '',
+  `Success` enum('Y','N') NOT NULL DEFAULT 'Y',
+  `Failcode` varchar(2) DEFAULT NULL,
+  `Fail_detail` varchar(255) DEFAULT NULL,
+  `Login_timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `IP_address` varchar(255) DEFAULT NULL,
+  `Page_requested` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`loginhistoryID`),
+  KEY `FK_user_login_history_1` (`userID`),
+  CONSTRAINT `FK_user_login_history_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
+)  ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -230,6 +230,20 @@ class SinglePointLogin extends PEAR
     function authenticate()
     {
         $this->_lastError = '';
+         
+         ///////////////////////////
+         ///initialization/////
+         //////////////////////////
+         $this->_username = $_POST['username'];
+         $setArray = array(
+             'userID'=> $this->_username,
+             'Success' => 'Y',
+             'Failcode' => null,
+             'Login_timestamp' => date('Y-m-d H:i:s'),
+             'IP_address' => $_SERVER['REMOTE_ADDR'],
+             'Page_requested' => $_SERVER['REQUEST_URI']
+         );
+
 
         // save the new password if the last password expired
         if (isset($_POST['expiry'])) {
@@ -249,10 +263,12 @@ class SinglePointLogin extends PEAR
         }
         if (empty($_POST['username'])) {
             $this->_lastError = 'Please enter a username';
+            $this->insertFailedDetail($this->_lastError, $setArray);///insert failed_detail into user_login_history
             return false;
         }
         if (empty($_POST['password'])) {
             $this->_lastError = 'Please enter a password';
+            $this->insertFailedDetail($this->_lastError, $setArray);///insert failed_detail into user_login_history
             return false;
         }
 
@@ -275,6 +291,8 @@ class SinglePointLogin extends PEAR
                 // check that the user is active
                 if ($row['Active'] == 'N') {
                     $this->_lastError = "Your account has been deactivated.  Please contact your project administrator to reactivate this account.";
+                    $this->insertFailedDetail("user account not active", $setArray);///insert failed_detail into user_login_history
+
                     return false;
                 }
 
@@ -286,12 +304,15 @@ class SinglePointLogin extends PEAR
 
                 // user is valid
                 $this->_username = $_POST['username'];
+                // insert the user into the user_login_history table
+                $result =  $DB->insert('user_login_history', $setArray);
                 return true;
             }
             // bad usename or password
         }
 
         $this->_lastError = "Incorrect username or password";
+        $this->insertFailedDetail($this->_lastError, $setArray);///insert failed_detail into user_login_history
         return false;
     }
 
@@ -332,5 +353,29 @@ class SinglePointLogin extends PEAR
 
         $_SESSION['State']->setUsername(null);
     }
+
+     /**
+     * Inserts the login (or failed-login) detail into the user_login_history
+     *
+     * @param String $description description for the failed-login 
+     * @param Array  $setArray    contains data to be inserted
+     * 
+     * @return null
+      */
+     function insertFailedDetail($description, $setArray)
+     {
+         // create DB object
+         $DB =& Database::singleton();
+         if (Utility::isErrorX($DB)) {
+             return PEAR::raiseError(
+                 "Could not connect to database: ".$DB->getMessage()
+             );
+         }
+         $setArray['Success'] = 'N';
+         $setArray['Fail_detail'] = $description;
+         // in future, add mapping of error message to Failcode field enum
+         $result =  $DB->insert('user_login_history', $setArray);
+     }
+
 }
 ?>


### PR DESCRIPTION
Adding user_login_history feature - including contributions from Zia
For all user login attempts, this logs into the new user_login_history table the userID (key from users table), timestamp, login success/result (Y/N), error message (if any), and which page the user was attempting to access.
For any failed login attempts, it currently logs the error message displayed in the front end - e.g. "Please enter a username" in the Fail_detail field.  (possibly in future it would be nice to standardize this into an enum Failcode)
