### PR TITLE
Fix timepoint date problem missing feedback type 7587

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
     # for the config file, and reset the Loris user's password for testing
     - mysql -e 'CREATE DATABASE LorisTest'
     - mysql LorisTest < SQL/0000-00-00-schema.sql
-    - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
+    - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
     - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - sed -e "s/%HOSTNAME%/localhost/g"
           -e "s/%USERNAME%/SQLTestUser/g"

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
         php -l $i || exit $?;
       done
     # Run unit tests to make sure functions still do what they should.
-    - vendor/bin/phpunit test/unittests/
+    - vendor/bin/phpunit --configuration test/phpunit.xml test/unittests/
 
     # Run integration tests to make sure everything didn't just
     # break

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -245,6 +245,57 @@ class NDB_BVL_Feedback
         return $list;
     }
 
+
+    /**
+     * Get feedback type id given the feedback type name
+     *
+     * @param string $name feedback type name
+     *
+     * @return int feedback type id, empty array if none found
+     */
+    public function getFeedbackTypeIdByName($name)
+    {
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->Database();
+
+        $query = "SELECT  `Feedback_type`
+                    FROM  `feedback_bvl_type`
+                    WHERE  `Name` LIKE  :name ";
+
+        return $db->pselectOne($query, array(':name' => $name));
+    }
+
+    /**
+     * Create new feedback type
+     *
+     * @param string $name        feedback type name
+     * @param string $description feedback type description
+     *
+     * @return int feedback type id
+     * @throws DatabaseException
+     * @throws LorisException
+     */
+    public function createFeedbackType($name, $description = null)
+    {
+        if (empty($name) || strlen($name)>100 ) {
+            throw new LorisException("Invalid feedback type name");
+        }
+
+        if (empty($description)) {
+            $description = null;
+        }
+
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->Database();
+
+        $values = array(
+                   'Name'        => $name,
+                   'Description' => $description,
+                  );
+        $db->insert("feedback_bvl_type", $values);
+        return $db->getLastInsertId();
+    }
+
     /**
      * Returns a type of the thread identified by the FeedbackID
      *

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -18,16 +18,19 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-//@TODO: This needs to be changed to use a test specific config.xml.
-// Tests should not use project/config.xml.
+
+// Tests should not use project/config.xml
 // When running tests LORIS app should connect to a test database because some tests
 // are destructive
 // (i.e. they wipe specific DB tables and repopulate them using test fixtures,
 // from /test/fixtures/ folder)
 
-//test specific config to use from test folder
-//define('CONFIG_XML', __DIR__ . "/config.xml");
-define('CONFIG_XML', __DIR__ . "/../project/config.xml");
+//Use environment variable LORIS_DB_CONFIG to specify a test specific config
+if ($configFile = getenv('LORIS_DB_CONFIG') ) {
+    define('CONFIG_XML', $configFile);
+} else {
+    define('CONFIG_XML', __DIR__ . "/../project/config.xml");
+}
 define('TABLE_FIXTURES_PATH', __DIR__ . "/fixtures/tables/");
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/test/fixtures/tables/NDB_BVL_FeedbackTest.xml
+++ b/test/fixtures/tables/NDB_BVL_FeedbackTest.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="LorisTest">
+	<table_data name="candidate">
+	<row>
+		<field name="ID">178</field>
+		<field name="CandID">591545</field>
+		<field name="PSCID">AAA18</field>
+		<field name="ExternalID" xsi:nil="true" />
+		<field name="DoB">2008-12-18</field>
+		<field name="EDC" xsi:nil="true" />
+		<field name="Gender">Female</field>
+		<field name="CenterID">2</field>
+		<field name="ProjectID">2</field>
+		<field name="Ethnicity" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2015-05-05</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2015-05-05</field>
+		<field name="flagged_caveatemptor">false</field>
+		<field name="flagged_reason" xsi:nil="true" />
+		<field name="flagged_other" xsi:nil="true" />
+		<field name="flagged_other_status" xsi:nil="true" />
+		<field name="Testdate">2015-05-05 22:55:34</field>
+		<field name="Entity_type">Human</field>
+		<field name="ProbandGender" xsi:nil="true" />
+		<field name="ProbandDoB" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">13</field>
+		<field name="CandID">595267</field>
+		<field name="PSCID">AAA0002</field>
+		<field name="ExternalID" xsi:nil="true" />
+		<field name="DoB">2009-05-02</field>
+		<field name="EDC" xsi:nil="true" />
+		<field name="Gender">Female</field>
+		<field name="CenterID">2</field>
+		<field name="ProjectID">1</field>
+		<field name="Ethnicity" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2013-04-05</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2013-04-05</field>
+		<field name="flagged_caveatemptor">false</field>
+		<field name="flagged_reason" xsi:nil="true" />
+		<field name="flagged_other" xsi:nil="true" />
+		<field name="flagged_other_status" xsi:nil="true" />
+		<field name="Testdate">2013-04-05 19:17:26</field>
+		<field name="Entity_type">Human</field>
+		<field name="ProbandGender" xsi:nil="true" />
+		<field name="ProbandDoB" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">179</field>
+		<field name="CandID">615362</field>
+		<field name="PSCID">AAA020</field>
+		<field name="ExternalID" xsi:nil="true" />
+		<field name="DoB">2008-01-20</field>
+		<field name="EDC" xsi:nil="true" />
+		<field name="Gender">Female</field>
+		<field name="CenterID">2</field>
+		<field name="ProjectID">1</field>
+		<field name="Ethnicity" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2015-05-06</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2015-05-06</field>
+		<field name="flagged_caveatemptor">false</field>
+		<field name="flagged_reason" xsi:nil="true" />
+		<field name="flagged_other" xsi:nil="true" />
+		<field name="flagged_other_status" xsi:nil="true" />
+		<field name="Testdate">2015-05-06 20:01:44</field>
+		<field name="Entity_type">Human</field>
+		<field name="ProbandGender" xsi:nil="true" />
+		<field name="ProbandDoB" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">63</field>
+		<field name="CandID">969664</field>
+		<field name="PSCID">AAA0011</field>
+		<field name="ExternalID" xsi:nil="true" />
+		<field name="DoB">2007-03-02</field>
+		<field name="EDC" xsi:nil="true" />
+		<field name="Gender">Male</field>
+		<field name="CenterID">2</field>
+		<field name="ProjectID" xsi:nil="true" />
+		<field name="Ethnicity" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2014-05-02</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2014-05-02</field>
+		<field name="flagged_caveatemptor">false</field>
+		<field name="flagged_reason">1</field>
+		<field name="flagged_other">Testing</field>
+		<field name="flagged_other_status" xsi:nil="true" />
+		<field name="Testdate">2015-05-08 18:26:49</field>
+		<field name="Entity_type">Human</field>
+		<field name="ProbandGender">Male</field>
+		<field name="ProbandDoB">2006-03-01</field>
+	</row>
+	</table_data>
+	<table_data name="session">
+	<row>
+		<field name="ID">11</field>
+		<field name="CandID">595267</field>
+		<field name="CenterID">2</field>
+		<field name="VisitNo">1</field>
+		<field name="Visit_label">V01</field>
+		<field name="SubprojectID">2</field>
+		<field name="Submitted">N</field>
+		<field name="Current_stage">Visit</field>
+		<field name="Date_stage_change">2013-04-10</field>
+		<field name="Screening" xsi:nil="true" />
+		<field name="Date_screening" xsi:nil="true" />
+		<field name="Visit">In Progress</field>
+		<field name="Date_visit">2011-02-02</field>
+		<field name="Approval" xsi:nil="true" />
+		<field name="Date_approval" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2013-04-10</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2013-04-10</field>
+		<field name="Testdate">2013-04-10 19:22:50</field>
+		<field name="Hardcopy_request">-</field>
+		<field name="BVLQCStatus" xsi:nil="true" />
+		<field name="BVLQCType" xsi:nil="true" />
+		<field name="BVLQCExclusion" xsi:nil="true" />
+		<field name="QCd" xsi:nil="true" />
+		<field name="Scan_done">Y</field>
+		<field name="MRIQCStatus"></field>
+		<field name="MRIQCPending">N</field>
+		<field name="MRIQCFirstChangeTime" xsi:nil="true" />
+		<field name="MRIQCLastChangeTime" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">16</field>
+		<field name="CandID">595267</field>
+		<field name="CenterID">2</field>
+		<field name="VisitNo">2</field>
+		<field name="Visit_label">V02</field>
+		<field name="SubprojectID">2</field>
+		<field name="Submitted">N</field>
+		<field name="Current_stage">Visit</field>
+		<field name="Date_stage_change">2013-04-22</field>
+		<field name="Screening" xsi:nil="true" />
+		<field name="Date_screening" xsi:nil="true" />
+		<field name="Visit">In Progress</field>
+		<field name="Date_visit">2012-08-06</field>
+		<field name="Approval" xsi:nil="true" />
+		<field name="Date_approval" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2013-04-22</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2013-04-22</field>
+		<field name="Testdate">2013-04-22 22:23:56</field>
+		<field name="Hardcopy_request">-</field>
+		<field name="BVLQCStatus" xsi:nil="true" />
+		<field name="BVLQCType" xsi:nil="true" />
+		<field name="BVLQCExclusion" xsi:nil="true" />
+		<field name="QCd" xsi:nil="true" />
+		<field name="Scan_done">N</field>
+		<field name="MRIQCStatus"></field>
+		<field name="MRIQCPending">N</field>
+		<field name="MRIQCFirstChangeTime" xsi:nil="true" />
+		<field name="MRIQCLastChangeTime" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">97</field>
+		<field name="CandID">969664</field>
+		<field name="CenterID">2</field>
+		<field name="VisitNo">1</field>
+		<field name="Visit_label">V01</field>
+		<field name="SubprojectID">1</field>
+		<field name="Submitted">N</field>
+		<field name="Current_stage">Visit</field>
+		<field name="Date_stage_change">2015-05-14</field>
+		<field name="Screening" xsi:nil="true" />
+		<field name="Date_screening" xsi:nil="true" />
+		<field name="Visit">Pass</field>
+		<field name="Date_visit">2008-03-03</field>
+		<field name="Approval" xsi:nil="true" />
+		<field name="Date_approval" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2014-05-02</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2014-05-02</field>
+		<field name="Testdate">2015-05-14 20:40:46</field>
+		<field name="Hardcopy_request">-</field>
+		<field name="BVLQCStatus" xsi:nil="true" />
+		<field name="BVLQCType"></field>
+		<field name="BVLQCExclusion" xsi:nil="true" />
+		<field name="QCd" xsi:nil="true" />
+		<field name="Scan_done">Y</field>
+		<field name="MRIQCStatus"></field>
+		<field name="MRIQCPending">N</field>
+		<field name="MRIQCFirstChangeTime" xsi:nil="true" />
+		<field name="MRIQCLastChangeTime" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">98</field>
+		<field name="CandID">969664</field>
+		<field name="CenterID">2</field>
+		<field name="VisitNo">2</field>
+		<field name="Visit_label">V02</field>
+		<field name="SubprojectID">1</field>
+		<field name="Submitted">N</field>
+		<field name="Current_stage">Visit</field>
+		<field name="Date_stage_change">2014-05-02</field>
+		<field name="Screening" xsi:nil="true" />
+		<field name="Date_screening" xsi:nil="true" />
+		<field name="Visit">In Progress</field>
+		<field name="Date_visit">2009-03-02</field>
+		<field name="Approval" xsi:nil="true" />
+		<field name="Date_approval" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2014-05-02</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2014-05-02</field>
+		<field name="Testdate">2014-05-02 19:06:52</field>
+		<field name="Hardcopy_request">-</field>
+		<field name="BVLQCStatus" xsi:nil="true" />
+		<field name="BVLQCType" xsi:nil="true" />
+		<field name="BVLQCExclusion" xsi:nil="true" />
+		<field name="QCd" xsi:nil="true" />
+		<field name="Scan_done">N</field>
+		<field name="MRIQCStatus"></field>
+		<field name="MRIQCPending">N</field>
+		<field name="MRIQCFirstChangeTime" xsi:nil="true" />
+		<field name="MRIQCLastChangeTime" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="ID">139</field>
+		<field name="CandID">591545</field>
+		<field name="CenterID">2</field>
+		<field name="VisitNo">1</field>
+		<field name="Visit_label">V10</field>
+		<field name="SubprojectID">1</field>
+		<field name="Submitted">N</field>
+		<field name="Current_stage">Visit</field>
+		<field name="Date_stage_change">2015-05-05</field>
+		<field name="Screening" xsi:nil="true" />
+		<field name="Date_screening" xsi:nil="true" />
+		<field name="Visit">In Progress</field>
+		<field name="Date_visit">2010-12-15</field>
+		<field name="Approval" xsi:nil="true" />
+		<field name="Date_approval" xsi:nil="true" />
+		<field name="Active">Y</field>
+		<field name="Date_active">2015-05-05</field>
+		<field name="RegisteredBy">admin</field>
+		<field name="UserID">admin</field>
+		<field name="Date_registered">2015-05-05</field>
+		<field name="Testdate">2015-05-05 23:02:40</field>
+		<field name="Hardcopy_request">-</field>
+		<field name="BVLQCStatus" xsi:nil="true" />
+		<field name="BVLQCType" xsi:nil="true" />
+		<field name="BVLQCExclusion" xsi:nil="true" />
+		<field name="QCd" xsi:nil="true" />
+		<field name="Scan_done">N</field>
+		<field name="MRIQCStatus"></field>
+		<field name="MRIQCPending">N</field>
+		<field name="MRIQCFirstChangeTime" xsi:nil="true" />
+		<field name="MRIQCLastChangeTime" xsi:nil="true" />
+	</row>
+	</table_data>
+</database>
+</mysqldump>

--- a/test/fixtures/tables/feedback_bvl_type.xml
+++ b/test/fixtures/tables/feedback_bvl_type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="loris">
+	<table_data name="feedback_bvl_type">
+	<row>
+		<field name="Feedback_type">1</field>
+		<field name="Name">Input</field>
+		<field name="Description">Input Errors</field>
+	</row>
+	<row>
+		<field name="Feedback_type">2</field>
+		<field name="Name">Scoring</field>
+		<field name="Description">Scoring Errors</field>
+	</row>
+	<row>
+		<field name="Feedback_type">5</field>
+		<field name="Name">other</field>
+		<field name="Description">Other</field>
+	</row>
+	</table_data>
+</database>
+</mysqldump>

--- a/test/fixtures/tables/feedback_bvl_type.xml
+++ b/test/fixtures/tables/feedback_bvl_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<database name="loris">
+<mysqldump>
+<database name="LorisTest">
 	<table_data name="feedback_bvl_type">
 	<row>
 		<field name="Feedback_type">1</field>

--- a/test/fixtures/tables/psc.xml
+++ b/test/fixtures/tables/psc.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="LorisTest">
+	<table_data name="psc">
+	<row>
+		<field name="CenterID">1</field>
+		<field name="Name">Data Coordinating Center</field>
+		<field name="PSCArea"></field>
+		<field name="Address"></field>
+		<field name="City"></field>
+		<field name="StateID">0</field>
+		<field name="ZIP"></field>
+		<field name="Phone1"></field>
+		<field name="Phone2"></field>
+		<field name="Contact1"></field>
+		<field name="Contact2"></field>
+		<field name="Alias">DCC</field>
+		<field name="MRI_alias"></field>
+		<field name="Account"></field>
+		<field name="Study_site">Y</field>
+	</row>
+	<row>
+		<field name="CenterID">2</field>
+		<field name="Name">AAA</field>
+		<field name="PSCArea">AAA</field>
+		<field name="Address"></field>
+		<field name="City"></field>
+		<field name="StateID">0</field>
+		<field name="ZIP"></field>
+		<field name="Phone1"></field>
+		<field name="Phone2"></field>
+		<field name="Contact1"></field>
+		<field name="Contact2"></field>
+		<field name="Alias">AAA</field>
+		<field name="MRI_alias">AAA</field>
+		<field name="Account"></field>
+		<field name="Study_site">Y</field>
+	</row>
+	<row>
+		<field name="CenterID">3</field>
+		<field name="Name">BBB</field>
+		<field name="PSCArea">BBB</field>
+		<field name="Address"></field>
+		<field name="City"></field>
+		<field name="StateID">0</field>
+		<field name="ZIP"></field>
+		<field name="Phone1"></field>
+		<field name="Phone2"></field>
+		<field name="Contact1"></field>
+		<field name="Contact2"></field>
+		<field name="Alias">BBB</field>
+		<field name="MRI_alias">BBB</field>
+		<field name="Account"></field>
+		<field name="Study_site">Y</field>
+	</row>
+	</table_data>
+</database>
+</mysqldump>

--- a/test/unittests/NDB_BVL_FeedbackTest.php
+++ b/test/unittests/NDB_BVL_FeedbackTest.php
@@ -32,7 +32,7 @@ class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
     {
         parent::setUp();
         $this->createLorisDBConnection();
-        $this->_feedbackObj = NDB_BVL_Feedback::singleton("karo_test", null, 3);
+        $this->_feedbackObj = NDB_BVL_Feedback::singleton("karo_test", null, 11);
     }
 
 
@@ -44,9 +44,22 @@ class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
      */
     protected function getDataSet()
     {
-        return $this->createMySQLXMLDataSet(
+        $ds1 = $this->createMySQLXMLDataSet(
             TABLE_FIXTURES_PATH . 'feedback_bvl_type.xml'
         );
+        $ds2 = $this->createMySQLXMLDataSet(
+            TABLE_FIXTURES_PATH . 'psc.xml'
+        );
+        $ds3 = $this->createMySQLXMLDataSet(
+            TABLE_FIXTURES_PATH . 'NDB_BVL_FeedbackTest.xml'
+        );
+
+        $compositeDs = new PHPUnit_Extensions_Database_DataSet_CompositeDataSet();
+        $compositeDs->addDataSet($ds1);
+        $compositeDs->addDataSet($ds2);
+        $compositeDs->addDataSet($ds3);
+
+        return $compositeDs;
     }
 
     /**

--- a/test/unittests/NDB_BVL_FeedbackTest.php
+++ b/test/unittests/NDB_BVL_FeedbackTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: kmarasinska
+ * Date: 03/06/15
+ * Time: 11:08 AM
+ */
+
+/**
+ * Class NDB_BVL_FeedbackTest
+ *
+ */
+class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
+{
+
+    /**
+     * NDB_BVL_Feedback object used for testing
+     *
+     * @var NDB_BVL_Feedback
+     */
+    private $_feedbackObj;
+
+
+    /**
+     * Setup test
+     *
+     * @throws Exception
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->createLorisDBConnection();
+        $this->_feedbackObj = NDB_BVL_Feedback::singleton("karo_test", null, 3);
+    }
+
+
+    /**
+     * Returns test data set.
+     * Populates table feedback_bvl_type.
+     *
+     * @return PHPUnit_Extensions_Database_DataSet_IDataSet
+     */
+    protected function getDataSet()
+    {
+        return $this->createMySQLXMLDataSet(
+            TABLE_FIXTURES_PATH . 'feedback_bvl_type.xml'
+        );
+    }
+
+    /**
+     * Test createFeedbackType passing an invalid name
+     *
+     * @covers NDB_BVL_Feedback::createFeedbackType
+     * @throws LorisException
+     * @return void
+     */
+    public function testCreateFeedbackTypeWithInvalidName()
+    {
+        $this->setExpectedException('LorisException');
+        $this->_feedbackObj->createFeedbackType("");
+    }
+
+    /**
+     * Test createFeedbackType: create a new valid feedback type
+     *
+     * @covers NDB_BVL_Feedback::createFeedbackType
+     * @throws LorisException
+     * @return void
+     */
+    public function testCreateNewFeedbackType()
+    {
+        $this->assertEquals(6, $this->_feedbackObj->createFeedbackType('New Test Type', 'Created from PHPUnit tests'));
+    }
+
+    /**
+     * Test getFeedbackTypeIdByName for existing name
+     *
+     * @covers NDB_BVL_Feedback::getFeedbackTypeIdByName
+     * @return void
+     */
+    public function testGetFeedbackTypeIdByNameForExistingValue()
+    {
+        $this->assertEquals(5, $this->_feedbackObj->getFeedbackTypeIdByName('Other'));
+
+    }
+
+    /**
+     * Test getFeedbackTypeIdByName for value which does not exist in feedback_bvl_type table
+     * @covers NDB_BVL_Feedback::getFeedbackTypeIdByName
+     * @return void
+     */
+    public function testGetFeedbackTypeIdByNameForNoneExistingValue()
+    {
+        $this->assertEmpty(
+            $res = $this->_feedbackObj->getFeedbackTypeIdByName(
+                'None existing value'
+            )
+        );
+    }
+}

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -313,13 +313,21 @@ function addInstrument($sessionID, $testName)
      */
     // feedback object
     print $user->getUsername();
-    $feedback =& NDB_BVL_Feedback::singleton($user->getUsername(), null, $sessionID, $commentID);
+    $feedback =& NDB_BVL_Feedback::singleton($user->getUsername(), null, $sessionID);
     if (PEAR::isError($feedback)) {
         return PEAR::raiseError("Failed to create feedback object: " . $feedback->getMessage());
     }
 
+    //get thread feedback type
+    $threadFeedbackType = $feedback->getFeedbackTypeIdByName('other');
+    if (empty($threadFeedbackType))
+    {
+        //create thread feedback type "Other", if it does not exist
+        $threadFeedbackType = $feedback->createFeedbackType("Other", "Other");
+    }
+
     // add the new thread
-    $success = $feedback->createThread('instrument', '5', "Instrument ($testName) has been added to the battery. You may now complete data entry for this instrument. Please respond to this feedback to acknowledge the changes.", 'Y');
+    $success = $feedback->createThread('instrument', $threadFeedbackType, "Instrument ($testName) has been added to the battery. You may now complete data entry for this instrument. Please respond to this feedback to acknowledge the changes.", 'Y');
     if (PEAR::isError($success)) {
         return PEAR::raiseError("Failed to create feedback: ". $success->getMessage());
     }


### PR DESCRIPTION
`fix_timepoint_date_problems.php add_instrument` was failing when feedback_bvl_type with `Feedback_type=5` (name= 'other') was missing. To fix this, added a check if feedback_bvl_type 'other' exists and create it if it doesn't.
- added 2 methods to NDB_BVL_Feedback class:
 - `getFeedbackTypeIdByName `
 - `createFeedbackType`
- calling those methods in `fix_timepoint_date_problems.php` 
- added unit test for those methods.  Modified .travis.yml, to run phpunit tests with phpunit.xml config. (This is required so `test/bootstrap.php` is run before the tests and loads the required classes for phpunit DB tests.)
- added `test/fixtures/tables/feedback_bvl_type.xml`: this is the fixture which populates  feedback_bvl_type table (required for unit test)