### PR TITLE
Fix offset table in imaging browser

### DIFF
--- a/smarty/templates/form_viewSession.tpl
+++ b/smarty/templates/form_viewSession.tpl
@@ -9,7 +9,9 @@
 
 <tr>
     <td>
+    <div class="row">
     {$headerTable}
+    </div>
     <table class='table-header-right'>
 	<tr><td>{if $files|@count}{$files|@count} file(s) displayed.</td></tr>
         <tr><td><div id="jivApplet">&nbsp;</div></td></tr>


### PR DESCRIPTION
This fixes a problem where the images in the imaging browser are beside the header table when viewed in firefox.
