### PR TITLE
Fixed javascript error when 0 results found in DICOM archive

### DIFF
--- a/modules/dicom_archive/templates/menu_dicom_archive.tpl
+++ b/modules/dicom_archive/templates/menu_dicom_archive.tpl
@@ -13,8 +13,8 @@
     <script>
     var pageLinks = RPaginationLinks(
         {
-                    RowsPerPage : {$rowsPerPage},
-                    Total: {$numTimepoints},
+                    RowsPerPage : {$rowsPerPage|default:10},
+                    Total: {$numTimepoints|default:0},
                     onChangePage: function(pageNum) {
                         location.href="{$baseurl}/main.php?test_name=dicom_archive&pageID=" + pageNum
                     },


### PR DESCRIPTION
Provide default value in smarty template when no timepoints are found so that the javascript on the dicom archive module does not break.