### PR TITLE
SupplementalSessionStatus check in Timepoint class

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -146,7 +146,7 @@ Class TimePoint
         }
         // New feature, older databases might not have the table created,
         // so require a config option to be set
-        if ($config->getSetting("SupplementalSessionStatus") == true) {
+        if ($config->getSetting("SupplementalSessionStatus") == 'true') {
 
             $query = "SELECT ss.Name, ss.Value
                         FROM session_status ss


### PR DESCRIPTION
The comparison check for the SupplementalSessionStatus config option was off in the Timepoint class, coming from within the Imaging Browser.