### PR TITLE
Dashboard: Adding line break on document repository item panels.

### DIFF
--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -271,7 +271,7 @@
                                     <span class="pull-left new-flag">NEW</span>
                                 {/if}
                                 <span class="pull-right text-muted small">Uploaded: {$link.Date_uploaded}</span>
-                                </br>
+                                <br>
                                 {$link.File_name}
                             </a>
                             {/foreach}


### PR DESCRIPTION
- On wide screens, the document repository test (new flag, date, filename) get pushed into one line. This pull request always puts the filenames on new lines
