### PR TITLE
Improved searches for all NDB_Menu_filters

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -419,6 +419,7 @@ class LorisForm
                 $this->defaultValues[$name]
             );
         }
+
         return null;
     }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -34,6 +34,7 @@ class LorisForm
     var $defaultValues = array();
     var $formRules     = array();
     var $errors        = array();
+    var $filters       = array();
     var $frozen        = false;
 
     /**
@@ -390,7 +391,7 @@ class LorisForm
     function getValue($name)
     {
         if (isset($_REQUEST[$name])) {
-            return $_REQUEST[$name];
+            return $this->_getFilteredValue($name, $_REQUEST[$name]);
         }
 
         $bracketIdx = strpos($name, '[');
@@ -405,14 +406,54 @@ class LorisForm
                     }
                     return 0;
                 }
-                return $_REQUEST[$fieldName][$fieldIdx];
+                return $this->_getFilteredValue(
+                    $fieldName,
+                    $_REQUEST[$fieldName][$fieldIdx]
+                );
             }
         }
 
         if (isset($this->defaultValues[$name])) {
-            return $this->defaultValues[$name];
+            return $this->_getFilteredValue(
+                $name,
+                $this->defaultValues[$name]
+            );
         }
         return null;
+    }
+
+    /**
+     * Gets the value of form element $name, after all filters have been
+     * applied. If there are no filters registered for element $name, then
+     * the original unmodified value is returned.
+     *
+     * @param string $name  name of the form element.
+     * @param string $value value of the form element.
+     *
+     * @return string value of the form element once all registered filters
+     *                (if any) have been applied.
+     */
+    private function _getFilteredValue($name, $value)
+    {
+        $newValue = $value;
+
+        // Apply field specific filters
+        if (isset($this->filters[$name])) {
+            if (in_array('trim', $this->filters[$name])) {
+                $new_value = trim($newValue);
+            }
+        }
+
+        // Apply filters that should be applied on all fields
+        if (isset($this->filters['__ALL__'])) {
+            foreach ($this->filters['__ALL__'] as $filterType) {
+                if (in_array('trim', $this->filters['__ALL__'])) {
+                    $newValue = trim($newValue);
+                }
+            }
+        }
+
+        return $newValue;
     }
 
     /**
@@ -723,13 +764,27 @@ class LorisForm
 
     /**
      * Reimplements the HTML_QuickForm applyFilter API.
-     * TODO: Implement this. We only ever use "trim", so that will be the only
-     *       thing implemented.
+     * Only trim operations are supported. Passing the special
+     * __ALL__ $elementName will apply the filter to every element
+     * in the form.
+     *
+     * @param string $elementName name of the element to which the filter
+     *                            should be applied.
+     * @param string $filterType  type of filter to apply.
      *
      * @return none
      */
