### PR TITLE
Fix CouchDB user syncing

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -424,11 +424,9 @@ class User extends UserPermissions
         }
         $userobj['password'] = $password;
 
-
         $response = $cdb->_postURL(
             "PUT /_users/org.couchdb.user:" . $username,
-            json_encode($userobj),
-            $auth
+            json_encode($userobj)
         );
     }
 }


### PR DESCRIPTION
The UpdateCouchDB user function was adding the Authorization header
to the HTTP request. The postURL function that it called was also
adding the header. This was causing the header to be duplicated in
the HTTP request which was causing the CouchDB user syncing to fail on certain
versions of CouchDB.

Removing it from the updateCouchDB function so that it's only added
in the postURL function should fix this problem.
