### PR TITLE
Rename function so that it passes PHPCS

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -198,7 +198,7 @@ class NDB_Config
             ) {
                 $this->_siteSettings          = $this->_settings;
                 $this->_siteSettings['study']
-                    = Utility::array_merge_recursive_overwriting(
+                    = Utility::arrayMergeRecursiveOverwriting(
                         $this->_settings['study'],
                         $this->_settings['sites'][$siteName]
                     );

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -567,7 +567,7 @@ class Utility extends PEAR
      *
      * @return An array with the two parameters recursively merged
      */
-    static function array_merge_recursive_overwriting(
+    static function arrayMergeRecursiveOverwriting(
         $array1,
         $array2,
         &$merged_array=null
@@ -579,7 +579,7 @@ class Utility extends PEAR
             if (is_array($array1[$key]) && isset($array1[$key][0])) {
                 $merged_array[$key] = $value;
             } elseif (is_array($array2[$key]) && !isset($array2[$key][0])) {
-                Utility::array_merge_recursive_overwriting(
+                Utility::arrayMergeRecursiveOverwriting(
                     $array1[$key],
                     $array2[$key],
                     $merged_array[$key]


### PR DESCRIPTION
Renamed the array_merge_recursive_overwriting Utility function and updated all the single reference to it.
