### PR TITLE
Fixing the casing for the subproject recruitment target patch

### DIFF
--- a/SQL/2015-08-11-AddRecruitmentTargetToSubproject.sql
+++ b/SQL/2015-08-11-AddRecruitmentTargetToSubproject.sql
@@ -1,1 +1,1 @@
-ALTER TABLE Subproject ADD RecruitmentTarget int(10) unsigned;
+ALTER TABLE subproject ADD RecruitmentTarget int(10) unsigned;


### PR DESCRIPTION
This patch failed because the case was wrong for the table name. So warning for everyone doing development on a Mac... they are case insensitive and you might not catch this error.