### PR TITLE
Excel Dump fix for PHP 5.3, still broken for >= PHP 5.4

### DIFF
--- a/tools/excelDump.php
+++ b/tools/excelDump.php
@@ -9,6 +9,7 @@
 // Future improvements:
 // The SQL to pull the instrument data rely on some nastry text matching (ie. where c.PSCID not like '1%').  Ideally, this junk could be purged directly from the DB, and the SQL made more plain.
 
+require_once __DIR__ . "/../vendor/autoload.php";
 require_once "generic_includes.php";
 require_once 'Spreadsheet/Excel/Writer.php';
 require_once "Archive/Tar.php";


### PR DESCRIPTION
\>= PHP 5.4 still experiencing call-time pass-by-reference errors.