### PR TITLE
Added PHPCS file to enforce standards

### DIFF
--- a/docs/LorisCS.xml
+++ b/docs/LorisCS.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<ruleset name="Loris Standard">
+    <description>The coding standard for the Loris project</description>
+
+    <!-- Include the PEAR standard -->
+    <rule ref="PEAR"/>
+
+    <!-- Pieces of other standards to include... -->
+
+    <!-- Make sure there's no weird spacing for array brackets -->
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
+
+    <!-- Pick up any calls to deprecated functions. -->
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+
+    <!-- Multiline functions should include one argument per line -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="allowMultipleArguments" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Equal signs need to be aligned with other equal signs -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="12"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- This includes many things about array declarations, but the
+         one that we care about the most is that it ensures the arrows
+         are aligned properly. Some of the other things it enforces are
+         a little annoying, but there's no other way to get just the
+         arrow alignment that I could find..-->
+    <rule ref="Squiz.Arrays.ArrayDeclaration" />
+
+    <!-- Do not allow call time pass by reference because it generates warnings
+         in the logs, they should be defined on the function not by the runtime -->
+    <rule ref="Generic.Functions.CallTimePassByReference" />
+
+    <!-- Do not allow characters before PHP opening tag because that can cause
+         problems with the HTML output. -->
+    <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
+
+    <!-- Do not allow errors to be silenced, they should be fixed. -->
+    <rule ref="Generic.PHP.NoSilencedErrors"/>
+
+    <!-- Deprecated functions that will cause errors on different versions
+         of PHP -->
+    <rule ref="PHPCompatibility.PHP.DeprecatedFunctions"/>
+</ruleset>


### PR DESCRIPTION
This includes a PHPCS standards file which can be used to analyse Loris code. It's slightly more strict than the default (PEAR), because it enforces equal sign alignment and looks for deprecated functions..
