### PR TITLE
Test that Test Battery Lookup works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
     # for the config file, and reset the Loris user's password for testing
     - mysql -e 'CREATE DATABASE LorisTest'
     - mysql LorisTest < SQL/0000-00-00-schema.sql
-    - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
+    - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
     - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - sed -e "s/%HOSTNAME%/localhost/g"
           -e "s/%USERNAME%/SQLTestUser/g"

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -517,9 +517,7 @@ CREATE TABLE `history` (
   `changeDate` timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
   `userID` varchar(255) NOT NULL default '',
   `type` char(1),
-  PRIMARY KEY  (`id`),
-  KEY `FK_history_1` (`userID`),
-  CONSTRAINT `FK_history_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
+  PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table keeps track of ongoing changes in the database. ';
 
 --

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -536,6 +536,9 @@ class Database extends PEAR
     {
         $this->_printQuery($query);
         $this->affected     = $this->_PDO->exec($query);
+        if($this->affected === false) {
+            throw new DatabaseException("Could not run query $query");
+        }
         $this->lastInsertID = $this->_PDO->lastInsertId();
     }
 
@@ -899,6 +902,8 @@ class Database extends PEAR
             foreach($rowData as $row) {
                 $this->insert($tableName, $row);
             }
+        } else {
+            throw new DatabaseException("Could not retrieve schema of table $tableName");
         };
 
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -904,6 +904,16 @@ class Database extends PEAR
                 "CREATE TEMPORARY TABLE",
                 $createStmt
             );
+            $createStmt = preg_replace(
+                "/(CONSTRAINT)(.*)(,)/",
+                "$3",
+                $createStmt
+            );
+            $createStmt = preg_replace(
+                "/,(\s*)(\))/",
+                ")",
+                $createStmt
+            );
 
             $this->run($createStmt);
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -869,5 +869,40 @@ class Database extends PEAR
     {
         return $this->affected;
     }
+
+    /**
+     * This function fakes the data in a table for testing purposes.
+     * It replaces the existing table with a temporary table for the
+     * session, and then inserts the data passed into the temporary
+     * table. This should allow people to write more robust data
+     * dependant unit tests that depend on the data in the database
+     * without mocking every single query that needs to be used in
+     * that test.
+     *
+     * @param string $tableName The table name to fake
+     * @param array  $rowData   An array of data to be inserted into
+     *                          the fake table.
+     *
+     * @return none
+     */
+    function setFakeTableData($tableName, $rowData) {
+        $originalTableQuery = $this->_PDO->query("SHOW CREATE TABLE $tableName");
+
+        if($originalTableQuery->execute()) {
+            $createRslt = $originalTableQuery->fetchAll();
+            $createStmt = $createRslt[0]['Create Table'];
+
+            $createStmt = preg_replace("/CREATE TABLE/", "CREATE TEMPORARY TABLE", $createStmt);
+
+            $this->run($createStmt);
+
+            foreach($rowData as $row) {
+                $this->insert($tableName, $row);
+            }
+        };
+
+
+
+    }
 }
 ?>

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -538,7 +538,8 @@ class Database extends PEAR
         $this->affected = $this->_PDO->exec($query);
 
         if ($this->affected === false) {
-            throw new DatabaseException("Could not run query $query"
+            throw new DatabaseException(
+                "Could not run query $query"
                 . print_r($this->_PDO->errorInfo(), true)
             );
         }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -538,7 +538,9 @@ class Database extends PEAR
         $this->affected = $this->_PDO->exec($query);
 
         if ($this->affected === false) {
-            throw new DatabaseException("Could not run query $query");
+            throw new DatabaseException("Could not run query $query"
+                . print_r($this->_PDO->errorInfo(), true)
+            );
         }
         $this->lastInsertID = $this->_PDO->lastInsertId();
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -535,8 +535,9 @@ class Database extends PEAR
     function run($query)
     {
         $this->_printQuery($query);
-        $this->affected     = $this->_PDO->exec($query);
-        if($this->affected === false) {
+        $this->affected = $this->_PDO->exec($query);
+
+        if ($this->affected === false) {
             throw new DatabaseException("Could not run query $query");
         }
         $this->lastInsertID = $this->_PDO->lastInsertId();
@@ -888,26 +889,30 @@ class Database extends PEAR
      *
      * @return none
      */
-    function setFakeTableData($tableName, $rowData) {
+    function setFakeTableData($tableName, $rowData)
+    {
         $originalTableQuery = $this->_PDO->query("SHOW CREATE TABLE $tableName");
 
-        if($originalTableQuery->execute()) {
+        if ($originalTableQuery->execute()) {
             $createRslt = $originalTableQuery->fetchAll();
             $createStmt = $createRslt[0]['Create Table'];
 
-            $createStmt = preg_replace("/CREATE TABLE/", "CREATE TEMPORARY TABLE", $createStmt);
+            $createStmt = preg_replace(
+                "/CREATE TABLE/",
+                "CREATE TEMPORARY TABLE",
+                $createStmt
+            );
 
             $this->run($createStmt);
 
-            foreach($rowData as $row) {
+            foreach ($rowData as $row) {
                 $this->insert($tableName, $row);
             }
         } else {
-            throw new DatabaseException("Could not retrieve schema of table $tableName");
+            throw new DatabaseException(
+                "Could not retrieve schema of table $tableName"
+            );
         };
-
-
-
     }
 }
 ?>

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -905,8 +905,8 @@ class Database extends PEAR
                 $createStmt
             );
             $createStmt = preg_replace(
-                "/(CONSTRAINT)(.*)(,)/",
-                "$3",
+                "/(\s*)(CONSTRAINT)(.*)(,*)(\s*)/",
+                "$4",
                 $createStmt
             );
             $createStmt = preg_replace(

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -478,6 +478,10 @@ class NDB_BVL_Battery extends PEAR
             $query .= " AND b.CenterID IS NULL";
         }
 
+        if ($firstVisit === false) {
+            $query .= " AND (b.firstVisit IS NULL OR b.firstVisit='N')";
+        }
+
         // get the list of instruments
         $tests = array();
         $rows  = $DB->pselect($query, $qparams);

--- a/test/integrationtests/BatteryLookup_Test.php
+++ b/test/integrationtests/BatteryLookup_Test.php
@@ -33,6 +33,67 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
         $this->DB = Database::singleton();
 
         $this->DB->setFakeTableData(
+            "test_names",
+            array(
+             array(
+              'ID'        => 1,
+              'Test_name' => 'ActiveTestByAge',
+              'Full_name' => 'Active Test 1',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 2,
+              'Test_name' => 'ActiveTestByAge2',
+              'Full_name' => 'Active Test 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 3,
+              'Test_name' => 'InactiveTest',
+              'Full_name' => 'Inactive Test 1',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 4,
+              'Test_name'    => 'ActiveTestByVisit',
+              'Full_name' => 'Active Test by Visit 1',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 5,
+              'Test_name'    => 'ActiveTestByVisit2',
+              'Full_name' => 'Active Test by Visit 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 6,
+              'Test_name'    => 'ActiveTestByFirstVisit',
+              'Full_name' => 'Active Test by First Visit 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 7,
+              'Test_name'    => 'ActiveTestByNotFirstVisit',
+              'Full_name' => 'Active Test by Not First Visit 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+            )
+        );
+        $this->DB->setFakeTableData(
             "test_battery",
             array(
              array(
@@ -122,67 +183,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
             )
         );
 
-        $this->DB->setFakeTableData(
-            "test_names",
-            array(
-             array(
-              'ID'        => 1,
-              'Test_name' => 'ActiveTestByAge',
-              'Full_name' => 'Active Test 1',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-             array(
-              'ID'        => 2,
-              'Test_name' => 'ActiveTestByAge2',
-              'Full_name' => 'Active Test 2',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-             array(
-              'ID'        => 3,
-              'Test_name' => 'InactiveTest',
-              'Full_name' => 'Inactive Test 1',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-             array(
-              'ID'        => 4,
-              'Test_name'    => 'ActiveTestByVisit',
-              'Full_name' => 'Active Test by Visit 1',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-             array(
-              'ID'        => 5,
-              'Test_name'    => 'ActiveTestByVisit2',
-              'Full_name' => 'Active Test by Visit 2',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-             array(
-              'ID'        => 6,
-              'Test_name'    => 'ActiveTestByFirstVisit',
-              'Full_name' => 'Active Test by First Visit 2',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-             array(
-              'ID'        => 7,
-              'Test_name'    => 'ActiveTestByNotFirstVisit',
-              'Full_name' => 'Active Test by Not First Visit 2',
-              'LimitAge'    => 0,
-              'Sub_group' => 1,
-              'IsDirectEntry' => 0
-             ),
-            )
-        );
     }
 
     function tearDown() {

--- a/test/integrationtests/BatteryLookup_Test.php
+++ b/test/integrationtests/BatteryLookup_Test.php
@@ -39,7 +39,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 1,
               'Test_name' => 'ActiveTestByAge',
               'Full_name' => 'Active Test 1',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),
@@ -47,7 +46,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 2,
               'Test_name' => 'ActiveTestByAge2',
               'Full_name' => 'Active Test 2',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),
@@ -55,7 +53,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 3,
               'Test_name' => 'InactiveTest',
               'Full_name' => 'Inactive Test 1',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),
@@ -63,7 +60,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 4,
               'Test_name'    => 'ActiveTestByVisit',
               'Full_name' => 'Active Test by Visit 1',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),
@@ -71,7 +67,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 5,
               'Test_name'    => 'ActiveTestByVisit2',
               'Full_name' => 'Active Test by Visit 2',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),
@@ -79,7 +74,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 6,
               'Test_name'    => 'ActiveTestByFirstVisit',
               'Full_name' => 'Active Test by First Visit 2',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),
@@ -87,7 +81,6 @@ class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
               'ID'        => 7,
               'Test_name'    => 'ActiveTestByNotFirstVisit',
               'Full_name' => 'Active Test by Not First Visit 2',
-              'LimitAge'    => 0,
               'Sub_group' => 1,
               'IsDirectEntry' => 0
              ),

--- a/test/integrationtests/BatteryLookup_Test.php
+++ b/test/integrationtests/BatteryLookup_Test.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * This tests the LorisForm replacement for HTML_QuickForm used by
+ * Loris.
+ *
+ * PHP Version 5
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * This tests the LorisForm replacement for HTML_QuickForm used by
+ * Loris.
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NDB_BVL_Battery_Test extends PHPUnit_Framework_TestCase
+{
+    function setUp() {
+        $client = new NDB_Client();
+        $client->makeCommandLine();
+        $client->initialize();
+
+        $this->DB = Database::singleton();
+
+        $this->DB->setFakeTableData(
+            "test_battery",
+            array(
+             array(
+              'ID'           => 1,
+              'Test_name'    => 'ActiveTestByAge',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 100,
+              'Active'       => 'Y',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 1,
+              'Visit_label'  => null,
+              'CenterID'     => null,
+              'firstVisit'   => null,
+             ),
+             array(
+              'ID'           => 2,
+              'Test_name'    => 'ActiveTestByAge2',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 100,
+              'Active'       => 'Y',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 1,
+              'Visit_label'  => null,
+              'CenterID'     => '1',
+              'firstVisit'   => null,
+             ),
+             array(
+              'ID'           => 3,
+              'Test_name'    => 'InactiveTest',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 0,
+              'Active'       => 'N',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 2,
+              'Visit_label'  => 'V01',
+              'CenterID'     => '1',
+              'firstVisit'   => null,
+             ),
+             array(
+              'ID'           => 4,
+              'Test_name'    => 'ActiveTestByVisit',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 0,
+              'Active'       => 'Y',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 2,
+              'Visit_label'  => 'V01',
+              'CenterID'     => null,
+              'firstVisit'   => null,
+             ),
+             array(
+              'ID'           => 5,
+              'Test_name'    => 'ActiveTestByVisit2',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 0,
+              'Active'       => 'Y',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 2,
+              'Visit_label'  => 'V01',
+              'CenterID'     => '1',
+              'firstVisit'   => null,
+             ),
+             array(
+              'ID'           => 6,
+              'Test_name'    => 'ActiveTestByFirstVisit',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 100,
+              'Active'       => 'Y',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 1,
+              'Visit_label'  => null,
+              'CenterID'     => '1',
+              'firstVisit'   => 'Y',
+             ),
+             array(
+              'ID'           => 7,
+              'Test_name'    => 'ActiveTestByNotFirstVisit',
+              'AgeMinDays'   => 0,
+              'AgeMaxDays'   => 100,
+              'Active'       => 'Y',
+              'Stage'        => 'Visit',
+              'SubprojectID' => 1,
+              'Visit_label'  => null,
+              'CenterID'     => '1',
+              'firstVisit'   => 'N',
+             ),
+            )
+        );
+
+        $this->DB->setFakeTableData(
+            "test_names",
+            array(
+             array(
+              'ID'        => 1,
+              'Test_name' => 'ActiveTestByAge',
+              'Full_name' => 'Active Test 1',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 2,
+              'Test_name' => 'ActiveTestByAge2',
+              'Full_name' => 'Active Test 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 3,
+              'Test_name' => 'InactiveTest',
+              'Full_name' => 'Inactive Test 1',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 4,
+              'Test_name'    => 'ActiveTestByVisit',
+              'Full_name' => 'Active Test by Visit 1',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 5,
+              'Test_name'    => 'ActiveTestByVisit2',
+              'Full_name' => 'Active Test by Visit 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 6,
+              'Test_name'    => 'ActiveTestByFirstVisit',
+              'Full_name' => 'Active Test by First Visit 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+             array(
+              'ID'        => 7,
+              'Test_name'    => 'ActiveTestByNotFirstVisit',
+              'Full_name' => 'Active Test by Not First Visit 2',
+              'LimitAge'    => 0,
+              'Sub_group' => 1,
+              'IsDirectEntry' => 0
+             ),
+            )
+        );
+    }
+
+    function tearDown() {
+        $this->DB->run("DROP TEMPORARY TABLE test_names");
+        $this->DB->run("DROP TEMPORARY TABLE test_battery");
+
+    }
+
+    function testLookupBatteryByAge() {
+        $battery = new NDB_BVL_Battery();
+
+        $instruments = $battery->lookupBattery(50, 1, 'Visit', 'V01', '1', null);
+
+        $this->assertEquals(
+            $instruments,
+            array(
+             'ActiveTestByAge',
+             'ActiveTestByAge2',
+             'ActiveTestByFirstVisit',
+             'ActiveTestByNotFirstVisit',
+         )
+     );
+    }
+
+    function testLookupBatteryByVisit() {
+        $battery = new NDB_BVL_Battery();
+
+        $instruments = $battery->lookupBattery(50, 2, 'Visit', 'V01', '1', true);
+
+        $this->assertEquals(
+            $instruments,
+            array(
+             'ActiveTestByVisit',
+             'ActiveTestByVisit2',
+            )
+        );
+    }
+
+    function testLookupBatteryWithoutCenterID() {
+        $battery = new NDB_BVL_Battery();
+
+        $instrumentsByAge   = $battery->lookupBattery(50, 1, 'Visit', 'V01', '2', true);
+        $instrumentsByVisit = $battery->lookupBattery(50, 2, 'Visit', 'V01', '2', true);
+
+        $this->assertEquals(
+            $instrumentsByAge,
+            array(
+             'ActiveTestByAge',
+              'ActiveTestByFirstVisit',
+             )
+        );
+
+        $this->assertEquals(
+            $instrumentsByVisit,
+            array(
+             'ActiveTestByVisit',
+            )
+        );
+    }
+
+    function testLookupBatteryByFirstVisit() {
+        $battery = new NDB_BVL_Battery();
+
+        $firstVisitInstruments = $battery->lookupBattery(50, 1, 'Visit', 'V01', '1', true);
+
+        $this->assertEquals(
+            $firstVisitInstruments,
+            array(
+             'ActiveTestByAge',
+             'ActiveTestByAge2',
+             'ActiveTestByFirstVisit',
+            )
+        );
+
+        $notFirstVisitInstruments = $battery->lookupBattery(50, 1, 'Visit', 'V01', '1', false);
+
+        $this->assertEquals(
+            $notFirstVisitInstruments,
+            array(
+             'ActiveTestByAge',
+             'ActiveTestByAge2',
+             'ActiveTestByNotFirstVisit',
+            )
+        );
+    }
+
+}
+?>

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -34,53 +34,25 @@ class Database_Test extends PHPUnit_Framework_TestCase
         $DB = Database::singleton();
 
         $DB->setFakeTableData(
-            "candidate",
+            "Config",
             array(
                 0 => array(
-                'CandID' => '123456',
-                'PSCID'  => 'FKE1234',
-                'DoB'    => '1900-01-01',
-                'Testdate' => '2015-04-15 11:32:34'
+                    'ID' => 99999,
+                'ConfigID' => '123456',
+                'Value'  => 'FKE1234',
             )
             )
         );
 
-        $allCandidates = $DB->pselect("SELECT * FROM candidate", array());
+        $allCandidates = $DB->pselect("SELECT * FROM Config", array());
 
         $this->assertEquals(
             $allCandidates,
             array(
                 0 => array(
-                    'ID' => 1568,
-                    'CandID' => 123456,
-                    'PSCID' => 'FKE1234',
-                    'ExternalID' => '',
-                    'DoB' => '1900-01-01',
-                    'EDC' => '',
-                    'Gender' => '',
-                    'CenterID' => 0,
-                    'ProjectID' => '',
-                    'Ethnicity' => '',
-                    'Active' => 'Y',
-                    'Date_active' =>  '',
-                    'Cancelled' => 'N',
-                    'Date_cancelled' => '',
-                    'RegisteredBy' => '',
-                    'UserID' => '',
-                    'Date_registered' => '',
-                    'Testdate' => '2015-04-15 11:32:34',
-                    'Entity_type' => 'Human',
-                    'IBISId' => '',
-                    'CandidateGUID' => '',
-                    'ProbandGUID' => '',
-                    'EARLIId' =>  '',
-                    'ProbandGender' => '',
-                    'ProbandDoB' => '',
-                    'flagged_caveatemptor' => 'false',
-                    'flagged_info' => '',
-                    'flagged_other' => '',
-                    'flagged_other_status' => '',
-                    'flagged_reason' => ''
+                    'ID' => 99999,
+                    'ConfigID' => 123456,
+                    'Value' => 'FKE1234',
                 )
 
             )

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This tests the LorisForm replacement for HTML_QuickForm used by
+ * Loris.
+ *
+ * PHP Version 5
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * This tests the LorisForm replacement for HTML_QuickForm used by
+ * Loris.
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Database_Test extends PHPUnit_Framework_TestCase
+{
+    function testSetFakeData() {
+        $client = new NDB_Client();
+        $client->makeCommandLine();
+        $client->initialize();
+
+
+        $DB = Database::singleton();
+
+        $DB->setFakeTableData(
+            "candidate",
+            array(
+                0 => array(
+                'CandID' => '123456',
+                'PSCID'  => 'FKE1234',
+                'DoB'    => '1900-01-01',
+                'Testdate' => '2015-04-15 11:32:34'
+            )
+            )
+        );
+
+        $allCandidates = $DB->pselect("SELECT * FROM candidate", array());
+
+        $this->assertEquals(
+            $allCandidates,
+            array(
+                0 => array(
+                    'ID' => 1568,
+                    'CandID' => 123456,
+                    'PSCID' => 'FKE1234',
+                    'ExternalID' => '',
+                    'DoB' => '1900-01-01',
+                    'EDC' => '',
+                    'Gender' => '',
+                    'CenterID' => 0,
+                    'ProjectID' => '',
+                    'Ethnicity' => '',
+                    'Active' => 'Y',
+                    'Date_active' =>  '',
+                    'Cancelled' => 'N',
+                    'Date_cancelled' => '',
+                    'RegisteredBy' => '',
+                    'UserID' => '',
+                    'Date_registered' => '',
+                    'Testdate' => '2015-04-15 11:32:34',
+                    'Entity_type' => 'Human',
+                    'IBISId' => '',
+                    'CandidateGUID' => '',
+                    'ProbandGUID' => '',
+                    'EARLIId' =>  '',
+                    'ProbandGender' => '',
+                    'ProbandDoB' => '',
+                    'flagged_caveatemptor' => 'false',
+                    'flagged_info' => '',
+                    'flagged_other' => '',
+                    'flagged_other_status' => '',
+                    'flagged_reason' => ''
+                )
+
+            )
+        );
+
+    }
+}
+?>


### PR DESCRIPTION
This adds test for NDB_BVL_Battery lookup battery to test different permutations of test batteries and ensure that things are looked up properly according to how the specifications of how test batteries are determined.

In particular, it checks for correct behaviour of:
1. Inactive tests not getting added.
2. Tests by age lookup working
3. Tests by visit lookup working
4. Tests with CenterID working
5. Tests with firstVisit set to true, false, and null working.