### PR TITLE
Imaging uploader reload

### DIFF
--- a/modules/imaging_uploader/js/imaging_uploader.js
+++ b/modules/imaging_uploader/js/imaging_uploader.js
@@ -126,8 +126,14 @@ function uploadFile() {
             return xhr;
         },
         success: function (data) {
-            alert("File Uploaded");
-            location.reload();
+            if (data.indexOf("The following errors occured while attempting to display this page:") > -1) {
+                document.open();
+                document.write(data);
+                document.close();
+            } else {
+                $("fileUpload").val("");
+                $("#mri_upload").submit();
+            }
         }
     });
 }

--- a/modules/imaging_uploader/js/imaging_uploader.js
+++ b/modules/imaging_uploader/js/imaging_uploader.js
@@ -144,14 +144,14 @@ Main function
 $(function () {
     "use strict";
     change();
-    // $(".submit-button").click(
-    //     function (e){
-    //         if(e.currentTarget.id === "filter"){
-    //             $("#mri_upload").submit();
-    //         } else if (e.currentTarget.id === "upload"){
-    //             e.preventDefault();
-    //             uploadFile();
-    //         }
-    //     }
-    // );
+    $(".submit-button").click(
+        function (e){
+            if(e.currentTarget.id === "filter"){
+                $("#mri_upload").submit();
+            } else if (e.currentTarget.id === "upload"){
+                e.preventDefault();
+                uploadFile();
+            }
+        }
+    );
 });

--- a/modules/imaging_uploader/js/imaging_uploader.js
+++ b/modules/imaging_uploader/js/imaging_uploader.js
@@ -132,7 +132,7 @@ function uploadFile() {
                 document.close();
             } else {
                 $("fileUpload").val("");
-                $("#mri_upload").submit();
+                $("#filter").click();
             }
         }
     });

--- a/modules/imaging_uploader/js/imaging_uploader.js
+++ b/modules/imaging_uploader/js/imaging_uploader.js
@@ -144,14 +144,14 @@ Main function
 $(function () {
     "use strict";
     change();
-    $(".submit-button").click(
-        function (e){
-            if(e.currentTarget.id === "filter"){
-                $("#mri_upload").submit();
-            } else if (e.currentTarget.id === "upload"){
-                e.preventDefault();
-                uploadFile();
-            }
-        }
-    );
+    // $(".submit-button").click(
+    //     function (e){
+    //         if(e.currentTarget.id === "filter"){
+    //             $("#mri_upload").submit();
+    //         } else if (e.currentTarget.id === "upload"){
+    //             e.preventDefault();
+    //             uploadFile();
+    //         }
+    //     }
+    // );
 });

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -251,7 +251,7 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
         $file_name = $file->fileInfo['name'];
         $file_path = $temp_dir. "/". $file_name;
         $isPhantom = $args['values']['IsPhantom'];
-        if (empty($isPhantom)){
+        if (empty($isPhantom)) {
             $errors[] ="Make sure 'Are these Phantom Scans' is filled out.";
         }
         ///////////////////////////////////////////////////////////////////////

--- a/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
+++ b/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
@@ -144,6 +144,14 @@
 </table>
 *}
 
+<!--  title table with pagination -->
+<table border="0" valign="bottom" width="100%">
+<tr>
+    <!-- display pagination links -->
+    <td align="right">{$page_links}</td>
+</tr>
+</table>
+
 <div class="row">
     <table class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
         <thead>

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -359,7 +359,7 @@
                                     </a>.
                                 </p>
                                 <p>
-                                    <a href="javascript:location.reload(true);">
+                                    <a href="javascript:history.back(-1)">
                                         Please click here to go back
                                     </a>.
                                 </p>


### PR DESCRIPTION
The page would say that the file was uploaded even if it wasn't. This was because the backend was returning the entire html if there was an error. This fix checks to see if the html contains an error message, if so it loads the html into the page. If not it will reload the page applying the filters.

We should either look into having the upload go through the imaging API once completed or creating a AJAX helper that will return the appropriate status. 

This also includes adding the missing page links. 