### PR TITLE
Fix editable user name

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -224,13 +224,11 @@ class NDB_Form_user_accounts extends NDB_Form
         }
 
         // password
-        /*
         $group[] = $this->createPassword('Password_md5');
-        $group = array_merge($group, $this->createCheckbox('NA_Password', 'Generate new password'));
+        $group[] = $this->createCheckbox('NA_Password', 'Generate new password');
         $this->addGroup($group, 'Password_Group', 'Password', $this->_GUIDelimiter, FALSE);
         $this->addPassword('__Confirm', 'Confirm Password');
         unset($group);
-         */
 
         // full name
         //$this->addBasicText('Real_name', 'Full name');
@@ -306,13 +304,19 @@ class NDB_Form_user_accounts extends NDB_Form
         foreach ($perms as $row) {
             if($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
-                $group[] = $this->form->createElement('static', null, null, '</div>' . 
-                        "<h3 id=\"header_$lastRole\" class=\"perm_header button\" style=\"text-align: center; margin-top: 5px;\">".ucwords($row['type']).'</h3>' 
+                $group[] = $this->form->createElement('static', null, null, '</div>' .
+                        "<h3 id=\"header_$lastRole\" class=\"perm_header button\" style=\"text-align: center; margin-top: 5px;\">".ucwords($row['type']).'</h3>'
                         . "<div id=\"perms_$lastRole\" style=\"margin-top: 5px;\">");
             }
-            $group = array_merge($group, $this->createCheckbox('permID['.$row['permID'].']', $this->_GUIDelimiter.$row['description'], "class=\"perm_$lastRole\"", '</label><br>'));
+            $group[] = $this->createCheckbox(
+                'permID['.$row['permID'].']',
+                "$row[description]<br>",
+                array(
+                 "class" => "perm_$lastRole",
+                )
+            );
         }
-        //$this->addGroup($group, 'PermID_Group', 'Permissions', "", FALSE);
+        $this->addGroup($group, 'PermID_Group', 'Permissions', "", FALSE);
         unset($group);
 
         if (!empty($this->identifier)) {

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -218,10 +218,8 @@ class NDB_Form_user_accounts extends NDB_Form
         }
         // it is an existing user
         else {
-            // user name
-            $this->addBasicText('UserID', 'User name');
-            $username =& $this->form->getElement('UserID');
-            $username->freeze();
+            // display user name
+            $this->addScoreColumn('UserID', 'User name');
         }
 
         // password
@@ -344,9 +342,7 @@ class NDB_Form_user_accounts extends NDB_Form
         //------------------------------------------------------------
 
         // user name
-        $this->addBasicText('UserID', 'User name');
-        $username =& $this->form->getElement('UserID');
-        $username->freeze();
+        $this->addScoreColumn('UserID', 'User name');
 
         // full name
         //$this->addBasicText('Real_name', 'Full name');

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -209,10 +209,7 @@ class NDB_Form_user_accounts extends NDB_Form
         if (empty($this->identifier)) {
             // user name
             $group[] = $this->createText('UserID', 'User name');
-            // $group[] = $this->form->createElement('static', null, null, '<label>');
-            //$group = array_merge($group, $this->createCheckbox('NA_UserID', "Make user name match email address"));
             $group[] = $this->createCheckbox('NA_UserID', "Make user name match email address");
-            // $group[] = $this->form->createElement('static', null, null, 'Make user name match email address</label>');
             $this->addGroup($group, 'UserID_Group', 'User name', $this->_GUIDelimiter, FALSE);
             unset($group);
 
@@ -263,7 +260,6 @@ class NDB_Form_user_accounts extends NDB_Form
         
         // email address
         $group[] = $this->createText('Email');
-        //$group = array_merge($group, $this->createCheckbox('SendEmail', 'Send email to user'));
         $group[] = $this->createCheckbox('SendEmail', 'Send email to user');
         $this->addGroup($group, 'Email_Group', 'Email address', $this->_GUIDelimiter, FALSE);
         unset($group);

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -210,7 +210,8 @@ class NDB_Form_user_accounts extends NDB_Form
             // user name
             $group[] = $this->createText('UserID', 'User name');
             // $group[] = $this->form->createElement('static', null, null, '<label>');
-            $group = array_merge($group, $this->createCheckbox('NA_UserID', "Make user name match email address"));
+            //$group = array_merge($group, $this->createCheckbox('NA_UserID', "Make user name match email address"));
+            $group[] = $this->createCheckbox('NA_UserID', "Make user name match email address");
             // $group[] = $this->form->createElement('static', null, null, 'Make user name match email address</label>');
             $this->addGroup($group, 'UserID_Group', 'User name', $this->_GUIDelimiter, FALSE);
             unset($group);
@@ -223,11 +224,13 @@ class NDB_Form_user_accounts extends NDB_Form
         }
 
         // password
+        /*
         $group[] = $this->createPassword('Password_md5');
         $group = array_merge($group, $this->createCheckbox('NA_Password', 'Generate new password'));
         $this->addGroup($group, 'Password_Group', 'Password', $this->_GUIDelimiter, FALSE);
         $this->addPassword('__Confirm', 'Confirm Password');
         unset($group);
+         */
 
         // full name
         //$this->addBasicText('Real_name', 'Full name');
@@ -262,7 +265,8 @@ class NDB_Form_user_accounts extends NDB_Form
         
         // email address
         $group[] = $this->createText('Email');
-        $group = array_merge($group, $this->createCheckbox('SendEmail', 'Send email to user'));
+        //$group = array_merge($group, $this->createCheckbox('SendEmail', 'Send email to user'));
+        $group[] = $this->createCheckbox('SendEmail', 'Send email to user');
         $this->addGroup($group, 'Email_Group', 'Email address', $this->_GUIDelimiter, FALSE);
         unset($group);
 
@@ -308,7 +312,7 @@ class NDB_Form_user_accounts extends NDB_Form
             }
             $group = array_merge($group, $this->createCheckbox('permID['.$row['permID'].']', $this->_GUIDelimiter.$row['description'], "class=\"perm_$lastRole\"", '</label><br>'));
         }
