### PR TITLE
Redmine 4219 - Run ConflictDetector only if both DDE and SDE 'Complete'

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-require_once'ConflictDetector.class.inc';
+require_once 'ConflictDetector.class.inc';
 
 /**
  * Behavioural instrument status class
@@ -40,39 +40,39 @@ class NDB_BVL_InstrumentStatus
      * The set of valid options for the data entry flag
      */
     var $_dataEntryOptions = array(
-                              null,
-                              'In Progress',
-                              'Complete',
-                             );
+        null,
+        'In Progress',
+        'Complete',
+    );
 
     /**
      * The set of valid options for the administration flag
      */
     var $_administrationOptions = array(
-                                   null,
-                                   'None',
-                                   'Partial',
-                                   'All',
-                                  );
+        null,
+        'None',
+        'Partial',
+        'All',
+    );
 
     /**
      * The set of valid options for the validity flag
      */
     var $_validityOptions = array(
-                             null,
-                             'Valid',
-                             'Questionable',
-                             'Invalid',
-                            );
+        null,
+        'Valid',
+        'Questionable',
+        'Invalid',
+    );
 
     /**
      * The set of valid options for the exclusion flag
      */
     var $_exclusionOptions = array(
-                              null,
-                              'Fail',
-                              'Pass',
-                             );
+        null,
+        'Fail',
+        'Pass',
+    );
 
 
     /**
@@ -93,7 +93,7 @@ class NDB_BVL_InstrumentStatus
         $query = "SELECT SessionID, Data_entry, Administration, Validity, Exclusion
             FROM flag
             WHERE CommentID=:CID";
-        $row   = $db->pselectRow($query, array('CID' => $this->_commentID));
+        $row = $db->pselectRow($query, array('CID' => $this->_commentID));
 
         // store the statuses into the _status property
         $this->_status = $row;
@@ -180,16 +180,17 @@ class NDB_BVL_InstrumentStatus
                 : substr($this->_commentID, 4)
             );
 
-            $DDECommentId = 'DDE_'.$principalCommentId;
+            $DDECommentId = 'DDE_' . $principalCommentId;
             $query = $this->DB->pselect(
-                "SELECT Data_entry FROM flag WHERE CommentID=$principalCommentId OR CommentID=$DDECommentId",
+                "SELECT Data_entry FROM flag
+                WHERE CommentID=$principalCommentId OR CommentID=$DDECommentId",
                 array()
             );
 
-            // Run ConflictDetector if Data_entry status of SDE and DDE are both Complete
+            // Run ConflictDetector if Data_entry of SDE and DDE are both Complete
             $count = 0;
-            foreach ($query as $dataEntryStatus) {
-                if ($dataEntryStatus == 'Complete'){
+            foreach ($query as $key => $dataEntryStatus) {
+                if ($dataEntryStatus == 'Complete') {
                     $count++;
                 }
                 if ($count > 1) {

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -180,7 +180,8 @@ class NDB_BVL_InstrumentStatus
             );
 
             $DDECommentId = 'DDE_' . $principalCommentId;
-            $selectStatement = "SELECT Data_entry FROM flag WHERE CommentID='" . $principalCommentId . "' OR CommentID='" . $DDECommentId . "'";
+            $selectStatement = "SELECT Data_entry FROM flag WHERE CommentID='" .
+                $principalCommentId . "' OR CommentID='" . $DDECommentId . "'";
             $query        = $this->DB->pselect($selectStatement, array());
 
             // Run ConflictDetector if Data_entry of SDE and DDE are both Complete

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -40,39 +40,39 @@ class NDB_BVL_InstrumentStatus
      * The set of valid options for the data entry flag
      */
     var $_dataEntryOptions = array(
-        null,
-        'In Progress',
-        'Complete',
-    );
+                              null,
+                              'In Progress',
+                              'Complete',
+                             );
 
     /**
      * The set of valid options for the administration flag
      */
     var $_administrationOptions = array(
-        null,
-        'None',
-        'Partial',
-        'All',
-    );
+                                   null,
+                                   'None',
+                                   'Partial',
+                                   'All',
+                                  );
 
     /**
      * The set of valid options for the validity flag
      */
     var $_validityOptions = array(
-        null,
-        'Valid',
-        'Questionable',
-        'Invalid',
-    );
+                             null,
+                             'Valid',
+                             'Questionable',
+                             'Invalid',
+                            );
 
     /**
      * The set of valid options for the exclusion flag
      */
     var $_exclusionOptions = array(
-        null,
-        'Fail',
-        'Pass',
-    );
+                              null,
+                              'Fail',
+                              'Pass',
+                             );
 
 
     /**
@@ -93,7 +93,7 @@ class NDB_BVL_InstrumentStatus
         $query = "SELECT SessionID, Data_entry, Administration, Validity, Exclusion
             FROM flag
             WHERE CommentID=:CID";
-        $row = $db->pselectRow($query, array('CID' => $this->_commentID));
+        $row   = $db->pselectRow($query, array('CID' => $this->_commentID));
 
         // store the statuses into the _status property
         $this->_status = $row;
@@ -181,7 +181,7 @@ class NDB_BVL_InstrumentStatus
             );
 
             $DDECommentId = 'DDE_' . $principalCommentId;
-            $query = $this->DB->pselect(
+            $query        = $this->DB->pselect(
                 "SELECT Data_entry FROM flag
                 WHERE CommentID=$principalCommentId OR CommentID=$DDECommentId",
                 array()
@@ -197,7 +197,6 @@ class NDB_BVL_InstrumentStatus
                     $instrumentName = NDB_BVL_Battery::getInstrumentNameForCommentId(
                         $principalCommentId
                     );
-
                     ConflictDetector::clearConflictsForInstance($principalCommentId);
                     $diff = ConflictDetector::detectConflictsForCommentIds(
                         $instrumentName,

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -179,10 +179,10 @@ class NDB_BVL_InstrumentStatus
                 : substr($this->_commentID, 4)
             );
 
-            $DDECommentId = 'DDE_' . $principalCommentId;
+            $DDECommentId    = 'DDE_' . $principalCommentId;
             $selectStatement = "SELECT Data_entry FROM flag WHERE CommentID='" .
                 $principalCommentId . "' OR CommentID='" . $DDECommentId . "'";
-            $query        = $this->DB->pselect($selectStatement, array());
+            $query           = $this->DB->pselect($selectStatement, array());
 
             // Run ConflictDetector if Data_entry of SDE and DDE are both Complete
             $count = 0;

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -180,17 +180,32 @@ class NDB_BVL_InstrumentStatus
                 : substr($this->_commentID, 4)
             );
 
-            $instrumentName = NDB_BVL_Battery::getInstrumentNameForCommentId(
-                $principalCommentId
+            $DDECommentId = 'DDE_'.$principalCommentId;
+            $query = $this->DB->pselect(
+                "SELECT Data_entry FROM flag WHERE CommentID=$principalCommentId OR CommentID=$DDECommentId",
+                array()
             );
 
-            ConflictDetector::clearConflictsForInstance($principalCommentId);
-            $diff = ConflictDetector::detectConflictsForCommentIds(
-                $instrumentName,
-                $principalCommentId,
-                'DDE_'.$principalCommentId
-            );
-            ConflictDetector::recordUnresolvedConflicts($diff);
+            // Run ConflictDetector if Data_entry status of SDE and DDE are both Complete
+            $count = 0;
+            foreach ($query as $dataEntryStatus) {
+                if ($dataEntryStatus == 'Complete'){
+                    $count++;
+                }
+                if ($count > 1) {
+                    $instrumentName = NDB_BVL_Battery::getInstrumentNameForCommentId(
+                        $principalCommentId
+                    );
+
+                    ConflictDetector::clearConflictsForInstance($principalCommentId);
+                    $diff = ConflictDetector::detectConflictsForCommentIds(
+                        $instrumentName,
+                        $principalCommentId,
+                        $DDECommentId
+                    );
+                    ConflictDetector::recordUnresolvedConflicts($diff);
+                }
+            }
         }
     }
 

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -178,11 +178,15 @@ class NDB_BVL_InstrumentStatus
                 ? $this->_commentID
                 : substr($this->_commentID, 4)
             );
-            $DDECommentId    = 'DDE_' . $principalCommentId;
+            $DDECommentId       = 'DDE_' . $principalCommentId;
 
             $query = $GLOBALS['DB']->pselect(
-                "SELECT Data_entry FROM flag WHERE CommentID=:PCID OR CommentID=:DDECID",
-                array('PCID' => $principalCommentId, 'DDECID' => $DDECommentId)
+                "SELECT Data_entry FROM flag
+                WHERE CommentID=:PCID OR CommentID=:DDECID",
+                array(
+                    'PCID' => $principalCommentId,
+                    'DDECID' => $DDECommentId,
+                )
             );
 
             // Run ConflictDetector if Data_entry of SDE and DDE are both Complete

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -184,8 +184,8 @@ class NDB_BVL_InstrumentStatus
                 "SELECT Data_entry FROM flag
                 WHERE CommentID=:PCID OR CommentID=:DDECID",
                 array(
-                    'PCID' => $principalCommentId,
-                    'DDECID' => $DDECommentId,
+                 'PCID'   => $principalCommentId,
+                 'DDECID' => $DDECommentId,
                 )
             );
 

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -73,8 +73,7 @@ class NDB_BVL_InstrumentStatus
                               'Fail',
                               'Pass',
                              );
-
-
+    
     /**
      * Loads the object with the current status of the instrument
      *

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -73,7 +73,7 @@ class NDB_BVL_InstrumentStatus
                               'Fail',
                               'Pass',
                              );
-    
+
     /**
      * Loads the object with the current status of the instrument
      *
@@ -196,6 +196,7 @@ class NDB_BVL_InstrumentStatus
                     $instrumentName = NDB_BVL_Battery::getInstrumentNameForCommentId(
                         $principalCommentId
                     );
+                    
                     ConflictDetector::clearConflictsForInstance($principalCommentId);
                     $diff = ConflictDetector::detectConflictsForCommentIds(
                         $instrumentName,

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -178,11 +178,12 @@ class NDB_BVL_InstrumentStatus
                 ? $this->_commentID
                 : substr($this->_commentID, 4)
             );
-
             $DDECommentId    = 'DDE_' . $principalCommentId;
-            $selectStatement = "SELECT Data_entry FROM flag WHERE CommentID='" .
-                $principalCommentId . "' OR CommentID='" . $DDECommentId . "'";
-            $query           = $this->DB->pselect($selectStatement, array());
+
+            $query = $GLOBALS['DB']->pselect(
+                "SELECT Data_entry FROM flag WHERE CommentID=:PCID OR CommentID=:DDECID",
+                array('PCID' => $principalCommentId, 'DDECID' => $DDECommentId)
+            );
 
             // Run ConflictDetector if Data_entry of SDE and DDE are both Complete
             $count = 0;

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -286,4 +286,4 @@ class NDB_BVL_InstrumentStatus
         $updateResult = $this->select($this->_commentID);
     }
 
-}
+} // end of class

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -196,7 +196,7 @@ class NDB_BVL_InstrumentStatus
                     $instrumentName = NDB_BVL_Battery::getInstrumentNameForCommentId(
                         $principalCommentId
                     );
-                    
+
                     ConflictDetector::clearConflictsForInstance($principalCommentId);
                     $diff = ConflictDetector::detectConflictsForCommentIds(
                         $instrumentName,

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -286,4 +286,4 @@ class NDB_BVL_InstrumentStatus
         $updateResult = $this->select($this->_commentID);
     }
 
-} // end class
+}

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -180,11 +180,8 @@ class NDB_BVL_InstrumentStatus
             );
 
             $DDECommentId = 'DDE_' . $principalCommentId;
-            $query        = $this->DB->pselect(
-                "SELECT Data_entry FROM flag
-                WHERE CommentID=$principalCommentId OR CommentID=$DDECommentId",
-                array()
-            );
+            $selectStatement = "SELECT Data_entry FROM flag WHERE CommentID='" . $principalCommentId . "' OR CommentID='" . $DDECommentId . "'";
+            $query        = $this->DB->pselect($selectStatement, array());
 
             // Run ConflictDetector if Data_entry of SDE and DDE are both Complete
             $count = 0;


### PR DESCRIPTION
Description (Copied from Redmine)

Found a bug in the conflict resolver: it doesn't check whether data entry was completed on DDE form of an instrument, before flagging conflicts. 
Therefore if only SDE is completed and DDE record values are default (e.g. NULL or not_answered in all fields), the Conflict Resolver module proposes populating the DDE field with the SDE field value. 
This is basically an easy way to avoid doing DDE.

Instead, the conflict resolver should check whether data entry is Complete on the DDE form before checking for conflicts.

(This could theoretically also speed up query/load time for the Conflict Resolver, though it should rarely be the case that SDE but not DDE is complete.)