### PR TITLE
Remove script loaded from third party (15.10.2)

### DIFF
--- a/smarty/templates/bvl_feedback_panel.tpl
+++ b/smarty/templates/bvl_feedback_panel.tpl
@@ -4,7 +4,6 @@
 <meta itemprop="sessionID" context="{$sessionID}">
 <meta itemprop="commentID" context="{$commentID}">
 <script src="/js/react-with-addons-0.13.3.js"></script>
-<script src="https://fb.me/JSXTransformer-0.13.3.js"></script>
 
 
 


### PR DESCRIPTION
This solves a bug where the feedback module was loading a JSX development script from a third party server. The file is unused, so the reference is just removed..