### PR TITLE
Remove 'click to go back' link on page-load errors

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
+                                    reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,15 +439,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
-
-        $ethnicityList = array(null=>'');
-        $success = Utility::getEthnicityList();
-        if (Utility::isErrorX($success)) {
-        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
-        }
-        $ethnicityList = array_merge($ethnicityList,$success);
-        unset($success);
-        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    reason_specify,
+                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,6 +439,15 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
+
+        $ethnicityList = array(null=>'');
+        $success = Utility::getEthnicityList();
+        if (Utility::isErrorX($success)) {
+        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
+        }
+        $ethnicityList = array_merge($ethnicityList,$success);
+        unset($success);
+        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -328,11 +328,6 @@
                                         report a bug to your administrator
                                     </a>.
                                 </p>
-                                <p>
-                                    <a href="javascript:history.back(-1)">
-                                        Please click here to go back
-                                    </a>.
-                                </p>
                             {elseif $test_name == ""}
                                 <h1 style="align:center" class="text-primary">
                                     Welcome to the LORIS Database!


### PR DESCRIPTION
This pull request removes the "Please click to go back" link that appears at the bottom of pages that fail to load in Loris.  This link wasn't working and is remover per ticket # 5818
