### PR TITLE
Fix dicom filters

### DIFF
--- a/htdocs/js/components/FilterTable.js
+++ b/htdocs/js/components/FilterTable.js
@@ -59,9 +59,12 @@ FilterField = React.createClass({displayName: 'FilterField',
         if(this.props.Type === 'Dropdown') {
             var that = this;
             var options = Object.keys(this.props.Options).map(function (keyID) {
+                if (keyID === "") {
+                    return;
+                }
                 return React.createElement("option", {value: keyID}, that.props.Options[keyID]);
             });
-            options.unshift(React.createElement("option", null, "All"));
+            options.unshift(React.createElement("option", {value: ""}, "All"));
             item =  React.createElement("div", {className: "col-sm-12 col-md-8"}, 
                 React.createElement("select", {name: this.props.FormName, className: "form-control input-sm"}, 
                 options

--- a/jsx/FilterTable.js
+++ b/jsx/FilterTable.js
@@ -59,9 +59,12 @@ FilterField = React.createClass({
         if(this.props.Type === 'Dropdown') {
             var that = this;
             var options = Object.keys(this.props.Options).map(function (keyID) {
+                if (keyID === "") {
+                    return;
+                }
                 return <option value={keyID}>{that.props.Options[keyID]}</option>;
             });
-            options.unshift(<option>All</option>);
+            options.unshift(<option value="">All</option>);
             item =  <div className="col-sm-12 col-md-8">
                 <select name={this.props.FormName} className="form-control input-sm">
                 {options}

--- a/modules/dicom_archive/templates/menu_dicom_archive.tpl
+++ b/modules/dicom_archive/templates/menu_dicom_archive.tpl
@@ -13,8 +13,8 @@
     <script>
     var pageLinks = RPaginationLinks(
         {
-                    RowsPerPage : {$rowsPerPage},
-                    Total: {$numTimepoints},
+                    RowsPerPage : {$rowsPerPage|default:10},
+                    Total: {$numTimepoints|default:0},
                     onChangePage: function(pageNum) {
                         location.href="{$baseurl}/main.php?test_name=dicom_archive&pageID=" + pageNum
                     },


### PR DESCRIPTION
    Fix treatment of "All" option in filter tables
    
    The "All" option was not explicitly setting the value of the
    dropdown to be empty when constructing a dropdown in JSX, and
    as a result the form was submitting the value of the option
    (that is, the string "All"), which was causing filters to return
    no results since no CenterID matched "All".
    
    This makes it a little smarter about adding the "All" option to
    the start of the dropdown and explicitly sets the value to the
    empty string.
