### PR TITLE
Remove testing mode from NDB_Factory class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
         php -l $i || exit $?;
       done
     # Run unit tests to make sure functions still do what they should.
-    - vendor/bin/phpunit test/unittests/
+    - vendor/bin/phpunit --configuration test/phpunit.xml test/unittests/
 
     # Run integration tests to make sure everything didn't just
     # break

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -1,11 +1,10 @@
 <?php
 /**
  * This class defines a factory which can be used to generate other objects that
- * are usually singletons. Instead of directly calling class::singleton staticly,
+ * are usually singletons. Instead of directly calling class::singleton statically,
  * this factory should be used so that a mock class can be subbed in for testing.
  *
- * If the Factory is in testing mode (setTesting(true) was called), a mock will
- * be returned. Otherwise, the normal NDB_ prefixed object will be returned.
+ * Note: Setters can be used to inject test doubles when writing unit tests.
  *
  * PHP Version 5
  *
@@ -32,28 +31,34 @@ require_once 'CouchDB.class.inc';
  */
 class NDB_Factory
 {
-    private static $_testdb = null;
-    private static $_db     = null;
-
-    private static $_couchdb = null;
-    private static $_user    = null;
-
-    var $Testing; // Whether or not Mock objects should be returned instead of
-                  // real ones
-    //
-    private static $_config = null;
+    /**
+     * Single instance of Database class
+     *
+     * @var Database
+     */
+    private static $_db = null;
 
     /**
-     * Sets whether the factory should return real objects or testing objects
+     * Single instance of CouchDB database wrapper class
      *
-     * @param boolean $val Whether testing should be enabled
-     *
-     * @return none
+     * @var CouchDB
      */
-    function setTesting($val)
-    {
-        $this->Testing = $val;
-    }
+    private static $_couchdb = null;
+
+    /**
+     * Single instance of Loris USer object
+     *
+     * @var User
+     */
+    private static $_user = null;
+
+    /**
+     * Single instance of NDB_Config object
+     *
+     * @var NDB_Config
+     */
+    private static $_config = null;
+
 
     /**
      * Returns a single factory object. This must be used instead of being
@@ -77,39 +82,31 @@ class NDB_Factory
      *
      * @return none
      */
-    function reset()
+    public function reset()
     {
-        self::$_testdb = null;
-        self::$_db     = null;
-
+        self::$_db      = null;
         self::$_couchdb = null;
         self::$_user    = null;
-
-        self::$_config = null;
+        self::$_config  = null;
     }
 
     /**
-     * Return either a real or mock NDB_Config object depending on testing
-     * status of this factory object.
+     * Return NDB_Config object
      *
-     * @param string $configfile Location of XML file to parse config from
+     * @param string $configFile Location of XML file to parse config from
      *
      * @return NDB_Config A config singleton
      */
-    function config($configfile = "../project/config.xml")
+    public function config($configFile = "../project/config.xml")
     {
         if (self::$_config !== null) {
             return self::$_config;
         }
-        if ($this->Testing) {
-            Mock::generate("NDB_Config");
-            $config = new MockNDB_Config();
-        } else {
-            $config = NDB_Config::singleton($configfile);
-        }
+
+        $config = NDB_Config::singleton($configFile);
 
         self::$_config = $config;
-        $config->load($configfile);
+        $config->load($configFile);
         return $config;
     }
 
@@ -128,21 +125,18 @@ class NDB_Factory
     }
 
     /**
-     * Return either a real or mock Loris User object.
+     * Returns Loris User object.
      *
      * @return User A user singleton
      */
-    function user()
+    public function user()
     {
         if (self::$_user !== null) {
             return self::$_user;
         }
-        if ($this->Testing) {
-            Mock::generate("User");
-            $user = new MockUser();
-        } else {
-            $user = User::singleton();
-        }
+
+        $user = User::singleton();
+
         self::$_user = $user;
         return $user;
     }
@@ -161,28 +155,20 @@ class NDB_Factory
     }
 
     /**
-     * Returns a connected reference to a database handler, or a Mock database
-     * that acts as a connected reference to a database handler.
+     * Returns a connected reference to a database handler
      *
      * @return Database A DB reference
      */
