### PR TITLE
Fix javascript bug in config module

### DIFF
--- a/modules/configuration/js/configuration.js
+++ b/modules/configuration/js/configuration.js
@@ -2,9 +2,11 @@
 $(function () {
     "use strict";
 
-    $('.tree').treegrid({
-          'initialState': 'collapsed',
+    if ($(".tree")[0]) {
+        $('.tree').treegrid({
+            'initialState': 'collapsed',
         });
+    }
 
     var count = 0;
     $(".add").click(function () {


### PR DESCRIPTION
When the user doesn't have permission to visit the configuration module, the javascript breaks when trying to load the page since it is calling a function on an element that isn't in the DOM. This new code first checks if the element exists before calling the function on it.

This was reported because it was breaking other javascript components of the page,namely the dropdown menus.
