### PR TITLE
Prevent a new user with an empty name to be created

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -300,8 +300,22 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         // full name
         //$this->addBasicText('Real_name', 'Full name');
-        $this->addBasicText('First_name', 'First name');
-        $this->addBasicText('Last_name', 'Last name');
+        $this->addBasicText(
+            'First_name',
+            'First name',
+            array(
+                'oninvalid' => "this.setCustomValidity('First name is required')",
+                'onchange'  => "this.setCustomValidity('')",
+            )
+        );
+        $this->addBasicText(
+            'Last_name',
+            'Last name',
+            array(
+                'oninvalid' => "this.setCustomValidity('Last name is required')",
+                'onchange'  => "this.setCustomValidity('')",
+            )
+        );
 
         $this->addRule('First_name', 'First name is required', 'required');
         $this->addRule('Last_name', 'Last name is required', 'required');
@@ -472,9 +486,24 @@ class NDB_Form_User_Accounts extends NDB_Form
         $this->addScoreColumn('UserID', 'User name');
 
         // full name
-        $this->addBasicText('First_name', 'First name');
-        $this->addBasicText('Last_name', 'Last name');
-
+        //$this->addBasicText('Real_name', 'Full name');
+        $this->addBasicText(
+            'First_name',
+            'First name',
+            array(
+                'oninvalid' => "this.setCustomValidity('First name is required')",
+                'onchange'  => "this.setCustomValidity('')",
+            )
+        );
+        $this->addBasicText(
+            'Last_name',
+            'Last name',
+            array(
+                'oninvalid' => "this.setCustomValidity('Last name is required')",
+                'onchange'  => "this.setCustomValidity('')",
+            )
+        );
+        
         $this->addRule('First_name', 'First name is required', 'required');
         $this->addRule('Last_name', 'Last name is required', 'required');
         $this->addRule(
@@ -506,8 +535,15 @@ class NDB_Form_User_Accounts extends NDB_Form
         }
 
         // email address
-        $this->addBasicText('Email', 'Email address');
-
+        $this->addBasicText(
+            'Email',
+            'Email address',
+            array(
+                'oninvalid' => "this.setCustomValidity('Email address is required')",
+                'onchange'  => "this.setCustomValidity('')",
+            )
+        );
+        
         // email address rules
         $this->addRule('Email', 'Email address is required', 'required');
         $this->addRule('Email', 'Your email address must be valid', 'email');

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1206,7 +1206,6 @@ class LorisForm
                 continue;
             }
 
-            // Normal case, just set it directly.
             // Check to see it the element type is a header or is a static
             // element without a request variable. If so do not add to the
             // reference array

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1192,8 +1192,9 @@ class LorisForm
                 $fieldIdx  = substr($name, $bracketIdx+1);
                 $fieldIdx  = strstr($fieldIdx, ']', true);
                 if (!isset($arr[$fieldName])) {
-                    $arr[$fieldName]
-                        = $this->getValue($fieldName, $_REQUEST[$fieldName]);
+                    $value           = isset($_REQUEST[$fieldName])
+                        ? $_REQUEST[$fieldName] : null;
+                    $arr[$fieldName] = $this->getValue($fieldName, $value);
                 }
                 if ($el['type'] === 'advcheckbox') {
                     $val = $this->getValue($name);
@@ -1212,14 +1213,15 @@ class LorisForm
             if (!($el['type'] === 'header'
                 || ($el['type'] === 'static' && empty($_REQUEST[$name])))
             ) {
-                $arr[$name] = $this->getValue($name, $_REQUEST[$name]);
+                $value      = isset($_REQUEST[$name]) ? $_REQUEST[$name] : null;
+                $arr[$name] = $this->getValue($name, $value);
             }
 
             if ($el['type'] === 'date') {
                 // Convert dates to the type of group that was used
                 // by HTML_QuickForm. This should eventually be modified
                 // to just use a normal HTML5 date.
-                $vals       = explode("-", $this->getValue($name, $arr[$name]));
+                $vals       = explode("-", $arr[$name]);
                 $arr[$name] = array(
                                'Y' => $vals[0],
                                'M' => $vals[1],

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -66,6 +66,10 @@ class LorisForm
         if (isset($attribs['value'])) {
             $el['value'] = $attribs['value'];
         }
+        if (isset($attribs['oninvalid'])) {
+            $el['oninvalid'] = $attribs['oninvalid'];
+        }
+
         return $el;
     }
     /**
@@ -616,6 +620,14 @@ class LorisForm
         }
         $value = $this->getValue($el['name']);
         return "<input name=\"$el[name]\" type=\"$type\" $cls"
+            . (
+                isset($el['onchange']) && $el['onchange']
+                ? " onchange=\"{$el['onchange']}\"" : ''
+              )
+            . (
+                isset($el['oninvalid']) && $el['oninvalid']
+                ? " oninvalid=\"{$el['oninvalid']}\"" : ''
+              )
             . (
                 isset($el['required']) && $el['required']
                 ? ' required' : ''

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -71,6 +71,7 @@ class NDB_Form extends NDB_Page
 
         // set the local variables
         $obj->_setupPage($name, $page, $identifier, null, 'test_form');
+        $obj->registerDefaultFilter();
 
         $access = $obj->_hasAccess();
 
@@ -92,6 +93,17 @@ class NDB_Form extends NDB_Page
         return $obj;
     }
 
+    /**
+     * By default, trim all fields on the form before any processing/validation
+     * is done. Derived classes can override this behavior if needed.
+     *
+     * @return void
+     * @access public
+     */
+    function registerDefaultFilter()
+    {
+        $this->form->applyFilter('__ALL__', 'trim');
+    }
 
     /**
      * Returns false if user does not have access to page.


### PR DESCRIPTION
Corrected a bug that allowed a user with a name that consists entirely of spaces to be created. The fix trims all fields of NDB_Form before any validation/save operation is performed. Consequently, all derived classes of NDB_Form will benefit from this fix.
