### PR TITLE
Switched the order of getSetting to have the config.xml take precedence

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -67,20 +67,12 @@ class NDB_Client
 
         include_once "NDB_BVL_Feedback.class.inc";
 
+        // Load the config file.
         $config =& NDB_Config::singleton($configFile);
 
-        // add extra include paths
-        $extLibs = $config->getSetting('extLibs');
-        if (!empty($extLibs)) {
-            set_include_path($extLibs.":".get_include_path());
-        }
-
-        // after the extra includes, as those include Smarty
-        include_once "Smarty_hook.class.inc";
-
-        /*
-        * new DB Object
-        */
+        // Load the database object with settings from config
+        // so that after this we can just call Database::singleton()
+        // with no parameters
         $dbConfig = $config->getSetting('database');
         $DB       =& Database::singleton(
             $dbConfig['database'],
@@ -88,6 +80,19 @@ class NDB_Client
             $dbConfig['password'],
             $dbConfig['host']
         );
+
+        // add extra include paths. This must be done
+        // after the database is connected, since the setting
+        // can come from the database.
+        $extLibs = $config->getSetting('extLibs');
+        if (!empty($extLibs)) {
+            set_include_path($extLibs.":".get_include_path());
+        }
+
+        // This must be done after the extra includes, as those may
+        // include Smarty
+        include_once "Smarty_hook.class.inc";
+
         if (Utility::isErrorX($DB)) {
             die("Could not connect to database: ".$DB->getMessage());
         }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -347,16 +347,16 @@ class NDB_Config
     function getSetting($name)
     {
         try {
-            $DBValue = $this->getSettingFromDB($name);
+            $XMLValue = $this->getSettingFromXML($name);
 
-            if ($DBValue !== null) {
-                return $DBValue;
+            if ($XMLValue !== null) {
+                return $XMLValue;
             }
         } catch(Exception $e) {
         }
 
-        // nothing in the database, so get the value from config.xml
-        return $this->getSettingFromXML($name);
+        // nothing in the config file, so get the value from the DB
+        return $this->getSettingFromDB($name);
     }
 
     /**


### PR DESCRIPTION
This switched the precedence of $config->getSetting(), so that the config.xml overrides the database instead of the other way around. In addition to being better for backwards compatibility with existing projects, this means that you can override settings in a sandbox/testing environment by putting them into your config.xml even if you have a SQL dump of your production server.