### PR TITLE
include QuickForm

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -160,7 +160,7 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     static function factory($instrument, $commentID, $page, $guarantee_exists = true)
     {
-        //include_once 'HTML/QuickForm.php';
+        include_once 'HTML/QuickForm.php';
         $class = "NDB_BVL_Instrument_$instrument";
 
         // Make sure the instrument class has been included/required!


### PR DESCRIPTION
Uncomment the line in NDB_BVL_Instrument class so the Quickform was included. This was causing most php based instruments to not load because Quickform was never included. 