### PR TITLE
Config child population

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -480,7 +480,6 @@ class LorisForm
      */
     function dateHTML($el)
     {
-        // print_r($el);
         $cls     = '';
         $minYear = '';
         $maxYear = '';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -480,14 +480,23 @@ class LorisForm
      */
     function dateHTML($el)
     {
-        $cls = '';
+        // print_r($el);
+        $cls     = '';
+        $minYear = '';
+        $maxYear = '';
         if (isset($el['class'])) {
             $cls = "class=\"$el[class]\"";
+        }
+        if (isset($el['options']['minYear'])) {
+            $minYear = "min=\"" . $el['options']['minYear'] . "-01-01\"";
+        }
+        if (isset($el['options']['maxYear'])) {
+            $maxYear = "max=\"" . $el['options']['maxYear'] . "-12-31\"";
         }
         $msg      = isset($el['requireMsg']) ? $el['requireMsg'] : 'Required';
         $required = isset($el['required']) ? "this.value === '' ? '$msg' : ''" : '';
         $value    = $this->getValue($el['name']);
-        $elmnt    = "<input name=\"$el[name]\" type=\"date\" $cls"
+        $elmnt    = "<input name=\"$el[name]\" type=\"date\" $cls $minYear $maxYear"
             . "onChange=\"this.setCustomValidity($required)\""
             . (isset($el['required']) ? "required" : '')
             . (

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -396,34 +396,30 @@ class NDB_Config
             $XMLValue = $this->getSettingFromXML($name);
 
             if ($XMLValue !== null) {
-                $DBValue = $this->getSettingFromDB($name);
-                // switch($name) {
-                // case 'database':
-                // case 'sandbox':
-                // case 'showDatabaseQueries':
-                //     return $XMLValue;
-                // }
-                // $db = Database::singleton();
-                // if ($db->isConnected() !== true) {
-                //     // no database connection, fall back on config.xml
-                //     throw new DatabaseException(
-                //         "No connection to database while trying to get setting $name"
-                //     );
-                // }
-                // $configSetting = $db->pselect(
-                //     "SELECT child.ID,child.Name
-                //     FROM ConfigSettings cs
-                //         LEFT JOIN ConfigSettings child ON (child.Parent=cs.ID)
-                //     WHERE cs.Name=:nm",
-                //     array("nm" => $name)
-                // );
+                switch($name) {
+                case 'database':
+                case 'sandbox':
+                case 'showDatabaseQueries':
+                    return $XMLValue;
+                }
+                $db = Database::singleton();
+                if ($db->isConnected() !== true) {
+                    // no database connection, fall back on config.xml
+                    throw new DatabaseException(
+                        "No connection to database while trying to get setting $name"
+                    );
+                }
+                $configSetting = $db->pselect(
+                    "SELECT child.ID,child.Name
+                    FROM ConfigSettings cs
+                        LEFT JOIN ConfigSettings child ON (child.Parent=cs.ID)
+                    WHERE cs.Name=:nm",
+                    array("nm" => $name)
+                );
                 foreach ($DBValue as $child) {
                     if (!isset($XMLValue[$child['Name']])) {
                         $XMLValue[$child['Name']] = $this->getSettingFromDB($child['Name'], $child['ID']);
                     }
-                }
-                if($name === "study"){
-                    print_r($DBValue);
                 }
                 return $XMLValue;
             }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -418,7 +418,8 @@ class NDB_Config
                 );
                 foreach ($configSetting as $child) {
                     if (!isset($XMLValue[$child['Name']])) {
-                        $XMLValue[$child['Name']] = $this->getSettingFromDB($child['Name'], $child['ID']);
+                        $XMLValue[$child['Name']]
+                            = $this->getSettingFromDB($child['Name'], $child['ID']);
                     }
                 }
                 return $XMLValue;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -416,7 +416,7 @@ class NDB_Config
                     WHERE cs.Name=:nm",
                     array("nm" => $name)
                 );
-                foreach ($DBValue as $child) {
+                foreach ($configSetting as $child) {
                     if (!isset($XMLValue[$child['Name']])) {
                         $XMLValue[$child['Name']] = $this->getSettingFromDB($child['Name'], $child['ID']);
                     }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -396,12 +396,44 @@ class NDB_Config
             $XMLValue = $this->getSettingFromXML($name);
 
             if ($XMLValue !== null) {
+                $DBValue = $this->getSettingFromDB($name);
+                // switch($name) {
+                // case 'database':
+                // case 'sandbox':
+                // case 'showDatabaseQueries':
+                //     return $XMLValue;
+                // }
+                // $db = Database::singleton();
+                // if ($db->isConnected() !== true) {
+                //     // no database connection, fall back on config.xml
+                //     throw new DatabaseException(
+                //         "No connection to database while trying to get setting $name"
+                //     );
+                // }
+                // $configSetting = $db->pselect(
+                //     "SELECT child.ID,child.Name
+                //     FROM ConfigSettings cs
+                //         LEFT JOIN ConfigSettings child ON (child.Parent=cs.ID)
+                //     WHERE cs.Name=:nm",
+                //     array("nm" => $name)
+                // );
+                foreach ($DBValue as $child) {
+                    if (!isset($XMLValue[$child['Name']])) {
+                        $XMLValue[$child['Name']] = $this->getSettingFromDB($child['Name'], $child['ID']);
+                    }
+                }
+                if($name === "study"){
+                    print_r($DBValue);
+                }
                 return $XMLValue;
             }
         } catch(ConfigurationException $e) {
             // There was no config in the database with this
             // name. It may exist in the XML, so we handle this
             // silently.
+        } catch(Exception $e) {
+            print_r($e);
+            throw $e;
         }
 
         // nothing in the config file, so get the value from the DB


### PR DESCRIPTION
In the config module if the desired config setting is set in the XML it would only look there to get all children setting. This was causing a bug if some of the child settings were set in the DB and not in the XML. This issue was first seen in the new_profile module where the settings like startYear weren't being set. 