### PR TITLE
Genomic browser download as cvs

### DIFF
--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -61,6 +61,8 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
+        $this->_displayBrief = !(isset($_REQUEST['format']));
+
         $this->columns = array(
                           'psc.Name AS PSC',
                           'candidate.CandID AS DCCID',

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -62,6 +62,8 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
+        $this->_displayBrief = !(isset($_REQUEST['format']));
+
         $this->columns = array(
                           'psc.Name AS PSC',
                           'candidate.CandID AS DCCID',

--- a/modules/genomic_browser/templates/menu_genomic_browser.tpl
+++ b/modules/genomic_browser/templates/menu_genomic_browser.tpl
@@ -221,6 +221,9 @@
       <!-- title -->
         {if {$resultcount} != '' }
           <td class="controlpanelsection">Variants found: <strong>{$resultcount}</strong> total</td>
+          <a href="{$csvUrl}" download="{$csvFile}.csv">
+            Download as CSV
+          </a>
         {else}
           <td>No variants found. </td>
         {/if}

--- a/modules/genomic_browser/templates/menu_genomic_browser.tpl
+++ b/modules/genomic_browser/templates/menu_genomic_browser.tpl
@@ -222,7 +222,7 @@
         {if {$resultcount} != '' }
           <td class="controlpanelsection">Variants found: <strong>{$resultcount}</strong> total</td>
           <a href="{$csvUrl}" download="{$csvFile}.csv">
-            Download as CSV
+            Download all fields as CSV
           </a>
         {else}
           <td>No variants found. </td>

--- a/modules/genomic_browser/templates/menu_snp_browser.tpl
+++ b/modules/genomic_browser/templates/menu_snp_browser.tpl
@@ -247,6 +247,9 @@
       <!-- title -->
       {if {$resultcount} != '' }
         <td class="controlpanelsection">Variants found: <strong>{$resultcount}</strong> total</td>
+        <a href="{$csvUrl}" download="{$csvFile}.csv">
+          Download as CSV
+        </a>
       {else}
         <td>No variants found. </td>
       {/if} 

--- a/modules/genomic_browser/templates/menu_snp_browser.tpl
+++ b/modules/genomic_browser/templates/menu_snp_browser.tpl
@@ -248,7 +248,7 @@
       {if {$resultcount} != '' }
         <td class="controlpanelsection">Variants found: <strong>{$resultcount}</strong> total</td>
         <a href="{$csvUrl}" download="{$csvFile}.csv">
-          Download as CSV
+          Download all fields as CSV
         </a>
       {else}
         <td>No variants found. </td>


### PR DESCRIPTION
- Adding link in the template
- There was a problem with column headers in the cvs file where only brief_fields columns where shown but all the data column. _displayBrief variable is now conditional to $_REQUEST['format']. It will still be overwrite by the Show_Brief_Results value of POST request.