### PR TITLE
Replaced duplicate Latest_Visit_Status with missing EDC and remove duplicate Scan_Done

### DIFF
--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -116,10 +116,10 @@
                     </div>
                     <div class="form-group col-sm-4">
                         <label class="col-sm-12 col-md-4">
-                            {$form.Latest_Visit_Status.label}
+                            {$form.edc.label}
                         </label>
                         <div class="col-sm-12 col-md-8">
-                            {$form.Latest_Visit_Status.html}
+                            {$form.edc.html}
                         </div>
                     </div>
                 </div>

--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -134,10 +134,10 @@
                     </div>
                     <div class="form-group col-sm-4">
                         <label class="col-sm-12 col-md-4">
-                            {$form.scan_done.label}
+                            &nbsp;
                         </label>
                         <div class="col-sm-12 col-md-8">
-                            {$form.scan_done.html}
+                            &nbsp;
                         </div>
                     </div>
                     <div class="form-group col-sm-4">

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -72,7 +72,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTest
         );
         $this->DB->update(
             "Config",
-            array("Value" => $this->useEDCBackup),
+            array("Value" => $this->_useEDCBackup),
             array("ConfigID" => $this->_useEDCId)
         );
         parent::tearDown();

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -26,6 +26,57 @@ require_once __DIR__
  */
 class CandidateListTestIntegrationTest extends LorisIntegrationTest
 {
+    private $_useEDCId;
+    private $_useEDCBackup;
+    private $_useProjectsId;
+    private $_useProjectsBackup;
+
+    /**
+     * Backs up the useEDC config value and sets the value to a known
+     * value (true) for testing.
+     *
+     * @return none
+     */
+    function setUp()
+    {
+        parent::setUp();
+
+        $this->_useEDCId = $this->DB->pselectOne(
+            "SELECT ID FROM ConfigSettings WHERE NAME=:useEDC",
+            array(":useEDC" => "useEDC")
+        );
+
+        $this->_useEDCBackup = $this->DB->pselectOne(
+            "SELECT Value FROM Config WHERE ConfigID=:useEDC",
+            array(":useEDC" => $this->_useEDCId)
+        );
+
+        $this->DB->update(
+            "Config",
+            array("Value" => "true"),
+            array("ConfigID" => $this->_useEDCId)
+        );
+
+    }
+
+    /**
+     * Restore the values backed up in the setUp function
+     *
+     * @return none
+     */
+    function tearDown()
+    {
+        $this->_useEDCBackup = $this->DB->pselectOne(
+            "SELECT Value FROM Config WHERE ConfigID=:useEDC",
+            array(":useEDC" => $this->_useEDCId)
+        );
+        $this->DB->update(
+            "Config",
+            array("Value" => $this->useEDCBackup),
+            array("ConfigID" => $this->_useEDCId)
+        );
+        parent::tearDown();
+    }
     /**
      * Tests that, when loading the candidate_list module, the breadcrumb
      * appears and the default filters are set to "Basic" mode.
@@ -54,6 +105,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTest
      */
     function testCandidateListAdvancedOptionsAppear()
     {
+
         $this->webDriver->get($this->url . "?test_name=candidate_list");
         $bodyText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector("body"))->getText();

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -27,17 +27,82 @@ require_once __DIR__
 class CandidateListTestIntegrationTest extends LorisIntegrationTest
 {
     /**
-     * Tests that, when loading the candidate_list module, some
-     * text appears in the body.
+     * Tests that, when loading the candidate_list module, the breadcrumb
+     * appears and the default filters are set to "Basic" mode.
      *
      * @return void
      */
-    function testCandidateListDoespageLoad()
+    function testCandidateListPageLoads()
     {
         $this->webDriver->get($this->url . "?test_name=candidate_list");
         $bodyText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("Access Profile", $bodyText);
+
+        $basicButton = $this->webDriver->findElement(WebDriverBy::Name("advanced"));
+
+        // Ensure that the default is basic mode (which means the button
+        // says "Advanced")
+        $this->assertEquals("Advanced", $basicButton->getAttribute("value"));
+    }
+
+    /**
+     * Tests that, after clicking the "Advanced" button, all of the
+     * advanced filters appear on the page and are the correct element type.
+     *
+     * @return void
+     */
+    function testCandidateListAdvancedOptionsAppear()
+    {
+        $this->webDriver->get($this->url . "?test_name=candidate_list");
+        $bodyText = $this->webDriver
+            ->findElement(WebDriverBy::cssSelector("body"))->getText();
+        $this->assertContains("Access Profile", $bodyText);
+
+        // Switch to Advanced mode
+        $basicButton = $this->webDriver->findElement(WebDriverBy::Name("advanced"));
+        $basicButton->click();
+
+        // Go through each element and ensure it's on the page after clicking
+        // advanced
+        $scanDoneOptions = $this->webDriver->findElement(
+            WebDriverBy::Name("scan_done")
+        );
+        $this->assertEquals("select", $scanDoneOptions->getTagName());
+
+        $participantsStatusOptions = $this->webDriver->findElement(
+            WebDriverBy::Name("Participant_Status")
+        );
+        $this->assertEquals("select", $participantsStatusOptions->getTagName());
+
+        $dobOptions = $this->webDriver->findElement(WebDriverBy::Name("dob"));
+        $this->assertEquals("input", $dobOptions->getTagName());
+        // Not currently done
+        //$this->assertEquals("date",$dobOptions->getAttribute("type"));
+
+        $genderOptions = $this->webDriver->findElement(WebDriverBy::Name("gender"));
+        $this->assertEquals("select", $genderOptions->getTagName());
+
+        $numVisits = $this->webDriver->findElement(WebDriverBy::Name("Visit_Count"));
+        $this->assertEquals("input", $dobOptions->getTagName());
+        // Not currently done in Loris.
+        //$this->assertEquals("number",$dobOptions->getAttribute("type"));
+        //$this->assertEquals("0",$dobOptions->getAttribute("min"));
+
+        $edcOptions = $this->webDriver->findElement(WebDriverBy::Name("edc"));
+        $this->assertEquals("input", $edcOptions->getTagName());
+        // Not currently done
+        //$this->assertEquals("date",$edcOptions->getAttribute("type"));
+
+        $latestVisitOptions = $this->webDriver->findElement(
+            WebDriverBy::Name("Latest_Visit_Status")
+        );
+        $this->assertEquals("select", $latestVisitOptions->getTagName());
+
+        $feedbackOptions = $this->webDriver->findElement(
+            WebDriverBy::Name("Feedback")
+        );
+        $this->assertEquals("select", $feedbackOptions->getTagName());
     }
 }
 ?>


### PR DESCRIPTION
The Latest_Visit_Status filter was on the candidate_list page twice,
but the EDC was missing even if useEDC was set to true in the config
file. Clearly, one of these was incorrect, so this updates one of the
duplicate dropdowns to be the correct EDC dropdown.

Scan_Done also appeared twice, but has nothing obvious to replace the second
instance with, so it's simply removed.