### PR TITLE
Added instrumentPermissions to sample config.xml

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -181,4 +181,28 @@
         <showDatabaseQueries>0</showDatabaseQueries>
     </gui>
 
+    <!-- used by _hasAccess in NDB_BVL_Instrument to determine
+         what permissions should be required for each instrument
+         on a configurable basis. -->
+    <instrumentPermissions>
+        <!-- By default anyone has permission -->
+        <useInstrumentPermissions>false</useInstrumentPermissions>
+        <!-- Add one instrument tag for each instrument that is
+             having it's permissions configured. If an instrument
+             is missing, the default is for users to have access
+             -->
+        <instrument>
+            <!-- Instrument name -->
+            <Test_name>sampleInstrument</Test_name>
+            <!-- Permission required for accessing instrument.
+                 If multiple permissions are added, *any* of
+                 them individually will allow access to the
+                 instrument -->
+            <permission>sampleInstrumentPermissionName</permission>
+        </instrument>
+        <instrument>
+            <Test_name>sampleInstrument2</Test_name>
+            <permission>sampleInstrument2PermissionName</permission>
+        </instrument>
+    </instrumentPermissions>
 </config>


### PR DESCRIPTION
The lack of this tag currently causes Loris to crash when
an instrument's hasAccess method tries to retrieve it. 

Note that it should be added to any existing project's config.xml
file to prevent Loris from throwing ConfigurationExceptions.