### PR TITLE
Removed participant_accounts from LorisMenu table ...

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1840,8 +1840,7 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
 
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
     ('User Accounts', 'main.php?test_name=user_accounts', 6, 1),
-    ('Survey Module', 'main.php?test_name=survey_accounts', 6,2);
-    ('Survey Module', 'main.php?test_name=participant_accounts', 6,2),
+    ('Survey Module', 'main.php?test_name=survey_accounts', 6,2),
     ('Help Editor', 'main.php?test_name=help_editor', 6,3);
 
 CREATE TABLE LorisMenuPermissions (


### PR DESCRIPTION
...and replaced the semicolon by a comma at the end of "survey_accounts".
