### PR TITLE
Installer upgrades

### DIFF
--- a/docs/config/apache2-site
+++ b/docs/config/apache2-site
@@ -2,12 +2,12 @@
 <VirtualHost *:80>  # change from 80 to 443 if you enable SSL
 	ServerAdmin webmaster@localhost
 	
-	DocumentRoot %LORISROOT%htdocs/
+	DocumentRoot %LORISROOT%/htdocs/
 	<Directory />
 		Options FollowSymLinks
 		AllowOverride None
 	</Directory>
-	<Directory %LORISROOT%htdocs/>
+	<Directory %LORISROOT%/htdocs/>
 		Options Indexes FollowSymLinks MultiViews
 		AllowOverride None
 		Order allow,deny
@@ -16,20 +16,19 @@
 
 	php_value include_path .:/usr/share/php:/usr/share/pear:%LORISROOT%project/libraries:%LORISROOT%php/libraries
 
-	DirectoryIndex main.php index.html
-
-	ErrorLog /var/log/apache2/%PROJECTNAME%-error.log
+	ErrorLog %LOGDIRECTORY%/%PROJECTNAME%-error.log
 
 	# Possible values include: debug, info, notice, warn, error, crit,
 	# alert, emerg.
 	LogLevel warn
 
-	CustomLog /var/log/apache2/%PROJECTNAME%-access.log combined
+	CustomLog %LOGDIRECTORY%/%PROJECTNAME%-access.log combined
 	ServerSignature Off
 
-	# SSLEngine Off  # change to On to enable, after updating cert paths below
-	# SSLCertificateFile /etc/apache2/ssl/%PROJECTNAME%-cert.pem
-	# SSLCertificateKeyFile /etc/apache2/ssl/%PROJECTNAME%-key.pem
-	# SSLCACertificateFile /etc/apache2/ssl/CA-cacert.pem
+    #SSLEngine Off  # change to On to enable, after updating cert paths below
+
+    #SSLCertificateFile /etc/apache2/ssl/%PROJECTNAME%-cert.pem
+    #SSLCertificateKeyFile /etc/apache2/ssl/%PROJECTNAME%-key.pem
+    #SSLCACertificateFile /etc/apache2/ssl/CA-cacert.pem
 
 </VirtualHost>

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -79,9 +79,17 @@ if [[ -n $(which composer) ]]; then
     echo ""
     echo "PHP Composer appears to be installed."
 else
-    echo ""
-    echo "PHP Composer does not appear to be installed. Aborting."
-    exit 2;
+    echo "PHP Composer does not appear to be installed. Attempting to install now..."
+    curl -sS https://getcomposer.org/installer | php
+    mv composer.phar /usr/local/bin/composer
+    if [[ -n $(which composer) ]]; then
+        echo ""
+        echo "PHP Composer successfully installed."
+    else
+        echo ""
+        echo "PHP Composer failed to install. Aborting."
+        exit 2;
+    fi
 fi
 
 cat <<QUESTIONS
@@ -322,8 +330,8 @@ echo "Creating/populuating database tables from schema."
 echo ""
 mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-00-schema.sql
 echo "Updating Loris admin user's password."
-mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aa$lorispass')), Pending_approval='N' WHERE ID=1"
-
+pw_expiry=$(date --date="6 month" +%Y-%m-%d)
+mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aa$lorispass')), Password_expiry=$pw_expiry, Pending_approval='N' WHERE ID=1"
 
 
 echo ""
@@ -351,23 +359,69 @@ cd ..
 composer install --no-dev
 cd tools
 
