### PR TITLE
Fix history when primary key not explicit

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -701,8 +701,8 @@ class Database extends PEAR
                     $primaryValues[] = $set[$key];
                 }
 
-                if($usePDOID) {
-                    if(is_array($this->lastInsertID)) {
+                if ($usePDOID) {
+                    if (is_array($this->lastInsertID)) {
                         $primaryValues = $this->lastInsertID;
                     } else {
                         $primaryValues = array($this->lastInsertID);


### PR DESCRIPTION
The Database wrapper currently prints and error message to the Apache log and uses empty for the primary key when inserting an element and the primary key is not explicitly set by the insert statement (ie. when MySQL generates the key on its own.) 

This detects that error and, in such a case, uses the lastInsertID from the PDO for the primary key.
