### PR TITLE
Remove Utility::isErrorX

### DIFF
--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -36,9 +36,6 @@ class NDB_Form_Configuration extends NDB_Form
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         return $user->hasPermission('config');
     }
 
@@ -53,12 +50,6 @@ class NDB_Form_Configuration extends NDB_Form
         $config =& NDB_Config::singleton();
 
         $this->DB = Database::singleton();
-        if (Utility::isErrorX($this->DB)) {
-            return PEAR::raiseError(
-                "Could not connect to database: ".$DB->getMessage()
-            );
-            die();
-        }
 
         $parentMenuItems = $this->DB->pselect(
             "SELECT Label, Name 

--- a/modules/help_editor/php/NDB_Form_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Form_help_editor.class.inc
@@ -39,9 +39,6 @@ class NDB_Form_help_editor extends NDB_Form
     {
         // create user object
         $user = User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
             // check user permissions
         return $user->hasPermission('context_help');
@@ -55,10 +52,6 @@ class NDB_Form_help_editor extends NDB_Form
     {
         $DB = Database::singleton();
         //Get the default values
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".
-                                     $DB->getMessage());
-        } 
         if (isset($_REQUEST['helpID'])) {
             $helpID = $_REQUEST['helpID'];
         }
@@ -108,10 +101,6 @@ class NDB_Form_help_editor extends NDB_Form
     { 
         $DB = Database::singleton();
         //Get the default values
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".
-                                     $DB->getMessage());
-        }
         if (isset($_REQUEST['helpID'])) {
             $helpID = $_REQUEST['helpID'];
         }
@@ -135,9 +124,6 @@ class NDB_Form_help_editor extends NDB_Form
                         'projectContent' => $values['content'],
                         'updated' => date('Y-m-d h:i:s', time())
                         ));
-            if (Utility::isErrorX($success)) {
-                $this->tpl_data['error_message'][] = $success->getMessage();
-            }
         } else {
             //content does not exist insert the help file
             if (!empty($_REQUEST['section']) 
@@ -151,9 +137,6 @@ class NDB_Form_help_editor extends NDB_Form
                             'created' => date('Y-m-d h:i:s', time())
                             ));
                  // check errors
-                if (Utility::isErrorX($parentID)) {
-                    $this->tpl_data['error_message'][] = $parentID->getMessage();
-                }
 
             }
             if (!empty($_REQUEST['section']) 
@@ -169,10 +152,6 @@ class NDB_Form_help_editor extends NDB_Form
                             'created' => date('Y-m-d h:i:s', time())
                             ));
 
-                // check errors
-                if (Utility::isErrorX($helpID)) {
-                    $this->tpl_data['error_message'][] = $helpID->getMessage();
-                }
             } else if ( !empty($_REQUEST['section']) 
                         && $_REQUEST['subsection'] == 'undefined') { 
                 //default case
@@ -183,10 +162,6 @@ class NDB_Form_help_editor extends NDB_Form
                             'created' => date('Y-m-d h:i:s', time())
                             ));
 
-                // check errors
-                if (Utility::isErrorX($helpID)) {
-                    $this->tpl_data['error_message'][] = $helpID->getMessage();
-                }
             }
 
         }

--- a/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
@@ -32,9 +32,6 @@ class NDB_Menu_Filter_help_editor extends NDB_Menu_Filter
     {
         // create user object
         $user = User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         return $user->hasPermission('context_help');
     }