-echo ""
+if type "lsb_release" > /dev/null 2>&1; then
+  os_distro=$(lsb_release -si)
+elif type "facter" > /dev/null 2>&1; then
+  os_distro=$(facter operatingsystem)
+else
+  os_distro="unknown"
+fi
+
+if [ $os_distro = "Ubuntu" ]; then
+  echo "Ubuntu distribution detected."
+  # for CentOS, the log directory is called httpd
+  logdirectory=/var/log/apache2
+  while true; do
+      read -p "Would you like to automatically create/install apache config files? (Works for Ubuntu 14.04 default Apache installations) [yn] " yn
+      echo $yn | tee -a $LOGFILE > /dev/null
+      case $yn in
+          [Yy]* )
+             if [ -f /etc/apache2/sites-available/$projectname ]; then
+                 echo "Apache appears to already be configured for $projectname. Aborting\n"
+                 exit 1
+             fi;
+             # Need to pipe to sudo tee because > is done as the logged in user, even if run through sudo
+             sed -e "s#%LORISROOT%#$RootDir/#g" \
+                 -e "s#%PROJECTNAME%#$projectname#g" \
+  		 -e "s#%LOGDIRECTORY%#$logdirectory#g" \
+                 < ../docs/config/apache2-site | sudo tee /etc/apache2/sites-available/$projectname.conf > /dev/null
+             sudo a2dissite 000-default
+             sudo a2ensite $projectname
+             break;;
+          [Nn]* )
+             echo "Not configuring apache."
+             break;;
+          * ) echo "Please enter 'y' or 'n'."
+      esac
+  done;
+elif [ $os_distro = "CentOS" ]; then
+echo "CentOS distribution detected."
+# for CentOS, the log directory is called httpd
+logdirectory=/var/log/httpd
 while true; do
-    read -p "Would you like to automatically create/install apache config files? (Works for Ubuntu 14.04 default Apache installations) [yn] " yn
+    read -p "Would you like to automatically create/install apache config files? (In development for CentOS 6.5) [yn] " yn
     echo $yn | tee -a $LOGFILE > /dev/null
     case $yn in
         [Yy]* )
-            if [ -f /etc/apache2/sites-available/$projectname ]; then
+            if [ -f /etc/httpd/sites-available/$projectname ]; then
                 echo "Apache appears to already be configured for $projectname. Aborting\n"
                 exit 1
             fi;
+            # make directories if missing
+            sudo mkdir -p /etc/httpd/sites-available;
+            sudo mkdir -p /etc/httpd/sites-enabled;
 
             # Need to pipe to sudo tee because > is done as the logged in user, even if run through sudo
-            sed -e "s#%LORISROOT%#$RootDir/#g" \
+            sed -e "s#%LORISROOT%#$RootDir#g" \
                 -e "s#%PROJECTNAME%#$projectname#g" \
-                < ../docs/config/apache2-site | sudo tee /etc/apache2/sites-available/$projectname.conf > /dev/null
-            sudo a2dissite 000-default
-            sudo a2ensite $projectname
+                -e "s#%LOGDIRECTORY%#$logdirectory#g" \
+                < ../docs/config/apache2-site | sudo tee /etc/httpd/sites-enabled/$projectname.conf > /dev/null
+            sudo ln -s /etc/httpd/sites-enabled/$projectname.conf /etc/httpd/sites-available/$projectname.conf
+            
+            # Insert a line in main apache config file to include new file
+            sudo sed -i '221 a\Include /etc/httpd/sites-available/*.conf' /etc/httpd/conf/httpd.conf
+            
+            sudo service httpd restart
             break;;
         [Nn]* )
             echo "Not configuring apache."
@@ -375,7 +429,9 @@ while true; do
          * ) echo "Please enter 'y' or 'n'."
     esac
 done;
+else
+    echo "$os_distro Linux distribution detected. We currently do not support this. Installation failed."
+    exit 1
+fi
 
 echo "Installation complete."
-
-


### PR DESCRIPTION
- linux distribution detection, with alternate versions of Ubuntu 12 and CentOS 6.5
- set admin password expiry = today + 6 months
- install local version of composer, and use it, instead of having composer as dependency
- change to apache config template to handle ubu and centos versions