### PR TITLE
Replaced Utility function unparse_str with PHP builtin

### DIFF
--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -209,7 +209,7 @@ class MRINavigation
     *
     * @param int $delta offset for the next/prev link
     *
-    * @return string $urlParams	parameters
+    * @return string $urlParams        parameters
     */
     function _otherLink($delta) 
     {
@@ -217,7 +217,9 @@ class MRINavigation
             $urlParams = $this->urlParams;
             $urlParams['sessionID'] = $this
                 ->FilteredSessionList[$this->currentListIndex+$delta];
-            $this->bits[1] = Utility::unparse_str($urlParams);
+
+            $this->bits[1] = http_build_query($urlParams);
+
             return implode('?', $this->bits);
         }
     }

--- a/php/libraries/NDB_Breadcrumb.class.inc
+++ b/php/libraries/NDB_Breadcrumb.class.inc
@@ -86,7 +86,7 @@ class NDB_Breadcrumb extends PEAR
 
         // set the query string
         $this->_breadcrumb[$this->_lastIndex]['query']
-            = Utility::unparse_str($this->_parameters);
+            = http_build_query($this->_parameters);
 
         // set the crumb text
         if (!is_null($text)) {

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -64,8 +64,7 @@ class SinglePointLogin extends PEAR
         $tpl_data['title']         = $config->getSetting('title');
         $tpl_data['css']           = $config->getSetting('css');
         $tpl_data['action']        = $_SERVER['PHP_SELF']
-            . '?'
-            . Utility::unparse_str($params);
+            . '?' . http_build_query($params);
         $tpl_data['error_message'] = $this->_lastError;
         $study_links = $config->getSetting('Studylinks');// print_r($study_links);
         foreach (Utility::toArray($study_links['link']) AS $link) {
@@ -117,7 +116,9 @@ class SinglePointLogin extends PEAR
         $tpl_data['study_title'] = $study_title;
         $tpl_data['study_logo']  = $study_logo;
 
-        $tpl_data['action'] = $_SERVER['PHP_SELF'].'?'.Utility::unparse_str($params);
+        $tpl_data['action'] = $_SERVER['PHP_SELF']
+            .'?'
+            . http_build_query($params);
 
         $tpl_data['error_message'] = $this->_lastError;
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -60,32 +60,6 @@ class Utility extends PEAR
     }
 
     /**
-     * Builds a query string
-     *
-     * @param array $params Array of parameters to put into query string format
-     *
-     * @return string
-     */
-    static function unparse_str ($params)
-    {
-        $str = '';
-        foreach ($params as $key => $value) {
-            if (is_array($value)) {
-                foreach ($value AS $vkey => $vval) {
-                    $str .= (strlen($str) < 1) ? '' : '&';
-                    $str .= $key . rawurlencode("[$vkey]")
-                        . '=' . rawurlencode($vval);
-                }
-            } else {
-                $str .= (strlen($str) < 1) ? '' : '&';
-                $str .= $key . '=' . rawurlencode($value);
-            }
-        }
-        return ($str);
-    }
-
-
-    /**
      * Converts a multi-dimensional array to a one-dimensional array
      *
      * @param array $array The multi-dimensional array


### PR DESCRIPTION
The built in PHP function http_build_query does the exact
same thing as the Utility function unparse_str, but is less
ambiguously named (and doesn't cause PHP_Codesniffer to complain).

This updates the references to use http_build_query.
