### PR TITLE
Redline ticket #7264  Candidate_list site dropdown appear only for users with access_all_profiles permission.

### DIFF
--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -44,7 +44,7 @@
                 </div>
             </div>
             <div class="row">
-                {if 1 < count($form.centerID.options)}
+                {if count($form.centerID.options) > 1}
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
                         {$form.centerID.label}

--- a/modules/candidate_list/templates/menu_candidate_list.tpl
+++ b/modules/candidate_list/templates/menu_candidate_list.tpl
@@ -44,6 +44,7 @@
                 </div>
             </div>
             <div class="row">
+                {if 1 < count($form.centerID.options)}
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
                         {$form.centerID.label}
@@ -52,6 +53,7 @@
                         {$form.centerID.html}
                     </div>
                 </div>
+                {/if}
                 <div class="form-group col-sm-4">
                     <label class="col-sm-12 col-md-4">
                         {$form.SubprojectID.label}


### PR DESCRIPTION
Show site filter only if the array of available sites contain more than one option. This happen when the user have the access_all_profiles permission.

https://redmine.cbrain.mcgill.ca/issues/7264