### PR TITLE
Doc repo firefox format

### DIFF
--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -289,6 +289,7 @@ label em {
 }
 #dir-tree>tr>td:first-child {
     padding: 0px;
+    height: 100%;
 }
 #dir-tree>tr>td:first-child>div{
     -webkit-box-sizing: border-box;

--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -289,7 +289,7 @@ label em {
 }
 #dir-tree>tr>td:first-child {
     padding: 0px;
-    height: 100%;
+    /*height: 100%;*/
 }
 #dir-tree>tr>td:first-child>div{
     -webkit-box-sizing: border-box;
@@ -327,4 +327,12 @@ label em {
 }
 .directoryRow{
     height: 50px;
+}
+.fileRow{
+    height: 60px;
+}
+@-moz-document url-prefix() {
+    .directoryRow>td{
+    height: 100%;
+}
 }

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -46,7 +46,7 @@
     </tr>
 </script>
 <script id="file" type="x-tmpl-mustache">
-    <tr class="{{ parentID }}a" {{ ^filtered }}style="display:none" {{ /filtered }}>
+    <tr class="{{ parentID }}a fileRow" {{ ^filtered }}style="display:none" {{ /filtered }}>
         <td class="blah fileColumn">
             {{ #depth }}
                 {{ #first }}


### PR DESCRIPTION
There was a formatting issue in firefox causing the document repository to not format properly. This fixes the issue by apply the required css but only in firefox