### PR TITLE
Show HTML printed to screen properly in console

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -216,7 +216,7 @@ if ($config->getSetting("sandbox") === '1') {
 
 // Assign the console output to a variable, then stop
 // capturing output so that smarty can render
-$tpl_data['console'] = ob_get_contents();
+$tpl_data['console'] = htmlspecialchars(ob_get_contents());
 ob_end_clean();
 
 


### PR DESCRIPTION
This escapes things that have HTML special characters when they're printed to the console, so that they're displayed properly in the front end even if there's ie an < printed.
