### PR TITLE
Creation of dummy MRI ranges in the dummy-schema.  

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -614,6 +614,12 @@ CREATE TABLE `mri_protocol` (
 LOCK TABLES `mri_protocol` WRITE;
 /*!40000 ALTER TABLE `mri_protocol` DISABLE KEYS */;
 /*!40000 ALTER TABLE `mri_protocol` ENABLE KEYS */;
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',48,'8000-14000','80-130',NULL,'0-200');
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',40,'1900-2700','10-30',NULL,'0-500');
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',44,'2000-2500','2-5',NULL,NULL);
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',45,'3000-9000','100-550',NULL,NULL);
+
+
 UNLOCK TABLES;
 
 --

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -614,10 +614,10 @@ CREATE TABLE `mri_protocol` (
 LOCK TABLES `mri_protocol` WRITE;
 /*!40000 ALTER TABLE `mri_protocol` DISABLE KEYS */;
 /*!40000 ALTER TABLE `mri_protocol` ENABLE KEYS */;
-INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',48,'8000-14000','80-130',NULL,'0-200');
-INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',40,'1900-2700','10-30',NULL,'0-500');
-INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',44,'2000-2500','2-5',NULL,NULL);
-INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,TI_range,slice_thickness_range) VALUES ('ZZZZ',45,'3000-9000','100-550',NULL,NULL);
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,time_range) VALUES ('ZZZZ',48,'8000-14000','80-130','0-200');
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,time_range) VALUES ('ZZZZ',40,'1900-2700','10-30','0-500');
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,time_range) VALUES ('ZZZZ',44,'2000-2500','2-5',NULL);
+INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,time_range) VALUES ('ZZZZ',45,'3000-9000','100-550',NULL);
 
 
 UNLOCK TABLES;


### PR DESCRIPTION
These ranges are based on the existent LORIS database's MRI protocols. 

!!! Important: DTI and BOLD acquisitions need to be first in the MRI protocol because their parameters overlap with T2 but since they have a time dimension, they can be differentiated this way. (MRI scripts check the protocols in the order they appear in the mri_protocol table).