### PR TITLE
Show console output in a tab if dynamic tabs is enabled

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -204,7 +204,19 @@
                 if not then just put page content in the div #page    -->
         <div id="page-content-wrapper">
             {/if}
+            {if $dynamictabs eq "dynamictabs"}
+                {if $console}
+                    <div class="alert alert-warning" role="alert">
+                        <h3>Console Output</h3>
+                        <div>
+                        <pre>{$console}</pre>
+                        </div>
+                    </div>
+                {/if}
+
+            {/if}
             {if $dynamictabs neq "dynamictabs"}
+            {* Add enough spacing to get below the menu *}
                 <br><br><br>
             <div class="page-content inset">
                 {if $console}


### PR DESCRIPTION
The console output HTML code was in a part of the template that was not displayed if in dynamic tabs. This adds it outside of that section if in a tab so that queries don't get eaten by a output from a tabbed page.
