### PR TITLE
fix bug where if the table wasn't unfreezing column

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -57,6 +57,7 @@ table th{
     width:7em; 
     left:0;
     top:auto;
+    word-wrap: break-word;
     border-right: 0px none black; 
     border-top-width:3px; /*only relevant for first row*/
 }

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -121,10 +121,11 @@
             statColWid = $("." + tableID + "FrozenColumn").outerWidth(),
             leftScrollPos = $(".leftScrollBar").offset().left,
             leftScrollWid = $(".leftScrollBar").outerWidth(),
-            nextColPos = $("." + tableID + "Next").offset().left;
+            nextColPos = $("." + tableID + "Next").offset().left,
+            tablePos = $("#" + tableID).offset().left;
 
         if (colm_static === true) {
-            if (nextColPos >= statColPos + statColWid) {
+            if (nextColPos >= statColPos + statColWid || statColPos <= tablePos) {
                 $("." + tableID).each(function (key, value) {
                     if (key >= 0) {
                         $(value).css("height", "");


### PR DESCRIPTION
When using FreezeColumn, the frozen column only unfroze when it's right column became fully visible again. This caused problems when the table had fully scrolled and the right column had not been fully shown. To fix this added that if the table is fully scrolled to unfreeze the column. Also add CSS to break words so that they fit in the column and do not overflow out.