### PR TITLE
Fixed bug in instrument manager: installing instrument was failing

### DIFF
--- a/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
+++ b/modules/instrument_manager/php/NDB_Menu_Filter_instrument_manager.class.inc
@@ -50,14 +50,18 @@ class NDB_Menu_Filter_instrument_manager extends NDB_Menu_Filter
             if($exists <= 0) {
                 $db_config = $config->getSetting('database');
                 exec("php generate_tables_sql_and_testNames.php < $new_file");
-                exec("mysql -u" . escapeshellarg($db_config['quatUser']) 
-                                . " -p" . escapeshellarg($db_config['quatPassword']) 
-                                ." " . escapeshellarg($db_config['database'])  
-                                . " < " . $this->path . "project/tables_sql/$instname.sql");
-                $db->insert("test_names", array(
-                    "Test_name" => $instname,
-                    'Sub_group' => 0
-                ));
+
+                $instrument =& NDB_BVL_Instrument::factory(
+                    $instname,
+                    NULL,
+                    NULL
+                );
+
+                exec("mysql -u" . escapeshellarg($db_config['quatUser'])
+                    . " -p" . escapeshellarg($db_config['quatPassword'])
+                    . " " . escapeshellarg($db_config['database'])
+                    . " < " . $this->path . "project/tables_sql/".$instrument->table.".sql");
+
             }
         }
     }

--- a/modules/instrument_manager/test/TestPlan
+++ b/modules/instrument_manager/test/TestPlan
@@ -2,7 +2,7 @@ Instrument Manager Test Plan
 
 1. User has access to Instrument Manager if he/she has permission “superuser”.
 2. Check that tab exists on a default install (for superusers).
-3. Check that the warning text above is accurate for both with and without the directory writeable by Apache. The select file/upload button shouuld only be there if it's writeable.
+3. Check that the warning text above is accurate for both with and without the directory writable by Apache. The select file/upload button should only be there if it's writable.
 4. Verify GUI is updated, menu tabs are working.
 5. Take a sample .linst instrument file with a variety of field types (dropdown, number, textbox).  Upload in Instrument Manager.
 Check that instrument gets installed properly - instruments/ tables_sql/ . 

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -221,7 +221,7 @@ class NDB_Caller extends PEAR
                 return $html;
             }
 
-            // it is an intrument
+            // it is an instrument
             $phpfile   = $base . "project/instruments/"
                                . "NDB_BVL_Instrument_$test_name.class.inc";
             $linstfile = $base."project/instruments/$test_name.linst";


### PR DESCRIPTION
- removed insert into test_names table. Insert is already done in instrument sql file. (+ it was failing due to foreign key constraint)
- Changed SQL file name to match the one which is generated by loris/tools/generate_tables_sql_and_testNames.php. (The issue was: file names were not matching. The file name of generated SQL file is the same as the table name, while the one being loaded was using the .linst file name.)