### PR TITLE
Re-adding reference in array that was breaking uploaders

### DIFF
--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -179,7 +179,7 @@ class File_Upload extends PEAR
         
         //Call the method
         $func = array($class, $method);
-        $args = array($this, $args);
+        $args = array(&$this, $args);
 
         $output=call_user_func_array($func, $args);
 


### PR DESCRIPTION
The callback from the File_Upload was broken because the functions being called were expecting a reference and the reference had been taken out.  This re-adds it to fix file upload instruments.
