### PR TITLE
Fix account creation

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -109,13 +109,6 @@ class NDB_Form_user_accounts extends NDB_Form
             }
         }
 
-        // prepend two random characters
-        if (isset($set['Password_md5'])) {
-            // Update CouchDB. Must do before password is salted/hashed.
-            $user->updatePassword($set['Password_md5']);
-        }
-
-
         // update the user
         if (empty($this->identifier)) {
             // insert a new user
@@ -140,6 +133,12 @@ class NDB_Form_user_accounts extends NDB_Form
             if (Utility::isErrorX($success)) {
                 return PEAR::raiseError("user_accounts::_process() update: ".$success->getMessage());
             }
+        }
+
+        // prepend two random characters
+        if (isset($set['Password_md5'])) {
+            // Update CouchDB. Must do before password is salted/hashed.
+            $user->updatePassword($set['Password_md5']);
         }
 
         // update the user permissions if applicable

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -83,13 +83,18 @@ $(document).ready(function() {
     <div class="row form-group form-inline form-inline has-error">
     {else}
     <div class="row form-group form-inline form-inline">
+    {/if}
     	<label class="col-sm-2">
     		{$form.Password_Group.label}
     	</label>
     	<div class="col-sm-10">
     		{$form.Password_Group.html}
     	</div>
-    {/if}
+        {if $form.errors.Password_Group}
+            <div class="col-sm-offset-2 col-xs-12">
+                <font class="form-error">{$form.errors.Password_Group}</font>
+            </div>
+        {/if}
     </div>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -83,20 +83,13 @@ $(document).ready(function() {
     <div class="row form-group form-inline form-inline has-error">
     {else}
     <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2 form-label">
+    	<label class="col-sm-2">
     		{$form.Password_Group.label}
     	</label>
     	<div class="col-sm-10">
-    		{$form.Password_Group.NA_Password.html} {$form.Password_Group.checkLabel.html}
-            <br>
-            {$form.Password_Group.Password_md5.html}
+    		{$form.Password_Group.html}
     	</div>
-        {if $form.errors.Password_Group}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.Password_Group}</font>
-            </div>
-        {/if}
+    {/if}
     </div>
     <div class="row form-group form-inline">
     	<label class="col-sm-2">

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -38,6 +38,19 @@ class user_accountsTestIntegrationTest extends LorisIntegrationTest
         $this->webDriver->get($this->url . "?test_name=user_accounts&subtest=edit_user");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("Edit User", $bodyText);
+
+        $this->assertEquals(
+            "password",
+            $this->webDriver->findElement(WebDriverBy::Name("Password_md5"))->getAttribute("type")
+        );;
+        $this->assertEquals(
+            "checkbox",
+            $this->webDriver->findElement(WebDriverBy::Name("NA_Password"))->getAttribute("type")
+        );
+        $this->assertEquals(
+            "password",
+            $this->webDriver->findElement(WebDriverBy::Name("__Confirm"))->getAttribute("type")
+        );
     }
 
     /**

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -42,7 +42,7 @@ class user_accountsTestIntegrationTest extends LorisIntegrationTest
         $this->assertEquals(
             "password",
             $this->webDriver->findElement(WebDriverBy::Name("Password_md5"))->getAttribute("type")
-        );;
+        );
         $this->assertEquals(
             "checkbox",
             $this->webDriver->findElement(WebDriverBy::Name("NA_Password"))->getAttribute("type")


### PR DESCRIPTION
Loris currently attempts to update the password for a user before the user is inserted into the database, causing an exception to be thrown. This moves the updatePassword call to after the user insert call to avoid that problem.