### PR TITLE
Add proper content type for JSON format

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -282,6 +282,7 @@ class NDB_Caller
                 }
                 break;
             case 'json':
+                header('Content-Type: application/json');
                 print $menu->toJSON();
                 exit(0);
                 break;


### PR DESCRIPTION
This adds the proper Content-Type header to requests with ?format=json, instead of the default text/html.