### PR TITLE
Config module - removing baseurl variable from the template

### DIFF
--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -106,9 +106,9 @@
 {/function}
 
 <p>Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer's guide.</p>
-<p>To configure study subprojects <a href="{$baseurl}/main.php?test_name=configuration&subtest=subproject">click here</a>.
+<p>To configure study subprojects <a href="main.php?test_name=configuration&subtest=subproject">click here</a>.
 {if $useProjects == 'true'}
-    To configure study projects <a href="{$baseurl}/main.php?test_name=configuration&subtest=project">click here</a>.
+    To configure study projects <a href="main.php?test_name=configuration&subtest=project">click here</a>.
 {/if}
 </p>
 <br>

--- a/modules/configuration/templates/form_project.tpl
+++ b/modules/configuration/templates/form_project.tpl
@@ -1,7 +1,7 @@
 <script language="javascript" src="GetJS.php?Module=configuration&file=project.js">
 </script>
 <p>Use this page to manage the configuration of existing projects, or to add a new one.</p>
-<p>To configure study subprojects <a href="{$baseurl}/main.php?test_name=configuration&subtest=subproject">click here</a>.</p>
+<p>To configure study subprojects <a href="main.php?test_name=configuration&subtest=subproject">click here</a>.</p>
 
 <div class="col-md-3">
 <ul class="nav nav-pills nav-stacked" role="tablist" data-tabs="tabs">


### PR DESCRIPTION
Fix by removing the variable and the slash from the links in the template.
- This variable is empty
- The link is broken because of the preceding slash.

https://redmine.cbrain.mcgill.ca/issues/8352