### PR TITLE
Add links from Bvl pages to Imaging Browser

### DIFF
--- a/modules/instrument_list/js/instrument_list.js
+++ b/modules/instrument_list/js/instrument_list.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
     // Filters will only get applied on a POST, so
     // on click we need to fake a form which posts
     // to the imaging_browser in order to get filters
-    $(".scanDoneLink").click(function(e) {
+    $(".instrument_list").click(function(e) {
         e.preventDefault();
         var form = $('<form />', {
             "action" : "main.php?test_name=imaging_browser",
@@ -12,7 +12,6 @@ $(document).ready(function() {
         });
         var values = {
             "reset"  : "true",
-            "DCCID"  : this.dataset.candID,
             "pscid"  : this.dataset.pscid,
             "VL"     : this.dataset.visitlabel,
             "filter" : "Show Data"

--- a/modules/instrument_list/js/instrument_list.js
+++ b/modules/instrument_list/js/instrument_list.js
@@ -1,0 +1,31 @@
+/*global document: false, $: false, window: false, unescape: false, Option: false,isElementsSet, alert*/
+
+$(document).ready(function() {
+    // Filters will only get applied on a POST, so
+    // on click we need to fake a form which posts
+    // to the imaging_browser in order to get filters
+    $(".scanDoneLink").click(function(e) {
+        e.preventDefault();
+        var form = $('<form />', {
+            "action" : "main.php?test_name=imaging_browser",
+            "method" : "post"
+        });
+        var values = {
+            "reset"  : "true",
+            "DCCID"  : this.dataset.candID,
+            "pscid"  : this.dataset.pscid,
+            "VL"     : this.dataset.visitlabel,
+            "filter" : "Show Data"
+        }
+
+        $.each(values, function(name, value) {
+            $("<input />", {
+                type  : 'hidden',
+                name  : name,
+                value : value
+            }).appendTo(form);
+        });
+
+        form.appendTo('body').submit();
+    });
+});

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -45,8 +45,8 @@
      <tr><td nowrap="nowrap">The battery has no registered instruments</td></tr>
 {/section}
 </table>
-  <br>
-  <br>
+  <div class="col-xs-12 row">
+  </div>
   <div class="col-xs-12 row">
     <button class="btn btn-primary" onclick="location.href='main.php?test_name=imaging_browser&subtest=viewSession&sessionID={$sessionID}'">View Imaging data</button>
   </div>

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -45,4 +45,9 @@
      <tr><td nowrap="nowrap">The battery has no registered instruments</td></tr>
 {/section}
 </table>
+  <br>
+  <br>
+  <div class="col-xs-12 row">
+    <button class="btn btn-primary" onclick="location.href='main.php?test_name=imaging_browser&subtest=viewSession&sessionID={$sessionID}'">View Imaging data</button>
+  </div>
 </div>

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -4,6 +4,11 @@
     <!-- </div> -->
     <!-- <div class="col-xs-4"> -->
         {$actions}
+        <a href="#" class="scanDoneLink" data-pscid="{$PSCID}">
+           <button class="btn btn-primary">
+              View Imaging datasets</button>
+        </a>
+
     <!-- </div> -->
 </div>
 <br>
@@ -26,7 +31,7 @@
             <th>Stage Status</th>
             <th>Date of Stage</th>
             <th>Sent To DCC</th>
-            <th>MR Scan Done</th>
+            <th>Imaging Scan Done</th>
             <th>Feedback</th>
             <th>BVL QC</th>
             <th>BVL Exclusion</th>

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -62,13 +62,16 @@
             </td>
             <td>
             {if $timePoints[timepoint].Scan_done != ""}
-                       {if $timePoints[timepoint].Scan_done == 'Y'}
-            					{assign var="scan_done" value="Yes"}
-                                <a href="#" class="timepoint_list" data-pscid="{$PSCID}" data-visitlabel="{$timePoints[timepoint].Visit_label}">{$scan_done}</a>
-    						{else}
-    							{assign var="scan_done" value="No"}
-    							{$scan_done}
-    		        		{/if}
+                    {if $timePoints[timepoint].Scan_done == 'Y'}
+                        {assign var="scan_done" value="Yes"}
+                        <a href="#" class="timepoint_list" 
+                            data-visitlabel="{$timePoints[timepoint].Visit_label}"
+                            data-pscid="{$PSCID}">
+                        {$scan_done}</a>
+                    {else}
+                        {assign var="scan_done" value="No"}
+                        {$scan_done}
+                    {/if}
             {else}
                 <img alt="Data Missing" src="images/help2.gif" border=0>
             {/if}


### PR DESCRIPTION
Adding/updating links from Timepoint List (aka Candidate Profile) and Instrument List pages to the Imaging Browser with filters pre-set for the given candidate and visit, respectively. 

Timepoint list: 
- Added javascript file
- Added button "View Imaging datasets" which links to all of this candidate's data in Imaging Browser
- updated "MR Scan Done" table header to "Imaging Scan Done"
- updated link to Imaging Browser under "Scan Done" column, and fixed a little template spacing 

Instrument list: 
- Added javascript file
- Added button "View Imaging data" which links to Imaging Browser View Session page for this visit