### PR TITLE
Fix link on dashboard tasks

### DIFF
--- a/modules/dashboard/js/dashboard.js
+++ b/modules/dashboard/js/dashboard.js
@@ -61,17 +61,17 @@ $(document).ready(function () {
 
     $(".new-scans").click(function(e) {
         e.preventDefault();
-        filterForm('imaging_browser', {"Pending" : "PN"});
+        applyFilter('imaging_browser', {"Pending" : "PN"});
     });
 
     $(".radiological-review").click(function(e) {
         e.preventDefault();
-        filterForm('final_radiological_review', {"Review_done" : "no"});
+        applyFilter('final_radiological_review', {"Review_done" : "no"});
     });
 
     $(".pending-accounts").click(function(e) {
         e.preventDefault();
-        filterForm('user_accounts', {"pending" : "Y"});
+        applyFilter('user_accounts', {"pending" : "Y"});
     });
 });
 


### PR DESCRIPTION
Some of the dashboard tasks were calling a non-existent method to apply filters on the respective pages to which they were navigating. This pull request corrects the method name they were using.