### PR TITLE
Removed status from order by in NDB_BVL_Feedback

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -495,7 +495,7 @@ class NDB_BVL_Feedback
         if (empty($this->_feedbackObjectInfo['CandID'])) {
             $query .= ", ft.CommentID";
         }
-        $query .= " ORDER BY ft.CandID, ft.Feedback_level, ft.Status";
+        $query .= " ORDER BY ft.CandID, ft.Feedback_level";
 
         $result = $db->pselect($query, $qparams);
 


### PR DESCRIPTION
The following error was being generated in MySQL >= 5.7.5:

```
Expression #3 of ORDER BY clause is not in GROUP BY clause and contains
nonaggregated column 'ft.Status' which is not functionally
dependent on columns in GROUP BY clause; this is incompatible with
sql_mode=only_full_group_by
```

This removes the non-aggregated order_by (ft.Status) which doesn't seem
to be needed by the query.