### PR TITLE
Fix to improve LorisForm security

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -433,13 +433,16 @@ class NDB_Form_User_Accounts extends NDB_Form
                     . "style=\"text-align: center; margin-top: 5px;\">"
                     .ucwords($row['type'])
                     . '</h3>'
-                    . "<div id=\"perms_$lastRole\" style=\"margin-top: 5px;\">"
+                    . "<div id=\"perms_$lastRole\" style=\"margin-top: 5px;\">",
+                    array(),
+                    false
                 );
             }
             $group[] = $this->createCheckbox(
                 'permID['.$row['permID'].']',
-                "$row[description]<br>",
-                array("class" => "perm_$lastRole")
+                htmlspecialchars($row[description]) . "<br>",
+                array("class" => "perm_$lastRole"),
+                false
             );
         }
         $this->addGroup($group, 'PermID_Group', 'Permissions', "", false);
@@ -465,13 +468,17 @@ class NDB_Form_User_Accounts extends NDB_Form
             . "<h3 id=\"header_supervisors\" class=\"perm_header button\" "
             . "style=\"text-align: center; margin-top: 5px;\"> "
             . "Data Supervisors to Email </h3> "
-            . "<div id=\"perms_supervisors\" style=\"margin-top: 5px;\">"
+            . "<div id=\"perms_supervisors\" style=\"margin-top: 5px;\">",
+            array(),
+            false
         );
 
         foreach ($results as $row) {
             $group[] = $this->createCheckbox(
-                'supervisorEmail['.$row['email'].']',
-                "$row[Real_Name]<br>"
+                'supervisorEmail['. htmlspecialchars($row['email']) .']',
+                "$row[Real_Name]<br>",
+                array(),
+                false
             );
         }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -44,18 +44,24 @@ class LorisForm
      * things specific to one type of element X should go in
      * the createX function.
      *
-     * @param string $name    The form name of the element being added
-     * @param string $label   The label to attach to the GUI in the form
-     * @param array  $attribs An array of extra HTML attributes to be
-     *                        added to this element.
+     * @param string $name       The form name of the element being added
+     * @param string $label      The label to attach to the GUI in the form
+     * @param array  $attribs    An array of extra HTML attributes to be
+     *                           added to this element.
+     * @param bool   $toEntities Whether all HTML special characters should
+     *                           be converted to HTML entities when obtaining
+     *                           the HTML representation for this element. The
+     *                           way the conversion takes place is dependant on
+     *                           the type of the element.
      *
      * @return array describing the form element
      */
