### PR TITLE
Check the visible flag on menus

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -244,9 +244,9 @@ class NDB_Config
     static function GetMenuTabs($parent = null) {
         $DB = Database::singleton();
         if($parent === null) {
-            $thisLevel = $DB->pselect("SELECT Label, 1 as Visible, Link, ID FROM LorisMenu WHERE Parent IS NULL", array());
+            $thisLevel = $DB->pselect("SELECT Label, CASE Visible WHEN 'false' THEN 0 ELSE 1 END as Visible, Link, ID FROM LorisMenu WHERE Parent IS NULL", array());
         } else {
-            $thisLevel = $DB->pselect("SELECT Label, 1 as Visible, Link, ID FROM LorisMenu WHERE Parent=:ParentID ", array('ParentID' => $parent));
+            $thisLevel = $DB->pselect("SELECT Label, CASE Visible WHEN 'false' THEN 0 ELSE 1 END as Visible, Link, ID FROM LorisMenu WHERE Parent=:ParentID ", array('ParentID' => $parent));
             if(NDB_Config::CheckMenuPermission($thisLevel[0]['ID'])) {
                 return $thisLevel;
             }

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -131,11 +131,13 @@
                                     </a>
                                     <ul class="dropdown-menu">
                                         {foreach from=$tab.subtabs item=mySubtab}
+                                            {if $mySubtab.Visible == 1}
                                             <li>
                                                         <a href="{$mySubtab.Link}">
                                                             {$mySubtab.Label}
                                                         </a>
                                             </li>
+                                            {/if}
                                         {/foreach}
                                     </ul>
                                 </li> 


### PR DESCRIPTION
This fixes a bug where the Menu visibility was not enforced and menus items were always visible, even when set to hidden.
