### PR TITLE
Project Specific Module Support

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -71,7 +71,8 @@ if (is_dir($basePath . "project/modules/$Module")
             : $basePath . "modules/$Module";
         set_include_path(
             get_include_path() . ':' .
-            $ModuleDir . "/php");
+            $ModuleDir . "/php"
+        );
 } else {
     error_log("ERROR: Module does not exist");
     header("HTTP/1.1 400 Bad Request");

--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -63,14 +63,22 @@ if (strpos("..", $File) !== false) {
     exit(4);
 }
 
+if (is_dir($basePath . "project/modules/$Module")
+    || is_dir($basePath . "modules/$Module")
+) {
+        $ModuleDir = is_dir($basePath . "project/modules/$Module")
+            ? $basePath . "project/modules/$Module"
+            : $basePath . "modules/$Module";
+        set_include_path(
+            get_include_path() . ':' .
+            $ModuleDir . "/php");
+} else {
+    error_log("ERROR: Module does not exist");
+    header("HTTP/1.1 400 Bad Request");
+    exit(5);
+}
 // Also check the module directory for PHP files
-set_include_path(
-    get_include_path() . ":" .
-    __DIR__ . "/../project/libraries:" .
-    __DIR__ . "/../php/libraries:" .
-    __DIR__ . "/../modules/$Module/php"
-);
-$FullPath = $basePath . "/modules/$Module/ajax/$File";
+$FullPath = "$ModuleDir/ajax/$File";
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -76,7 +76,18 @@ if (strpos("..", $File) !== false) {
 if ($Instrument !== null) {
     $FullPath = $basePath . "/project/instruments/$File";
 } else {
-    $FullPath = $basePath . "/modules/$Module/css/$File";
+    if (is_dir($basePath . "project/modules/$Module")
+        || is_dir($basePath . "modules/$Module")
+    ) {
+        $ModuleDir = is_dir($basePath . "project/modules/$Module")
+            ? $basePath . "project/modules/$Module"
+            : $basePath . "modules/$Module";
+    } else {
+        error_log("ERROR: Module does not exist");
+        header("HTTP/1.1 400 Bad Request");
+        exit(5);
+    }
+    $FullPath = "$ModuleDir/css/$File";
 }
 
 if (!file_exists($FullPath)) {

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -69,7 +69,8 @@ if (is_dir($basePath . "project/modules/$Module")
         : $basePath . "modules/$Module";
     set_include_path(
         get_include_path() . ':' .
-        $ModuleDir . "/php");
+        $ModuleDir . "/php"
+    );
 } else {
     error_log("ERROR: Module does not exist");
     header("HTTP/1.1 400 Bad Request");

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -54,12 +54,27 @@ if (!isset($_GET['file']) || empty($_GET['file'])) {
 } else {
     $File = $_GET['file'];
 }
+
 if (empty($Module) || empty($File)) {
     error_log("Missing required parameters for request");
     header("HTTP/1.1 400 Bad Request");
     exit(2);
 }
 
+if (is_dir($basePath . "project/modules/$Module")
+    || is_dir($basePath . "modules/$Module")
+) {
+    $ModuleDir = is_dir($basePath . "project/modules/$Module")
+        ? $basePath . "project/modules/$Module"
+        : $basePath . "modules/$Module";
+    set_include_path(
+        get_include_path() . ':' .
+        $ModuleDir . "/php");
+} else {
+    error_log("ERROR: Module does not exist");
+    header("HTTP/1.1 400 Bad Request");
+    exit(5);
+}
 // File validation
 if (strpos($File, ".js") === false) {
     error_log("ERROR: Not a javascript file.");
@@ -77,7 +92,7 @@ if (strpos("..", $File) !== false) {
 }
 
 
-$FullPath = $basePath . "/modules/$Module/js/$File";
+$FullPath = "$ModuleDir/js/$File";
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");

--- a/htdocs/GetStatic.php
+++ b/htdocs/GetStatic.php
@@ -58,6 +58,20 @@ if (empty($Module) || empty($File)) {
     exit(2);
 }
 
+if (is_dir($basePath . "project/modules/$Module")
+    || is_dir($basePath . "modules/$Module")
+) {
+    $ModuleDir = is_dir($basePath . "project/modules/$Module")
+        ? $basePath . "project/modules/$Module"
+        : $basePath . "modules/$Module";
+    set_include_path(
+        get_include_path() . ':' .
+        $ModuleDir . "/php");
+} else {
+    error_log("ERROR: Module does not exist");
+    header("HTTP/1.1 400 Bad Request");
+    exit(5);
+}
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $basePath
@@ -68,7 +82,7 @@ if (strpos("..", $File) !== false) {
 }
 
 
-$FullPath = $basePath . "/modules/$Module/static/$File";
+$FullPath = "$ModuleDir/static/$File";
 
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $File does not exist");

--- a/htdocs/GetStatic.php
+++ b/htdocs/GetStatic.php
@@ -66,7 +66,8 @@ if (is_dir($basePath . "project/modules/$Module")
         : $basePath . "modules/$Module";
     set_include_path(
         get_include_path() . ':' .
-        $ModuleDir . "/php");
+        $ModuleDir . "/php"
+    );
 } else {
     error_log("ERROR: Module does not exist");
     header("HTTP/1.1 400 Bad Request");

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -96,7 +96,9 @@ class NDB_Caller
         // get the files path, aka the base directory
         $base = $config->getSetting('base');
 
-        if (is_dir($base . "project/modules/$test_name") || is_dir($base . "modules/$test_name")) {
+        if (is_dir($base . "project/modules/$test_name")
+            || is_dir($base . "modules/$test_name")
+        ) {
             $ModuleDir = is_dir($base . "project/modules/$test_name")
                 ? $base . "project/modules/$test_name"
                 : $base . "modules/$test_name";

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -96,14 +96,15 @@ class NDB_Caller
         // get the files path, aka the base directory
         $base = $config->getSetting('base');
 
-        if (is_dir($base . "modules/$test_name")) {
+        if (is_dir($base . "project/modules/$test_name") || is_dir($base . "modules/$test_name")) {
+            $ModuleDir = is_dir($base . "project/modules/$test_name")
+                ? $base . "project/modules/$test_name"
+                : $base . "modules/$test_name";
             // New module style
             // Only supports Menu_Filters and Forms.
             // Modules can not have instruments or reliability.
             set_include_path(
-                $base . "project/libraries:"
-                . $base . "modules/$test_name:"
-                . $base . "modules/$test_name/php:"
+                "$ModuleDir/php:"
                 . get_include_path()
             );
 

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -53,7 +53,8 @@ class Smarty_NeuroDB extends Smarty
 
         $this->loristemplate_dir    = $basePath . "smarty/templates/";
         $this->project_template_dir = $basePath . "project/templates/";
-        $this->modules_dir          = is_dir($basePath . "project/modules/$moduleName")
+
+        $this->modules_dir = is_dir($basePath . "project/modules/$moduleName")
             ? $basePath . "project/modules/$moduleName"
             : $basePath . "modules/$moduleName" ;
 

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -45,13 +45,17 @@ class Smarty_NeuroDB extends Smarty
 
         $paths = $config->getSetting('paths');
 
+        $basePath = $paths['base'];
+
         // NeuroDB plugin is no longer needed now that Smarty3 supports
         // multiple template directories
         //$this->addPluginsDir($paths['base']."php/libraries/smarty/plugins");
 
-        $this->loristemplate_dir    = $paths['base']."smarty/templates/";
-        $this->project_template_dir = $paths['base']."project/templates/";
-        $this->modules_dir          = $paths['base'] . 'modules/' . $moduleName;
+        $this->loristemplate_dir    = $basePath . "smarty/templates/";
+        $this->project_template_dir = $basePath . "project/templates/";
+        $this->modules_dir          = is_dir($basePath . "project/modules/$moduleName")
+            ? $basePath . "project/modules/$moduleName"
+            : $basePath . "modules/$moduleName" ;
 
         // These are probably not needed anymore and can use the smarty
         // defaults, but keep them for now to ensure that Loris doesn't
@@ -76,8 +80,8 @@ class Smarty_NeuroDB extends Smarty
         // Set the template directories. First check for project overrides,
         // then check for modules, then check for old Loris jumbled together
         // templates
-        $this->setTemplateDir($this->project_template_dir);
-        $this->addTemplateDir($this->modules_dir . "/templates");
+        $this->setTemplateDir($this->modules_dir . "/templates");
+        $this->addTemplateDir($this->project_template_dir);
         $this->addTemplateDir($this->loristemplate_dir);
 
         $currentDir = $this->getConfigDir();


### PR DESCRIPTION
This adds the ability to ook into either project or LORIS directory for modules

This adds the ability to look into the project/modules directory for LORIS, so that projects can create their own non-generic modules.
    
At the same time, the ability to override modules partially in project/libraries is removed so that you can't break existing modules by partially overriding it. Modules need to either come entirely from the project, or entirely from LORIS.