### PR TITLE
Removed claims to throw PEAR_Error, which mostly aren't true anyways

### DIFF
--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -233,7 +233,6 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
      * Sets the template data for the list of candidates, users, etc.
      *
      * @return void
-     * @throws PEAR_Error
      * @access private
      */
     function _setDataTable()

--- a/modules/help_editor/php/HelpFile.class.inc
+++ b/modules/help_editor/php/HelpFile.class.inc
@@ -29,7 +29,6 @@ class HelpFile extends PEAR
      *
      * @param  int         Help file's ID
      * @return HelpFile
-     * @throws PEAR_Error
      * @access public
      */
     function &factory($helpID)
@@ -57,7 +56,6 @@ class HelpFile extends PEAR
      *
      * @param  array       Associative array of values
      * @return int         New help file's ID
-     * @throws PEAR_Error
      * @access public
      * @static
      */
@@ -78,7 +76,6 @@ class HelpFile extends PEAR
      *
      * @param  array       Associative array of values
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function update($set)
@@ -98,7 +95,6 @@ class HelpFile extends PEAR
      *
      * @param  array       Array of related help file IDs
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function addLinks($relatedIDs)
@@ -123,7 +119,6 @@ class HelpFile extends PEAR
      *
      * @param  array       Array of related help file IDs
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function removeLinks($relatedIDs)
@@ -151,7 +146,6 @@ class HelpFile extends PEAR
      *
      * @param  array       Array of related help file IDs
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function updateLinks($relatedIDs)
@@ -174,7 +168,6 @@ class HelpFile extends PEAR
      * Returns whether or not the topic has subtopics
      *
      * @return bool
-     * @throws PEAR_Error
      * @access public
      */
     function hasChild()
@@ -193,7 +186,6 @@ class HelpFile extends PEAR
      * @param  int         Stop at this depth
      * @param  int         Depth
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function childIDs($stopat = 1, $level = 1)
@@ -383,7 +375,6 @@ class HelpFile extends PEAR
      * Returns an array of its related link's IDs
      *
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function relationIDs()
@@ -408,7 +399,6 @@ class HelpFile extends PEAR
      * Returns an array of its related links' IDs and topics
      *
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function relationData()
@@ -513,7 +503,6 @@ class HelpFile extends PEAR
      * Dumps the HelpFile as an array
      *
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function toArray()

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -146,7 +146,6 @@ class Imaging_Session_ControlPanel
      *
      * @return string
      * @access public
