### PR TITLE
No longer depend on dev version of facebook webdriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "squizlabs/php_codesniffer" : ">= 2.0",
         "phpunit/phpunit" : "4.3.*",
         "phpunit/dbunit": ">=1.2",
-        "facebook/webdriver" : "dev-master"
+        "facebook/webdriver" : "~1.0"
     },
     "autoload" : {
         "classmap": ["php/libraries", "php/exceptions"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e6e185c83c67ebefe973125cd49b47a1",
+    "hash": "422b991a523803b3e21a460713d0ca80",
     "packages": [
         {
             "name": "pear-pear.php.net/Benchmark",
@@ -145,16 +145,16 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.21",
+            "version": "v3.1.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a"
+                "reference": "4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a",
-                "reference": "1f878e6d746ecc8ec8d00d9c75044cf7d23ad94a",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2",
+                "reference": "4537d8aae6c4a26f5439bc3a05d3437d25c2c4d2",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "classmap": [
                     "libs/Smarty.class.php",
                     "libs/SmartyBC.class.php",
-                    "libs/sysplugins/smarty_security.php"
+                    "libs/sysplugins/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -196,22 +196,22 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2015-05-23 17:22:14"
+            "time": "2015-06-18 00:55:59"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
-                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
@@ -222,7 +222,7 @@
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
@@ -231,8 +231,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Instantiator\\": "src"
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -252,40 +252,42 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2014-10-13 12:58:55"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "facebook/webdriver",
-            "version": "dev-master",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "c6ee1e95953a3050c62fc0a81d13561e8c3eb005"
+                "reference": "8eb1952d6be0725e1064c4fe0630d0d4d1de7639"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/c6ee1e95953a3050c62fc0a81d13561e8c3eb005",
-                "reference": "c6ee1e95953a3050c62fc0a81d13561e8c3eb005",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/8eb1952d6be0725e1064c4fe0630d0d4d1de7639",
+                "reference": "8eb1952d6be0725e1064c4fe0630d0d4d1de7639",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.19"
             },
             "require-dev": {
-                "phpdocumentor/phpdocumentor": "2.*",
-                "phpunit/phpunit": "3.7.*"
+                "phpunit/phpunit": "4.6.*"
+            },
+            "suggest": {
+                "phpdocumentor/phpdocumentor": "2.*"
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "lib/"
-                ]
+                "psr-4": {
+                    "Facebook\\WebDriver\\": "lib/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
-            "description": "A php client for WebDriver",
+            "description": "A PHP client for WebDriver",
             "homepage": "https://github.com/facebook/php-webdriver",
             "keywords": [
                 "facebook",
@@ -293,27 +295,27 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2015-05-21 20:19:23"
+            "time": "2015-07-16 19:31:12"
         },
         {
             "name": "phpunit/dbunit",
-            "version": "1.3.2",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/dbunit.git",
-                "reference": "1507040c2541bdffd7fbd71fc792cecdea6a7c61"
+                "reference": "1afe25c90834ec499f007f48dd73767fdec3bf4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/1507040c2541bdffd7fbd71fc792cecdea6a7c61",
-                "reference": "1507040c2541bdffd7fbd71fc792cecdea6a7c61",
+                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/1afe25c90834ec499f007f48dd73767fdec3bf4f",
+                "reference": "1afe25c90834ec499f007f48dd73767fdec3bf4f",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-simplexml": "*",
                 "php": ">=5.3.3",
-                "phpunit/phpunit": "~3.7|~4.0",
+                "phpunit/phpunit": "~4.0",
                 "symfony/yaml": "~2.1"
             },
             "bin": [
@@ -352,20 +354,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-03-29 14:23:04"
+            "time": "2015-05-21 21:11:02"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.2",
+            "version": "2.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f"
+                "reference": "6044546998c7627ab997501a3d0db972b3db9790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f",
-                "reference": "6b7d2094ca2a685a2cad846cb7cd7a30e8b9470f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6044546998c7627ab997501a3d0db972b3db9790",
+                "reference": "6044546998c7627ab997501a3d0db972b3db9790",
                 "shasum": ""
             },
             "require": {
@@ -414,7 +416,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-06-01 07:35:26"
+            "time": "2015-07-13 11:25:58"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -463,16 +465,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -481,20 +483,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -503,20 +502,20 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83fe1bdc5d47658b727595c14da140da92b3d66d",
+                "reference": "83fe1bdc5d47658b727595c14da140da92b3d66d",
                 "shasum": ""
             },
             "require": {
@@ -525,13 +524,10 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -547,20 +543,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2015-06-13 07:35:30"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "eab81d02569310739373308137284e0158424330"
+                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/eab81d02569310739373308137284e0158424330",
-                "reference": "eab81d02569310739373308137284e0158424330",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
+                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
                 "shasum": ""
             },
             "require": {
@@ -596,7 +592,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-04-08 04:46:07"
+            "time": "2015-06-19 03:43:16"
         },
         {
             "name": "phpunit/phpunit",
@@ -674,16 +670,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.3",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7"
+                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/253c005852591fd547fc18cd5b7b43a1ec82d8f7",
-                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/1c330b1b6e1ea8fd15f2fbea46770576e366855c",
+                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c",
                 "shasum": ""
             },
             "require": {
@@ -725,7 +721,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-05-29 05:19:18"
+            "time": "2015-07-04 05:41:32"
         },
         {
             "name": "sebastian/comparator",
@@ -1014,16 +1010,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
-                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
             "type": "library",
@@ -1045,20 +1041,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-02-24 06:35:25"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e96d8579fbed0c95ecf2a0501ec4f307a4aa6404"
+                "reference": "c1a26c729508f73560c1a4f767f60b8ab6b4a666"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e96d8579fbed0c95ecf2a0501ec4f307a4aa6404",
-                "reference": "e96d8579fbed0c95ecf2a0501ec4f307a4aa6404",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/c1a26c729508f73560c1a4f767f60b8ab6b4a666",
+                "reference": "c1a26c729508f73560c1a4f767f60b8ab6b4a666",
                 "shasum": ""
             },
             "require": {
@@ -1119,20 +1115,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2015-04-28 23:28:20"
+            "time": "2015-06-24 03:16:23"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.0",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3"
+                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4a29a5248aed4fb45f626a7bbbd330291492f5c3",
-                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4bfbe0ed3909bfddd75b70c094391ec1f142f860",
+                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860",
                 "shasum": ""
             },
             "require": {
@@ -1168,14 +1164,12 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:21:08"
+            "time": "2015-07-01 11:25:50"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "facebook/webdriver": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/modules/brainbrowser/test/brainbrowserTest.php
+++ b/modules/brainbrowser/test/brainbrowserTest.php
@@ -13,6 +13,8 @@
 
 require_once __DIR__ . "/../../../test/integrationtests/"
     . "LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 
 /**
  * Implements automated integration tests for BrainBrowser within Loris

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -14,6 +14,8 @@
 
 require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 
 /**
  * CandidateListTestIntegrationTest

--- a/modules/candidate_parameters/test/candidate_parametersTest.php
+++ b/modules/candidate_parameters/test/candidate_parametersTest.php
@@ -11,6 +11,8 @@
  * @link     https://github.com/aces/Loris
  */
 
+use Facebook\WebDriver\WebDriverBy;
+
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
 class candidateParametersTestIntegrationTest extends LorisIntegrationTest
 {

--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -13,6 +13,8 @@
 
 require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 
 /**
  * Configuration module automated integration tests

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -13,15 +13,8 @@
 
 require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
-/**
- * Implements tests for conflict resolver
- *
- * @category Test
- * @package  Loris
- * @author   Ted Strauss <ted.strauss@mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
- */
+use Facebook\WebDriver\WebDriverBy;
+
 class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class createTimepointTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -13,6 +13,7 @@
 
 require_once __DIR__ .
     "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
 
 /**
  * Dashboard module automated integration tests

--- a/modules/data_integrity_flag/test/data_integrity_flagTest.php
+++ b/modules/data_integrity_flag/test/data_integrity_flagTest.php
@@ -12,6 +12,7 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
 class dataIntegrityFlagTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/data_team_helper/test/data_team_helperTest.php
+++ b/modules/data_team_helper/test/data_team_helperTest.php
@@ -12,6 +12,7 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
 class dataTeamHelperTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class datadictTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class dicomArchiveTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class documentRepositoryTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/examiner/test/ExaminerTest.php
+++ b/modules/examiner/test/ExaminerTest.php
@@ -14,6 +14,8 @@
 require_once __DIR__ .
     "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
 
+use Facebook\WebDriver\WebDriverBy;
+
 /**
  * Examiner module automated integration tests
  *

--- a/modules/final_radiological_review/test/final_radiological_reviewTest.php
+++ b/modules/final_radiological_review/test/final_radiological_reviewTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class finalRadiologicalReviewTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -12,6 +12,8 @@
  */
 require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 
 /**
  * GenomicBrowserTestIntegrationTest

--- a/modules/help_editor/test/help_editorTest.php
+++ b/modules/help_editor/test/help_editorTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class helpEditorTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class imagingBrowserTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/instrument_builder/test/instrument_builderTest.php
+++ b/modules/instrument_builder/test/instrument_builderTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class instrumentBuilderTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/instrument_list/test/instrument_listTest.php
+++ b/modules/instrument_list/test/instrument_listTest.php
@@ -11,7 +11,10 @@
  * @link     https://github.com/aces/Loris
  */
 
+
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class instrumentListTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/instrument_manager/test/instrument_managerTest.php
+++ b/modules/instrument_manager/test/instrument_managerTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class instrumentManagerTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/mri_upload/test/mri_uploadTest.php
+++ b/modules/mri_upload/test/mri_uploadTest.php
@@ -1,5 +1,7 @@
 <?php
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class mri_uploadTestIntegrationTest extends LorisIntegrationTest
 {
     function testMriUploadDoespageLoad()

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class MriViolationsTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class newProfileTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/next_stage/test/next_stageTest.php
+++ b/modules/next_stage/test/next_stageTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class nextStageTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/reliability/test/reliabilityTest.php
+++ b/modules/reliability/test/reliabilityTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class reliabilityTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/statistics/test/Statistics_Test.php
+++ b/modules/statistics/test/Statistics_Test.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
 use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\Exception\ElementNotVisibleException;
 
 class Statistics_Test extends LorisIntegrationTest
 {

--- a/modules/statistics/test/Statistics_Test.php
+++ b/modules/statistics/test/Statistics_Test.php
@@ -1,5 +1,7 @@
 <?php
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class Statistics_Test extends LorisIntegrationTest
 {
     public function testTabsFrameworkLoads()

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class survey_accountsTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/timepoint_flag/test/timepoint_flagTest.php
+++ b/modules/timepoint_flag/test/timepoint_flagTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class timepoint_flagTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/timepoint_list/test/timepoint_listTest.php
+++ b/modules/timepoint_list/test/timepoint_listTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class timepointListTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/modules/training/test/TrainingTest.php
+++ b/modules/training/test/TrainingTest.php
@@ -13,6 +13,8 @@
 
 require_once __DIR__ .
     "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 
 /**
  * Training module automated integration tests

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -12,6 +12,8 @@
  */
 
 require_once __DIR__ . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+use Facebook\WebDriver\WebDriverBy;
+
 class user_accountsTestIntegrationTest extends LorisIntegrationTest
 {
     /**

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -73,8 +73,12 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
      */
     function _save($values)
     {
-        unset($values['test_name'], $values['subtest'],
-        $values['identifier'], $values['fire_away']);
+        unset(
+            $values['test_name'],
+            $values['subtest'],
+            $values['identifier'],
+            $values['fire_away']
+        );
 
         // clear any fields starting with __
         foreach (array_keys($values) AS $key) {

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -155,7 +155,7 @@ Class TimePoint
 
             $statuses = $db->pselect($query, array(":sessionID" => $sessionID));
             foreach ($statuses as $row) {
-                if (!isset( $this->_timePointInfo['status'])) {
+                if (!isset($this->_timePointInfo['status'])) {
                     $this->_timePointInfo['status'] = array();
                 }
                 $this->_timePointInfo['status'][$row['Name']] = $row['Value'];

--- a/test/integrationtests/Login_Test.php
+++ b/test/integrationtests/Login_Test.php
@@ -1,5 +1,7 @@
 <?php
 require_once __DIR__ . '/LorisIntegrationTest.class.inc';
+use Facebook\WebDriver\WebDriverBy;
+
 class LorisLoginTest extends LorisIntegrationTest
 {
     function testLoginFailure()

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -15,6 +15,12 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Facebook\WebDriver\Remote\DesiredCapabilities;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+use Facebook\WebDriver\WebDriverBy;
+use Facebook\WebDriver\WebDriverExpectedCondition;
 /**
  * Implementation of LorisIntegrationTest helper class.
  *
@@ -84,7 +90,8 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         $user = User::factory('UnitTester');
         $user->updatePassword('4test4');
         // Set up WebDriver implementation and login
-        $capabilities = array(\WebDriverCapabilityType::BROWSER_NAME => 'firefox');
+        $capabilities = \Facebook\WebDriver\Remote\DesiredCapabilities::firefox();
+        $capabilities = DesiredCapabilities::firefox();
 
         $this->webDriver = RemoteWebDriver::create(
             'http://localhost:4444/wd/hub',

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -86,6 +86,10 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
         $this->DB->run(
             "INSERT INTO user_perm_rel SELECT 999990, PermID FROM permissions"
         );
+        $this->DB->update("psc",
+            array('Study_site' => 'Y'),
+            array('CenterID' => '1')
+        );
 
         $user = User::factory('UnitTester');
         $user->updatePassword('4test4');
@@ -167,27 +171,40 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
             array(":configName" => $configName)
         );
 
-        $oldVal = $this->DB->pselectOne(
-            "SELECT Value FROM Config WHERE ConfigID=:confID",
-            array(":confID" => $configID)
-        );
+        if(!empty($configID)) {
+            $oldVal = $this->DB->pselectOne(
+                "SELECT Value FROM Config WHERE ConfigID=:confID",
+                array("confID" => $configID)
+            );
 
-        $this->_oldConfig[$configName] = array(
-            'ConfigID' => $configID,
-            'OldValue' => $oldVal,
-        );
+            $this->_oldConfig[$configName] = array(
+                'ConfigID' => $configID,
+                'OldValue' => $oldVal,
+            );
+            $this->DB->update(
+                "Config",
+                array("Value" => $value),
+                array("ConfigID" => $configID)
+            );
+        } else {
+            $this->_oldConfig[$configName] = array(
+                'ConfigID' => null,
+                'OldValue' => null,
+                'Mock' => true
+            );
+        }
 
-        $this->DB->update(
-            "Config",
-            array("Value" => $value),
-            array("ConfigID" => $configID)
-        );
     }
 
     function restoreConfigSetting($configName) {
         if(!isset($this->_oldConfig[$configName])) {
             throw new LorisException("Attempted to restore unsaved config setting");
         }
+        if($this->oldConfig[$configName]['Mock'] === true) {
+            unset($this->oldConfig[$configName]);
+            return;
+        }
+
         $this->DB->update(
             "Config",
             array("Value"    => $this->_oldConfig[$configName]['OldValue']),


### PR DESCRIPTION
Version 1.0 of the facebook/webdriver has been released, so we no longer need to depend on the development branch to install it. This updates composer settings accordingly.