### PR TITLE
Fixed bug where password box wasn't showing up in user accounts

### DIFF
--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -83,20 +83,13 @@ $(document).ready(function() {
     <div class="row form-group form-inline form-inline has-error">
     {else}
     <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2 form-label">
+    	<label class="col-sm-2">
     		{$form.Password_Group.label}
     	</label>
     	<div class="col-sm-10">
-    		{$form.Password_Group.NA_Password.html} {$form.Password_Group.checkLabel.html}
-            <br>
-            {$form.Password_Group.Password_md5.html}
+    		{$form.Password_Group.html}
     	</div>
-        {if $form.errors.Password_Group}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.Password_Group}</font>
-            </div>
-        {/if}
+    {/if}
     </div>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -83,13 +83,13 @@ $(document).ready(function() {
     <div class="row form-group form-inline form-inline has-error">
     {else}
     <div class="row form-group form-inline form-inline">
+    {/if}
     	<label class="col-sm-2">
     		{$form.Password_Group.label}
     	</label>
     	<div class="col-sm-10">
     		{$form.Password_Group.html}
     	</div>
-    {/if}
     </div>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -90,6 +90,11 @@ $(document).ready(function() {
     	<div class="col-sm-10">
     		{$form.Password_Group.html}
     	</div>
+        {if $form.errors.Password_Group}
+            <div class="col-sm-offset-2 col-xs-12">
+                <font class="form-error">{$form.errors.Password_Group}</font>
+            </div>
+        {/if}
     </div>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -38,6 +38,19 @@ class user_accountsTestIntegrationTest extends LorisIntegrationTest
         $this->webDriver->get($this->url . "?test_name=user_accounts&subtest=edit_user");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("Edit User", $bodyText);
+
+        $this->assertEquals(
+            "password",
+            $this->webDriver->findElement(WebDriverBy::Name("Password_md5"))->getAttribute("type")
+        );;
+        $this->assertEquals(
+            "checkbox",
+            $this->webDriver->findElement(WebDriverBy::Name("NA_Password"))->getAttribute("type")
+        );
+        $this->assertEquals(
+            "password",
+            $this->webDriver->findElement(WebDriverBy::Name("__Confirm"))->getAttribute("type")
+        );
     }
 
     /**

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -42,7 +42,7 @@ class user_accountsTestIntegrationTest extends LorisIntegrationTest
         $this->assertEquals(
             "password",
             $this->webDriver->findElement(WebDriverBy::Name("Password_md5"))->getAttribute("type")
-        );;
+        );
         $this->assertEquals(
             "checkbox",
             $this->webDriver->findElement(WebDriverBy::Name("NA_Password"))->getAttribute("type")


### PR DESCRIPTION
The user accounts page was using a QuickForm hack to treat a group as an array instead for the password box, which makes it not render correctly in LorisForm.

This updates it to use the group's html attribute to render the element, so that it appears correctly on the user accounts page.