### PR TITLE
Quickform parser bug

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -841,10 +841,8 @@ class NDB_BVL_Instrument extends NDB_Page
 
         $CertificationConfig  = $config->getSetting("Certification");
         $CertificationEnabled = $CertificationConfig['EnableCertification'];
-        $CertificationProjects = array();
-        $CertificationInstruments = array();
-
         if ($CertificationEnabled) {
+            $CertificationProjects = array();
             foreach (
                 Utility::toArray($CertificationConfig['CertificationProjects'])
                 AS $key => $value
@@ -853,6 +851,7 @@ class NDB_BVL_Instrument extends NDB_Page
                     $CertificationProjects[$projID] = $projID;
                 }
             }
+            $CertificationInstruments = array();
             foreach (
                 Utility::toArray($CertificationConfig['CertificationInstruments'])
                 AS $instrument

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -841,8 +841,10 @@ class NDB_BVL_Instrument extends NDB_Page
 
         $CertificationConfig  = $config->getSetting("Certification");
         $CertificationEnabled = $CertificationConfig['EnableCertification'];
+        $CertificationProjects = array();
+        $CertificationInstruments = array();
+
         if ($CertificationEnabled) {
-            $CertificationProjects = array();
             foreach (
                 Utility::toArray($CertificationConfig['CertificationProjects'])
                 AS $key => $value
@@ -851,7 +853,6 @@ class NDB_BVL_Instrument extends NDB_Page
                     $CertificationProjects[$projID] = $projID;
                 }
             }
-            $CertificationInstruments = array();
             foreach (
                 Utility::toArray($CertificationConfig['CertificationInstruments'])
                 AS $instrument

--- a/tools/quickform_parser.php
+++ b/tools/quickform_parser.php
@@ -67,7 +67,9 @@ foreach($files AS $file){
         echo "Building instrument page '$subtest[Name]'...\n";
         $obj->_setupForm();
     }
-    
+
+    $output = "";
+
     if(!empty($output)){$output.="{-@-}";}
     
     echo "Parsing instrument object...\n";
@@ -85,6 +87,7 @@ fclose($fp);
     
 function parseElements($elements, $groupLabel=""){
     global $obj;
+    $output = "";
     foreach($elements AS $element){
         $label=$element->_label!="" ? str_replace("&nbsp;","",$element->_label) : $groupLabel;
         switch(strtolower(get_class($element))){


### PR DESCRIPTION
Here is a transcript of PHP Notices that prompted this fix.
The script was working correctly, but the PHP notices still needed a fix.

```
tstrauss@ace-ws-10:/var/www/ccna/tools$ ls ../project/instruments/NDB_BVL_Instrument_General_Health_Vision.class.inc | php quickform_parser.php 
../project/instruments/NDB_BVL_Instrument_General_Health_Vision.class.inc
Reading file ../project/instruments/NDB_BVL_Instrument_General_Health_Vision.class.inc
Instrument found: NDB_BVL_Instrument_General_Health_Vision
Requiring file...
Instantiating new object...
Initializing instrument object...
Building instrument page 'General_Health_Vision_page1'...
Parsing instrument object...
PHP Notice:  Undefined variable: output in /var/www/ccna/tools/quickform_parser.php on line 75
PHP Stack trace:
PHP   1. {main}() /var/www/ccna/tools/quickform_parser.php:0
PHP Notice:  Undefined variable: output in /var/www/ccna/tools/quickform_parser.php on line 132
PHP Stack trace:
PHP   1. {main}() /var/www/ccna/tools/quickform_parser.php:0
PHP   2. parseElements() /var/www/ccna/tools/quickform_parser.php:79
PHP Notice:  Undefined variable: output in /var/www/ccna/tools/quickform_parser.php on line 111
PHP Stack trace:
PHP   1. {main}() /var/www/ccna/tools/quickform_parser.php:0
PHP   2. parseElements() /var/www/ccna/tools/quickform_parser.php:79
PHP   3. parseElements() /var/www/ccna/tools/quickform_parser.php:128
Parsing complete
---------------------------------------------------------------------
```