### PR TITLE
Modify tarchive_series table to include PET DICOMs.

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1240,6 +1240,7 @@ CREATE TABLE `tarchive_series` (
   `PhaseEncoding` varchar(255) default NULL,
   `NumberOfFiles` int(11) NOT NULL default '0',
   `SeriesUID` varchar(255) default NULL,
+  `Modality` ENUM ('MR', 'PT') default NULL,
   PRIMARY KEY  (`TarchiveSeriesID`),
   KEY `TarchiveID` (`TarchiveID`),
   CONSTRAINT `tarchive_series_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE

--- a/SQL/2015-06-13_ModifyTarchiveSeriesTableToIncludePET.sql
+++ b/SQL/2015-06-13_ModifyTarchiveSeriesTableToIncludePET.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tarchive_series ADD Modality ENUM ('MR', 'PT');

--- a/SQL/2015-06-13_ModifyTarchiveSeriesTableToIncludePET.sql
+++ b/SQL/2015-06-13_ModifyTarchiveSeriesTableToIncludePET.sql
@@ -1,1 +1,1 @@
-ALTER TABLE tarchive_series ADD Modality ENUM ('MR', 'PT');
+ALTER TABLE tarchive_series ADD Modality ENUM ('MR', 'PT') default NULL;


### PR DESCRIPTION
Adding a Modality field to the tarchive_series in order to differentiate PET and MR images.