### PR TITLE
Imaging Browser Results=0 Bug7889

### DIFF
--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -178,6 +178,8 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         );
         $this->EqualityFilters = array('f.AcquisitionProtocolID');
         $this->searchKeyword    = array();
+        
+        $this->tpl_data['numTimepoints'] = 0;
     }
 
     /**


### PR DESCRIPTION
When there are no results, it says:
subject timepoint(s) selected.

Should say:
0 subject timepoint(s) selected.