### PR TITLE
Namespaced exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ script:
     - phpunit test/integrationtests/
 
     # Run PHPCS on the entire libraries directory.
-    - vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries
+    - vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries php/exceptions
 
     # Run PHPCS on specific modules
     - vendor/bin/phpcs --standard=docs/LorisCS.xml modules/mri_upload/php/NDB_Menu_Filter_mri_upload.class.inc

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
         "phpunit/phpunit-selenium" : ">=1.2"
     },
     "autoload" : {
-        "classmap": ["php/libraries"]
+        "classmap": ["php/libraries", "php/exceptions"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "73434ff35bd299bbcba9d5b19ed5aaf1",
+    "hash": "64e488d09818ab54aea0a821a456d583",
     "packages": [
         {
             "name": "pear-pear.php.net/Benchmark",

--- a/php/exceptions/ConfigurationException.class.inc
+++ b/php/exceptions/ConfigurationException.class.inc
@@ -1,4 +1,26 @@
 <?php
+/**
+ * This class is a wrapper around Configuration errors thrown from
+ * the Loris database
+ *
+ * PHP Version 5
+ *
+ * @category Errors
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
+/**
+ * The LorisException class.
+ *
+ * @category Errors
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
 class ConfigurationException extends LorisException
 {
 }

--- a/php/exceptions/ConfigurationException.class.inc
+++ b/php/exceptions/ConfigurationException.class.inc
@@ -1,0 +1,5 @@
+<?php
+class ConfigurationException extends LorisException
+{
+}
+?>

--- a/php/exceptions/DatabaseException.class.inc
+++ b/php/exceptions/DatabaseException.class.inc
@@ -1,0 +1,5 @@
+<?php
+class DatabaseException extends LorisException
+{
+}
+?>

--- a/php/exceptions/DatabaseException.class.inc
+++ b/php/exceptions/DatabaseException.class.inc
@@ -1,5 +1,46 @@
 <?php
+/**
+ * This class is a wrapper around Database exceptions thrown from the Loris
+ * database.
+ *
+ * PHP Version 5
+ *
+ * @category Errors
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
+/**
+ * The DatabaseException class.
+ *
+ * @category Errors
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
 class DatabaseException extends LorisException
 {
+    var $query;
+    var $params;
+
+    /**
+     * Constructs a database exception. Optionally may specify the
+     * QUERY that generated the exception and bind parameters that
+     * were used to try and execute it.
+     *
+     * @param string $msg        The error message to associate to this exception
+     * @param string $query      The SQL query that generated this exception
+     * @param array  $bindparams The prepared statement bindings used to try
+     *                           and execute this statement
+     */
+    function __construct($msg, $query = '', $bindparams = array())
+    {
+        parent::__construct();
+        $this->query  = $query;
+        $this->params = $query;
+    }
 }
 ?>

--- a/php/exceptions/LorisException.class.inc
+++ b/php/exceptions/LorisException.class.inc
@@ -1,0 +1,5 @@
+<?php
+class LorisException extends Exception
+{
+}
+?>

--- a/php/exceptions/LorisException.class.inc
+++ b/php/exceptions/LorisException.class.inc
@@ -1,4 +1,28 @@
 <?php
+/**
+ * This class is a wrapper around any Database exceptions thrown Loris
+ * It represents the base of the exception hierarchy, as well as any
+ * other type of exception that does not fit into any other category.
+ *
+ * PHP Version 5
+ *
+ * @category Errors
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
+/**
+ * The LorisException class.
+ *
+ * @category Errors
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
 class LorisException extends Exception
 {
 }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -271,7 +271,9 @@ class Database extends PEAR
         $result = $prep->execute($exec_params);
         if ($result === false) {
             throw new DatabaseException(
-                "Insert statement did not execute successfully."
+                "Insert statement did not execute successfully.",
+                $prepQ,
+                $exec_params
             );
         }
 
@@ -354,7 +356,8 @@ class Database extends PEAR
 
         if (preg_match("/=NULL/", $where)) {
             throw new DatabaseException(
-                "NULL values not allowed in a WHERE structure."
+                "NULL values not allowed in a WHERE structure.",
+                $prepQ
             );
         }
 
@@ -368,7 +371,9 @@ class Database extends PEAR
         $result = $prep->execute($exec_params);
         if ($result === false) {
             throw new DatabaseException(
-                "Update statement did not execute successfully."
+                "Update statement did not execute successfully.",
+                $prepQ,
+                $exec_params
             );
         }
         $this->affected = $prep->rowCount();
@@ -399,7 +404,8 @@ class Database extends PEAR
 
         if (preg_match("/=NULL/", $query)) {
             throw new DatabaseException(
-                "NULL values not allowed in a WHERE structure."
+                "NULL values not allowed in a WHERE structure.",
+                $query
             );
         }
 
@@ -439,8 +445,8 @@ class Database extends PEAR
             && strpos(strtoupper($query), 'DESCRIBE') !== 0
         ) {
             throw new DatabaseException(
-                "Only SELECT statements can be run with Database::select()."
-                . "  Query was '$query'"
+                "Only SELECT statements can be run with Database::select().",
+                $query
             );
         }
 
@@ -455,7 +461,7 @@ class Database extends PEAR
             }
             return $result;
         } catch(Exception $e) {
-            throw new DatabaseException("Invalid SELECT statement, $query");
+            throw new DatabaseException("Invalid SELECT statement", $query);
         }
     }
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -102,7 +102,7 @@ class Database extends PEAR
                 $connection = current($connections);
                 return $connection;
             } else {
-                throw new Exception("No database connection exists");
+                throw new DatabaseException("No database connection exists");
             }
         } else {
             // name the connection
@@ -120,7 +120,7 @@ class Database extends PEAR
                 );
                 if ($connections[$connection]->isError($ok)) {
                     unset($connections[$connection]);
-                    throw new Exception(
+                    throw new DatabaseException(
                         'Could not connect to database: '.$ok->getMessage()
                     );
                 }
@@ -270,7 +270,7 @@ class Database extends PEAR
         $prep   = $this->_PDO->prepare($prepQ);
         $result = $prep->execute($exec_params);
         if ($result === false) {
-            throw new Exception(
+            throw new DatabaseException(
                 "Insert statement did not execute successfully."
             );
         }
@@ -353,7 +353,7 @@ class Database extends PEAR
         }
 
         if (preg_match("/=NULL/", $where)) {
-            throw new Exception(
+            throw new DatabaseException(
                 "NULL values not allowed in a WHERE structure."
             );
         }
@@ -367,7 +367,7 @@ class Database extends PEAR
         $prep   = $this->_PDO->prepare($prepQ);
         $result = $prep->execute($exec_params);
         if ($result === false) {
-            throw new Exception(
+            throw new DatabaseException(
                 "Update statement did not execute successfully."
             );
         }
@@ -398,7 +398,7 @@ class Database extends PEAR
         }
 
         if (preg_match("/=NULL/", $query)) {
-            throw new Exception(
+            throw new DatabaseException(
                 "NULL values not allowed in a WHERE structure."
             );
         }
@@ -438,7 +438,7 @@ class Database extends PEAR
             && strpos(strtoupper($query), 'SHOW') !== 0
             && strpos(strtoupper($query), 'DESCRIBE') !== 0
         ) {
-            throw new Exception(
+            throw new DatabaseException(
                 "Only SELECT statements can be run with Database::select()."
                 . "  Query was '$query'"
             );
@@ -455,7 +455,7 @@ class Database extends PEAR
             }
             return $result;
         } catch(Exception $e) {
-            throw new Exception("Invalid SELECT statement, $query");
+            throw new DatabaseException("Invalid SELECT statement, $query");
         }
     }
 


### PR DESCRIPTION
This begins the process of updating our code to use different types of exceptions instead of always the generic "Exception".

In particular, the database class will now throw Database exceptions. There are (currently) three types of exceptions which may be thrown.

1. DatabaseExceptions, when there is a database error
2. ConfigurationExceptions, when there is an error with the configuration
3. LorisExceptions (of which both of the above derive), for any exception from Loris that does not fit into either of the above.