### PR TITLE
detect_conflicts.php now working for instrument flag all - Redmine[7487]

### DIFF
--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -227,10 +227,10 @@ function getCommentIDs($test_name, $visit_label=null, $candid=null)
 {
     $db =& Database::singleton();
     $params = array();
-        $query = "SELECT CommentID, s.visit_label,Test_name,
-            CONCAT('DDE_', CommentID) AS DDECommentID FROM flag f
-            JOIN session s ON (s.ID=f.SessionID)
-            JOIN candidate c ON (c.CandID=s.CandID)";
+    $query = "SELECT CommentID, s.visit_label,Test_name,
+        CONCAT('DDE_', CommentID) AS DDECommentID FROM flag f
+        JOIN session s ON (s.ID=f.SessionID)
+        JOIN candidate c ON (c.CandID=s.CandID)";
     $where = " WHERE CommentID NOT LIKE 'DDE%'
         AND s.Active='Y' AND c.Active='Y'
         AND s.Visit <> 'Failure'";

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -100,8 +100,7 @@ if (($instrument=='all') ||($instrument=='All')) {
     $Factory       = NDB_Factory::singleton();
     $DB            = $Factory->Database(); //=& Database::singleton();
     $instruments_q = $DB->pselect(
-        "SELECT Test_name FROM test_names WHERE Test_name <> 'JUST_ONE_QUESTION' AND Test_name <> 'CBCL_one_question'
-        AND Test_name <> 'figs_year3' AND Test_name <> 'InstManagerTestPlan'",
+        "SELECT Test_name FROM test_names",
         array()
     );
 

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -50,6 +50,7 @@ $change = false;
 $change_all = false;
 $instrument = null;
 $visit_label = null;
+
 if (!is_array($opts)) {
     print "There was a problem reading in the options.\n\n";
     exit(1);
@@ -83,7 +84,6 @@ if ($change && $change_all) {
 $config = NDB_Config::singleton();
 $db = Database::singleton();
 $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
-$config = NDB_Config::singleton();
 $db_config = $config->getSetting('database');
 $paths = $config->getSetting('paths');
 $dataDir = $paths['base'] . $config->getSetting('log');
@@ -96,15 +96,37 @@ $conflicts_to_be_excluded = array();
 
 // Check to see if the variable instrument is set
 if (($instrument=='all') ||($instrument=='All')) {
-    $instruments = Utility::getAllInstruments();
+
+    $Factory       = NDB_Factory::singleton();
+    $DB            = $Factory->Database(); //=& Database::singleton();
+    $instruments_q = $DB->pselect(
+        "SELECT Test_name FROM test_names WHERE Test_name <> 'JUST_ONE_QUESTION' AND Test_name <> 'CBCL_one_question'
+        AND Test_name <> 'figs_year3' AND Test_name <> 'InstManagerTestPlan'",
+        array()
+    );
+
+    $instruments   = array();
+
+    foreach ($instruments_q as $row) {
+        if (isset($row['Test_name'])) {
+            $instruments[$row['Test_name']] =$row['Test_name'];
+        }
+    }
+
 } else {
     $instruments = array($instrument=>$instrument);
 }
 foreach ($instruments as $instrument) {
     if (isset($instrument)) {
-        
-        include_once $paths['base'].
-        "project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
+
+        $php_class_path = $paths['base'].
+            "project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
+
+
+        if (file_exists($php_class_path)) {
+            include_once $php_class_path;
+        }
+
         print  "instrument is $instrument \n";
 
         //Run the script for all the instruments
@@ -211,10 +233,10 @@ function getCommentIDs($test_name, $visit_label=null, $candid=null)
 {
     $db =& Database::singleton();
     $params = array();
-    $query = "SELECT CommentID, s.visit_label,Test_name,
-        CONCAT('DDE_', CommentID) AS DDECommentID FROM flag f
-        JOIN session s ON (s.ID=f.SessionID) 
-        JOIN candidate c ON (c.CandID=s.CandID)";
+        $query = "SELECT CommentID, s.visit_label,Test_name,
+            CONCAT('DDE_', CommentID) AS DDECommentID FROM flag f
+            JOIN session s ON (s.ID=f.SessionID)
+            JOIN candidate c ON (c.CandID=s.CandID)";
     $where = " WHERE CommentID NOT LIKE 'DDE%'
         AND s.Active='Y' AND c.Active='Y'
         AND s.Visit <> 'Failure'";

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -119,13 +119,8 @@ if (($instrument=='all') ||($instrument=='All')) {
 foreach ($instruments as $instrument) {
     if (isset($instrument)) {
 
-        $php_class_path = $paths['base'].
+        include_once $paths['base'].
             "project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
-
-
-        if (file_exists($php_class_path)) {
-            include_once $php_class_path;
-        }
 
         print  "instrument is $instrument \n";
 


### PR DESCRIPTION
Previously the detect_conflicts.php script was not functional with the instrument flag 'all'.

This was caused by the fact that the instrument array was returned by a call to ```Utility::getAllInstruments();``` but this function returns a list of the ```Full_name```s not the ```Test_name```s. 

Changed this script so we get an array of all the ```Test_name```s.

