### PR TITLE
Fix "Sync Volumes" button of BrainBrowser. 

### DIFF
--- a/modules/brainbrowser/css/brainbrowser.css
+++ b/modules/brainbrowser/css/brainbrowser.css
@@ -35,8 +35,15 @@ body {
     width: 230px;
 }
 
+#sync-volumes-wrapper {
+    padding: initial;
+}
+
 #capture-slices, #sync-volumes {
     font-size: 12px;
+    padding: 3px 10px;
+    margin: 0;
+    line-height: 2;
 }
 
 


### PR DESCRIPTION
This fix allows the whole surface of the button to be clickable active. 
Resolves Redmine ticket [#6694](https://redmine.cbrain.mcgill.ca/issues/6694)