### PR TITLE
Adding labels back to the recruitment bar chart.

### DIFF
--- a/modules/dashboard/ajax/get_recruitment_bar_data.php
+++ b/modules/dashboard/ajax/get_recruitment_bar_data.php
@@ -20,7 +20,7 @@ $genderData    = array();
 $list_of_sites = Utility::getAssociativeSiteList(true, false);
 
 foreach ($list_of_sites as $siteID => $siteName) {
-    $genderData['labels'][] = $site;
+    $genderData['labels'][] = $siteName;
     $genderData['datasets']['female'][] = $DB->pselectOne(
         "SELECT COUNT(c.CandID)
          FROM candidate c


### PR DESCRIPTION
While modifying the queries for that dashboard, I didn't rename a variable, which removed the labels from the recruitment bar chart.