### PR TITLE
Fix reset button in examiner module

### DIFF
--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -319,6 +319,8 @@ class NDB_Form_Examiner extends NDB_Form
             "SELECT full_name FROM examiners WHERE examinerID=:EID",
             array('EID' => $this->identifier)
         );
+        // Get identifier, to be added to the Reset button href
+        $this->tpl_data['identifier'] = $this->identifier;
 
         $this->form->addFormRule(array(&$this, '_validateEditExaminer'));
     }

--- a/modules/examiner/templates/form_editExaminer.tpl
+++ b/modules/examiner/templates/form_editExaminer.tpl
@@ -41,7 +41,7 @@
                                 <input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit">
                             </div>
                             <div class="col-sm-6 col-md-2 col-xs-12">
-                                <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" onclick="location.href='main.php?test_name=examiner&subtest=editExaminer&reset=true'">
+                                <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" onclick="location.href='main.php?test_name=examiner&subtest=editExaminer&reset=true&identifier={$identifier}'">
                             </div>
                         </div>
                         {/if}


### PR DESCRIPTION
Added identifier value in "Reset" button href. "Reset" button was not working, it was giving error message: "Incorrect URL: No examiner ID provided."