### PR TITLE
Fixed problems with PHPCS 2.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11,13 +11,13 @@
             "version": "v3.1.21",
             "source": {
                 "type": "git",
-                "url": "https://github.com/uwetews/smarty3-dist.git",
-                "reference": "1441f32fce8494a0b153551fe2b659f5ce8e7eed"
+                "url": "https://github.com/smarty-php/smarty.git",
+                "reference": "1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/uwetews/smarty3-dist/zipball/1441f32fce8494a0b153551fe2b659f5ce8e7eed",
-                "reference": "1441f32fce8494a0b153551fe2b659f5ce8e7eed",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a",
+                "reference": "1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a",
                 "shasum": ""
             },
             "require": {
@@ -59,7 +59,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2014-10-17 23:19:29"
+            "time": "2014-10-31 04:22:20"
         }
     ],
     "packages-dev": [
@@ -119,16 +119,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.13",
+            "version": "2.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "0e7d2eec5554f869fa7a4ec2d21e4b37af943ea5"
+                "reference": "ca158276c1200cc27f5409a5e338486bc0b4fc94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0e7d2eec5554f869fa7a4ec2d21e4b37af943ea5",
-                "reference": "0e7d2eec5554f869fa7a4ec2d21e4b37af943ea5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca158276c1200cc27f5409a5e338486bc0b4fc94",
+                "reference": "ca158276c1200cc27f5409a5e338486bc0b4fc94",
                 "shasum": ""
             },
             "require": {
@@ -180,7 +180,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-12-03 06:41:44"
+            "time": "2014-12-26 13:28:33"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -781,16 +781,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43"
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
-                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/a77d9123f8e809db3fbdea15038c27a95da4058b",
+                "reference": "a77d9123f8e809db3fbdea15038c27a95da4058b",
                 "shasum": ""
             },
             "type": "library",
@@ -812,20 +812,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2014-03-07 15:35:33"
+            "time": "2014-12-15 14:25:24"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5b63fd3fe960e2020770c845e04254e5ca2b722a"
+                "reference": "d2a1d4c58fd2bb09ba376d0d19e67c0ab649e401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5b63fd3fe960e2020770c845e04254e5ca2b722a",
-                "reference": "5b63fd3fe960e2020770c845e04254e5ca2b722a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d2a1d4c58fd2bb09ba376d0d19e67c0ab649e401",
+                "reference": "d2a1d4c58fd2bb09ba376d0d19e67c0ab649e401",
                 "shasum": ""
             },
             "require": {
@@ -885,7 +885,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2014-12-05 00:14:12"
+            "time": "2014-12-18 02:37:51"
         },
         {
             "name": "symfony/yaml",
@@ -939,6 +939,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
     "platform-dev": []
 }

--- a/modules/mri_upload/php/File_Decompress.class.inc
+++ b/modules/mri_upload/php/File_Decompress.class.inc
@@ -50,7 +50,7 @@ class File_Decompress extends PEAR
      * @param String $file_name        File to be decompressed
      * @param String $destination_path Path of the destination folder
      */