-    protected function &createBase($name, $label, $attribs=array())
+    protected function &createBase($name, $label, $attribs=array(), $toEntities=true)
     {
         $el = array(
-               'label' => $label,
-               'name'  => $name,
+               'label'      => $label,
+               'name'       => $name,
+               'toEntities' => $toEntities,
               );
         if (isset($attribs['class'])) {
             $el['class'] = $attribs['class'];
@@ -80,17 +86,22 @@ class LorisForm
      * of any shared attributes that are shared between different
      * element types.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $attribs An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $attribs    An array of other attributes that should
+     *                           get added. Currently only the "class"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters should
+     *                           be converted to HTML entities when obtaining
+     *                           the HTML representation for this element. The
+     *                           way the conversion is performed is dependant on
+     *                           the type of the element.
      *
      * @return &array A reference to the array that was added to $this->form
      */
-    protected function &addBase($name, $label, $attribs)
+    protected function &addBase($name, $label, $attribs, $toEntities=true)
     {
-        $el = $this->createBase($name, $label, $attribs);
+        $el = $this->createBase($name, $label, $attribs, $toEntities);
         $this->form[$name] =& $el;
         return $el;
     }
@@ -98,19 +109,28 @@ class LorisForm
     /**
      * Reimplementation of HTML_QuickForm's "addSelect" API.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of the options (values) to add
-     *                        to this select dropdown.
-     * @param array  $attribs An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of the options (values) to add
+     *                           to this select dropdown.
+     * @param array  $attribs    An array of other attributes that should
+     *                           get added. Currently only the "class"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    public function addSelect($name, $label, $options, $attribs = array())
-    {
-        $el            =& $this->addBase($name, $label, $attribs);
+    public function addSelect(
+        $name,
+        $label,
+        $options,
+        $attribs = array(),
+        $toEntities=true
+    ) {
+        $el            =& $this->addBase($name, $label, $attribs, $toEntities);
         $el['type']    = 'select';
         $el['options'] = $options;
         if (isset($attribs['multiple'])) {
@@ -124,66 +144,82 @@ class LorisForm
      *
      * Reimplementation of HTML_QuickForm's "addStatic" API.
      *
-     * @param string $name  The element name.
-     * @param string $label The label to attach to this element.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, but modifies $this->form as a side-effect
      */
-    public function addStatic($name, $label)
+    public function addStatic($name, $label, $toEntities=true)
     {
-        $el         =& $this->addBase($name, $label, array());
+        $el         =& $this->addBase($name, $label, array(), $toEntities);
         $el['type'] = 'static';
     }
 
     /**
      * Reimplementation of HTML_QuickForm's "addPassword" API.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of other attributes that should
+     *                           get added. Currently only the "class"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    public function addPassword($name, $label, $options=array())
+    public function addPassword($name, $label, $options=array(), $toEntities=true)
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $options, $toEntities);
         $el['type'] = 'password';
     }
 
     /**
      * Reimplementation of HTML_QuickForm's "addText" API.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of other attributes that should
+     *                           get added. Currently only the "class"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    public function addText($name, $label, $options=array())
+    public function addText($name, $label, $options=array(), $toEntities=true)
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $options, $toEntities);
         $el['type'] = 'text';
     }
 
     /**
      * Reimplementation of HTML_QuickForm's "addTextArea" API.
      *
-     * @param string $elname  The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class",
-     *                        "rows", and "cols" attributes will get
-     *                        added.
+     * @param string $elname     The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of other attributes that should
+     *                           get added. Currently only the "class",
+     *                           "rows", and "cols" attributes will get
+     *                           added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    public function addTextArea($elname, $label, $options=array())
+    public function addTextArea($elname, $label, $options=array(), $toEntities=true)
     {
-        $el         =& $this->addBase($elname, $label, $options);
+        $el         =& $this->addBase($elname, $label, $options, $toEntities);
         $el['type'] = 'textarea';
         if (isset($options['cols'])) {
             $el['cols'] = $options['cols'];
@@ -199,19 +235,28 @@ class LorisForm
      * HTML5 input type="date" element, while QuickForm added three dropdowns
      * for year/month/day.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of options that should get added,
-     *                        such as the date format, min or max date etc.
-     * @param array  $attribs An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of options that should get added,
+     *                           such as the date format, min or max date etc.
+     * @param array  $attribs    An array of other attributes that should
+     *                           get added. Currently only the "class"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    public function addDate($name, $label, $options, $attribs = array())
-    {
-        $el            =& $this->addBase($name, $label, $attribs);
+    public function addDate(
+        $name,
+        $label,
+        $options,
+        $attribs = array(),
+        $toEntities=true
+    ) {
+        $el            =& $this->addBase($name, $label, $attribs, $toEntities);
         $el['type']    = 'date';
         $el['options'] = $options;
     }
@@ -219,51 +264,63 @@ class LorisForm
     /**
      * Adds a file to the current form.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of other attributes that should
+     *                           get added. Currently only the "class"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    function addFile($name, $label, $options)
+    function addFile($name, $label, $options, $toEntities=true)
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $options, $toEntities);
         $el['type'] = 'file';
     }
 
     /**
      * Adds a checkobox to the current form.
      *
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "value"
-     *                        attribute gets added.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of other attributes that should
+     *                           get added. Currently only the "value"
+     *                           attribute gets added.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, modifies $this->form as a side-effect.
      */
-    function addCheckbox($name, $label, $options)
+    function addCheckbox($name, $label, $options, $toEntities=true)
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $options, $toEntities);
         $el['type'] = 'advcheckbox';
     }
 
     /**
      * Adds a header element to this LorisForm.
      *
-     * @param string $name    The name of the header element, may be null
-     * @param string $label   The description for the header
-     * @param array  $options Other options for this header element
+     * @param string $name       The name of the header element, may be null
+     * @param string $label      The description for the header
+     * @param array  $options    Other options for this header element
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none
      */
-    function addHeader($name, $label, $options = array())
+    function addHeader($name, $label, $options = array(), $toEntities=true)
     {
         $name = $this->_generateName($name);
 
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $options, $toEntities);
         $el['type'] = 'header';
     }
     /**
@@ -288,17 +345,21 @@ class LorisForm
      * calls the appropriate $this->addX wrapper based on the "type"
      * passed to the function call.
      *
-     * @param string $type    The type of element to add.
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other options that should
-     *                        be added. This generalls maps to the
-     *                        third option of the addX wrapper.
-     * @param array  $attribs Other attributes to be added. This is
-     *                        mostly only used for the "select" type,
-     *                        where "options" has a different meaning
-     *                        and attribs takes the place of what "options"
-     *                        is for other types.
+     * @param string $type       The type of element to add.
+     * @param string $name       The element name.
+     * @param string $label      The label to attach to this element.
+     * @param array  $options    An array of other options that should
+     *                           be added. This generalls maps to the
+     *                           third option of the addX wrapper.
+     * @param array  $attribs    Other attributes to be added. This is
+     *                           mostly only used for the "select" type,
+     *                           where "options" has a different meaning
+     *                           and attribs takes the place of what "options"
+     *                           is for other types.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none, but modifies this->form as a side-effect
      */
