### PR TITLE
Fixed error where HTML classes were not included in textAreas

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -168,12 +168,12 @@ class LorisForm
      */
     public function addTextArea($elname, $label, $options=array())
     {
-        $el         =& $this->addBase($elname, $label);
+        $el         =& $this->addBase($elname, $label, $options);
         $el['type'] = 'textarea';
-        if ($options['cols']) {
+        if (isset($options['cols'])) {
             $el['cols'] = $options['cols'];
         }
-        if ($options['rows']) {
+        if (isset($options['rows'])) {
             $el['rows'] = $options['rows'];
         }
         return $el;


### PR DESCRIPTION
The addTextArea function in LorisForm was missing an parameter,
and thereby losing the options (such as class name) that were
supposed to get added to the element.