### PR TITLE
Moved instrument installer into a module named instrument_manager

### DIFF
--- a/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
+++ b/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
@@ -1,7 +1,7 @@
 <?php
 require_once 'NDB_Menu_Filter.class.inc';
 
-class NDB_Menu_Filter_instrument_installer extends NDB_Menu_Filter
+class NDB_Menu_Filter_instrument_manager extends NDB_Menu_Filter
 {
     function _hasAccess()
     {
@@ -9,7 +9,6 @@ class NDB_Menu_Filter_instrument_installer extends NDB_Menu_Filter
         if (PEAR::isError($user)) {
             return PEAR::raiseError("User Error: " .$user->getMessage());
         }
-        return true;
         return $user->hasPermission('superuser');
     }
 

--- a/modules/instrument_manager/templates/menu_instrument_manager.tpl
+++ b/modules/instrument_manager/templates/menu_instrument_manager.tpl
@@ -1,5 +1,5 @@
 <!-- start the selection table -->
-<form method="post" action="main.php?test_name=instrument_installer" enctype="multipart/form-data">
+<form method="post" action="main.php?test_name=instrument_manager" enctype="multipart/form-data">
 <table border="0" valign="top" class="std">
     <tr>
         <th nowrap="nowrap" colspan="4">Selection Filter</th>


### PR DESCRIPTION
Moved the instrument_installer into a proper module and renamed it to instrument_manager, because it's a little more generic than just an installer.

It should still be converted into an NDB_Menu_Filter_Form and updated to the bootstrap GUI before adding it to the Admin menu, but this cleans up the php/libraries directory.
