### PR TITLE
Fixing spelling of 'accompanying' in NDB Page

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -155,7 +155,7 @@ class NDB_Page
 
 
     /**
-     * Adds a text element to the current page with no accompagnying
+     * Adds a text element to the current page with no accompanying
      * not answered option
      *
      * @param string $field   The name of the text element to add
@@ -171,7 +171,7 @@ class NDB_Page
     }
 
     /**
-     * Adds a text area to the current page with no accompagnying not answered
+     * Adds a text area to the current page with no accompanying not answered
      * option.
      *
      * @param string $field          The name of the text area to add
@@ -193,7 +193,7 @@ class NDB_Page
     }
 
     /**
-     * Adds a date field (without an accompagnying not answered option) to the
+     * Adds a date field (without an accompanying not answered option) to the
      * current page.
      *
      * @param string $field   The name of the date field


### PR DESCRIPTION
'accompanying; not 'accompagnying'