### PR TITLE
The PHP Database wrapper did not throw exceptions on invalid deletes.

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -265,7 +265,8 @@ class Database extends PEAR
         $result = $prep->execute($exec_params);
         if ($result === false) {
             throw new DatabaseException(
-                "Insert statement did not execute successfully.",
+                "Insert statement did not execute successfully: "
+                . print_r($prep->errorInfo(), true),
                 $prepQ,
                 $exec_params
             );
@@ -407,11 +408,24 @@ class Database extends PEAR
         // one.
         $err = $this->_trackChanges($table, array(), $where, 'D');
         if ($this->isError($err)) {
-            return $err;
+            throw new DatabaseException(
+                "Unable to track changes for delete statement.",
+                $query,
+                $where
+            );
         }
 
         $this->_printQuery($query);
         $this->affected = $this->_PDO->exec($query);
+        if ($this->affected === false) {
+            throw new DatabaseException(
+                "Database DELETE did not execute successfully."
+                . print_r($this->_PDO->errorInfo(), true),
+                $query,
+                $where
+            );
+
+        }
     }
 
     /**


### PR DESCRIPTION
The Database.class.inc file was not throwing exceptions when DELETE
statements failed, only inserts and selects. Instead, DELETE was
silently failing.

This adds an exception for consistency, and also includes the MySQL
error in the exception thrown so that we can see the reason for
statements failing in Travis.