### PR TITLE
Add confirm email text field when creating a new user

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -379,6 +379,12 @@ class NDB_Form_User_Accounts extends NDB_Form
         );
         unset($group);
 
+        // Add a confirm email text field only if creating a new user
+        // (to make sure that account creation email goes through)
+        if ($this->isCreatingNewUser()) {
+            $this->addBasicText('__ConfirmEmail', 'Confirm Email');
+        }
+
         //------------------------------------------------------------
 
         // get user permissions
@@ -737,6 +743,10 @@ class NDB_Form_User_Accounts extends NDB_Form
             $emailError = $this->_getEmailError($DB, $values['Email']);
             if (!is_null($emailError)) {
                 $errors['Email_Group'] = $emailError;
+            } elseif ($this->isCreatingNewUser()) {
+                if ($values['Email'] != $values['__ConfirmEmail']) {
+                    $errors['__ConfirmEmail'] = 'Email and confirmed email do not match'; 
+                }
             }
         } else {
             // No email entered: error

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -31,7 +31,7 @@ $(document).ready(function() {
 <form method="post" name="edit_user">
     {if $form.errors}
         <div class="alert alert-danger" role="alert">
-            Please ensure that all required fields are filled
+            The form you submitted contains data entry errors
         </div>
     {/if}
    <div class="panel panel-default">
@@ -270,6 +270,26 @@ $(document).ready(function() {
             </div>
         {/if}
     </div>
+    {if $form.__ConfirmEmail}
+    {if $form.errors.__ConfirmEmail}
+    <div class="row form-group form-inline form-inline has-error">
+    {else}
+    <div class="row form-group form-inline form-inline">
+    {/if}
+    	<label class="col-sm-2">
+    		{$form.__ConfirmEmail.label}
+    	</label>
+    	<div class="col-sm-10">
+    		{$form.__ConfirmEmail.html}
+    	</div>
+        {if $form.errors.__ConfirmEmail}
+            <div class="col-sm-offset-2 col-xs-12">
+                <font class="form-error">{$form.errors.__ConfirmEmail}</font>
+            </div>
+        {/if}
+    </div>
+    {/if}
+    <div 
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
     		{$form.CenterID.label}


### PR DESCRIPTION
When creating a new user, a confirm email text field will apprear on the user account page: this will hopefully minimize data entry errors for the email address and ensure that the account creation email is properly sent. Fix for Redmine ticket #8308.