### PR TITLE
Show Mantis link only if set in Config module.   

### DIFF
--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -18,7 +18,9 @@
         <li><a href="main.php?test_name=radiology_review&candID={$subject.candid}&sessionID={$subject.sessionID}&commentID={$subject.RadiologyReviewCommentID}">Radiology Review</a></li>
         {foreach from=$subject.tarchiveids item=tarchive}
         <li><a href="main.php?test_name=dicom_archive&subtest=viewDetails&tarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive(s) {$tarchive.TarchiveID}</a></li>{/foreach}
-        <li><a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a></li>
+        {if $mantis}
+            <li><a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a></li>
+        {/if}
     </ul>
 
     <h3>Visit Controls</h3>


### PR DESCRIPTION
 Added an if statement checking if mantis link is set in the Configs. If not, won't display it on the side panel.
