### PR TITLE
Corrected so that the only valid values are 1 or 2. - Bug7988

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -61,7 +61,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         $user =& User::singleton();
 
         foreach ($values AS $key => $val) {
-            // The only valid values are 1, 2 or none.  Therefore we are only 
+            // The only valid values are 1, 2 or none.  Therefore we are only
             // allowing an update if 1 or 2 rather than different from none.
             if (($val == 1) || ($val == 2)) {
                 $hash = $key;

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -52,8 +52,6 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
      */
     function _process($values)
     {
-        print_r($values); // die();
-        
         if (!is_array($values) || count($values) == 0) {
             return true;
         }

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -61,7 +61,8 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         $user =& User::singleton();
 
         foreach ($values AS $key => $val) {
-            // The only valid values are 1, 2 or none.  Therefore we are only allowing an update if 1 or 2 rather than different from none.
+            // The only valid values are 1, 2 or none.  Therefore we are only 
+            // allowing an update if 1 or 2 rather than different from none.
             if (($val == 1) || ($val == 2)) {
                 $hash = $key;
                 $row  = $DB->pselectRow(

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -52,6 +52,8 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
      */
     function _process($values)
     {
+        print_r($values); // die();
+        
         if (!is_array($values) || count($values) == 0) {
             return true;
         }
@@ -61,7 +63,8 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         $user =& User::singleton();
 
         foreach ($values AS $key => $val) {
-            if ($val != 'none') {
+            // The only valid values are 1, 2 or none.  Therefore we are only allowing an update if 1 or 2 rather than different from none.
+            if (($val == 1) || ($val == 2)) {
                 $hash = $key;
                 $row  = $DB->pselectRow(
                     "SELECT cr.ConflictID, cr.TableName, cr.ExtraKeyColumn,


### PR DESCRIPTION
Prevents unresolved conflicts from being resolve by submitting empty IDs 