### PR TITLE
Use Config Variable For Hostname in tests

### DIFF
--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -27,8 +27,6 @@ require_once __DIR__
  */
 class ConfigurationTest extends LorisIntegrationTest
 {
-    protected $url = 'http://localhost/main.php?test_name=configuration';
-
     /**
      * Tests that, when loading the Configuration module, the word
      * "Configuration" appears somewhere on the page
@@ -37,7 +35,7 @@ class ConfigurationTest extends LorisIntegrationTest
      */
     public function testConfigurationPageLoads()
     {
-        $this->webDriver->get($this->url);
+        $this->webDriver->get($this->url . "?test_name=configuration");
 
         $bodyText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector("body"))->getText();

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -27,8 +27,6 @@ require_once __DIR__ .
  */
 class DashboardTest extends LorisIntegrationTest
 {
-    protected $url = 'http://localhost/main.php?test_name=dashboard';
-
     /**
      * Tests that, when loading the Dashboard, the word "Welcome" appears
      * in the welcome panel
@@ -37,7 +35,7 @@ class DashboardTest extends LorisIntegrationTest
      */
     public function testDashboardPageLoads()
     {
-        $this->webDriver->get($this->url);
+        $this->webDriver->get($this->url . '?test_name=dashboard');
 
         $welcomeText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector(".welcome"))->getText();

--- a/modules/mri_upload/test/mri_uploadTest.php
+++ b/modules/mri_upload/test/mri_uploadTest.php
@@ -4,7 +4,7 @@ class mri_uploadTestIntegrationTest extends LorisIntegrationTest
 {
     function testMriUploadDoespageLoad()
     {
-        $this->webDriver->get('http://localhost/main.php?test_name=mri_upload');
+        $this->webDriver->get($this->url . '?test_name=mri_upload');
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("mri_upload", $bodyText);
     }

--- a/modules/statistics/tests/Statistics_Test.php
+++ b/modules/statistics/tests/Statistics_Test.php
@@ -4,7 +4,7 @@ class Statistics_Test extends LorisIntegrationTest
 {
     public function testTabsFrameworkLoads()
     {
-        $this->webDriver->get('http://localhost/main.php?test_name=statistics');
+        $this->webDriver->get($this->url . '?test_name=statistics');
 
         try {
             // If this is the mobile view, we need to expand the dropdown
@@ -30,7 +30,7 @@ class Statistics_Test extends LorisIntegrationTest
     }
 
     public function testGeneralDescriptionTabLoads() {
-        $this->webDriver->get('http://localhost/main.php?test_name=statistics&subtest=stats_general&dynamictabs=dynamictabs');
+        $this->webDriver->get($this->url . '?test_name=statistics&subtest=stats_general&dynamictabs=dynamictabs');
         $header = $this->webDriver->findElement(WebDriverBy::XPath("//div[@id = 'page']/h2"));
         $this->assertContains("Welcome to the statistics page", $header->getText());
 

--- a/test/integrationtests/Login_Test.php
+++ b/test/integrationtests/Login_Test.php
@@ -4,7 +4,7 @@ class LorisLoginTest extends LorisIntegrationTest
 {
     function testLoginFailure()
     {
-       $this->webDriver->get('http://localhost/main.php?logout=true');
+       $this->webDriver->get($this->url . '?logout=true');
 
        $username = $this->webDriver->findElement(WebDriverBy::Name("username"));
        $this->assertEquals('', $username->getAttribute("value"));
@@ -28,7 +28,7 @@ class LorisLoginTest extends LorisIntegrationTest
 
     function testLoginSuccess()
     {
-       $this->webDriver->get('http://localhost/main.php?logout=true');
+       $this->webDriver->get($this->url . '?logout=true');
        $username = $this->webDriver->findElement(WebDriverBy::Name("username"));
        $this->assertEquals('', $username->getAttribute("value"));
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -55,7 +55,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
             $database['host'],
             1
         );
-        $this->url = $this->config->getSetting("url");
+        $this->url = $this->config->getSetting("url") . "/main.php";
 
         $this->DB->insert(
             "users",

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -31,6 +31,9 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
      * to use to script a web browser.
      */
     protected $webDriver;
+    protected $config;
+    protected $DB;
+    protected $url;
 
     /**
      * Does basic setting up of Loris variables for this test, such as
@@ -52,6 +55,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
             $database['host'],
             1
         );
+        $this->url = $this->config->getSetting("url");
 
         $this->DB->insert(
             "users",
@@ -101,7 +105,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
      */
     protected function login($username, $password)
     {
-        $this->webDriver->get('http://localhost/main.php');
+        $this->webDriver->get($this->url);
 
         $usernameEl = $this->webDriver->findElement(WebDriverBy::Name("username"));
         $passwordEl = $this->webDriver->findElement(WebDriverBy::Name("password"));


### PR DESCRIPTION
Most of our tests hard localhost/main.php hardcoded as the site to be tested.

This updates the tests to use the url config variable, so that we can support running the tests on a different port (or hostname)