### PR TITLE
Hide passwords on user accounts page

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -121,6 +121,23 @@ class LorisForm
     }
 
     /**
+     * Reimplementation of HTML_QuickForm's "addPassword" API.
+     *
+     * @param string $name    The element name.
+     * @param string $label   The label to attach to this element.
+     * @param array  $options An array of other attributes that should
+     *                        get added. Currently only the "class"
+     *                        attribute gets added.
+     *
+     * @return none, modifies $this->form as a side-effect.
+     */
+    public function addPassword($name, $label, $options=array())
+    {
+        $el         =& $this->addBase($name, $label, $options);
+        $el['type'] = 'password';
+    }
+
+    /**
      * Reimplementation of HTML_QuickForm's "addText" API.
      *
      * @param string $name    The element name.
@@ -240,6 +257,9 @@ class LorisForm
             break;
         case 'textarea':
             $el = $this->addTextArea($name, $label, $options);
+            break;
+        case 'password':
+            $el = $this->addPassword($name, $label, $options);
             break;
         case 'text':
         default:
@@ -443,18 +463,20 @@ class LorisForm
      * Generates the HTML to add to the page when rendered for a text
      * element.
      *
-     * @param array $el The element to render from $this->form
+     * @param array  $el   The element to render from $this->form
+     * @param string $type The HTML input type to user for this input
+     *                     box
      *
      * @return string A string of the HTML markup to render
      */
-    function textHTML($el)
+    function textHTML($el, $type='text')
     {
         $cls = '';
         if (isset($el['class'])) {
             $cls = "class=\"$el[class]\"";
         }
         $value = $this->getValue($el['name']);
-        return "<input name=\"$el[name]\" type=\"text\" $cls"
+        return "<input name=\"$el[name]\" type=\"$type\" $cls"
             . (
                 !empty($value)
                 ? ' value="' . $this->getValue($el['name']) . '"'
@@ -654,8 +676,9 @@ class LorisForm
             return $this->textareaHTML($el);
         case 'file':
             return $this->fileHTML($el);
-        case 'text':
         case 'password':
+            return $this->textHTML($el, 'password');
+        case 'text':
             return $this->textHTML($el);
         case 'advcheckbox':
             return $this->checkboxHTML($el);

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -86,6 +86,16 @@ class SinglePointLogin extends PEAR
             // If StudyLinks aren't defined, it shouldn't be fatal.
         }
 
+        $tpl_data['study_title'] = $study_title;
+        try {
+            $tpl_data['study_logo'] = $study_logo;
+        } catch(ConfigurationException $e) {
+            $tpl_data['study_logo'] = '';
+        }
+
+        // If there's no study, we have a bigger problem
+        $study_title = $config->getSetting('title');
+
         //Output template using Smarty
         $smarty = new Smarty_neurodb;
         $smarty->assign($tpl_data);

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -86,16 +86,6 @@ class SinglePointLogin extends PEAR
             // If StudyLinks aren't defined, it shouldn't be fatal.
         }
 
-        $tpl_data['study_title'] = $study_title;
-        try {
-            $tpl_data['study_logo'] = $study_logo;
-        } catch(ConfigurationException $e) {
-            $tpl_data['study_logo'] = '';
-        }
-
-        // If there's no study, we have a bigger problem
-        $study_title = $config->getSetting('title');
-
         //Output template using Smarty
         $smarty = new Smarty_neurodb;
         $smarty->assign($tpl_data);

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -139,6 +139,21 @@ class LorisForms_Test extends PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * Test that the addDate wrapper adds an element of the appropriate
+     * type to the page
+     *
+     * @return none
+     */
+    function testAddPassword()
+    {
+        $this->form->addPassword("abc", "Hello", array());
+        $this->assertType("abc", "password");
+        $this->assertLabel("abc", "Hello");
+    }
+
+
+
 
 
     /**
@@ -205,6 +220,21 @@ class LorisForms_Test extends PHPUnit_Framework_TestCase
         $this->form->addElement("file", "abc", "Hello");
     }
 
+    /**
+     * Test that the addElement wrapper with type "password" adds an element of
+     * the appropriate type to the page
+     *
+     * @return none
+     */
+    function testAddElementPassword()
+    {
+        $this->form = $this->getMockBuilder('LorisForm')
+            ->setMethods(array('addPassword'))
+            ->getMock();
+        $this->form->expects($this->once())
+            ->method('addPassword');
+        $this->form->addElement("password", "abc", "Hello");
+    }
 
 
 }


### PR DESCRIPTION
The LorisForm QuickForm replacement did not implement the password
input type, causing it to fall back to a textbox which displays the
password. This adds password element type support to the LorisForm
wrapper so that the password is not displayed in plain text.