### PR TITLE
Add vendor directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ smarty/templates_c
 .gitmodules
 project-*
 *.un~
+vendor


### PR DESCRIPTION
Composer creates a vendor directory containing LORIS dependencies, which should not be included in our repository.