### PR TITLE
remove overwrite initialization PDO in database class

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -184,7 +184,7 @@ class Database extends PEAR
             ." (:histtable, :histcolumn, :newval, :oldval,"
             ." :primaryKeys, :primaryVals, :userID, :type)"
         );
-        
+
         if (is_null($this->_HistoryPDO)) {
             if (is_null($historydb)) {
                 $this->_HistoryPDO =& $this->_PDO;

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -184,13 +184,7 @@ class Database extends PEAR
             ." (:histtable, :histcolumn, :newval, :oldval,"
             ." :primaryKeys, :primaryVals, :userID, :type)"
         );
-
-        $this->_PDO = new PDO(
-            "mysql:host=$host;dbname=$database",
-            $username,
-            $password
-        );
-
+        
         if (is_null($this->_HistoryPDO)) {
             if (is_null($historydb)) {
                 $this->_HistoryPDO =& $this->_PDO;


### PR DESCRIPTION
The charset was is not set after the connect function is called. The initialization of the PDO is being set twice, setting the charset in the first initialization but then not setting it the second. The second initialization is not needed as it is already set at that point so it has been removed. 