### PR TITLE
Removed PEAR dependencies installed from composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,27 +10,6 @@ before_install:
 install:
     # Install composer modules
     - composer install --dev
-    # List of PEAR modules installed by install script
-    - pear config-get php_dir
-    # Currently commented out because all we do is run
-    # PHPCS and php -l on the code from Travis.
-    #- pear upgrade
-    - pear install Benchmark
-    #- pear install Config
-    #- pear install File_Archive
-    #- pear install HTML_Common
-    - pear install HTML_QuickForm
-    - pear config-set preferred_state beta
-    #- pear install HTML_QuickForm2
-    #- pear install Mail
-    #- pear install Mail_Mime
-    #- pear install Net_SMTP
-    #- pear install OLE
-    - pear install Pager
-    #- pear install PHPDocumentor
-    #- pear install XML_Parser
-
-    # Travis-CI requires this.
     - phpenv rehash
 
       # Download a Selenium Web Driver release


### PR DESCRIPTION
Travis spends a lot of time downloading PEAR libraries, when are now loaded from composer. This removes them to speed up the build process instead of downloading/installing each PEAR module twice.