### PR TITLE
Add header field support to LorisForms

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -222,15 +222,35 @@ class LorisForm
         $el['type'] = 'file';
     }
 
-    private function generateName($name) {
+    /**
+     * Generates a name for an element, and creates a new
+     * random name if no name is given.
+     *
+     * @param string $name The name of the element called.
+     *
+     * @return $name if not empty, otherwise an unused name.
+     */
+    private function _generateName($name)
+    {
         static $num = 1;
-        if(!empty($name)) {
+        if (!empty($name)) {
             return $name;
         }
         return 'anonymous' . ($num++);
     }
-    function addHeader($name, $label, $options = array()) {
-        $name = $this->generateName($name);
+
+    /**
+     * Adds a header element to this LorisForm.
+     *
+     * @param string $name    The name of the header element, may be null
+     * @param string $label   The description for the header
+     * @param array  $options Other options for this header element
+     *
+     * @return none
+     */
+    function addHeader($name, $label, $options = array())
+    {
+        $name = $this->_generateName($name);
 
         $el         =& $this->addBase($name, $label, $options);
         $el['type'] = 'header';
@@ -774,9 +794,19 @@ class LorisForm
         );
     }
 
-    function headerHTML($el) {
+    /**
+     * Generates the HTML for a header type element
+     *
+     * @param array $el An array of the form used by $this->form
+     *                  for a header
+     *
+     * @return string The HTML for the given header element
+     */
+    function headerHTML($el)
+    {
         return "<h2>$el[label]</h2>";
     }
+
     /**
      * Generates the HTML for a header element
      *

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -222,6 +222,19 @@ class LorisForm
         $el['type'] = 'file';
     }
 
+    private function generateName($name) {
+        static $num = 1;
+        if(!empty($name)) {
+            return $name;
+        }
+        return 'anonymous' . ($num++);
+    }
+    function addHeader($name, $label, $options = array()) {
+        $name = $this->generateName($name);
+
+        $el         =& $this->addBase($name, $label, $options);
+        $el['type'] = 'header';
+    }
     /**
      * Generates a unique element name for anonymous elements to use
      * to differentiate things in the internal elements array.
@@ -761,6 +774,9 @@ class LorisForm
         );
     }
 
+    function headerHTML($el) {
+        return "<h2>$el[label]</h2>";
+    }
     /**
      * Generates the HTML for a header element
      *

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -223,23 +223,6 @@ class LorisForm
     }
 
     /**
-     * Generates a name for an element, and creates a new
-     * random name if no name is given.
-     *
-     * @param string $name The name of the element called.
-     *
-     * @return $name if not empty, otherwise an unused name.
-     */
-    private function _generateName($name)
-    {
-        static $num = 1;
-        if (!empty($name)) {
-            return $name;
-        }
-        return 'anonymous' . ($num++);
-    }
-
-    /**
      * Adds a header element to this LorisForm.
      *
      * @param string $name    The name of the header element, may be null
@@ -270,25 +253,6 @@ class LorisForm
             return $name;
         }
         return 'anonymous' . ($num++);
-    }
-
-    /**
-     * Adds a header to the current form.
-     *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
-     *
-     * @return none, modifies $this->form as a side-effect.
-     */
-    function addHeader($name, $label, $options = array())
-    {
-        $name = $this->_generateName($name);
-
-        $el         =& $this->addBase($name, $label, $options);
-        $el['type'] = 'header';
     }
 
     /**
@@ -807,18 +771,6 @@ class LorisForm
         return "<h2>$el[label]</h2>";
     }
 
-    /**
-     * Generates the HTML for a header element
-     *
-     * @param array $el An array of the form used by $this->form
-     *                  for a header
-     *
-     * @return string the HTML for the given header element.
-     */
-    function headerHTML($el)
-    {
-        return "<h2>$el[label]</h2>";
-    }
     /**
      * Generates the HTML for an advcheckbox type element
      *


### PR DESCRIPTION
This adds support for the "header" element type to LorisForms, which are sometimes used by instruments.