### PR TITLE
new project/data subdirectory

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -160,7 +160,7 @@ if [ ! -f ../SQL/0000-00-00-schema.sql ] ; then
 fi
 
 # Create some subdirectories, if needed.
-mkdir -p ../project ../project/libraries ../project/instruments ../project/templates ../project/tables_sql ../smarty/templates_c
+mkdir -p ../project ../project/data ../project/libraries ../project/instruments ../project/templates ../project/tables_sql ../smarty/templates_c
 
 # Setting 777 permissions for templates_c
 chmod 777 ../smarty/templates_c


### PR DESCRIPTION
The install script will now create a project-specific data/ subdirectory so that file uploads and documents can be stored under the project/ directory (instead of under modules/, e.g.) 