### PR TITLE
 Rename field IsValidated in mri_upload table

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1613,7 +1613,7 @@ CREATE TABLE `mri_upload` (
   `number_of_mincCreated` int(11) DEFAULT NULL,
   `TarchiveID` int(11) DEFAULT NULL,
   `SessionID` int(10) unsigned DEFAULT NULL,
-  `IsValidated` tinyint(1) NOT NULL DEFAULT '0',
+  `IsCandidateInfoValidated` tinyint(1) DEFAULT NULL,
   `IsTarchiveValidated` tinyint(1) NOT NULL DEFAULT '0',
   `IsPhantom` enum('N','Y') NOT NULL DEFAULT 'N',
   PRIMARY KEY (`UploadID`)

--- a/SQL/2016-01-22-IsValidatedRenamedInMRIUploadTable.sql
+++ b/SQL/2016-01-22-IsValidatedRenamedInMRIUploadTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mri_upload CHANGE `IsValidated` `IsCandidateInfoValidated` tinyint(1) DEFAULT NULL;


### PR DESCRIPTION
to IsCandidateInfoValidated, and set its default to NULL
This is related to pull request: https://github.com/aces/Loris-MRI/pull/106 
in LORIS-MRI
