### PR TITLE
Removal of the objective column

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -509,7 +509,6 @@ CREATE TABLE `mri_protocol` (
   `ID` int(11) unsigned NOT NULL auto_increment,
   `Center_name` varchar(4) NOT NULL default '',
   `ScannerID` int(10) unsigned NOT NULL default '0',
-  `Objective` tinyint(1) unsigned default NULL,
   `Scan_type` int(10) unsigned NOT NULL default '0',
   `TR_range` varchar(255) default NULL,
   `TE_range` varchar(255) default NULL,

--- a/SQL/2014-08-18-mri_protocol_violations_objective_removal.sql
+++ b/SQL/2014-08-18-mri_protocol_violations_objective_removal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mri_protocol DROP COLUMN Objective;


### PR DESCRIPTION
This pull request removes the objective column (since it's not used any-more) from the mri_protocol table for both existing and new databases 
