### PR TITLE
Remove unecessary step in configuration migration.

### DIFF
--- a/modules/configuration/readme.md
+++ b/modules/configuration/readme.md
@@ -16,7 +16,6 @@ Care should be taken when editing the fields as there is currently no way to "un
 2. Create the ConfigSettings and Config table by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-08-29-ConfigSettings.sql)
 3. Update a data type in the Config table by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-09-24-Config_Value_Datatype.sql)
 4. Fill the ConfigSettings table by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-09-25-ConfigToDB.sql)
-5. Fill the Config table with default values by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-09-26-DefaultConfig.sql)
-6. Add the configuration module to the LORIS menu by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-10-02-ConfigMenu.sql)
-7. Add the configuration help text by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-10-15-ConfigHelp.sql)
-8. Run the config migration script, which moves values from your project's config.xml to the database. From the tools directory, run `php config_to_db.php`
+5. Add the configuration module to the LORIS menu by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-10-02-ConfigMenu.sql)
+6. Add the configuration help text by running [this patch](https://github.com/aces/Loris/blob/master/SQL/Archive/Pre-14.10/2014-10-15-ConfigHelp.sql)
+7. Run the config migration script, which moves values from your project's config.xml to the database. From the tools directory, run `php config_to_db.php`


### PR DESCRIPTION
In the configuration module readme, there is a patch for migration that doesn't need to be run. Running this patch twice currently creates a bug in the configuration module. I'm removing the step since it's not necessary, and could lead to duplication of config values in the config table.
