### PR TITLE
Reload the Edit Examiner page after a change is made.

### DIFF
--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -235,7 +235,8 @@ class NDB_Form_Examiner extends NDB_Form
                 }
             }
         }
-        $this->editExaminer();
+        $url = "main.php?test_name=examiner&subtest=editExaminer&identifier=" . $examinerID;
+        header("Location: " . $url, true, 303);
     }
 
     /**

--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -235,7 +235,8 @@ class NDB_Form_Examiner extends NDB_Form
                 }
             }
         }
-        $url = "main.php?test_name=examiner&subtest=editExaminer&identifier=" . $examinerID;
+        $url = "main.php?test_name=examiner&subtest=editExaminer&identifier="
+               . $examinerID;
         header("Location: " . $url, true, 303);
     }
 

--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -235,6 +235,7 @@ class NDB_Form_Examiner extends NDB_Form
                 }
             }
         }
+        $this->editExaminer();
     }
 
     /**


### PR DESCRIPTION
Previously, you needed to refresh the page yourself in order to see the change. This pull request causes the page to reload automatically.