### PR TITLE
Add a setFakeTableData function to the Database wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
     # for the config file, and reset the Loris user's password for testing
     - mysql -e 'CREATE DATABASE LorisTest'
     - mysql LorisTest < SQL/0000-00-00-schema.sql
-    - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
+    - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
     - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - sed -e "s/%HOSTNAME%/localhost/g"
           -e "s/%USERNAME%/SQLTestUser/g"

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -536,6 +536,9 @@ class Database extends PEAR
     {
         $this->_printQuery($query);
         $this->affected     = $this->_PDO->exec($query);
+        if($this->affected === false) {
+            throw new DatabaseException("Could not run query $query");
+        }
         $this->lastInsertID = $this->_PDO->lastInsertId();
     }
 
@@ -899,6 +902,8 @@ class Database extends PEAR
             foreach($rowData as $row) {
                 $this->insert($tableName, $row);
             }
+        } else {
+            throw new DatabaseException("Could not retrieve schema of table $tableName");
         };
 
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -869,5 +869,40 @@ class Database extends PEAR
     {
         return $this->affected;
     }
+
+    /**
+     * This function fakes the data in a table for testing purposes.
+     * It replaces the existing table with a temporary table for the
+     * session, and then inserts the data passed into the temporary
+     * table. This should allow people to write more robust data
+     * dependant unit tests that depend on the data in the database
+     * without mocking every single query that needs to be used in
+     * that test.
+     *
+     * @param string $tableName The table name to fake
+     * @param array  $rowData   An array of data to be inserted into
+     *                          the fake table.
+     *
+     * @return none
+     */
+    function setFakeTableData($tableName, $rowData) {
+        $originalTableQuery = $this->_PDO->query("SHOW CREATE TABLE $tableName");
+
+        if($originalTableQuery->execute()) {
+            $createRslt = $originalTableQuery->fetchAll();
+            $createStmt = $createRslt[0]['Create Table'];
+
+            $createStmt = preg_replace("/CREATE TABLE/", "CREATE TEMPORARY TABLE", $createStmt);
+
+            $this->run($createStmt);
+
+            foreach($rowData as $row) {
+                $this->insert($tableName, $row);
+            }
+        };
+
+
+
+    }
 }
 ?>

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -535,8 +535,9 @@ class Database extends PEAR
     function run($query)
     {
         $this->_printQuery($query);
-        $this->affected     = $this->_PDO->exec($query);
-        if($this->affected === false) {
+        $this->affected = $this->_PDO->exec($query);
+
+        if ($this->affected === false) {
             throw new DatabaseException("Could not run query $query");
         }
         $this->lastInsertID = $this->_PDO->lastInsertId();
@@ -888,26 +889,30 @@ class Database extends PEAR
      *
      * @return none
      */
-    function setFakeTableData($tableName, $rowData) {
+    function setFakeTableData($tableName, $rowData)
+    {
         $originalTableQuery = $this->_PDO->query("SHOW CREATE TABLE $tableName");
 
-        if($originalTableQuery->execute()) {
+        if ($originalTableQuery->execute()) {
             $createRslt = $originalTableQuery->fetchAll();
             $createStmt = $createRslt[0]['Create Table'];
 
-            $createStmt = preg_replace("/CREATE TABLE/", "CREATE TEMPORARY TABLE", $createStmt);
+            $createStmt = preg_replace(
+                "/CREATE TABLE/",
+                "CREATE TEMPORARY TABLE",
+                $createStmt
+            );
 
             $this->run($createStmt);
 
-            foreach($rowData as $row) {
+            foreach ($rowData as $row) {
                 $this->insert($tableName, $row);
             }
         } else {
-            throw new DatabaseException("Could not retrieve schema of table $tableName");
+            throw new DatabaseException(
+                "Could not retrieve schema of table $tableName"
+            );
         };
-
-
-
     }
 }
 ?>

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -34,53 +34,25 @@ class Database_Test extends PHPUnit_Framework_TestCase
         $DB = Database::singleton();
 
         $DB->setFakeTableData(
-            "candidate",
+            "Config",
             array(
                 0 => array(
-                'CandID' => '123456',
-                'PSCID'  => 'FKE1234',
-                'DoB'    => '1900-01-01',
-                'Testdate' => '2015-04-15 11:32:34'
+                    'ID' => 99999,
+                'ConfigID' => '123456',
+                'Value'  => 'FKE1234',
             )
             )
         );
 
-        $allCandidates = $DB->pselect("SELECT * FROM candidate", array());
+        $allCandidates = $DB->pselect("SELECT * FROM Config", array());
 
         $this->assertEquals(
             $allCandidates,
             array(
                 0 => array(
-                    'ID' => 1568,
-                    'CandID' => 123456,
-                    'PSCID' => 'FKE1234',
-                    'ExternalID' => '',
-                    'DoB' => '1900-01-01',
-                    'EDC' => '',
-                    'Gender' => '',
-                    'CenterID' => 0,
-                    'ProjectID' => '',
-                    'Ethnicity' => '',
-                    'Active' => 'Y',
-                    'Date_active' =>  '',
-                    'Cancelled' => 'N',
-                    'Date_cancelled' => '',
-                    'RegisteredBy' => '',
-                    'UserID' => '',
-                    'Date_registered' => '',
-                    'Testdate' => '2015-04-15 11:32:34',
-                    'Entity_type' => 'Human',
-                    'IBISId' => '',
-                    'CandidateGUID' => '',
-                    'ProbandGUID' => '',
-                    'EARLIId' =>  '',
-                    'ProbandGender' => '',
-                    'ProbandDoB' => '',
-                    'flagged_caveatemptor' => 'false',
-                    'flagged_info' => '',
-                    'flagged_other' => '',
-                    'flagged_other_status' => '',
-                    'flagged_reason' => ''
+                    'ID' => 99999,
+                    'ConfigID' => 123456,
+                    'Value' => 'FKE1234',
                 )
 
             )

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This tests the LorisForm replacement for HTML_QuickForm used by
+ * Loris.
+ *
+ * PHP Version 5
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * This tests the LorisForm replacement for HTML_QuickForm used by
+ * Loris.
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Database_Test extends PHPUnit_Framework_TestCase
+{
+    function testSetFakeData() {
+        $client = new NDB_Client();
+        $client->makeCommandLine();
+        $client->initialize();
+
+
+        $DB = Database::singleton();
+
+        $DB->setFakeTableData(
+            "candidate",
+            array(
+                0 => array(
+                'CandID' => '123456',
+                'PSCID'  => 'FKE1234',
+                'DoB'    => '1900-01-01',
+                'Testdate' => '2015-04-15 11:32:34'
+            )
+            )
+        );
+
+        $allCandidates = $DB->pselect("SELECT * FROM candidate", array());
+
+        $this->assertEquals(
+            $allCandidates,
+            array(
+                0 => array(
+                    'ID' => 1568,
+                    'CandID' => 123456,
+                    'PSCID' => 'FKE1234',
+                    'ExternalID' => '',
+                    'DoB' => '1900-01-01',
+                    'EDC' => '',
+                    'Gender' => '',
+                    'CenterID' => 0,
+                    'ProjectID' => '',
+                    'Ethnicity' => '',
+                    'Active' => 'Y',
+                    'Date_active' =>  '',
+                    'Cancelled' => 'N',
+                    'Date_cancelled' => '',
+                    'RegisteredBy' => '',
+                    'UserID' => '',
+                    'Date_registered' => '',
+                    'Testdate' => '2015-04-15 11:32:34',
+                    'Entity_type' => 'Human',
+                    'IBISId' => '',
+                    'CandidateGUID' => '',
+                    'ProbandGUID' => '',
+                    'EARLIId' =>  '',
+                    'ProbandGender' => '',
+                    'ProbandDoB' => '',
+                    'flagged_caveatemptor' => 'false',
+                    'flagged_info' => '',
+                    'flagged_other' => '',
+                    'flagged_other_status' => '',
+                    'flagged_reason' => ''
+                )
+
+            )
+        );
+
+    }
+}
+?>


### PR DESCRIPTION
This function fakes the data in a table for testing purposes.

It replaces the existing table with a temporary table for the
(testing) session, and then inserts the data passed into the
temporary table. This should allow people to write more robust
data dependant unit tests that depend on the data in the database
without mocking every single query that needs to be used in
that test.