### PR TITLE
This ensures that the NDB_Config object is instantiated before use

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -58,6 +58,7 @@ class NDB_Form_user_accounts extends NDB_Form
 
     function _process($values)
     {
+        $config = NDB_Config::singleton();
     	// build the "real name"
     	$values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
     	
@@ -181,7 +182,6 @@ class NDB_Form_user_accounts extends NDB_Form
         }
 
         // get config options relating to proftpd
-        $config =& NDB_Config::singleton();
         $ftpSettings = $config->getSetting("proftpd");
         
         // if proftpd stuff is enabled:


### PR DESCRIPTION
In some code paths in NDB_Form_user_accounts the code may try to access $config->getSetting() before it's been instantiated. This moves the instantiation to the start of the function to ensure that doesn't happen.