### PR TITLE
Log Database errors to Apache error log

### DIFF
--- a/php/exceptions/DatabaseException.class.inc
+++ b/php/exceptions/DatabaseException.class.inc
@@ -41,6 +41,7 @@ class DatabaseException extends LorisException
         parent::__construct($msg);
         $this->query  = $query;
         $this->params = $bindparams;
+        error_log("Could not execute $query. Stack trace" . $this->getTraceAsString());
     }
 }
 ?>

--- a/php/exceptions/DatabaseException.class.inc
+++ b/php/exceptions/DatabaseException.class.inc
@@ -41,7 +41,9 @@ class DatabaseException extends LorisException
         parent::__construct($msg);
         $this->query  = $query;
         $this->params = $bindparams;
-        error_log("Could not execute $query. Stack trace" . $this->getTraceAsString());
+        error_log(
+            "Could not execute $query. Stack trace" . $this->getTraceAsString()
+        );
     }
 }
 ?>


### PR DESCRIPTION
This adds code to the DatabaseException constructor to log the failed queries to the apache error log.