### PR TITLE
Made group by more strict in candidate_list

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -75,7 +75,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             array(
              'min(s.SubprojectID) as Subproject',
              'DATE_FORMAT(c.DoB,\'%Y-%m-%d\') AS DoB',
-             's.Scan_done as scan_Done',
+             'MAX(s.Scan_done) as scan_Done',
             )
         );
 
@@ -127,8 +127,9 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             $this->query .= " AND c.CenterID=" . $user->getCenterID();
         }
 
-        $this->group_by = 'c.CandID';
-        $this->order_by = 'psc.Name, c.CandID DESC, s.VisitNo';
+                          //'COALESCE(pso.ID,1) AS Participant_Status',
+        $this->group_by = 'c.CandID, psc.Name, c.PSCID, c.Gender';
+        $this->order_by = 'psc.Name, c.CandID DESC';
 
         if ($useProjects) {
             $this->validFilters[] = 'c.ProjectID';


### PR DESCRIPTION
The SQL generated by the candidate_list page can fail depending on the strictness of the MySQL settings, because you're not supposed to refer to non-aggregate columns that aren't in the GroupBy of a query according to standard SQL.

This causes problems with setups that use a stricter MySQL standards compliance (ie. the default one used by a Docker MySQL installation, and possibly other distros.) This updates the query to group by appropriate columns so that the query doesn't fail.