### PR TITLE
Remove PEAR_ERROR_PRINT constant

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -68,7 +68,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, Or
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'css', 'CSS file used for rendering (default main.css)', 1, 0, 'text', ID, 'CSS file', 1 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'rowsPerPage', 'Number of table rows to display per page', 1, 0, 'text', ID, 'Table rows per page', 2 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showTiming', 'Show breakdown of timing information for page loading', 1, 0, 'boolean', ID, 'Show page load timing', 3 FROM ConfigSettings WHERE Name="gui";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showPearErrors', 'Print PEAR errors', 1, 0, 'boolean', ID, 'Show PEAR errors', 4 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'StudyDescription', 'Description of the Study', 1, 0, 'textarea', ID , 'Study Description', 2 FROM ConfigSettings WHERE Name="gui";
 
 -- www
@@ -146,7 +145,6 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/MRI-Upload/" FROM Conf
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 25 FROM ConfigSettings WHERE Name="rowsPerPage";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name="showTiming";
-INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name="showPearErrors";
 
 -- default www settings
 INSERT INTO Config (ConfigID, Value) SELECT ID, "localhost" FROM ConfigSettings WHERE Name="host";

--- a/SQL/2016-01-19-ConfigSetting-showPearErrors.sql
+++ b/SQL/2016-01-19-ConfigSetting-showPearErrors.sql
@@ -1,2 +1,2 @@
-DELETE FROM LORIS.Config where ConfigID = (SELECT ID FROM LORIS.ConfigSettings where name = 'showPearErrors');
-DELETE FROM LORIS.ConfigSettings where name = 'showPearErrors';
+DELETE FROM Config where ConfigID = (SELECT ID FROM ConfigSettings where name = 'showPearErrors');
+DELETE FROM ConfigSettings where name = 'showPearErrors';

--- a/SQL/2016-01-19-ConfigSetting-showPearErrors.sql
+++ b/SQL/2016-01-19-ConfigSetting-showPearErrors.sql
@@ -1,0 +1,2 @@
+DELETE FROM LORIS.Config where ConfigID = (SELECT ID FROM LORIS.ConfigSettings where name = 'showPearErrors');
+DELETE FROM LORIS.ConfigSettings where name = 'showPearErrors';

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -104,12 +104,6 @@ class NDB_Client
 
         $GLOBALS['DB'] =& $DB;
 
-        // tell Pear to print errors if the config says so
-        if ($config->getSetting('showPearErrors')) {
-            $GLOBALS['_PEAR_default_error_mode'] = PEAR_ERROR_PRINT;
-            //$setoptions  = &$GLOBALS['_PEAR_default_error_options'];
-        }
-
         // stop here if this is a command line client
         if (!$this->_isWebClient) {
             return true;


### PR DESCRIPTION
Removing the PEAR constant from NDB_Client and the showPearErrors ConfigSetting since we no longer use PEAR.