### PR TITLE
Add check for useProjects

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -186,7 +186,10 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // SubprojectID
         $list_of_subprojects = Utility::getSubprojectList();
-        $list_of_projects    = Utility::getProjectList();
+        
+        if ($config->getSetting("useProjects")=="true") {
+           $list_of_projects    = Utility::getProjectList();
+        }
 
         // list of feedback statuses
         $feedback_status_options = array(

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -55,6 +55,9 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // set the class variables
         $useProjects = $config->getSetting("useProjects");
+        if ($useProjects === "false") {
+            $useProjects = false;
+        }
 
         // set the class variables
         $this->columns = array(
@@ -64,7 +67,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                           'c.Gender',
                           'COALESCE(pso.ID,1) AS Participant_Status',
                          );
-        if ($useProjects === "true") {
+        if ($useProjects) {
             $this->columns[] = 'min(c.ProjectID) as Project';
         }
         $this->columns =array_merge(
@@ -73,8 +76,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
              'min(s.SubprojectID) as Subproject',
              'DATE_FORMAT(c.DoB,\'%Y-%m-%d\') AS DoB',
              's.Scan_done as scan_Done',
-            )
-        );
+            ));
+
         if ($config->getSetting("useEDC")==="true") {
             $this->columns[]           ='DATE_FORMAT((c.EDC),\'%Y-%m-%d\') AS EDC';
             $this->formToFilter['edc'] = 'c.EDC';
@@ -91,8 +94,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
              "$VisitCountSQL as Visit_count",
              'max(s.Current_stage) as Latest_visit_status',
              "$FeedbackSQL as Feedback",
-            )
-        );
+            ));
 
         $this->query = " FROM candidate c
             LEFT JOIN psc ON (c.CenterID=psc.CenterID)
@@ -111,13 +113,18 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->group_by = 'c.CandID';
         $this->order_by = 'psc.Name, c.CandID DESC, s.VisitNo';
 
-        $this->validFilters       = array(
+        $this->validFilters = array(
                                      'pso.ID',
                                      'c.CenterID',
                                      'c.CandID',
                                      'c.PSCID',
                                      'c.Gender',
-                                     'c.ProjectID',
+                                    );
+        if ($useProjects) {
+            $this->validFilters[] = 'c.ProjectID';
+        }
+        $this->validFilters = array_merge($this->validFilters, 
+                                  array(
                                      's.SubprojectID',
                                      'c.DoB',
                                      $VisitCountSQL,
@@ -125,7 +132,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                                      $FeedbackSQL,
                                      's.Scan_done',
                                      's.Visit_label',
-                                    );
+                                  ));
+
         $this->validHavingFilters = array(
                                      $VisitCountSQL,
                                      'max(s.Current_stage)',
@@ -139,7 +147,13 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                                'PSCID'               => 'c.PSCID',
                                'gender'              => 'c.Gender',
                                'SubprojectID'        => 's.SubprojectID',
-                               'ProjectID'           => 'c.ProjectID',
+                                    );
+        if ($useProjects) {
+            $this->formToFilter = array_merge($this->formToFilter,
+                                      array('ProjectID' => 'c.ProjectID')); 
+        }
+        $this->formToFilter = array_merge($this->formToFilter,
+                                   array(
                                'dob'                 => 'c.DoB',
                                'Visit_Count'         => $VisitCountSQL,
                                'Latest_Visit_Status' => 'max(s.Current_stage)',
@@ -147,7 +161,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                                'Participant_Status'  => 'pso.ID',
                                'scan_done'           => 's.Scan_done',
                                'Visit_label'         => 's.Visit_label',
-                              );
+                              ));
+
         return true;
     }
 
@@ -186,11 +201,6 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // SubprojectID
         $list_of_subprojects = Utility::getSubprojectList();
-
-        // Project list, if applicable
-        if ($config->getSetting("useProjects")=="true") {
-            $list_of_projects = Utility::getProjectList();
-        }
 
         // list of feedback statuses
         $feedback_status_options = array(
@@ -261,7 +271,10 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             $participant_status_options
         );
         $this->addSelect('scan_done', 'Scan Done', $scan_options);
