### PR TITLE
Link to mri violations caveat list was pointing to wrong place

### DIFF
--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -92,7 +92,7 @@
                                  {else}
                                  <div class="static-info">
                                  {if $files[file].Caveat}
-                                  <a href="main.php?test_name=mri_protocol_check_violations&SeriesUID={$files[file].SeriesUID}&filter=true">Caveat List</a>
+                                  <a href="main.php?test_name=mri_violations&submenu=mri_protocol_check_violations&SeriesUID={$files[file].SeriesUID}&filter=true">Caveat List</a>
                                  {else}No caveats{/if}
                                  </div>
                                  {/if}


### PR DESCRIPTION
The protocol check violations is in the mri_violations module, the
link was incorrectly pointing to the old module name