### PR TITLE
Cleaned up the user properly for LorisIntegrationTests

### DIFF
--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -17,10 +17,6 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
             1
         );
 
-        // Create a UnitTester user with all permissions.
-        $this->DB->delete("users", array("UserID" => 'UnitTester'));
-        $this->DB->delete("user_perm_rel", array("UserID" => '999990'));
-
         $this->DB->insert(
             "users",
             array(
@@ -36,10 +32,12 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
                 'Active' => 'Y',
                 'Examiner' => 'N',
                 'Password_md5' => 'a601e42ba82bb37a68ca3c8b7752f2e222',
+                'Password_hash' => null,
                 'Password_expiry' => '2099-12-31',
-                'Pending_approval' => false
+                'Pending_approval' => 'N'
             )
         );
+
         $this->DB->run(
             "INSERT INTO user_perm_rel SELECT 999990, PermID FROM permissions"
         );
@@ -62,17 +60,20 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         $passwordEl->sendKeys($password);
 
         $login= $this->webDriver->findElement(WebDriverBy::Name("login"));
-
         $login->click();
     }
+
     public function tearDown()
     {
-        // Close the browser and end the session
-        $this->webDriver->quit();
 
         // Delete the temporary user.
-        $this->DB->delete("users", array("UserID" => 'UnitTester'));
+        $this->DB->delete("user_login_history", array('userID' => 'UnitTester'));
         $this->DB->delete("user_perm_rel", array("UserID" => '999990'));
+        $this->DB->delete("users", array("UserID" => 'UnitTester'));
+        // Close the browser and end the session
+        if($this->webDriver) {
+            $this->webDriver->quit();
+        }
     }
 }
 ?>

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -1,13 +1,49 @@
 <?php
+/**
+ * This contains an abstract class for Loris tests to extend.
+ * It sets up the database handler, creates a user, creates a
+ * webDriver instance, and logs in so that tests can focus on
+ * the module being tested and not the overhead of logging in
+ * to Loris.
+ *
+ * PHP Version 5
+ *
+ * @category Test
+ * @package  Test
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * Implementation of LorisIntegrationTest helper class.
+ *
+ * @category Test
+ * @package  Test
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
 abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * A reference to the Selenium WebDriver object for the test
+     * to use to script a web browser.
+     */
     protected $webDriver;
 
+    /**
+     * Does basic setting up of Loris variables for this test, such as
+     * instantiting the config and database objects, creating a user
+     * to user for the tests, and logging in.
+     *
+     * @return none
+     */
     public function setUp()
     {
         // Set up database wrapper and config
         $this->config = NDB_Config::singleton(__DIR__ . "/../../project/config.xml");
-        $database = $this->config->getSetting('database');
+        $database     = $this->config->getSetting('database');
 
         $this->DB = Database::singleton(
             $database['database'],
@@ -20,21 +56,21 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         $this->DB->insert(
             "users",
             array(
-                'ID' => 999990,
-                'UserID' => 'UnitTester',
-                'Real_name' => 'Unit Tester',
-                'First_name' => 'Unit',
-                'Last_name' => 'Tester',
-                'Email' => 'tester@example.com',
-                'CenterID' => 1,
-                'Privilege' => 0,
-                'PSCPI' => 'N',
-                'Active' => 'Y',
-                'Examiner' => 'N',
-                'Password_md5' => 'a601e42ba82bb37a68ca3c8b7752f2e222',
-                'Password_hash' => null,
-                'Password_expiry' => '2099-12-31',
-                'Pending_approval' => 'N'
+             'ID'               => 999990,
+             'UserID'           => 'UnitTester',
+             'Real_name'        => 'Unit Tester',
+             'First_name'       => 'Unit',
+             'Last_name'        => 'Tester',
+             'Email'            => 'tester@example.com',
+             'CenterID'         => 1,
+             'Privilege'        => 0,
+             'PSCPI'            => 'N',
+             'Active'           => 'Y',
+             'Examiner'         => 'N',
+             'Password_md5'     => 'a601e42ba82bb37a68ca3c8b7752f2e222',
+             'Password_hash'    => null,
+             'Password_expiry'  => '2099-12-31',
+             'Pending_approval' => 'N',
             )
         );
 
@@ -44,13 +80,27 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
 
         // Set up WebDriver implementation and login
         $capabilities = array(\WebDriverCapabilityType::BROWSER_NAME => 'firefox');
-        $this->webDriver = RemoteWebDriver::create('http://localhost:4444/wd/hub', $capabilities);
+
+        $this->webDriver = RemoteWebDriver::create(
+            'http://localhost:4444/wd/hub',
+            $capabilities
+        );
 
         $this->login("UnitTester", "4test4");
 
     }
 
-    protected function login($username, $password) {
+    /**
+     * Helper function to login to the loris instance which is being pointed to by
+     * this test.
+     *
+     * @param string $username The username to log in as
+     * @param string $password The (plain text) password to login as.
+     *
+     * @return none, side-effect logs in active webDriver
+     */
+    protected function login($username, $password)
+    {
         $this->webDriver->get('http://localhost/main.php');
 
         $usernameEl = $this->webDriver->findElement(WebDriverBy::Name("username"));
@@ -59,10 +109,17 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         $usernameEl->sendKeys($username);
         $passwordEl->sendKeys($password);
 
-        $login= $this->webDriver->findElement(WebDriverBy::Name("login"));
+        $login = $this->webDriver->findElement(WebDriverBy::Name("login"));
         $login->click();
     }
 
+    /**
+     * Cleans up this test by deleting the temporary user that was created and all
+     * its permissions. user_login_history also must be purged as it contains a
+     * foreign key to users
+     *
+     * @return none
+     */
     public function tearDown()
     {
 
@@ -71,7 +128,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         $this->DB->delete("user_perm_rel", array("UserID" => '999990'));
         $this->DB->delete("users", array("UserID" => 'UnitTester'));
         // Close the browser and end the session
-        if($this->webDriver) {
+        if ($this->webDriver) {
             $this->webDriver->quit();
         }
     }


### PR DESCRIPTION
There's a problem with the LorisIntegrationTest test helper where the user isn't being deleted correctly, which causes further tests to fail when it attempts to insert a user that already exists.

This is caused by the user_login_history table having a foreign key to users, which causes the delete from users to fail. For now, the tests delete from user_login_history, but it would probably make more sense to just delete the foreign key since it's a history table and has no reason to be normalized.