### PR TITLE
Fixed filters on dashboard tasks.

### DIFF
--- a/modules/dashboard/js/dashboard.js
+++ b/modules/dashboard/js/dashboard.js
@@ -58,7 +58,46 @@ $(document).ready(function () {
             scanLineChart.resize();
         }
     });
+
+    $(".new-scans").click(function(e) {
+        e.preventDefault();
+        filterForm('imaging_browser', {"Pending" : "PN"});
+    });
+
+    $(".radiological-review").click(function(e) {
+        e.preventDefault();
+        filterForm('final_radiological_review', {"Review_done" : "no"});
+    });
+
+    $(".pending-accounts").click(function(e) {
+        e.preventDefault();
+        filterForm('user_accounts', {"pending" : "Y"});
+    });
 });
+
+function applyFilter(test_name, filters) {
+    var form = $('<form />', {
+        "action" : "main.php?test_name=" + test_name,
+        "method" : "post"
+    });
+
+    var values = {
+        "reset" : "true",
+        "filter" : "Show Data"
+    }
+
+    $.extend(values, filters);
+
+    $.each(values, function(name, value) {
+        $("<input />", {
+            type: 'hidden',
+            name: name,
+            value: value
+        }).appendTo(form);
+    });
+
+    form.appendTo('body').submit();
+}
 
 function formatPieData(data) {
     "use strict";

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -176,7 +176,7 @@ class NDB_Form_dashboard extends NDB_Form
         }
 
         // Accounts pending approval
-        if ($user->hasPermission('user_accounts_multisite')) {
+        if ($user->hasPermission('user_accounts_multisite') && $user->hasPermission('user_accounts')) {
             $this->tpl_data['pending_users'] = $DB->pselectOne(
                 "SELECT count(*) FROM users WHERE Pending_approval='Y'", array()
             );

--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -192,7 +192,7 @@
                                 </a>
                             {/if}
                             {if $new_scans neq "" and $new_scans neq 0}
-                                <a href="main.php?test_name=imaging_browser&Pending=PN&filter=Show%20Data" class="list-group-item">
+                                <a href="main.php?test_name=imaging_browser" class="list-group-item new-scans">
                                     <div class="row">
                                         <div class="col-xs-8 text-left">
                                             <div class="huge">{$new_scans}</div>
@@ -220,7 +220,7 @@
                                 </a>
                             {/if}
                             {if $radiology_review neq "" and $radiology_review neq 0}
-                            <a href="main.php?test_name=final_radiological_review&Review_done=no&filter=Show%20Data" class="list-group-item">
+                            <a href="main.php?test_name=final_radiological_review" class="list-group-item radiological-review">
                                 <div class="row">
                                     <div class="col-xs-8 text-left">
                                         <div class="huge">{$radiology_review}</div>
@@ -234,7 +234,7 @@
                             </a>
                             {/if}
                             {if $pending_users neq "" and $pending_users neq 0}
-                            <a href="main.php?test_name=user_accounts&pending=Y&filter=Show+Data" class="list-group-item">
+                            <a href="main.php?test_name=user_accounts" class="list-group-item pending-accounts">
                                 <div class="row">
                                     <div class="col-xs-8 text-left">
                                         <div class="huge">{$pending_users}</div>


### PR DESCRIPTION
Dashboard task links were no longer applying filters to their respective menu filter pages. The filters now have to be applied through a POST request.

This functionality will be generalized and added to a new main.js file post-release.
