### PR TITLE
fix footer position for instruments

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -546,6 +546,11 @@
                 {$workspace}
             {/if}
         </div>
+
+        {if $control_panel}
+        </div></div>
+        {/if}
+
         {if $dynamictabs neq "dynamictabs"}
             {if $control_panel}
             <div id="footer" class="footer navbar-bottom wrapper">


### PR DESCRIPTION
The two div tags removed in pull request #971 were there to close div tags opened in the case where the control_panel flag is set. Reinserted the closing tags but in a check to see if flag is set.