-        $this->addGroup($group, 'PermID_Group', 'Permissions', "", FALSE);
+        //$this->addGroup($group, 'PermID_Group', 'Permissions', "", FALSE);
         unset($group);
 
         if (!empty($this->identifier)) {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -408,9 +408,10 @@ class LorisForm
     {
         $val = $this->getValue($el['name']);
 
+        /*
         if (!empty($el['label'])) {
             return $el['label'] . $val;
-        }
+        }*/
         return $val;
     }
     /**

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -406,12 +406,11 @@ class LorisForm
      */
     function staticHTML($el)
     {
+        if (empty($el['name'])) {
+            return $el['label'];
+        }
         $val = $this->getValue($el['name']);
 
-        /*
-        if (!empty($el['label'])) {
-            return $el['label'] . $val;
-        }*/
         return $val;
     }
     /**

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -421,22 +421,13 @@ class NDB_Page
      */
     function createCheckbox($field, $label, $options=null, $closer='</label>')
     {
-        $group   = array();
-        $group[] = $this->form->createElement('static', null, null, '<label>');
-        $group[] = $this->form->createElement(
-            'advcheckbox',
+        return $this->form->createElement(
+            "advcheckbox",
             $field,
-            null,
-            null,
-            $options
+            $label,
+            $options,
+            array()
         );
-        $group[] = $this->form->createElement(
-            'static',
-            'checkLabel',
-            null,
-            $label.$closer
-        );
-        return $group;
     }
 
     /**


### PR DESCRIPTION
This fixes the issue where the user name was editable on the my preferences page, because it was a frozen (not supported) text element and not a static element by changing it into a static element.

Adding this support broke the user preferences labels, because it was done in a hack-ey way. This removes a lot of the hacks and changes them to a proper group of elements without HTML hardcoded into them.