### PR TITLE
Database PEAR require_once

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -10,6 +10,8 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
+require_once 'PEAR.php';
+
 define("DEBUG", false);
 
 /**


### PR DESCRIPTION
Missing require_once('PEAR') in Database class.

request_account/process_new_account.php can't load without it.