### PR TITLE
Update the generic includes to use the NDB_Client framework

### DIFF
--- a/tools/generic_includes.php
+++ b/tools/generic_includes.php
@@ -1,25 +1,18 @@
 <?php
 
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+
+require_once __DIR__ . "/../vendor/autoload.php";
+$configFile = "../project/config.xml";
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize($configFile);
+$DB = Database::singleton();
+
 // PEAR::Config
-require_once "Config.php";
 
 //allow instruments to find libraries
 require_once 'Utility.class.inc';
-
-// define which configuration file we're using for this installation
-$configFile = "../project/config.xml";
-
-// load the configuration data into a global variable $config
-$configObj = new Config;
-$root =& $configObj->parseConfig($configFile, "XML");
-if(Utility::isErrorX($root)) {
-    die("Config error: ".$root->getMessage());
-}
-$configObj =& $root->searchPath(array('config'));
-$configxml = $configObj->toArray();
-$configxml = $configxml['config'];
-unset($configObj, $root);
 
 // require all relevant OO class libraries
 require_once "Database.class.inc";
@@ -27,14 +20,5 @@ require_once "NDB_Config.class.inc";
 require_once "NDB_BVL_Instrument.class.inc";
 require_once "Candidate.class.inc";
 
-/*
- * new DB Object
- * gets connection name and user name..
- */
-$DB =& Database::singleton($configxml['database']['database'], $configxml['database']['username'], $configxml['database']['password'], $configxml['database']['host']);
-if(Utility::isErrorX($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-    die();
-}
 
 ?>


### PR DESCRIPTION
This updates the generic_includes to use the NDB_Client/Database::singleton() methods of DB instantiation, rather than using a (non-existant?) Config.php class and manually parsing the XML file.