@@ -307,37 +368,38 @@ class LorisForm
         $name,
         $label,
         $options=array(),
-        $attribs=array()
+        $attribs=array(),
+        $toEntities=true
     ) {
         $el = null;
         switch($type)  {
         case 'select':
-            $el = $this->addSelect($name, $label, $options, $attribs);
+            $el = $this->addSelect($name, $label, $options, $attribs, $toEntities);
             break;
         case 'date':
-            $el = $this->addDate($name, $label, $options, $attribs);
+            $el = $this->addDate($name, $label, $options, $attribs, $toEntities);
             break;
         case 'file':
-            $el = $this->addFile($name, $label, $options);
+            $el = $this->addFile($name, $label, $options, $toEntities);
             break;
         case 'static':
-            $el = $this->addStatic($name, $label);
+            $el = $this->addStatic($name, $label, $toEntities);
             break;
         case 'textarea':
-            $el = $this->addTextArea($name, $label, $options);
+            $el = $this->addTextArea($name, $label, $options, $toEntities);
             break;
         case 'password':
-            $el = $this->addPassword($name, $label, $options);
+            $el = $this->addPassword($name, $label, $options, $toEntities);
             break;
         case 'header':
-            $el = $this->addHeader($name, $label);
+            $el = $this->addHeader($name, $label, $toEntities);
             break;
         case 'advcheckbox':
-            $el = $this->addCheckbox($name, $label, $options);
+            $el = $this->addCheckbox($name, $label, $options, $toEntities);
             break;
         case 'text':
         default:
-            $el = $this->addText($name, $label, $options);
+            $el = $this->addText($name, $label, $options, $toEntities);
             break;
         }
     }
@@ -348,18 +410,22 @@ class LorisForm
      * Creates a text element that can be added to the page but
      * does not itself add the element.
      *
-     * @param string $elname  The name of the element to be added to
-     *                        the form
-     * @param string $label   The name of the label to attach to the
-     *                        form
-     * @param array  $attribs An array of extra HTML attributes to be
-     *                        added to this element.
+     * @param string $elname     The name of the element to be added to
+     *                           the form
+     * @param string $label      The name of the label to attach to the
+     *                           form
+     * @param array  $attribs    An array of extra HTML attributes to be
+     *                           added to this element.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return array of the form that can be added to $this->form
      */
-    function createText($elname, $label, $attribs = array())
+    function createText($elname, $label, $attribs = array(), $toEntities=true)
     {
-        $el         =& $this->createBase($elname, $label, $attribs);
+        $el         =& $this->createBase($elname, $label, $attribs, $toEntities);
         $el['type'] = 'text';
         return $el;
     }
@@ -370,16 +436,20 @@ class LorisForm
      * Creates a text element that can be added to the page but
      * does not itself add the element.
      *
-     * @param string $elname The name of the element to be added to
-     *                       the form
-     * @param string $label  The name of the label to attach to the
-     *                       form
+     * @param string $elname     The name of the element to be added to
+     *                           the form
+     * @param string $label      The name of the label to attach to the
+     *                           form
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return array of the form that can be added to $this->form
      */
-    function createTextArea($elname, $label)
+    function createTextArea($elname, $label, $toEntities=true)
     {
-        $el         =& $this->createBase($elname, $label);
+        $el         =& $this->createBase($elname, $label, $toEntities);
         $el['type'] = 'textarea';
         return $el;
     }
@@ -566,8 +636,10 @@ class LorisForm
                 $selected = 'selected="selected"';
             }
 
-            $strOptions .= "<option value='$optionKey' $selected>"
-                .$optionVal
+            $strOptions .= "<option value='"
+                . $this->_getHtml($optionKey, $el['toEntities'])
+                . "' $selected>"
+                . $this->_getHtml($optionVal, $el['toEntities'])
                 . "</option>";
         }
 
@@ -580,7 +652,9 @@ class LorisForm
         if (isset($el['multiple'])) {
             $multiple = "multiple=\"multiple\"";
         }
