### PR TITLE
assign_missing_instruments' getBattery should probably take 3 parameters

### DIFF
--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -103,7 +103,8 @@ function populateVisitLabel($result, $visit_label)
     );
     $actual_battery  =$battery->getBattery(
         $timePoint->getCurrentStage(),
-        $result['subprojectID']
+        $result['subprojectID'],
+        $visit_label
     );
 
     $diff =array_diff($defined_battery, $actual_battery);


### PR DESCRIPTION
Although in reality it's unused within the function call...