### PR TITLE
Brainbrowser can not extract the time dimension due to a typo in minc…

### DIFF
--- a/modules/brainbrowser/ajax/minc.php
+++ b/modules/brainbrowser/ajax/minc.php
@@ -78,7 +78,7 @@ function initialize($minc_file)
 
     //for 4D (BOLD or DTI)
     if (count($order) == 4) {
-        $headers['time'] = extractDimensions("time", $minc_file);
+        $headers['time'] = extractDimension("time", $minc_file);
     }
 
     $headers['order'] = $order;


### PR DESCRIPTION
….php, resulting in a HTTP response 500 error