### PR TITLE
Mri violations problem column

### DIFF
--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -410,10 +410,10 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
                     $this->form->form[$hash]['name'] = "resolvable[$hash]";
                 }
                 if ($key === 'Problem') {
-                    if($val="Could not identify scan type"){
+                    if($val === "Could not identify scan type"){
                         $this->tpl_data['join_tbl'] = "mri_protocol_violated_scans";
                     }
-                    elseif($val="Protocol Violation"){
+                    elseif($val === "Protocol Violation"){
                         $this->tpl_data['join_tbl'] = "mri_violations_log";
                     }
                     else{

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -410,10 +410,10 @@ class NDB_Menu_Filter_Form_resolved_violations extends NDB_Menu_Filter_Form
                     // do nothing
                 }
                 if ($key === 'Problem') {
-                    if($val="Could not identify scan type"){    
+                    if($val === "Could not identify scan type"){
                         $this->tpl_data['join_tbl'] = "mri_protocol_violated_scans";
                     }
-                    elseif($val="Protocol Violation"){
+                    elseif($val === "Protocol Violation"){
                         $this->tpl_data['join_tbl'] = "mri_violations_log";
                     }
                     else{


### PR DESCRIPTION
Fix the bug in the mri_violation where the problem's column where the all rows were populated with ```Could not identify scan type```. The bug was caused by the fact that in an if statement the variable was being assigned instead of compared to the string. 