-        $retVal = "<select name=\"$el[name]\" $cls $changehandler $multiple";
+        $retVal = "<select name=\""
+            . $this->_getHtml($el['name'], $el['toEntities'])
+            . "\" $cls $changehandler $multiple";
         if (isset($el['required']) && $el['required']) {
             $retVal .= ' required';
             if ($el['requireMsg']) {
@@ -596,6 +670,21 @@ class LorisForm
     }
 
     /**
+     * Gets the HTML representation associated with the value passed as
+     * argument.
+     *
+     * @param string $value      the value to write in HTML.
+     * @param bool   $toEntities whether special HTML characters should
+     *                           be converted to HTML entities during
+     *                           the conversion.
+     *
+     * @return string HTML text for the supplied value.
+     */
+    private function _getHtml($value, $toEntities=true)
+    {
+        return $toEntities ? htmlspecialchars($value) : $value;
+    }
+    /**
      * Generates the HTML to add to the page when rendered for a static
      * element.
      *
@@ -606,9 +695,9 @@ class LorisForm
     function staticHTML($el)
     {
         if (empty($el['name'])) {
-            return $el['label'];
+            return $this->_getHtml($el['label'], $el['toEntities']);
         }
-        $val = $this->getValue($el['name']);
+        $val = $this->_getHtml($this->getValue($el['name'], $el['toEntities']));
 
         return $val;
     }
@@ -636,13 +725,15 @@ class LorisForm
         }
         $msg      = isset($el['requireMsg']) ? $el['requireMsg'] : 'Required';
         $required = isset($el['required']) ? "this.value === '' ? '$msg' : ''" : '';
-        $value    = $this->getValue($el['name']);
-        $elmnt    = "<input name=\"$el[name]\" type=\"date\" $cls $minYear $maxYear"
+        $value    = $this->_getHtml($this->getValue($el['name']), $el['toEntities']);
+        $elmnt    = "<input name=\""
+            . $this->_getHtml($el['name'], $el['toEntities'])
+            . "\" type=\"date\" $cls $minYear $maxYear"
             . "onChange=\"this.setCustomValidity($required)\""
             . (isset($el['required']) ? "required" : '')
             . (
             !empty($value)
-                ? ' value="' . $this->getValue($el['name']) . '" '
+                ? ' value="' . $value . '" '
                 : ''
             )
             . ">";
@@ -711,7 +802,7 @@ class LorisForm
               )
             . (
                 !empty($value)
-                ? ' value="' . $this->getValue($el['name']) . '"'
+                ? ' value="' . $this->_getHtml($value, $el['toEntities']) . '"'
                 : ''
               )
             .">";
@@ -728,11 +819,13 @@ class LorisForm
     function fileHTML($el)
     {
         $cls = '';
-        $val = $this->getValue($el['name']);
+        $val = $this->_getHtml($this->getValue($el['name']), $el['toEntities']);
         if (isset($el['class'])) {
             $cls = "class=\"$el[class]\"";
         }
-        return "<input name=\"$el[name]\" type=\"file\" $cls"
+        return "<input name=\""
+            . $this->_getHtml($el['name'], $el['toEntities'])
+            . "\" type=\"file\" $cls"
             . (
                 !empty($val)
                 ? ' value="' . $val . '"'
@@ -763,11 +856,13 @@ class LorisForm
         if (isset($el['cols'])) {
             $dims .= " cols=\"$el[cols]\"";
         }
-        $value = $this->getValue($el['name']);
-        return "<textarea name=\"$el[name]\" $cls $dims>"
+        $value = $this->_getHtml($this->getValue($el['name']), $el['toEntities']);
+        return "<textarea name=\""
+            . $this->_getHtml($el['name'], $el['toEntities'])
+            . "\" $cls $dims>"
             . (
                 !empty($value)
-                ? $this->getValue($el['name']) : ''
+                ? $value : ''
               )
             ."</textarea>";
     }
@@ -950,7 +1045,7 @@ class LorisForm
      */
     function headerHTML($el)
     {
-        return "<h2>$el[label]</h2>";
+        return "<h2>" . $this->_getHtml($el['label'], $el['toEntities']) . "</h2>";
     }
 
     /**
@@ -963,18 +1058,23 @@ class LorisForm
      */
     function checkboxHTML($el)
     {
-        $val     = $this->getValue($el['name']);
+        $val     = $this->_getHtml($this->getValue($el['name'], $el['toEntities']));
         $checked = '';
         $value   = '';
         if (!empty($val)) {
             $checked = 'checked="checked"';
         }
         if (isset($el['value'])) {
-            $value = "value=\"$el[value]\"";
+            $value = "value=\""
+                . $this->_getHtml($el['value'], $el['toEntities'])
+                . "\"";
         }
-        return "<input name=\"$el[name]\" type=\"checkbox\" $checked $value/>"
-            . " $el[label]";
+        return "<input name=\""
+            . $this->_getHtml($el['name'], $el['toEntities'])
+            . "\" type=\"checkbox\" $checked $value/> "
+            . $this->_getHtml($el['label'], $el['toEntities']);
     }
+
     /**
      * This is a slight difference from the HTML_QuickForm API.
      * Whereas in HTML_QuickForm, you instantiated an array renderer,
@@ -1184,35 +1284,62 @@ class LorisForm
      *
      * Creates an element without adding it to the form.
      *
-     * @param string $type    The type of element to be created.
-     * @param string $elname  The name of the element to be added
-     * @param string $label   The label to attach to the element
-     * @param array  $options Element specific options to pass
-     *                        to create* wrappers
-     * @param array  $attribs An array of extra HTML attributes to
-     *                        add to the element.
+     * @param string $type       The type of element to be created.
+     * @param string $elname     The name of the element to be added
+     * @param string $label      The label to attach to the element
+     * @param array  $options    Element specific options to pass
+     *                           to create* wrappers
+     * @param array  $attribs    An array of extra HTML attributes to
+     *                           add to the element.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return array of the form supported by $this->form
      */
-    function createElement($type, $elname, $label, $options, $attribs=array())
-    {
+    function createElement(
+        $type,
+        $elname,
+        $label,
+        $options,
+        $attribs=array(),
+        $toEntities=true
+    ) {
         switch($type) {
         case 'text':
-            return $this->createText($elname, $label, $options, $attribs);
+            return $this->createText(
+                $elname,
+                $label,
+                $options,
+                $attribs,
+                $toEntities
+            );
         case 'select':
-            return $this->createSelect($elname, $label, $options, $attribs);
+            return $this->createSelect(
+                $elname,
+                $label,
+                $options,
+                $attribs,
+                $toEntities
+            );
         case 'static':
             /* Label seems to usually be the wrong attribute for static
              * elements?
              */
-            $el         = $this->createBase($elname, $options, $attribs);
+            $el         = $this->createBase(
+                $elname,
+                $options,
+                $attribs,
+                $toEntities
+            );
             $el['type'] = 'static';
             break;
         case 'advcheckbox':
         case 'textarea':
         case 'date':
         case 'password':
-            $el         = $this->createBase($elname, $label, $options);
+            $el         = $this->createBase($elname, $label, $options, $toEntities);
             $el['type'] = $type;
             break;
         default:
@@ -1224,18 +1351,27 @@ class LorisForm
     /**
      * Creates a select element but does not add it to the page.
      *
-     * @param string $name    The name of the element to be added
-     * @param string $label   The label to attach to the element
-     * @param array  $options Array of options to add to the select
-     *                        dropdown.
-     * @param array  $attribs An array of extra HTML attributes to
-     *                        add to the element.
+     * @param string $name       The name of the element to be added
+     * @param string $label      The label to attach to the element
+     * @param array  $options    Array of options to add to the select
+     *                           dropdown.
+     * @param array  $attribs    An array of extra HTML attributes to
+     *                           add to the element.
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return array of the form supported by $this->form
      */
-    public function createSelect($name, $label, $options, $attribs = array())
-    {
-        $el            =& $this->createBase($name, $label, $attribs);
+    public function createSelect(
+        $name,
+        $label,
+        $options,
+        $attribs = array(),
+        $toEntities=true
+    ) {
+        $el            =& $this->createBase($name, $label, $attribs, $toEntities);
         $el['type']    = 'select';
         $el['options'] = $options;
         if (isset($attribs['multiple'])) {

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -80,77 +80,102 @@ class NDB_Page
     /**
      * Wrapper to create a file element and add it to the current page
      *
-     * @param string $name  The name of this file element
-     * @param string $label The label to attach to this element
+     * @param string $name       The name of this file element
+     * @param string $label      The label to attach to this element
+     * @param bool   $toEntities Whether all HTML special characters in $name and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
-    function addFile($name, $label)
+    function addFile($name, $label, $toEntities=true)
     {
         $this->form->addElement(
             'file',
             $name,
             $label,
-            array('class' => 'fileUpload')
+            array('class' => 'fileUpload'),
+            $toEntities
         );
     }
 
     /**
      * Wrapper to create a header
      *
-     * @param string $header The text to put in the header
+     * @param string $header     The text to put in the header
+     * @param bool   $toEntities Whether all HTML special characters in the header
+     *                           text should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
-    function addHeader($header)
+    function addHeader($header, $toEntities=true)
     {
-        $this->form->addElement('header', null, $header);
+        $this->form->addElement('header', null, $header, $toEntities);
     }
 
     /**
      * Wrapper to create a select drop-down list
      *
-     * @param string $name     The field name of this select dropdown
-     * @param string $label    The label to attach to this dropdown
-     * @param array  $options  Options to pass to QuickForm for this
-     *                         select
-     * @param array  $optional Optional extra HTML attributes to add
-     *                         to the select
+     * @param string $name       The field name of this select dropdown
+     * @param string $label      The label to attach to this dropdown
+     * @param array  $options    Options to pass to QuickForm for this
+     *                           select
+     * @param array  $optional   Optional extra HTML attributes to add
+     *                           to the select
+     * @param bool   $toEntities Whether all HTML special characters in $name, $label
+     *                           and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return none
      */
-    function addSelect($name, $label, $options, $optional=array())
+    function addSelect($name, $label, $options, $optional=array(), $toEntities=true)
     {
         $optional = array_merge(
             array('class' => 'form-control input-sm'),
             $optional
         );
-        $this->form->addElement('select', $name, $label, $options, $optional);
+        $this->form->addElement(
+            'select',
+            $name,
+            $label,
+            $options,
+            $optional,
+            $toEntities
+        );
     }
 
     /**
      * Wrapper to create a static label to the current page
      *
-     * @param string $label The text to add to the label.
+     * @param string $label      The text to add to the label.
+     * @param bool   $toEntities Whether all HTML special characters in $label
+     *                           should be converted to HTML entities when obtaining
+     *                           the HTML representation for this element.
      *
      * @return none
      */
-    function addLabel($label)
+    function addLabel($label, $toEntities)
     {
-        $this->form->addElement('static', null, $label);
+        $this->form->addElement('static', null, $label, $toEntities);
     }
 
     /**
      * Wrapper to create a static score column
      *
-     * @param string $name  The name of the score column
-     * @param string $label Label to attach to the score
+     * @param string $name       The name of the score column
+     * @param string $label      Label to attach to the score
+     * @param bool   $toEntities Whether all HTML special characters in $name
+     *                           and $label should be converted to HTML
+     *                           entities when obtaining the HTML representation
+     *                           for this element.
      *
      * @return none
      */
-    function addScoreColumn($name, $label)
+    function addScoreColumn($name, $label, $toEntities=true)
     {
-        $this->form->addElement('static', $name, $label);
+        $this->form->addElement('static', $name, $label, $toEntities);
     }
 
 
@@ -158,16 +183,19 @@ class NDB_Page
      * Adds a text element to the current page with no accompanying
      * not answered option
      *
-     * @param string $field   The name of the text element to add
-     * @param string $label   Label to attach to the text element
-     * @param array  $options QuickForm options to pass to addElement
+     * @param string $field      The name of the text element to add
+     * @param string $label      Label to attach to the text element
+     * @param array  $options    QuickForm options to pass to addElement
+     * @param bool   $toEntities Whether all HTML special characters in $name and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
-    function addBasicText($field, $label, $options=array())
+    function addBasicText($field, $label, $options=array(), $toEntities=true)
     {
         $options = array_merge(array('class' => 'form-control input-sm'), $options);
-        $this->form->addElement('text', $field, $label, $options);
+        $this->form->addElement('text', $field, $label, $options, $toEntities);
     }
 
     /**
@@ -177,29 +205,43 @@ class NDB_Page
      * @param string $field          The name of the text area to add
      * @param string $label          Label to attach to the text area field
      * @param array  $specifications Extra HTML options to add to the textarea
+     * @param bool   $toEntities     Whether all HTML special characters in $name
+     *                               and $label should be converted to HTML entities
+     *                               when obtaining the HTML representation for this
+     *                               element.
      *
      * @return none
      */
     function addBasicTextArea(
         $field,
         $label,
-        $specifications=array()
+        $specifications=array(),
+        $toEntities=true
     ) {
         $specifications = array_merge(
             array('class' => 'form-control input-sm'),
             $specifications
         );
-        $this->form->addElement('textarea', $field, $label, $specifications);
+        $this->form->addElement(
+            'textarea',
+            $field,
+            $label,
+            $specifications,
+            $toEntities
+        );
     }
 
     /**
      * Adds a date field (without an accompanying not answered option) to the
      * current page.
      *
-     * @param string $field   The name of the date field
-     * @param string $label   Label to attach to the date field in the frontend
-     * @param array  $options Options to pass to HTML_QuickForm
-     * @param array  $attr    Extra HTML attributes to add to the date group.
+     * @param string $field      The name of the date field
+     * @param string $label      Label to attach to the date field in the frontend
+     * @param array  $options    Options to pass to HTML_QuickForm
+     * @param array  $attr       Extra HTML attributes to add to the date group.
+     * @param bool   $toEntities Whether all HTML special characters in $name and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
@@ -210,30 +252,53 @@ class NDB_Page
         $attr=array(
                'class' => 'form-control input-sm',
                'style' => 'max-width:33%; display:inline-block;',
-              )
+              ),
+        $toEntities=true
     ) {
-        $this->form->addElement('date', $field, $label, $options, $attr);
+        $this->form->addElement(
+            'date',
+            $field,
+            $label,
+            $options,
+            $attr,
+            $toEntities
+        );
     }
 
     /**
      * Wrapper to create a checkbox
      *
-     * @param string $name     The field name of this checkbox
-     * @param string $label    The label to attach to this checkbox
-     * @param array  $options  Options to pass to QuickForm for this
-     *                         checkbox
-     * @param array  $optional Optional extra HTML attributes to add
-     *                         to the checkbox
+     * @param string $name       The field name of this checkbox
+     * @param string $label      The label to attach to this checkbox
+     * @param array  $options    Options to pass to QuickForm for this
+     *                           checkbox
+     * @param array  $optional   Optional extra HTML attributes to add
+     *                           to the checkbox
+     * @param bool   $toEntities Whether all HTML special characters in $name and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
-    function addCheckbox($name, $label, $options, $optional=array())
-    {
+    function addCheckbox(
+        $name,
+        $label,
+        $options,
+        $optional=array(),
+        $toEntities=true
+    ) {
         $optional = array_merge(
             array('class' => 'form-control input-sm'),
             $optional
         );
-        $this->form->addElement('advcheckbox', $name, $label, $options, $optional);
+        $this->form->addElement(
+            'advcheckbox',
+            $name,
+            $label,
+            $options,
+            $optional,
+            $toEntities
+        );
     }
 
     /**
@@ -243,12 +308,15 @@ class NDB_Page
      * @param string $label      The label to attach to the element
      * @param array  $attributes List of HTML attributes to add to the
      *                           element
+     * @param bool   $toEntities Whether all HTML special characters in $label
+     *                           should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
-    function addHidden($label, $attributes=null)
+    function addHidden($label, $attributes=null, $toEntities=true)
     {
-        $this->form->addElement('hidden', $label, $attributes);
+        $this->form->addElement('hidden', $label, $attributes, $toEntities);
     }
 
     /**
@@ -259,6 +327,10 @@ class NDB_Page
      * @param string $label                The label to attach to this field
      * @param array  $not_answered_options List of options to use in the "_status"
      *                                     dropdown.
+     * @param bool   $toEntities           Whether all HTML special characters in
+     *                                     $field and $label should be converted to
+     *                                     HTML entities when obtaining the HTML
+     *                                     representation for this element.
      *
      * @return none
      */
@@ -268,15 +340,17 @@ class NDB_Page
         $not_answered_options=array(
                                ''             => '',
                                'not_answered' => 'Not Answered',
-                              )
+                              ),
+        $toEntities=true
     ) {
         $group   = array();
-        $group[] = $this->createTextArea($field, '');
+        $group[] = $this->createTextArea($field, '', $toEntities);
         $group[] = $this->createSelect(
             $field . '_status',
             '',
             $not_answered_options,
-            array('class' => 'form-control input-sm not-answered')
+            array('class' => 'form-control input-sm not-answered'),
+            $toEntities
         );
 
         $this->addGroup($group, $field . '_group', $label, null, false);
@@ -286,18 +360,22 @@ class NDB_Page
     /**
      * Creates a password element and adds it to the current form.
      *
-     * @param string $field The name of the password field to add
-     * @param string $label The label to attach to this element
-     * @param array  $attr  List of extra HTML attributes to add to the element
+     * @param string $field      The name of the password field to add
+     * @param string $label      The label to attach to this element
+     * @param array  $attr       List of extra HTML attributes to add to the element
+     * @param bool   $toEntities Whether all HTML special characters in $field and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return none
      */
     function addPassword(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=array('class' => 'form-control input-sm'),
+        $toEntities=true
     ) {
-        $this->form->addElement('password', $field, $label, $attr);
+        $this->form->addElement('password', $field, $label, $attr, $toEntities);
     }
 
     /**
@@ -351,10 +429,14 @@ class NDB_Page
     /**
      * Creates a QuickForm Select dropdown but does not add it to the page
      *
-     * @param string $field   The field name for this select
-     * @param string $label   The label to attach to the element
-     * @param array  $options Extra options to pass to QuickForm
-     * @param array  $attr    Extra HTML attributes to add to the element
+     * @param string $field      The field name for this select
+     * @param string $label      The label to attach to the element
+     * @param array  $options    Extra options to pass to QuickForm
+     * @param array  $attr       Extra HTML attributes to add to the element
+     * @param bool   $toEntities Whether all HTML special characters in $field,
+     *                           $label and all $options should be converted to HTML
+     *                           entities when obtaining the HTML representation for
+     *                           this element.
      *
      * @return HTML_QuickForm select element
      */
@@ -362,43 +444,65 @@ class NDB_Page
         $field,
         $label,
         $options=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=array('class' => 'form-control input-sm'),
+        $toEntities=true
     ) {
-        return $this->form->createElement("select", $field, $label, $options, $attr);
+        return $this->form->createElement(
+            "select",
+            $field,
+            $label,
+            $options,
+            $attr,
+            $toEntities
+        );
     }
 
     /**
      * Creates a QuickForm text element but does not add it to the form
      *
-     * @param string $field The field name for this text element
-     * @param string $label The label to attach to the element
-     * @param array  $attr  Extra HTML attributes to add to the element
+     * @param string $field      The field name for this text element
+     * @param string $label      The label to attach to the element
+     * @param array  $attr       Extra HTML attributes to add to the element
+     * @param bool   $toEntities Whether all HTML special characters in $field and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return HTML_QuickForm Text element
      */
     function createText(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=array('class' => 'form-control input-sm'),
+        $toEntities=true
     ) {
-        return $this->form->createElement("text", $field, $label, $attr);
+        return $this->form->createElement(
+            "text",
+            $field,
+            $label,
+            $attr,
+            $toEntities
+        );
     }
 
     /**
      * Creates a QuickForm TextArea element but does not add it to the form.
      *
-     * @param string $field The field name for the TextArea
-     * @param string $label The label to attach to this TextArea
+     * @param string $field      The field name for the TextArea
+     * @param string $label      The label to attach to this TextArea
+     * @param bool   $toEntities Whether all HTML special characters in $field and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return HTML_QuickForm textarea element
      */
-    function createTextArea($field, $label=null)
+    function createTextArea($field, $label=null, $toEntities=true)
     {
         return $this->form->createElement(
             "textarea",
             $field,
             $label,
-            array('class' => 'form-control input-sm')
+            array('class' => 'form-control input-sm'),
+            $toEntities
         );
     }
 
@@ -410,6 +514,9 @@ class NDB_Page
      * @param array  $dateOptions List of options to pass to QuickForm
      * @param array  $attr        List of HTML attributes to add to the date
      *                            group.
+     * @param bool   $toEntities  Whether all HTML special characters in $field and
+     *                            $label should be converted to HTML entities when
+     *                            obtaining the HTML representation for this element.
      *
      * @return HTML_QuickForm date element
      */
@@ -420,53 +527,68 @@ class NDB_Page
         $attr=array(
                'class' => 'form-control input-sm',
                'style' => 'max-width:33%; display:inline-block;',
-              )
+              ),
+        $toEntities=true
     ) {
         return $this->form->createElement(
             "date",
             $field,
             $label,
             $dateOptions,
-            $attr
+            $attr,
+            $toEntities
         );
     }
 
     /**
      * Creates an HTML checkbox but does not add it to the form.
      *
-     * @param string $field   The fieldname for this checkbox
-     * @param string $label   The label to attach to this checkbox
-     * @param string $options Options to pass to HTML_QuickForm
-     * @param string $closer  ?????
+     * @param string $field      The fieldname for this checkbox
+     * @param string $label      The label to attach to this checkbox
+     * @param string $options    Options to pass to HTML_QuickForm
+     * @param bool   $toEntities Whether all HTML special characters in $name and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return QuickForm_Element representing checkbox
      */
-    function createCheckbox($field, $label, $options=null, $closer='</label>')
+    function createCheckbox($field, $label, $options=null, $toEntities=true)
     {
         return $this->form->createElement(
             "advcheckbox",
             $field,
             $label,
             $options,
-            array()
+            array(),
+            $toEntities
         );
     }
 
     /**
      * Creates a password form element but does not add it to the page
      *
-     * @param string $field The fieldname for the password box
-     * @param string $label The label to attach to the form element
-     * @param array  $attr  List of HTML attributes to add to the element
+     * @param string $field      The fieldname for the password box
+     * @param string $label      The label to attach to the form element
+     * @param array  $attr       List of HTML attributes to add to the element
+     * @param bool   $toEntities Whether all HTML special characters in $name and
+     *                           $label should be converted to HTML entities when
+     *                           obtaining the HTML representation for this element.
      *
      * @return QuickForm_Element Form element
      */
     function createPassword(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=array('class' => 'form-control input-sm'),
+        $toEntities=true
     ) {
-        return $this->form->createElement('password', $field, $label, $attr);
+        return $this->form->createElement(
+            'password',
+            $field,
+            $label,
+            $attr,
+            $toEntities
+        );
     }
 
     /**

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -156,7 +156,7 @@ class NDB_Page
      *
      * @return none
      */
-    function addLabel($label, $toEntities)
+    function addLabel($label, $toEntities=true)
     {
         $this->form->addElement('static', null, $label, $toEntities);
     }


### PR DESCRIPTION
Fix for the security bugs in LorisForm. The form will now use PHP's htmlspecialchars to convert to HTML entities all HTML special characters that occur in all input fields. This prevents javascript injection by malicious users on any form that uses LorisForm for data entry.