### PR TITLE
Buf fixes for the LorisForm and the user account page

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -26,6 +26,16 @@ require_once "Email.class.inc";
 class NDB_Form_User_Accounts extends NDB_Form
 {
     /**
+     * Determines whether this form is in edit or create mode.
+     *
+     * @return boolean true if in crete mode, false otherwise.
+     */
+    function isCreatingNewUser()
+    {
+        return $this->page == 'edit_user' && $this->identifier == '';
+    }
+
+    /**
      * Controls who's got access to this page, namely those who have the
      * 'user_accounts' and who either have permission
      * 'user_accounts_multisite' or whose site matches the site of the user they
@@ -39,7 +49,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         $editor =& User::singleton();
 
         if ($this->page == 'edit_user') {
-            if (!empty($this->identifier)) {
+            if (!$this->isCreatingNewUser()) {
                 $user =& User::factory($this->identifier);
             }
 
@@ -48,7 +58,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                     return true;
                 }
 
-                if (empty($this->identifier)) {
+                if ($this->isCreatingNewUser()) {
                     return true;
                 }
 
@@ -71,7 +81,7 @@ class NDB_Form_User_Accounts extends NDB_Form
     {
         $defaults = array();
 
-        if (!empty($this->identifier)) {
+        if (!$this->isCreatingNewUser()) {
             $user =& User::factory($this->identifier);
             // get the user defaults
             $defaults = $user->getData();
@@ -103,15 +113,15 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         //The arrays that contain the edited permissions
         $permissionsRemoved = array();
-        $permissionsAdded = array();
+        $permissionsAdded   = array();
 
         $editor =& User::singleton();
-        
+
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
 
         //create the user
-        if (!empty($this->identifier)) {
+        if (!is_null($this->identifier)) {
             $user =& User::factory($this->identifier);
         } else {
             // Since the form has been validated there are two possibilities:
@@ -128,43 +138,41 @@ class NDB_Form_User_Accounts extends NDB_Form
         // store the permission IDs
         if (!empty($values['permID'])) {
             $permIDs = $values['permID'];
-            unset($values['permID']);
         }
+        unset($values['permID']);
 
         // store whether to send an email or not
         if (!empty($values['SendEmail'])) {
             $send = $values['SendEmail'];
-	        unset($values['SendEmail']);
-	    }
-        
+        }
+        unset($values['SendEmail']);
+
         //store the supervisors emails
         if (!empty($values['supervisorEmail'])) {
             $supervisorEmails = $values['supervisorEmail'];
-            unset($values['supervisorEmail']);
         }
+        unset($values['supervisorEmail']);
 
         // make user name match email address
         if (!empty($values['NA_UserID'])) {
             $values['UserID'] = $values['Email'];
-            unset($values['NA_UserID']);
         }
+        unset($values['NA_UserID']);
 
         // generate new password
         if (!empty($values['NA_Password'])) {
             $values['Password_md5']    = User::newPassword();
             $values['Password_expiry'] = '0000-00-00';
-            unset($values['NA_Password']);
         }
+        unset($values['NA_Password']);
 
         // make the set
         foreach ($values as $key => $value) {
-            if (!empty($value) || $value === '0') {
-                $set[$key] = $value;
-            }
+            $set[$key] = $value;
         }
 
         // update the user
-        if (empty($this->identifier)) {
+        if ($this->isCreatingNewUser()) {
             // insert a new user
             $success = User::insert($set);
             $user    =& User::factory($set['UserID']);
@@ -177,7 +185,9 @@ class NDB_Form_User_Accounts extends NDB_Form
         // prepend two random characters
         if (isset($set['Password_md5'])) {
             // Update CouchDB. Must do before password is salted/hashed.
-            $user->updatePassword($set['Password_md5']);
+            $expiry = isset($values['Password_expiry'])
+                ? $values['Password_expiry'] : null;
+            $user->updatePassword($set['Password_md5'], $expiry);
         }
 
         // update the user permissions if applicable
@@ -190,7 +200,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                     ///Then insert into the user_account_history as 'D'
                     if (in_array($key, $current_permissionids)) {
                         $user->insertIntoUserAccountHistory($key, 'D');
-                        $permissionsRemoved[] = $this->getDescriptionUsingPermID($key);                        
+                        $permissionsRemoved[]
+                            = $this->getDescriptionUsingPermID($key);
                     }
                     unset($permIDs[$key]);
                 } else {
@@ -200,26 +211,34 @@ class NDB_Form_User_Accounts extends NDB_Form
                     */
                     if (!(in_array($key, $current_permissionids))) {
                         $user->insertIntoUserAccountHistory($key, 'I');
-                        $permissionsAdded[] = $this->getDescriptionUsingPermID($key);                        
+                        $permissionsAdded[]
+                            = $this->getDescriptionUsingPermID($key);
                     }
                 }
             }
 
