### PR TITLE
Fixed Scan Done Link on Candidate List

### DIFF
--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -253,7 +253,7 @@
                 {elseif $items[item][piece].name == "scan_Done"}
                     {if $items[item][piece].value == 'Y'}
                         {assign var="scan_done" value="Yes"}
-                        <a href="{$baseurl}/main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data">{$scan_done}</a>
+                        <a class="scanDoneLink" data-pscid="{$PSCID}" href="{$baseurl}/main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data">{$scan_done}</a>
                     {else}
                         {assign var="scan_done" value="No"}
                         {$scan_done}


### PR DESCRIPTION
The link for the scan done column in candidate list was missing

1. The HTML class that causes the javascript to be bound to it
2. The data-pscid attribute used by the javascript.

Re-adding them fixes the issue of the link not properly filtering.