### PR TITLE
Fixed table name in conflicts resolved search keyword

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -138,7 +138,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             array(
              'CandID'   => 'session.CandID',
              'PSCID'    => 'candidate.PSCID',
-             'Question' => 'conflicts_unresolved.Fieldname',
+             'Question' => 'conflicts_resolved.Fieldname',
             )
         );
         return true;


### PR DESCRIPTION
This fixes a bug with the conflicts_resolved "Search keyword" filter, where it was looking in the conflicts_unresolved table (which isn't joined) instead of the conflicts_resolved table (which is the correct place.)