### PR TITLE
Fix PHP warnings generated on login from dashboard AJAX calls

### DIFF
--- a/modules/dashboard/ajax/get_recruitment_bar_data.php
+++ b/modules/dashboard/ajax/get_recruitment_bar_data.php
@@ -25,17 +25,17 @@ $client->initialize();
 
 $DB =& Database::singleton();
 $genderData = array();
-$list_of_sites =& Utility::getSiteList();
+$list_of_sites = Utility::getSiteList();
 foreach ($list_of_sites as $site) {
     $genderData['labels'][] = $site;
     $genderData['datasets']['female'][] = $DB->pselectOne(
-        "SELECT count(c.CandID) FROM candidate c 
-        LEFT JOIN psc ON (psc.CenterID=c.CenterID) 
+        "SELECT count(c.CandID) FROM candidate c
+        LEFT JOIN psc ON (psc.CenterID=c.CenterID)
         WHERE c.Gender='female' AND c.Active='Y' AND psc.Name=:Site", array('Site' => $site)
     );
     $genderData['datasets']['male'][] = $DB->pselectOne(
-        "SELECT count(c.CandID) FROM candidate c 
-        LEFT JOIN psc ON (psc.CenterID=c.CenterID) 
+        "SELECT count(c.CandID) FROM candidate c
+        LEFT JOIN psc ON (psc.CenterID=c.CenterID)
         WHERE c.Gender='male' AND c.Active='Y' AND psc.Name=:Site", array('Site' => $site)
     );
 }

--- a/modules/dashboard/ajax/get_recruitment_line_data.php
+++ b/modules/dashboard/ajax/get_recruitment_line_data.php
@@ -32,9 +32,9 @@ $recruitmentStartDate = $DB->pselectOne(
 $recruitmentEndDate = $DB->pselectOne(
     "SELECT max(Date_registered) FROM candidate", array()
 );
-$recruitmentData['labels'] 
+$recruitmentData['labels']
     = createChartLabels($recruitmentStartDate, $recruitmentEndDate);
-$list_of_sites =& Utility::getSiteList();
+$list_of_sites = Utility::getSiteList();
 foreach ($list_of_sites as $dataset) {
     $recruitmentData['datasets'][] = array(
         "name" => $dataset,

--- a/modules/dashboard/ajax/get_recruitment_pie_data.php
+++ b/modules/dashboard/ajax/get_recruitment_pie_data.php
@@ -23,13 +23,13 @@ $client->initialize();
 
 $DB =& Database::singleton();
 $recruitmentBySiteData = array();
-$list_of_sites =& Utility::getSiteList();
+$list_of_sites = Utility::getSiteList();
 foreach ($list_of_sites as $site) {
     $recruitmentBySiteData[] = array(
         "label" => $site,
         "total" => $DB->pselectOne(
-            "SELECT count(c.CandID) 
-            FROM candidate c LEFT JOIN psc ON (psc.CenterID=c.CenterID) 
+            "SELECT count(c.CandID)
+            FROM candidate c LEFT JOIN psc ON (psc.CenterID=c.CenterID)
             WHERE c.Active='Y' AND psc.Name=:Site", array('Site' => $site)
         )
     );

--- a/modules/dashboard/ajax/get_scan_line_data.php
+++ b/modules/dashboard/ajax/get_scan_line_data.php
@@ -32,9 +32,9 @@ $scanStartDate = $DB->pselectOne(
 $scanEndDate = $DB->pselectOne(
     "SELECT max(AcquisitionDate) FROM mri_acquisition_dates", array()
 );
-$scanData['labels'] 
+$scanData['labels']
     = createChartLabels($scanStartDate, $scanEndDate);
-$list_of_sites =& Utility::getSiteList();
+$list_of_sites = Utility::getSiteList();
 foreach ($list_of_sites as $dataset) {
     $scanData['datasets'][] = array(
         "name" => $dataset,


### PR DESCRIPTION
There are 4 PHP E_STRICT warnings generated by the dashboard on every login. This addresses those to keep the error logs cleaner.