### PR TITLE
Fix Travis with PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ php:
     - 5.6
     - '7'
 
-matrix:
-    allow_failures:
-        - php: '7'
-
 sudo: false
 
 before_install:

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -38,10 +38,8 @@ class BVL_Feedback_Panel
      * @param int  $candID    The candidate ID.
      * @param null $sessionID The session ID for a given visit. Optional.
      * @param null $commentID The comment ID for a given instrument. Optional.
-     *
-     * @return null
      */
-    function BVL_Feedback_Panel($candID, $sessionID=null, $commentID=null)
+    function __construct($candID, $sessionID=null, $commentID=null)
     {
         $user     =& User::singleton();
         $username = $user->getUsername();


### PR DESCRIPTION
With the release of PHP7 coming this month, we should be sure that our tests run with it to support it.

This branch makes the code changes that are necessary to work with PHP7.

In particular:
1. PHP7 tests are no longer allowed to fail, since it's going to be a real release soon
2. PHP4 style constructors that result in errors in tests are changed to modern PHP constructors