### PR TITLE
Using flag table instead of intrument`s table to fetch userIDs

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -81,11 +81,11 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
 
                     // insert into conflicts_resolved
                     $user1         = $DB->pselectOne(
-                        "SELECT UserID FROM $row[TableName] WHERE CommentID=:CID",
+                        "SELECT UserID FROM flag WHERE CommentID=:CID",
                         array('CID' => $row['CommentId1'])
                     );
                     $user2         = $DB->pselectOne(
-                        "SELECT UserID FROM $row[TableName] WHERE CommentID=:CID",
+                        "SELECT UserID FROM flag WHERE CommentID=:CID",
                         array('CID' => $row['CommentId2'])
                     );
                     $resolutionLog = array(


### PR DESCRIPTION
Because not all instrument have a userID column and all instrument have a unique flag (which have a userID)