### PR TITLE
Fix for a secutiry bug in the navagation bar

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -245,7 +245,7 @@
                         </li>
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown" style="padding-right:25px;">
-                                {$user.Real_name} <b class="caret"></b>
+                                {$user.Real_name|escape} <b class="caret"></b>
                             </a>
                             <ul class="dropdown-menu">
                                 <li>


### PR DESCRIPTION
There is a bug in the navigation bar: a user can inject javascript code in his first or last name and since the user's full name is displayed in the navigation bar, this code will be executed. Fix for this security hole.