@@ -42,9 +39,6 @@ class NDB_Menu_Filter_help_editor extends NDB_Menu_Filter
     function _setupVariables()
     {
         $user = User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // the base query
         $query = " FROM help WHERE hash IS NOT NULL AND topic IS NOT NULL";
@@ -80,10 +74,6 @@ class NDB_Menu_Filter_help_editor extends NDB_Menu_Filter
     {
         $DB = Database::singleton();
         //Get the default values
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".
-                                     $DB->getMessage());
-        }
         $help = $DB->pselect("SELECT helpID, topic from help", array());
         foreach ($help as $row) {
             $help_section[$row['helpID']] = $row['topic'];

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -27,42 +27,24 @@ Class Instrument_List_ControlPanel extends TimePoint
 
         // start next stage
         $this->tpl_data['access']['next_stage'] = $this->_displayStartNextStage();
-        if (Utility::isErrorX($this->tpl_data['access']['next_stage'])) {
-            return PEAR::raiseError("Instrument_List_ControlPanel: ".$this->tpl_data['access']['next_stage']->getMessage());
-        }
-                
+
         // generate the time point status buttons
         $this->tpl_data['access']['status'] = $this->_displayStatus();
-        if (Utility::isErrorX($this->tpl_data['access']['status'])) {
-            return PEAR::raiseError("Instrument_List_ControlPanel: ".$this->tpl_data['access']['status']->getMessage());
-        }
         // send to DCC
         $this->tpl_data['access']['send_to_dcc'] = $this->_displaySendToDCC();
         if(!$this->tpl_data['access']['send_to_dcc']){
         	$this->tpl_data['access']['send_to_dcc_status_message']=$this->_getSendToDCCStatusMessage();
         }
-        if (Utility::isErrorX($this->tpl_data['access']['send_to_dcc'])) {
-            return PEAR::raiseError("Instrument_List_ControlPanel: ".$this->tpl_data['access']['send_to_dcc']->getMessage());
-        }
 
         // BVLQC - get permission and set the tpl element
         $user =& User::singleton();
         $this->tpl_data['access']['bvl_qc'] = $user->hasPermission('bvl_feedback');
-        if (isset($this->tpl_data['access']['bvl_qc_type']) && Utility::isErrorX($this->tpl_data['access']['bvl_qc_type'])) {
-            return PEAR::raiseError("Instrument_List_ControlPanel: ".$this->tpl_data['access']['bvl_qc_type']->getMessage());
-        }
-        
+
         // BVLQCType
         $success = $this->_displayBVLQCType();
-        if (Utility::isErrorX($success)) {
-            return PEAR::raiseError("Instrument_List_ControlPanel: ".$success->getMessage());
-        }
         // BVLQCStatus
         $success = $this->_displayBVLQCStatus();
-        if (Utility::isErrorX($success)) {
-            return PEAR::raiseError("Instrument_List_ControlPanel: ".$success->getMessage());
-        }
-        
+
         $smarty = new Smarty_neurodb("instrument_list");
         $smarty->assign($this->tpl_data);
         $html = $smarty->fetch("instrument_list_controlpanel.tpl");
@@ -78,7 +60,7 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
         $currentStage = $this->getData('Current_stage');
         $currentStatus = $this->getData($currentStage);
-        
+
         // update the status of the current stage
         if (!empty($_REQUEST['setStageUpdate'])
             && $this->_hasAccess_Status()
@@ -140,21 +122,12 @@ Class Instrument_List_ControlPanel extends TimePoint
             if ($nextStage = 'Recycling Bin'){ 
                 
                 $battery = new NDB_BVL_Battery();
-                if(Utility::isErrorX($battery)) {
-                    return PEAR::raiseError("Battery Error: ".$battery->getMessage());
-                }
                 
                 // set the SessionID for the battery
                 $success = $battery->selectBattery($this->getData('SessionID'));
-                if(Utility::isErrorX($success)) {
-                    return PEAR::raiseError("Battery Error (".$this->getData('SessionID')."): ".$success->getMessage());
-                }
 
                 // get the list of instruments
                 $batteryList = $battery->getBatteryVerbose();
-                if (Utility::isErrorX($batteryList)) {
-                    return PEAR::raiseError("Instrument List CP::_displayStatus: " . $batteryList->getMessage());
-                }
                 
                 // Get the list of DDE instruments
                 $config =& NDB_Config::singleton();
@@ -189,22 +162,10 @@ Class Instrument_List_ControlPanel extends TimePoint
                 $this->startStage($previousStage);
                   
                 $battery = new NDB_BVL_Battery();
-                if(Utility::isErrorX($battery)) {
-                    return PEAR::raiseError("Battery Error: ".$battery->getMessage());
-                }
-                
                 // set the SessionID for the battery
                 $success = $battery->selectBattery($this->getData('SessionID'));
-                if(Utility::isErrorX($success)) {
-                    return PEAR::raiseError("Battery Error (".$this->getData('SessionID')."): ".$success->getMessage());
-                }
-                
                 // get the list of instruments
                 $batteryList = $battery->getBatteryVerbose();
-                if (Utility::isErrorX($batteryList)) {
-                    return PEAR::raiseError("Instrument List CP::_displayStatus: " . $batteryList->getMessage());
-                }
-                
                 // Get the list of DDE instruments
                 $config =& NDB_Config::singleton();
                 $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
@@ -272,39 +233,21 @@ Class Instrument_List_ControlPanel extends TimePoint
 
         // new DB Object
         $db =& Database::singleton();
-        if(Utility::isErrorX($db)) {
-            return PEAR::raiseError ("Could not connect to database: ".$db->getMessage());
-        }
-            
+
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError('User Error: '.$user->getMessage());
-        }
 
         $hasAccess = $this->_hasAccess_Status();
-        if (Utility::isErrorX($hasAccess)) {
-            return PEAR::raiseError("Instrument List CP::_displayStatus: ".$hasAccess->getMessage());
-        }
 
         // check that all the instruments' Data Entry is market Complete
         $battery = new NDB_BVL_Battery;
-        if(Utility::isErrorX($battery)) {
-            return PEAR::raiseError("Battery Error: ".$battery->getMessage());
-        }
 
         // set the SessionID for the battery
         $success = $battery->selectBattery($_REQUEST['sessionID']);
-        if(Utility::isErrorX($success)) {
-            return PEAR::raiseError("Battery Error (".$_REQUEST['sessionID']."): ".$success->getMessage());
-        }
 
         // get the list of instruments
         $batteryList = $battery->getBatteryVerbose();
-        if (Utility::isErrorX($batteryList)) {
-            return PEAR::raiseError("Instrument List CP::_displayStatus: " . $batteryList->getMessage());
-        }
-           
+
         // Get the list of DDE instruments
         $config =& NDB_Config::singleton();
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
@@ -376,9 +319,6 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
         // get user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         
         // disable the button for all these users
         $currentStage = $this->getCurrentStage();
@@ -442,9 +382,6 @@ Class Instrument_List_ControlPanel extends TimePoint
         $study = $config->getSetting('study');
         
         $hasAccess = $this->_hasAccess_SendToDCC();
-        if (Utility::isErrorX($hasAccess)) {
-            return PEAR::raiseError("Instrument List CP::_displaySendToDCC: ".$hasAccess->getMessage());
-        }
 
         // This is a toggle button.
         if ($this->getData('Submitted')=='Y') {
@@ -462,21 +399,12 @@ Class Instrument_List_ControlPanel extends TimePoint
         }
 
         $battery = new NDB_BVL_Battery();
-        if(Utility::isErrorX($battery)) {
-            return PEAR::raiseError("Battery Error: ".$battery->getMessage());
-        }
         
         // set the SessionID for the battery
         $success = $battery->selectBattery($this->getData('SessionID'));
-        if(Utility::isErrorX($success)) {
-            return PEAR::raiseError("Battery Error (".$this->getData('SessionID')."): ".$success->getMessage());
-        }
         
         // get the list of instruments
         $batteryList = $battery->getBatteryVerbose();
-        if (Utility::isErrorX($batteryList)) {
-            return PEAR::raiseError("Instrument List CP::_displayStatus: " . $batteryList->getMessage());
-        }
         
         // Get the list of DDE instruments
         $config =& NDB_Config::singleton();
@@ -543,21 +471,12 @@ Class Instrument_List_ControlPanel extends TimePoint
         }
         
         $battery = new NDB_BVL_Battery();
-        if(Utility::isErrorX($battery)) {
-            return PEAR::raiseError("Battery Error: ".$battery->getMessage());
-        }
         
         // set the SessionID for the battery
         $success = $battery->selectBattery($this->getData('SessionID'));
-        if(Utility::isErrorX($success)) {
-            return PEAR::raiseError("Battery Error (".$this->getData('SessionID')."): ".$success->getMessage());
-        }
         
         // get the list of instruments
         $batteryList = $battery->getBatteryVerbose();
-        if (Utility::isErrorX($batteryList)) {
-            return PEAR::raiseError("Instrument List CP::_displayStatus: " . $batteryList->getMessage());
-        }
         
         // Get the list of DDE instruments
         $config =& NDB_Config::singleton();
@@ -596,9 +515,6 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 		$config =& NDB_Config::singleton();
 		
         // get the value of the session.Scan_done field

--- a/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
+++ b/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
@@ -12,20 +12,11 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-        if (Utility::isErrorX($timePoint)) {
-            return PEAR::raiseError("TimePoint Error (".$_REQUEST['sessionID']."): ".$timePoint->getMessage());
-        }
         $candID = $timePoint->getCandID();
 
         $candidate =& Candidate::singleton($candID);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($candID): ".$candidate->getMessage());
-        }
 
         // check user permissions
     	return ($user->hasPermission('access_all_profiles') || $user->getData('CenterID') == $candidate->getData('CenterID') || $user->getData('CenterID') == $timePoint->getData('CenterID'));
