### PR TITLE
Remove 'All Instruments' duplicate from dropdown in Data Integrity Flag module

### DIFF
--- a/modules/data_integrity_flag/js/data_integrity_flag.js
+++ b/modules/data_integrity_flag/js/data_integrity_flag.js
@@ -22,7 +22,6 @@ function changeVisitLabels() {
         visit_label_value = visit_label_dropdown.value,
         request = getQueryVariable("visit_label"),
         instrument_dropdown_value,
-        temp_array = ["All Instruments"],
         instruments;
     if ($.trim(visit_label_value) === 'All Visits') {visit_label_value = ''; }
     if (request !== undefined) {
@@ -35,7 +34,6 @@ function changeVisitLabels() {
     $.get("AjaxHelper.php?Module=data_team_helper&script=GetInstruments.php&visit_label=" + visit_label_value,
         function (data) {
             instruments = data.split("\n");
-            instruments = temp_array.concat(instruments); //adds 'All instruments to the array'
             instrument_dropdown.options.length = 0;
             var i, numInstruments = instruments.length, val;
             for (i = 0; i < numInstruments; i += 1) {


### PR DESCRIPTION
Removed *'All Instruments'* in JavaScript, it's already present in data returned by Ajax call to `GetInstruments.php`