### PR TITLE
Throw an exception if trying to check invalid permission

### DIFF
--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -78,8 +78,8 @@ class UserPermissions
         $DB =& Database::singleton();
 
         // get all the permissions for this user
-        $query = "SELECT code FROM permissions, user_perm_rel
-            WHERE permissions.permID = user_perm_rel.permID AND userID = :UID";
+        $query = "SELECT p.code, pr.userID FROM permissions p
+                    LEFT JOIN user_perm_rel pr ON (p.permID=pr.permID AND pr.userID=:UID)";
 
         $results = $DB->pselect($query, array('UID' => $this->userID));
 
@@ -88,7 +88,11 @@ class UserPermissions
 
         // fill the array
         foreach ($results AS $row) {
-            $this->permissions[$row['code']] = true;
+            if(!empty($row['userID']) && $row['userID'] === $this->userID) {
+                $this->permissions[$row['code']] = true;
+            } else {
+                $this->permissions[$row['code']] = false;
+            }
         }
 
         return true;
@@ -104,7 +108,11 @@ class UserPermissions
      */
     function hasPermission($code)
     {
-        if (isset($this->permissions[$code]) && $this->permissions[$code] === true) {
+        if (!isset($this->permissions[$code]))
+        {
+            throw new ConfigurationException("Invalid permission code $code");
+        }
+        if ($this->permissions[$code] === true) {
             return true;
         }
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -79,7 +79,8 @@ class UserPermissions
 
         // get all the permissions for this user
         $query = "SELECT p.code, pr.userID FROM permissions p
-                    LEFT JOIN user_perm_rel pr ON (p.permID=pr.permID AND pr.userID=:UID)";
+            LEFT JOIN user_perm_rel pr
+            ON (p.permID=pr.permID AND pr.userID=:UID)";
 
         $results = $DB->pselect($query, array('UID' => $this->userID));
 
@@ -88,7 +89,9 @@ class UserPermissions
 
         // fill the array
         foreach ($results AS $row) {
-            if(!empty($row['userID']) && $row['userID'] === $this->userID) {
+            if (!empty($row['userID'])
+                && $row['userID'] === $this->userID
+            ) {
                 $this->permissions[$row['code']] = true;
             } else {
                 $this->permissions[$row['code']] = false;
@@ -108,8 +111,7 @@ class UserPermissions
      */
     function hasPermission($code)
     {
-        if (!isset($this->permissions[$code]))
-        {
+        if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
         }
         if ($this->permissions[$code] === true) {


### PR DESCRIPTION
This modifies the hasPermission function to throw an exception if the permission being checked does not exist in the permissions table. This should help detect misconfigured Loris instances (such as ones missing a patch) more proactively, instead of silently failing.

Tagged as Caveat because misconfigured Loris instances may start failing with this patch merged.