### PR TITLE
Imaging browser typo fixes:

### DIFF
--- a/modules/imaging_browser/templates/menu_imaging_browser.tpl
+++ b/modules/imaging_browser/templates/menu_imaging_browser.tpl
@@ -109,7 +109,7 @@
 <table id="LogEntries" border="0" valign="bottom" width="100%">
 <tr>
     <!-- title -->
-    <td class="controlPanelSection">List of Log Entries</td>
+    <td class="controlPanelSection">List of Imaging Datasets found</td>
 
     <!-- display pagination links -->
     <td align="right">{$page_links}</td>

--- a/php/libraries/NDB_Breadcrumb.class.inc
+++ b/php/libraries/NDB_Breadcrumb.class.inc
@@ -71,6 +71,7 @@ class NDB_Breadcrumb extends PEAR
             $this->_breadcrumb[$this->_lastIndex]['text'] = $text;
         } elseif (!is_null($parameter)) {
             $this->_breadcrumb[$this->_lastIndex]['text'] = ucwords(str_replace('_', ' ', $this->_parameters[$parameter]));
+            $this->_breadcrumb[$this->_lastIndex]['text'] = ucwords(preg_replace('/([A-Z])/', ' $1', $this->_breadcrumb[$this->_lastIndex]['text'] ));
         } else {
             $this->_breadcrumb[$this->_lastIndex]['text'] = $this->_userFriendlyNames[$this->_parameters['test_name']];
         }


### PR DESCRIPTION
- "List of Log Entries" replaced by "List of Imaging Datasets found" in the main page of the Imaging browser
- Modified NDB_Breadcrumb.class.inc so that subtest like "ViewSession" displays on the frontend as "View Session"
