### PR TITLE
Fixing bug in wrapper with monthYear date field

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -702,8 +702,8 @@ class NDB_BVL_Instrument extends NDB_Page
             foreach ($this->monthYearFields as $field) {
                 //Stops it from wiping dates already saved on other pages.
                 if (isset($values[$field])) {
-                    $values[$field]      = $this->_getDatabaseDate($values[$field]);
                     $values[$field]['d'] = 15;
+                    $values[$field]      = $this->_getDatabaseDate($values[$field]);
                 }
             }
         }


### PR DESCRIPTION
* The day field in the date array should be initialized before calling the getDatabaseDate function. This breaks instruments that use the monthYear date wrapper.