### PR TITLE
Adding check for Document Repository permission in My Preferences

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -478,8 +478,11 @@ class NDB_Form_user_accounts extends NDB_Form
         $this->form->addElement('password', '__Confirm', 'Confirm Password');
 
         // document repository notifications
-        $doc_Repo_Notifications_Options = array('N' => 'No', 'Y' => 'Yes');
-        $this->addSelect('Doc_Repo_Notifications', 'Receive Document Repository email notifications', $doc_Repo_Notifications_Options); 
+        $editor =& User::singleton();
+        if ($editor->hasPermission('file_upload')) {
+                $doc_Repo_Notifications_Options = array('N' => 'No', 'Y' => 'Yes');
+                $this->addSelect('Doc_Repo_Notifications', 'Receive Document Repository email notifications', $doc_Repo_Notifications_Options); 
+        }
 
         //------------------------------------------------------------
 


### PR DESCRIPTION
Only show option to toggle document repository notifications in My Preferences if user has permission for document repository

Redmine: https://redmine.cbrain.mcgill.ca/issues/6106
