### PR TITLE
Fixed bug where the logo was turning grey on hover in the login page

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -151,3 +151,8 @@ ul#navlist {
     cursor: inherit;
     display: block;
 }
+
+div.navbar div.container div.navbar-brand {
+    background: inherit;
+    text-align: center;
+}

--- a/smarty/templates/login.tpl
+++ b/smarty/templates/login.tpl
@@ -133,7 +133,7 @@ BrowserDetect.init();
 	
  	<div class="navbar navbar-default" role="navigation" style="height:90px">
  		<div class="container">
-	 		<div class="navbar-brand" style="align:center;">
+	 		<div class="navbar-brand">
                 {if $study_logo}
 		 		<img src="{$study_logo}" border="0" width="64" height="57" />
                 {/if}


### PR DESCRIPTION
The CSS for the navbar-brand was changing gray on hover on the login page. This explicitly sets the background colour to inherit on the element (with a specific enough selector that it will take precedence over whatever was causing the hover change)