@@ -33,27 +24,16 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
 
     function getControlPanel() {
         $controlPanel = new Instrument_List_ControlPanel($_REQUEST['sessionID']);
-        if (Utility::isErrorX($controlPanel)) {
-            $tpl_data['error_message'][] = $controlPanel->getMessage();
-        } else {
-            // save possible changes from the control panel...
-            $success = $controlPanel->save();
-            if (Utility::isErrorX($success)) {
-                return $success;
-            }
+        // save possible changes from the control panel...
+        $success = $controlPanel->save();
 
-            // display the control panel
-            $html = $controlPanel->display();
-            if (Utility::isErrorX($html)) {
-                return $html;
-            }
-            // I don't know why this is here, but it
-            // was in main.php, so moved it to be safe.
-            $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-            $timePoint->select($_REQUEST['sessionID']);
-            return $html;
-        }
-
+        // display the control panel
+        $html = $controlPanel->display();
+        // I don't know why this is here, but it
+        // was in main.php, so moved it to be safe.
+        $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
+        $timePoint->select($_REQUEST['sessionID']);
+        return $html;
     }
     function setup()
     {
@@ -64,26 +44,14 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
         $this->_setupPage(null, null, null, null, 'filter');
         // get behavioral battery for this visit (time point)
         $battery = new NDB_BVL_Battery;
-        if (Utility::isErrorX($battery)) {
-            return PEAR::raiseError('Battery Error: '.$battery->getMessage());
-        }
         $success = $battery->selectBattery($_REQUEST['sessionID']);
-        if (Utility::isErrorX($success)) {
-            return PEAR::raiseError('instrument_list::setup() battery: '.$success->getMessage());
-        }
 
         // get the list of instruments
         $listOfInstruments = $battery->getBatteryVerbose();
-        if(Utility::isErrorX($listOfInstruments)) {
-            return PEAR::raiseError('instrument_list::setup() instruments: '.$listOfInstruments->getMessage());
-        }
 
         // display list of instruments
         if (!empty($listOfInstruments)) {
             $user =& User::singleton();
-            if (Utility::isErrorX($user)) {
-                return PEAR::raiseError ("User Error: ".$user->getMessage());
-            }
             $username = $user->getData('UserID');
 
             $feedback_select_inactive = null;
@@ -105,15 +73,9 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
                 // make an instrument status object
                 $status = new NDB_BVL_InstrumentStatus;
                 $success = $status->select($instrument['CommentID']);
-                if(Utility::isErrorX($success)) {
-                    return PEAR::raiseError("instrument_list::setup() instrument status: ".$success->getMessage());
-                }
 
                 $ddeStatus = new NDB_BVL_InstrumentStatus;
                 $success = $ddeStatus->select($instrument['DDECommentID']);
-                if(Utility::isErrorX($success)) {
-                    return PEAR::raiseError("instrument_list::setup() instrument status: ".$success->getMessage());
-                }
 		
                 $this->tpl_data['instruments'][$x][$i]['fullName'] = $instrument['Full_name'];
                 $this->tpl_data['instruments'][$x][$i]['dataEntryStatus'] = $status->getDataEntryStatus();
@@ -127,19 +89,10 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
                 		
                 // create feedback object for the time point
                 $feedback = NDB_BVL_Feedback::singleton($username, null, null, $instrument['CommentID']);
-                if (Utility::isErrorX($feedback)) {
-                    return PEAR::raiseError("Feedback Error (".$instrument['CommentID']."): ".$feedback->getMessage());
-                }
 		
                 $feedback_status = $feedback->getMaxThreadStatus($feedback_select_inactive);
-                if (Utility::isErrorX($feedback_status)) {
-                    return PEAR::raiseError("instrument_list::setup() feedback status: ".$feedback_status->getMessage());
-                }
 
                 $feedback_count = $feedback->getThreadCount();
-                if (Utility::isErrorX($feedback_count)) {
-                    return PEAR::raiseError("instrument_list::setup() feedback count: ".$feedback_count->getMessage());
-                }
 
                 $this->tpl_data['instruments'][$x][$i]['feedbackCount'] = (empty($feedback_count)) ? $feedback_status : $feedback_count;
                 if(!empty($feedback_status)){
@@ -155,15 +108,9 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
         }
 
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-        if (Utility::isErrorX($timePoint)) {
-            return PEAR::raiseError("TimePoint Error (".$_REQUEST['sessionID']."): ".$timePoint->getMessage());
-        }
         $candID = $timePoint->getCandID();
 
         $candidate =& Candidate::singleton($candID);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($candID): ".$candidate->getMessage());
-        }
 
         $this->tpl_data['display'] = array_merge($candidate->getData(), $timePoint->getData());
     }

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -11,14 +11,8 @@ class NDB_Form_new_profile extends NDB_Form
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         $site =& Site::singleton($user->getData('CenterID'));
-        if (Utility::isErrorX($site)) {
-            return PEAR::raiseError("Unable to construct the list_of_sites array: ".$site->getMessage());
-        }
         if ($site->isStudySite()) {
             return $user->hasPermission('data_entry');
         }
