### PR TITLE
Added consent to all other import scripts

### DIFF
--- a/tools/CouchDB_Confirm_Integrity.php
+++ b/tools/CouchDB_Confirm_Integrity.php
@@ -91,7 +91,7 @@ class CouchDBIntegrityChecker
             } else if ($sqlDB['Visit_label'] !== $vl) {
                 print "Visit Label case sensitivity mismatch for $row[id].\n";
                 $this->CouchDB->deleteDoc($row['id']);
-            } else if ($sqlDB['study_consent'] !== 'yes') {
+            } else if (!isset($sqlDB['study_consent']) || $sqlDB['study_consent'] !== 'yes') {
                 print "No consent for candidate for $row[id].\n";
                 $this->CouchDB->deleteDoc($row['id']);
             }

--- a/tools/CouchDB_Confirm_Integrity.php
+++ b/tools/CouchDB_Confirm_Integrity.php
@@ -73,6 +73,7 @@ class CouchDBIntegrityChecker
                 "SELECT c.*, s.Visit_label, s.Active
                 FROM candidate c
                 LEFT JOIN session s USING (CandID)
+                LEFT JOIN participant_status ps ON (ps.CandID=c.CandID) LEFT JOIN participant_status_options pso ON (pso.ID=ps.participant_status)
                 WHERE c.PSCID=:PID AND s.Visit_label=:VL",
                 array(
                     "PID" => $pscid,
@@ -89,6 +90,9 @@ class CouchDBIntegrityChecker
                 $this->CouchDB->deleteDoc($row['id']);
             } else if ($sqlDB['Visit_label'] !== $vl) {
                 print "Visit Label case sensitivity mismatch for $row[id].\n";
+                $this->CouchDB->deleteDoc($row['id']);
+            } else if ($sqlDB['study_consent'] !== 'yes') {
+                print "No consent for candidate for $row[id].\n";
                 $this->CouchDB->deleteDoc($row['id']);
             }
         }

--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -59,7 +59,7 @@ class CouchDBInstrumentImporter {
     }
 
     function generateDocumentSQL($instrument) {
-        return "SELECT c.PSCID, s.Visit_label, f.Administration, f.Data_entry, f.Validity, CASE WHEN EXISTS (SELECT 'x' FROM conflicts_unresolved cu WHERE i.CommentID=cu.CommentId1 OR i.CommentID=cu.CommentId2) THEN 'Y' ELSE 'N' END AS Conflicts_Exist, CASE ddef.Data_entry='Complete' WHEN 1 THEN 'Y' WHEN NULL THEN 'Y' ELSE 'N' END AS DDE_Complete, i.* FROM $instrument i JOIN flag f USING (CommentID) JOIN session s ON (s.ID=f.SessionID) JOIN candidate c ON (c.CandID=s.CandID) LEFT JOIN flag ddef ON (ddef.CommentID=CONCAT('DDE_', f.CommentID)) WHERE f.CommentID NOT LIKE 'DDE%' AND s.Active='Y' AND c.Active='Y'";
+        return "SELECT c.PSCID, s.Visit_label, f.Administration, f.Data_entry, f.Validity, CASE WHEN EXISTS (SELECT 'x' FROM conflicts_unresolved cu WHERE i.CommentID=cu.CommentId1 OR i.CommentID=cu.CommentId2) THEN 'Y' ELSE 'N' END AS Conflicts_Exist, CASE ddef.Data_entry='Complete' WHEN 1 THEN 'Y' WHEN NULL THEN 'Y' ELSE 'N' END AS DDE_Complete, i.* FROM $instrument i JOIN flag f USING (CommentID) JOIN session s ON (s.ID=f.SessionID) JOIN candidate c ON (c.CandID=s.CandID) LEFT JOIN flag ddef ON (ddef.CommentID=CONCAT('DDE_', f.CommentID)) LEFT JOIN participant_status ps ON (ps.CandID=c.CandID) LEFT JOIN participant_status_options pso ON (pso.ID=ps.participant_status) WHERE f.CommentID NOT LIKE 'DDE%' AND s.Active='Y' AND c.Active='Y' AND ps.study_consent='yes' AND ps.study_consent_withdrawal IS NULL";
     }
     function UpdateCandidateDocs($Instruments) {
         $results = array('new' => 0, 'modified' => 0, 'unchanged' => 0);

--- a/tools/CouchDB_Import_MRI.php
+++ b/tools/CouchDB_Import_MRI.php
@@ -149,8 +149,11 @@ class CouchDBMRIImporter
         $Query .= " FROM session s JOIN candidate c USING (CandID) 
                     LEFT JOIN feedback_mri_comments fmric 
                     ON (fmric.CommentTypeID=7 AND fmric.SessionID=s.ID)
+                    LEFT JOIN participant_status ps ON (ps.CandID=c.CandID) 
+                    LEFT JOIN participant_status_options pso ON (pso.ID=ps.participant_status)
                     WHERE c.PSCID <> 'scanner' AND c.PSCID NOT LIKE '%9999' 
-                          AND c.Active='Y' AND s.Active='Y' AND c.CenterID <> 1";
+                    AND c.Active='Y' AND s.Active='Y' AND c.CenterID <> 1
+                    AND ps.study_consent='yes' AND ps.study_consent_withdrawal IS NULL";
         return $Query;
     }
 

--- a/tools/CouchDB_Import_RadiologicalReview.php
+++ b/tools/CouchDB_Import_RadiologicalReview.php
@@ -124,7 +124,10 @@ class CouchDBRadiologicalReviewImporter {
             LEFT JOIN session s ON (s.ID=f.SessionID) 
             LEFT JOIN candidate c ON (c.CandID=s.CandID)
             LEFT JOIN examiners eFinal ON (eFinal.ExaminerID=frr.Final_Examiner)
-            LEFT JOIN examiners eExtra ON (eExtra.ExaminerID=frr.Final_Examiner2)", array());
+            LEFT JOIN examiners eExtra ON (eExtra.ExaminerID=frr.Final_Examiner2)
+            LEFT JOIN participant_status ps ON (ps.CandID=c.CandID) LEFT JOIN participant_status_options pso ON (pso.ID=ps.participant_status)
+            WHERE s.Active='Y' AND c.Active='Y' AND ps.study_consent='yes' AND ps.study_consent_withdrawal IS NULL AND c.PSCID <> 'scanner'
+            ", array());
         
         // Adding the data to CouchDB documents
         foreach($finalradiologicalreview as $review) {


### PR DESCRIPTION
Only the CouchDB_Import_Demographics script was verifying consent when importing data. This updates both the instrument, MRI, and radiologicalReview scripts to also verify consent before importing.

The Confirm_Integrity check is also modified to delete documents for which the candidate does not have consent information as "yes" in the database.