### PR TITLE
Adding tpl_data[baseurl] to From class

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -90,6 +90,11 @@ class NDB_Form extends NDB_Page
             throw new Exception("Form does not exist: $name $page", 404);
         }
 
+        //set the baseurl of the tpl_data
+        $config =& NDB_Config::singleton();
+        $www    = $config->getSetting('www');
+        $obj->tpl_data['baseurl'] = $www['url'];
+
         return $obj;
     }
 


### PR DESCRIPTION
To fix the broken links in Configuration module, candidate list, DICOM archive, data dictionary and server process manager. (all the templates where $baseurl is used. 

tpl_data[baseurl] variable wasn't defined in NDB_Form class. 
This was causing problems in the templates populated by those objects.