### PR TITLE
Add instrument support to GetCSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,9 @@ script:
     # Run PHPCS on the entire libraries directory.
     - vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries
 
+    # Run PHPCS on htdocs files that have had it run already
+    - vendor/bin/phpcs --standard=docs/LorisCS.xml htdocs/GetCSS.php
+
     # Run PHPCS on specific modules
     - vendor/bin/phpcs --standard=docs/LorisCS.xml modules/mri_upload/php/NDB_Menu_Filter_mri_upload.class.inc
     - vendor/bin/phpcs --standard=docs/LorisCS.xml modules/mri_upload/php/File_Decompress.class.inc

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -3,7 +3,7 @@
  * Controls access to a module's javascript CSS styles on the filesystem. This script
  * should ensure that only files relative to module's path specified are
  * accessible.
- * By calling new NDB_Client(), it also makes sure that the user is logged in to 
+ * By calling new NDB_Client(), it also makes sure that the user is logged in to
  * Loris.
  *
  * It also does validation to make sure required config settings are specified.
@@ -17,7 +17,6 @@
  *  @author   Dave MacFarlane <driusan@bic.mni.mcgill.ca>
  *  @license  Loris license
  *  @link     https://github.com/aces/Loris-Trunk
- *
  */
 
 
@@ -38,17 +37,22 @@ $config =& NDB_Config::singleton();
 $paths  = $config->getSetting('paths');
 
 // Basic config validation
-$basePath    = $paths['base'];
+$basePath = $paths['base'];
 if (empty($basePath)) {
     error_log("ERROR: Config settings are missing");
-    header("HTTP/1.1 500 Internal Server Error"); 
+    header("HTTP/1.1 500 Internal Server Error");
     exit(1);
 }
 
 
 // Now get the file and do file validation
-$Module = $_GET['Module'];
-if (empty($_REQUEST['file'])) {
+$Module     = $_GET['Module'];
+$Instrument = null;
+
+if (!empty($_GET['Instrument'])) {
+    $Instrument = $_GET['Instrument'];
+    $File       = $Instrument . ".css";
+} elseif (empty($_REQUEST['file'])) {
     $File = $Module . ".css";
 } else {
     $File = $_REQUEST['file'];
@@ -71,10 +75,14 @@ if (strpos("..", $File) !== false) {
 }
 
 
-$FullPath = $basePath . "/modules/$Module/css/$File";
+if ($Instrument !== null) {
+    $FullPath = $basePath . "/project/instruments/$File";
+} else {
+    $FullPath = $basePath . "/modules/$Module/css/$File";
+}
 
 if (!file_exists($FullPath)) {
-    error_log("ERROR: File $File does not exist");
+    error_log("ERROR: File $FullPath does not exist");
     header("HTTP/1.1 404 Not Found");
     exit(5);
 }

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -108,13 +108,12 @@ if (!empty($TestName)) {
         $tpl_data['test_name_css'] = "css/$TestName";
     }
 
-    // Used for CSS for a specific instrument. This should eventually be
-    // rolled into the GetCSS wrapper
-    if (file_exists("css/instruments/$TestName.css")) {
+    // Used for CSS for a specific instrument.
+    if (file_exists($paths['base'] . "project/instruments/$TestName.css")) {
         if(strpos($_SERVER['REQUEST_URI'], "main.php") === false) {
             $tpl_data['test_name_css'] = "css/instruments/$TestName.css";
         } else {
-            $tpl_data['test_name_css'] = "GetCSS.php?Module=$TestName";
+            $tpl_data['test_name_css'] = "GetCSS.php?Instrument=$TestName";
         }
     }
 }


### PR DESCRIPTION
This adds the ability for instruments to have their own CSS in the project/instruments directory. Currently, this can be done by putting a css file in htdocs, but since the CSS should go with the instrument (and definitely not be part of a directory that's part of aces/Loris), we update the code to use the new-ish GetCSS wrapper and add instrument support to it, rather than just module support.