### PR TITLE
clickable rows in candidate list

### DIFF
--- a/modules/candidate_list/css/candidate_list.css
+++ b/modules/candidate_list/css/candidate_list.css
@@ -1,0 +1,3 @@
+.clickable_row {
+    cursor: pointer;
+}

--- a/modules/candidate_list/js/candidate_list.js
+++ b/modules/candidate_list/js/candidate_list.js
@@ -100,4 +100,14 @@ $(document).ready(function() {
         checkAccessProfileForm();
     })
 
+
+    $('table#cand tr').click(function(){
+        location.href = $(this).find('td a#pscid').attr('href');
+    });
+
+    $('table#cand a.scanDoneLink').click(function(e) {
+        e.stopImmediatePropagation();
+    });
+
+
 });

--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -241,7 +241,7 @@
     <tbody>
         {section name=item loop=$items}
 		<!-- clicking row takes you to the candidate page --> 
-		<tr onclick="location.href = $(this).find('td a#pscid').attr('href');" style="cursor:pointer;">
+		<tr class="clickable_row">
             <!-- print out data rows -->
             {section name=piece loop=$items[item]}
                 {if $items[item][piece].bgcolor != ''}
@@ -255,7 +255,7 @@
                 {elseif $items[item][piece].name == "scan_Done"}
                     {if $items[item][piece].value == 'Y'}
                         {assign var="scan_done" value="Yes"}
-                        <a class="scanDoneLink" data-pscid="{$PSCID}" href="{$baseurl}/main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data"  onclick="event.stopImmediatePropagation();">{$scan_done}</a>
+                        <a class="scanDoneLink" data-pscid="{$PSCID}" href="{$baseurl}/main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data">{$scan_done}</a>
                     {else}
                         {assign var="scan_done" value="No"}
                         {$scan_done}

--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -255,7 +255,7 @@
                 {elseif $items[item][piece].name == "scan_Done"}
                     {if $items[item][piece].value == 'Y'}
                         {assign var="scan_done" value="Yes"}
-                        <a class="scanDoneLink" data-pscid="{$PSCID}" href="{$baseurl}/main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data">{$scan_done}</a>
+                        <a class="scanDoneLink" data-pscid="{$PSCID}" href="{$baseurl}/main.php?test_name=imaging_browser&pscid={$PSCID}&filter=Show%20Data"  onclick="event.stopImmediatePropagation();">{$scan_done}</a>
                     {else}
                         {assign var="scan_done" value="No"}
                         {$scan_done}

--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -240,7 +240,8 @@
     </thead>
     <tbody>
         {section name=item loop=$items}
-            <tr>
+		<!-- clicking row takes you to the candidate page --> 
+		<tr onclick="location.href = $(this).find('td a#pscid').attr('href');" style="cursor:pointer;">
             <!-- print out data rows -->
             {section name=piece loop=$items[item]}
                 {if $items[item][piece].bgcolor != ''}
@@ -250,7 +251,7 @@
                 {/if}
                 {if $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
                     {assign var="PSCID" value=$items[item][piece].value}
-                    <a href="{$baseurl}/main.php?test_name=timepoint_list&candID={$items[item][piece].DCCID}">{$items[item][piece].value}</a>
+                    <a href="{$baseurl}/main.php?test_name=timepoint_list&candID={$items[item][piece].DCCID}" id="pscid">{$items[item][piece].value}</a>
                 {elseif $items[item][piece].name == "scan_Done"}
                     {if $items[item][piece].value == 'Y'}
                         {assign var="scan_done" value="Yes"}


### PR DESCRIPTION
this allows the rows to be clickable in the candidate list, taking the user to the candidate summary. Links to the imaging viewer are maintained. inline styling for cursor:pointer should be moved to css