### PR TITLE
Made CouchDB wrapper throw exceptions on error

### DIFF
--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -72,6 +72,11 @@ class SocketWrapper
     function open()
     {
         $this->socket = fsockopen($this->host, $this->port);
+        if ($this->socket === false) {
+            throw new \LorisException(
+                "Could not connect to CouchDB server at $this->host:$this->port"
+            );
+        }
     }
 
     /**
@@ -81,7 +86,10 @@ class SocketWrapper
      */
     function close()
     {
-        fclose($this->socket);
+        $status = fclose($this->socket);
+        if ($status === false) {
+            throw new \LorisException("Could not close CouchDB network socket");
+        };
     }
 
     /**
@@ -104,7 +112,13 @@ class SocketWrapper
     function gets()
     {
         if ($this->socket) {
-            return fgets($this->socket);
+            $status = fgets($this->socket);
+            if ($status === false) {
+                throw new \LorisException(
+                    "Could not read from CouchDB server at $this->host:$this->port"
+                );
+            }
+            return $status;
         }
     }
 
@@ -117,7 +131,10 @@ class SocketWrapper
      */
     function write($str)
     {
-        fwrite($this->socket, $str);
+        $status = fwrite($this->socket, $str);
+        if ($status === false) {
+            throw new \LorisException("Could not write to CouchDB server");
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the network socket wrappers were just directly wrapping
around the (C-based) PHP procedural file I/O calls. This updates the
wrapper to check the return codes and convert errors to exceptions
where appropriate.

This should make the errors more visible when problems happen with ie.
CouchDB user account syncing, which currently just freeze the system.