### PR TITLE
LorisForm selectHTML bug fix

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -366,7 +366,7 @@ class LorisForm
         foreach ($options as $optionKey => $optionVal) {
             $selected = '';
 
-            if ($optionKey == $this->getValue($el['name'])) {
+            if ($optionKey === $this->getValue($el['name'])) {
                 $selected = 'selected="selected"';
             }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -366,6 +366,10 @@ class LorisForm
         foreach ($options as $optionKey => $optionVal) {
             $selected = '';
 
+            if (!is_null($optionKey)) {
+                $optionKey = (string) $optionKey;
+            }
+
             if ($optionKey === $this->getValue($el['name'])) {
                 $selected = 'selected="selected"';
             }


### PR DESCRIPTION
This fixes a bug where LorisForm does not create the correct HTML for selects that have options that include both the "null" key and the "0" key

Changes a comparison to the === operator, which required casting the optionKey to a string so that the identical (===) operator does not return false when comparing to the string values from the post request