### PR TITLE
Manual Instructions for Installing on CentOS 6.x

### DIFF
--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -1,0 +1,119 @@
+#LORIS CentOS 6.x Notes
+
+Note that the README in LORIS assumes that LORIS is being run on Ubuntu.
+
+This document contains details on how to manually perform a basic CentOS 6.x
+install of LORIS without using the install script (as the install script
+makes some assumptions about apt-get being installed.)
+
+It assumes you already understand basic UNIX, MySQL and Apache setup and
+settings. If you're not already comfortable troubleshooting sysadmin issues,
+you should not follow this guide.
+
+# 1. System Requirements
+
+The yum packages to be installed vary from the Ubuntu packages referenced
+in the LORIS README
+
+The following should be installed with yum:
+ 
+```bash
+yum install httpd
+yum install php
+yum install php-pear
+yum install php-pdo
+yum install php-mysql
+yum install mysql
+```
+
+PHP Composer must also be installed:
+
+```bash
+curl -sS https://getcomposer.org/installer | php
+sudo mv composer.phar /usr/local/bin/composer
+```
+
+Note that the version of PHP installed by CentOS 6.x is approximately 600 years
+old, and doesn't meet the minimum requirements of many development dependencies.
+As a result, you need to either upgrade your version of PHP or run composer
+with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
+assume you just want to get it running, so we'll run it with `--no-dev`.)
+
+```bash
+# Will download all of LORIS's library requirements, assuming an
+# active internet connection. This must be done from the LORIS
+# root directory that you downloaded and extracted LORIS into
+composer install --no-dev
+```
+
+## 1.1 MySQL
+
+This details how to manual populate the MySQL database which is assumed
+to already exist (if not, create one before proceeding)
+
+Connect to MySQL, use your database and source the 
+`SQL/0000-00-00-schema.sql` file into it.
+
+There are a few settings in the Config module that LORIS currently depends
+on being updated to load correctly that must be set manually from MySQL as
+they're normally set by the install script.
+
+```SQL
+UPDATE Config SET Value='/var/www/loris/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base');
+UPDATE Config SET Value='localhost' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='host');
+UPDATE Config SET Value='http://localhost' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url');
+```
+
+Where `/var/www/loris/` is the location where LORIS is installed and assuming
+you'll be running on localhost (otherwise update host and url appropriately)
+
+While connected to MySQL, you can also reset the admin password:
+
+```SQL
+-- Reset password to YOURPASSWORD
+UPDATE users SET Password_md5=CONCAT('aa', MD5('aaYOURPASSWORD')) WHERE ID=1;
+```
+
+## 1.2 Config.xml
+
+Create a directory named "project" directory under the LORIS root, and copy
+the sample config.xml from `docs/config/config.xml` to `project/config.xml`
+
+Update the database section of the config.xml to point to the database you
+just configured with an appropriate user.
+
+## 1.3 Apache
+
+A sample apache configuration file is in `docs/config/apache2-site.conf`.
+You can copy this file to `/etc/httpd/conf.d` and update the paths and
+settings as appropriate for your server. Ensure that the DocumentRoot
+is pointing to the htdocs/ directory under your LORIS root (usually
+`/var/www/loris/htdocs`)
+
+You'll have to create a `smarty/templates_c/` directory under the LORIS
+root and assure that it's writable by Apache.
+
+## 1.4 Last steps
+
+Finally, SELinux will block MySQL connections from PHP. For now, we'll 
+disable SELinux (though on a production server you should learn how to
+properly configure it instead.)
+
+```bash
+echo 0 >/selinux/enforce
+```
+
+And restart apache
+```bash
+service httpd stop
+service httpd start
+```
+
+At this point, you should be able to log in to LORIS
+at http://localhost/ using the username "admin" and the password that
+you set in section 1.1. Further configuration can be done using the
+LORIS configuration module.
+
+If there are any errors or you get a blank page, you'll have to troubleshoot
+based on the errors in your apache error log (by default
+ `/var/log/httpd/error_log`) 


### PR DESCRIPTION
Added a new README which includes instructions for
a sysadmin to manually install LORIS on a CentOS
system, since the install script may not work.