### PR TITLE
Fix generate_tables scripts

### DIFF
--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -24,36 +24,10 @@ if (version_compare(phpversion(),'4.3.0','<'))
 }
 
 
-// PEAR::Config
-require_once "Config.php";
-
-// define which configuration file we're using for this installation
-$configFile = "../project/config.xml";
-
-// load the configuration data into a global variable $config
-$configObj = new Config;
-$root =& $configObj->parseConfig($configFile, "XML");
-if(PEAR::isError($root)) {
-    die("Config error: ".$root->getMessage());
-}
-$configObj =& $root->searchPath(array('config'));
-$config =& $configObj->toArray();
-$config = $config['config'];
-unset($configObj, $root);
-
 // require all relevant OO class libraries
 require_once "../php/libraries/Database.class.inc";
 require_once "../php/libraries/NDB_Config.class.inc";
 require_once "../php/libraries/NDB_BVL_Instrument.class.inc";
-
-/*
-* new DB Object
-*/
-$DB =& Database::singleton($config['database']['database'], $config['database']['username'], $config['database']['password'], $config['database']['host']);
-if(PEAR::isError($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-    die();
-}
 
 
 $fp=fopen("ip_output.txt","r");

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -14,37 +14,11 @@
 
 //Ensure php version compatability
 //taken from php.net notes
-// PEAR::Config
-require_once "Config.php";
-
-// define which configuration file we're using for this installation
-$configFile = "../project/config.xml";
-
-// load the configuration data into a global variable $config
-$configObj = new Config;
-$root =& $configObj->parseConfig($configFile, "XML");
-if(PEAR::isError($root)) {
-    die("Config error: ".$root->getMessage());
-}
-$configObj =& $root->searchPath(array('config'));
-$config =& $configObj->toArray();
-$config = $config['config'];
-unset($configObj, $root);
 
 // require all relevant OO class libraries
 require_once "../php/libraries/Database.class.inc";
 require_once "../php/libraries/NDB_Config.class.inc";
 require_once "../php/libraries/NDB_BVL_Instrument.class.inc";
-
-/*
-* new DB Object
-*/
-$DB =& Database::singleton($config['database']['database'], $config['database']['username'], $config['database']['password'], $config['database']['host']);
-if(PEAR::isError($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-    die();
-}
-
 
 $data = stream_get_contents(STDIN);
 


### PR DESCRIPTION
Bug Fix : Removing old calls to create Config and Database objects unnecessarily in
* tools/generate_tables_and_sql.php
* tools/generate_tables_and_sql_and_testNames.php

As of release 14.12, these old calls were triggering errors hindering generation of table schemas from instrument files (*.php and *.linst).