### PR TITLE
Fixed query for dicom archive

### DIFF
--- a/php/libraries/NDB_Menu_Filter_dicom_archive.class.inc
+++ b/php/libraries/NDB_Menu_Filter_dicom_archive.class.inc
@@ -54,9 +54,9 @@ class NDB_Menu_Filter_Dicom_Archive extends NDB_Menu_Filter
     {
         $this->_setDicomArchiveSettings();
                 
-        $this->query = " FROM session s 
-            JOIN candidate c ON (c.CandID=s.CandID)
-            JOIN tarchive t ON (s.ID=t.SessionID)";
+        $this->query = " FROM tarchive t
+            LEFT JOIN session s ON (s.ID=t.SessionID)
+            LEFT JOIN candidate c ON (c.CandID=s.CandID)";
 
         $colsFirst = array(
             't.TarchiveID as TarchiveID',


### PR DESCRIPTION
The DICOM Archive module shows nothing if the session ID isn't set in the tarchive table (ie if the scan hasn't been run, or in the case of IBIS if it's overwritten by the workstations..)

This changes the query to be based on the tarchive table instead of the session and use LEFT JOINs instead of INNER JOINs to make sure everything from tarchive is displayed, regardless of session id.
