### PR TITLE
extend the navigation menu to allow for raw URLs in menu items

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -191,11 +191,19 @@
                                     <ul class="dropdown-menu">
                                         {foreach from=$tab.subtabs item=mySubtab}
                                             {if $mySubtab.Visible == 1}
-                                            <li>
+                                                {if substr($mySubtab.Link,0,4) eq 'http'}
+                                                    <li>
+                                                        <a href="{$mySubtab.Link}">
+                                                            {$mySubtab.Label}
+                                                        </a>
+                                                    </li>
+                                                {else}
+                                                    <li>
                                                         <a href="{$baseurl}/{$mySubtab.Link}">
                                                             {$mySubtab.Label}
                                                         </a>
-                                            </li>
+                                                    </li>
+                                                {/if}
                                             {/if}
                                         {/foreach}
                                     </ul>


### PR DESCRIPTION
adding a condition to the main navigation menu template so that full URLs
can be specified for lins as well as the usual `main.tpl?test=module_name` format for links.