### PR TITLE
Make check for Pending_approval match schema.

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -313,7 +313,7 @@ class SinglePointLogin
                     return false;
                 }
 
-                if ($row['Pending_approval'] == '1') {
+                if ($row['Pending_approval'] == 'Y') {
                     $this->_lastError = "Your account has not yet been activated."
                         . " Please contact your project administrator to activate"
                         . " this account.";


### PR DESCRIPTION
The definition of the Pending_approval flag was changed from boolean
to enum('Y', 'N') at some point, but the check itself was not updated
to reflect this, so any Pending accounts were able to log in.