-        if ($config->getSetting("useProjects")=="true") {
+
+        // Project list, if applicable
+        if ($config->getSetting("useProjects")==="true") {
+            $list_of_projects = Utility::getProjectList();
             $this->addSelect(
                 'ProjectID',
                 'Project',

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -274,12 +274,12 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // Project list, if applicable
         if ($config->getSetting("useProjects")==="true") {
-            $list_of_projects = Utility::getProjectList();
-            $this->addSelect(
-                'ProjectID',
-                'Project',
-                array('' => 'All') + $list_of_projects
-            );
+            $list_of_projects = array(null =>'All');
+            $projectList = Utility::getProjectList();
+            foreach ($projectList as $key => $value) {
+                $list_of_projects[$key] =$value;
+            }
+            $this->addSelect('ProjectID', 'Project', $list_of_projects); 
         }
         if ($config->getSetting("useEDC")=="true") {
             $this->addBasicText(

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -186,7 +186,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // SubprojectID
         $list_of_subprojects = Utility::getSubprojectList();
-        
+
+	// Project list, if applicable
         if ($config->getSetting("useProjects")=="true") {
             $list_of_projects = Utility::getProjectList();
         }

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -76,7 +76,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
              'min(s.SubprojectID) as Subproject',
              'DATE_FORMAT(c.DoB,\'%Y-%m-%d\') AS DoB',
              's.Scan_done as scan_Done',
-            ));
+            )
+        );
 
         if ($config->getSetting("useEDC")==="true") {
             $this->columns[]           ='DATE_FORMAT((c.EDC),\'%Y-%m-%d\') AS EDC';
@@ -94,7 +95,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
              "$VisitCountSQL as Visit_count",
              'max(s.Current_stage) as Latest_visit_status',
              "$FeedbackSQL as Feedback",
-            ));
+            )
+        );
 
         $this->query = " FROM candidate c
             LEFT JOIN psc ON (c.CenterID=psc.CenterID)
@@ -114,12 +116,12 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->order_by = 'psc.Name, c.CandID DESC, s.VisitNo';
 
         $this->validFilters = array(
-                                     'pso.ID',
-                                     'c.CenterID',
-                                     'c.CandID',
-                                     'c.PSCID',
-                                     'c.Gender',
-                                    );
+                               'pso.ID',
+                               'c.CenterID',
+                               'c.CandID',
+                               'c.PSCID',
+                               'c.Gender',
+                        );
         if ($useProjects) {
             $this->validFilters[] = 'c.ProjectID';
         }

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -128,13 +128,13 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->validFilters = array_merge(
             $this->validFilters,
             array(
-                's.SubprojectID',
-                'c.DoB',
-                $VisitCountSQL,
-                'max(s.Current_stage)',
-                $FeedbackSQL,
-                's.Scan_done',
-                's.Visit_label',
+             's.SubprojectID',
+             'c.DoB',
+             $VisitCountSQL,
+             'max(s.Current_stage)',
+             $FeedbackSQL,
+             's.Scan_done',
+             's.Visit_label',
             )
         );
 
@@ -161,13 +161,13 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->formToFilter = array_merge(
             $this->formToFilter,
             array(
-                'dob'                 => 'c.DoB',
-                'Visit_Count'         => $VisitCountSQL,
-                'Latest_Visit_Status' => 'max(s.Current_stage)',
-                'Feedback'            => $FeedbackSQL,
-                'Participant_Status'  => 'pso.ID',
-                'scan_done'           => 's.Scan_done',
-                'Visit_label'         => 's.Visit_label',
+             'dob'                 => 'c.DoB',
+             'Visit_Count'         => $VisitCountSQL,
+             'Latest_Visit_Status' => 'max(s.Current_stage)',
+             'Feedback'            => $FeedbackSQL,
+             'Participant_Status'  => 'pso.ID',
+             'scan_done'           => 's.Scan_done',
+             'Visit_label'         => 's.Visit_label',
             )
         );
 

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -125,16 +125,18 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         if ($useProjects) {
             $this->validFilters[] = 'c.ProjectID';
         }
