### PR TITLE
Subproject Management Front end

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2299,9 +2299,9 @@ CREATE TABLE subproject (
     useEDC boolean,
     WindowDifference enum('optimal', 'battery'),
     PRIMARY KEY (SubprojectID)
-);
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COMMENT='Stores Subprojects used in Loris';
 INSERT INTO subproject (SubprojectID, title, useEDC, WindowDifference) VALUES (1, 'Control', false, 'optimal');
-INSERT INTO subproject (SubprojectID, title, useEDC, WindowDifference) VALUES (1, 'Experimental', false, 'optimal');
+INSERT INTO subproject (SubprojectID, title, useEDC, WindowDifference) VALUES (2, 'Experimental', false, 'optimal');
 
 CREATE TABLE StatisticsTabs(
     ID INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2293,6 +2293,16 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "no-reply@example.com" FROM Conf
 INSERT INTO Config (ConfigID, Value) SELECT ID, "no-reply@example.com" FROM ConfigSettings WHERE Name="Reply-to";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "Produced by LorisDB" FROM ConfigSettings WHERE Name="X-MimeOLE";
 
+CREATE TABLE subproject (
+    SubprojectID int(10) unsigned NOT NULL auto_increment,
+    title varchar(255) NOT NULL,
+    useEDC boolean,
+    WindowDifference enum('optimal', 'battery'),
+    PRIMARY KEY (SubprojectID)
+);
+INSERT INTO subproject (SubprojectID, title, useEDC, WindowDifference) VALUES (1, 'Control', false, 'optimal');
+INSERT INTO subproject (SubprojectID, title, useEDC, WindowDifference) VALUES (1, 'Experimental', false, 'optimal');
+
 CREATE TABLE StatisticsTabs(
     ID INTEGER UNSIGNED NOT NULL AUTO_INCREMENT,
     ModuleName varchar(255) NOT NULL,
@@ -2456,3 +2466,4 @@ CREATE TABLE `server_processes` (
   KEY `FK_task_1` (`userid`),
   CONSTRAINT `FK_task_1` FOREIGN KEY (`userid`) REFERENCES `users` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/SQL/2015-06-11-subprojectConfigTable.sql
+++ b/SQL/2015-06-11-subprojectConfigTable.sql
@@ -1,0 +1,8 @@
+CREATE TABLE subproject (
+    SubprojectID int(10) unsigned NOT NULL auto_increment,
+    title varchar(255) NOT NULL,
+    useEDC boolean,
+    WindowDifference enum('optimal', 'battery'),
+    PRIMARY KEY (SubprojectID)
+);
+

--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -82,24 +82,6 @@
                 <recruitmentTarget>50</recruitmentTarget>
             </project>
         </Projects>
-        <!-- number of subprojects in the project - corresponds to the list of subpojects below -->
-        <!-- max number of timepoints per subject (integer)-->
-        <subprojects>
-            <subproject>
-                <id>1</id>
-                <title>Control</title>
-                <options>
-                    <useEDC>false</useEDC>
-                </options>
-            </subproject>
-            <subproject>
-                <id>2</id>
-                <title>Experimental</title>
-                <options>
-                    <useEDC>false</useEDC>
-                </options>
-            </subproject>
-        </subprojects>
 
         <!-- defines how visit labels are assigned -->
         <visitLabel subprojectID="1">

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -26,11 +26,6 @@ require_once __DIR__
  */
 class CandidateListTestIntegrationTest extends LorisIntegrationTest
 {
-    private $_useEDCId;
-    private $_useEDCBackup;
-    private $_useProjectsId;
-    private $_useProjectsBackup;
-
     /**
      * Backs up the useEDC config value and sets the value to a known
      * value (true) for testing.
@@ -41,22 +36,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTest
     {
         parent::setUp();
 
-        $this->_useEDCId = $this->DB->pselectOne(
-            "SELECT ID FROM ConfigSettings WHERE NAME=:useEDC",
-            array(":useEDC" => "useEDC")
-        );
-
-        $this->_useEDCBackup = $this->DB->pselectOne(
-            "SELECT Value FROM Config WHERE ConfigID=:useEDC",
-            array(":useEDC" => $this->_useEDCId)
-        );
-
-        $this->DB->update(
-            "Config",
-            array("Value" => "true"),
-            array("ConfigID" => $this->_useEDCId)
-        );
-
+        $this->setupConfigSetting("useEDC", "true");
     }
 
     /**
@@ -66,16 +46,8 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTest
      */
     function tearDown()
     {
-        $this->_useEDCBackup = $this->DB->pselectOne(
-            "SELECT Value FROM Config WHERE ConfigID=:useEDC",
-            array(":useEDC" => $this->_useEDCId)
-        );
-        $this->DB->update(
-            "Config",
-            array("Value" => $this->_useEDCBackup),
-            array("ConfigID" => $this->_useEDCId)
-        );
         parent::tearDown();
+        $this->restoreConfigSetting("useEDC");
     }
     /**
      * Tests that, when loading the candidate_list module, the breadcrumb

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is used by the Configuration module to update
+ * or insert values into the Config table.
+ *
+ * PHP version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Tara Campbell <tara.campbell@mail.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
+require_once __DIR__ . "/../../../vendor/autoload.php";
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize();
+
+$factory = NDB_Factory::singleton();
+$db = $factory->database();
+
+$db->update(
+    "subproject",
+    array(
+     "title" => $_POST['title'],
+     "useEDC" => $_POST['useEDC'],
+     "WindowDifference" => $_POST['WindowDifference'],
+    ),
+    array("SubprojectID" => $_POST['subprojectID'])
+);
+header("HTTP/1.1 200 OK");
+print '{ "ok" : "Success" }';
+exit();
+
+?>

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -20,15 +20,26 @@ $client->initialize();
 $factory = NDB_Factory::singleton();
 $db = $factory->database();
 
-$db->update(
-    "subproject",
-    array(
-     "title" => $_POST['title'],
-     "useEDC" => $_POST['useEDC'],
-     "WindowDifference" => $_POST['WindowDifference'],
-    ),
-    array("SubprojectID" => $_POST['subprojectID'])
-);
+if($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
+    $db->insert(
+        "subproject",
+        array(
+         "title" => $_POST['title'],
+         "useEDC" => $_POST['useEDC'],
+         "WindowDifference" => $_POST['WindowDifference'],
+        )
+    );
+} else {
+    $db->update(
+        "subproject",
+        array(
+            "title" => $_POST['title'],
+            "useEDC" => $_POST['useEDC'],
+            "WindowDifference" => $_POST['WindowDifference'],
+        ),
+        array("SubprojectID" => $_POST['subprojectID'])
+    );
+}
 header("HTTP/1.1 200 OK");
 print '{ "ok" : "Success" }';
 exit();

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -18,14 +18,14 @@ $client->makeCommandLine();
 $client->initialize();
 
 $factory = NDB_Factory::singleton();
-$db = $factory->database();
+$db      = $factory->database();
 
-if($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
+if ($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
     $db->insert(
         "subproject",
         array(
-         "title" => $_POST['title'],
-         "useEDC" => $_POST['useEDC'],
+         "title"            => $_POST['title'],
+         "useEDC"           => $_POST['useEDC'],
          "WindowDifference" => $_POST['WindowDifference'],
         )
     );
@@ -33,9 +33,9 @@ if($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
     $db->update(
         "subproject",
         array(
-            "title" => $_POST['title'],
-            "useEDC" => $_POST['useEDC'],
-            "WindowDifference" => $_POST['WindowDifference'],
+         "title"            => $_POST['title'],
+         "useEDC"           => $_POST['useEDC'],
+         "WindowDifference" => $_POST['WindowDifference'],
         ),
         array("SubprojectID" => $_POST['subprojectID'])
     );

--- a/modules/configuration/js/subproject.js
+++ b/modules/configuration/js/subproject.js
@@ -1,0 +1,35 @@
+$(document).ready(function() {
+    "use strict";
+    $(".savesubproject").click(function(e) {
+        var form = $(e.currentTarget).closest('form');
+
+        var subprojectID = $(form.find(".subprojectID")).val();
+        var title = $(form.find(".subprojectTitle")).val();
+        var useEDC= $(form.find(".subprojectuseEDC")).val();
+        var windowDifference= $(form.find(".subprojectWindowDifference")).val();
+        e.preventDefault();
+        var successClosure = function(i, form) {
+            return function() {
+                $(form.find(".saveStatus")).text("Successfully saved").fadeIn(500).delay(1000).fadeOut(500)
+
+            }
+        }
+
+        jQuery.ajax(
+                {
+                    "type" : "post",
+                    "url" : "AjaxHelper.php?Module=configuration&script=updateSubproject.php",
+                    "data" : {
+                        "subprojectID" : subprojectID,
+                        "title" : title,
+                        "useEDC" : useEDC,
+                        "WindowDifference" : windowDifference,
+                    },
+                    "success" : successClosure(subprojectID, form)
+                }
+
+          );
+
+
+    });
+});

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -104,6 +104,30 @@ class NDB_Form_Configuration extends NDB_Form
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
 
     }
+
+    function subproject() {
+        $factory = NDB_Factory::singleton();
+        $config = $factory->config();
+
+        $subprojectList = Utility::getSubprojectList();
+        $subprojects = array();
+        foreach($subprojectList as $subprojectID => $title) {
+            $subprojects[$subprojectID] = $config->getSubprojectSettings($subprojectID);
+        }
+        $this->tpl_data['subprojects'] = $subprojects;
+
+        $this->tpl_data['useEDCOptions']
+            = array(
+               '1' => 'Yes',
+               '0' => 'No',
+              );
+
+        $this->tpl_data['WindowDifferenceOptions']
+            = array(
+               'battery' => 'Closest Test Battery',
+               'optimal' => 'Optimal Visit Window for Visit Label',
+              );
+    }
 }
 
 ?>

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -105,14 +105,21 @@ class NDB_Form_Configuration extends NDB_Form
 
     }
 
-    function subproject() {
+    /**
+     * Loads the subproject management submodule
+     *
+     * @return none
+     */
+    function subproject()
+    {
         $factory = NDB_Factory::singleton();
-        $config = $factory->config();
+        $config  = $factory->config();
 
         $subprojectList = Utility::getSubprojectList();
-        $subprojects = array();
-        foreach($subprojectList as $subprojectID => $title) {
-            $subprojects[$subprojectID] = $config->getSubprojectSettings($subprojectID);
+        $subprojects    = array();
+        foreach ($subprojectList as $subprojectID => $title) {
+            $subprojects[$subprojectID]
+                = $config->getSubprojectSettings($subprojectID);
         }
         $this->tpl_data['subprojects'] = $subprojects;
 

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -106,6 +106,7 @@
 {/function}
 
 <p>Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer's guide.</p>
+<p>To configure study subprojects <a href="{$baseurl}/main.php?test_name=configuration&subtest=subproject">click here</a>.</p>
 <br>
 
 <div class="col-md-3">

--- a/modules/configuration/templates/form_subproject.tpl
+++ b/modules/configuration/templates/form_subproject.tpl
@@ -9,6 +9,7 @@
     {foreach from=$subprojects key=subprojectID item=subproject name=configContent}
     <li><a href="#subproject{$subprojectID}" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>{$subproject.title}</a></li>
     {/foreach}
+    <li><a href="#subprojectnew" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>New SubprojectID</a></li>
 </ul>
 </div>
 
@@ -52,4 +53,40 @@
         </form>
     </div>
     {/foreach}
+    <div id="subprojectnew" class="tab-pane {if $smarty.foreach.tabContent.first} active{/if}">
+        <h2>New Subproject</h2>
+        <br>
+        <form class="form-horizontal" role="form" method="post" id="form{$subprojectID}">
+            <fieldset>
+                <input type="hidden" name="subprojectID" value="new" class="subprojectID">
+                <div class="form-group">
+                    <label class="col-sm-12 col-md-4">Subproject Title</label>
+                    <div class="col-sm-12 col-md-8">
+                        <input class="form-control subprojectTitle" name="title" placeholder="Subroject Title goes here" value="">
+                    </div>
+                </div>
+                <div class="form-group">
+
+                    <label class="col-sm-12 col-md-4">Use <abbr title="Expect Date of Confinement (ie. baby's due date)">EDC</abbr></label>
+                    <div class="col-sm-12 col-md-8">
+                        {html_options options=$useEDCOptions name="useEDC" selected="Yes" class="form-control subprojectuseEDC"}
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="col-sm-12 col-md-4">Calculate Window Difference for instruments based on:</label>
+                    <div class="col-sm-12 col-md-8">
+                        {html_options options=$WindowDifferenceOptions name="WindowDifference" selected="battery" class="form-control subprojectWindowDifference"}
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-4 col-sm-8 submit-area">
+                        <button id="savesubprojectnew" class="btn btn-primary savesubproject">Save</button>
+                        <button class="btn btn-default" type="reset">Reset</button>
+                        <label class="saveStatus"></label>
+                    </div>
+                </div>
+
+            </fieldset>
+        </form>
+    </div>
 </div>

--- a/modules/configuration/templates/form_subproject.tpl
+++ b/modules/configuration/templates/form_subproject.tpl
@@ -1,0 +1,55 @@
+<script language="javascript" src="GetJS.php?Module=configuration&file=subproject.js">
+
+</script>
+<p>Use this page to manage the configuration of existing subprojects, or to add a new one.</p>
+
+
+<div class="col-md-3">
+<ul class="nav nav-pills nav-stacked" role="tablist" data-tabs="tabs">
+    {foreach from=$subprojects key=subprojectID item=subproject name=configContent}
+    <li><a href="#subproject{$subprojectID}" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>{$subproject.title}</a></li>
+    {/foreach}
+</ul>
+</div>
+
+<div class="col-md-9">
+    <div class="tab-content">
+    {foreach from=$subprojects key=subprojectID item=subproject name=tabContent}
+    <div id="subproject{$subprojectID}" class="tab-pane {if $smarty.foreach.tabContent.first} active{/if}">
+        <h2>{$subproject.title} (SubprojectID: {$subprojectID})</h2>
+        <br>
+        <form class="form-horizontal" role="form" method="post" id="form{$subprojectID}">
+            <fieldset>
+                <input type="hidden" name="subprojectID" value="{$subprojectID}" class="subprojectID">
+                <div class="form-group">
+                    <label class="col-sm-12 col-md-4">Subproject Title</label>
+                    <div class="col-sm-12 col-md-8">
+                        <input class="form-control subprojectTitle" name="title" value="{$subproject.title}">
+                    </div>
+                </div>
+                <div class="form-group">
+
+                    <label class="col-sm-12 col-md-4">Use <abbr title="Expect Date of Confinement (ie. baby's due date)">EDC</abbr></label>
+                    <div class="col-sm-12 col-md-8">
+                        {html_options options=$useEDCOptions name="useEDC" selected=$subproject.options.useEDC class="form-control subprojectuseEDC"}
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="col-sm-12 col-md-4">Calculate Window Difference for instruments based on:</label>
+                    <div class="col-sm-12 col-md-8">
+                        {html_options options=$WindowDifferenceOptions name="WindowDifference" selected=$subproject.options.WindowDifference class="form-control subprojectWindowDifference"}
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-4 col-sm-8 submit-area">
+                        <button id="savesubproject{$subprojectID}" class="btn btn-primary savesubproject">Save</button>
+                        <button class="btn btn-default" type="reset">Reset</button>
+                        <label class="saveStatus"></label>
+                    </div>
+                </div>
+
+            </fieldset>
+        </form>
+    </div>
+    {/foreach}
+</div>

--- a/modules/configuration/templates/form_subproject.tpl
+++ b/modules/configuration/templates/form_subproject.tpl
@@ -7,9 +7,9 @@
 <div class="col-md-3">
 <ul class="nav nav-pills nav-stacked" role="tablist" data-tabs="tabs">
     {foreach from=$subprojects key=subprojectID item=subproject name=configContent}
-    <li><a href="#subproject{$subprojectID}" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>{$subproject.title}</a></li>
+    <li {if $smarty.foreach.configContent.first}class="active"{/if}><a href="#subproject{$subprojectID}" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>{$subproject.title}</a></li>
     {/foreach}
-    <li><a href="#subprojectnew" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>New SubprojectID</a></li>
+    <li {if $smarty.foreach.configContent.first}class="active"{/if}><a href="#subprojectnew" data-toggle="tab" {if $smarty.foreach.configContent.first}class="active"{/if}>New SubprojectID</a></li>
 </ul>
 </div>
 

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -32,6 +32,8 @@ foreach($subprojs['subproject'] as $row) {
     if($row['options']['useEDC'] === '1' || $row['options']['useEDC'] === 'true') {
         $ins['useEDC'] = 1;
     }
+    Utility::nullifyEmpty($ins, 'WindowDifference');
+    Utility::nullifyEmpty($ins, 'useEDC');
     $db->insert('subproject', $ins);
 }
 ?>

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -26,7 +26,7 @@ foreach($subprojs['subproject'] as $row) {
     $ins = array(
             'SubprojectID'     => $row['id'],
             'title'            => $row['title'],
-            'useEDC'           => false,
+            'useEDC'           => 0,
             'WindowDifference' => $row['options']['WindowDifference'],
            );
     if($row['options']['useEDC'] === '1' || $row['options']['useEDC'] === 'true') {

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This script should be used to migrate existing ProjectIDs and
+ * SubprojectIDs from the config.xml to the subprojects table, so that
+ * they can be managed from the frontend.
+ *
+ * PHP Version 5
+ *
+ * @category Loris
+ * @package  Configuration
+ * @author   Dave MacFarlane <driusan@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+require_once __DIR__ . "/../../../vendor/autoload.php";
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize();
+
+$factory = NDB_Factory::singleton();
+$config = $factory->config(__DIR__ . "/../../../project/config.xml");
+$subprojs = $config->getSettingFromXML("subprojects");
+$db = $factory->database();
+foreach($subprojs['subproject'] as $row) {
+    $ins = array(
+            'SubprojectID'     => $row['id'],
+            'title'            => $row['title'],
+            'useEDC'           => false,
+            'WindowDifference' => $row['options']['WindowDifference'],
+           );
+    if($row['options']['useEDC'] === '1' || $row['options']['useEDC'] === 'true') {
+        $ins['useEDC'] = 1;
+    }
+    $db->insert('subproject', $ins);
+}
+?>

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -18,13 +18,13 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize();
 
-$factory = NDB_Factory::singleton();
-$config = $factory->config(__DIR__ . "/../../../project/config.xml");
+$factory  = NDB_Factory::singleton();
+$config   = $factory->config(__DIR__ . "/../../../project/config.xml");
 $subprojs = $config->getSettingFromXML("subprojects");
-$db = $factory->database();
-foreach($subprojs['subproject'] as $row) {
+$db       = $factory->database();
+foreach ($subprojs['subproject'] as $row) {
     $windowDiff = "optimal";
-    if(isset($row['options']) && isset($row['options']['WindowDifference'])) {
+    if (isset($row['options']) && isset($row['options']['WindowDifference'])) {
         $windowDiff = $row['options']['WindowDifference'];
     }
     $ins = array(
@@ -33,7 +33,7 @@ foreach($subprojs['subproject'] as $row) {
             'useEDC'           => 0,
             'WindowDifference' => $windowDiff,
            );
-    if($row['options']['useEDC'] === '1' || $row['options']['useEDC'] === 'true') {
+    if ($row['options']['useEDC'] === '1' || $row['options']['useEDC'] === 'true') {
         $ins['useEDC'] = 1;
     }
     Utility::nullifyEmpty($ins, 'WindowDifference');

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -23,7 +23,7 @@ $config = $factory->config(__DIR__ . "/../../../project/config.xml");
 $subprojs = $config->getSettingFromXML("subprojects");
 $db = $factory->database();
 foreach($subprojs['subproject'] as $row) {
-    $windowDiff = null;
+    $windowDiff = "optimal";
     if(isset($row['options']) && isset($row['options']['WindowDifference'])) {
         $windowDiff = $row['options']['WindowDifference'];
     }

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -23,11 +23,15 @@ $config = $factory->config(__DIR__ . "/../../../project/config.xml");
 $subprojs = $config->getSettingFromXML("subprojects");
 $db = $factory->database();
 foreach($subprojs['subproject'] as $row) {
+    $windowDiff = null;
+    if(isset($row['options']) && isset($row['options']['WindowDifference'])) {
+        $windowDiff = $row['options']['WindowDifference'];
+    }
     $ins = array(
             'SubprojectID'     => $row['id'],
             'title'            => $row['title'],
             'useEDC'           => 0,
-            'WindowDifference' => $row['options']['WindowDifference'],
+            'WindowDifference' => $windowDiff,
            );
     if($row['options']['useEDC'] === '1' || $row['options']['useEDC'] === 'true') {
         $ins['useEDC'] = 1;

--- a/modules/create_timepoint/php/NDB_Form_create_timepoint.class.inc
+++ b/modules/create_timepoint/php/NDB_Form_create_timepoint.class.inc
@@ -84,7 +84,6 @@ class NDB_Form_create_timepoint extends NDB_Form
         $sp_labelOptions = array(null => '');
 
         foreach($allSubprojects as $subprojectID => $title) {
-            print_r($subproject);
             if( ! empty($subprojList)) {
                 if(in_array($subprojectID, $subprojList)){
                     $sp_labelOptions[$subprojectID] = $title;

--- a/modules/create_timepoint/php/NDB_Form_create_timepoint.class.inc
+++ b/modules/create_timepoint/php/NDB_Form_create_timepoint.class.inc
@@ -77,18 +77,21 @@ class NDB_Form_create_timepoint extends NDB_Form
             $subprojList = $candidate->getValidSubprojects();
         }
         // List of all subprojects from config file
-        $subprojectSettings= $config->getSetting('subprojects');
+        
+
         //Loop through the subprojects to get an id out and to create the subproject drop down.
+        $allSubprojects = Utility::getSubprojectList();
         $sp_labelOptions = array(null => '');
-        foreach(Utility::toArray($subprojectSettings['subproject']) AS $subproject){
-            if( ! empty($subprojList)){
-                if(in_array($subproject['id'], $subprojList)){
-                    $sp_labelOptions[$subproject['id']] = $subproject['title'];
+
+        foreach($allSubprojects as $subprojectID => $title) {
+            print_r($subproject);
+            if( ! empty($subprojList)) {
+                if(in_array($subprojectID, $subprojList)){
+                    $sp_labelOptions[$subprojectID] = $title;
                 }
-             } else { 
-                    $sp_labelOptions[$subproject['id']] = $subproject['title'];
-                 
-                 }
+            } else {
+                $sp_labelOptions[$subprojectID] = $title;
+            }
         }
         
         $attributes=array("onchange"=>"location.href='main.php?test_name=create_timepoint&candID=".$this->identifier."&identifier=".$this->identifier."&subprojectID='+this[this.selectedIndex].value;");

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -423,20 +423,25 @@ class NDB_Config
      */
     function getSubprojectSettings($subprojectID)
     {
-        // Sub Project
-        $subprojectSettings =$this->getSetting('subprojects');
-
-        //Loop through the subprojects to get an id out and to create
-        //the subproject drop down.
-        foreach (Utility::toArray($subprojectSettings['subproject'])
-            AS $subproject
-        ) {
-            if ($subproject['id']==$subprojectID) {
-                return $subproject;
-            }
+        $factory = NDB_Factory::singleton();
+        $DB = $factory->database();
+        try {
+            $info = $DB->pselectRow(
+                "SELECT * FROM subproject WHERE SubprojectID=:sp",
+                array('sp' => $subprojectID)
+            );
+        } catch(DatabaseException $e) {
+            return null;
         }
-        // no nodes found - returning null
-        return null;
+        // Format the results the same way it was formatted in config.xml
+        return array(
+            'id' => $info['SubprojectID'],
+            'title' => $info['title'],
+            'options' => array(
+                'useEDC' => $info['useEDC'],
+                'WindowDifference' => $info['WindowDifference']
+            )
+        );
     }
 
     /**

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -424,7 +424,8 @@ class NDB_Config
     function getSubprojectSettings($subprojectID)
     {
         $factory = NDB_Factory::singleton();
-        $DB = $factory->database();
+        $DB      = $factory->database();
+
         try {
             $info = $DB->pselectRow(
                 "SELECT * FROM subproject WHERE SubprojectID=:sp",
@@ -435,13 +436,13 @@ class NDB_Config
         }
         // Format the results the same way it was formatted in config.xml
         return array(
-            'id' => $info['SubprojectID'],
-            'title' => $info['title'],
-            'options' => array(
-                'useEDC' => $info['useEDC'],
-                'WindowDifference' => $info['WindowDifference']
-            )
-        );
+                'id'      => $info['SubprojectID'],
+                'title'   => $info['title'],
+                'options' => array(
+                              'useEDC'           => $info['useEDC'],
+                              'WindowDifference' => $info['WindowDifference'],
+                             ),
+               );
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -276,16 +276,16 @@ class Utility extends PEAR
      */
     static function getSubprojectList()
     {
+        $DB = Database::singleton();
         $config =& NDB_Config::singleton();
 
-        // get the list of Subprojects
-        $subprojectSettings = $config->getSetting('subprojects');
-        foreach (Utility::toArray(
-            $subprojectSettings['subproject']
-        ) as $subproject) {
-            $list[$subproject['id']] =$subproject['title'];
+        $subprojects = $DB->pselect("SELECT * FROM subproject", array());
+
+        $subprojs = array();
+        foreach($subprojects as $row) {
+            $subprojs[$row['SubprojectID']] = $row['title'];
         }
-        return $list;
+        return $subprojs;
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -276,13 +276,13 @@ class Utility extends PEAR
      */
     static function getSubprojectList()
     {
-        $DB = Database::singleton();
-        $config =& NDB_Config::singleton();
+        $DB     = Database::singleton();
+        $config = NDB_Config::singleton();
 
         $subprojects = $DB->pselect("SELECT * FROM subproject", array());
 
         $subprojs = array();
-        foreach($subprojects as $row) {
+        foreach ($subprojects as $row) {
             $subprojs[$row['SubprojectID']] = $row['title'];
         }
         return $subprojs;

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -160,6 +160,11 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
             array(":configName" => $configName)
         );
 
+        if(is_array($configID) && empty($configID)) {
+            // This likely just means the config is in config.xml
+            //throw new LorisException("Attempting to update Config setting not in database");
+            return;
+        }
         $oldVal = $this->DB->pselectOne(
             "SELECT Value FROM Config WHERE ConfigID=:confID",
             array(":confID" => $configID)
@@ -178,14 +183,18 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
     }
 
     function restoreConfigSetting($configName) {
+        /*
         if(!isset($this->_oldConfig[$configName])) {
             throw new LorisException("Attempted to restore unsaved config setting");
         }
-        $this->DB->update(
-            "Config",
-            array("Value"    => $this->_oldConfig[$configName]['OldValue']),
-            array("ConfigID" => $this->_oldConfig[$configName]['ConfigID'])
-        );
+         */
+        if(isset($this->_oldConfig[$configName])) {
+            $this->DB->update(
+                "Config",
+                array("Value"    => $this->_oldConfig[$configName]['OldValue']),
+                array("ConfigID" => $this->_oldConfig[$configName]['ConfigID'])
+            );
+        }
     }
 
 }

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -107,6 +107,11 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
     protected function login($username, $password)
     {
         $this->webDriver->get($this->url);
+        $this->webDriver->wait(120, 1000)->until(
+            WebDriverExpectedCondition::presenceOfElementLocated(
+                WebDriverBy::Name("username")
+            )
+        );
 
         $usernameEl = $this->webDriver->findElement(WebDriverBy::Name("username"));
         $passwordEl = $this->webDriver->findElement(WebDriverBy::Name("password"));


### PR DESCRIPTION
This creates a new "subproject" table and moves all of the subprojects out of the config.xml into the table,   updating the code to use the table instead of the config.xml. It also adds a frontend to the configuration module available at ?test_name=configuration&subtest=subproject to manage the table.

The script import_projects.php will have to be run by existing projects to migrate their settings from the config.xml to the table.