### PR TITLE
Make user name non-editable

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -218,10 +218,8 @@ class NDB_Form_user_accounts extends NDB_Form
         }
         // it is an existing user
         else {
-            // user name
-            $this->addBasicText('UserID', 'User name');
-            $username =& $this->form->getElement('UserID');
-            $username->freeze();
+            // display user name
+            $this->addScoreColumn('UserID', 'User name');
         }
 
         // password
@@ -344,9 +342,7 @@ class NDB_Form_user_accounts extends NDB_Form
         //------------------------------------------------------------
 
         // user name
-        $this->addBasicText('UserID', 'User name');
-        $username =& $this->form->getElement('UserID');
-        $username->freeze();
+        $this->addScoreColumn('UserID', 'User name');
 
         // full name
         //$this->addBasicText('Real_name', 'Full name');

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -408,9 +408,10 @@ class LorisForm
     {
         $val = $this->getValue($el['name']);
 
+        /*
         if (!empty($el['label'])) {
             return $el['label'] . $val;
-        }
+        }*/
         return $val;
     }
     /**


### PR DESCRIPTION
This should address a bug wherein the username is displayed as a textbox instead of as a frozen/score column in the my_preferences and edit_user pages.

It does it by replacing it with a static ("score") field instead of a frozen textbox.