### PR TITLE
Added sandbox config setting for smarty3

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -251,6 +251,9 @@ foreach(Utility::toArray($links['link']) AS $link){
 }
 
 
+if ($config->getSetting("sandbox") === '1') {
+    $tpl_data['sandbox'] = true;
+}
 
 // Assign the console output to a variable, then stop
 // capturing output so that smarty can render
@@ -260,6 +263,7 @@ ob_end_clean();
 
 //Output template using Smarty
 $tpl_data['css'] = $config->getSetting('css');
+
 $smarty = new Smarty_neurodb;
 $smarty->assign($tpl_data);
 $smarty->display('main.tpl');

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -28,6 +28,12 @@ class Smarty_neurodb extends Smarty {
         $this->config_dir = $paths['base']."smarty/configs/";
         $this->cache_dir = $paths['base']."smarty/cache/";
 
+        $sandbox = $config->getSetting("sandbox");
+
+        if($sandbox === '1') {
+            $this->force_compile = true;
+        }
+
         $this->assign('app_name','NeuroDB');
 
         // Set the template directories. First check for project overrides,

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -121,7 +121,7 @@
                         </a>
                     {/if}
 
-                    <a class="navbar-brand" href="main.php">LORIS</a>
+                    <a class="navbar-brand" href="main.php">LORIS{if $sandbox}: DEV{/if}</a>
                </div>
                <div class="collapse navbar-collapse" id="example-navbar-collapse">
                     <ul class="nav navbar-nav">


### PR DESCRIPTION
Smarty3 might take a few page loads between template changes to recompile when you switch branches or edit a tpl file. This is annoying on a sandbox where you're doing development.

This lets you add a <sandbox>1</sandbox> tag to your config that will enable a smarty setting to force a recompile on every load (according to Smarty docs, it should never be set on production.)

It also adds a "DEV" to the menu if sandbox is true, to make it easier to see that you're on your sandbox..
