### PR TITLE
Allow code to change the default page that loads to a different module

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -40,8 +40,9 @@ function tplFromRequest($param) {
     }
 }
 
-tplFromRequest('test_name');
-tplFromRequest('subtest');
+$tpl_data['test_name'] = $TestName;
+$tpl_data['subtest']   = $subtest;
+
 tplFromRequest('candID');
 tplFromRequest('sessionID');
 tplFromRequest('commentID');


### PR DESCRIPTION
Currently, if you try and change the default TestName that loads when there is no $_REQUEST['Test_name'] set it will run the correct PHP code but load the wrong template file. With this fix, we can change the default test_name (or subtest) for ie. a dashboard, or adding a feature that allows users to customize their default page.
