### PR TITLE
Install script catch errors

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -284,7 +284,7 @@ while true; do
     else
         break;
     fi
-done
+done;
 
 
 


### PR DESCRIPTION
Specify errors caught: either access denied or couldn't create the database and propose actions accordingly.
