### PR TITLE
Permission fix for imaging browser

### DIFF
--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -44,7 +44,7 @@ class NDB_Form_Imaging_Browser extends NDB_Form
     /**
      * Determine whether the user has permission to view the imaging_browser page
      *
-     * @return bool whether the user hass access
+     * @return bool whether the user has access
      */
     function _hasAccess()
     {


### PR DESCRIPTION
Fix part of the bug (6392) reported in redmine: 
"Permissions not working properly. They should match Imaging Browser front page. Instead, anyone can see any page (This will be important when Imaging data is linked directly from a BVL-side timepoint page."
