### PR TITLE
Fixed Imaging Browser Menu table QCStatus.

### DIFF
--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -100,7 +100,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $PendingFailSubquery = "
             CASE s.MRIQCStatus
                 WHEN 'Fail' THEN
-                    IF(s.MRIQCPending, 'Pending Fail', 'Fail')
+                    IF(s.MRIQCPending='Y', 'Pending Fail', 'Fail')
                 WHEN 'Pass' THEN
                     IF(s.MRIQCPending='Y', 'Pending Pass', 'Pass')
                 ELSE s.MRIQCStatus


### PR DESCRIPTION
'Fail' QCStatus was being displayed as 'Pending Fail' because of a missing condition in the IF(s.MRIQCPending, 'Pending Fail', 'Fail') statement.