### PR TITLE
Fixed the Participant_Status filter in candidate_list page

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -112,7 +112,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->order_by = 'psc.Name, c.CandID DESC, s.VisitNo';
 
         $this->validFilters       = array(
-                                     'participant_status_options.ID',
+                                     'pso.ID',
                                      'c.CenterID',
                                      'c.CandID',
                                      'c.PSCID',


### PR DESCRIPTION
The item in the "ValidFilters" array did not match the way that the column was referred to in formToFilter array.