-        $this->validFilters = array_merge($this->validFilters, 
-                                  array(
-                                     's.SubprojectID',
-                                     'c.DoB',
-                                     $VisitCountSQL,
-                                     'max(s.Current_stage)',
-                                     $FeedbackSQL,
-                                     's.Scan_done',
-                                     's.Visit_label',
-                                  ));
+        $this->validFilters = array_merge(
+            $this->validFilters,
+            array(
+                                   's.SubprojectID',
+                                   'c.DoB',
+                                   $VisitCountSQL,
+                                   'max(s.Current_stage)',
+                                   $FeedbackSQL,
+                                   's.Scan_done',
+                                   's.Visit_label',
+                                  )
+        );
 
         $this->validHavingFilters = array(
                                      $VisitCountSQL,
@@ -144,26 +146,29 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->EqualityFilters    = array('session.SubprojectID');
 
         $this->formToFilter = array(
-                               'centerID'            => 'c.CenterID',
-                               'DCCID'               => 'c.CandID',
-                               'PSCID'               => 'c.PSCID',
-                               'gender'              => 'c.Gender',
-                               'SubprojectID'        => 's.SubprojectID',
-                                    );
+                               'centerID'     => 'c.CenterID',
+                               'DCCID'        => 'c.CandID',
+                               'PSCID'        => 'c.PSCID',
+                               'gender'       => 'c.Gender',
+                               'SubprojectID' => 's.SubprojectID',
+                              );
         if ($useProjects) {
-            $this->formToFilter = array_merge($this->formToFilter,
-                                      array('ProjectID' => 'c.ProjectID')); 
+            $this->formToFilter = array_merge(
+                                      $this->formToFilter,
+                                      array('ProjectID' => 'c.ProjectID')
+            );
         }
         $this->formToFilter = array_merge($this->formToFilter,
-                                   array(
-                               'dob'                 => 'c.DoB',
-                               'Visit_Count'         => $VisitCountSQL,
-                               'Latest_Visit_Status' => 'max(s.Current_stage)',
-                               'Feedback'            => $FeedbackSQL,
-                               'Participant_Status'  => 'pso.ID',
-                               'scan_done'           => 's.Scan_done',
-                               'Visit_label'         => 's.Visit_label',
-                              ));
+            array(
+                                    'dob'                 => 'c.DoB',
+                                    'Visit_Count'         => $VisitCountSQL,
+                                    'Latest_Visit_Status' => 'max(s.Current_stage)',
+                                    'Feedback'            => $FeedbackSQL,
+                                    'Participant_Status'  => 'pso.ID',
+                                    'scan_done'           => 's.Scan_done',
+                                    'Visit_label'         => 's.Visit_label',
+                                   )
+                    );
 
         return true;
     }
@@ -276,12 +281,12 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         // Project list, if applicable
         if ($config->getSetting("useProjects")==="true") {
-            $list_of_projects = array(null =>'All');
-            $projectList = Utility::getProjectList();
+            $list_of_projects = array(null => 'All');
+            $projectList      = Utility::getProjectList();
             foreach ($projectList as $key => $value) {
                 $list_of_projects[$key] =$value;
             }
-            $this->addSelect('ProjectID', 'Project', $list_of_projects); 
+            $this->addSelect('ProjectID', 'Project', $list_of_projects);
         }
         if ($config->getSetting("useEDC")=="true") {
             $this->addBasicText(

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -187,7 +187,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         // SubprojectID
         $list_of_subprojects = Utility::getSubprojectList();
 
-	// Project list, if applicable
+        // Project list, if applicable
         if ($config->getSetting("useProjects")=="true") {
             $list_of_projects = Utility::getProjectList();
         }

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -121,21 +121,21 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                                'c.CandID',
                                'c.PSCID',
                                'c.Gender',
-                        );
+                              );
         if ($useProjects) {
             $this->validFilters[] = 'c.ProjectID';
         }
         $this->validFilters = array_merge(
             $this->validFilters,
             array(
-                                   's.SubprojectID',
-                                   'c.DoB',
-                                   $VisitCountSQL,
-                                   'max(s.Current_stage)',
-                                   $FeedbackSQL,
-                                   's.Scan_done',
-                                   's.Visit_label',
-                                  )
+                's.SubprojectID',
+                'c.DoB',
+                $VisitCountSQL,
+                'max(s.Current_stage)',
+                $FeedbackSQL,
+                's.Scan_done',
+                's.Visit_label',
+            )
         );
 
         $this->validHavingFilters = array(
@@ -154,21 +154,22 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                               );
         if ($useProjects) {
             $this->formToFilter = array_merge(
-                                      $this->formToFilter,
-                                      array('ProjectID' => 'c.ProjectID')
+                $this->formToFilter,
+                array('ProjectID' => 'c.ProjectID')
             );
         }
-        $this->formToFilter = array_merge($this->formToFilter,
+        $this->formToFilter = array_merge(
+            $this->formToFilter,
             array(
-                                    'dob'                 => 'c.DoB',
-                                    'Visit_Count'         => $VisitCountSQL,
-                                    'Latest_Visit_Status' => 'max(s.Current_stage)',
-                                    'Feedback'            => $FeedbackSQL,
-                                    'Participant_Status'  => 'pso.ID',
-                                    'scan_done'           => 's.Scan_done',
-                                    'Visit_label'         => 's.Visit_label',
-                                   )
-                    );
+                'dob'                 => 'c.DoB',
+                'Visit_Count'         => $VisitCountSQL,
+                'Latest_Visit_Status' => 'max(s.Current_stage)',
+                'Feedback'            => $FeedbackSQL,
+                'Participant_Status'  => 'pso.ID',
+                'scan_done'           => 's.Scan_done',
+                'Visit_label'         => 's.Visit_label',
+            )
+        );
 
         return true;
     }

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -188,7 +188,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $list_of_subprojects = Utility::getSubprojectList();
         
         if ($config->getSetting("useProjects")=="true") {
-           $list_of_projects    = Utility::getProjectList();
+            $list_of_projects = Utility::getProjectList();
         }
 
         // list of feedback statuses

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -224,11 +224,14 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         );
 
         $config =& NDB_Config::singleton();