-    function File_Decompress(&$file_name, &$destination_path)
+    function __construct(&$file_name, &$destination_path)
     {
         $this->file_name = $file_name;
         $this->dest_path = $destination_path;

--- a/modules/mri_upload/php/NDB_Menu_Filter_mri_upload.class.inc
+++ b/modules/mri_upload/php/NDB_Menu_Filter_mri_upload.class.inc
@@ -894,35 +894,35 @@ class NDB_Menu_Filter_Mri_Upload extends NDB_Menu_Filter_Form
             //if the minc is not inserted into the files table/////////////
             ////Run the minc-insertion pipeline////////////////////////////
             ///////////////////////////////////////////////////////////////
-        if ($count==0) {
-            $this->message->addMessage(
-                "Inserting MINC into the".
-                " files table \n"
-            );
-            $output = $this->runCommand($command);
-            if ($this->show_queries) {
-                print "command is $command";
-                $this->message->addMessage("command is $command");
-                print $output;
-                $this->message->addMessage($output);
-            }
-            ////////////////////TODO://////////////////////////////////
-            //extra checks can be added to make sure that the//////////
-            /// mincs are created, before the minc-inserted is set/////
-            /////////// to true////////////////////////////////////////
-            if ($output==0) {
-                 $this->message->addMessage(
-                     "The minc file for" .
-                     " patient-name $patient_name is now inserted into db".
-                     "\n"
-                 );
+            if ($count==0) {
+                $this->message->addMessage(
+                    "Inserting MINC into the".
+                    " files table \n"
+                );
+                $output = $this->runCommand($command);
+                if ($this->show_queries) {
+                    print "command is $command";
+                    $this->message->addMessage("command is $command");
+                    print $output;
+                    $this->message->addMessage($output);
+                }
+                ////////////////////TODO://////////////////////////////////
+                //extra checks can be added to make sure that the//////////
+                /// mincs are created, before the minc-inserted is set/////
+                /////////// to true////////////////////////////////////////
+                if ($output==0) {
+                     $this->message->addMessage(
+                         "The minc file for" .
+                         " patient-name $patient_name is now inserted into db".
+                         "\n"
+                     );
                                  $this->message->addMessage(
                                      "The process completed".
                                      "successfully \n"
                                  );
-                $this->tpl_data['minc_success'] = true;
+                                 $this->tpl_data['minc_success'] = true;
+                }
             }
-        }
     }
 
     /**

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -44,7 +44,7 @@ class FeedbackMRI
      * @param int $fileID    The fileID that this feedback is for
      * @param int $sessionID The SessionID that this feedback is for
      */
-    function FeedbackMRI($fileID='', $sessionID='')
+    function __construct($fileID='', $sessionID='')
     {
         // set object properties
         $this->fileID    = $fileID;

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -33,7 +33,7 @@ class File_Upload extends PEAR
      * Construct the File_Upload class. This sets the default parameters
      * for a file which can be overwritten by calling the set* methods
      */
-    function File_Upload()
+    function __construct()
     {
         //Set Defaults
         $this->renameMode        = "incremental";

--- a/php/libraries/Log.class.inc
+++ b/php/libraries/Log.class.inc
@@ -35,7 +35,7 @@ class Log extends PEAR
      * @param String $file_name The name of the log file
      * @param String $location  The path of the log file
      */
-    function Log($file_name,$location=null)
+    function __construct($file_name,$location=null)
     {
         $today = getdate();
         $date  = sprintf(

--- a/php/libraries/MRIFile.class.inc
+++ b/php/libraries/MRIFile.class.inc
@@ -31,7 +31,7 @@ class MRIFile
      *
      * @param integer $fileID The FileID to be loaded
      */
-    function MRIFile($fileID)
+    function __construct($fileID)
     {
         $db     =& Database::singleton();
         $params = array('FID' => $fileID);

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -40,7 +40,7 @@ class NDB_BVL_Battery extends PEAR
     /**
      * Constructor - merely asserts that the environment is suitable
      */
-    function NDB_BVL_Battery()
+    function __construct()
     {
     }
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -374,7 +374,7 @@ class NDB_BVL_Feedback
             $qparams['CanID'] = $this->_feedbackObjectInfo['CandID'];
             $queryBy          = " CandID";
         } elseif (!empty($this->_feedbackObjectInfo['FieldName'])) {
-            $query           .= 	" AND FieldName = :FName";
+            $query           .=     " AND FieldName = :FName";
             $qparams['FName'] = $this->_feedbackObjectInfo['FieldName'];
             $queryBy          = " FieldName";
         } else {

--- a/php/libraries/NDB_BVL_Instrument_instrument_preview.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_instrument_preview.class.inc
@@ -40,7 +40,7 @@ class NDB_BVL_Instrument_Instrument_Preview extends NDB_BVL_Instrument
      * Loads a LINST file and rules from the data posted to it in order
      * to preview how Loris would render that file.
      */
-    function NDB_BVL_Instrument_Instrument_Preview()
+    function __construct()
     {
         $this->loadInstrumentFile(
             "data:text/plain;base64," . base64_encode($_REQUEST['instrumentdata']),

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -380,33 +380,34 @@ class NDB_Reliability extends NDB_Form
      */
     function _getExaminerNames()
     {
-         $db       =& Database::singleton();
-         $user     =& User::singleton();
-         $centerID = $user->getCenterID();
+        $db       =& Database::singleton();
+        $user     =& User::singleton();
+        $centerID = $user->getCenterID();
 
-         // UofA is a special case--they never enter their own data.
-         // So the available examiners are either the ones at the logged
-         // in user's site, or UofA
-         $results = $db->pselect(
-             "SELECT examinerID, full_name
-                 FROM examiners
-             WHERE centerID IN (:CentID, 6)
-                 ORDER BY full_name",
-             array('CentID' => $centerID)
-         );
+        // UofA is a special case--they never enter their own data.
+        // So the available examiners are either the ones at the logged
+        // in user's site, or UofA
+        $results = $db->pselect(
+            "SELECT examinerID, full_name
+                FROM examiners
+            WHERE centerID IN (:CentID, 6)
+                ORDER BY full_name",
+            array('CentID' => $centerID)
+        );
         if ($db->isError($results)) {
             return $this->raiseError(
                 "Could not get examiner names: ".$results->getMessage()
             );
         }
 
-            $examiners = array('' => '');
+        $examiners = array('' => '');
+
         if (is_array($results) && !empty($results)) {
             foreach ($results AS $row) {
                 $examiners[$row['examinerID']] = $row['full_name'];
             }
         }
-            return $examiners;
+        return $examiners;
     }
 
     /**

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -266,14 +266,15 @@ class SinglePointLogin extends PEAR
         $this->_username = isset($_POST['username'])
             ? $_POST['username']
             : 'Unknown';
-         $setArray       = array(
-                            'userID'          => $this->_username,
-                            'Success'         => 'Y',
-                            'Failcode'        => null,
-                            'Login_timestamp' => date('Y-m-d H:i:s'),
-                            'IP_address'      => $_SERVER['REMOTE_ADDR'],
-                            'Page_requested'  => $_SERVER['REQUEST_URI'],
-                           );
+
+        $setArray = array(
+                     'userID'          => $this->_username,
+                     'Success'         => 'Y',
+                     'Failcode'        => null,
+                     'Login_timestamp' => date('Y-m-d H:i:s'),
+                     'IP_address'      => $_SERVER['REMOTE_ADDR'],
+                     'Page_requested'  => $_SERVER['REQUEST_URI'],
+                    );
 
         // save the new password if the last password expired
         if (isset($_POST['expiry'])) {
@@ -288,6 +289,7 @@ class SinglePointLogin extends PEAR
         if (empty($_POST['login'])) {
             return false;
         }
+
         if (empty($_POST['username'])) {
             $this->_lastError = 'Please enter a username';
             $this->insertFailedDetail(
@@ -296,6 +298,7 @@ class SinglePointLogin extends PEAR
             );
             return false;
         }
+
         if (empty($_POST['password'])) {
             $this->_lastError = 'Please enter a password';
             $this->insertFailedDetail(
@@ -310,9 +313,9 @@ class SinglePointLogin extends PEAR
 
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
-                         Password_md5, Password_expiry, Active, Pending_approval
-                    FROM users
-                  WHERE UserID = :username
+                     Password_md5, Password_expiry, Active, Pending_approval
+                FROM users
+              WHERE UserID = :username
                   GROUP BY UserID";
         $row   = $DB->pselectRow($query, array('username' => $_POST['username']));
 
@@ -354,7 +357,7 @@ class SinglePointLogin extends PEAR
             }
         }
 
-            // bad usename or password
+        // bad usename or password
         $this->_lastError = "Incorrect username or password";
         return false;
     }

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -39,10 +39,10 @@ class Smarty_NeuroDB extends Smarty
      */
     function __construct($moduleName = null)
     {
+        parent::__construct();
+
         $config =& NDB_Config::singleton();
         $paths  = $config->getSetting('paths');
-
-        $this->__construct();
 
         // NeuroDB plugin is no longer needed now that Smarty3 supports
         // multiple template directories

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -37,7 +37,7 @@ class Smarty_NeuroDB extends Smarty
      *
      * @param string $moduleName The name of the module to search through
      */
-    function Smarty_NeuroDB($moduleName = null)
+    function __construct($moduleName = null)
     {
         $config =& NDB_Config::singleton();
         $paths  = $config->getSetting('paths');


### PR DESCRIPTION
Updated libraries installed by composer, including PHPCS and fixed stylistic problems detected by the new versions.

Mostly, they were complaining about a missing @return tag because the constructors were PHP4 style named-after-the-class instead of PHP5-style __construct functions, but also some indentation issues were detected that had to be fixed.