### PR TITLE
Change message from NeuroDB to Loris

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -10,7 +10,7 @@
 
 If you are not automatically redirected please
 <a href="javascript:pop_me_up('main.php', 'MBIDGUI', 'width=800,height=600,resizable=yes,scrollbars=yes,status=no,toolbar=no,location=no,menubar=no')">
-click here</a> to access the NeuroDB database system
+click here</a> to access the LORIS database system
 
 </BODY>
 

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
+                                    reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,15 +439,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
-
-        $ethnicityList = array(null=>'');
-        $success = Utility::getEthnicityList();
-        if (Utility::isErrorX($success)) {
-        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
-        }
-        $ethnicityList = array_merge($ethnicityList,$success);
-        unset($success);
-        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -158,7 +158,7 @@ class NDB_Form_candidate_parameters extends NDB_Form
  
        // Getting participant status default values
         $ps_info = $DB->pselectRow("SELECT study_consent,study_consent_date,study_consent_withdrawal,
-                                    reason_specify,
+                                    ndar_consent,ndar_consent_date,ndar_consent_withdrawal,reason_specify,
                                     participant_status,participant_suboptions FROM participant_status 
                                     WHERE CandID = :cid", array('cid'=>$this->identifier));
         if (empty ($ps_info['participant_status'])) {
@@ -439,6 +439,15 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         $DB =& Database::singleton();
         $config =& NDB_Config::singleton();
+
+        $ethnicityList = array(null=>'');
+        $success = Utility::getEthnicityList();
+        if (Utility::isErrorX($success)) {
+        	return PEAR::raiseError("Utility::getEthnicityList error: ".$success->getMessage());
+        }
+        $ethnicityList = array_merge($ethnicityList,$success);
+        unset($success);
+        
         $candidate =& Candidate::singleton($this->identifier);
         if (Utility::isErrorX($candidate)) {
             return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());


### PR DESCRIPTION
Upon logging into LORIS everyone sees the brief message:
"If you are not automatically redirected please click here to access the NeuroDB database system'
This pull request changes "NeuroDB" to "LORIS"