### PR TITLE
Reset candidate list filters on clicking "Scan_Done" link

### DIFF
--- a/modules/candidate_list/js/candidate_list.js
+++ b/modules/candidate_list/js/candidate_list.js
@@ -36,15 +36,30 @@ $(function(){
 	});
 });
 
-$(document).ready(function(){
-    $.getScript("js/modules/dynamic_table.table.js")
-        .done(function(){
-            Table.setup("content", "scrollRight", "scrollLeft");
-            Table.checkOverflow("content", "scrollRight", "scrollLeft");
+$(document).ready(function() {
+    // Filters will only get applied on a POST, so
+    // on click we need to fake a form which posts
+    // to the imaging_browser in order to get filters
+    $(".scanDoneLink").click(function(e) {
+        e.preventDefault();
+        var form = $('<form />', {
+            "action" : "main.php?test_name=imaging_browser",
+            "method" : "post"
         });
-    // checkOverflow();
-});
-$(window).resize(function(){
-    Table.checkOverflow("content", "scrollRight", "scrollLeft");
-    // checkOverflow();
+        var values = {
+            "reset" : "true",
+            "pscid" : this.dataset.pscid,
+            "filter" : "Show Data"
+        }
+
+        $.each(values, function(name, value) {
+            $("<input />", {
+                type: 'hidden',
+                name: name,
+                value: value
+            }).appendTo(form);
+        });
+
+        form.appendTo('body').submit();
+    });
 });

--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -1,9 +1,3 @@
-
-<script src="js/jquery/jquery-1.11.0.min.js" type="text/javascript"></script>
-
-<script type="text/javascript" src="js/jquery/jquery-ui-1.10.4.custom.min.js"></script>
-<script type="text/javascript" src="js/advancedMenu.js"></script>
-
 <div class="row">
 <div class="col-sm-9">
 <div class="panel panel-primary">
@@ -117,8 +111,6 @@
                             {$form.Latest_Visit_Status.html}
                         </div>
                     </div>
-                    {if $form.ProjectID}
-                    {else}
                     <div class="form-group col-sm-6">
                         <label class="col-sm-12 col-md-4">
                             {$form.scan_done.label}
@@ -127,7 +119,6 @@
                             {$form.scan_done.html}
                         </div>
                     </div>
-                    {/if}
                 </div>
                 <div class="row">
                     <div class="form-group col-sm-6">
@@ -198,8 +189,6 @@
     </form>
 </div>
 </div>
-<!-- <table> -->
-<!--  title table with pagination -->
 <div class="row">
 <table border="0" valign="bottom" width="100%">
 <tr>
@@ -209,63 +198,46 @@
     <td align="right">{$page_links}</td>
 </tr>
 </table>
-<!-- </form> -->
-<!-- start data table -->
-<div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
-    <div class="carousel-inner">
-        <!-- <div class="col-xs-10 col-xs-offset-1" style="overflow-y:auto"> -->
-        <div class="table-scroll" id="content">
-            <table  class ="table table-hover table-primary table-bordered" border="0" width="100%">
-                <thead>
-                    <tr class="info">
-                     <th>No.</th>
-                        <!-- print out column headings - quick & dirty hack -->
-                        {section name=header loop=$headers}
-                            <th><a href="main.php?test_name=candidate_list&filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">{$headers[header].displayName}</a></th>
-                        {/section}
-                    </tr>
-                </thead>
-                <tbody>
-                    {section name=item loop=$items}
-                        <tr>
-                        <!-- print out data rows -->
-                        {section name=piece loop=$items[item]}
-                            {if $items[item][piece].bgcolor != ''}
-                                <td style="background-color:{$items[item][piece].bgcolor}">
-                            {else}
-                                <td>
-                            {/if}
-                    		{if $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
-                    		    {assign var="PSCID" value=$items[item][piece].value}
-                    		    <a href="main.php?test_name=timepoint_list&candID={$items[item][piece].DCCID}">{$items[item][piece].value}</a>
-                    		    	
-                    		{elseif $items[item][piece].name == "scan_Done"}
-                            	{if $items[item][piece].value == 'Y'}
-                            		{assign var="scan_done" value="Yes"}
-                            		<a href="main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data">{$scan_done}</a>
-                                {else}
-                                    {assign var="scan_done" value="No"}
-                                    {$scan_done}
-                                {/if}
-                            {else}
-                                {$items[item][piece].value}
-                            {/if}
-                    		</td>
-                        {/section}
-                        </tr>           
-                    {sectionelse}
-                        <tr><td colspan="12">No candidates found</td></tr>
-                    {/section}
-                </tbody>                   
-            <!-- end data table -->
-            </table>
-        </div>
-        <a class="left carousel-control"  id="scrollLeft" href="#carousel-example-generic">
-            <span class="glyphicon glyphicon-chevron-left"></span>
-        </a>
-        <a class="right carousel-control" id="scrollRight" href="#carousel-example-generic" data-slide="next">
-            <span class="glyphicon glyphicon-chevron-right"></span>
-        </a>
-    </div>
-</div>
-</div>
+<table class="table table-hover table-primary table-bordered dynamictable" border="0" width="100%">
+    <thead>
+        <tr class="info">
+         <th>No.</th>
+            <!-- print out column headings - quick & dirty hack -->
+            {section name=header loop=$headers}
+                <th><a href="main.php?test_name=candidate_list&filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">{$headers[header].displayName}</a></th>
+            {/section}
+        </tr>
+    </thead>
+    <tbody>
+        {section name=item loop=$items}
+            <tr>
+            {section name=piece loop=$items[item]}
+                {if $items[item][piece].bgcolor != ''}
+                    <td style="background-color:{$items[item][piece].bgcolor}">
+                {else}
+                    <td>
+                {/if}
+                {if $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
+                    {assign var="PSCID" value=$items[item][piece].value}
+                    <a href="main.php?test_name=timepoint_list&candID={$items[item][piece].DCCID}">{$items[item][piece].value}</a>
+
+                {elseif $items[item][piece].name == "scan_Done"}
+                    {if $items[item][piece].value == 'Y'}
+                        {assign var="scan_done" value="Yes"}
+                        {* PSCID will have been assigned on previous iteration of loop, since Scan_done is after PSCID in the table *}
+                        <a href="#" class="scanDoneLink" data-pscid="{$PSCID}">{$scan_done}</a>
+                    {else}
+                        {assign var="scan_done" value="No"}
+                        {$scan_done}
+                    {/if}
+                {else}
+                    {$items[item][piece].value}
+                {/if}
+                </td>
+            {/section}
+            </tr>
+        {sectionelse}
+            <tr><td colspan="12">No candidates found</td></tr>
+        {/section}
+    </tbody>
+</table>


### PR DESCRIPTION
The Scan_done link did not previously reset the filters for the imaging
browser, so if a filter had previously been set it would still be
applied and result in the Imaging Browser showing no results returned.
This adds a reset="true" flag to the HTTP request so that the proper
filter will be applied.

It also updates the table format to use the dynamictable jquery plugin.
