### PR TITLE
Fixed singletons loading of config files

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -80,6 +80,9 @@ class NDB_Config
     {
         // load the configuration data into a global variable $config
         $newroot         = simplexml_load_file($configFile);
+        if($newroot === FALSE || $newroot === null) {
+            throw new Exception("Could not load Loris config file $configFile");
+        }
         $this->_settings = NDB_Config::convertToArray($newroot);
     }
 

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -79,10 +79,14 @@ class NDB_Config
     function load($configFile = "../project/config.xml")
     {
         // load the configuration data into a global variable $config
-        $newroot         = simplexml_load_file($configFile);
-        if($newroot === FALSE || $newroot === null) {
-            throw new Exception("Could not load Loris config file $configFile");
+        $newroot = simplexml_load_file($configFile);
+
+        if ($newroot === false || $newroot === null) {
+            throw new Exception(
+                "Could not load Loris config file $configFile"
+            );
         }
+
         $this->_settings = NDB_Config::convertToArray($newroot);
     }
 

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -89,7 +89,10 @@ class NDB_Factory
     }
 
     /**
-     * Return either a real or mock NDB_Config object.
+     * Return either a real or mock NDB_Config object depending on testing
+     * status of this factory object.
+     *
+     * @param string $configfile Location of XML file to parse config from
      *
      * @return NDB_Config A config singleton
      */

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -93,7 +93,7 @@ class NDB_Factory
      *
      * @return NDB_Config A config singleton
      */
-    function config()
+    function config($configfile = "../project/config.xml")
     {
         if (self::$_config !== null) {
             return self::$_config;
@@ -102,11 +102,11 @@ class NDB_Factory
             Mock::generate("NDB_Config");
             $config = new MockNDB_Config();
         } else {
-            $config = new NDB_Config();
+            $config = NDB_Config::singleton($configfile);
         }
 
         self::$_config = $config;
-        $config->load();
+        $config->load($configfile);
         return $config;
     }
 
@@ -164,7 +164,7 @@ class NDB_Factory
             if ($db_ref !== null) {
                 return $db_ref;
             }
-            self::$_db = new Database();
+            self::$_db = Database::singleton();
         }
         $config = $this->config();
         $dbc    = $config->getSetting('database');


### PR DESCRIPTION
There was an issue where, if using the NDB_Factory class, the factory would try and load config using the default "../project/config.xml" config file, regardless of if you tried to initialize the config file to something else (ie. if you're running a script from a different directory.

This change:
1. Makes the factory class have an optional configFile
2. Makes the factory use the class ::singleton instead of new ClassName where applicable
3. Throws an exception if there's a problem parsing the config file (to make debugging easier)