### PR TITLE
Visit label as argument can now be used

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -467,16 +467,19 @@ class NDB_Config
         // Format the results the same way it was formatted in config.xml
         // This variable assignment was done for phpcs... if anyone figures out
         // a way around this, please correct it
-        $x = $info['WindowDifference'];
-        return array(
-                'id'                => $info['SubprojectID'],
-                'title'             => $info['title'],
-                'options'           => array(
-                                        'useEDC'           => $info['useEDC'],
-                                        'WindowDifference' => $x,
-                                       ),
-                'RecruitmentTarget' => $info['RecruitmentTarget'],
-               );
+        if (!empty($info))
+        {
+            $x = $info['WindowDifference'];            
+            return array(
+                    'id'                => $info['SubprojectID'],
+                    'title'             => $info['title'],
+                    'options'           => array(
+                                            'useEDC'           => $info['useEDC'],
+                                            'WindowDifference' => $x,
+                                           ),
+                    'RecruitmentTarget' => $info['RecruitmentTarget'],
+                   );
+        }
     }
 
     /**

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -467,9 +467,8 @@ class NDB_Config
         // Format the results the same way it was formatted in config.xml
         // This variable assignment was done for phpcs... if anyone figures out
         // a way around this, please correct it
-        if (!empty($info))
-        {
-            $x = $info['WindowDifference'];            
+        if (!empty($info)) {
+            $x = $info['WindowDifference'];
             return array(
                     'id'                => $info['SubprojectID'],
                     'title'             => $info['title'],

--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -55,9 +55,7 @@ if ((isset($argv[1]) && $argv[1] === "confirm")
 }
 
 $DB    = Database::singleton();
-$query = "SELECT ID, subprojectID from session";
 if (!empty($argv[1]) && $argv[1]!="confirm") {
-    $query .=" WHERE visit_label='$argv[1]'";
     $visit_label = $argv[1];
 } else {
     $visit_labels = $DB->pselect(
@@ -127,12 +125,12 @@ function populateVisitLabel($result, $visit_label)
 }
 
 if (isset($visit_label)) {
-    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session 
+    $query ="SELECT s.ID, s.subprojectID, s.CandID from session 
             s LEFT JOIN candidate c USING (CandID) 
             WHERE s.Active='Y'
             AND c.Active='Y' AND s.visit_label=:vl";
-    $where   = array('vl' => $argv[1]);
-    
+    $where = array('vl' => $argv[1]);
+
     $results = $DB->pselect($query, $where);
     foreach ($results AS $result) {
         populateVisitLabel($result, $visit_label);

--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -127,8 +127,9 @@ function populateVisitLabel($result, $visit_label)
 }
 
 if (isset($visit_label)) {
-    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session s 
-            LEFT JOIN candidate c USING (CandID) WHERE s.Active='Y'
+    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session
+            s LEFT JOIN candidate c USING (CandID)
+            WHERE s.Active='Y'
             AND c.Active='Y' AND s.visit_label =:vl";
     $where   = array('vl' => $argv[1]);
     

--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -54,7 +54,7 @@ if ((isset($argv[1]) && $argv[1] === "confirm")
     $confirm = true;
 }
 
-$DB    = Database::singleton();
+$DB = Database::singleton();
 if (!empty($argv[1]) && $argv[1]!="confirm") {
     $visit_label = $argv[1];
 } else {

--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -127,10 +127,10 @@ function populateVisitLabel($result, $visit_label)
 }
 
 if (isset($visit_label)) {
-    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session
-            s LEFT JOIN candidate c USING (CandID)
+    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session 
+            s LEFT JOIN candidate c USING (CandID) 
             WHERE s.Active='Y'
-            AND c.Active='Y' AND s.visit_label =:vl";
+            AND c.Active='Y' AND s.visit_label=:vl";
     $where   = array('vl' => $argv[1]);
     
     $results = $DB->pselect($query, $where);

--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -58,6 +58,7 @@ $DB    = Database::singleton();
 $query = "SELECT ID, subprojectID from session";
 if (!empty($argv[1]) && $argv[1]!="confirm") {
     $query .=" WHERE visit_label='$argv[1]'";
+    $visit_label = $argv[1];
 } else {
     $visit_labels = $DB->pselect(
         "SELECT DISTINCT Visit_label FROM session
@@ -66,6 +67,7 @@ if (!empty($argv[1]) && $argv[1]!="confirm") {
         array()
     );
 }
+
 /**
  * Adds the missing instruments based on the visit_label
  *
@@ -125,11 +127,11 @@ function populateVisitLabel($result, $visit_label)
 }
 
 if (isset($visit_label)) {
-    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session 
-            s LEFT JOIN candidate c USING (CandID) 
-            WHERE s.Active='Y'
-            AND c.Active='Y' AND s.visit_label=:vl";
-    $where   = array('vl' => "'".$argv[1]."'");
+    $query   ="SELECT s.ID, s.subprojectID, s.CandID from session s 
+            LEFT JOIN candidate c USING (CandID) WHERE s.Active='Y'
+            AND c.Active='Y' AND s.visit_label =:vl";
+    $where   = array('vl' => $argv[1]);
+    
     $results = $DB->pselect($query, $where);
     foreach ($results AS $result) {
         populateVisitLabel($result, $visit_label);


### PR DESCRIPTION
$visit_label was not getting set, so skipping the if statement.

second argument of an array  of pselect does not need to be surrounded by single  quotes.