### PR TITLE
multiline documents support for gets

### DIFF
--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -118,6 +118,9 @@ class SocketWrapper
                     "Could not read from CouchDB server at $this->host:$this->port"
                 );
             }
+            while (!feof($this->socket)) {
+                $status .= fgets($this->socket);
+            }
             return $status;
         }
     }


### PR DESCRIPTION
This fix the problem that occur when a document containing '\n' characters gets read by the gets function.  Since gets only read one line the buffer isn't emptied and provoque error on the next read attempt.
The while lop id there to empty the buffer.
