### PR TITLE
Improved password hashing

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1353,6 +1353,7 @@ CREATE TABLE `users` (
   `Active` enum('Y','N') NOT NULL default 'Y',
   `Examiner` enum('Y','N') NOT NULL default 'N',
   `Password_md5` varchar(34) default NULL,
+  `Password_hash` varchar(255) default NULL,
   `Password_expiry` date NOT NULL default '0000-00-00',
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',

--- a/SQL/2014-12-15-password_hash.sql
+++ b/SQL/2014-12-15-password_hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN Password_hash varchar(255);

--- a/SQL/2014-12-15-password_hash.sql
+++ b/SQL/2014-12-15-password_hash.sql
@@ -1,1 +1,1 @@
-ALTER TABLE users ADD COLUMN Password_hash varchar(255);
+ALTER TABLE users ADD COLUMN Password_hash varchar(255) AFTER Password_md5;

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -313,15 +313,42 @@ class SinglePointLogin extends PEAR
 
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
-                     Password_md5, Password_expiry, Active, Pending_approval
-                FROM users
-              WHERE UserID = :username
+                        Password_md5, Password_expiry, Active,
+                        Pending_approval, Password_hash
+                    FROM users
+                  WHERE UserID = :username
                   GROUP BY UserID";
         $row   = $DB->pselectRow($query, array('username' => $_POST['username']));
 
         if ($row['User_count'] == 1) {
             // validate the user
-            if (User::MD5Unsalt($_POST['password'], $row['Password_md5'])) {
+
+            // Check if the PHP 5.5 password hashing API is available.
+            $php55 = false;
+            if (function_exists("password_verify")) {
+                $php55 = true;
+            }
+
+            // If either the password hashing isn't available, or the Password_hash column is empty,
+            // we check using Loris's old MD5Unsalt method that the passwords are equal.
+            // If there is a saved Password_hash, then we verify using the PHP 5.5+ password hashing
+            // API.
+            if (((!$php55 || empty($row['Password_hash']))&& User::MD5Unsalt($_POST['password'], $row['Password_md5'])) ||
+                (password_verify($_POST['password'], $row['Password_hash']))
+                ) {
+                // If the PHP password hashing is available, check if a rehash is required and if so, rehash it.
+                // (If Password_hash is null, skip the password_needs_rehash check, because we know that we have
+                // access to the password hashing API, and we know it's never been hashed using password_hash.
+                if($php55) {
+                    if(empty($row['Password_hash'])
+                        || password_needs_rehash($row['Password_hash'], PASSWORD_DEFAULT)
+                    ) {
+                        // Hash the password using PHP defaults.
+                        $hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
+                        // Save the new hash and wipe out the old, insecure MD5 sum.
+                        $DB->update("users", array('Password_hash' => $hash, 'Password_MD5' => null), array('UserID' => $_POST['username']));
+                        }
+                }
                 // check that the user is active
                 if ($row['Active'] == 'N') {
                     $this->_lastError = "Your account has been deactivated."

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -313,8 +313,11 @@ class SinglePointLogin extends PEAR
 
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
-                        Password_md5, Password_expiry, Active,
-                        Pending_approval, Password_hash
+                        Password_md5,
+                        Password_expiry,
+                        Active,
+                        Pending_approval,
+                        Password_hash
                     FROM users
                   WHERE UserID = :username
                   GROUP BY UserID";
@@ -329,25 +332,40 @@ class SinglePointLogin extends PEAR
                 $php55 = true;
             }
 
-            // If either the password hashing isn't available, or the Password_hash column is empty,
-            // we check using Loris's old MD5Unsalt method that the passwords are equal.
-            // If there is a saved Password_hash, then we verify using the PHP 5.5+ password hashing
-            // API.
-            if (((!$php55 || empty($row['Password_hash']))&& User::MD5Unsalt($_POST['password'], $row['Password_md5'])) ||
-                (password_verify($_POST['password'], $row['Password_hash']))
-                ) {
-                // If the PHP password hashing is available, check if a rehash is required and if so, rehash it.
-                // (If Password_hash is null, skip the password_needs_rehash check, because we know that we have
-                // access to the password hashing API, and we know it's never been hashed using password_hash.
-                if($php55) {
-                    if(empty($row['Password_hash'])
-                        || password_needs_rehash($row['Password_hash'], PASSWORD_DEFAULT)
+            // If either the password hashing isn't available, or the
+            // Password_hash column is empty, we check using Loris's old
+            // MD5Unsalt method that the passwords are equal.
+            //
+            // If there is a saved Password_hash, then we verify using the
+            // PHP 5.5+ password hashing API.
+            if (((!$php55 || empty($row['Password_hash']))
+                && User::MD5Unsalt($_POST['password'], $row['Password_md5']))
+                || (password_verify($_POST['password'], $row['Password_hash']))
+            ) {
+                // If the PHP password hashing is available, check if a rehash
+                // is required and if so, rehash it.
+                //
+                // (If Password_hash is null, skip the password_needs_rehash
+                // check, because we know that we have access to the password
+                // hashing API, and we know it's never been hashed using
+                // password_hash.
+                if ($php55) {
+                    $oldhash = $row['Password_hash'];
+                    if (empty($oldhash)
+                        || password_needs_rehash($oldhash, PASSWORD_DEFAULT)
                     ) {
                         // Hash the password using PHP defaults.
                         $hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
                         // Save the new hash and wipe out the old, insecure MD5 sum.
-                        $DB->update("users", array('Password_hash' => $hash, 'Password_MD5' => null), array('UserID' => $_POST['username']));
-                        }
+                        $DB->update(
+                            "users",
+                            array(
+                             'Password_hash' => $hash,
+                             'Password_MD5'  => null,
+                            ),
+                            array('UserID' => $_POST['username'])
+                        );
+                    }
                 }
                 // check that the user is active
                 if ($row['Active'] == 'N') {

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -338,9 +338,10 @@ class SinglePointLogin extends PEAR
             //
             // If there is a saved Password_hash, then we verify using the
             // PHP 5.5+ password hashing API.
-            if (((!$php55 || empty($row['Password_hash']))
+            $oldhash = $row['Password_hash'];
+            if (((!$php55 || empty($oldhash))
                 && User::MD5Unsalt($_POST['password'], $row['Password_md5']))
-                || ($php55 && password_verify($_POST['password'], $row['Password_hash']))
+                || ($php55 && password_verify($_POST['password'], $oldhash))
             ) {
                 // If the PHP password hashing is available, check if a rehash
                 // is required and if so, rehash it.
@@ -350,7 +351,6 @@ class SinglePointLogin extends PEAR
                 // hashing API, and we know it's never been hashed using
                 // password_hash.
                 if ($php55) {
-                    $oldhash = $row['Password_hash'];
                     if (empty($oldhash)
                         || password_needs_rehash($oldhash, PASSWORD_DEFAULT)
                     ) {

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -340,7 +340,7 @@ class SinglePointLogin extends PEAR
             // PHP 5.5+ password hashing API.
             if (((!$php55 || empty($row['Password_hash']))
                 && User::MD5Unsalt($_POST['password'], $row['Password_md5']))
-                || (password_verify($_POST['password'], $row['Password_hash']))
+                || ($php55 && password_verify($_POST['password'], $row['Password_hash']))
             ) {
                 // If the PHP password hashing is available, check if a rehash
                 // is required and if so, rehash it.


### PR DESCRIPTION
This adds support for PHP 5.5+'s password hashing API to Loris. It is implemented in such a way that if it's not available, it will fall back on the old Loris authentication method.

It works by checking if the "new" hash is available in the Password_hash column, and if so using that, if not falling back on the old Password_MD5 column. If the hash is null, it will calculate the hash using the best algorithm available on the PHP install and save it to the database, deleting the old, insecure hash in the process.

If using a version of PHP that does not support the PHP password hashing API (as determined by checking for the existence of the "password_verify" function), behaviour should be identical to previously.

Once a password has been hashed using the PHP password API, the old MD5 is deleted from the database for security reasons. (This shouldn't be a problem for anyone, since once the server's been upgraded to a version of PHP that has the password api, it's unlikely to ever be downgraded to a version that doesn't.)