### PR TITLE
Run php -l on module and htdoc files from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_script:
 script:
     # Run PHP -l on everything to ensure there's no syntax
     # errors.
-    - for i in `ls php/libraries/*.class.inc modules/*/php/ modules/*/ajax/ htdocs/*.php htdocs/*/*.php`;
+    - for i in `ls php/libraries/*.class.inc modules/*/php/* modules/*/ajax/* htdocs/*.php htdocs/*/*.php`;
       do
         php -l $i || exit $?;
       done


### PR DESCRIPTION
Travis currently verifies that there's no syntax errors in files in php/libraries by using "php -l". This expands the check to also check module / php, module / ajax, and htdocs php files for syntax errors.
