### PR TITLE
Fix feedback filter in candidate_list menu

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -83,14 +83,14 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // Need distinct because of joining with feedback_bvl_thread
         $VisitCountSQL = 'COUNT(DISTINCT s.Visit_label)';
-        $FeedbackSQL   = 'MIN(feedback_bvl_thread.Status+0) as Feedback';
+        $FeedbackSQL   = 'MIN(feedback_bvl_thread.Status+0)';
 
         $this->columns = array_merge(
             $this->columns,
             array(
              "$VisitCountSQL as Visit_count",
              'max(s.Current_stage) as Latest_visit_status',
-             $FeedbackSQL,
+             "$FeedbackSQL as Feedback",
             )
         );
 
@@ -191,11 +191,11 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         // list of feedback statuses
         $feedback_status_options = array(
                                     null => 'All',
-                                    '1'  => 'None',
-                                    '2'  => 'opened',
-                                    '3'  => 'answered',
-                                    '4'  => 'closed',
-                                    '5'  => 'comment',
+                                    '0'  => 'None',
+                                    '1'  => 'opened',
+                                    '2'  => 'answered',
+                                    '3'  => 'closed',
+                                    '4'  => 'comment',
                                    );
 
         $latest_visit_status_options = array(


### PR DESCRIPTION
The feedback filter in the candidate_list menu did not work due to 2 problems.

1. The SQL in the where clause included the "as Feedback" column alias incorrectly
2. After fixing this, the options in the dropdown were off by 1 since the column is defined
   as enum+0, but they were indexed starting at 1.