### PR TITLE
Delete from conflicts_unresolved table only if Data Entry Status was set in the past

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -213,7 +213,7 @@ class NDB_BVL_InstrumentStatus
 
         // Remove conflicts for SDE & DDE form from the
         // Conflict Resolver if new status is 'In Progress'
-        if ($status == 'In Progress') {
+        if ($this->getDataEntryStatus() != null && $status == 'In Progress') {
             $deleteWhere1 = array('CommentId1' => $this->_commentID);
             $deleteWhere2 = array('CommentId2' => $this->_commentID);
             $GLOBALS['DB']->delete('conflicts_unresolved', $deleteWhere1);


### PR DESCRIPTION
This could definitely be more robust, but does the job for now.