### PR TITLE
Fixing menu filter sorting for filtered tables

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -221,7 +221,7 @@ class NDB_Menu_Filter extends NDB_Menu
             if (isset($values[$formKey])) {
                 // Call to form->getValue will apply all the form filters that
                 // will modify the submitted data
-                $filteredValue = $this->form->getValue($formKey, $values[$formKey]);
+                $filteredValue = $values[$formKey];
                 if ($filteredValue !== '') {
                     if (in_array($dbField, $this->validFilters)) {
                         $newFormFilters[$dbField] = $filteredValue;


### PR DESCRIPTION
@jstirling91 reported that the examiner menu filter was losing its filter when columns were sorted. That is, applying filters, and then clicking on column headers to sort caused all rows to be returned, not just the filtered rows. This appears to be the case for all menu filters currently. Also, if you refresh a page with filters applied, all rows appear upon refresh.

The bugs seems to have been introduced with @nicolasbrossard's pull request #1240 

This pull request fixes the issue with sorting and refreshing, but it might remove some functionality from the code that Nic introduced. @nicolasbrossard, do you think you could have a look at this? I'm not sure exactly what was trying to be accomplished with your pull request.

As far as I can tell, it is calling a function from LorisForm (getValue) to get the value for all of the filter form elements. However, this function doesn't seem to get any value when the "Submit" button on the form is not pressed explicitly, i.e., when you refresh the page or click on column headers. So it thinks there are no filters in these cases, and returns all the table rows.