### PR TITLE
Fixes the document repository's upload/download and delete functions

### DIFF
--- a/SQL/2014-12-15-DocumentRepositoryDataDir.sql
+++ b/SQL/2014-12-15-DocumentRepositoryDataDir.sql
@@ -1,0 +1,15 @@
+--
+-- Updates all rows of the document_repository table:
+--
+-- if column data_dir has a value the starts with the string '../document_respository', this 
+-- part is removed from the value. If it does not start with the target string, it is left 
+-- untouched.
+--
+
+UPDATE document_repository
+SET Data_dir =  if (
+                    locate('../document_repository/', data_dir) = 1, 
+                    substr(data_dir,length('../document_repository/')+1),
+                    data_dir
+                );
+

--- a/modules/document_repository/ajax/GetFile.php
+++ b/modules/document_repository/ajax/GetFile.php
@@ -45,7 +45,7 @@ if (strpos("..", $File) !== false) {
 $FullPath = __DIR__ . "/../user_uploads/$File";
 
 if (!file_exists($FullPath)) {
-    error_log("ERROR: File $File does not exist");
+    error_log("ERROR: File $FullPath does not exist");
     header("HTTP/1.1 404 Not Found");
     exit(5);
 }

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -20,6 +20,8 @@ $fileName = $DB->pselectOne("Select File_name from document_repository where rec
                             array(':identifier' => $rid));
 $userName = $DB->pselectOne("Select uploaded_by from document_repository where record_id =:identifier",
                             array(':identifier'=> $rid));
+$dataDir  = $DB->pselectOne("Select Data_dir from document_repository where record_id =:identifier",
+                            array(':identifier'=> $rid));
 
 $user =& User::singleton();
 if (Utility::isErrorX($user)) {
@@ -39,7 +41,7 @@ if ($user->hasPermission('file_upload')) {
     }
 }
 
-$path = "document_repository/" . $userName . "/" . $fileName;
+$path = __DIR__ . "/../user_uploads/$dataDir";
 
 if (file_exists($path))
     unlink($path);


### PR DESCRIPTION
- The SQL patch included in this commit basically modifies the file paths stored in the database for all files that were uploaded with an earlier version of the document repository: the path will now be set to the new upload directory, under modules/document_repository.
- After running the patch, one has to run (sudo) cp -p -r /var/www/loris/document_repository/\* /var/www/loris/modules/document_repository/user_uploads. This will move the actual files from their old location to the new one.
