### PR TITLE
PEAR constant removed

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -85,12 +85,6 @@ class NDB_Client
 
         $GLOBALS['DB'] =& $DB;
 
-        // tell Pear to print errors if the config says so
-        if ($config->getSetting('showPearErrors')) {
-            $GLOBALS['_PEAR_default_error_mode'] = PEAR_ERROR_PRINT;
-            //$setoptions  = &$GLOBALS['_PEAR_default_error_options'];
-        }
-
         // stop here if this is a command line client
         if (!$this->_isWebClient) {
             return true;


### PR DESCRIPTION
Removing the PEAR constant from NDB_Client and the showPearErrors ConfigSetting since we no longer use PEAR.