### PR TITLE
Removing php5-dev as a "Prerequisite"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LORIS is a web-accessible database solution for neuroimaging, providing a secure
  * LINUX (Optimized for Ubuntu 14.04) or Mac OS X (tested for Mavericks - OS X 10.9)
  * Apache2 (libapache2-mod-php5)
  * MySQL (libmysqlclient15-dev mysql-client mysql-server)
- * PHP/PEAR 5.3+ (php5 php-pear php5-dev php5-mysql php5-gd)
+ * PHP/PEAR 5.3+ (php5 php-pear php5-mysql php5-gd)
  * php5-json (for Debian/Ubuntu distributions)
  * Smarty 3
  * Package manager (for LINUX distributions)


### PR DESCRIPTION
php5-dev is for developing php modules