@@ -42,9 +36,6 @@ class NDB_Form_new_profile extends NDB_Form
 
         // create the candidate
         $candID = Candidate::createNew($user->getData('CenterID'), $dob, $edc, $values['gender'], $values['PSCID']);
-        if (Utility::isErrorX($candID)) {
-            return PEAR::raiseError("new_profile::_process(): ".$candID->getMessage());
-        }
 
         // get the candidate
         $candidate =& Candidate::singleton($candID);
@@ -52,9 +43,6 @@ class NDB_Form_new_profile extends NDB_Form
         if($config->getSetting('useProjects') == "true") {
             $candidate->setData('ProjectID', $values['ProjectID']);
 
-        }
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($candID): ".$candidate->getMessage());
         }
 
         //------------------------------------------------------------

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -1,6 +1,5 @@
 <?php
 require_once 'NDB_Menu_Filter.class.inc';
-require_once 'Utility.class.inc';
 /**
  * The menu for the reliability checking
  * @package mri
@@ -45,9 +44,6 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
     var $reliability_table;
     function _hasAccess() {
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         if($user->hasPermission('access_all_profiles') || $user->hasPermission('reliability_edit_all')) {
             return true;
         }
@@ -66,9 +62,6 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
     function _setupVariables()
     {
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // create the centerID map
         $db =& Database::singleton();
@@ -128,17 +121,11 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
     {
     	// create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
            // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles') || $user->hasPermission('reliability_edit_all')) {
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = Utility::getSiteList(false);
-            if(Utility::isErrorX($list_of_sites)) {
-                return PEAR::raiseError("DB Error: ".$list_of_sites->getMessage());
-            }
             if(is_array($list_of_sites)) 
             {
                 $new_list = array('' => 'All');
@@ -150,9 +137,6 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
         }else {
             // allow only to view own site data
             $site =& Site::singleton($user->getData('CenterID'));
-            if (Utility::isErrorX($site)) {
-                return PEAR::raiseError("DB Error: ".$site->getMessage());
-            }
             //if ($site->isStudySite()) {
                 $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
             //}
@@ -435,9 +419,6 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
 
     function _swap_candidates() {
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         if (!($user->hasPermission('reliability_swap_candidates'))) {
             return array("error" => "You do not have permission to swap candidates");
         }
@@ -502,9 +483,6 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
     function _addCandidate() {
         $user =& User::singleton();
         $DB =& Database::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         $params = array(); 
         $params['Instrument'] = $_POST['AddInstrument'];
         $params['Visit_label']= $_POST['AddVisit_label'];

--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -10,9 +10,6 @@ class NDB_Form_statistics extends NDB_Form
 {
     function _hasAccess() {
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         return $user->hasPermission('data_entry');
     }
 
@@ -70,9 +67,6 @@ class NDB_Form_statistics extends NDB_Form
     function statistics()
     {
         $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
 
         $this->tpl_data['StatsTabs'] = $DB->pselect(
             "SELECT ModuleName, SubModuleName, Description
@@ -84,22 +78,14 @@ class NDB_Form_statistics extends NDB_Form
 
     function stats_general()
     {
-        $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
+        //$DB =& Database::singleton();
     }
 
     function stats_behavioural()
     {
         $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
         $DB->select("SELECT CONCAT('C', CenterID) as ID, CenterID as NumericID, PSCArea as LongName, Name as ShortName FROM psc WHERE CenterID <> '1' AND Study_site = 'Y'", $centers);
-        if(Utility::isErrorX($centers)) {
-            return PEAR::raiseError("DB Error: ".$centers->getMessage());
-        }
+
         $this->tpl_data['Centers'] = $centers;
         $this->tpl_data['Sites'] = array('' => 'All Sites');
 
@@ -215,9 +201,6 @@ class NDB_Form_statistics extends NDB_Form
     function stats_MRI()
     {
         $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
 
         $projects[null] = 'All Projects';
         foreach(Utility::getProjectList() as $key => $value) {
@@ -249,9 +232,6 @@ class NDB_Form_statistics extends NDB_Form
         $this->tpl_data['Projects'] = $projects;
 
         $DB->select("SELECT CONCAT('C', CenterID) as ID, CenterID as NumericID, PSCArea as LongName, Name as ShortName FROM psc WHERE CenterID <> '1' AND Study_site = 'Y'", $centers);
-        if(Utility::isErrorX($centers)) {
-            return PEAR::raiseError("DB Error: ".$centers->getMessage());
-        }
         $this->tpl_data['Centers'] = $centers;
         $this->tpl_data['Sites'] = array('' => 'All Sites');
         foreach ($centers as $row) {
@@ -430,23 +410,14 @@ class NDB_Form_statistics extends NDB_Form
             $name = $center['LongName'];
             // -------- MRI STATS---------------
             $DB->select("SELECT COUNT(distinct s.CandID, s.Visit_label) FROM tarchive as t, session as s WHERE MID(t.PatientName,9,6)=s.CandID AND s.SubprojectID IN ($subprojList) AND s.CenterID={$center['NumericID']};", $result23);
-            if (Utility::isErrorX($result23)) {
-                return PEAR::raiseError("DB Error: ".$result23->getMessage());
-            }
             list(,$result23)=each($result23[0]);
             $work_station_count = $result23;
 
             $DB->select("SELECT COUNT(s.CandID) FROM session as s, psc as p, candidate as c WHERE c.CandID=s.CandID AND s.Active='Y' AND s.CenterID=p.CenterID  AND s.Scan_done='Y' AND s.SubprojectID IN ($subprojList) $ExtraProject_Criteria AND s.CenterID={$id} ORDER BY s.CandID;", $result24);
-            if (Utility::isErrorX($result24)) {
-                return PEAR::raiseError("DB Error: ".$result24->getMessage());
-            }
             list(,$result24)=each($result24[0]);
             $claimed_count = $result24;
 
             $DB->select("SELECT COUNT(s.CandID) FROM mri_parameter_form as pf, session as s, flag as f, psc as p, candidate as c WHERE f.CommentID=pf.CommentID AND s.ID=f.SessionID AND c.CandID=s.CandID AND s.Active='Y' AND s.CenterID=p.CenterID AND pf.Data_entry_completion_status='Complete' AND s.CenterID={$id} AND s.SubprojectID IN ($subprojList) $ExtraProject_Criteria ORDER BY p.Name;", $result25);
-            if (Utility::isErrorX($result25)) {
-                return PEAR::raiseError("DB Error: ".$result25->getMessage());
-            }
             list(,$result25)=each($result25[0]);
             $forms_count = $result25;
             $three_scans = $DB->selectOne("SELECT count(distinct CandID) FROM session v06  join flag f06 ON (f06.SessionID=v06.ID and Test_name='mri_parameter_form' AND CommentID NOT LIKE 'DDE%') join mri_parameter_form m06 ON (f06.CommentID=m06.CommentID)
@@ -523,13 +494,7 @@ class NDB_Form_statistics extends NDB_Form
     function stats_reliability()
     {
         $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
         $DB->select("SELECT CONCAT('C', CenterID) as ID, CenterID as NumericID, PSCArea as LongName, Name as ShortName FROM psc WHERE CenterID <> '1' AND Study_site = 'Y'", $centers);
-        if(Utility::isErrorX($centers)) {
-            return PEAR::raiseError("DB Error: ".$centers->getMessage());
-        }
         $this->tpl_data['Centers'] = $centers;
         $this->tpl_data['Sites'] = array('' => 'All Sites');
         $projects[null] = 'All Projects';
@@ -560,9 +525,6 @@ class NDB_Form_statistics extends NDB_Form
     function stats_demographic()
     {
         $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
 
         $projects[null] = 'All Projects';
         foreach(Utility::getProjectList() as $key => $value) {
@@ -604,9 +566,6 @@ class NDB_Form_statistics extends NDB_Form
 
             // Total, explicitly calculated instead of added in the loop to ensure there's no one double registered in 2 different cohorts
             $DB->select("SELECT count(distinct(c.PSCID)) from candidate as c WHERE c.PSCID<>'scanner' AND c.CenterID<>'1' AND c.Active='Y' $ExtraSite_Criteria $ExtraProject_Criteria", $total);
-            if (Utility::isErrorX($total)) {
-                return PEAR::raiseError("DB Error: ".$total->getMessage());
-            }
             list(,$total)=each($total[0]);
             $Total_candidates = $total;
             $this->tpl_data['Total_candidates'] = $Total_candidates;
@@ -657,9 +616,6 @@ class NDB_Form_statistics extends NDB_Form
         // Adds a C to the start of the centerid, because that's how the
         // template is looking for it. Exclude DCC 
         $DB->select("SELECT CONCAT('C', CenterID) as ID, CenterID as NumericID, PSCArea as LongName, Name as ShortName FROM psc WHERE CenterID <> '1' AND Study_site = 'Y'", $centers);
-        if(Utility::isErrorX($centers)) {
-            return PEAR::raiseError("DB Error: ".$centers->getMessage());
-        }
         $this->tpl_data['Centers'] = $centers;
         $this->tpl_data['Sites'] = array('' => 'All Sites');
         foreach ($centers as $row) {
@@ -722,9 +678,6 @@ class NDB_Form_statistics extends NDB_Form
                 AND COALESCE(s.Screening,'') NOT IN ('Failure', 'Withdrawal')
                 AND COALESCE(s.Visit,'') NOT IN ('Failure', 'Withdrawal')
                 GROUP BY c.CenterID, SubprojectID, VLabel, Subcat", $result);
-            if (Utility::isErrorX($result)) {
-                return PEAR::raiseError("DB Error: ".$result->getMessage());
-            }
             $this->tpl_data['RecruitsTable'] = $this->render_stats_table("Breakdown of Registered Candidates", $Subcategories, $Visits, "DemographicInstrument", $instruments, '', $centers, $result, "demographics", $currentProject);
 
         }

--- a/modules/statistics/php/NDB_Menu_statistics_mri_site.class.inc
+++ b/modules/statistics/php/NDB_Menu_statistics_mri_site.class.inc
@@ -127,9 +127,6 @@ class NDB_Menu_statistics_mri_site extends NDB_Menu_statistics_site
             header("Location: ?test_name=statistics#data_entry");
         }
         $DB =& Database::singleton();
-        if(PEAR::isError($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
         $center = $DB->pselectRow("SELECT CenterID as ID, PSCArea as Name FROM psc WHERE CenterID=:cid", array('cid'=>$_REQUEST['CenterID'])); 
         $id = $center['ID'];
         $name = $center['Name'];

--- a/modules/statistics/php/NDB_Menu_statistics_site.class.inc
+++ b/modules/statistics/php/NDB_Menu_statistics_site.class.inc
@@ -56,9 +56,6 @@ class NDB_Menu_statistics_site extends NDB_Menu
                 AND s.Current_stage <> 'Recycling Bin'
                 AND f.Administration='All' 
                 AND i.CommentID NOT LIKE 'DDE%'", $this->query_vars);
-        if (PEAR::isError($result)) {
-            return PEAR::raiseError("DB Error: ".$result->getMessage());
-        }
         return $count;
     }
 
@@ -76,9 +73,6 @@ class NDB_Menu_statistics_site extends NDB_Menu
                 $this->query_criteria
                 AND (f.Data_entry is NULL OR f.Data_entry<>'Complete') 
                 AND i.CommentID NOT LIKE 'DDE%' ORDER BY s.Visit_label, c.PSCID", $this->query_vars);
-        if (PEAR::isError($result)) {
-            return PEAR::raiseError("DB Error: ".$result->getMessage());
-        }
         return $result;
     }
 
@@ -91,9 +85,6 @@ class NDB_Menu_statistics_site extends NDB_Menu
             header("Location: ?test_name=statistics#data_entry");
         }
         $DB =& Database::singleton();
-        if(PEAR::isError($DB)) {
-            return PEAR::raiseError("Could not connect to database: ".$DB->getMessage());
-        }
         if (!empty($_REQUEST['CenterID']))
         {
             $center = $DB->pselectRow("SELECT CenterID as ID, PSCArea as Name FROM psc WHERE CenterID =:cid", array('cid'=>$_REQUEST['CenterID'])); 

--- a/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
+++ b/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
@@ -12,14 +12,8 @@ class NDB_Menu_timepoint_list extends NDB_Menu
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         $candidate =& Candidate::singleton($_REQUEST['candID']);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error (".$_REQUEST['candID']."): ".$candidate->getMessage());
-        }
 
         // check user permissions
     	if ($user->hasPermission('access_all_profiles') || $user->getData('CenterID') == $candidate->getData('CenterID')) {
@@ -33,10 +27,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
         foreach ($listOfTimePoints as $sessionID) {
             // create timepoint object
             $timePoint =& TimePoint::singleton($sessionID);
-            if(Utility::isErrorX($timePoint)) {
-                return PEAR::raiseError("TimePoint Error ($sessionID): ".$timePoint->getMessage());
-            }
-
             // check if at least one timepoint belongs to the user's site
             if ($user->getData('CenterID') == $timePoint->getData('CenterID')) {
                 return true;
@@ -50,9 +40,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
     {
         // create candidate object
         $candidate =& Candidate::singleton($_REQUEST['candID']);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error (".$_REQUEST['candID']."): ".$candidate->getMessage());
-        }
         
         $numberOfVisits = 0;
         $this->tpl_data['candID'] = $_REQUEST['candID'];
@@ -61,9 +48,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
     
         if (!empty($listOfTimePoints)) {
             $user =& User::singleton();
-            if (Utility::isErrorX($user)) {
-                return PEAR::raiseError("User Error: ".$user->getMessage());
-            }
             $username = $user->getData('UserID');
 
             $feedback_select_inactive = null;
@@ -77,9 +61,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
             $x = 0;
             foreach ($listOfTimePoints as $currentTimePoint) {
                 $timePoint =& TimePoint::singleton($currentTimePoint);
-                if (Utility::isErrorX($timePoint)) {
-                    return PEAR::raiseError("TimePoint Error ($currentTimePoint): ".$timePoint->getMessage());
-                }
             
                 // get the first date of visit in order to
                 // turn on the future time points bit if we have a date of visit
@@ -100,19 +81,10 @@ class NDB_Menu_timepoint_list extends NDB_Menu
                 
                 // create feedback object for the time point            
                 $feedback = NDB_BVL_Feedback::singleton($username, null, $timePoint->getData('SessionID'));
-                if (Utility::isErrorX($feedback)) {
-                    return PEAR::raiseError("Feedback Error (".$timePoint->getData('SessionID')."): ".$feedback->getMessage());
-                }
 
                 $feedback_status = $feedback->getMaxThreadStatus($feedback_select_inactive);
-                if (Utility::isErrorX($feedback_status)) {
-                    return PEAR::raiseError("timepoint_list::setup() feedback status: ".$feedback_status->getMessage());
-                }
 
                 $feedback_count = $feedback->getThreadCount();
-                if (Utility::isErrorX($feedback_count)) {
-                    return PEAR::raiseError("timepoint_list::setup() feedback count: ".$feedback_count->getMessage());
-                }
 
                 $this->tpl_data['timePoints'][$x]['feedbackCount'] = (empty($feedback_count)) ? $feedback_status : $feedback_count;
                 $this->tpl_data['timePoints'][$x]['feedbackStatus'] = $feedback_status;
@@ -124,9 +96,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
 
                     // get the outcome data
                     $outcomeStage = $this->_determinePreviousStage($currentTimePoint);
-                    if (Utility::isErrorX($outcomeStage)) {
-                        return PEAR::raiseError("timepoint_list::setup() outcome stage: ".$outcomeStage->getMessage());
-                    }
                     $getStatusMethod = 'get'.$outcomeStage.'Status';
                     $getDateMethod = 'getDateOf'.$outcomeStage;
 
@@ -147,9 +116,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
              */
             if (isset($firstDateOfVisit)) {
                 $timePoint = TimePoint::singleton($listOfTimePoints[0]);
-                if (Utility::isErrorX($timePoint)) {
-                    return PEAR::raiseError("TimePoint Error ($listOfTimePoints[0]): ".$timePoint->getMessage());
-                }
 
                 $this->tpl_data['SubprojectID'] = $timePoint->getSubprojectID();
 				
@@ -163,9 +129,6 @@ class NDB_Menu_timepoint_list extends NDB_Menu
     {
         // create timepoint object
         $timePoint =& TimePoint::singleton($sessionID);
-        if (Utility::isErrorX($timePoint)) {
-            return PEAR::raiseError("TimePoint Error ($sessionID): ".$timePoint->getMessage());
-        }
 
         // outcome stage is the last stage (approval || visit || screening || not started, in that order) with a non-null status
         if($timePoint->getData('Approval') != NULL) {

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -433,9 +433,6 @@ class NDB_BVL_Feedback
         $query .= " GROUP BY $queryBy";
 
         $success = $db->pselectOne($query, $qparams);
-        if (Utility::isErrorX($success)) {
-            return "DB Error: ".$success->getMessage();
-        }
         return $success;
     }
 
@@ -514,9 +511,6 @@ class NDB_BVL_Feedback
 
         // create user object
         $user =& User::singleton($this->_username);
-        if (Utility::isErrorX($user)) {
-            return "Unable to create user object".$user->getMessage();
-        }
         $hasReadPermission = $user->hasPermission('access_all_profiles');
 
         $query   = "SELECT c.CandID as CandID, c.PSCID as PSCID";
@@ -894,10 +888,6 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         $user =& User::singleton($this->_username);
-        if (Utility::isErrorX($user)) {
-            return "Unable to create user object in activate threads: "
-                . $user->getMessage();
-        }
 
         $setArray = array(
                      "Active"   => 'Y',

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2127,7 +2127,7 @@ class NDB_BVL_Instrument extends NDB_Page
                     $BasePath
                     . "NDB_BVL_Instrument_$TestName.class.inc"
                 )
-                || file_exists($BasePath . "$TestName.linst")
+                    || file_exists($BasePath . "$TestName.linst")
                 ) {
                     // save possible changes from the control panel...
                     $success = $controlPanel->save();

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -542,17 +542,9 @@ class NDB_BVL_Instrument extends NDB_Page
             // the database
             $dataEntryCompletionStatus
                 = $this->_determineDataEntryCompletionStatus();
-            if (Utility::isErrorX($dataEntryCompletionStatus)) {
-                print "Could not determine DECS: "
-                    .  $dataEntryCompletionStatus->getMessage()
-                    ."<br>\n";
-            }
             $success = $this->_setDataEntryCompletionStatus(
                 $dataEntryCompletionStatus
             );
-            if (Utility::isErrorX($success)) {
-                print "Could not set DECS: ".$success->getMessage()."<br>\n";
-            }
         } else {
             $submittedData = $this->form->getSubmitValues();
 
@@ -1042,9 +1034,6 @@ class NDB_BVL_Instrument extends NDB_Page
     {
         // get a database connection
         $db =& Database::singleton();
-        if (Utility::isErrorX($db)) {
-            return $db;
-        }
 
         $query = "SELECT Subtest_name AS Name, Description
             FROM instrument_subtests
@@ -1052,9 +1041,6 @@ class NDB_BVL_Instrument extends NDB_Page
                 ORDER BY Order_number";
 
         $results = $db->pselect($query, array('TN' => $this->testName));
-        if (Utility::isErrorX($results)) {
-            return $results;
-        }
 
         return $results;
     }
@@ -2131,27 +2117,20 @@ class NDB_BVL_Instrument extends NDB_Page
             $controlPanel = new NDB_BVL_InstrumentStatus_ControlPanel;
             $success      = $controlPanel->select($_REQUEST['commentID']);
 
-            if (Utility::isErrorX($success)) {
-                $tpl_data['error_message'][] = $success->getMessage();
-            } else {
-                $config = NDB_Config::singleton();
-                $paths  = $config->getSetting('paths');
-                if (empty($subtest)) {
-                    // check if the file/class exists
-                    $BasePath = $paths['base'] . 'project/instruments/';
-                    $TestName = $this->testName;
-                    if (file_exists(
-                        $BasePath
-                        . "NDB_BVL_Instrument_$TestName.class.inc"
-                    )
-                        || file_exists($BasePath . "$TestName.linst")
-                    ) {
-                        // save possible changes from the control panel...
-                        $success = $controlPanel->save();
-                        if (Utility::isErrorX($success)) {
-                            $tpl_data['error_message'][] = $success->getMessage();
-                        }
-                    }
+            $config = NDB_Config::singleton();
+            $paths  = $config->getSetting('paths');
+            if (empty($subtest)) {
+                // check if the file/class exists
+                $BasePath = $paths['base'] . 'project/instruments/';
+                $TestName = $this->testName;
+                if (file_exists(
+                    $BasePath
+                    . "NDB_BVL_Instrument_$TestName.class.inc"
+                )
+                || file_exists($BasePath . "$TestName.linst")
+                ) {
+                    // save possible changes from the control panel...
+                    $success = $controlPanel->save();
                 }
 
                 // display the control panel

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -414,9 +414,6 @@ class NDB_Caller
                 $_REQUEST['sessionID']
             );
         }
-        if (Utility::isErrorX($instrument)) {
-            return $instrument;
-        }
 
         // save instrument form data
         $success = $instrument->save();

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -102,9 +102,6 @@ class NDB_Client
         // include Smarty
         include_once "Smarty_hook.class.inc";
 
-        if (Utility::isErrorX($DB)) {
-            die("Could not connect to database: ".$DB->getMessage());
-        }
         $GLOBALS['DB'] =& $DB;
 
         // tell Pear to print errors if the config says so
@@ -140,8 +137,7 @@ class NDB_Client
         }
         if (!$login->isLoggedIn()) {
             $auth = $login->authenticate();
-            if (Utility::isErrorX($auth)) {
-            } elseif ($auth === true) {
+            if ($auth === true) {
                 $error = $login->setState();
             } elseif ($auth === false) {
                 header("HTTP/1.1 403 Forbidden");
@@ -157,9 +153,6 @@ class NDB_Client
         }
 
         $user =& User::singleton($_SESSION['State']->getUsername());
-        if (Utility::isErrorX($user)) {
-             die("Could not validate user: ".$user->getMessage());
-        }
 
         // finished initializing
         return true;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -42,7 +42,9 @@ class Utility
      */
     static function isErrorX($data, $code=null)
     {
-        throw new LorisException("Utility::isErrorX has been deprecated. Anywhere using them should use real PHP exceptions instead.");
+        throw new LorisException(
+            "Utility::isErrorX has been deprecated. Use PHP5 exceptions instead."
+        );
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -42,17 +42,7 @@ class Utility
      */
     static function isErrorX($data, $code=null)
     {
-        if (!is_a($data, 'PEAR_Error')) {
-            return false;
-        }
-
-        if (is_null($code)) {
-            return true;
-        } elseif (is_string($code)) {
-            return $data->getMessage() == $code;
-        }
-
-        return $data->getCode() == $code;
+        throw new LorisException("Utility::isErrorX has been deprecated. Anywhere using them should use real PHP exceptions instead.");
     }
 
     /**


### PR DESCRIPTION
This begins the process of removing the Utility::isErrorX function for the next release. The function is converted to throw an exception when called, so that all references to it can be updated and converted to PHP5 style errors, with the goal of eventually removing the function entirely.