### PR TITLE
Autoescape HTML Insertion and Update

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -826,9 +826,11 @@ class Database
         $this->select("SHOW INDEX FROM $table", $description);
 
         // find the primary key columns
-        foreach ($description AS $column) {
-            if ($column['Key_name']=='PRIMARY') {
-                $primaryKeys[] = $column['Column_name'];
+        if(is_array($description)) {
+            foreach ($description AS $column) {
+                if ($column['Key_name']=='PRIMARY') {
+                    $primaryKeys[] = $column['Column_name'];
+                }
             }
         }
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -267,7 +267,7 @@ class Database
      *
      * @return A copy of $set with the HTML characters escaped
      */
-    private function HTMLEscapeArray($set)
+    private function _HTMLEscapeArray($set)
     {
         $retVal = array();
         foreach ($set as $key => $val) {
@@ -291,7 +291,7 @@ class Database
     private function _realinsert($table, $set, $autoescape = true)
     {
         if ($autoescape === true) {
-            $set = $this->HTMLEscapeArray($set);
+            $set = $this->_HTMLEscapeArray($set);
         }
         $query  = "INSERT INTO $table SET ";
         $query .= $this->_implodeWithKeys(', ', $set);
@@ -323,7 +323,7 @@ class Database
         $this->lastInsertID = $this->_PDO->lastInsertId();
 
         // Track changes must be called after last insertId is set
-        $err = $this->_trackChanges($table, $set, '2=1', 'I');
+        $err = $this->trackChanges($table, $set, '2=1', 'I');
         return true;
     }
 
@@ -415,7 +415,7 @@ class Database
     private function _realupdate($table, $set, $i_where, $autoescape = true)
     {
         if ($autoescape === true) {
-            $set = $this->HTMLEscapeArray($set);
+            $set = $this->_HTMLEscapeArray($set);
         }
         /* This is still here to print the easily readable version on
          * the top of the page when showDatabaseQueries is on. It isn't
@@ -450,7 +450,7 @@ class Database
             );
         }
 
-        $err = $this->_trackChanges($table, $set, $where);
+        $err = $this->trackChanges($table, $set, $where);
         $this->_printQuery($query.$where);
 
         $prep   = $this->_PDO->prepare($prepQ);
@@ -497,7 +497,7 @@ class Database
 
         // There is no set clause for a delete, so add a fake
         // one.
-        $err = $this->_trackChanges($table, array(), $where, 'D');
+        $err = $this->trackChanges($table, array(), $where, 'D');
 
         $this->_printQuery($query);
         $this->affected = $this->_PDO->exec($query);
@@ -769,8 +769,9 @@ class Database
      * @return string A string that can be used to generate a prepared statement with
      *                appropriate variable names generated for data binding.
      */
-    private function _implodeAsPrepared($glue, $dataArray, &$exec_vals = null, $prefix='')
-    {
+    private function _implodeAsPrepared(
+        $glue, $dataArray, &$exec_vals = null, $prefix=''
+    ) {
         if (!is_array($dataArray) || count($dataArray)==0) {
             return '';
         }
@@ -813,7 +814,7 @@ class Database
      *
      * @return none As a side-effect populates history table
      */
-    protected function _trackChanges($table, $set, $where, $type='U')
+    protected function trackChanges($table, $set, $where, $type='U')
     {
         // Tracking changes on the history table would result in an
         // infinite loop

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -228,18 +228,71 @@ class Database
     }
 
     /**
-     * Inserts a row
+     * Insert a row into the database
      *
-     * Inserts a single row into the specified table, containing the values specified
+     * This will insert a row. HTML from any field in the row will be automatically
+     * escaped to avoid injection.
      *
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the new row
      *
      * @return none
-     * @access public
      */
-    function insert($table, $set)
+    public function insert($table, $set)
     {
+        return $this->_realinsert($table, $set, true);
+    }
+
+    /**
+     * Insert a row into the database without validating input.
+     *
+     * This will insert a row. HTML from any field in the row will *not* be
+     * automatically * escaped. This should only be called when we know the source of
+     * the input is trustworthy and must contain HTML.
+     *
+     * @param string $table the table into which to insert the row
+     * @param array  $set   the values with which to fill the new row
+     *
+     * @return none
+     */
+    public function unsafeinsert($table, $set)
+    {
+        return $this->_realinsert($table, $set, false);
+    }
+
+    /**
+     * Escapes the HTML from an array that is about to be inserted into the database
+     *
+     * @param array $set The array to be inserted as a new row
+     *
+     * @return A copy of $set with the HTML characters escaped
+     */
+    public function HTMLEscapeArray($set)
+    {
+        $retVal = array();
+        foreach ($set as $key => $val) {
+            $retVal[$key] = htmlspecialchars($val);
+        }
+        return $retVal;
+    }
+
+    /**
+     * Inserts a row
+     *
+     * Inserts a single row into the specified table, containing the values specified
+     *
+     * @param string $table      the table into which to insert the row
+     * @param array  $set        the values with which to fill the new row
+     * @param bool   $autoescape determines whether the values to be set should
+     *                           automatically have the html escaped
+     *
+     * @return none
+     */
+    private function _realinsert($table, $set, $autoescape = true)
+    {
+        if ($autoescape === true) {
+            $set = $this->HTMLEscapeArray($set);
+        }
         $query  = "INSERT INTO $table SET ";
         $query .= $this->_implodeWithKeys(', ', $set);
 
@@ -315,17 +368,56 @@ class Database
     /**
      * Updates a row
      *
-     * Updates a single row in the specified table
+     * Updates a single row in the specified table. This will automatically escape
+     * any HTML in the data being inserted for security.
      *
      * @param string $table   the table into which to insert the row
      * @param array  $set     the values with which to fill the new row
      * @param array  $i_where the selection filter, joined as a boolean and
      *
      * @return none
+     */
+    public function update($table, $set, $i_where)
+    {
+        return $this->_realupdate($table, $set, $i_where, true);
+    }
+
+    /**
+     * Updates a row
+     *
+     * Updates a single row in the specified table. This will *not* automatically
+     * escape and should be used with caution, only when you know you need to
+     * insert HTML and know that you can trust it.
+     *
+     * @param string $table   the table into which to insert the row
+     * @param array  $set     the values with which to fill the new row
+     * @param array  $i_where the selection filter, joined as a boolean and
+     *
+     * @return none
+     */
+    public function unsafeupdate($table, $set, $i_where)
+    {
+        return $this->_realupdate($table, $set, $i_where, false);
+    }
+    /**
+     * Updates a row
+     *
+     * Updates a single row in the specified table
+     *
+     * @param string $table      the table into which to insert the row
+     * @param array  $set        the values with which to fill the new row
+     * @param array  $i_where    the selection filter, joined as a boolean and
+     * @param bool   $autoescape determines whether the values to be set should
+     *                           automatically have the html escaped
+     *
+     * @return none
      * @access public
      */
-    function update($table, $set, $i_where)
+    private function _realupdate($table, $set, $i_where, $autoescape = true)
     {
+        if ($autoescape === true) {
+            $set = $this->HTMLEscapeArray($set);
+        }
         /* This is still here to print the easily readable version on
          * the top of the page when showDatabaseQueries is on. It isn't
          * actually executed. */

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -247,7 +247,7 @@ class Database
      * Insert a row into the database without validating input.
      *
      * This will insert a row. HTML from any field in the row will *not* be
-     * automatically * escaped. This should only be called when we know the source of
+     * automatically escaped. This should only be called when we know the source of
      * the input is trustworthy and must contain HTML.
      *
      * @param string $table the table into which to insert the row

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -267,7 +267,7 @@ class Database
      *
      * @return A copy of $set with the HTML characters escaped
      */
-    public function HTMLEscapeArray($set)
+    private function HTMLEscapeArray($set)
     {
         $retVal = array();
         foreach ($set as $key => $val) {
@@ -307,7 +307,6 @@ class Database
 
         // There is no where clause for an insert, so add a fake
         // one.
-
         $this->_printQuery($query);
         $prep   = $this->_PDO->prepare($prepQ);
         $result = $prep->execute($exec_params);
@@ -770,7 +769,7 @@ class Database
      * @return string A string that can be used to generate a prepared statement with
      *                appropriate variable names generated for data binding.
      */
-    function _implodeAsPrepared($glue, $dataArray, &$exec_vals = null, $prefix='')
+    private function _implodeAsPrepared($glue, $dataArray, &$exec_vals = null, $prefix='')
     {
         if (!is_array($dataArray) || count($dataArray)==0) {
             return '';
@@ -814,7 +813,7 @@ class Database
      *
      * @return none As a side-effect populates history table
      */
-    private function _trackChanges($table, $set, $where, $type='U')
+    protected function _trackChanges($table, $set, $where, $type='U')
     {
         // Tracking changes on the history table would result in an
         // infinite loop

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -826,7 +826,7 @@ class Database
         $this->select("SHOW INDEX FROM $table", $description);
 
         // find the primary key columns
-        if(is_array($description)) {
+        if (is_array($description)) {
             foreach ($description AS $column) {
                 if ($column['Key_name']=='PRIMARY') {
                     $primaryKeys[] = $column['Column_name'];

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1000,7 +1000,7 @@ class Database
             $this->run($createStmt);
 
             foreach ($rowData as $row) {
-                $this->insert($tableName, $row);
+                $this->unsafeinsert($tableName, $row);
             }
         } else {
             throw new DatabaseException(

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -19,7 +19,7 @@ class FakePDO extends PDO
 }
 
 class FakeDatabase extends Database {
-    protected function _trackChanges($table, $set, $where, $type='U') {
+    protected function trackChanges($table, $set, $where, $type='U') {
     }
 }
 

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -13,6 +13,16 @@
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+class FakePDO extends PDO
+{
+    public function __construct () {}
+}
+
+class FakeDatabase extends Database {
+    protected function _trackChanges($table, $set, $where, $type='U') {
+    }
+}
+
 /**
  * This tests the LorisForm replacement for HTML_QuickForm used by
  * Loris.
@@ -25,6 +35,12 @@ require_once __DIR__ . '/../../vendor/autoload.php';
  */
 class Database_Test extends PHPUnit_Framework_TestCase
 {
+    function _getAllMethodsExcept($methods) {
+        $AllMethods = get_class_methods('Database');
+
+        return array_diff($AllMethods, $methods);
+    }
+
     function testSetFakeData() {
         $client = new NDB_Client();
         $client->makeCommandLine();
@@ -59,5 +75,87 @@ class Database_Test extends PHPUnit_Framework_TestCase
         );
 
     }
+
+
+    function testUpdateEscapesHTML() {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('update')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+
+        $stmt->expects($this->once())->method("execute")->with(
+            $this->equalTo(array(
+                'set_field' => '&lt;b&gt;Hello&lt;/b&gt;'
+            )
+            )
+        );
+
+        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->update("test", array('field' => '<b>Hello</b>'), array());
+
+    }
+
+    function testUnsafeUpdateDoesntEscapeHTML() {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('unsafeupdate')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+
+        $stmt->expects($this->once())->method("execute")->with(
+            $this->equalTo(array(
+                'set_field' => '<b>Hello</b>'
+            )
+            )
+        );
+
+        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->unsafeupdate("test", array('field' => '<b>Hello</b>'), array());
+
+    }
+    function testInsertEscapesHTML() {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('insert')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+
+        $stmt->expects($this->once())->method("execute")->with(
+            $this->equalTo(array(
+                'field' => '&lt;b&gt;Hello&lt;/b&gt;'
+            )
+            )
+        );
+
+        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->insert("test", array('field' => '<b>Hello</b>'), array());
+
+    }
+
+    function testUnsafeInsertDoesntEscapeHTML() {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('unsafeinsert')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+
+        $stmt->expects($this->once())->method("execute")->with(
+            $this->equalTo(array(
+                'field' => '<b>Hello</b>'
+            )
+            )
+        );
+
+        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->unsafeinsert("test", array('field' => '<b>Hello</b>'), array());
+
+    }
 }
+
+
 ?>


### PR DESCRIPTION
This modifies the database wrapper to make it more difficult for users to inject HTML. Any HTML attempting to be inserted or updated by the database wrapper is automatically escaped so that a safe version is inserted.

An UnsafeInsert and UnsafeUpdate function is added to be used when you need to directly save HTML into the database, but you must be making an explicit decision to use the Unsafe version when you know you want to save HTML into the database, the default is to automatically escape when using the insert/update wrappers.