### PR TITLE
Remove classify algorithm

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -437,7 +437,6 @@ CREATE TABLE `files` (
   `SeriesUID` varchar(64) DEFAULT NULL,
   `EchoTime` double DEFAULT NULL,
   `CoordinateSpace` varchar(255) default NULL,
-  `ClassifyAlgorithm` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
   `AcquisitionProtocolID` int(10) unsigned default NULL,
   `FileType` enum('mnc','obj','xfm','xfmmnc','imp','vertstat','xml','txt','nii','nii.gz') default NULL,

--- a/SQL/2015-08-06-removeClassifyAlgorithm.sql
+++ b/SQL/2015-08-06-removeClassifyAlgorithm.sql
@@ -1,0 +1,1 @@
+ALTER TABLE files DROP COLUMN ClassifyAlgorithm;


### PR DESCRIPTION
This column is never populated. Removed from the files table. 

Need to merge following pull request on the LORIS-MRI side before running the patch:
https://github.com/aces/Loris-MRI/pull/94/files