### PR TITLE
Use the same code for resetting password regardless of how it's triggered

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -42,6 +42,9 @@
             <link url='http://www.loris.ca'>Important Website</link>
         </dashboardLinks>
     </dashboard>
+    <CouchDB>
+        <SyncAccounts>false</SyncAccounts>
+    </CouchDB>
 
     <!-- study variables -->
     <study>

--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -58,12 +58,8 @@ if (isset($_POST['username'])) {
             $password = User::newPassword();
 
             // reset the password in the database
-            $success = $user->update(
-                array(
-                 'Password_md5'    => User::MD5Salt($password),
-                 'Password_expiry' => '0000-00-00',
-                )
-            );
+            $success = $user->updatePassword($password);
+
             if (PEAR::isError($success)) {
                 $tpl_data['error_message'] = $success->getMessage();
             }

--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -60,10 +60,6 @@ if (isset($_POST['username'])) {
             // reset the password in the database
             $success = $user->updatePassword($password);
 
-            if (PEAR::isError($success)) {
-                $tpl_data['error_message'] = $success->getMessage();
-            }
-
             // send the user an email
             $msg_data['study']    = $config->getSetting('title');
             $msg_data['url']      = $config->getSetting('url');

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -112,13 +112,7 @@ class NDB_Form_user_accounts extends NDB_Form
         // prepend two random characters
         if (isset($set['Password_md5'])) {
             // Update CouchDB. Must do before password is salted/hashed.
-            $config =& NDB_Config::singleton();
-            $couch_config = $config->getSetting("CouchDB");
-            if ($couch_config['SyncAccounts'] === "true") {
-                $user->updateCouchUser($set['Password_md5']);
-            }
-
-            $set['Password_md5'] = User::MD5Salt($set['Password_md5']);
+            $user->updatePassword($set['Password_md5']);
         }
 
 

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -11,7 +11,6 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-require_once 'PEAR.php';
 
 /**
  * SinglePointLogin class
@@ -26,7 +25,7 @@ require_once 'PEAR.php';
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class SinglePointLogin extends PEAR
+class SinglePointLogin
 {
     /**
      * Defines whether a user is currently logged in
@@ -200,19 +199,7 @@ class SinglePointLogin extends PEAR
             return false;
         }
 
-        // make the set
-        $expiry = date(
-            'Y-m-d',
-            mktime(0, 0, 0, date('n') + 6, date('j'), date('Y'))
-        );
-        $set    = array(
-                   'Password'        => null,
-                   'Password_md5'    => User::MD5Salt($_POST['password']),
-                   'Password_expiry' => $expiry,
-                  );
-
-        // update the user
-        $success = $user->update($set);
+        $user->updatePassword($_POST['password']);
         return true;
     }
 
@@ -309,31 +296,14 @@ class SinglePointLogin extends PEAR
                 && User::MD5Unsalt($_POST['password'], $row['Password_md5']))
                 || ($php55 && password_verify($_POST['password'], $oldhash))
             ) {
-                // If the PHP password hashing is available, check if a rehash
-                // is required and if so, rehash it.
-                //
-                // (If Password_hash is null, skip the password_needs_rehash
-                // check, because we know that we have access to the password
-                // hashing API, and we know it's never been hashed using
-                // password_hash.
-                if ($php55) {
-                    if (empty($oldhash)
-                        || password_needs_rehash($oldhash, PASSWORD_DEFAULT)
-                    ) {
-                        // Hash the password using PHP defaults.
-                        $hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
-                        // Save the new hash and wipe out the old, insecure MD5 sum.
-                        $DB->update(
-                            "users",
-                            array(
-                             'Password_hash' => $hash,
-                             'Password_MD5'  => null,
-                            ),
-                            array('UserID' => $_POST['username'])
-                        );
-                    }
+                if($php55
+                    && (empty($oldhash) || password_needs_rehash($oldhash, PASSWORD_DEFAULT))
+                ) {
+                    $user =& User::factory($_POST['username']);
+                    $user->updatePassword($_POST['password']);
                 }
-                // check that the user is active
+
+
                 if ($row['Active'] == 'N') {
                     $this->_lastError = "Your account has been deactivated."
                         . " Please contact your project administrator to"

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -296,13 +296,13 @@ class SinglePointLogin
                 && User::MD5Unsalt($_POST['password'], $row['Password_md5']))
                 || ($php55 && password_verify($_POST['password'], $oldhash))
             ) {
-                if($php55
-                    && (empty($oldhash) || password_needs_rehash($oldhash, PASSWORD_DEFAULT))
+                if ($php55
+                    && (empty($oldhash)
+                    || password_needs_rehash($oldhash, PASSWORD_DEFAULT))
                 ) {
                     $user =& User::factory($_POST['username']);
                     $user->updatePassword($_POST['password']);
                 }
-
 
                 if ($row['Active'] == 'N') {
                     $this->_lastError = "Your account has been deactivated."

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -359,7 +359,16 @@ class User extends UserPermissions
         return ($this->userInfo['CenterID']== 1);
     }
 
-    function updatePassword($password) {
+    /**
+     * Updates the password for this user into the appropriate field in the
+     * database.
+     *
+     * @param string $password The plain text password to be hashed and saved.
+     *
+     * @return none
+     */
+    function updatePassword($password)
+    {
         // Check if the PHP 5.5 password hashing API is available.
         $php55 = false;
         if (function_exists("password_verify")) {
@@ -371,25 +380,25 @@ class User extends UserPermissions
             mktime(0, 0, 0, date('n') + 6, date('j'), date('Y'))
         );
 
-        $updateArray = array(
-                        'Password_expiry' => $expiry
-        );
+        $updateArray = array('Password_expiry' => $expiry);
 
         // Update the appropriate password field, null the other one
         // for security.
         if ($php55) {
-            $updateArray['Password_hash'] = password_hash($password, PASSWORD_DEFAULT);
-            $updateArray['Password_MD5'] = null;
+            $updateArray['Password_hash'] = password_hash(
+                $password,
+                PASSWORD_DEFAULT
+            );
+            $updateArray['Password_MD5']  = null;
         } else {
             $updateArray['Password_hash'] = null;
-            $updateArray['Password_MD5'] = User::MD5Salt($password);
+            $updateArray['Password_MD5']  = User::MD5Salt($password);
         }
 
         $this->update($updateArray);
 
-        $config =& NDB_Config::singleton();
+        $config       =& NDB_Config::singleton();
         $couch_config = $config->getSetting("CouchDB");
-
         if ($couch_config['SyncAccounts'] === "true") {
             $user->updateCouchUser($set['Password_md5']);
         }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -359,7 +359,41 @@ class User extends UserPermissions
         return ($this->userInfo['CenterID']== 1);
     }
 
+    function updatePassword($password) {
+        // Check if the PHP 5.5 password hashing API is available.
+        $php55 = false;
+        if (function_exists("password_verify")) {
+            $php55 = true;
+        }
 
+        $expiry = date(
+            'Y-m-d',
+            mktime(0, 0, 0, date('n') + 6, date('j'), date('Y'))
+        );
+
+        $updateArray = array(
+                        'Password_expiry' => $expiry
+        );
+
+        // Update the appropriate password field, null the other one
+        // for security.
+        if ($php55) {
+            $updateArray['Password_hash'] = password_hash($password, PASSWORD_DEFAULT);
+            $updateArray['Password_MD5'] = null;
+        } else {
+            $updateArray['Password_hash'] = null;
+            $updateArray['Password_MD5'] = User::MD5Salt($password);
+        }
+
+        $this->update($updateArray);
+
+        $config =& NDB_Config::singleton();
+        $couch_config = $config->getSetting("CouchDB");
+
+        if ($couch_config['SyncAccounts'] === "true") {
+            $user->updateCouchUser($set['Password_md5']);
+        }
+    }
     /**
      * Updates the CouchDB user for this user to synchronize
      * the password with Loris.

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -82,6 +82,8 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
             "INSERT INTO user_perm_rel SELECT 999990, PermID FROM permissions"
         );
 
+        $user = User::factory('UnitTester');
+        $user->updatePassword('4test4');
         // Set up WebDriver implementation and login
         $capabilities = array(\WebDriverCapabilityType::BROWSER_NAME => 'firefox');
 


### PR DESCRIPTION
The code for updating passwords is not shared between the different places that it's done (password expiry, my preferences, reset password), and only 1 of them properly updates the Password_hash column and resets the Password_md5.

This updates the code to share the password update code by adding an updatePassword method into the User class and using that throughout Loris.