-    function database()
+    public function database()
     {
         $db_ref = null;
-        if ($this->Testing) {
-            $db_ref = &self::$_testdb;
-            if ($db_ref !== null) {
-                return $db_ref;
-            }
-            Mock::generate("Database");
-            self::$_testdb = new MockDatabase();
-        } else {
-            $db_ref = &self::$_db;
-            if ($db_ref !== null) {
-                return $db_ref;
-            }
-            self::$_db = Database::singleton();
+
+        $db_ref = &self::$_db;
+        if ($db_ref !== null) {
+            return $db_ref;
         }
+        self::$_db = Database::singleton();
+
         $config = $this->config();
         $dbc    = $config->getSetting('database');
         $db_ref->connect(
@@ -214,27 +200,14 @@ class NDB_Factory
      *
      * @return CouchDB CouchDB singleton
      */
-    function couchDB()
+    public function couchDB()
     {
         if (self::$_couchdb !== null) {
             return self::$_couchdb;
         }
-        if ($this->Testing) {
-            Mock::generatePartial(
-                'CouchDB',
-                'MockCouchDBWrap',
-                /* mock out the functions that make HTTP requests */
-                array(
-                 '_getRelativeURL',
-                 '_postRelativeURL',
-                 '_postURL',
-                 '_getURL',
-                )
-            );
-            self::$_couchdb = new MockCouchDBWrap();
-        } else {
-            self::$_couchdb = CouchDB::singleton(); //new CouchDB();
-        }
+
+        self::$_couchdb = CouchDB::singleton(); //new CouchDB();
+
         return self::$_couchdb;
     }
 

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -114,6 +114,20 @@ class NDB_Factory
     }
 
     /**
+     * Set config
+     * (Can used for injecting test doubles)
+     *
+     * @param NDB_Config $config config object
+     *
+     * @return NDB_Config config object which was passed in
+     */
+    public function setConfig(NDB_Config $config)
+    {
+        self::$_config = $config;
+        return $config;
+    }
+
+    /**
      * Return either a real or mock Loris User object.
      *
      * @return User A user singleton
@@ -140,7 +154,7 @@ class NDB_Factory
      *
      * @return User The same user that was passed in.
      */
-    function setUser($user)
+    public function setUser(User $user)
     {
         self::$_user = $user;
         return $user;
@@ -182,6 +196,20 @@ class NDB_Factory
     }
 
     /**
+     * Explicitly set the database singleton that is being used by the factory
+     * (Can be used for injecting test doubles)
+     *
+     * @param Database $db Database object
+     *
+     * @return Database same Database object which was passed in
+     */
+    public function setDatabase(Database $db)
+    {
+        self::$_db = $db;
+        return $db;
+    }
+
+    /**
      * Returns a reference to a Loris CouchDB database wrapper.
      *
      * @return CouchDB CouchDB singleton
@@ -208,6 +236,20 @@ class NDB_Factory
             self::$_couchdb = CouchDB::singleton(); //new CouchDB();
         }
         return self::$_couchdb;
+    }
+
+    /**
+     * Explicitly set the Couch DB singleton that is being used by the factory
+     * (Can be used for injecting test doubles)
+     *
+     * @param CouchDB $couchDB CouchDB database wrapper
+     *
+     * @return CouchDB
+     */
+    public function setCouchDB(CouchDB $couchDB)
+    {
+        self::$_couchdb = $couchDB;
+        return $couchDB;
     }
 }
 ?>

--- a/test/unittests/NDB_FactoryTest.php
+++ b/test/unittests/NDB_FactoryTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: kmarasinska
+ * Date: 19/06/15
+ * Time: 12:17 PM
+ */
+
+class NDB_FactoryTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * Instance of NDB_Factory used in tests
+     *
+     * @var NDB_Factory
+     */
+    private $_factory;
+
+    /**
+     * Creates instance of NDB_Factory
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->_factory = NDB_Factory::singleton();
+    }
+
+    /**
+     * Unset factory static variables between each test
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        $this->_factory->reset();
+    }
+
+
+    /**
+     * Test config() method returns instance of NDB_Config object
+     *
+     * @covers NDB_Factory::config
+     * @return void
+     */
+    public function testConfigReturnsConfigObject()
+    {
+        $this->assertInstanceOf('NDB_Config', $this->_factory->config(CONFIG_XML));
+    }
+
+    /**
+     * Test user() method returns instance of User object
+     *
+     * @covers NDB_Factory::user
+     * @return void
+     */
+    public function testUserReturnsUserObject()
+    {
+        $userStub = $this->getMockBuilder('User')->getMock();
+        $this->_factory->setUser($userStub);
+
+        $this->assertInstanceOf('User', $this->_factory->user());
+    }
+
+    /**
+     * Test database() method returns instance of Database object
+     *
+     * @covers NDB_Factory::database
+     * @return void
+     */
+    public function testDatabaseReturnsDatabaseObject()
+    {
+        $dbStub = $this->getMockBuilder('Database')->getMock();
+        $this->_factory->setDatabase($dbStub);
+
+        $this->assertInstanceOf('Database', $this->_factory->database());
+    }
+
+    /**
+     * Test couchDB() method returns instance of CouchDB object
+     *
+     * @covers NDB_Factory::couchDB
+     * @return void
+     */
+    public function testCouchDBReturnsCouchDBObject()
+    {
+        $this->assertInstanceOf('CouchDB', $this->_factory->couchDB());
+    }
+}


### PR DESCRIPTION
- removed testing mode from NDB_Factory class
- TO BE DISCUSSED: added setter methods for testing purposes, so we can inject test doubles. (Other possible solution is to have a test version of the NDB_Factory class which returns test doubles instead of real object instances. This should be discussed)
- added basic unit tests for NDB_Factory