### PR TITLE
Add check for pending flag on user login

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -279,7 +279,7 @@ class SinglePointLogin extends PEAR
         }
 
         // check users table to see if we have a valid user
-        $query = "SELECT COUNT(*) AS User_count, Password_md5, Password_expiry, Active FROM users WHERE UserID = :username GROUP BY UserID";
+        $query = "SELECT COUNT(*) AS User_count, Password_md5, Password_expiry, Active, Pending_approval FROM users WHERE UserID = :username GROUP BY UserID";
         $row = $DB->pselectRow($query, array('username' => $_POST['username']));
         if (Utility::isErrorX($row)) {
             return PEAR::raiseError("DB Error: ".$row->getMessage());
@@ -293,6 +293,12 @@ class SinglePointLogin extends PEAR
                     $this->_lastError = "Your account has been deactivated.  Please contact your project administrator to reactivate this account.";
                     $this->insertFailedDetail("user account not active", $setArray);///insert failed_detail into user_login_history
 
+                    return false;
+                }
+
+                if ($row['Pending_approval'] == '1') {
+                    $this->_lastError = "Your account has not yet been activated.  Please contact your project administrator to activate this account.";
+                    $this->insertFailedDetail("user account pending", $setArray);
                     return false;
                 }
 


### PR DESCRIPTION
The pending_approval flag of the account logging in is not checked anywhere when the user is logging in. 

![You had one job!](http://cdn.meme.li/instances/52729571.jpg)
