### PR TITLE
Fix review finalized filter

### DIFF
--- a/modules/final_radiological_review/php/NDB_Menu_Filter_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Menu_Filter_final_radiological_review.class.inc
@@ -183,7 +183,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
             'r.Final_Exclusionary',
             $conflict_condition1,
             $conflict_condition2,
-            'r.Finalized',
+            "COALESCE(r.Finalized, 'no')",
             'c.CenterID',
             'c.ProjectID',
             'keyword'
@@ -205,7 +205,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
                                     'SAS'         => 'r.sas',
                                     'Conflict'    => $conflict_condition1,
                                     'Conflict2'   => $conflict_condition2,
-                                    'Finalized'   => 'r.Finalized',
+                                    'Finalized'   => "COALESCE(r.Finalized, 'no')",
                                     'keyword'     => 'r.Final_Incidental_Findings'
         );
         $this->EqualityFilters = array($conflict_condition1, $conflict_condition2,'r.Final_Exclusionary','r.Finalized',"COALESCE(r.Review_Done, 'no')");


### PR DESCRIPTION
The "Review finalized" filter was not showing blank fields when the filter was set to "No", as is done with the "Review done" filter.