### PR TITLE
Remove inefficiency query from stats page

### DIFF
--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -361,6 +361,7 @@ class NDB_Form_statistics extends NDB_Form
         }
         // MRI INTEGRITY STATS
         // MRI parameter form is completed, but nothing in tarchive
+        /*
         $DB->select("SELECT COUNT(distinct f.CommentID) as val,
                             s.CenterID as CenterID
                             FROM flag f JOIN session s ON (f.SessionID=s.ID) 
@@ -382,6 +383,7 @@ class NDB_Form_statistics extends NDB_Form
         foreach($result as $row) {
             $this->tpl_data['mri_errors'][$row['CenterID']]['no_tarchive'] = $row['val'];
         }
+         */
 
         // MRI parameter form completed, but nothing in browser
         $DB->select("SELECT s.CenterID as CenterID,

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -92,7 +92,7 @@
           <tr class="info">
                 <th>No Parameter Form Completed</th>
                 <th>Nothing in Imaging Browser for Form</th>
-                <th>No tarchive Entry for Form</th>
+                {* <th>No tarchive Entry for Form</th> *}
                 <th>Breakdown of Problems</th>
           </tr>
         </thead>
@@ -101,7 +101,7 @@
           <tr>
                 <td>{$mri_errors[$center.NumericID].no_parameter}</td>
                 <td>{$mri_errors[$center.NumericID].no_browser}</td>
-                <td>{$mri_errors[$center.NumericID].no_tarchive}</td>
+                {* <td>{$mri_errors[$center.NumericID].no_tarchive}</td> *}
                 <td><a href="?test_name=statistics&submenu=statistics_mri_site&CenterID={$mri_center}&ProjectID={$mri_project}">Click Here for breakdown per participant</a></td>
           </tr>
           {/foreach}


### PR DESCRIPTION
This removes an inefficient query which was crashing/timing out the statistics imaging stats page when there's large amounts of data.