### PR TITLE
Updated quickform_parser and data_dictionary_builder to use Loris framework

### DIFF
--- a/tools/data_dictionary_builder.php
+++ b/tools/data_dictionary_builder.php
@@ -37,48 +37,16 @@
  * @subpackage query_gui
  */
 
-  set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+set_include_path(get_include_path().":../project/libraries:../php/libraries:");
 
-//Ensure php version compatability
-//taken from php.net notes
-if (version_compare(phpversion(),'4.3.0','<'))
-{
-    define('STDIN',fopen("php://stdin","r"));
-    register_shutdown_function( create_function( '' , 'fclose(STDIN);
-    fclose(STDOUT); fclose(STDERR); return true;' ) );
-}
-
-
-// PEAR::Config
-require_once "Config.php";
+require_once __DIR__ . "/../vendor/autoload.php";
+$configFile = "../project/config.xml";
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize($configFile);
+$DB = Database::singleton();
 
 // define which configuration file we're using for this installation
-$configFile = "../project/config.xml";
-
-// load the configuration data into a global variable $config
-$configObj = new Config;
-$root =& $configObj->parseConfig($configFile, "XML");
-if(PEAR::isError($root)) {
-    die("Config error: ".$root->getMessage());
-}
-$configObj =& $root->searchPath(array('config'));
-$config =& $configObj->toArray();
-$config = $config['config'];
-unset($configObj, $root);
-
-// require all relevant OO class libraries
-require_once "../php/libraries/Database.class.inc";
-require_once "../php/libraries/NDB_Config.class.inc";
-
-/*
-* new DB Object
-*/
-$DB =& Database::singleton($config['database']['database'], $config['database']['username'], $config['database']['password'], $config['database']['host']);
-if(PEAR::isError($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-    die();
-}
-
 //Get the entries we already have in the DB
 getColumns("Select Name, ParameterTypeID from parameter_type", $DB, $parameter_types);
 

--- a/tools/quickform_parser.php
+++ b/tools/quickform_parser.php
@@ -10,47 +10,14 @@
  * @package behavioural
  */
 
-
-//Ensure php version compatability
-//taken from php.net notes
-if (version_compare(phpversion(),'4.3.0','<')) 
-{
-    define('STDIN',fopen("php://stdin","r"));
-    register_shutdown_function( create_function( '' , 'fclose(STDIN);
-    fclose(STDOUT); fclose(STDERR); return true;' ) );
-}
-
-
-// PEAR::Config
-require_once "Config.php";
-
-
-//allow instruments to find libraries
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
 
-// define which configuration file we're using for this installation
-$configFile = "../project/config.xml";
+require_once __DIR__ . "/../vendor/autoload.php";
 
-// load the configuration data into a global variable $config
-$configObj = new Config;
-$root =& $configObj->parseConfig($configFile, "XML");
-if(PEAR::isError($root)) {
-    die("Config error: ".$root->getMessage());
-}
-$configObj =& $root->searchPath(array('config'));
-$config =& $configObj->toArray();
-$config = $config['config'];
-unset($configObj, $root);
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize("../project/config.xml");
 
-// require all relevant OO class libraries
-require_once "Database.class.inc";
-require_once "NDB_Config.class.inc";
-require_once "NDB_BVL_Instrument.class.inc";
-require_once "Candidate.class.inc";
-
-
-////////instruments to be excluded
- 
 $instrumentsToSkip = array();
 $instruments = getExcludedInstruments();
 foreach ($instruments as $instrument) {
@@ -58,16 +25,6 @@ foreach ($instruments as $instrument) {
         $instrumentsToSkip[] = $instrument;
     }
 }
-
-/*
- * new DB Object
- */
-$DB =& Database::singleton($config['database']['database'], $config['database']['username'], $config['database']['password'], $config['database']['host']);
-if(PEAR::isError($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-    die();
-}
-
 
 //Get the list of files from STDIN
 while($file=fgets(STDIN)){


### PR DESCRIPTION
The quickform parser and data dictionary scripts try to use some Config.php file(?) instead of Loris's NDB_Config object to create a database session. This updates the two scripts to work in a more Loris-idiomatic way and use NDB_Client to initialize the config and database objects.