### PR TITLE
Tidy menu permissions

### DIFF
--- a/SQL/2014-12-12-TidyMenuPermissions.sql
+++ b/SQL/2014-12-12-TidyMenuPermissions.sql
@@ -1,11 +1,7 @@
 -- OPTIONAL patch : Corrects for errors in previous patch 2014-12-03-UpdatePermissions.sql
 
 -- Update Menu permissions for Instrument Builder, to remove access granted by a permission other than the instrument_builder permission(s). 
-
 DELETE FROM LorisMenuPermissions WHERE MenuID IN (SELECT m.ID FROM LorisMenu m WHERE m.Label="Instrument Builder") AND PermID NOT IN (SELECT p.PermID FROM permissions p WHERE p.code LIKE '%instrument_builder%');
-
--- Update Menu permissions for Data Dictionary, to remove access granted by a permission other than the data_dict...* permissions. 
-DELETE FROM LorisMenuPermissions WHERE MenuID IN (SELECT m.ID FROM LorisMenu m WHERE m.Label="Data Dictionary") AND PermID NOT IN (SELECT p.PermID FROM permissions p WHERE p.code LIKE 'data_dict%');
 
 -- Update Menu permissions for Data Team Helper, to remove access granted by a permission other than data_team_helper* permission(s). 
 DELETE FROM LorisMenuPermissions WHERE MenuID IN (SELECT m.ID FROM LorisMenu m WHERE m.Label="Data Team Helper") AND PermID NOT IN (SELECT p.PermID FROM permissions p WHERE p.code LIKE 'data_team_helper%');


### PR DESCRIPTION
Optional patch to clean old menu permissions out of LorisMenuPermissions table. 
Prevents users without the correct permission from viewing the module in a menu, clicking in on it, and finding access is denied.
Follow-up to UpdatePermissions #841 
For modules recently granted module-specific permissions - Instrument Builder and Data Team Helper - 
this removes access to menu item if user does not have the module-specific permission.  
Caveat: includes 2 delete statements 
