### PR TITLE
Fix PHP Fatal errors in fix_timepoint_date_problems.php add_instrument

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -287,8 +287,9 @@ class Database extends PEAR
 
     /**
      * Get last insert ID.
+     * Will return a valid insert ID only if called after Database::insert() method.
      *
-     * @return mixed
+     * @return string ID of the last inserted row
      */
     public function getLastInsertId()
     {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -34,6 +34,7 @@ class Database extends PEAR
     /**
      * The database handle, created by the connect() method
      *
+     * @var PDO
      * @access private
      */
     var $_PDO = null;
@@ -79,7 +80,7 @@ class Database extends PEAR
      * @param boolean $trackChanges boolean determining if changes should be
      *                              logged to the history table
      *
-     * @return object
+     * @return Database
      * @access public
      */
     static function &singleton(
@@ -281,6 +282,16 @@ class Database extends PEAR
             return $err;
         }
         return true;
+    }
+
+    /**
+     * Get last insert ID.
+     *
+     * @return mixed
+     */
+    public function getLastInsertId()
+    {
+        return $this->lastInsertID;
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -34,7 +34,7 @@ class Database extends PEAR
     /**
      * The database handle, created by the connect() method
      *
-     * @var PDO
+     * @var    PDO
      * @access private
      */
     var $_PDO = null;
@@ -81,6 +81,7 @@ class Database extends PEAR
      *                              logged to the history table
      *
      * @return Database
+     * @throws DatabaseException
      * @access public
      */
     static function &singleton(

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -593,17 +593,15 @@ class NDB_BVL_Feedback
      *                           attached to
      *
      * @return void
+     *
+     * @throws DatabaseException
+     * @throws Exception
      */
     function createThread($level, $type, $comment, $public=null,$fieldname=null)
     {
         // new DB Object
-        $db =& Database::singleton();
-
-        // get the FeedbackID for the new thread
-        $feedbackID = $db->pselectOne(
-            "SELECT MAX(FeedbackID)+1 AS FeedbackID FROM feedback_bvl_thread",
-            array()
-        );
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->Database();
 
         // public threads are inactive by default
         if ($public == 'Y') {
@@ -669,6 +667,9 @@ class NDB_BVL_Feedback
         }
 
         $success = $db->insert('feedback_bvl_thread', $setArray);
+
+        // get the FeedbackID for the new thread
+        $feedbackID = $db->getLastInsertId();
 
         // INSERT entry for the the thread into the feedback_bvl_thread
         $this->createEntry($feedbackID, $comment);

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -260,7 +260,7 @@ function addInstrument($sessionID, $testName)
         return PEAR::raiseError("Error: Database user named " . getenv('USER') . " does not exist. Please create and then retry script\n");
     }
     if (PEAR::isError($user)) {
-    	return ("Error, failed to create User object for (".$getenv('USER')."):".$user->getMessage()." \n");
+    	return ("Error, failed to create User object for (".getenv('USER')."):".$user->getMessage()." \n");
     }
 
     // check the args


### PR DESCRIPTION
Fix for bug in method NDB_BVL_Feedback::createThread()
- using the last inserted ID as $feedbackID. SELECT MAX(FeedbackID)+1 AS FeedbackID FROM feedback_bvl_thread" will fail in cases where table’s auto_increment value is greater than the MAX(FeedbackID)+1.
- using factory instead of singleton to create DB object
- adding accessor method Database::getLastInsertId() instead of accessing member variable lastInsertID
