### PR TITLE
Fix parameter type table geometric_distortion name

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -862,7 +862,7 @@ LOCK TABLES `parameter_type` WRITE;
 /*!40000 ALTER TABLE `parameter_type` DISABLE KEYS */;
 INSERT INTO `parameter_type` VALUES 
 	(1,'Selected','varchar(10)',NULL,NULL,NULL,NULL,NULL,NULL,NULL,0,0),
-	(2,'Geometric_intensity','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
+	(2,'Geometric_distortion','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
 	(3,'Intensity_artifact','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
 	(4,'Movement_artifacts_within_scan','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
 	(5,'Movement_artifacts_between_packets','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),

--- a/SQL/2015-10-13-GeometricDistortionFix.sql
+++ b/SQL/2015-10-13-GeometricDistortionFix.sql
@@ -1,0 +1,1 @@
+update parameter_type SET Name='Geometric_distortion' WHERE Name='Geometric_intensity';


### PR DESCRIPTION
The names of the feedback types were changed in
e229d93aa74ccad3f3472cb4f14177030910cd06 to "clarify" them,
however the parameter_type table was not updated to match
the new names. This results in the Geometric_distortion
dropdown not saving correctly, because it couldn't find it
in the parameter_type table where it was still Geometric_intensity