### PR TITLE
Email supervisor feature in user account module does not work

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -228,7 +228,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             if (isset($supervisorEmails)) {
                 foreach ($supervisorEmails as $email => $checkValue) {
                     if (!empty($permissionsAdded) || !empty($permissionsRemoved)) {
-                        if ($checkValue == 1) {
+                        if ($checkValue == 'on') {
                             $msg_data['current_user'] = $editor->getFullname();
                             $msg_data['study']        = $config->getSetting('title');
                             $msg_data['realname']     = $values['Real_name'];


### PR DESCRIPTION
Fix for the following bug:

I edited a user account and added a permission. I also selected a supervisor in the provided list and saved my changes. No email was sent to the supervisor...