### PR TITLE
Composer Autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,14 @@
         "url" : "https://github.com/pear/Pager"
     },
     {
-        "type" : "pear",
-        "url" : "https://pear.php.net"
+        "type" : "vcs",
+        "url" : "https://github.com/pear/Benchmark"
     }
     ],
     "require" : {
         "smarty/smarty" : "3.1.*",
-        "pear/Pager" : "*"
+        "pear/Pager" : "*",
+        "pear/Benchmark" : "*"
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : ">= 2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,18 @@
 {
-    "minimum-stability" : "dev",
-    "prefer-stable" : true,
     "name": "aces/loris",
     "license" : "GPL-3.0+",
     "description" : "LORIS (Longitudinal Online Research and Imaging System) is a web-accessible database solution for neuroimaging.",
     "repositories" : [
     {
-        "type" : "vcs",
-        "url" : "https://github.com/pear/Pager"
-    },
-    {
-        "type" : "vcs",
-        "url" : "https://github.com/pear/Benchmark"
+        "type" : "pear",
+        "url" : "https://pear.php.net"
     }
     ],
     "require" : {
         "smarty/smarty" : "~3.1",
-        "pear/Pager" : "*",
-        "pear/Benchmark" : "*"
+        "pear-pear.php.net/Pager" : "*",
+        "pear-pear.php.net/Benchmark" : "*",
+        "pear-pear.php.net/HTML_QuickForm" : "*"
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : ">= 2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
     ],
     "require" : {
-        "smarty/smarty" : "3.1.*",
+        "smarty/smarty" : "~3.1",
         "pear/Pager" : "*",
         "pear/Benchmark" : "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,10 @@
     ],
     "require" : {
         "smarty/smarty" : "~3.1",
-        "pear-pear.php.net/Pager" : "*",
-        "pear-pear.php.net/Benchmark" : "*",
-        "pear-pear.php.net/HTML_QuickForm" : "*"
+        "pear-pear.php.net/Pager" : "~2.4",
+        "pear-pear.php.net/Benchmark" : "~1.2",
+        "pear-pear.php.net/HTML_QuickForm" : "~3.2",
+        "pear-pear.php.net/Mail" : "~1.2"
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : ">= 2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,29 @@
 {
+    "minimum-stability" : "dev",
+    "prefer-stable" : true,
+    "name": "aces/loris",
+    "license" : "GPL-3.0+",
+    "description" : "LORIS (Longitudinal Online Research and Imaging System) is a web-accessible database solution for neuroimaging.",
+    "repositories" : [
+    {
+        "type" : "vcs",
+        "url" : "https://github.com/pear/Pager"
+    },
+    {
+        "type" : "pear",
+        "url" : "https://pear.php.net"
+    }
+    ],
     "require" : {
-        "smarty/smarty" : "3.1.*"
+        "smarty/smarty" : "3.1.*",
+        "pear/Pager" : "*"
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : ">= 2.0",
         "phpunit/phpunit" : "4.3.*",
         "phpunit/phpunit-selenium" : ">=1.2"
+    },
+    "autoload" : {
+        "classmap": ["php/libraries", "php/exceptions"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
         "phpunit/phpunit-selenium" : ">=1.2"
     },
     "autoload" : {
-        "classmap": ["php/libraries", "php/exceptions"]
+        "classmap": ["php/libraries"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "64e488d09818ab54aea0a821a456d583",
+    "hash": "73434ff35bd299bbcba9d5b19ed5aaf1",
     "packages": [
         {
             "name": "pear-pear.php.net/Benchmark",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0a99094469981e7bd4b7cb87e635ddee",
+    "hash": "53d982c2d42d11ef0c0a600360804209",
     "packages": [
         {
             "name": "pear/benchmark",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,54 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4e3750136714ae3fb8751bad362feade",
+    "hash": "0a99094469981e7bd4b7cb87e635ddee",
     "packages": [
+        {
+            "name": "pear/benchmark",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Benchmark.git",
+                "reference": "1275e3e3c8a02810a6cc007eb57c2a8d1f8f909b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Benchmark/zipball/1275e3e3c8a02810a6cc007eb57c2a8d1f8f909b",
+                "reference": "1275e3e3c8a02810a6cc007eb57c2a8d1f8f909b",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear_exception": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-bcmath": "May require the bcmath PHP extension"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ]
+            },
+            "license": [
+                "New BSD"
+            ],
+            "authors": [
+                {
+                    "email": "anant@kix.in",
+                    "name": "Anant Narayanan",
+                    "role": "Lead"
+                }
+            ],
+            "description": "More info available on: http://pear.php.net/package/Benchmark",
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Benchmark",
+                "source": "https://github.com/pear/Benchmark"
+            },
+            "time": "2014-02-20 19:26:09"
+        },
         {
             "name": "pear/pager",
             "version": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,128 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "678871c4286338e3307228665131d5f0",
+    "hash": "4e3750136714ae3fb8751bad362feade",
     "packages": [
+        {
+            "name": "pear/pager",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Pager.git",
+                "reference": "2bbf01511adb5bfb96720d2aed9e5ec530868053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Pager/zipball/2bbf01511adb5bfb96720d2aed9e5ec530868053",
+                "reference": "2bbf01511adb5bfb96720d2aed9e5ec530868053",
+                "shasum": ""
+            },
+            "require": {
+                "pear/pear_exception": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Pager": "./"
+                }
+            },
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "email": "l.alberton@quipo.it",
+                    "name": "Lorenzo Alberton",
+                    "role": "Lead"
+                },
+                {
+                    "email": "richard@phpguru.org",
+                    "name": "Richard Heyes",
+                    "role": "Lead"
+                }
+            ],
+            "description": "More info available on: http://pear.php.net/package/Pager",
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Pager",
+                "source": "https://github.com/pear/Pager"
+            },
+            "time": "2014-05-14 08:34:23"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "1.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "f053615c7cbdfaba5a3b7021ee58a48523b8576c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/f053615c7cbdfaba5a3b7021ee58a48523b8576c",
+                "reference": "f053615c7cbdfaba5a3b7021ee58a48523b8576c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PEAR": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net",
+                    "role": "Helper"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2014-02-21 17:29:07"
+        },
         {
             "name": "smarty/smarty",
             "version": "v3.1.21",
             "source": {
                 "type": "git",
-                "url": "https://github.com/uwetews/smarty3-dist.git",
-                "reference": "1441f32fce8494a0b153551fe2b659f5ce8e7eed"
+                "url": "https://github.com/smarty-php/smarty.git",
+                "reference": "1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/uwetews/smarty3-dist/zipball/1441f32fce8494a0b153551fe2b659f5ce8e7eed",
-                "reference": "1441f32fce8494a0b153551fe2b659f5ce8e7eed",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a",
+                "reference": "1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a",
                 "shasum": ""
             },
             "require": {
@@ -59,7 +167,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2014-10-17 23:19:29"
+            "time": "2014-10-31 04:22:20"
         }
     ],
     "packages-dev": [
@@ -936,9 +1044,9 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "platform": [],
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,161 +4,138 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "53d982c2d42d11ef0c0a600360804209",
+    "hash": "64e488d09818ab54aea0a821a456d583",
     "packages": [
         {
-            "name": "pear/benchmark",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pear/Benchmark.git",
-                "reference": "1275e3e3c8a02810a6cc007eb57c2a8d1f8f909b"
-            },
+            "name": "pear-pear.php.net/Benchmark",
+            "version": "1.2.9",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pear/Benchmark/zipball/1275e3e3c8a02810a6cc007eb57c2a8d1f8f909b",
-                "reference": "1275e3e3c8a02810a6cc007eb57c2a8d1f8f909b",
-                "shasum": ""
+                "type": "file",
+                "url": "https://pear.php.net/get/Benchmark-1.2.9.tgz",
+                "reference": null,
+                "shasum": null
             },
             "require": {
-                "pear/pear_exception": "*"
+                "php": ">=4.0.0.0"
             },
-            "require-dev": {
-                "phpunit/phpunit": "*"
+            "replace": {
+                "pear-pear/benchmark": "== 1.2.9.0"
             },
-            "suggest": {
-                "ext-bcmath": "May require the bcmath PHP extension"
-            },
-            "type": "library",
+            "type": "pear-library",
             "autoload": {
                 "classmap": [
-                    "./"
+                    ""
                 ]
             },
-            "license": [
-                "New BSD"
+            "include-path": [
+                "/"
             ],
-            "authors": [
-                {
-                    "email": "anant@kix.in",
-                    "name": "Anant Narayanan",
-                    "role": "Lead"
-                }
-            ],
-            "description": "More info available on: http://pear.php.net/package/Benchmark",
-            "support": {
-                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Benchmark",
-                "source": "https://github.com/pear/Benchmark"
-            },
-            "time": "2014-02-20 19:26:09"
+            "description": "Framework to benchmark PHP scripts or function calls."
         },
         {
-            "name": "pear/pager",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pear/Pager.git",
-                "reference": "2bbf01511adb5bfb96720d2aed9e5ec530868053"
-            },
+            "name": "pear-pear.php.net/HTML_Common",
+            "version": "1.2.5",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pear/Pager/zipball/2bbf01511adb5bfb96720d2aed9e5ec530868053",
-                "reference": "2bbf01511adb5bfb96720d2aed9e5ec530868053",
-                "shasum": ""
+                "type": "file",
+                "url": "https://pear.php.net/get/HTML_Common-1.2.5.tgz",
+                "reference": null,
+                "shasum": null
             },
             "require": {
-                "pear/pear_exception": "*"
+                "php": ">=4.0.4.0"
             },
-            "require-dev": {
-                "phpunit/phpunit": "*"
+            "replace": {
+                "pear-pear/html_common": "== 1.2.5.0"
             },
-            "type": "library",
+            "type": "pear-library",
             "autoload": {
-                "psr-0": {
-                    "Pager": "./"
-                }
+                "classmap": [
+                    ""
+                ]
             },
             "include-path": [
-                "./"
+                "/"
             ],
-            "license": [
-                "BSD"
-            ],
-            "authors": [
-                {
-                    "email": "l.alberton@quipo.it",
-                    "name": "Lorenzo Alberton",
-                    "role": "Lead"
-                },
-                {
-                    "email": "richard@phpguru.org",
-                    "name": "Richard Heyes",
-                    "role": "Lead"
-                }
-            ],
-            "description": "More info available on: http://pear.php.net/package/Pager",
-            "support": {
-                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Pager",
-                "source": "https://github.com/pear/Pager"
-            },
-            "time": "2014-05-14 08:34:23"
+            "description": "The PEAR::HTML_Common package provides methods for html code display and attributes handling.\n* Methods to set, remove, update html attributes.\n* Handles comments in HTML code.\n* Handles layout, tabs, line endings for nicer HTML code."
         },
         {
-            "name": "pear/pear_exception",
-            "version": "1.0-beta1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pear/PEAR_Exception.git",
-                "reference": "f053615c7cbdfaba5a3b7021ee58a48523b8576c"
-            },
+            "name": "pear-pear.php.net/HTML_QuickForm",
+            "version": "3.2.14",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/f053615c7cbdfaba5a3b7021ee58a48523b8576c",
-                "reference": "f053615c7cbdfaba5a3b7021ee58a48523b8576c",
-                "shasum": ""
+                "type": "file",
+                "url": "https://pear.php.net/get/HTML_QuickForm-3.2.14.tgz",
+                "reference": null,
+                "shasum": null
             },
             "require": {
-                "php": ">=4.4.0"
+                "pear-pear.php.net/html_common": ">=1.2.1.0",
+                "php": ">=4.3.0.0"
             },
-            "require-dev": {
-                "phpunit/phpunit": "*"
+            "replace": {
+                "pear-pear/html_quickform": "== 3.2.14.0"
             },
-            "type": "class",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
+            "type": "pear-library",
             "autoload": {
-                "psr-0": {
-                    "PEAR": ""
-                }
+                "classmap": [
+                    ""
+                ]
             },
-            "notification-url": "https://packagist.org/downloads/",
             "include-path": [
-                "."
+                "/"
             ],
-            "license": [
-                "BSD-2-Clause"
+            "description": "NOTICE: development of HTML_QuickForm version 3 is frozen. Please submit\nfeature requests for HTML_QuickForm2 package.\n\nThe HTML_QuickForm package provides methods to dynamically create, validate\nand render HTML forms.\n\nFeatures:\n* More than 20 ready-to-use form elements.\n* XHTML compliant generated code.\n* Numerous mixable and extendable validation rules.\n* Automatic server-side validation and filtering.\n* On request javascript code generation for client-side validation.\n* File uploads support.\n* Total customization of form rendering.\n* Support for external template engines (ITX, Sigma, Flexy, Smarty).\n* Pluggable elements, rules and renderers extensions."
+        },
+        {
+            "name": "pear-pear.php.net/Mail",
+            "version": "1.2.0",
+            "dist": {
+                "type": "file",
+                "url": "https://pear.php.net/get/Mail-1.2.0.tgz",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "php": ">=4.4.9.0"
+            },
+            "replace": {
+                "pear-pear/mail": "== 1.2.0.0"
+            },
+            "type": "pear-library",
+            "autoload": {
+                "classmap": [
+                    ""
+                ]
+            },
+            "include-path": [
+                "/"
             ],
-            "authors": [
-                {
-                    "name": "Helgi Thormar",
-                    "email": "dufuz@php.net",
-                    "role": "Lead"
-                },
-                {
-                    "name": "Greg Beaver",
-                    "email": "cellog@php.net",
-                    "role": "Helper"
-                }
+            "description": "PEAR's Mail package defines an interface for implementing mailers under the PEAR hierarchy.  It also provides supporting functions useful to multiple mailer backends.  Currently supported backends include: PHP's native mail() function, sendmail, and SMTP.  This package also provides a RFC822 email address list validation utility class."
+        },
+        {
+            "name": "pear-pear.php.net/Pager",
+            "version": "2.4.9",
+            "dist": {
+                "type": "file",
+                "url": "https://pear.php.net/get/Pager-2.4.9.tgz",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "php": ">=4.0.0.0"
+            },
+            "replace": {
+                "pear-pear/pager": "== 2.4.9.0"
+            },
+            "type": "pear-library",
+            "autoload": {
+                "classmap": [
+                    ""
+                ]
+            },
+            "include-path": [
+                "/"
             ],
-            "description": "The PEAR Exception base class.",
-            "homepage": "https://github.com/pear/PEAR_Exception",
-            "keywords": [
-                "exception"
-            ],
-            "time": "2014-02-21 17:29:07"
+            "description": "It takes an array of data as input and pages it according to various parameters.\nIt also builds links within a specified range, and allows complete customization of the output (it even works with front controllers and mod_rewrite).\nTwo operating modes available: \"Jumping\" and \"Sliding\" window style."
         },
         {
             "name": "smarty/smarty",
@@ -1090,9 +1067,10 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": true,
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }

--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -26,6 +26,7 @@ set_include_path(
     __DIR__ . "/../php/libraries"
 );
 
+require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -27,7 +27,7 @@ set_include_path(
     __DIR__ . "/../project/libraries:" .
     __DIR__ . "/../php/libraries"
 );
-
+require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -28,6 +28,7 @@ set_include_path(
     __DIR__ . "/../php/libraries"
 );
 
+require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -6,11 +6,10 @@ set_include_path(get_include_path().":../project/libraries:../php/libraries:");
 require_once __DIR__ . "/../vendor/autoload.php";
 ini_set('default_charset', 'utf-8');
 ob_start('ob_gzhandler');
-// Create an output buffer to capture console output, separately from the 
+// Create an output buffer to capture console output, separately from the
 // gzip handler.
 ob_start();
 // start benchmarking
-require_once 'Benchmark/Timer.php';
 $timer = new Benchmark_Timer;
 $timer->start();
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -3,6 +3,7 @@
  * @package main
  */
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+require_once __DIR__ . "/../vendor/autoload.php";
 ini_set('default_charset', 'utf-8');
 ob_start('ob_gzhandler');
 // Create an output buffer to capture console output, separately from the 
@@ -14,12 +15,10 @@ $timer = new Benchmark_Timer;
 $timer->start();
 
 // load the client
-require_once 'NDB_Client.class.inc';
 $client = new NDB_Client;
 $client->initialize();
 
 // require additional libraries
-require_once 'NDB_Breadcrumb.class.inc';
 
 $TestName = isset($_REQUEST['test_name']) ? $_REQUEST['test_name'] : 'dashboard';
 $subtest = isset($_REQUEST['subtest']) ? $_REQUEST['subtest'] : '';

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -27,13 +27,6 @@ require_once 'NDB_Form.class.inc';
 */
 class NDB_Form_Configuration extends NDB_Form
 {
-    function verifyDependencies() {
-        if (Database::CheckTable("ConfigSettings") === false
-            || Database::CheckTable("Config") === false
-        ) {
-            throw new Exception("Missing tables for config module.");
-        };
-    }
     /**
      * _has_access returns true
      * if the user has the specific permission

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -27,6 +27,13 @@ require_once 'NDB_Form.class.inc';
 */
 class NDB_Form_Configuration extends NDB_Form
 {
+    function verifyDependencies() {
+        if (Database::CheckTable("ConfigSettings") === false
+            || Database::CheckTable("Config") === false
+        ) {
+            throw new Exception("Missing tables for config module.");
+        };
+    }
     /**
      * _has_access returns true
      * if the user has the specific permission

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -25,7 +25,6 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-require_once 'smarty3/Smarty.class.php';
 require_once 'User.class.inc';
 require_once 'Database.class.inc';
 

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -11,7 +11,6 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-require_once 'smarty3/Smarty.class.php';
 
 /**
  * This overrides the Smarty base class in order to look into module/templates,

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -526,6 +526,7 @@
                                     {/if}
                                 {/if}
                                 <div id="kgkjgkjg">
+            Smarty: {$smarty.version}
                                     {$workspace}
                                 </div>  
                             {/if}

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -526,7 +526,6 @@
                                     {/if}
                                 {/if}
                                 <div id="kgkjgkjg">
-            Smarty: {$smarty.version}
                                     {$workspace}
                                 </div>  
                             {/if}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -75,12 +75,12 @@ else
     exit 2;
 fi
 
-if [[ -n $(which pear) ]]; then
+if [[ -n $(which composer) ]]; then
     echo ""
-    echo "PEAR appears to be installed."
+    echo "PHP Composer appears to be installed."
 else
     echo ""
-    echo "PEAR does not appear to be installed. Aborting."
+    echo "PHP Composer does not appear to be installed. Aborting."
     exit 2;
 fi
 
@@ -343,21 +343,9 @@ mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPD
 mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$projectname/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
 
 
+# Install external libraries using composer
 
-echo ""
-while true; do
-    read -p "Would you like to install PEAR libraries (affects system files)? [yn] " yn
-    echo $yn | tee -a $LOGFILE > /dev/null
-    case $yn in
-        [Yy]* )
-            composer install --nodev
-        [Nn]* )
-            echo "Not installing PEAR libraries."
-            break;;
-        * ) echo "Please enter 'y' or 'n'."
-   esac
-done;
-
+composer install --nodev
 
 echo ""
 while true; do

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -350,25 +350,7 @@ while true; do
     echo $yn | tee -a $LOGFILE > /dev/null
     case $yn in
         [Yy]* )
-            echo "Installing PEAR libraries (may prompt for sudo password)."
-            echo ""
-            echo "Upgrading PEAR..."
-            sudo pear upgrade-all
-            echo "Installing PEAR Benchmark..."
-            sudo pear install Benchmark
-            echo "Installing PEAR HTML_Common..."
-            sudo pear install HTML_Common
-            echo "Installing PEAR HTML_QuickForm..."
-            sudo pear install HTML_QuickForm
-            echo "Configuring PEAR preferred state..."
-            sudo pear config-set preferred_state beta
-            echo "Installing PEAR Mail..."
-            sudo pear install Mail
-            echo "Installing PEAR Pager..."
-            sudo pear install Pager
-            echo "Installing PEAR Structures_Graph..."
-            sudo pear install Structures_Graph
-            break;;
+            composer install --nodev
         [Nn]* )
             echo "Not installing PEAR libraries."
             break;;

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -344,8 +344,9 @@ mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPD
 
 
 # Install external libraries using composer
-
-composer install --nodev
+cd ..
+composer install --no-dev
+cd tools
 
 echo ""
 while true; do


### PR DESCRIPTION
This updates the code to use composer's class autoloading, and at the same time installs all the currently required PEAR libraries using composer instead of PEAR install. 

Existing projects should run composer install --no-dev in order to generate the autoload file (even if they're still using the system PEAR libraries)