### PR TITLE
Ordering has been updated to be consistent as the file names

### DIFF
--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -153,7 +153,7 @@ class NDB_Form_Imaging_Browser extends NDB_Form
             WHERE SessionID=:SID AND (AcquisitionProtocolID IS NULL 
             OR AcquisitionProtocolID not in (1, 2, 3, 52)) 
             AND PendingStaging=0 $extra_where_string 
-            ORDER BY files.OutputType, sel.Value DESC, AcquisitionProtocolID",
+            ORDER BY files.File",
             array(
                'SID' => $this->sessionID,
                'selectedTypeID' => $this->DB->selectOne(

--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -153,7 +153,7 @@ class NDB_Form_Imaging_Browser extends NDB_Form
             WHERE SessionID=:SID AND (AcquisitionProtocolID IS NULL 
             OR AcquisitionProtocolID not in (1, 2, 3, 52)) 
             AND PendingStaging=0 $extra_where_string 
-            ORDER BY files.File",
+            ORDER BY files.OutputType, files.File",
             array(
                'SID' => $this->sessionID,
                'selectedTypeID' => $this->DB->selectOne(


### PR DESCRIPTION
MRI Browser: can volumes appear from left to right either in the order they were selected (or in alphabetical order). when the order changes, it makes it difficult to relate QC information from the 3rd image in the Volume Viewer back to the 002 image in the browser.