### PR TITLE
add required classes to the addBasicDate  so it is applied in LorisForm

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -186,16 +186,19 @@ class LorisForm
      *
      * @param string $name    The element name.
      * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
+     * @param array  $options An array of options that should get added,
+     *                        such as the date format, min or max date etc.
+     * @param array  $attribs An array of other attributes that should
      *                        get added. Currently only the "class"
      *                        attribute gets added.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    public function addDate($name, $label, $options)
+    public function addDate($name, $label, $options, $attribs = array())
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $attribs);
         $el['type'] = 'date';
+        $el['options'] = $options;
     }
 
     /**
@@ -247,7 +250,7 @@ class LorisForm
             $el = $this->addSelect($name, $label, $options, $attribs);
             break;
         case 'date':
-            $el = $this->addDate($name, $label, $options);
+            $el = $this->addDate($name, $label, $options, $attribs);
             break;
         case 'file':
             $el = $this->addFile($name, $label, $options);

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -196,8 +196,8 @@ class LorisForm
      */
     public function addDate($name, $label, $options, $attribs = array())
     {
-        $el         =& $this->addBase($name, $label, $attribs);
-        $el['type'] = 'date';
+        $el            =& $this->addBase($name, $label, $attribs);
+        $el['type']    = 'date';
         $el['options'] = $options;
     }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -212,7 +212,6 @@ class NDB_Page
                'style' => 'max-width:33%; display:inline-block;',
               )
     ) {
-        $options = array_merge(array('class' => 'form-control input-sm'), $options);
         $this->form->addElement('date', $field, $label, $options, $attr);
     }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -212,6 +212,7 @@ class NDB_Page
                'style' => 'max-width:33%; display:inline-block;',
               )
     ) {
+        $options = array_merge(array('class' => 'form-control input-sm'), $options);
         $this->form->addElement('date', $field, $label, $options, $attr);
     }
 


### PR DESCRIPTION
The form-control and input-sm classes weren't being added to the date elements causing them to stack on one another without any space in the new profile module