### PR TITLE
This fixes some PHP warnings that are being generated by Loris

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -496,7 +496,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
         $this->addScoreColumn('pscid', 'PSCID');
         $this->tpl_data['pscid'] = $pscid;
 
-        $options = $this->getParticipantStatusOptions();
+        $options = self::getParticipantStatusOptions();
         $options = array('') + $options;
         $this->tpl_data['pstatus_options'] = $options;
         $this->tpl_data['pstat'] = $_REQUEST['participant_status'];
@@ -595,9 +595,9 @@ class NDB_Form_candidate_parameters extends NDB_Form
         $this->tpl_data['pscid'] = $pscid;
         $parentID = $DB->pselectOne('SELECT participant_status FROM participant_status Where CandID = :candid',
                                      array('candid'=>$this->identifier));
-        $sub_options = $this->getParticipantStatusSubOptions($parentID);
+        $sub_options = self::getParticipantStatusSubOptions($parentID);
         $sub_options = array('') + $sub_options;
-        $options = $this->getParticipantStatusOptions();
+        $options = self::getParticipantStatusOptions();
       //  $options = array('') + $options;
         $this->tpl_data['pstatus_options'] = $options;
         $this->tpl_data['pstatus_suboptions'] = $sub_options;
@@ -806,7 +806,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
     { 
         $config =& NDB_Config::singleton();
         $errors=array();
-        $options = $this->getParticipantStatusOptionsVerbose();
+        $options = self::getParticipantStatusOptionsVerbose();
 
         $DB =& Database::singleton();
         if($fields['ProbandDoB']['M'] != $fields['ProbandDoB2']['M'] ||
@@ -901,7 +901,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
      * @return array Options array suitable for use in QuickForm select
      *               element
      */
-    function getParticipantStatusOptions()
+    static function getParticipantStatusOptions()
     {
         $DB =& Database::singleton();
         $options = $DB->pselect(
@@ -923,7 +923,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
      *               the entire row from participant_status_options instead of
      *               only the description
      */
-    function getParticipantStatusOptionsVerbose()
+    static function getParticipantStatusOptionsVerbose()
     {
         $DB =& Database::singleton();
         $options = $DB->pselect(
@@ -947,7 +947,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
      * @return array Options array suitable for use in QuickForm select
      *               element
      */
-    function getParticipantStatusSubOptions($parentID)
+    static function getParticipantStatusSubOptions($parentID)
     {
         $DB =& Database::singleton();
         $options = $DB->pselect(

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -308,7 +308,11 @@ class NDB_Menu_Filter extends NDB_Menu
             // the filters values remain populated correctly in the front-end,
             // not just in the query..
             $defaults = $this->_getDefaults();
-            $this->_setDefaults(array_merge($defaults, $savedFilters));
+            if(is_array($savedFilters)) {
+                $this->_setDefaults(array_merge($defaults, $savedFilters));
+            } else {
+                $this->_setDefaults($defaults);
+            }
         } else if ($_SERVER['REQUEST_METHOD'] === 'POST'
             && isset($_POST['filter'])
         ) {

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -308,7 +308,7 @@ class NDB_Menu_Filter extends NDB_Menu
             // the filters values remain populated correctly in the front-end,
             // not just in the query..
             $defaults = $this->_getDefaults();
-            if(is_array($savedFilters)) {
+            if (is_array($savedFilters)) {
                 $this->_setDefaults(array_merge($defaults, $savedFilters));
             } else {
                 $this->_setDefaults($defaults);


### PR DESCRIPTION
There's a few pages which generate warnings in the PHP logs, but they're mostly hidden by the number of warnings created by HTML_QuickForm. This fixes (some of?) the ones that come from Loris.