### PR TITLE
Recommend email as username for New User accounts

### DIFF
--- a/modules/user_accounts/css/user_accounts.css
+++ b/modules/user_accounts/css/user_accounts.css
@@ -1,0 +1,7 @@
+.newUserAccountNotes {
+ padding-left:0%;
+}
+
+.newUserAccountNotes li {
+  font-weight: bold;
+}

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -73,7 +73,7 @@ $(document).ready(function() {
                 NOTES:
     	</label>
     	<div class="col-sm-10">
-                <B>It is highly recommended to use an email address as the username. </B>
+                <B>It is recommended to use an email address as the username, for clarity and uniqueness.</B>
                 <br><br>
                 <B>When generating a new password, please notify the user by checking 'Send email to user' box below!</B>
     	</div>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -70,13 +70,14 @@ $(document).ready(function() {
     <br>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
-    		NOTE:
+    		NOTES:
     	</label>
     	<div class="col-sm-10">
-    		<B>When generating a new password, please notify the user by checking 'Send email to user' box!</B>
+    		<B>It is highly recommended to use an email address as the username. </B>
+                <br><br>
+    		<B>When generating a new password, please notify the user by checking 'Send email to user' box below!</B>
     	</div>
     </div>
-    <br>
     {if $form.errors.Password_Group}
     <div class="row form-group form-inline form-inline has-error">
     {else}

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -73,9 +73,9 @@ $(document).ready(function() {
     		NOTES:
     	</label>
     	<div class="col-sm-10">
-    		<B>It is highly recommended to use an email address as the username. </B>
+                <B>It is highly recommended to use an email address as the username. </B>
                 <br><br>
-    		<B>When generating a new password, please notify the user by checking 'Send email to user' box below!</B>
+                <B>When generating a new password, please notify the user by checking 'Send email to user' box below!</B>
     	</div>
     </div>
     {if $form.errors.Password_Group}

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -73,12 +73,10 @@ $(document).ready(function() {
             NOTES:
     	</label>
     	<div class="col-sm-11">
-            <strong>
-            <ul style="padding-left:0%;">
+            <ul class="newUserAccountNotes" > <!--style="padding-left:0%;"-->
                <li>It is recommended to use an email address as the username, for clarity and uniqueness.</li>
                <li>When generating a new password, please notify the user by checking 'Send email to user' box below!</li>
             </ul>
-            </strong>
     	</div>
     </div>
     {if $form.errors.Password_Group}

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -70,7 +70,7 @@ $(document).ready(function() {
     <br>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
-    		NOTES:
+                NOTES:
     	</label>
     	<div class="col-sm-10">
                 <B>It is highly recommended to use an email address as the username. </B>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -69,13 +69,16 @@ $(document).ready(function() {
     <!-- </div> -->
     <br>
     <div class="row form-group form-inline">
-    	<label class="col-sm-2">
-                NOTES:
+    	<label class="col-sm-1">
+            NOTES:
     	</label>
-    	<div class="col-sm-10">
-                <B>It is recommended to use an email address as the username, for clarity and uniqueness.</B>
-                <br><br>
-                <B>When generating a new password, please notify the user by checking 'Send email to user' box below!</B>
+    	<div class="col-sm-11">
+            <strong>
+            <ul style="padding-left:0%;">
+               <li>It is recommended to use an email address as the username, for clarity and uniqueness.</li>
+               <li>When generating a new password, please notify the user by checking 'Send email to user' box below!</li>
+            </ul>
+            </strong>
     	</div>
     </div>
     {if $form.errors.Password_Group}


### PR DESCRIPTION
In User Accounts: Add/Edit User dialog,  added a message that it is highly recommended to use the email address as username for all new user accounts. 