-    function applyFilter()
+    function applyFilter($elementName, $filterType)
     {
+        if ($filterType == 'trim') {
+            if (!isset($this->filters[$elementName])) {
+                $this->filters[$elementName] = array();
+            }
+
+            $this->filters[$elementName][] = 'trim';
+        }
+
+        // Eventually, support for more filter types will be added here
     }
 
     /**
@@ -1136,7 +1191,8 @@ class LorisForm
                 $fieldIdx  = substr($name, $bracketIdx+1);
                 $fieldIdx  = strstr($fieldIdx, ']', true);
                 if (!isset($arr[$fieldName])) {
-                    $arr[$fieldName] = $_REQUEST[$fieldName];
+                    $arr[$fieldName]
+                        = $this->getValue($fieldName, $_REQUEST[$fieldName]);
                 }
                 if ($el['type'] === 'advcheckbox') {
                     $val = $this->getValue($name);
@@ -1149,21 +1205,21 @@ class LorisForm
                 continue;
             }
 
-            // normal case, just set it directly
+            // Normal case, just set it directly.
             // Check to see it the element type is a header or is a static
-            // element without a request varible. If so do not add to the
+            // element without a request variable. If so do not add to the
             // reference array
             if (!($el['type'] === 'header'
                 || ($el['type'] === 'static' && empty($_REQUEST[$name])))
             ) {
-                $arr[$name] = $_REQUEST[$name];
+                $arr[$name] = $this->getValue($name, $_REQUEST[$name]);
             }
 
             if ($el['type'] === 'date') {
                 // Convert dates to the type of group that was used
                 // by HTML_QuickForm. This should eventually be modified
                 // to just use a normal HTML5 date.
-                $vals       = explode("-", $arr[$name]);
+                $vals       = explode("-", $this->getValue($name, $arr[$name]));
                 $arr[$name] = array(
                                'Y' => $vals[0],
                                'M' => $vals[1],

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -137,6 +137,8 @@ class NDB_Menu_Filter extends NDB_Menu
 
         // start the filter form
         $this->_setupPage(null, null, null, null, 'filter');
+        $this->registerDefaultFilter();
+
         // $this->form = new HTML_QuickForm('filter');
 
         // set the filters
@@ -146,6 +148,18 @@ class NDB_Menu_Filter extends NDB_Menu
         $success = $this->_build();
 
         return true;
+    }
+
+    /**
+     * By default, trim all fields on the form before any processing/validation
+     * is done. Derived classes can override this behavior if needed.
+     *
+     * @return void
+     * @access public
+     */
+    function registerDefaultFilter()
+    {
+        $this->form->applyFilter('__ALL__', 'trim');
     }
 
     /**
@@ -204,15 +218,19 @@ class NDB_Menu_Filter extends NDB_Menu
 
         // Go through the form's fields and set the valid ones.
         foreach ($this->formToFilter as $formKey => $dbField) {
-            if (isset($values[$formKey]) && $values[$formKey] !== '') {
-                $value = $values[$formKey];
-                if (in_array($dbField, $this->validFilters)) {
-                    $newFormFilters[$dbField] = $value;
+            if (isset($values[$formKey])) {
+                // Call to form->getValue will apply all the form filters that
+                // will modify the submitted data
+                $filteredValue = $this->form->getValue($formKey, $values[$formKey]);
+                if ($filteredValue !== '') {
+                    if (in_array($dbField, $this->validFilters)) {
+                        $newFormFilters[$dbField] = $filteredValue;
 
-                    if (in_array($dbField, $this->validHavingFilters)) {
-                        $this->having[$dbField] = $value;
-                    } else {
-                        $this->filter[$dbField] = $value;
+                        if (in_array($dbField, $this->validHavingFilters)) {
+                            $this->having[$dbField] = $filteredValue;
+                        } else {
+                            $this->filter[$dbField] = $filteredValue;
+                        }
                     }
                 }
             }
@@ -360,7 +378,6 @@ class NDB_Menu_Filter extends NDB_Menu
         // show data table with user information and access URLs
         $success = $this->_setDataTable();
     }
-
 
     /**
      * Sets the template data for the filter form

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -72,6 +72,8 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
      *     2. Invalid filters are thrown away.
      *     3. Only validFilters are set in $this->filter
      *     4. Only validHavingFilters are set in $this->having
+     *     5. Values of all fields are (PHP) trimmed before being put into the 
+     *        filter
      *
      * @covers NDB_Menu_Filter::_setFilters
      */
@@ -80,6 +82,15 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
         $allOtherMethods = $this->_getAllMethodsExcept($method);
         $stub = $this->getMock('NDB_Menu_Filter', $this->_getAllMethodsExcept($method));
 
+        $stub->form = new LorisForm('filter');
+        $stub->form->applyFilter('__ALL__', 'trim');
+        $submittedValues = array(
+                'FakeField'        => '      I should be put into filter     ',
+                'FakeInvalidField' => 'I should not be set',
+                'FakeHaving'       => 'I should be put into having'
+        );
+        $_REQUEST =& $submittedValues;
+
         $stub->formToFilter = array(
             'FakeField'  => 'table.column',
             'FakeHaving' => 'abcd.def'
@@ -87,13 +98,7 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
         $stub->validFilters = array('table.column', 'abcd.def');
         $stub->validHavingFilters = array('abcd.def');
 
-        $stub->_setFilters(
-            array(
-                'FakeField'        => 'I should be put into filter',
-                'FakeInvalidField' => 'I should not be set',
-                'FakeHaving'       => 'I should be put into having'
-            )
-            );
+        $stub->_setFilters($submittedValues);
 
         $this->assertEquals(
             $stub->filter,


### PR DESCRIPTION
I added logic in LorisForm and NDB_Menu_filter so that when you perform a search based on a keyword and you either append or prepend spaces to it they are stripped (with PHP trim) before any validation/processing is done. All NDB_Menu_Filters now inherit from this behavior but it can be overriden it if need be. This fixes Redmine ticket #6470.