### PR TITLE
You are redirected to a blank page if you change your (expired) password

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -400,7 +400,7 @@ class User extends UserPermissions
         $config       =& NDB_Config::singleton();
         $couch_config = $config->getSetting("CouchDB");
         if ($couch_config['SyncAccounts'] === "true") {
-            $user->updateCouchUser($set['Password_md5']);
+            $this->updateCouchUser($password);
         }
     }
     /**


### PR DESCRIPTION
If you are prompted to change your password because it has expired, you are redirected to a blank page even though you enter a (new) valid password. Refers to redmine ticket #7341.