### PR TITLE
Bind {$mantis} smarty variable in control panel

### DIFF
--- a/php/libraries/Imaging_Session_ControlPanel.class.inc
+++ b/php/libraries/Imaging_Session_ControlPanel.class.inc
@@ -111,6 +111,7 @@ class Imaging_Session_ControlPanel
         
         $config =& NDB_Config::singleton();
         
+        $this->tpl_data['mantis'] = $config->getSetting('mantis_url');
         $subjectData['mantis'] = $config->getSetting('mantis_url');
         $subjectData['has_permission'] = $this->_hasAccess();
         $subjectData['status_options'] = array (


### PR DESCRIPTION
The mantis URL variable was not properly bound to the tpl in the control panel, causing the "Report a bug" link to just re-open the same page..
