### PR TITLE
Bvl feedback possible improvement

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1111,14 +1111,6 @@ class NDB_BVL_Feedback
                     $instruments_q = $DB->pselect(
                         "SELECT Count(*) FROM test_names WHERE Test_name=:testName",
                         array('testName' => $test_name)
-                    );
-                    error_log("message");
-                    error_log("message");
-                    error_log("message");
-                    error_log(print_r($instruments_q, true));
-                    error_log("message");
-                    error_log("message");
-                    error_log("message");
                     if ($instruments_q == 1) {
                         return true;
                     }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -327,7 +327,7 @@ class NDB_BVL_Feedback
      */
     static function getThreadColor($status)
     {
-        if (empty($status)) {
+        if (empty($statFeedbackPanelRowus)) {
             return '';
         }
 
@@ -1109,14 +1109,11 @@ class NDB_BVL_Feedback
                     $Factory       = NDB_Factory::singleton();
                     $DB            = $Factory->Database();
                     $instruments_q = $DB->pselect(
-                        "SELECT Test_name FROM test_names",
-                        array()
+                        "SELECT Test_name FROM test_names WHERE Test_name=:testName",
+                        array('testName' => $test_name)
                     );
-
-                    foreach ($instruments_q as $row) {
-                        if ($row['Test_name'] == $test_name) {
-                            return true;
-                        }
+                    if (sizeof($instruments_q) === 1) {
+                        return true;
                     }
                 }
             }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1111,6 +1111,7 @@ class NDB_BVL_Feedback
                     $instruments_q = $DB->pselect(
                         "SELECT Count(*) FROM test_names WHERE Test_name=:testName",
                         array('testName' => $test_name)
+                    );
                     if ($instruments_q == 1) {
                         return true;
                     }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -327,7 +327,7 @@ class NDB_BVL_Feedback
      */
     static function getThreadColor($status)
     {
-        if (empty($statFeedbackPanelRowus)) {
+        if (empty($status)) {
             return '';
         }
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1109,10 +1109,17 @@ class NDB_BVL_Feedback
                     $Factory       = NDB_Factory::singleton();
                     $DB            = $Factory->Database();
                     $instruments_q = $DB->pselect(
-                        "SELECT Test_name FROM test_names WHERE Test_name=:testName",
+                        "SELECT Count(*) FROM test_names WHERE Test_name=:testName",
                         array('testName' => $test_name)
                     );
-                    if (sizeof($instruments_q) === 1) {
+                    error_log("message");
+                    error_log("message");
+                    error_log("message");
+                    error_log(print_r($instruments_q, true));
+                    error_log("message");
+                    error_log("message");
+                    error_log("message");
+                    if ($instruments_q == 1) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Remove the unnecessary for loop to check if test_name exits in the test_names table. This can be done in a single query