### PR TITLE
Add ETag Support to wrapper scripts

### DIFF
--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -87,10 +87,13 @@ if (!file_exists($FullPath)) {
 }
 
 $MimeType = "text/css";
-$etag = md5(filemtime($FullPath));
 header("Content-type: $MimeType");
+
+$etag = md5(filemtime($FullPath));
 header("ETag: $etag");
-if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+if (isset($_SERVER['HTTP_IF_NONE_MATCH'])
+    && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag
+) {
     header("HTTP/1.1 304 Not Modified");
     exit(0);
 }

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -1,8 +1,7 @@
 <?php
 /**
  * Controls access to a module's javascript CSS styles on the filesystem. This script
- * should ensure that only files relative to module's path specified are
- * accessible.
+ * should ensure that only files relative to module's path specified are accessible.
  * By calling new NDB_Client(), it also makes sure that the user is logged in to
  * Loris.
  *

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -18,8 +18,7 @@
  *  @license  Loris license
  *  @link     https://github.com/aces/Loris-Trunk
  */
-
-
+session_cache_limiter('public');
 // Load config file and ensure paths are correct
 set_include_path(
     get_include_path() . ":" .
@@ -88,7 +87,13 @@ if (!file_exists($FullPath)) {
 }
 
 $MimeType = "text/css";
+$etag = md5(filemtime($FullPath));
 header("Content-type: $MimeType");
+header("ETag: $etag");
+if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+    header("HTTP/1.1 304 Not Modified");
+    exit(0);
+}
 $fp = fopen($FullPath, 'r');
 fpassthru($fp);
 fclose($fp);

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -85,11 +85,14 @@ if (!file_exists($FullPath)) {
     exit(5);
 }
 
-$etag = md5(filemtime($FullPath));
 $MimeType = "application/javascript";
 header("Content-type: $MimeType");
+
+$etag = md5(filemtime($FullPath));
 header("ETag: $etag");
-if(isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+if (isset($_SERVER['HTTP_IF_NONE_MATCH'])
+    && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag
+) {
     header("HTTP/1.1 304 Not Modified");
     exit(0);
 }

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -18,6 +18,7 @@
  *  @license  Loris license
  *  @link     https://github.com/aces/Loris-Trunk
  */
+session_cache_limiter('public');
 
 
 // Load config file and ensure paths are correct
@@ -84,8 +85,14 @@ if (!file_exists($FullPath)) {
     exit(5);
 }
 
+$etag = md5(filemtime($FullPath));
 $MimeType = "application/javascript";
 header("Content-type: $MimeType");
+header("ETag: $etag");
+if(isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+    header("HTTP/1.1 304 Not Modified");
+    exit(0);
+}
 $fp = fopen($FullPath, 'r');
 fpassthru($fp);
 fclose($fp);

--- a/htdocs/GetStatic.php
+++ b/htdocs/GetStatic.php
@@ -77,11 +77,14 @@ if (!file_exists($FullPath)) {
 }
 
 $MimeType = "text/css";
+
 $etag = md5(filemtime($FullPath));
 header("ETag: $etag");
-if(isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
-        header("HTTP/1.1 304 Not Modified");
-            exit(0);
+if (isset($_SERVER['HTTP_IF_NONE_MATCH'])
+    && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag
+) {
+    header("HTTP/1.1 304 Not Modified");
+    exit(0);
 }
 
 // $MimeType = "application/javascript";

--- a/htdocs/GetStatic.php
+++ b/htdocs/GetStatic.php
@@ -18,6 +18,8 @@
  *  @license  Loris license
  *  @link     https://github.com/aces/Loris-Trunk
  */
+session_cache_limiter('private');
+
 
 
 // Load config file and ensure paths are correct
@@ -72,6 +74,14 @@ if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");
     header("HTTP/1.1 404 Not Found");
     exit(5);
+}
+
+$MimeType = "text/css";
+$etag = md5(filemtime($FullPath));
+header("ETag: $etag");
+if(isset($_SERVER['HTTP_IF_NONE_MATCH']) && $_SERVER['HTTP_IF_NONE_MATCH'] === $etag) {
+        header("HTTP/1.1 304 Not Modified");
+            exit(0);
 }
 
 // $MimeType = "application/javascript";


### PR DESCRIPTION
This adds ETag support to the GetCSS/GetStatic/GetJS wrapper scripts based on the file's last modification time, so that browsers (and proxies) can cache the results and minimize network traffic.