### PR TITLE
Updated instrument_manager error check to see if tables_sql also writable

### DIFF
--- a/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
+++ b/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
@@ -28,13 +28,16 @@ class NDB_Menu_Filter_instrument_manager extends NDB_Menu_Filter
         $this->formToFilter = array (
         );
 
-        if(!is_writeable($this->path . "project/instruments")) {
-            $this->tpl_data['writeable'] = false;
+        $writable = true;
+        if (!is_writeable($this->path . "project/instruments") || !is_writable($this->path . "project/tables_sql")) {
+            $writable = false;
         } else {
-            $this->tpl_data['writeable'] = true;
+            $writable = true;
         }
-            
-        if($_POST['install'] == 'Install Instrument') {
+
+        $this->tpl_data['writeable'] = $writable;
+
+        if($writable && $_POST['install'] == 'Install Instrument') {
             $db = Database::singleton();
             $instname = basename($_FILES['install_file']['name'], '.linst');
 
@@ -42,7 +45,7 @@ class NDB_Menu_Filter_instrument_manager extends NDB_Menu_Filter
             move_uploaded_file($_FILES['install_file']['tmp_name'], $new_file);
             chmod($new_file, 0644);
             chdir($this->path . "/tools");
-            
+
             $exists = $db->pselectOne("SELECT count(*) FROM test_names WHERE Test_name=:testname", array('testname' => $_FILES['install_file']['name']));
             if($exists <= 0) {
                 $db_config = $config->getSetting('database');

--- a/modules/instrument_manager/templates/menu_instrument_manager.tpl
+++ b/modules/instrument_manager/templates/menu_instrument_manager.tpl
@@ -18,7 +18,8 @@
 </div>
 {else}
 <div class="alert alert-info">
-Instrument directory not writeable. Automatic uploading of instruments has been disabled.
+Instrument directory or tables_sql not writeable.
+Automatic uploading of instruments has been disabled.
 </div>
 {/if}
 


### PR DESCRIPTION
The instrument_manager requires write permission to both tables_sql AND instruments. This updates the check to ensure both are writable, not just project/instruments.
