### PR TITLE
Examiner bug, fixed by toArray

### DIFF
--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -364,6 +364,8 @@ class NDB_Form_Examiner extends NDB_Form
         $certificationConfig      = $config->getSetting("Certification");
         $certificationInstruments = $certificationConfig['CertificationInstruments'];
 
+        $certificationInstruments['test']
+            = Utility::toArray($certificationInstruments['test']);
         $instruments = array();
 
         foreach ($certificationInstruments['test'] as $certificationInstrument) {


### PR DESCRIPTION
This is the same bug that Ted found in the training module - the list of certification instruments from the config.xml needs to use toArray to work properly when there is only one certification instrument.