### PR TITLE
More flexible config loading

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -47,7 +47,7 @@ class NDB_Client
     *
     * @return true on success
     */
-    function initialize($configFile = "../project/config.xml")
+    function initialize($configFile = null)
     {
         // require all relevant OO class libraries
         include_once "NDB_Config.class.inc";
@@ -68,7 +68,7 @@ class NDB_Client
         include_once "NDB_BVL_Feedback.class.inc";
 
         // Load the config file.
-        $config =& NDB_Config::singleton($configFile);
+        $config = NDB_Config::singleton($configFile);
 
         // Load the database object with settings from config
         // so that after this we can just call Database::singleton()

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -58,10 +58,29 @@ class NDB_Config
      *
      * @return NDB_Config object
      */
-    static function &singleton($configFile = "../project/config.xml")
+    static function &singleton($configFile = null)
     {
         static $config = null;
         if (is_null($config)) {
+            // If calling singleton without any parameter, first check
+            // for a project/config.xml, then check for the config
+            // file in a standard unix filesystem location.
+            // /etc/loris/config.xml
+            if($configFile === null) {
+                if (file_exists(__DIR__ "/../../project/config.xml")) {
+                    // "Classic" Loris location of project directory
+                    // parallel to php directory
+                    $configFile = __DIR__ . "/../../loris/config.xml";
+                } else if (file_exists("/etc/loris/config.xml")) {
+                    // Standard Unix filesystem layout
+                    $configFile = "/etc/loris/config.xml";
+                } else if (file_exists("/usr/local/etc/loris/config.xml")) {
+                    // Standard Unix filesystem layout, option 2
+                    $configFile = "/usr/local/etc/loris/config.xml";
+                }
+            }
+
+            // Load the file
             $config  = new NDB_Config();
             $success = $config->load($configFile);
         }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -66,9 +66,12 @@ class NDB_Config
             // for a project/config.xml, then check for the config
             // file in a standard unix filesystem location.
             // /etc/loris/config.xml
-            if($configFile === null) {
-                if(!empty(getenv('LORIS_CONFIG'))) {
-                    $configFile = getenv('LORIS_CONFIG');
+            if ($configFile === null) {
+                // Can't directly check !empty because of a bug
+                // in PHP < 5.5, need to assign to a variable first
+                $env = getenv('LORIS_CONFIG');
+                if (!empty($env)) {
+                    $configFile = $env;
                 } else if (file_exists(__DIR__ . "/../../project/config.xml")) {
                     // "Classic" Loris location of project directory
                     // parallel to php directory

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -67,7 +67,9 @@ class NDB_Config
             // file in a standard unix filesystem location.
             // /etc/loris/config.xml
             if($configFile === null) {
-                if (file_exists(__DIR__ "/../../project/config.xml")) {
+                if(!empty(getenv('LORIS_CONFIG'))) {
+                    $configFile = getenv('LORIS_CONFIG');
+                } else if (file_exists(__DIR__ . "/../../project/config.xml")) {
                     // "Classic" Loris location of project directory
                     // parallel to php directory
                     $configFile = __DIR__ . "/../../loris/config.xml";

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -75,7 +75,7 @@ class NDB_Config
                 } else if (file_exists(__DIR__ . "/../../project/config.xml")) {
                     // "Classic" Loris location of project directory
                     // parallel to php directory
-                    $configFile = __DIR__ . "/../../loris/config.xml";
+                    $configFile = __DIR__ . "/../../project/config.xml";
                 } else if (file_exists("/etc/loris/config.xml")) {
                     // Standard Unix filesystem layout
                     $configFile = "/etc/loris/config.xml";


### PR DESCRIPTION
This adds support for multiple different ways to load the Loris config (and as a side-effect opens the possibility of multiple loris instances on a single host using the same version of Loris).

Instead of just looking for ../project/config.xml, it searches in the following order:

1. If a LORIS_CONFIG environment setting is set, use that config file.
2. Next, check for __DIR__  . "../../project/config.xml" (relative to the php/libraries where NDB_Config is located). This should be the same behaviour as currently, but more robust if a script is located outside of htdocs/ or tools/
3. Next, check for /etc/loris/config.xml
4. Next, check for /usr/local/etc/loris/config.xml