### PR TITLE
NDB_Page Wrapper improvements

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -11,27 +11,6 @@ require_once 'HTML/QuickForm/Renderer/ArraySmarty.php';
 class NDB_Form extends NDB_Page
 {
     /**
-     * Class name
-     * @var    string
-     * @access private
-     */
-    var $name;
-
-    /**
-     * Page name
-     * @var    string
-     * @access private
-     */
-    var $page;
- 
-    /**
-     * Stores the form data
-     * @var    HTML_QuickForm 
-     * @access private
-     */
-    var $form;
- 
-    /**
      * Stores the template
      * @var    string 
      * @access private
@@ -39,25 +18,11 @@ class NDB_Form extends NDB_Page
     var $template;
  
     /**
-     * Identifies the item to edit
-     * @var    string 
-     * @access private
-     */
-    var $identifier;
-
-    /**
      * Redirect URL
      * @var    string 
      * @access private
      */
     var $redirect;
-
-    /**
-     * Form defaults
-     * @var    array 
-     * @access private
-     */
-    var $defaults = array();
 
     /**
      * Separates the group elements

--- a/php/libraries/NDB_Form_candidate_parameters.class.inc
+++ b/php/libraries/NDB_Form_candidate_parameters.class.inc
@@ -476,7 +476,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
         
         //Loop through the fields and add them appropriately
         foreach ($field_results AS $fresult) {
-            $this->form->addElement('static', "PTID_".$fresult['ParameterTypeID'], $fresult['Description']);
+            $this->addScoreColumn("PTID_".$fresult['ParameterTypeID'], $fresult['Description']);
         }
         
         $this->addScoreColumn('ProbandGUID', 'Proband GUID:');

--- a/php/libraries/NDB_Form_create_timepoint.class.inc
+++ b/php/libraries/NDB_Form_create_timepoint.class.inc
@@ -88,7 +88,7 @@ class NDB_Form_create_timepoint extends NDB_Form
         
         $attributes=array("onchange"=>"location.href='main.php?test_name=create_timepoint&candID=".$this->identifier."&identifier=".$this->identifier."&subprojectID='+this[this.selectedIndex].value;");
         $this->addSelect('subprojectID', 'Subproject', $sp_labelOptions, $attributes);
-        $this->form->setDefaults(array("subprojectID"=>$this->subprojectID));
+        $this->_setDefaults(array("subprojectID"=>$this->subprojectID));
         
         
         // visit label

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -59,13 +59,6 @@ class NDB_Menu_Filter extends NDB_Menu
     var $order_by = '1';
 
     /**
-     * Stores the filter form data, or other form data
-     * @var    HTML_QuickForm 
-     * @access private
-     */
-    var $form;
-
-    /**
      * Items selected from the GUI selection form
      * @var    array
      * @access private
@@ -280,7 +273,7 @@ class NDB_Menu_Filter extends NDB_Menu
            
             // set the filter form's defaults
             if (!empty($defaults)) {
-                eval("\$this->form->setDefaults(
+                eval("\$this->_setDefaults(
                     array(".implode(', ', $defaults).")
                 );");
             }
@@ -292,7 +285,7 @@ class NDB_Menu_Filter extends NDB_Menu
             $this->searchKey[$key] = $val;
         }
         // set the filter form's defaults
-        $this->form->setDefaults($defaults);
+        $this->_setDefaults($defaults);
 
       
         // set only the valid filters

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -6,12 +6,40 @@ include_once ('HTML/QuickForm/Renderer/Default.php');
 
 class NDB_Page extends PEAR
 {
+    /**
+     * The name of the test_name being accessed
+     */
+    var $name;
+
+    /**
+     * The name of the page (subtest) being accessed
+     */
+    var $page;
+
+    /**
+     * Reference to the HTML QuickForm
+     */
+    var $form;
+
+    /**
+     * The identifier for the item to edit
+     * (ie. the CommentID)
+     */
+    var $identifier;
+    var $commentID;
+
+    /**
+     * Form defaults
+     */
+    var $defaults = array();
+
     function _setupPage($name, $page, $identifier, $commentID, $formname) {
         $this->form = new HTML_QuickForm($formname);
         $this->name = $name;
         $this->page = $page;
         $this->identifier = $identifier;
         $this->commentID = $commentID;
+        $this->defaults = array();
     }
     
     
@@ -150,7 +178,7 @@ class NDB_Page extends PEAR
         }
         if(!is_array($localDefaults)) { $localDefaults = array(); }
         // set the quickform object defaults
-        $this->form->setDefaults(array_merge($this->defaults, $localDefaults));
+        $this->_setDefaults(array_merge($this->defaults, $localDefaults));
 
             // trim all values
         $this->form->applyFilter('__ALL__', 'trim');
@@ -178,8 +206,18 @@ class NDB_Page extends PEAR
      */
     function _getDefaults()
     {
-        return array();
+        return $this->defaults;
     }
 
+    /**
+     * Sets the form-specific defaults for this page
+     *
+     * @return array The defaults
+     */
+    function _setDefaults($defaults = array()) {
+        $this->defaults = $defaults;
+        $this->form->setDefaults($defaults);
+        return $defaults;
+    }
 }
 ?>


### PR DESCRIPTION
This moves some things that are supposed to be in NDB_Page to NDB_Page, and makes sure that subclasses don't hide the variables there by re-declaring them. Part of the groundwork for an eventual QuickForm2 upgrade so that it will be entirely self-contained in NDB_Page..
