### PR TITLE
Conflict resolver menu permission

### DIFF
--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -77,7 +77,7 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
 
 -- Conflict Resolver
 INSERT INTO LorisMenuPermissions (MenuID, PermID) 
-    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Conflict Resolver';
+    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='conflict_resolver' AND m.Label='Conflict Resolver';
 
 -- Examiner
 INSERT INTO LorisMenuPermissions (MenuID, PermID) 

--- a/SQL/2015-11-27_conflict_resolver_menu_item_permission.sql
+++ b/SQL/2015-11-27_conflict_resolver_menu_item_permission.sql
@@ -1,0 +1,3 @@
+UPDATE LorisMenuPermissions SET PermID = (SELECT permID FROM permissions WHERE code = 'conflict_resolver') 
+  WHERE PermID = (SELECT permID FROM permissions where code = 'data_entry') 
+  AND MenuId = (SELECT ID FROM LorisMenu WHERE Label = 'Conflict Resolver');


### PR DESCRIPTION
The permission required to access the module is now the same than the permission required to view the menu.