### PR TITLE
Remove s from participant status table

### DIFF
--- a/modules/candidate_parameters/templates/form_candidate_parameters.tpl
+++ b/modules/candidate_parameters/templates/form_candidate_parameters.tpl
@@ -90,7 +90,7 @@
             {foreach from=$history_list item=row}
                 <tr>
                     {foreach from=$row item=value key=name}
-                        <td>{$value}s</td>
+                        <td>{$value}</td>
                     {/foreach}
                 </tr>
             {/foreach}


### PR DESCRIPTION
As seen by @rathisekaran - there was an s appearing at the end of each table cell in the participant status table in the candidate_parameters module.
