### PR TITLE
Explicitly adding 'main.php' to the base URL

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -178,7 +178,7 @@
                         </a>
                     {/if}
 
-                    <a class="navbar-brand" href="{$baseurl}/">LORIS{if $sandbox}: DEV{/if}</a>
+                    <a class="navbar-brand" href="{$baseurl}/main.php">LORIS{if $sandbox}: DEV{/if}</a>
                </div>
                <div class="collapse navbar-collapse" id="example-navbar-collapse">
                     <ul class="nav navbar-nav">


### PR DESCRIPTION
This would fail to load Dashboard resources in certain cases because of the way main.php fetches things