### PR TITLE
Remove showTiming setting from config schema

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -67,7 +67,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'css', 'CSS file used for rendering (default main.css)', 1, 0, 'text', ID, 'CSS file', 1 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'rowsPerPage', 'Number of table rows to display per page', 1, 0, 'text', ID, 'Table rows per page', 2 FROM ConfigSettings WHERE Name="gui";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showTiming', 'Show breakdown of timing information for page loading', 1, 0, 'boolean', ID, 'Show page load timing', 3 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showPearErrors', 'Print PEAR errors', 1, 0, 'boolean', ID, 'Show PEAR errors', 4 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'StudyDescription', 'Description of the Study', 1, 0, 'textarea', ID , 'Study Description', 2 FROM ConfigSettings WHERE Name="gui";
 
@@ -145,7 +144,6 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/MRI-Upload/" FROM Conf
 -- default gui settings
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 25 FROM ConfigSettings WHERE Name="rowsPerPage";
-INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name="showTiming";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name="showPearErrors";
 
 -- default www settings

--- a/SQL/2016-01-18-RemoveShowTimingFromConfig.sql
+++ b/SQL/2016-01-18-RemoveShowTimingFromConfig.sql
@@ -1,3 +1,3 @@
-DELETE FROM Config WHERE ConfigID=(SELECT FROM ConfigSettings WHERE Name='showTiming');
+DELETE FROM Config WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='showTiming');
 
 DELETE FROM ConfigSettings WHERE Name='showTiming';

--- a/SQL/2016-01-18-RemoveShowTimingFromConfig.sql
+++ b/SQL/2016-01-18-RemoveShowTimingFromConfig.sql
@@ -1,0 +1,3 @@
+DELETE FROM Config WHERE ConfigID=(SELECT FROM ConfigSettings WHERE Name='showTiming');
+
+DELETE FROM ConfigSettings WHERE Name='showTiming';


### PR DESCRIPTION
As @christinerogers reported, the showTiming setting is no longer being used (see #1347). This removes the setting from the config module.