### PR TITLE
    Run tests in PHP 5.4, 5.6 and 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php: 5.4
+sudo: false
 
 before_install:
-    - sudo apt-get update
     # Start Xvfb in a desktop screen size,
     # otherwise some tests will fail because the links
     # are hidden when Selenium tries to find them.
@@ -22,16 +22,8 @@ install:
       # Download a Selenium Web Driver release
     - wget "http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar"
 
-    # Install requirements for php-fpm as per Travis DOCs
-    - sudo apt-get install apache2 libapache2-mod-fastcgi smarty3
-    # /usr/share/php gets obliterated from the path by phpenv, so make
-    # a symlink to fake it.
-    - ln -s /usr/share/php/smarty3 ~/.phpenv/versions/$(phpenv version-name)/pear
-    - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
-    - sudo a2enmod rewrite actions fastcgi alias
-    - sudo a2dismod php5
-    - echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-    - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+    - php -S localhost:8000 -t htdocs&
+
     # Start Selenium and redirect Selenium WebDriver
     # output to /dev/null so that it doesn't flood the
     # screen in the middle of our other tests
@@ -54,11 +46,7 @@ before_script:
           -e "s/%DATABASE%/LorisTest/g"
           < docs/config/config.xml > project/config.xml
     - mysql LorisTest -e "UPDATE Config SET Value='$(pwd)/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
-
-      # Configure apache
-    - sudo cp -f docs/config/apache2-fastcgi /etc/apache2/sites-available/default
-    - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)/htdocs?g" --in-place /etc/apache2/sites-available/default
-    - sudo service apache2 restart
+    - mysql LorisTest -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
 
 script:
     # Run PHP -l on everything to ensure there's no syntax

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 
-php: 5.4
+php:
+    - 5.4
+    - 5.6
+
 sudo: false
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
       # Download a Selenium Web Driver release
     - wget "http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar"
 
-    - php -S localhost:8000 -t htdocs&
+    - php -S localhost:8000 -t htdocs 2>&1 > /dev/null &
 
     # Start Selenium and redirect Selenium WebDriver
     # output to /dev/null so that it doesn't flood the

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
       # Download a Selenium Web Driver release
     - wget "http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar"
 
-    - php -S localhost:8000 -t htdocs 2>&1 > /dev/null &
+    - php -S localhost:8000 -t htdocs 2>1 > /dev/null &
 
     # Start Selenium and redirect Selenium WebDriver
     # output to /dev/null so that it doesn't flood the

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: php
 php:
     - 5.4
     - 5.6
+    - '7'
+
+matrix:
+    allow_failures:
+        - php: '7'
 
 sudo: false
 


### PR DESCRIPTION
PHP 5.4 is the earliest version of PHP supported by Travis. Since
we claim to support 5.3, that's the closest we can get to running
our testing suite in PHP 5.3.

PHP 5.6 is the most recent version of PHP. Since our tests should
also pass there, we run our tests with it.

We make the assumption that if it works with 5.4 and 5.6, it should
work with versions in between and don't explicitly test it.

PHP 7 is added as an allowed failure, so that we should
at least know if it will work when it comes out.