### PR TITLE
Remove confusing text from create_timepoint.

### DIFF
--- a/modules/create_timepoint/templates/form_create_timepoint.tpl
+++ b/modules/create_timepoint/templates/form_create_timepoint.tpl
@@ -4,8 +4,6 @@
 
 {else}
 
-<p>The suggested visit label appears in the field!</p>
-
 <form method="post" name="create_timepoint" id="create_timepoint">
 
     <h3>Create Time Point</h3>


### PR DESCRIPTION
This text appears at the top of the create timepoint module: "The suggested visit label appears in the field!"

There is not always a timepoint label suggested, so this is confusing.
