### PR TITLE
Add showDatabaseQueries back to config.xml

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -181,7 +181,12 @@
                 <label>Consent to Study</label>
             </Consent>
         </ConsentModule>
+
     </study>
     <!-- end of study definition -->
+
+    <gui>
+        <showDatabaseQueries>0</showDatabaseQueries>
+    </gui>
 
 </config>


### PR DESCRIPTION
This setting was accidentally removed during the creation of the configuration module, but should be there as it is not stored in the config database tables and cannot be edited from the frontend.
