### PR TITLE
Minor updates in the test plan for the survey accounts and imaging browser

### DIFF
--- a/modules/imaging_browser/test/imaging_browser_test_plan.md
+++ b/modules/imaging_browser/test/imaging_browser_test_plan.md
@@ -10,7 +10,7 @@
 
 #B. ViewSession / Volume List 
 7. Sidebar:  all links work 
-8. 3d panel overlay etc - they work.  add panel checkbox works
+8. 3d panel overlay etc - they work.  add panel checkbox works. 3D only or 3D+Overlay loads files if at least one image exists and is selected
 9. "Visit Level Feedback" - pops up QC window (see section D below)
 10. Visit level QC controls (Pass/Fail, Pending) viewable to all, editable IFF permission imaging_browser_qc
 11. Save button appears IFF permission imaging_browser_qc
@@ -20,7 +20,7 @@
 
 #C. Main panel:  per acquisition:
 14. Files can be downloaded (links clickable) only IFF has permission (future feature not implemented yet)
-15. Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable iff permission imaging_browser_qc
+15. Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable iff permission imaging_browser_qc. Caveat List link is viewable with the Violated Scans: View all-sites Violated Scans permission
 16. Selected:  can be set back to Null (blank)
 17. Selected:  cannot be set to t2 if the scan is a t1 (future feature)
 18. BrainBrowser link works (launches window)

--- a/modules/survey_accounts/test/TestPlan.md
+++ b/modules/survey_accounts/test/TestPlan.md
@@ -1,6 +1,6 @@
 # Survey Module Test Plan
 
-1.  Check user permission: User Management/Survey Participant Management.
+1.  Check user permission: User Management.
 2.  Selection Filter:  try filtering by PSCID, Visit, and Instrument.
 3.  Enter a PSCID, email, visit label and Instrument then use “Clear Form”:
     should show visit and instrument “All” and blank for PSCID and email.
@@ -11,16 +11,16 @@
     and you hit save and continue fields you have filled out are not erased.
 6.  Add Survey button:
     a. Try sending the URL to yourself -  make sure that both email addresses match in order for the “Email Survey” button to work
-      (try mismatched email addresses to make sure you get an error message if they do not match.
+      (try mismatched email addresses to make sure that the "Email Survey" button remains inactive).
     b. Once you hit “Email Survey” you should get a blank page where you can customize an email to go along with the URL –
     enter in a message and make sure it sends (also try the cancel button on this page).
     The email can be pre-populated for each instrument using participant_emails table.
     c. Ensure that the instrument being sent is what you get (and that the URL brings you to the correct survey).
     d. Use the `Create Survey` button (no email address should be specified).
     e. Use the `Email survey` button by specifying email address.
-    e. Try mismatched PSCID and DCCID and should get an error message.
-    f. Try creating duplicate instrument for a candidate for a visit, should get an error message.
-    g. Try creating instrument for a candidate in a non-existing visit, should get an error message.
+    f. Try mismatched PSCID and DCCID and should get an error message.
+    g. Try creating duplicate instrument for a candidate for a visit, should get an error message.
+    h. Try creating instrument for a candidate in a non-existing visit, should get an error message.
 7.  Enable a new instrument for Survey module and verify survey can be created. (IsDirectEntry set to 1 in test_names table).
 8.  Verify Status column in the module updates appropriately
     a. When survey is created Status should be set to `Created` when no email address is specified


### PR DESCRIPTION
In the imaging browser:

-Caveat list link only viewable with the correct permission (bug#8445)
-3D Only/3D+Overlay require at least one image to be present and selected (bug#8450)


In the survey account:

-User permission in step 1
-Typo in step 6 (e, f, g)
-In step 6a, no error message is generated in case of mismatched email, but rather, the button is inactive.