### PR TITLE
Dashboard no longer shows "array" for project description when none was set.

### DIFF
--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -10,7 +10,9 @@
             <div class="panel-body">
                 <h3 class="welcome">Welcome, {$username}.</h3>
                 <p class="pull-right small login-time">Last login: {$last_login}</p>
+                {if !is_null($project_description)}
                 <p class="project-description">{$project_description}</p>
+                {/if}
             </div>
             <!-- Only add the welcome panel footer if there are links -->
             {if $dashboard_links neq ""}

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -309,6 +309,9 @@ class NDB_Config
                     "SELECT Value FROM Config WHERE ConfigID=:CID",
                     array('CID' => $configSetting['ParentID'])
                 );
+                if (empty($val)) {
+                    return null;
+                }
                 return $val;
             } else {
                 // Allows multiple, but has no child elements. Was called


### PR DESCRIPTION
This is actually a bug in how config settings are grabbed from the database. Previously, an empty array was returned if there was no value. Now, null is returned.