### PR TITLE
More useful SQL error messages

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -189,6 +189,12 @@ try {
 } catch(ConfigurationException $e) {
     header("HTTP/1.1 500 Internal Server Error");
     $tpl_data['error_message'][] = $e->getMessage();
+} catch(DatabaseException $e) {
+    header("HTTP/1.1 500 Internal Server Error");
+    $tpl_data['error_message'][] = $e->getMessage();
+    $tpl_data['error_message'][] = "Query: " . $e->query;
+    $tpl_data['error_message'][] = "Bind parameters: " . print_r($e->params, true);
+
 } catch(Exception $e) {
     switch($e->getCode()) {
     case 404: header("HTTP/1.1 404 Not Found");

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -192,9 +192,11 @@ try {
 } catch(DatabaseException $e) {
     header("HTTP/1.1 500 Internal Server Error");
     $tpl_data['error_message'][] = $e->getMessage();
-    $tpl_data['error_message'][] = "Query: " . $e->query;
+    $tpl_data['error_message'][] = "Query: <pre>" . $e->query . "</pre>";
     $tpl_data['error_message'][] = "Bind parameters: " . print_r($e->params, true);
-
+    $tpl_data['error_message'][] = "Stack Trace: <pre>"
+        . $e->getTraceAsString()
+        . "</pre>";
 } catch(Exception $e) {
     switch($e->getCode()) {
     case 404: header("HTTP/1.1 404 Not Found");

--- a/php/exceptions/DatabaseException.class.inc
+++ b/php/exceptions/DatabaseException.class.inc
@@ -38,9 +38,9 @@ class DatabaseException extends LorisException
      */
     function __construct($msg, $query = '', $bindparams = array())
     {
-        parent::__construct();
+        parent::__construct($msg);
         $this->query  = $query;
-        $this->params = $query;
+        $this->params = $bindparams;
     }
 }
 ?>

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -554,7 +554,7 @@ class Database extends PEAR
     function execute($prepared, $params)
     {
         $execRun = $prepared->execute($params);
-        if($execRun === FALSE) {
+        if ($execRun === false) {
             $err = $prepared->errorInfo();
             throw new DatabaseException($err[2], $prepared->queryString, $params);
         }
@@ -576,7 +576,7 @@ class Database extends PEAR
     function pselect($query, $params)
     {
         $this->_printQuery($query, $params);
-        $stmt = $this->prepare($query);
+        $stmt   = $this->prepare($query);
         $result = $this->execute($stmt, $params);
         return $result;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -554,7 +554,12 @@ class Database extends PEAR
     function execute($prepared, $params)
     {
         $execRun = $prepared->execute($params);
-        $rows    = $prepared->fetchAll(PDO::FETCH_ASSOC);
+        if($execRun === FALSE) {
+            $err = $prepared->errorInfo();
+            throw new DatabaseException($err[2], $prepared->queryString, $params);
+        }
+
+        $rows = $prepared->fetchAll(PDO::FETCH_ASSOC);
         return $rows;
     }
     /**
@@ -572,7 +577,8 @@ class Database extends PEAR
     {
         $this->_printQuery($query, $params);
         $stmt = $this->prepare($query);
-        return $this->execute($stmt, $params);
+        $result = $this->execute($stmt, $params);
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This fixes a bug where the database wrapper wasn't throwing an exception on an invalid SQL statement. It now throws an exception and properly handles it in main.php so that you can see the statement that generated the error and the SQL error that it generated without having to turn on showDatabaseQueries and copy/paste to a MySQL shell.