### PR TITLE
Added a Content-Security-Policy to Loris

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -115,6 +115,21 @@ class NDB_Client
             return true;
         }
 
+        // Content-Security policy for LORIS
+        // 1. By default, only allow things that are self-hosted
+        // 2. Allow inline CSS and JS (inline JS is required for
+        //    the Loris base class to load smarty variables
+        // 3. Allow unsafe-eval because jQuery requires it to load
+        //    our menus. It will be fixed in jQuery 3.0.0.
+        //    See: https://github.com/jquery/jquery/issues/2012
+        // 4. Allow data URLs for fonts, because our bootstrap theme
+        //    seems to load a font that way.
+        header(
+            "Content-Security-Policy: "
+            . "default-src 'self' 'unsafe-inline'; "
+            . "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+            . "font-src 'self' data:"
+        );
         // start php session
         session_start();
 


### PR DESCRIPTION
This adds a Content-Security-Policy header to LORIS requests loaded through main.php in order to help prevent XSS attacks.

The policy it implements is:
1. By default, only allow things that are self-hosted
2. Allow inline CSS and JS (inline JS is required for the Loris base class to load smarty variables). We should eventually try and find a way to tighten up this policy.
3. Allow unsafe-eval because jQuery requires it to load our menus. It will be fixed in jQuery 3.0.0.
    See: jquery/jquery#2012). After we upgrade jQuery, we should remove this.
 4. Allow data URLs for fonts, because our bootstrap theme seems to load a font that way. We should probably update our theme to use a real URL and remove this.