### PR TITLE
Cache the vendor directory in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+cache:
+    directories:
+        - vendor
+
 php:
     - 5.4
     - 5.6


### PR DESCRIPTION
This speeds up the Travis build by caching the vendor directory
generated by composer, so that it doesn't need to download and
install all third party dependencies on every build.