-        $projAr = $allAr; 
         if ($config->getSetting('useProjects') === "true") {
-            $projAr += Utility::getProjectList(); 
+            $list_of_projects = $allAr;
+            $projectList = Utility::getProjectList();
+            foreach ($projectList as $key => $value) {
+                $list_of_projects[$key] =$value;
+            }
+            $this->addSelect('ProjectID', 'Project', $list_of_projects);  
         }
-        $this->addSelect('ProjectID', 'Project', $projAr);  
 
         $this->addSelect('SiteID', 'Site', $list_of_sites);
         $this->addSelect(

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -223,13 +223,12 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             'DCCID', 'DCCID', array('size' => 10, "maxlength" => 25)
         );
 
-        if ($config->getSetting('useProjects') == "true") {
-            $this->addSelect('ProjectID', 'Project', 
-               $allAr + Utility::getProjectList());
+        $config =& NDB_Config::singleton();
+        $projAr = $allAr; 
+        if ($config->getSetting('useProjects') === "true") {
+            $projAr += Utility::getProjectList(); 
         }
-        else { 
-            $this->addSelect('ProjectID', 'Project', $allAr);  
-        }
+        $this->addSelect('ProjectID', 'Project', $projAr);  
 
         $this->addSelect('SiteID', 'Site', $list_of_sites);
         $this->addSelect(

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -222,7 +222,15 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $this->addBasicText(
             'DCCID', 'DCCID', array('size' => 10, "maxlength" => 25)
         );
-        $this->addSelect('ProjectID', 'Project', $allAr + Utility::getProjectList());
+
+        if ($config->getSetting('useProjects') == "true") {
+            $this->addSelect('ProjectID', 'Project', 
+               $allAr + Utility::getProjectList());
+        }
+        else { 
+            $this->addSelect('ProjectID', 'Project', $allAr);  
+        }
+
         $this->addSelect('SiteID', 'Site', $list_of_sites);
         $this->addSelect(
             'VisitQCStatus',

--- a/modules/imaging_browser/templates/menu_imaging_browser.tpl
+++ b/modules/imaging_browser/templates/menu_imaging_browser.tpl
@@ -21,20 +21,20 @@
     <div class="panel-body" id="panel-body">
         <form method="post" action="main.php?test_name=imaging_browser">
              <div class="row">
-                 <div class="form-group col-sm-4">
-                    <label class="col-sm-12 col-md-4">
-                        {$form.DCCID.label}
-                    </label>
-                    <div class="col-sm-12 col-md-8">
-                        {$form.DCCID.html}
-                    </div>
-                </div>
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
                         {$form.pscid.label}
                     </label>
                     <div class="col-sm-12 col-md-8">
                         {$form.pscid.html}
+                    </div>
+                </div>
+                 <div class="form-group col-sm-4">
+                    <label class="col-sm-12 col-md-4">
+                        {$form.DCCID.label}
+                    </label>
+                    <div class="col-sm-12 col-md-8">
+                        {$form.DCCID.html}
                     </div>
                 </div>
                  <div class="form-group col-sm-4">
@@ -47,14 +47,6 @@
                 </div>
             </div>
             <div class="row">
-                <div class="form-group col-sm-4">
-                    <label class="col-sm-12 col-md-4">
-                        {$form.ProjectID.label}
-                    </label>
-                    <div class="col-sm-12 col-md-8">
-                        {$form.ProjectID.html}
-                    </div>
-                </div>
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
                         {$form.SiteID.label}
@@ -71,22 +63,32 @@
                         {$form.VisitQCStatus.html}
                     </div>
                 </div>
-            </div>
-            <div class="row">
+                {if $form.ProjectID}
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
-                        {$form.Pending.label}
+                        {$form.ProjectID.label}
                     </label>
                     <div class="col-sm-12 col-md-8">
-                        {$form.Pending.html}
+                        {$form.ProjectID.html}
                     </div>
                 </div>
+                {/if}
+            </div>
+            <div class="row">
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
                         {$form.Scan_type.label}
                    </label>
                     <div class="col-sm-12 col-md-8">
                         {$form.Scan_type.html}
+                    </div>
+                </div>
+                <div class="form-group col-sm-4">
+                    <label class="col-sm-12 col-md-4">
+                        {$form.Pending.label}
+                    </label>
+                    <div class="col-sm-12 col-md-8">
+                        {$form.Pending.html}
                     </div>
                 </div>
                 <div class="col-sm-2 col-sm-offset-8">


### PR DESCRIPTION
Before retrieving the list of projects, check that useProjects is set to true.
Resolves bugs in Access Profiles and Imaging Browser - these modules won't load for Loris instances that don't have a \<Projects\> tagset in their config.xml 
