### PR TITLE
Prevent searchKeyword from adding to where clause when keyword is empty

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -462,7 +462,7 @@ class NDB_Menu_Filter extends NDB_Menu
             }
         }
        
-         if(is_array($this->searchKey) && count($this->searchKey) > 0) {
+         if(is_array($this->searchKey) && count($this->searchKey) > 0 && $this->searchKey['keyword'] !== '') {
             $query .= " AND (";
             $fields = array();
             foreach ($this->searchKeyword as $field) {


### PR DESCRIPTION
The searchKey WHERE clause was getting added to the WHERE part of a query even when the keyword was empty, causing it to add a field like "WHERE field LIKE CONCAT('%', '', '%')", thereby slowing down the query considerably for a NOOP. This adds a check to make sure the query is not empty before adding to the query.
