### PR TITLE
Data Integrity Flag module: display flag status name

### DIFF
--- a/modules/data_integrity_flag/php/NDB_Form_data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/NDB_Form_data_integrity_flag.class.inc
@@ -136,7 +136,14 @@ class NDB_Form_data_integrity_flag extends NDB_Form
                 );
 
         $this->addBasicDate('date', "Date:", $dateOptions); //date drop down
-        $this->addSelect('flag_status', 'Flag Status:', array(''=>null,"1"=>'1- Ready For Review',"2"=>'2- Review Completed', "3"=>'3- Feedbacks Closed', "4"=>'4- Finalization')); //flag status
+        $flag_status_list = array(
+            '' => null,
+            "1" => '1- Ready For Review',
+            "2" => '2- Review Completed',
+            "3" => '3- Feedbacks Closed',
+            "4" => '4- Finalization'
+        );
+        $this->addSelect('flag_status', 'Flag Status:', $flag_status_list); //flag status
         $this->addBasicTextArea('comment','Comment:',array('rows' => 2, 'cols' => 20));//comment box
 
         //static or hiddent elements
@@ -160,7 +167,7 @@ class NDB_Form_data_integrity_flag extends NDB_Form
             $this->tpl_data['elements_list_names'] [] = $data['dataflag_id'];
             $full_name = $DB->pselectOne("SELECT Full_name from test_names where Test_name = :tname",array('tname'=>$data['dataflag_instrument']));
             $this->tpl_data['elements_array'][$data['dataflag_id']]['date']= $data['dataflag_date'];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['flag'] = $data['dataflag_status'];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['flag'] = $flag_status_list[$data['dataflag_status']];
             $this->tpl_data['elements_array'][$data['dataflag_id']]['comment']= $data['dataflag_comment'];
             $this->tpl_data['elements_array'][$data['dataflag_id']]['instrument']= $data['dataflag_instrument'];
             $this->tpl_data['elements_array'][$data['dataflag_id']]['full_name']= $full_name;


### PR DESCRIPTION
In data integrity flag module table, Flag Status column: display flag status name together with the status id. 
*eg:* instead of *"1"*, display *"1- Ready For Review"*