### PR TITLE
Fixed bug where search keyword crashes other menus

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -514,9 +514,9 @@ class NDB_Menu_Filter extends NDB_Menu
             }
         }
 
-        if (is_array($this->searchKey)
-            && count($this->searchKey) > 0
-            && $this->searchKey['keyword'] !== ''
+        if (is_array($this->searchKeyword)
+            && count($this->searchKeyword) > 0
+            && !empty($this->searchKey['keyword'])
         ) {
             $WhereClause .= " AND (";
             $fields       = array();


### PR DESCRIPTION
The base NDB_Menu_Filter class maintains the filters
as you go between pages. This means that if you set
a search key, and then go to a page which doesn't have
any searchKeywords fields defined, the SQL generated
becomes invalid.

This updates the code so that the filter checks if
$this->searchKeyword is set and non-empty (the field
defined by the form) instead of $this->searchKey['keyword']
(the field with the user input)