### PR TITLE
Added support for addElement('file') to LorisForm

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -116,6 +116,11 @@ class LorisForm
         $el['type'] = 'date';
     }
 
+    function addFile($name, $label, $options) {
+        $el         =& $this->addBase($name, $label, $options);
+        $el['type'] = 'file';
+    }
+
     /**
      * An implementation of QuickForm's addElement function. This only
      * calls the appropriate $this->addX wrapper based on the "type"
@@ -149,6 +154,9 @@ class LorisForm
             break;
         case 'date':
             $el = $this->addDate($name, $label, $options);
+            break;
+        case 'file':
+            $el = $this->addFile($name, $label, $options);
             break;
         case 'text':
         default:
@@ -272,6 +280,20 @@ class LorisForm
             .">";
     }
 
+    function fileHTML($el) {
+        $cls = '';
+        $val = $this->getDefault($el['name']);
+        if (isset($el['class'])) {
+            $cls = "class=\"$el[class]\"";
+        }
+        return "<input name=\"$el[name]\" type=\"file\" $cls"
+            . (
+                !empty($val)
+                ? ' value="' . $val . '"'
+                : ''
+              )
+            .">";
+    }
 
     /**
      * Reimplements the HTML_QuickForm setDefaults API.
@@ -356,6 +378,9 @@ class LorisForm
                 break;
             case 'text':
                 $el['html'] = $this->textHTML($el);
+                break;
+            case 'file':
+                $el['html'] = $this->fileHTML($el);
                 break;
 
             }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -116,7 +116,19 @@ class LorisForm
         $el['type'] = 'date';
     }
 
-    function addFile($name, $label, $options) {
+    /**
+     * Adds a file to the current form.
+     *
+     * @param string $name    The element name.
+     * @param string $label   The label to attach to this element.
+     * @param array  $options An array of other attributes that should
+     *                        get added. Currently only the "class"
+     *                        attribute gets added.
+     *
+     * @return none, modifies $this->form as a side-effect.
+     */
+    function addFile($name, $label, $options)
+    {
         $el         =& $this->addBase($name, $label, $options);
         $el['type'] = 'file';
     }
@@ -280,7 +292,16 @@ class LorisForm
             .">";
     }
 
-    function fileHTML($el) {
+    /**
+     * Generates the HTML to add to the page when a file is
+     * added to the form.
+     *
+     * @param array $el The element to render from $this->form
+     *
+     * @return string A string of the HTML markup to render
+     */
+    function fileHTML($el)
+    {
         $cls = '';
         $val = $this->getDefault($el['name']);
         if (isset($el['class'])) {

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -124,6 +124,23 @@ class LorisForms_Test extends PHPUnit_Framework_TestCase
         $this->assertLabel("abc", "Hello");
     }
 
+
+    /**
+     * Test that the addDate wrapper adds an element of the appropriate
+     * type to the page
+     *
+     * @return none
+     */
+    function testAddFile()
+    {
+        $this->form->addFile("abc", "Hello", array());
+        $this->assertType("abc", "file");
+        $this->assertLabel("abc", "Hello");
+    }
+
+
+
+
     /**
      * Test that the addElement wrapper with type "select" adds an element of
      * the appropriate type to the page
@@ -171,6 +188,24 @@ class LorisForms_Test extends PHPUnit_Framework_TestCase
             ->method('addText');
         $this->form->addElement("text", "abc", "Hello");
     }
+
+    /**
+     * Test that the addElement wrapper with type "text" adds an element of
+     * the appropriate type to the page
+     *
+     * @return none
+     */
+    function testAddElementFile()
+    {
+        $this->form = $this->getMockBuilder('LorisForm')
+            ->setMethods(array('addFile'))
+            ->getMock();
+        $this->form->expects($this->once())
+            ->method('addFile');
+        $this->form->addElement("file", "abc", "Hello");
+    }
+
+
 
 }
 ?>


### PR DESCRIPTION
This adds support to generate the HTML for file element types into the LorisForm QuickForm replacement.