### PR TITLE
Fixed typo in table name in snp_browser

### DIFF
--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -119,7 +119,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
             JOIN SNP ON (candidate.CandID = SNP.CandID)
             LEFT JOIN genome_loc ON (genome_loc.GenomeLocID = SNP.GenomeLocID)  
             LEFT JOIN gene ON (gene.GenomeLocID = SNP.GenomeLocID)
-            LEFT JOIN genoytyping_platform ON 
+            LEFT JOIN genotyping_platform ON 
               (SNP.PlatformID = genotyping_platform.PlatformID)
             WHERE 
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";


### PR DESCRIPTION
There is a typo in an SQL query in the snp_browser of the genomic_browser, where it was trying to join a table that doesn't exist.

This fixes the obvious typo and instead joins the correct table.