### PR TITLE
Replacing the infinite loading by an info panel when there is no result to show

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -175,3 +175,10 @@ div.navbar div.container div.navbar-brand {
     to { transform: scale(1) rotate(360deg);}
 }
 
+/*
+ *      CSS for alert div
+ */
+.no-result-found-panel {
+    color: #FFFFFF;
+    background-color: #1c70b6;
+}

--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -1,4 +1,6 @@
 StaticDataTable = React.createClass({
+    displayName: 'StaticDataTable',
+
     mixins: [React.addons.PureRenderMixin],
     propTypes: {
         Headers: React.PropTypes.array.isRequired,
@@ -50,6 +52,19 @@ StaticDataTable = React.createClass({
         });
     },
     render: function () {
+        if (this.props.Data == null) {
+            return React.createElement(
+                'div',
+                {
+                    className: 'alert alert-info no-result-found-panel'
+                },
+                React.createElement(
+                    'strong',
+                    null,
+                    'No result found.'
+                )
+            );
+        }
         var rowsPerPage = this.state.RowsPerPage;
         var headers = [React.createElement(
             'th',

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -50,6 +50,15 @@ StaticDataTable = React.createClass({
        });
     },
     render: function() {
+        if (this.props.Data == null) {
+            return (
+                <div 
+                    className="alert alert-info no-result-found-panel"
+                >
+                    <strong>No result found.</strong>
+                </div>
+            );
+        }
         var rowsPerPage = this.state.RowsPerPage;
         var headers = [<th onClick={this.setSortColumn(-1)}>{this.props.RowNumLabel}</th>];
         for(var i = 0; i < this.props.Headers.length; i += 1) {


### PR DESCRIPTION
When the SaticDataTable component is call with a null Data property, the loading button was not replace by the table. Now there will be a bootstrap info-alert telling the user that there is no result found.

<img width="1426" alt="screen shot 2015-12-21 at 3 50 10 pm" src="https://cloud.githubusercontent.com/assets/12155214/11941020/8c65bb00-a7fa-11e5-8c9b-b29fcb481830.png">