### PR TITLE
fix the formatting in firefox

### DIFF
--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -324,3 +324,6 @@ label em {
 .fileColumn{
     min-width: 350px;
 }
+.directoryRow{
+    height: 50px;
+}

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -21,7 +21,7 @@
 
 <script id="dir" type="x-tmpl-mustache">
     <tr id="{{ id }}a" {{ #parentID }}class="{{ parentID }}a directoryRow" style="display:none"{{ /parentID }}>
-        <td class="fileColumn">
+        <td class="fileColumn" colspan="10">
             {{ #depth }}
                 {{ #first }}
                     <div class="spacer" style="border-left: none;"> </div>
@@ -43,7 +43,6 @@
                 </span>
             {{ /indent }}
         </td>
-        <td colspan="9"></td>
     </tr>
 </script>
 <script id="file" type="x-tmpl-mustache">


### PR DESCRIPTION
The Document Repository tree structure wasn't formatting properly in firefox 