### PR TITLE
Updated project MRI_parameter_form to work for PHP 5.4 and above.

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
@@ -204,13 +204,13 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
           {
               $timepoint =& TimePoint::singleton($this->getSessionID());
               $candidate =& Candidate::singleton($timepoint->getCandID());
-              $this->_nullStatus(&$values);
+              $this->_nullStatus($values);
 
               if(isset($values['Date_taken'])) {
                   $date = $values['Date_taken'];
                   if(!empty($date['Y']) && !empty($date['M']) && !empty($date['d'])) {
                       $values['Date_taken'] = $this->_getDatabaseDate($date); //sprintf("%04d-%02d-%02d", $date['Y'], $date['M'], $date['d']);
-                      $this->_saveCandidateAge(&$values);
+                      $this->_saveCandidateAge($values);
                   }  else {
                       unset($values['Date_taken']);
                   }
@@ -299,7 +299,7 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
                 $file->registerForm($this->form);
 
                 //Tell File_Upload what file handlers to use.
-                $file->setFileHandler("directions_file", &$this);
+                $file->setFileHandler("directions_file", $this);
 
                 //Set the target directory that you want files moved into once they are validated and processed.
                 $config = NDB_Config::singleton();


### PR DESCRIPTION
Updated the project MRI parameter form as in PHP 5.4 and above "call-time pass-by-reference" is deprecated.
This was causing the form to not load on systems with PHP > 5.3.x. In systems with 5.3.x this feature is still present but a warning will arise. 