### PR TITLE
Addition of 'a2enmod rewrite' as part of the installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ For more information, please read the [Install Script wiki page](https://github.
     ```
     cd /var/www/$projectname/tools
     ./install.sh
-    sudo service apache2 reload
+    sudo a2enmod rewrite
+    sudo service apache2 restart
     ```
 
 4. Go to http://localhost to verify that the LORIS core database has been successfully installed. Congratulations!


### PR DESCRIPTION
Add `a2enmod rewrite` is for Pretty URLs, this solves some localhost problems such as Access forbidden Error 403. Additionally, we don't need to reload apache, we need to restart it. 