### PR TITLE
Wait for C3 to be loaded before running dashboard JS

### DIFF
--- a/modules/dashboard/js/dashboard.js
+++ b/modules/dashboard/js/dashboard.js
@@ -1,4 +1,5 @@
 /*global document: false, $: false*/
+$(document).ready(function() {
 
 var scanLineChart, recruitmentPieChart, recruitmentBarChart, recruitmentLineChart;
 
@@ -267,4 +268,5 @@ $.ajax({
         console.log(xhr);
         console.log("Details: " + desc + "\nError:" + err);
     }
+});
 });


### PR DESCRIPTION
The javascript for the dashboard.js gets run immediately
upon loading. However, at the point that the test_name.js
is run the C3 library used by it has not been loaded yet.

This puts it in a jQuery document.ready() handler to ensure
that the C3 library is loaded before the JS is run.