### PR TITLE
Consent history bugfix

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -399,8 +399,8 @@ class NDB_Form_candidate_parameters extends NDB_Form
                    array("cid"=>$values['CandID'])
                    );
 
-	   // inserting to consent_info_history table before participant_status
-           // because else{} below adds a field specific to participant_status table
+           // Insert to consent_info_history table first, before participant_status
+           // because else{} below adds a column specific to participant_status table
            $success = $DB->insert("consent_info_history", $participant_vals); 
 
            if ($ParticipantCount > 0) {


### PR DESCRIPTION
Fixing error produced when saving consent as the first participant status change for a candidate.  Was failing  when trying to insert to consent_info_history table on non-existent participant_status column.  (Redmine 6761)
Also cleaned up a little obsolete Pear error checking. 
