### PR TITLE
escape special chars in survey accounts

### DIFF
--- a/modules/survey_accounts/templates/menu_survey_accounts.tpl
+++ b/modules/survey_accounts/templates/menu_survey_accounts.tpl
@@ -95,7 +95,7 @@
                         {section name=piece loop=$items[item]}
                         <td nowrap="nowrap">
                             {if  $items[item][piece].name == "URL"}
-                            <a href="survey.php?key={$items[item][piece].value}">{$items[item][piece].value}</a>
+                            <a href="survey.php?key={$items[item][piece].value|escape:"url}">{$items[item][piece].value}</a>
                             {else}
                             {$items[item][piece].value}
                             {/if}


### PR DESCRIPTION
In some cases, the OneTimePassword had special chars specific to URLs leading to the key passed in the query string to be truncated into a substring 