### PR TITLE
Fix template directory precedence

### DIFF
--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -45,7 +45,7 @@ class Smarty_neurodb extends Smarty {
         // Set the template directories. First check for project overrides,
         // then check for modules, then check for old Loris jumbled together
         // templates
-        $this->addTemplateDir($this->project_template_dir);
+        $this->setTemplateDir($this->project_template_dir);
         $this->addTemplateDir($this->modules_dir . "/templates");
         $this->addTemplateDir($this->loristemplate_dir);
 


### PR DESCRIPTION
When calling addTemplateDir in the smarty templates, a "./templates" is left behind, which causes the wrong file to be loaded on older versions of Smarty. This should fix the bug so that the first call to addTemplateDir is replaced by setTemplateDir, thereby getting rid of the default smarty "./templates" directory and fixing the overriding.
