### PR TITLE
Changed email templates - Bug8526 & Bug8524

### DIFF
--- a/smarty/templates/email/document_repository.tpl
+++ b/smarty/templates/email/document_repository.tpl
@@ -1,3 +1,7 @@
+Subject: [LORIS Study {$study}] Document Repository Changes 
+
+You are receiving this automated email because: 
+
 {if isset($newDocument)}
 New document named "{$document}" was added!
 Visit {$newDocument} to view the updates.
@@ -14,3 +18,7 @@ Visit {$deleteDocument} to view the updates.
 New category named "{$category}" was added!
 Visit {$newCategory} to view the updates.
 {/if}
+
+Thank you,
+
+LORIS Team

--- a/smarty/templates/email/permissions_change_notify_supervisor.tpl
+++ b/smarty/templates/email/permissions_change_notify_supervisor.tpl
@@ -1,4 +1,4 @@
-Subject: Permission Changes for {$realname} - {$study} - LORIS
+Subject: [LORIS Study {$study}] Permission Changes for {$realname}
 
 You are receiving this email because user {$current_user} has edited the permissions for {$realname} (username: {$username}).
 


### PR DESCRIPTION
When permission change emails are sent to a user, the email subject is:
"Permission Changes for Jabba Desilijic Tiure - LORIS Study Testing VM - LORIS‏"

It was made clearer by changing it to:
"[LORIS Study Testing VM] Permission Changes for Jabba Desilijic Tiure"

opt out logic will be added in next release.