### PR TITLE
add link to Installation Schematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ LORIS is a web-accessible database solution for neuroimaging, providing a secure
     Download the latest release from the [releases page](https://github.com/aces/Loris/releases) and
     extract it to `/var/www/$projectname`
 
-3. Run installer script to install core code, libraries, and MySQL schema (see LORIS Setup Schematic). The script will prompt for information, including usernames and folders which it will create automatically.
+3. Run installer script to install core code, libraries, and MySQL schema (see [LORIS Installation Schematic] (https://demo.loris.ca/LORIS_Installation_schematic.14-10.PDF)). The script will prompt for information, including usernames and folders which it will create automatically.
 
     ```
     cd /var/www/$projectname/tools


### PR DESCRIPTION
Adding link in the README to Loris Installation schematic (diagram).
This was linked from the old googledoc adding it into the Readme.
