### PR TITLE
Adds support for CouchDB bulk transactions to instrument importer

### DIFF
--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -64,6 +64,7 @@ class CouchDBInstrumentImporter {
     function UpdateCandidateDocs($Instruments) {
         $results = array('new' => 0, 'modified' => 0, 'unchanged' => 0);
         foreach($Instruments as $instrument => $name) {
+            $this->CouchDB->beginBulkTransaction();
             $preparedStatement = $this->SQLDB->prepare($this->generateDocumentSQL($instrument), array('inst' => $instrument));
             $preparedStatement->execute();
             while($row = $preparedStatement->fetch(PDO::FETCH_ASSOC)) {
@@ -92,6 +93,7 @@ class CouchDBInstrumentImporter {
                 $results[$success] += 1;
             }
 
+            $result = $this->CouchDB->commitBulkTransaction();
         }
         return $results;
     }


### PR DESCRIPTION
The CouchDB Import script has no reason not to use CouchDB bulk transactions. It increases the efficiency of the script immensely by sending one HTTP request to update all documents in an instrument in bulk, rather than one for each CommentID in the instrument. This has been live in IBIS for quite a while but never merged into Loris.