### PR TITLE
Update ghosting mri feedback comment

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -304,7 +304,7 @@ INSERT INTO `feedback_mri_predefined_comments` VALUES
 	(4,2,'noisy scan'),
 	(5,2,'susceptibilty artifact above the ear canals.'),
 	(6,2,'susceptibilty artifact due to dental work'),
-	(7,2,'sagittal ghosts'),
+	(7,2,'ghosting in direction of phase encoding'),
 	(8,3,'slight ringing artefacts'),
 	(9,3,'severe ringing artefacts'),
 	(10,3,'movement artefact due to eyes'),

--- a/SQL/2015-04-01_UpdateGhostingFeedbackMRI.sql
+++ b/SQL/2015-04-01_UpdateGhostingFeedbackMRI.sql
@@ -1,0 +1,1 @@
+UPDATE feedback_mri_predefined_comments SET Comment = 'ghosting in direction of phase encoding' WHERE Comment = 'sagittal ghosts'; 

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
+                                    reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,15 +439,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
-
-        $ethnicityList = array(null=>'');
-        $success = Utility::getEthnicityList();
-        if (Utility::isErrorX($success)) {
-        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
-        }
-        $ethnicityList = array_merge($ethnicityList,$success);
-        unset($success);
-        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    reason_specify,
+                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,6 +439,15 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
+
+        $ethnicityList = array(null=>'');
+        $success = Utility::getEthnicityList();
+        if (Utility::isErrorX($success)) {
+        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
+        }
+        $ethnicityList = array_merge($ethnicityList,$success);
+        unset($success);
+        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());


### PR DESCRIPTION
This pull request modifies a Predefined MRI Feedback Comment - instead of "sagittal ghosts", comment is now "ghosting in phase encoding direction".  This improves feedback accuracy/applicability for scans collected in other direction (e.g. coronal, some T2s).

Caveat for existing projects: Note this comment change may affect filters or analysis parameters.