-            // send the selected supervisors an email (only if permissions have changed for the user)
-            foreach($supervisorEmails as $email => $checkValue) {
-                if (!empty($permissionsAdded) || !empty($permissionsRemoved)) {
-                    if ($checkValue == 1) {
-                        $msg_data['current_user'] = $editor->getFullname();
-                        $msg_data['study'] = $config->getSetting('title');
-                        $msg_data['realname'] = $values['Real_name'];
-                        $msg_data['username'] = $user->getUsername();
-                        $msg_data['permissions_added'] = $permissionsAdded;
-                        $msg_data['permissions_removed'] = $permissionsRemoved;
-                        Email::send($email, 'permissions_change_notify_supervisor.tpl', $msg_data);
+            // send the selected supervisors an email
+            // (only if permissions have changed for the user)
+            if (isset($supervisorEmails)) {
+                foreach ($supervisorEmails as $email => $checkValue) {
+                    if (!empty($permissionsAdded) || !empty($permissionsRemoved)) {
+                        if ($checkValue == 1) {
+                            $msg_data['current_user'] = $editor->getFullname();
+                            $msg_data['study']        = $config->getSetting('title');
+                            $msg_data['realname']     = $values['Real_name'];
+                            $msg_data['username']     = $user->getUsername();
+                            $msg_data['permissions_added']   = $permissionsAdded;
+                            $msg_data['permissions_removed'] = $permissionsRemoved;
+                            Email::send(
+                                $email,
+                                'permissions_change_notify_supervisor.tpl',
+                                $msg_data
+                            );
+                        }
                     }
                 }
             }
-            
+
             $success = $user->addPermissions(array_keys($permIDs));
         }
 
@@ -235,7 +254,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             $msg_data['username'] = $user->getUsername();
             $msg_data['password'] = $values['Password_md5'];
 
-            $template = (empty($this->identifier))
+            $template = (is_null($this->identifier))
                 ? 'new_user.tpl' : 'edit_user.tpl';
             Email::send($values['Email'], $template, $msg_data);
         }
@@ -253,7 +272,7 @@ class NDB_Form_User_Accounts extends NDB_Form
     // @codingStandardsIgnoreStart
     function edit_user()
     {
-    // @codingStandardsIgnoreEnd
+        // @codingStandardsIgnoreEnd
         $this->redirect = "test_name=$this->name";
 
         ///get the value for additional_user_info flag
@@ -263,7 +282,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         //------------------------------------------------------------
 
         // it is a new user
-        if (empty($this->identifier)) {
+        if ($this->identifier == '') {
             // user name
             $group[] = $this->createText('UserID', 'User name');
             $group[] = $this->createCheckbox(
@@ -298,38 +317,37 @@ class NDB_Form_User_Accounts extends NDB_Form
         $this->addPassword('__Confirm', 'Confirm Password');
         unset($group);
 
-        // full name
-        //$this->addBasicText('Real_name', 'Full name');
+        // The supplied pattern is:
+        //   - must have at least one non-whitespace characters
+        //   - once leading and trailing spaces are stripped, the field should
+        //       not exceed 120 chars
+        $onInvalidMsg
+            = "this.setCustomValidity('First name is required and "
+              . "should not exceed 120 characters')";
         $this->addBasicText(
             'First_name',
             'First name',
             array(
-                'oninvalid' => "this.setCustomValidity('First name is required')",
-                'onchange'  => "this.setCustomValidity('')",
+             'oninvalid' => $onInvalidMsg,
+             'onchange'  => "this.setCustomValidity('')",
+             'pattern'   => '^\s*\S.{0,119}\s*$',
             )
         );
+        // The supplied pattern is:
+        //   - must have at least one non-whitespace characters
+        //   - once leading and trailing spaces are stripped, the field should
+        //       not exceed 120 chars
+        $onInvalidMsg
+            = "this.setCustomValidity('Last name is required and "
+              . "should not exceed 120 characters')";
         $this->addBasicText(
             'Last_name',
             'Last name',
             array(
-                'oninvalid' => "this.setCustomValidity('Last name is required')",
-                'onchange'  => "this.setCustomValidity('')",
+             'oninvalid' => $onInvalidMsg,
+             'onchange'  => "this.setCustomValidity('')",
+             'pattern'   => '^\s*\S.{0,119}\s*$',
             )
-        );
-
-        $this->addRule('First_name', 'First name is required', 'required');
-        $this->addRule('Last_name', 'Last name is required', 'required');
-        $this->addRule(
-            'First_name',
-            'First name must be less than 120 characters long',
-            'maxlength',
-            120
-        );
-        $this->addRule(
-            'Last_name',
-            'Last name must be less than 120 characters long',
-            'maxlength',
-            120
         );
 
         // extra info
@@ -420,31 +438,40 @@ class NDB_Form_User_Accounts extends NDB_Form
         $this->addGroup($group, 'PermID_Group', 'Permissions', "", false);
         unset($group);
 
-        //getting users name and emails to create checkboxes to email supervisors on permissions changes
+        //getting users name and emails to create checkboxes
+        // to email supervisors on permissions changes
         $DB_factory =& NDB_Factory::singleton();
-        $DB = $DB_factory->database();
+        $DB         = $DB_factory->database();
 
         $query = "SELECT u.Real_Name, u.email FROM permissions p
                   JOIN user_perm_rel up ON (p.permID = up.PermID)
                   JOIN users u ON (u.ID = up.userID)
                   WHERE p.code = 'send_to_dcc'";
-        
-        $results = $DB->select($query);
 
+        $results = $DB->pselect($query, array());
 
-        $group[] = $this->form->createElement('static', null, null, '</div>' .
-            "<h3 id=\"header_supervisors\" class=\"perm_header button\" style=\"text-align: center; margin-top: 5px;\"> Data Supervisors to Email </h3> "
-            . "<div id=\"perms_supervisors\" style=\"margin-top: 5px;\">");
+        $group[] = $this->form->createElement(
+            'static',
+            null,
+            null,
+            '</div>'
+            . "<h3 id=\"header_supervisors\" class=\"perm_header button\" "
+            . "style=\"text-align: center; margin-top: 5px;\"> "
+            . "Data Supervisors to Email </h3> "
+            . "<div id=\"perms_supervisors\" style=\"margin-top: 5px;\">"
+        );
 
-        foreach ($results as $row){
-            $group[] = $this->createCheckbox('supervisorEmail['.$row['email'].']',"$row[Real_Name]<br>");
+        foreach ($results as $row) {
+            $group[] = $this->createCheckbox(
+                'supervisorEmail['.$row['email'].']',
+                "$row[Real_Name]<br>"
+            );
         }
 
-        $this->addGroup($group, 'Supervisors_Group', 'Supervisors', "", FALSE);
+        $this->addGroup($group, 'Supervisors_Group', 'Supervisors', "", false);
         unset($group);
-        
-        
-        if (!empty($this->identifier)) {
+
+        if (!$this->isCreatingNewUser()) {
             $user =& User::factory($this->identifier);
 
             // add hidden permissions if editor has less permissions than user
@@ -472,7 +499,6 @@ class NDB_Form_User_Accounts extends NDB_Form
      */
     // @codingStandardsIgnoreStart
     function my_preferences()
-    // @codingStandardIgnoreEnd
     {
         $this->identifier = $_SESSION['State']->getUsername();
 
@@ -486,37 +512,31 @@ class NDB_Form_User_Accounts extends NDB_Form
         $this->addScoreColumn('UserID', 'User name');
 
         // full name
-        //$this->addBasicText('Real_name', 'Full name');
+        // The supplied pattern is:
+        //   - must have at least one non-whitespace characters (i.e. required)
+        //   - once leading and trailing spaces are stripped, the field should
+        //       not exceed 120 chars
         $this->addBasicText(
             'First_name',
             'First name',
             array(
-                'oninvalid' => "this.setCustomValidity('First name is required')",
-                'onchange'  => "this.setCustomValidity('')",
+             'oninvalid' => "this.setCustomValidity('First name is required and should not exceed 120 characters')",
+             'onchange'  => "this.setCustomValidity('')",
+             'pattern'   => '^\s*\S.{0,119}\s*$',
             )
         );
+        // The supplied pattern is:
+        //   - must have at least one non-whitespace characters (i.e. required)
+        //   - once leading and trailing spaces are stripped, the field should
+        //       not exceed 120 chars
         $this->addBasicText(
             'Last_name',
             'Last name',
             array(
-                'oninvalid' => "this.setCustomValidity('Last name is required')",
-                'onchange'  => "this.setCustomValidity('')",
+             'oninvalid' => "this.setCustomValidity('Last name is required and should not exceed 120 characters')",
+             'onchange'  => "this.setCustomValidity('')",
+             'pattern'   => '^\s*\S.{0,119}\s*$',
             )
-        );
-        
-        $this->addRule('First_name', 'First name is required', 'required');
-        $this->addRule('Last_name', 'Last name is required', 'required');
-        $this->addRule(
-            'First_name',
-            'First name must be less than 120 characters long',
-            'maxlength',
-            120
-        );
-        $this->addRule(
-            'Last_name',
-            'Last name must be less than 120 characters long',
-            'maxlength',
-            120
         );
 
         // extra info
@@ -539,11 +559,11 @@ class NDB_Form_User_Accounts extends NDB_Form
             'Email',
             'Email address',
             array(
-                'oninvalid' => "this.setCustomValidity('Email address is required')",
-                'onchange'  => "this.setCustomValidity('')",
+             'oninvalid' => "this.setCustomValidity('Email address is required')",
+             'onchange'  => "this.setCustomValidity('')",
             )
         );
-        
+
         // email address rules
         $this->addRule('Email', 'Email address is required', 'required');
         $this->addRule('Email', 'Your email address must be valid', 'email');
@@ -590,29 +610,29 @@ class NDB_Form_User_Accounts extends NDB_Form
     function _validateEditUser($values)
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB     =& Database::singleton();
         $errors = array();
 
         //============================================
         //         Validate UserID and NA_UserID
         //============================================
-        if (empty($this->identifier)) {
+        if ($this->isCreatingNewUser()) {
             // Clicked on "UID == email" and specified a UID
-            if (!empty($values['UserID']) && $values['NA_UserID'] == 'on') {
+            if (!is_null($values['UserID']) && $values['NA_UserID'] == 'on') {
                 $errors['UserID_Group']
-                    = 'You cannot enter a user name "
-                    . "if you want it to match the email address';
-            } elseif (empty($values['UserID']) && $values['NA_UserID'] != 'on') {
+                    = 'You cannot enter a user name '
+                    . 'if you want it to match the email address';
+            } elseif (is_null($values['UserID']) && $values['NA_UserID'] != 'on') {
                 // Not clicked on "UID == email" and not specified a UID
                 $errors['UserID_Group']
                     = 'You must enter a user name '
                     . 'or choose to make it match the email address';
-            } elseif (!empty($values['UserID'])
+            } elseif (!is_null($values['UserID'])
                 || ($values['NA_UserID'] == 'on' && $values['Email'])
             ) {
                 // Either specified a UID or clicked on "UID = email"
                 // with a non-empty email
-                $effectiveUID = empty($values['UserID'])
+                $effectiveUID = is_null($values['UserID'])
                     ? $values['Email'] : $values['UserID'];
 
                 // check username's uniqueness
@@ -635,7 +655,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         //==================================
         //        Password validation
         //==================================
-        if (!empty($this->identifier)) {
+        if (!is_null($this->identifier)) {
             $pass = $DB->pselectOne(
                 "SELECT COALESCE(Password_hash, Password_md5) "
                 . "as Current_password FROM users WHERE UserID = :UID",
@@ -645,8 +665,8 @@ class NDB_Form_User_Accounts extends NDB_Form
             //case of new user the password column will be null
             //so either password should be set or
             // password should be generated
-            if (empty($pass)
-                && empty($values['Password_md5'])
+            if (is_null($pass)
+                && is_null($values['Password_md5'])
                 && $values['NA_Password'] != 'on'
             ) {
                 $errors['Password_Group']
@@ -686,7 +706,12 @@ class NDB_Form_User_Accounts extends NDB_Form
                    . 'please notify the user by checking Send email to user box';
         }
 
-        if (empty($this->identifier)
+        if ($values['NA_Password'] == 'on' && $values['Password_md5'] != '') {
+            $errors['Password_Group'] = 'You must leave the password field empty '
+                . 'if you want the system to generate one for you';
+        }
+
+        if (is_null($this->identifier)
             && ($values['NA_Password'] != 'on')
             && empty($values['Password_md5'])
         ) {
@@ -719,7 +744,7 @@ class NDB_Form_User_Accounts extends NDB_Form
     function _validateMyPreferences($values)
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB     =& Database::singleton();
         $errors = array();
 
         // if password is user-defined, and user wants to change password
@@ -729,7 +754,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                 $values['Password_md5'],
                 array(
                  $values['__Confirm'],
-                 $values['identifier'],
+                 $values['UserID'],
                  $values['Email'],
                 ),
                 array(
@@ -738,7 +763,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                  '!=',
                 )
             );
-            if (!$isPasswordString) {
+            if (!$isPasswordStrong) {
                 $errors['Password_md5']
                     = 'The password is weak, or the passwords do not match';
             }
@@ -754,7 +779,7 @@ class NDB_Form_User_Accounts extends NDB_Form
     }
 
     /**
-     * Validates that en email address entered for a given user 
+     * Validates that en email address entered for a given user
      * (either new or existing) is valid and unique.
      *
      * @return string error message if email is invalid, null otherwise.
@@ -784,8 +809,8 @@ class NDB_Form_User_Accounts extends NDB_Form
     function getDescriptionUsingPermID($permID)
     {
         $db_factory =& NDB_Factory::singleton();
-        $db = $db_factory->database();
-        
+        $db         = $db_factory->database();
+
         $permission = $db->pselectOne(
             "SELECT Description FROM permissions WHERE permID =:pID",
             array('pID' => $permID)
@@ -794,6 +819,6 @@ class NDB_Form_User_Accounts extends NDB_Form
             list(,$description) = each($permission[0]);
         }
         return $permission;
-    }    
+    }
 }
 ?>

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -696,6 +696,16 @@ class NDB_Form_User_Accounts extends NDB_Form
             if (!$isPasswordStrong) {
                 $errors['Password_Group']
                     = 'The password is weak, or the passwords do not match';
+            } else {
+                $currentPass = $DB->pselectOne(
+                    "SELECT COALESCE(Password_hash, Password_md5) "
+                    . "as Current_password FROM users WHERE UserID = :UID",
+                    array('UID' => $this->identifier)
+                );
+                if (User::MD5Unsalt($values['Password_md5'], $currentPass)) {
+                    $errors['Password_Group']
+                        = 'New and old passwords are identical: choose another one';
+                }
             }
         }
 
@@ -766,6 +776,16 @@ class NDB_Form_User_Accounts extends NDB_Form
             if (!$isPasswordStrong) {
                 $errors['Password_md5']
                     = 'The password is weak, or the passwords do not match';
+            }  else {
+                $currentPass = $DB->pselectOne(
+                    "SELECT COALESCE(Password_hash, Password_md5) "
+                    . "as Current_password FROM users WHERE UserID = :UID",
+                    array('UID' => $this->identifier)
+                );
+                if (User::MD5Unsalt($values['Password_md5'], $currentPass)) {
+                    $errors['Password_Group']
+                        = 'New and old passwords are identical: choose another one';
+                }
             }
         }
 

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -764,7 +764,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                 $values['Password_md5'],
                 array(
                  $values['__Confirm'],
-                 $values['UserID'],
+                 $this->identifier,
                  $values['Email'],
                 ),
                 array(

--- a/modules/user_accounts/test/TestPlan
+++ b/modules/user_accounts/test/TestPlan
@@ -29,6 +29,9 @@ When creating or editing a user: (subtest: edit_user)
     for this new password. Check that after logging in, the user is immediately asked to update his/her password.
 12. Check that if creating a new user an email is sent to him/her (requires email server). Also check that when a new
     user is logging in for the first time he/she is asked to change his/her password.
+12a. Check that when creating a new user, leading and trailing spaces in the username are stripped.
+12b. Check that you can create a new user with name 00 (double zero).
+12c. Check that you can delete one of the additional fields (organization, fax, etc...) that was previously set and that the save is performed.
 13. Check that if modifying a password for a user an email is sent to that user containing the new password (requires
     email server).
 14. Check that when editing a user account it is not possible to set the password to its actual value (i.e. it needs to change).
@@ -51,7 +54,7 @@ On the My Preferences page:
 22. Check that all users (even those with NO permissions) have access to the My Preferences page.
 23. Change the user’s password.  Check that the password rules are enforced..
 24. Check that if password and confirmed password do not match you get an error.
-25. Check that saving fails if any field is left blank. 
+25. Check that saving fails if any field is left blank (except password). 
 26. Check that if you do not enter an email address that is syntactically valid you get an error.
 27. Modify any field on the page and save, and go to the User Account page. Check that the modifications are 
     displayed when looking at the modified user account.  

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -69,6 +69,9 @@ class LorisForm
         if (isset($attribs['oninvalid'])) {
             $el['oninvalid'] = $attribs['oninvalid'];
         }
+        if (isset($attribs['pattern'])) {
+            $el['pattern'] = $attribs['pattern'];
+        }
 
         return $el;
     }
@@ -394,24 +397,53 @@ class LorisForm
      */
     function getValue($name)
     {
+        // Not all elements of the form go into $_REQUEST, thus the isset test
         if (isset($_REQUEST[$name])) {
-            return $this->_getFilteredValue($name, $_REQUEST[$name]);
+            // If submitted value in $_REQUEST is an array return the array
+            // of filtered values
+            if (is_array($_REQUEST[$name])) {
+                $filteredValues = array();
+                foreach ($_REQUEST[$name] as $k => $v) {
+                    // Checkbox values get converted from (on,off) to (1,0)
+                    if ($this->_isAdvCheckbox("{$name}[$k]")) {
+                        $rawValue = $_REQUEST[$name][$k] == 'on' ? 1 : 0;
+                    } else {
+                        $rawValue = $_REQUEST[$name][$k];
+                    }
+                    // This is more for consistency since it would be odd to apply a
+                    // filter to a checkbox value
+                    $filteredValues[$k]
+                        = $this->_getFilteredValue("[$name}[$k]", $rawValue);
+                }
+
+                return $filteredValues;
+            } else {
+                // if submitted value is not an array, filter it
+                return $this->_getFilteredValue($name, $_REQUEST[$name]);
+            }
         }
 
+        // Check to see if the element name is of the form name[idx]
+        // (if so there should be a 'name' array in $_REQUEST)
         $bracketIdx = strpos($name, '[');
         if ($bracketIdx !== false) {
             $fieldName = strstr($name, '[', true);
             $fieldIdx  = substr($name, $bracketIdx+1);
             $fieldIdx  = strstr($fieldIdx, ']', true);
+            // This should always be true
             if (isset($_REQUEST[$fieldName])) {
-                if ($this->form[$name]['type'] === 'advcheckbox') {
-                    if ($_REQUEST[$fieldName][$fieldIdx] == 'on') {
-                        return 1;
-                    }
-                    return 0;
+                if ($this->_isAdvCheckbox($name)) {
+                    // Only the checkboxes turned on are put in $_REQUEST,
+                    // thus the isset check
+                    $value = isset($_REQUEST[$fieldName][$fieldIdx])
+                        ? $_REQUEST[$fieldName][$fieldIdx] : null;
+
+                    $rawValue = $value == 'on' ? 1 : 0;
+                    return $this->_getFilteredValue($name, $rawValue);
                 }
+
                 return $this->_getFilteredValue(
-                    $fieldName,
+                    $name,
                     $_REQUEST[$fieldName][$fieldIdx]
                 );
             }
@@ -428,24 +460,54 @@ class LorisForm
     }
 
     /**
+     * Determines if a fomr element if of type 'advcheckbox'.
+     *
+     * @param string $elementName Name of a form element that exists in the $form.
+     *
+     * @return boolean true if the element is a checkbox, false otherwise.
+     */
+    private function _isAdvCheckbox($elementName)
+    {
+        // If the element is not in a group
+        if (isset($this->form[$elementName])) {
+            return $this->form[$elementName]['type'] == 'advcheckbox';
+        }
+
+        // Element is in a groug: check in each group
+        foreach ($this->form as $element) {
+            if (is_array($element) && $element['type'] == 'group') {
+                // Check all elements of the current group for the element
+                foreach ($element['elements'] as $groupElement) {
+                    // Check if name is right
+                    if ($groupElement['name'] == $elementName) {
+                        return $groupElement['type'] == 'advcheckbox';
+                    }
+                }
+            }
+        }
+
+        // Should not happen
+        return false;
+    }
+
+    /**
      * Gets the value of form element $name, after all filters have been
      * applied. If there are no filters registered for element $name, then
      * the original unmodified value is returned.
      *
-     * @param string $name  name of the form element.
-     * @param string $value value of the form element.
+     * @param string $name  name of the form element in the $form.
+     * @param string $value value of the form element in $_REQUEST or null if
+     *               none was found.
      *
      * @return string value of the form element once all registered filters
      *                (if any) have been applied.
      */
     private function _getFilteredValue($name, $value)
     {
-        $newValue = $value;
-
         // Apply field specific filters
         if (isset($this->filters[$name])) {
             if (in_array('trim', $this->filters[$name])) {
-                $new_value = trim($newValue);
+                $new_value = trim($value);
             }
         }
 
@@ -453,7 +515,18 @@ class LorisForm
         if (isset($this->filters['__ALL__'])) {
             foreach ($this->filters['__ALL__'] as $filterType) {
                 if (in_array('trim', $this->filters['__ALL__'])) {
-                    $newValue = trim($newValue);
+                    // Value for the element is in array so filter all
+                    // elements in the array of values
+                    if (is_array($value)) {
+                        $newValue = array();
+                        foreach ($value as $k => $v) {
+                            $newValue[$k]
+                                = $this->_getFilteredValue("{$name}[$k]", $v);
+                        }
+                    } else {
+                        // Submitted value not an array: trim it
+                        $newValue = trim($value);
+                    }
                 }
             }
         }
@@ -627,6 +700,10 @@ class LorisForm
             . (
                 isset($el['oninvalid']) && $el['oninvalid']
                 ? " oninvalid=\"{$el['oninvalid']}\"" : ''
+              )
+            . (
+                isset($el['pattern']) && $el['pattern']
+                ? " pattern=\"{$el['pattern']}\"" : ''
               )
             . (
                 isset($el['required']) && $el['required']
@@ -1204,17 +1281,7 @@ class LorisForm
                 $fieldIdx  = substr($name, $bracketIdx+1);
                 $fieldIdx  = strstr($fieldIdx, ']', true);
                 if (!isset($arr[$fieldName])) {
-                    $value           = isset($_REQUEST[$fieldName])
-                        ? $_REQUEST[$fieldName] : null;
-                    $arr[$fieldName] = $this->getValue($fieldName, $value);
-                }
-                if ($el['type'] === 'advcheckbox') {
-                    $val = $this->getValue($name);
-                    if ($val === 'on') {
-                        $arr[$fieldName][$fieldIdx] = 1;
-                    } else {
-                        $arr[$fieldName][$fieldIdx] = 0;
-                    }
+                    $arr[$fieldName] = $this->getValue($fieldName);
                 }
                 continue;
             }
@@ -1225,8 +1292,7 @@ class LorisForm
             if (!($el['type'] === 'header'
                 || ($el['type'] === 'static' && empty($_REQUEST[$name])))
             ) {
-                $value      = isset($_REQUEST[$name]) ? $_REQUEST[$name] : null;
-                $arr[$name] = $this->getValue($name, $value);
+                  $arr[$name] = $this->getValue($name);
             }
 
             if ($el['type'] === 'date') {

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -267,7 +267,7 @@ class User extends UserPermissions
     /**
      * Generates a random alphanumeric password
      *
-     * @param int $length Length of password to generate
+     * @param int $length Length of password to generate (has to be >= 2)
      *
      * @return string
      * @access public
@@ -278,14 +278,36 @@ class User extends UserPermissions
         // start with a blank password
         $password = '';
 
-        // define possible characters
-        $possible = '0123456789bcdfghjkmnpqrstvwxyz';
+        $numbers      = '0123456789';
+        $specialChars = '!@#$%^&*()';
+
+        $possible = $numbers . $specialChars . 'abcdefghijklmnopqrstuvwxyz';
 
         // length of possible characters minus one
-        $possible_cnt = 29; //strlen($possible) - 1;
+        $possible_cnt = strlen($possible) - 1;
 
         // add random characters to $password until $length is reached
-        for ($i = 0; $i < $length; $i++) {
+        for ($i = 0; $i < $length-2; $i++) {
+            $password .= substr($possible, mt_rand(0, $possible_cnt), 1);
+        }
+
+        if (strpbrk($password, $specialChars) === false) {
+            $password .= substr(
+                $specialChars,
+                mt_rand(0, strlen($specialChars)-1),
+                1
+            );
+        }
+
+        if (strpbrk($password, $numbers) === false) {
+            $password .= substr(
+                $numbers,
+                mt_rand(0, strlen($numbers)-1),
+                1
+            );
+        }
+
+        for ($i = strlen($password); $i < $length; $i++) {
             $password .= substr($possible, mt_rand(0, $possible_cnt), 1);
         }
 
@@ -364,10 +386,12 @@ class User extends UserPermissions
      * database.
      *
      * @param string $password The plain text password to be hashed and saved.
+     * @param string $expiry   The password expiry date. If not supplied, the
+     *                         password expiry date will be set to now+6months.
      *
      * @return none
      */
-    function updatePassword($password)
+    function updatePassword($password, $expiry = null)
     {
         // Check if the PHP 5.5 password hashing API is available.
         $php55 = false;
@@ -375,10 +399,12 @@ class User extends UserPermissions
             $php55 = true;
         }
 
-        $expiry = date(
-            'Y-m-d',
-            mktime(0, 0, 0, date('n') + 6, date('j'), date('Y'))
-        );
+        if (is_null($expiry)) {
+            $expiry = date(
+                'Y-m-d',
+                mktime(0, 0, 0, date('n') + 6, date('j'), date('Y'))
+            );
+        }
 
         $updateArray = array('Password_expiry' => $expiry);
 


### PR DESCRIPTION
- Fixed LorisForm bug when submitted value for a parameter was an array (i.e user account permissions)
- Fields on the user account page for which PHP's empty($field) returned true (as '0' or '000') were not submitted.
- PFixed HP warning when no supervisor was selected on user account page and page was submitted
- Max length for first and last names were not enforced on user account page.
- Password expiry date was not submitted properly when generating a new password.
- The password generated automatically by the system did not respect the requirements for a "strong" password.