### PR TITLE
fix layout bug with table formats for instruments in firefox

### DIFF
--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -8,6 +8,7 @@
 	 }
 </style>
 <form {$form.attributes}>
+<div class="row">
 	{$form.hidden}
 	{$form.errors.mainError}
 	{assign var="inTable" value="FALSE"}
@@ -235,4 +236,5 @@
 		{assign var="inTable" value="FALSE"}
 		</table>
 	{/if}
+</div>
 </form>


### PR DESCRIPTION
Tables in firefox in instruments were showing on the right of the page causing users to have to scroll over to view them. This makes the tables fit within the window. 