### PR TITLE
fix examiners list in intruments

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -869,12 +869,13 @@ class NDB_BVL_Instrument extends NDB_Page
         $CertificationInstruments = array();
 
         if ($CertificationEnabled) {
-            foreach (
-                Utility::toArray($CertificationConfig['CertificationProjects'])
-                AS $key => $value
-            ) {
-                foreach ($value as $k=>$projID) {
-                    $CertificationProjects[$projID] = $projID;
+            if (!empty($CertificationConfig['CertificationProjects'])) {
+                $ProjectList = $CertificationConfig['CertificationProjects'];
+                foreach (
+                    $ProjectList['CertificationProject']
+                    AS $key => $value
+                ) {
+                    $CertificationProjects[$key] = $value;
                 }
             }
             foreach (

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -869,13 +869,15 @@ class NDB_BVL_Instrument extends NDB_Page
         $CertificationInstruments = array();
 
         if ($CertificationEnabled) {
-            if (!empty($CertificationConfig['CertificationProjects'])) {
-                $ProjectList = $CertificationConfig['CertificationProjects'];
-                foreach (
-                    $ProjectList['CertificationProject']
-                    AS $key => $value
-                ) {
-                    $CertificationProjects[$key] = $value;
+            foreach (
+                Utility::toArray($CertificationConfig['CertificationProjects'])
+                AS $key => $value
+            ) {
+                if(is_array($value['CertificationProject'])) {
+                    $value = $value['CertificationProject'];
+                }
+                foreach ($value as $k=>$projID) {
+                    $CertificationProjects[$projID] = $projID;
                 }
             }
             foreach (

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -873,7 +873,7 @@ class NDB_BVL_Instrument extends NDB_Page
                 Utility::toArray($CertificationConfig['CertificationProjects'])
                 AS $key => $value
             ) {
-                if(is_array($value['CertificationProject'])) {
+                if (is_array($value['CertificationProject'])) {
                     $value = $value['CertificationProject'];
                 }
                 foreach ($value as $k=>$projID) {


### PR DESCRIPTION
Instruments always shown all examiners instead of looking for certified examiners.

This was caused by the if statement at [line 928](https://github.com/xlecours/Loris/blob/12c2293342165a6b08f3e493cc028d59680df23d/php/libraries/NDB_BVL_Instrument.class.inc#L928) that was returning false because the $CertificationProjects was an empty array.

The Utility::toArray was putting everything that is in $CertificationConfig['CertificationProjects'] into a new array. At the end, $projID was equal to an array on projectID.

 