### PR TITLE
URL redirection correction

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -86,10 +86,12 @@ class NDB_Caller extends PEAR
             && isset($_POST['login'])
         ) {
             header("HTTP/1.1 303 See Other");
-             $url  = $config->getSetting('url');
-             $url .= $_SERVER['REQUEST_URI'];
-             // sending user to the url that was requested
-             header("Location: $url");
+            $url  = $_SERVER['REQUEST_SCHEME'];
+            $url .= "://";
+            $url .= $config->getSetting('host');
+            $url .= $_SERVER['REQUEST_URI'];
+            // sending user to the url that was requested
+            header("Location: $url");
         }
         if (empty($CommentID) && isset($_REQUEST['commentID'])) {
             $CommentID = $_REQUEST['commentID'];


### PR DESCRIPTION
Upon successful login, the NDB_Caller class build an url based on configs and php variables. When the site is hosted on hostname/something/main.php, the "something" is included in the url config and in the $_SERVER['REQUEST_URI'] variable.

Now using host instead of url from configs to avoid duplication in the url.