### PR TITLE
Added explicit wait after login attempt

### DIFF
--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -116,6 +116,15 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
 
         $login = $this->webDriver->findElement(WebDriverBy::Name("login"));
         $login->click();
+
+        // Explicitly wait until the page is loaded.
+        // Wait up to a minute, because sometimes when multiple tests
+        // are run one will fail due to the login taking too long?
+        $this->webDriver->wait(60, 1000)->until(
+            WebDriverExpectedCondition::presenceOfElementLocated(
+                WebDriverBy::id("page")
+            )
+        );
     }
 
     /**

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -120,7 +120,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         // Explicitly wait until the page is loaded.
         // Wait up to a minute, because sometimes when multiple tests
         // are run one will fail due to the login taking too long?
-        $this->webDriver->wait(60, 1000)->until(
+        $this->webDriver->wait(120, 1000)->until(
             WebDriverExpectedCondition::presenceOfElementLocated(
                 WebDriverBy::id("page")
             )


### PR DESCRIPTION
This adds an explicit wait for the page to load after clicking on the "login" button in our integration
tests. If the gods are good, this should hopefully fix the issues with different integration tests randomly
failing for no known reason on different Travis runs.