### PR TITLE
Requiring vendor autoload for some files in htdocs

### DIFF
--- a/htdocs/GetStatic.php
+++ b/htdocs/GetStatic.php
@@ -28,6 +28,7 @@ set_include_path(
     __DIR__ . "/../php/libraries"
 );
 
+require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -29,6 +29,7 @@ set_include_path(
 // inline. They'll still show up in the Apache logs.
 ini_set("display_errors", "Off");
 
+require_once __DIR__ . "/../../../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();


### PR DESCRIPTION
This was causing get_file.php and Brain Browser to fail