### PR TITLE
Retire super sql file extension

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
+                                    reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,15 +439,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
-
-        $ethnicityList = array(null=>'');
-        $success = Utility::getEthnicityList();
-        if (Utility::isErrorX($success)) {
-        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
-        }
-        $ethnicityList = array_merge($ethnicityList,$success);
-        unset($success);
-        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    reason_specify,
+                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,6 +439,15 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
+
+        $ethnicityList = array(null=>'');
+        $success = Utility::getEthnicityList();
+        if (Utility::isErrorX($success)) {
+        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
+        }
+        $ethnicityList = array_merge($ethnicityList,$success);
+        unset($success);
+        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());

--- a/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
+++ b/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
@@ -53,7 +53,7 @@ class NDB_Menu_Filter_instrument_manager extends NDB_Menu_Filter
                 exec("mysql -u" . escapeshellarg($db_config['quatUser']) 
                                 . " -p" . escapeshellarg($db_config['quatPassword']) 
                                 ." " . escapeshellarg($db_config['database'])  
-                                . " < " . $this->path . "project/tables_sql/$instname.super_sql");
+                                . " < " . $this->path . "project/tables_sql/$instname.sql");
                 $db->insert("test_names", array(
                     "Test_name" => $instname,
                     'Sub_group' => 0

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -41,7 +41,7 @@ foreach($instruments AS $instrument){
             case "table":
                 $tablename = $bits[1];
 
-                $filename="../project/tables_sql/".$bits[1].".super_sql";
+                $filename="../project/tables_sql/".$bits[1].".sql";
                 $output="CREATE TABLE `$bits[1]` (\n";
                 $output.="`CommentID` varchar(255) NOT NULL default '',
                           `UserID` varchar(255) default NULL,


### PR DESCRIPTION
Retiring the *.super_sql file extension that was generated on all table schemas created by generate_tables_sql_and_testNames.php on *.linst files
Table schema files will be just *.sql 