### PR TITLE
Remove isErrorX references from modules

### DIFF
--- a/htdocs/request_account/process_new_account.php
+++ b/htdocs/request_account/process_new_account.php
@@ -33,9 +33,6 @@ $client->makeCommandLine();
 $client->initialize($configFile);
 
 $DB = Database::singleton();
-if (Utility::isErrorX($DB)) {
-     return("Could not connect to database: ".$DB->getMessage());
-}
 session_start();
 $tpl_data = array();
 
@@ -135,16 +132,10 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             "SELECT COUNT(*) FROM users WHERE Email = :VEmail",
             array('VEmail' => $from)
         );
-        if (Utility::isErrorX($result)) {
-            return PEAR::raiseError("DB Error: ".$result->getMessage());
-        }
 
         if ($result == 0) {
             // insert into db only if email address if it doesnt exist
             $success = $DB->insert('users', $vals);
-            if (Utility::isErrorX($success)) {
-                return PEAR::raiseError("DB Error: ".$success->getMessage());
-            }
         }
         unset($_SESSION['tntcon']);
         //redirect to a new page

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -266,10 +266,6 @@ class DirectDataEntryMainPage
             array('key' => $this->key)
         );
 
-        if (Utility::isErrorX($currentStatus)) {
-            return false;
-        }
-
         if ($currentStatus === 'Complete') {
             // Already completed, don't want to accidentally change it back to
             // started or some other status..

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -42,25 +42,18 @@ class NDB_Form_candidate_parameters extends NDB_Form
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // check that the $candID is passed b/c the profile needs to be opened
         if ($this->identifier != $_REQUEST['candID']) {
-            return PEAR::raiseError("NDB_Form_candidate_parameters::_access: 
+            throw new LorisException("NDB_Form_candidate_parameters::_access: 
                        Candidate Profile Error (".$_REQUEST['candID']."): ");
         }
 
         $candidate =& Candidate::singleton($this->identifier);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error 
-                           ($this->identifier): ".$candidate->getMessage());
-        }
 
         // check user permissions
-	return ($user->hasPermission('candidate_parameter_edit')  
-                && $user->getData('CenterID') == $candidate->getData('CenterID'));  
+        return ($user->hasPermission('candidate_parameter_edit')  
+            && $user->getData('CenterID') == $candidate->getData('CenterID'));  
     }
      /**
       * Returns default values for all candidate parameters
@@ -106,16 +99,12 @@ class NDB_Form_candidate_parameters extends NDB_Form
         $familyid = $DB->pselectOne("SELECT FamilyID from family WHERE 
                                     CandID=:CandidateID",
                                     array('CandidateID'=>$this->identifier));
-        if (Utility::isErrorX($familyid)) {
-            return PEAR::raiseError("Error: ".$familyid->getMessage());
-        } else {
-            $this->tpl_data['familyID'] = $familyid;
-            $relations                  = $DB->pselect("SELECT CandID, Relationship_type 
-                                          FROM family WHERE FamilyID=:fam_id AND 
-                                          CandID <> '$this->identifier'",
-                                          array('fam_id'=> $familyid));
+        $this->tpl_data['familyID'] = $familyid;
+        $relations                  = $DB->pselect("SELECT CandID, Relationship_type 
+            FROM family WHERE FamilyID=:fam_id AND 
+            CandID <> '$this->identifier'",
+            array('fam_id'=> $familyid));
 
-        }
         $this->tpl_data['sibling_list'] = array();
         foreach ($relations as $relation) {
             $relation['Relationship_type']    = $this->relationType[$relation['Relationship_type']];
@@ -282,32 +271,20 @@ class NDB_Form_candidate_parameters extends NDB_Form
 
        if (isset($values['FamilyMemberID'])) { 
            $fid = $DB->pselectOne("SELECT FamilyID FROM family WHERE CandID=:CaID", array('CaID' => $this->identifier));
-           if (Utility::isErrorX($fid)) {
-               return PEAR::raiseError("Could not family id: ".$fid->getMessage());
-           }
            if (empty($fid)) {
                $famID = $DB->pselectOne("SELECT max(FamilyID) from family");
-               if (Utility::isErrorX($famID)) {
-                   return PEAR::raiseError("Could not family id: ".$famID->getMessage());
-               }
                if (empty($famID)) {
                    $famID = 0;
                }
                $fid = $famID+1;
                $success = $DB->insert('family', array('CandID'=>$this->identifier, 'FamilyID'=>$fid,
                            'Relationship_type'=>$values['relation_type']));
-               if (Utility::isErrorX($success)) {
-                   return PEAR::raiseError("DB Error: ".$success->getMessage());
-               }
 
            }
 
            $value   = $values['FamilyMemberID'];
            $success = $DB->insert('family', array('CandID'=>$value,'FamilyID'=>$fid,
                                   'Relationship_type'=>$values['relation_type']));
-           if (Utility::isErrorX($success)) {
-               return PEAR::raiseError("DB Error: ".$success->getMessage());
-           }
           
        }
        // updating participant status
@@ -345,12 +322,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
                $success = $DB->insert("participant_status",$participant_vals);
            }
 
-           if (Utility::isErrorX($success)) {
-               return PEAR::raiseError(
-                       "NDB_Form_candidate_parameters::_process: ".$success->getMessage()
-                       );
-           }
-
            $current_status = $DB->pselectOne("SELECT participant_status FROM participant_status_history
                                               WHERE CandID = :cid ORDER BY data_entry_date DESC", 
                                               array("cid"=>$values['CandID']) );
@@ -362,12 +333,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
                                 'CandID' => $participant_vals['CandID'],
                                 'reason_specify'=>$participant_vals['reason_specify'],
                                 'reason_specify_status'=>$participant_vals['reason_specify_status']));
-               if (Utility::isErrorX($success)) {
-                   return PEAR::raiseError(
-                           "NDB_Form_candidate_parameters::_process: ".$success->getMessage()
-                           );
-               }
-
            }
           
        }
@@ -444,9 +409,6 @@ class NDB_Form_candidate_parameters extends NDB_Form
         $config =& NDB_Config::singleton();
         
         $candidate =& Candidate::singleton($this->identifier);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());
-        }
 
         // candID
         $this->tpl_data['candID'] = $candidate->getData('CandID');

--- a/modules/create_timepoint/php/NDB_Form_create_timepoint.class.inc
+++ b/modules/create_timepoint/php/NDB_Form_create_timepoint.class.inc
@@ -16,14 +16,8 @@ class NDB_Form_create_timepoint extends NDB_Form
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         $candidate =& Candidate::singleton($this->identifier);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());
-        }
 
         // check user permissions
     	return ($user->hasPermission('data_entry') && $user->getData('CenterID') == $candidate->getData('CenterID'));
@@ -32,23 +26,14 @@ class NDB_Form_create_timepoint extends NDB_Form
     function _getDefaults()
     {
         $candidate =& Candidate::singleton($this->identifier);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());
-        }
 
         $defaults['visitLabel'] = $candidate->getNextVisitLabel();
-        if (Utility::isErrorX($defaults['visitLabel'])) {
-            return PEAR::raiseError("create_timepoint::_getDefaults(): ".$defaults['visitLabel']->getMessage());
-        }
         return $defaults;
     }
 
     function _process($values)
     {
         $success = TimePoint::createNew($this->identifier, $values['subprojectID'], $values['visitLabel']);
-        if(Utility::isErrorX($success)) {
-            return PEAR::raiseError("create_timepoint::_process(): ".$success->getMessage());
-        }
 
         $this->tpl_data['success'] = true;
 
@@ -68,9 +53,6 @@ class NDB_Form_create_timepoint extends NDB_Form
         $this->tpl_data['candID'] = $this->identifier;
         $this->addHidden('candID', $this->identifier);
         $candidate =& Candidate::singleton($this->identifier);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());
-        }
         $subprojList = null; 
         //List of valid subprojects for a given project
         if($config->getSetting('useProjects') === 'true') {
@@ -155,14 +137,8 @@ class NDB_Form_create_timepoint extends NDB_Form
         }
 
         $candidate =& Candidate::singleton($this->identifier);
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());
-        }
 
         $timePointArray = $candidate->getListOfVisitLabels();
-        if (Utility::isErrorX($timePointArray)) {
-            return PEAR::raiseError("create_timepoint::_validate(): ".$timePointArray->getMessage());
-        }
 
         //If the visitLabel is already in use then let the user pick another
         foreach($timePointArray AS $used_label) {

--- a/modules/data_team_helper/php/NDB_Form_data_team_helper.class.inc
+++ b/modules/data_team_helper/php/NDB_Form_data_team_helper.class.inc
@@ -35,9 +35,6 @@ class NDB_Form_data_team_helper extends NDB_Form
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         return ($user->hasPermission('data_team_helper'));
     }
     /**
@@ -569,9 +566,6 @@ class NDB_Form_data_team_helper extends NDB_Form
             );
         }
 
-        if (Utility::isErrorX($test_names)) {
-            return PEAR::raiseError("DB Error: ".$instruments->getMessage());
-        }
         return $test_names;
     }
 }

--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -30,9 +30,6 @@ if (get_magic_quotes_gpc()) {
 
 // create user object
 $user =& User::singleton();
-if (Utility::isErrorX($user)) {
-	return PEAR::raiseError("User Error: ".$user->getMessage());
-}
 
 if ($user->hasPermission('data_dict_edit')) { //if user has edit permission
 	if ($DB->pselectOne("SELECT COUNT(*) FROM parameter_type_override WHERE Name =:id",array('id'=>$name))==0) {  //if it doesn't exist

--- a/modules/datadict/php/NDB_Menu_Filter_datadict.class.inc
+++ b/modules/datadict/php/NDB_Menu_Filter_datadict.class.inc
@@ -16,9 +16,6 @@ class NDB_Menu_Filter_datadict extends NDB_Menu_Filter
 	{
 		// create user object
 		$user =& User::singleton();
-		if(Utility::isErrorX($user)) {
-			return PEAR::raiseError("User Error: ".$user->getMessage());
-		}
 
 		return ($user->hasPermission('data_dict_view') || $user->hasPermission('data_dict_edit'));
 	}

--- a/modules/dicom_archive/php/NDB_Form_dicom_archive.class.inc
+++ b/modules/dicom_archive/php/NDB_Form_dicom_archive.class.inc
@@ -53,10 +53,6 @@ class NDB_Form_Dicom_Archive extends NDB_Form
     function viewDetails()
     {
         $this->DB = Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-            die();
-        }
 
         if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess())) {
             $tarchiveID = $_REQUEST['tarchiveID'];
@@ -123,11 +119,7 @@ class NDB_Form_Dicom_Archive extends NDB_Form
             break;
         }
         
-        if (Utility::isErrorX($array)) { 
-            return null;
-        } else {
-            return $array;
-        }
+        return $array;
     }
     /**
     * Validates PatientName and PatientID,
@@ -175,13 +167,13 @@ class NDB_Form_Dicom_Archive extends NDB_Form
      */
     function _setProtocols() 
     {
-        $query = "SELECT Scan_type, TR_range, TE_range, TI_range, 
-            slice_thickness_range FROM mri_protocol";
-        $this->protocols = $this->DB->pselect($query, array());
-        if (Utility::isErrorX($this->protocols)) { 
-            return false;
-        } else {
+        try {
+            $query = "SELECT Scan_type, TR_range, TE_range, TI_range, 
+                slice_thickness_range FROM mri_protocol";
+            $this->protocols = $this->DB->pselect($query, array());
             return true;
+        } catch(LorisException $e) {
+            return false;
         }
     }
     /**
@@ -267,12 +259,12 @@ class NDB_Form_Dicom_Archive extends NDB_Form
      */
     function _getProtocolNameFromID($id) 
     {
-        $query = "SELECT Scan_type FROM mri_scan_type WHERE ID=:ID";
-        $array = $this->DB->pselectRow($query, array('ID' => $id));
-        if (Utility::isErrorX($array)) {
-            return "Unknown";
-        } else {
+        try {
+            $query = "SELECT Scan_type FROM mri_scan_type WHERE ID=:ID";
+            $array = $this->DB->pselectRow($query, array('ID' => $id));
             return $array['Scan_type'];
+        } catch (LorisException $e) {
+            return "Unknown";
         }
     }
 }

--- a/modules/dicom_archive/php/NDB_Menu_Filter_dicom_archive.class.inc
+++ b/modules/dicom_archive/php/NDB_Menu_Filter_dicom_archive.class.inc
@@ -171,9 +171,6 @@ class NDB_Menu_Filter_Dicom_Archive extends NDB_Menu_Filter
     {
         $list_of_sites = array('' => 'All');
         $sitesList = Utility::getSiteList(false);
-        if (Utility::isErrorX($sitesList)) {
-            return PEAR::raiseError("DB Error: ".$sitesList->getMessage());
-        }
 
         foreach ($sitesList as $key=>$value) {
             $list_of_sites[$key]= $value;

--- a/modules/document_repository/ajax/addCategory.php
+++ b/modules/document_repository/ajax/addCategory.php
@@ -29,11 +29,6 @@ $config = NDB_Config::singleton();
 
 // create Database object
 $DB =& Database::singleton();
-if (Utility::isErrorX($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n"; die();
-}
-
-
 
 if (empty($_POST['category_name']) && $_POST['category_name'] !== '0') {
     header("HTTP/1.1 400 Bad Request");
@@ -54,10 +49,6 @@ if ($_POST['comments'] !== '') {
 }
 
 $user =& User::singleton();
-if (Utility::isErrorX($user)) {
-    return PEAR::raiseError("User Error: ".$user->getMessage());
-}
-
 //if user has document repository permission
 if ($user->hasPermission('document_repository_view') || $user->hasPermission('document_repository_delete')) {
     $DB->insert(

--- a/modules/document_repository/ajax/categoryEdit.php
+++ b/modules/document_repository/ajax/categoryEdit.php
@@ -24,9 +24,6 @@ $client->initialize("../../project/config.xml");
 
 // create Database object
 $DB =& Database::singleton();
-if (Utility::isErrorX($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n"; die();
-}
 
 if (get_magic_quotes_gpc()) {
     // Magic quotes adds \ to description, get rid of it.
@@ -38,9 +35,6 @@ if (get_magic_quotes_gpc()) {
 }
 
 $user =& User::singleton();
-if (Utility::isErrorX($user)) {
-    return PEAR::raiseError("User Error: ".$user->getMessage());
-}
 
 //if user has document repository permission
 if ($user->hasPermission('document_repository_view') || $user->hasPermission('document_repository_delete')) {

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -17,9 +17,6 @@ $config = NDB_Config::singleton();
 
 // create Database object
 $DB =& Database::singleton();
-if (Utility::isErrorX($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n"; die();
-}
 
 $rid = $_POST['id'];
 
@@ -31,9 +28,6 @@ $dataDir  = $DB->pselectOne("Select Data_dir from document_repository where reco
                             array(':identifier'=> $rid));
 
 $user =& User::singleton();
-if (Utility::isErrorX($user)) {
-    return PEAR::raiseError("User Error: ".$user->getMessage());
-}
 
 //if user has document repository delete permission
 if ($user->hasPermission('document_repository_delete')) {

--- a/modules/document_repository/ajax/documentEditUpload.php
+++ b/modules/document_repository/ajax/documentEditUpload.php
@@ -17,15 +17,8 @@ $config = NDB_Config::singleton();
 
 // create Database object
 $DB =& Database::singleton();
-if (Utility::isErrorX($DB)) {
-    print "Could not connect to database: ".$DB->getMessage()."<br>\n"; die();
-}
 
 $action = $_POST['action'];
-
-if (Utility::isErrorX($userSingleton)) {
-    return PEAR::raiseError("User Error: ".$userSingleton->getMessage());
-}
 
 //if user has document repository permission
 if ($userSingleton->hasPermission('document_repository_view') || $userSingleton->hasPermission('document_repository_delete')) {

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -36,9 +36,6 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         
         //create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User error: " . $user->getMessage());
-        }
 
         return $user->hasPermission('document_repository_view') || $user->hasPermission('document_repository_delete');
     
@@ -47,9 +44,6 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
     function _setupVariables()
     {
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // create the centerID map
         $db =& Database::singleton();
@@ -94,24 +88,15 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         $list_of_sites = Utility::getSiteList(true, false);
            // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles')) { 
             // get the list of study sites - to be replaced by the Site object
-            if (Utility::isErrorX($list_of_sites)) {
-                return PEAR::raiseError("DB Error: ".$list_of_sites->getMessage());
-            }
             if (is_array($list_of_sites)) $list_of_sites = array(null => 'Any') + $list_of_sites;
         } else {
             // allow only to view own site data
             $site =& Site::singleton($user->getData('CenterID'));
-            if (Utility::isErrorX($site)) {
-                return PEAR::raiseError("DB Error: ".$site->getMessage());
-            }
             if ($site->isStudySite()) {
                 $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
             }
@@ -195,13 +180,6 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
     function _getPreparedQuery() 
     {
         $DB = Database::singleton();
-      // create DB object
-        $DB =& Database::singleton();
-        if (Utility::isErrorX($DB)) {
-            return PEAR::raiseError(
-                "Could not connect to database: ".$DB->getMessage()
-            );
-        }
 
         $qparams = array();
         // add the base query

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -30,10 +30,6 @@ require_once "HelpFile.class.inc";
 
 // create DB object
 $DB =& Database::singleton();
-if (Utility::isErrorX($DB)) {
-    return PEAR::raiseError("Could not connect to database: ".
-                             $DB->getMessage());
-}
 
 // store some request information
 if (!empty($_REQUEST['helpID'])) {

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -55,9 +55,6 @@ class Imaging_Session_ControlPanel
     function _hasAccess()
     {
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: " .$user->getMessage());
-        }
         return $user->hasPermission('imaging_browser_qc');
     }
 
@@ -70,9 +67,6 @@ class Imaging_Session_ControlPanel
     {
         $DB        = Database::singleton();
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-        if (Utility::isErrorX($timePoint)) {
-            print $timePoint->getMessage()."<br>";
-        }
 
         $subjectData['sessionID'] = $_REQUEST['sessionID'];
         $subjectData['candid']    = $timePoint->getCandID();
@@ -87,20 +81,17 @@ class Imaging_Session_ControlPanel
         );
 
         $candidate =& Candidate::singleton($timePoint->getCandID());
-        if (Utility::isErrorX($candidate)) {
-            print $candidate->getMessage()."<br>";
+
+        $params     = array();
+        $EntityType = $candidate->getData('Entity_type');
+        if ($EntityType == 'Scanner') {
+            $ID = ":PPSCID";
+            $params['PPSCID'] = $timePoint->getData('PSCID');
         } else {
-            $params     = array();
-            $EntityType = $candidate->getData('Entity_type');
-            if ($EntityType == 'Scanner') {
-                $ID = ":PPSCID";
-                $params['PPSCID'] = $timePoint->getData('PSCID');
-            } else {
-                $ID = "LOWER(CONCAT(:PPSCID, '_', :PCandID, '_', :PVL, '%'))";
-                $params['PPSCID']  = $candidate->getPSCID();
-                $params['PCandID'] = $timePoint->getCandID();
-                $params['PVL']     = $timePoint->getVisitLabel();
-            }
+            $ID = "LOWER(CONCAT(:PPSCID, '_', :PCandID, '_', :PVL, '%'))";
+            $params['PPSCID']  = $candidate->getPSCID();
+            $params['PCandID'] = $timePoint->getCandID();
+            $params['PVL']     = $timePoint->getVisitLabel();
         }
         $tarchiveIDs = $DB->pselect(
             "SELECT TarchiveID 

--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -49,15 +49,9 @@ class NDB_Form_Imaging_Browser extends NDB_Form
     function _hasAccess()
     {
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: " .$user->getMessage());
-        }
 
         // allow only to view own site data
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-        if (Utility::isErrorX($timePoint)) {
-            return PEAR::raiseError("TimePoint Error (".$_REQUEST['sessionID']."): ".$timePoint->getMessage());
-        }
 
         return ($user->hasPermission('imaging_browser_view_allsites') || ($user->getData('CenterID') == $timePoint->getData('CenterID') && $user->hasPermission('imaging_browser_view_site')));
     }
@@ -70,9 +64,6 @@ class NDB_Form_Imaging_Browser extends NDB_Form
     function _hasQCPerm()
     {
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: " .$user->getMessage());
-        }
 
         return $user->hasPermission('imaging_browser_qc');
     }
@@ -85,10 +76,6 @@ class NDB_Form_Imaging_Browser extends NDB_Form
     function viewSession() 
     {
         $this->DB = Database::singleton();
-        if (Utility::isErrorX($this->DB)) {
-            print "Could not connect to database: ".$DB->getMessage()."<br>\n";
-            die();
-        }
 
         $this->sessionID = $_REQUEST['sessionID'];
 
@@ -344,9 +331,6 @@ class NDB_Form_Imaging_Browser extends NDB_Form
                     $success = $this->DB->update(
                         'files_qcstatus', $updateSet, $updateWhere
                     );
-                    if (Utility::isErrorX($success)) {
-                        die("DB Error: ".$success->getMessage());
-                    }
                 } else {
                     $file = new MRIFile($curFileID);
                     $updateSet['SeriesUID'] = $file->getParameter(
@@ -444,9 +428,6 @@ class NDB_Form_Imaging_Browser extends NDB_Form
                         $success = $this->DB->insert('parameter_file', $insertSet);
                     }
                 }
-                if (Utility::isErrorX($success)) {
-                    die("DB Error: ".$success->getMessage());
-                }
             }
         }
     }
@@ -489,9 +470,6 @@ class NDB_Form_Imaging_Browser extends NDB_Form
             $success = $this->DB->update(
                 'session', $updateSet, array('ID'=>$this->sessionID)
             );
-            if (Utility::isErrorX($success)) {
-                die("DB Error: ".$success->getMessage());
-            }
             // sppool a message to the mri qc status rss channel
             if (($save_visit_status != $old_visit_status) 
                 || ($old_pending_status != $_POST['visit_pending'])
@@ -548,9 +526,6 @@ class NDB_Form_Imaging_Browser extends NDB_Form
     function getSubjectData() 
     {
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-        if (Utility::isErrorX($timePoint)) {
-            print $timePoint->getMessage()."<br>";
-        }
 
         $subjectData['sessionID'] = $_REQUEST['sessionID'];
         $subjectData['SubprojectID'] = $timePoint->getSubprojectID();
@@ -567,36 +542,33 @@ class NDB_Form_Imaging_Browser extends NDB_Form
         $subjectData['mriqcpending'] = $qcstatus['MRIQCPending'];
         $subjectData['candid'] = $timePoint->getCandID();
         $subjectData['scanner'] = $this->scanner;
-        $candidate =& Candidate::singleton($timePoint->getCandID());
-        if (Utility::isErrorX($candidate)) { 
-            print $candidate->getMessage()."<br>";
-        } else {
-            $subjectData['pscid'] = $candidate->getPSCID();
-            $subjectData['dob'] = $candidate->getCandidateDoB();
-            $subjectData['edc'] = $candidate->getCandidateEDC();
-            $subjectData['gender'] = $candidate->getCandidateGender();
 
-            // This doesn't work. 
-            //Need to find the proper way to get the TarchiveID. 
-            //It should be per file, not per candidate. --Dave
-            $params = array();
-            $EntityType = $candidate->getData('Entity_type');
-            if ($EntityType == 'Scanner') {
-                $ID = ":PPSCID";
-                $params['PPSCID'] = $timePoint->getData('PSCID');
-            } else {
-                $ID = "LOWER(CONCAT(:PPSCID, '_', :PCandID, '_', :PVL, '%'))";
-                $params['PPSCID'] = $candidate->getPSCID();
-                $params['PCandID'] = $timePoint->getCandID();
-                $params['PVL'] = $timePoint->getVisitLabel();
-            }
-            $tarchiveIDs = $this->DB->pselect(
-                "SELECT TarchiveID 
-                FROM tarchive 
-                WHERE PatientName LIKE $ID", $params
-            );
-            $subjectData['tarchiveids'] = $tarchiveIDs;
+        $candidate =& Candidate::singleton($timePoint->getCandID());
+        $subjectData['pscid'] = $candidate->getPSCID();
+        $subjectData['dob'] = $candidate->getCandidateDoB();
+        $subjectData['edc'] = $candidate->getCandidateEDC();
+        $subjectData['gender'] = $candidate->getCandidateGender();
+
+        // This doesn't work. 
+        //Need to find the proper way to get the TarchiveID. 
+        //It should be per file, not per candidate. --Dave
+        $params = array();
+        $EntityType = $candidate->getData('Entity_type');
+        if ($EntityType == 'Scanner') {
+            $ID = ":PPSCID";
+            $params['PPSCID'] = $timePoint->getData('PSCID');
+        } else {
+            $ID = "LOWER(CONCAT(:PPSCID, '_', :PCandID, '_', :PVL, '%'))";
+            $params['PPSCID'] = $candidate->getPSCID();
+            $params['PCandID'] = $timePoint->getCandID();
+            $params['PVL'] = $timePoint->getVisitLabel();
         }
+        $tarchiveIDs = $this->DB->pselect(
+            "SELECT TarchiveID 
+            FROM tarchive 
+            WHERE PatientName LIKE $ID", $params
+        );
+        $subjectData['tarchiveids'] = $tarchiveIDs;
         // Cache the data
         return $subjectData;
     }

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -36,15 +36,9 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
     function _hasAccess()
     {
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: " .$user->getMessage());
-        }
 
         // allow only to view own site data
         $site =& Site::singleton($user->getData('CenterID'));
-        if (Utility::isErrorX($site)) {
-            return PEAR::raiseError("DB Error: ".$site->getMessage());
-        }
 
         return ($user->hasPermission('imaging_browser_view_allsites') || ($site->isStudySite() && $user->hasPermission('imaging_browser_view_site')));
     }
@@ -191,25 +185,16 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         
         // PSC
         if ($user->hasPermission('imaging_browser_view_allsites')) {
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = Utility::getSiteList();
-            if(Utility::isErrorX($list_of_sites)) {
-                return PEAR::raiseError("DB Error: ".$list_of_sites->getMessage());
-            }
             if(is_array($list_of_sites)) $list_of_sites = array('' => 'All') + $list_of_sites;
         }
         else {
             // allow only to view own site data
             $site =& Site::singleton($user->getData('CenterID'));
-            if (Utility::isErrorX($site)) {
-                return PEAR::raiseError("DB Error: ".$site->getMessage());
-            }
             if ($site->isStudySite()) {
                 $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
             }

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -36,9 +36,6 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         $this->tpl_data['violated_scans_modifications'] 
             = $user->hasPermission('violated_scans_edit');
         return ($user->hasPermission('violated_scans_view_allsites'));
@@ -51,9 +48,6 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
         }
         $DB =& Database::singleton();
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         foreach ($values['resolvable'] AS $key=>$val) {
             $hash = $key;
             $row = $DB->pselectRow(
@@ -146,9 +140,6 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
         // set the class variables
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         $config =& NDB_Config::singleton();
         $useProjects = $config->getSetting("useProjects");
@@ -288,9 +279,6 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
         $config =& NDB_Config::singleton();
         $study = $config->getSetting('study');
         $dateOptions = array(
@@ -339,9 +327,6 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
             $sites = Utility::getSiteList();
-            if(Utility::isErrorX($sites)) {
-                return PEAR::raiseError("DB Error: ".$sites->getMessage());
-            }
             if(is_array($sites)){
                 $sites = array('' => 'All') + $sites;
             }
@@ -349,9 +334,6 @@ class NDB_Menu_Filter_Form_mri_violations extends NDB_Menu_Filter_Form
         else {
             // allow only to view own site data
             $site =& Site::singleton($user->getData('CenterID'));
-            if (Utility::isErrorX($site)) {
-                return PEAR::raiseError("DB Error: ".$site->getMessage());
-            }
             if ($site->isStudySite()) {
                 $sites = array($user->getData('CenterID') => $user->getData('Site'));
             }

--- a/modules/next_stage/php/NDB_Form_next_stage.class.inc
+++ b/modules/next_stage/php/NDB_Form_next_stage.class.inc
@@ -49,9 +49,6 @@ class NDB_Form_next_stage extends NDB_Form
         // create a new battery object && new battery
         $battery = new NDB_BVL_Battery;
         $candidate =& Candidate::singleton($timePoint->getCandID() );
-        if (Utility::isErrorX($candidate)) {
-            return PEAR::raiseError("Candidate Error ($this->identifier): ".$candidate->getMessage());
-        }
 
         $firstVisit = false;
         $vLabel = $candidate->getFirstVisit();//get first visit for candidate 

--- a/modules/survey_accounts/ajax/GetEmailContent.php
+++ b/modules/survey_accounts/ajax/GetEmailContent.php
@@ -36,7 +36,7 @@ $result = $DB->pselectOne(
     "SELECT DefaultEmail FROM participant_emails WHERE Test_name=:TN",
     array('TN' => $_REQUEST['test_name'])
 );
-if (Utility::isErrorX($result) || empty($result)) {
+if (empty($result)) {
     print "";
 } else {
     print $result;

--- a/modules/survey_accounts/php/NDB_Form_survey_accounts.class.inc
+++ b/modules/survey_accounts/php/NDB_Form_survey_accounts.class.inc
@@ -37,9 +37,6 @@ class NDB_Form_survey_accounts extends NDB_Form
     {
         // create user object
         $editor =& User::singleton();
-        if (Utility::isErrorX($editor)) {
-            return PEAR::raiseError("User Error: ".$editor->getMessage());
-        }
 
         return $editor->hasPermission('user_accounts');
     }
@@ -203,9 +200,6 @@ class NDB_Form_survey_accounts extends NDB_Form
                 'CommentID'        => $commentID
             )
         );
-        if (Utility::isErrorX($success)) {
-            return PEAR::raiseError("DB Error: ".$success->getMessage());
-        }
         $this->tpl_data['success'] = $success;
  
         if ($email) {

--- a/modules/survey_accounts/php/NDB_Menu_Filter_survey_accounts.class.inc
+++ b/modules/survey_accounts/php/NDB_Menu_Filter_survey_accounts.class.inc
@@ -33,9 +33,6 @@ class NDB_Menu_Filter_survey_accounts extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         return $user->hasPermission('user_accounts');
     }
@@ -49,9 +46,6 @@ class NDB_Menu_Filter_survey_accounts extends NDB_Menu_Filter
     function _setupVariables()
     {
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // the base query
         $query = " FROM participant_accounts p 
@@ -98,10 +92,6 @@ class NDB_Menu_Filter_survey_accounts extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        if (Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
-
         $this->addBasicText('PSCID', 'PSCID');
         // add form elements
         $this->addSelect(

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -11,9 +11,6 @@ class NDB_Menu_Filter_user_accounts extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         return $user->hasPermission('user_accounts');
     }
@@ -21,9 +18,6 @@ class NDB_Menu_Filter_user_accounts extends NDB_Menu_Filter
     function _setupVariables()
     {
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // the base query
         $query = " FROM users LEFT JOIN psc ON (psc.CenterID = users.CenterID) WHERE 1=1 ";
@@ -53,25 +47,16 @@ class NDB_Menu_Filter_user_accounts extends NDB_Menu_Filter
     {
     	// create user object
         $user =& User::singleton();
-        if(Utility::isErrorX($user)) {
-            return PEAR::raiseError("User Error: ".$user->getMessage());
-        }
 
         // PSC
         if ($user->hasPermission('user_accounts_multisite')) {
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites =& Utility::getSiteList(false);
-            if(Utility::isErrorX($list_of_sites)) {
-                return PEAR::raiseError("DB Error: ".$list_of_sites->getMessage());
-            } 
             if(is_array($list_of_sites)) $list_of_sites = array('' => 'All',0=>'Not Assigned') + $list_of_sites;
         }
         else {
             // allow only to view own site data
             $site =& Site::singleton($user->getData('CenterID'));
-            if (Utility::isErrorX($site)) {
-                return PEAR::raiseError("Unable to construct the list_of_sites array: ".$site->getMessage());
-            }
             $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
         }
 

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -147,11 +147,6 @@ class NDB_Form extends NDB_Page
     {
         if ($this->form->validate()) {
             $success = $this->form->process(array(&$this, "_save"), false);
-            // Just in case QuickForm returned a PEAR error instead of an
-            // exception..
-            if (Utility::isErrorX($success)) {
-                throw new Exception($success->getMessage());
-            }
         }
     }
 

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -48,14 +48,6 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
         ) {
             if ($this->form->validate()) {
                 $success = $this->form->process(array(&$this, "_save"), false);
-                // QuickForm may have returned a PEAR error, so convert it
-                // to an exception. If this is ever upgraded to QF2, this
-                // if statement can probably be removed.
-                if (Utility::isErrorX($success) ) {
-                    throw new Exception(
-                        "NDB_Form::save(): ". $success->getMessage()
-                    );
-                }
             }
         }
     }
@@ -88,12 +80,6 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
         }
 
         $success = $this->_process($values);
-
-        // Who knows what lurks in the hearts of overridden methods.
-        // Convert PEAR errors to exceptions.
-        if (Utility::isErrorX($success)) {
-            throw new Exception("NDB_Form::_save(): ".$success->getMessage());
-        }
     }
 
 


### PR DESCRIPTION
There were (many) modules still referencing Utility::isErrorX. Since the method now throws an exception, the modules are currently crashing. 

This removes all remaining references to Utility::isErrorX (hopefully)