### PR TITLE
remove script tag to get react.js from instrument_builder template

### DIFF
--- a/modules/instrument_builder/templates/form_instrument_builder.tpl
+++ b/modules/instrument_builder/templates/form_instrument_builder.tpl
@@ -1,7 +1,6 @@
 <meta charset="utf-8"/>
 <script type="text/javascript" src="GetJS.php?Module=instrument_builder&file=instrument_builder.instrument.js"></script>
 <script type="text/javascript" src="GetJS.php?Module=instrument_builder&file=instrument_builder.rules.js"></script>
-<script src="/js/react.js"></script>
 <script src="GetJS.php?Module=instrument_builder&file=react.elements.js"></script>
 <script src="GetJS.php?Module=instrument_builder&file=react.questions.js"></script>
 <script src="GetJS.php?Module=instrument_builder&file=react.instrument_builder.js"></script>


### PR DESCRIPTION
The react js files are called in the main.tpl so this shouldn't have been there