-     * @throws PEAR_Error
      */
     function display()
     {

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -19,7 +19,6 @@ Class Instrument_List_ControlPanel extends TimePoint
      * generates the HTML to display the set of buttons for the timepoint status flags
      * @return string
      * @access public
-     * @throws PEAR_Error
      */
     function display()
     {
@@ -74,7 +73,6 @@ Class Instrument_List_ControlPanel extends TimePoint
      * saves changes to the session table based on interaction with the control panel
      * @return void
      * @access public
-     * @throws PEAR_Error
      */
     function save()
     {
@@ -258,7 +256,6 @@ Class Instrument_List_ControlPanel extends TimePoint
      * generates the HTML to display the set of buttons for the Time Point status update 
      * @return string
      * @access private
-     * @throws PEAR_Error
      */
     function _displayStatus()
     {
@@ -414,7 +411,6 @@ Class Instrument_List_ControlPanel extends TimePoint
      * generates the HTML to display the set of buttons for the Time Point status update
      * @return string
      * @access private
-     * @throws PEAR_Error
      */
     function _displayBVLQCStatus()
     {
@@ -439,7 +435,6 @@ Class Instrument_List_ControlPanel extends TimePoint
      * generates the HTML to display the set of buttons for the Time Point status update 
      * @return string
      * @access private
-     * @throws PEAR_Error
      */
     function _displaySendToDCC()
     {

--- a/modules/timepoint_flag/php/NDB_Menu_Filter_timepoint_flag.class.inc
+++ b/modules/timepoint_flag/php/NDB_Menu_Filter_timepoint_flag.class.inc
@@ -39,7 +39,6 @@ class NDB_Menu_Filter_timepoint_flag extends NDB_Menu_Filter
     * Overwriting this menu to call the _save method b/c this menu containg a form
     *
     * @return void
-    * @throws PEAR_Error
     * @access public
     */
     function setup()
@@ -381,7 +380,6 @@ class NDB_Menu_Filter_timepoint_flag extends NDB_Menu_Filter
     * checks the form element and if the status was set/changed updates the record
     *
     * @return void
-    * @throws PEAR_Error
     * @access public
     */
     function _save()
@@ -473,7 +471,6 @@ class NDB_Menu_Filter_timepoint_flag extends NDB_Menu_Filter
     * @param int SessionID
     * @param string name of the flag
     * @return array flag info
-    * @throws PEAR_error
     * @access private
     */
     function _getCurrentFlagInfo($sessionID, $flagName)
@@ -487,7 +484,6 @@ class NDB_Menu_Filter_timepoint_flag extends NDB_Menu_Filter
     * generates tpl_data elements for the talbe with the flag to evaluate timepoint exclusions
     * @return bool
     * @access private
-    * @throws PEAR_Error
     */
     function _displayEvaluateTimepoint($sessionID)
     {
@@ -543,7 +539,6 @@ class NDB_Menu_Filter_timepoint_flag extends NDB_Menu_Filter
     /**
     * returns true if the user has a permission to evaluate timepoint overall exclusion
     * @return bool
-    * @throws PEAR_Error
     */
     function _hasAccess_EvaluateTimepoint()
     {

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -182,7 +182,6 @@ class Candidate
      * @param string $PSCID       PSCID specified by the user, if available
      *
      * @return int   $candID      candidate id of the new candidate
-     * @throws PEAR::Error
      * @static
      */
     static function createNew($centerID, $dateOfBirth, $edc, $gender, $PSCID=null)
@@ -466,7 +465,6 @@ class Candidate
      * Returns the list of visit labels w/ corresponding SessionID as key
      *
      *@return array Associative array in the format SessionID=>Visit_label
-     *@throws PEAR:Error
      */
     function getListOfVisitLabels()
     {
@@ -495,7 +493,6 @@ class Candidate
      *
      * @return     integer Next visit number for candidate
      * @deprecated
-     *@throws     PEAR:Error
      */
     function getNextVisitNo()
     {
@@ -520,7 +517,6 @@ class Candidate
      * can be called statically
      *
      * @return string Next suggested visit label
-     * @throws PEAR:Error
      */
     function getNextVisitLabel()
     {
@@ -571,7 +567,6 @@ class Candidate
      * project
      *
      * @return array Array of the form SubprojectID => SubprojectID
-     * @throws PEAR::Error
      */
     function getValidSubprojects()
     {
@@ -617,7 +612,6 @@ class Candidate
     * Generates a new random CandID
     *
     * @return integer An unused random 6 digit candidate id
-    * @throws PEAR::Error
     */
     static function _generateCandID()
     {
@@ -645,7 +639,6 @@ class Candidate
     * @param string $prefix The prefix to use for the PSCID
     *
     * @return string Project candidate id in format defined by config.xml
-    * @throws PEAR::Error
     */
     static function _generatePSCID($prefix)
     {
@@ -686,7 +679,6 @@ class Candidate
      * This is based on _generatePSCID.
      *
      * @return string Anonymized ExternalID for distributing data
-     * @throws PEAR::Error
      */
     function _generateExternalID()
     {

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -83,7 +83,6 @@ class FeedbackMRI
      * Clears all comments from the object
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function clearAllComments()

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -155,7 +155,6 @@ class NDB_BVL_Feedback
      * to be able to complete various queries.
      *
      * @return void
-     * @throws PEAR::Error
      */
     function _setCandidateProfileInfo()
     {
@@ -225,7 +224,6 @@ class NDB_BVL_Feedback
      * Returns an array of feedback types array format: [Type][Name, Label]
      *
      * @return array
-     * @throws PEAR::Error
      */
     function getFeedbackTypes()
     {
@@ -253,7 +251,6 @@ class NDB_BVL_Feedback
      * @param integer $feedbackID ID of the thread whose type we want to get
      *
      * @return string feedback type of the thread
-     * @throws PEAR::Error
      * @fixme  This seems to try selecting a column that doesn't exist in Loris?
      */
     function getThreadType($feedbackID)
@@ -773,7 +770,6 @@ class NDB_BVL_Feedback
      * @param integer $feedbackID The ID of the feedback thread being closed
      *
      * @return void
-     * @throws PEAR::Error
      * FIXME: deleteTread is spelled wrong. Find all references (none?) and
      *        rename or delete this function if it's unused
      */

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -170,7 +170,6 @@ class NDB_BVL_Instrument extends NDB_Page
      *                                  missing.
      *
      * @return object the new object of $instrument type
-     * @throws PEAR:error
      * @access public
      */
     function factory($instrument, $commentID, $page, $guarantee_exists = true)
@@ -1022,7 +1021,6 @@ class NDB_BVL_Instrument extends NDB_Page
      * Gets a list of subtests of the current instrument
      *
      * @return array
-     * @throws PEAR::Error
      */
     function getSubtestList()
     {

--- a/php/libraries/NDB_Breadcrumb.class.inc
+++ b/php/libraries/NDB_Breadcrumb.class.inc
@@ -140,7 +140,6 @@ class NDB_Breadcrumb extends PEAR
      * Makes a breadcrumb
      *
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function getBreadcrumb()

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -51,7 +51,6 @@ class NDB_Caller extends PEAR
      * Singleton method
      *
      * @return NDB_Caller
-     * @throws PEAR_Error
      * @access public
      * @static
      */

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -128,7 +128,6 @@ class NDB_Form extends NDB_Page
      * saves the validated data into the database
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function save()

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -126,7 +126,6 @@ class NDB_Menu_Filter extends NDB_Menu
      * Calls other member functions to do all the work necessary to create the menu
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function setup()
@@ -350,7 +349,6 @@ class NDB_Menu_Filter extends NDB_Menu
      * Contructs the menu
      *
      * @return void
-     * @throws PEAR_Error
      * @access private
      */
     function _build()
@@ -431,7 +429,6 @@ class NDB_Menu_Filter extends NDB_Menu
      * Returns a list of candidates, users, etc.
      *
      * @return array
-     * @throws PEAR_Error
      * @access private
      */
     function _getList()
@@ -576,7 +573,6 @@ class NDB_Menu_Filter extends NDB_Menu
      * Sets the template data for the list of candidates, users, etc.
      *
      * @return void
-     * @throws PEAR_Error
      * @access private
      */
     function _setDataTable()

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -38,7 +38,6 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
      * saves the validated data into the database
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function save()

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -129,7 +129,6 @@ class NDB_Reliability extends NDB_Form
      * saves the validated data into the database
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function save()

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -161,7 +161,6 @@ class SinglePointLogin extends PEAR
      * Saves the new password if last was expired
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function save()
@@ -221,7 +220,6 @@ class SinglePointLogin extends PEAR
      * Checks whether a given username and password are valid
      *
      * @return bool
-     * @throws PEAR_Error
      * @access public
      */
     function authenticate()

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -42,7 +42,6 @@ class User extends UserPermissions
      * @param string $username Identifies the user
      *
      * @return User
-     * @throws PEAR_Error
      * @access public
      */
     static function &factory($username)
@@ -79,7 +78,6 @@ class User extends UserPermissions
      * @param string $username Identifies the user
      *
      * @return User
-     * @throws PEAR_Error
      * @access public
      * @static
      */
@@ -99,7 +97,6 @@ class User extends UserPermissions
      * @param array $set The array formatted for use in a Database call
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      * @static
      */
@@ -120,7 +117,6 @@ class User extends UserPermissions
      * @param array $set The array formatted for use in a Database call
      *
      * @return void
-     * @throws PEAR_Error
      * @access public
      */
     function update($set)

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -69,7 +69,6 @@ class UserPermissions
      * Loads the users's permissions
      *
      * @return void
-     * @throws PEAR_Error
      * @access private
      */
     function setPermissions()
@@ -212,7 +211,6 @@ class UserPermissions
      * Returns an array of the user's permission IDs
      *
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function getPermissionIDs()
@@ -235,7 +233,6 @@ class UserPermissions
      * Returns an array with all permissions information for the user
      *
      * @return array
-     * @throws PEAR_Error
      * @access public
      */
     function getPermissionsVerbose()

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -156,7 +156,6 @@ class Utility extends PEAR
      * Returns a list of available ethnicities that can be assigned to subjects
      *
      * @return  array       an associative array("ethnicity" => "ethnicity")
-     * @throws  PEAR_Error
      * @access  public
      * @static
      * @note    This is no longer used and should be removed
@@ -184,7 +183,6 @@ class Utility extends PEAR
      * Returns a list of existing ethnicities of all candidates
      *
      * @return  array       an associative array("ethnicity" => "ethnicity")
-     * @throws  PEAR_Error
      * @access  public
      * @static
      * @note    This is no longer used and should be removed
@@ -301,7 +299,6 @@ class Utility extends PEAR
     /**
      * Returns a list of study Subprojects
      *
-     * @throws PEAR_Error
      * @return array       an associative array("SubprojectID" => "Subproject title")
      */
     static function getSubprojectList()


### PR DESCRIPTION
This begins the process of updating our code to not reference PEAR, since we now use real PHP exceptions instead of fake PEAR Error exceptions. We start by only removing comments referencing PEAR_Error.