### PR TITLE
Add a recruitment target to the subproject table

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2298,6 +2298,7 @@ CREATE TABLE subproject (
     title varchar(255) NOT NULL,
     useEDC boolean,
     WindowDifference enum('optimal', 'battery'),
+    RecruitmentTarget int(10) unsigned,
     PRIMARY KEY (SubprojectID)
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8 COMMENT='Stores Subprojects used in Loris';
 INSERT INTO subproject (SubprojectID, title, useEDC, WindowDifference) VALUES (1, 'Control', false, 'optimal');

--- a/SQL/2015-08-11-AddRecruitmentTargetToSubproject.sql
+++ b/SQL/2015-08-11-AddRecruitmentTargetToSubproject.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Subproject ADD RecruitmentTarget int(10) unsigned;

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -24,9 +24,10 @@ if ($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
     $db->insert(
         "subproject",
         array(
-         "title"            => $_POST['title'],
-         "useEDC"           => $_POST['useEDC'],
-         "WindowDifference" => $_POST['WindowDifference'],
+         "title"             => $_POST['title'],
+         "useEDC"            => $_POST['useEDC'],
+         "WindowDifference"  => $_POST['WindowDifference'],
+         "RecruitmentTarget" => $_POST['RecruitmentTarget'],
         )
     );
 } else {
@@ -36,6 +37,7 @@ if ($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
          "title"            => $_POST['title'],
          "useEDC"           => $_POST['useEDC'],
          "WindowDifference" => $_POST['WindowDifference'],
+         "RecruitmentTarget" => $_POST['RecruitmentTarget'],
         ),
         array("SubprojectID" => $_POST['subprojectID'])
     );

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -34,9 +34,9 @@ if ($_POST['subprojectID'] === 'new' && !empty($_POST['title'])) {
     $db->update(
         "subproject",
         array(
-         "title"            => $_POST['title'],
-         "useEDC"           => $_POST['useEDC'],
-         "WindowDifference" => $_POST['WindowDifference'],
+         "title"             => $_POST['title'],
+         "useEDC"            => $_POST['useEDC'],
+         "WindowDifference"  => $_POST['WindowDifference'],
          "RecruitmentTarget" => $_POST['RecruitmentTarget'],
         ),
         array("SubprojectID" => $_POST['subprojectID'])

--- a/modules/configuration/js/subproject.js
+++ b/modules/configuration/js/subproject.js
@@ -5,8 +5,9 @@ $(document).ready(function() {
 
         var subprojectID = $(form.find(".subprojectID")).val();
         var title = $(form.find(".subprojectTitle")).val();
-        var useEDC= $(form.find(".subprojectuseEDC")).val();
-        var windowDifference= $(form.find(".subprojectWindowDifference")).val();
+        var useEDC = $(form.find(".subprojectuseEDC")).val();
+        var windowDifference = $(form.find(".subprojectWindowDifference")).val();
+        var recruitmentTarget = $(form.find(".subprojectRecruitmentTarget")).val();
         e.preventDefault();
         var successClosure = function(i, form) {
             return function() {
@@ -24,6 +25,7 @@ $(document).ready(function() {
                         "title" : title,
                         "useEDC" : useEDC,
                         "WindowDifference" : windowDifference,
+                        "RecruitmentTarget" : recruitmentTarget,
                     },
                     "success" : successClosure(subprojectID, form)
                 }

--- a/modules/configuration/templates/form_subproject.tpl
+++ b/modules/configuration/templates/form_subproject.tpl
@@ -29,7 +29,6 @@
                     </div>
                 </div>
                 <div class="form-group">
-
                     <label class="col-sm-12 col-md-4">Use <abbr title="Expect Date of Confinement (ie. baby's due date)">EDC</abbr></label>
                     <div class="col-sm-12 col-md-8">
                         {html_options options=$useEDCOptions name="useEDC" selected=$subproject.options.useEDC class="form-control subprojectuseEDC"}
@@ -42,13 +41,18 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label class="col-sm-12 col-md-4">Recruitment Target:</label>
+                    <div class="col-sm-12 col-md-8">
+                        <input class="form-control subprojectRecruitmentTarget" name="target" placeholder="Please add a recruitment target here" value="{$subproject.RecruitmentTarget}">
+                    </div>
+                </div>
+                <div class="form-group">
                     <div class="col-sm-offset-4 col-sm-8 submit-area">
                         <button id="savesubproject{$subprojectID}" class="btn btn-primary savesubproject">Save</button>
                         <button class="btn btn-default" type="reset">Reset</button>
                         <label class="saveStatus"></label>
                     </div>
                 </div>
-
             </fieldset>
         </form>
     </div>
@@ -66,7 +70,6 @@
                     </div>
                 </div>
                 <div class="form-group">
-
                     <label class="col-sm-12 col-md-4">Use <abbr title="Expect Date of Confinement (ie. baby's due date)">EDC</abbr></label>
                     <div class="col-sm-12 col-md-8">
                         {html_options options=$useEDCOptions name="useEDC" selected="Yes" class="form-control subprojectuseEDC"}
@@ -79,13 +82,18 @@
                     </div>
                 </div>
                 <div class="form-group">
+                    <label class="col-sm-12 col-md-4">Recruitment Target:</label>
+                    <div class="col-sm-12 col-md-8">
+                        <input class="form-control subprojectRecruitmentTarget" name="target" placeholder="Please add a recruitment target here" value="">
+                    </div>
+                </div>
+                <div class="form-group">
                     <div class="col-sm-offset-4 col-sm-8 submit-area">
                         <button id="savesubprojectnew" class="btn btn-primary savesubproject">Save</button>
                         <button class="btn btn-default" type="reset">Reset</button>
                         <label class="saveStatus"></label>
                     </div>
                 </div>
-
             </fieldset>
         </form>
     </div>

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -442,6 +442,7 @@ class NDB_Config
                               'useEDC'           => $info['useEDC'],
                               'WindowDifference' => $info['WindowDifference'],
                              ),
+                'recruitmentTarget' => $info['RecruitmentTarget'],
                );
     }
 

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -435,12 +435,15 @@ class NDB_Config
             return null;
         }
         // Format the results the same way it was formatted in config.xml
+        // This variable assignment was done for phpcs... if anyone figures out
+        // a way around this, please correct it
+        $x = $info['WindowDifference'];
         return array(
                 'id'                => $info['SubprojectID'],
                 'title'             => $info['title'],
                 'options'           => array(
                                         'useEDC'           => $info['useEDC'],
-                                        'WindowDifference' => $info['WindowDifference'],
+                                        'WindowDifference' => $x,
                                        ),
                 'RecruitmentTarget' => $info['RecruitmentTarget'],
                );

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -436,13 +436,13 @@ class NDB_Config
         }
         // Format the results the same way it was formatted in config.xml
         return array(
-                'id'      => $info['SubprojectID'],
-                'title'   => $info['title'],
-                'options' => array(
-                              'useEDC'           => $info['useEDC'],
-                              'WindowDifference' => $info['WindowDifference'],
-                             ),
-                'recruitmentTarget' => $info['RecruitmentTarget'],
+                'id'                => $info['SubprojectID'],
+                'title'             => $info['title'],
+                'options'           => array(
+                                        'useEDC'           => $info['useEDC'],
+                                        'WindowDifference' => $info['WindowDifference'],
+                                       ),
+                'RecruitmentTarget' => $info['RecruitmentTarget'],
                );
     }
 


### PR DESCRIPTION
This is necessary for some new dashboard charts, that will show the recruitment breakdown by "subproject" (for now, until cohort table gets added).

Maybe @driusan you have some comments about treating subproject like cohort in the meantime...