### PR TITLE
Generic integration.sh config.xml (+.travis.yml)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_script:
     - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
     - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - cp test/config.xml project/config.xml
+    - sed -i -e "s/%HOSTNAME%/localhost/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" project/config.xml
     - mysql LorisTest -e "UPDATE Config SET Value='$(pwd)/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
     - mysql LorisTest -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_script:
     - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - cp test/config.xml project/config.xml
     - sed -i -e "s/%HOSTNAME%/127.0.0.1/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" project/config.xml
+    - sed -i -e "s/%HOSTNAME%/127.0.0.1/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" test/config.xml
     - mysql LorisTest -e "UPDATE Config SET Value='$(pwd)/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
     - mysql LorisTest -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
     - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
     - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - cp test/config.xml project/config.xml
-    - sed -i -e "s/%HOSTNAME%/localhost/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" project/config.xml
+    - sed -i -e "s/%HOSTNAME%/127.0.0.1/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" project/config.xml
     - mysql LorisTest -e "UPDATE Config SET Value='$(pwd)/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
     - mysql LorisTest -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
 

--- a/test/config.xml
+++ b/test/config.xml
@@ -15,11 +15,11 @@
     </dev>
 
     <!-- database settings -->
-<database>
-        <host>127.0.0.1</host>
-        <username>SQLTestUser</username>
-        <password>TestPassword</password>
-        <database>LorisTest</database>
+    <database>
+        <host>%HOSTNAME%</host>
+        <username>%USERNAME%</username>
+        <password>%PASSWORD%</password>
+        <database>%DATABASE%</database>
         <quatUser>SQLTestUser</quatUser>
         <quatPassword>TestPassword</quatPassword>
         <name>Test database</name>

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -7,7 +7,7 @@
 #       example: bash integration.sh configuration
 
 # Test database and test config.xml have to be created before running tests. This is a one time setup.
-#   1 - create a LorisTest DB and source the default schema (SQL/0000-00-00-schema.sql)
+#   1 - create a LorisTest DB and source the default schemas (SQL/0000-00-*.sql)
 #   2 - create a MySQL user SQLTestUser with password TestPassword.
 #   3 - Modify config.xml file in test/ folder if necessary.
 #       Some changes to verify in this test/config.xml file:
@@ -16,7 +16,7 @@
 #       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
 
 #start PHP's built in webserver
-php -S localhost:8000 -t ../htdocs ../htdocs/router.php 2>1 > /dev/null &
+php -S localhost:8000 -t ../htdocs ../htdocs/router.php 2>&1 > /dev/null &
 
 # Start Selenium and redirect Selenium WebDriver
 # output to /dev/null so that it doesn't flood the

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -26,7 +26,7 @@ echo "******************************************************************
   REMINDER: Selenium needs to be running to run integration tests
 ******************************************************************";
 
-host="localhost"
+host="127.0.0.1"
 database="LorisTest"
 username="SQLTestUser"
 password="TestPassword"

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -30,15 +30,40 @@ echo "******************************************************************
 ******************************************************************";
 
 # Set config values in LorisTest DB
-mysql -D LorisTest -u SQLTestUser -pTestPassword -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
+host="localhost"
+database="LorisTest"
+username="SQLTestUser"
+password="TestPassword"
+url="http://localhost:8000"
 
-mysql -D LorisTest -u SQLTestUser -pTestPassword -e "UPDATE Config SET Value='$(pwd | sed "s#test##")' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
+while getopts ":m:h:D:u:p:l:" opt; do
+  case $opt in
+    m) module="$OPTARG"
+    ;;
+    h) host="$OPTARG"
+    ;;
+    D) database="$OPTARG"
+    ;;
+    u) username="$OPTARG"
+    ;;
+    p) password="$OPTARG"
+    ;;
+    l) url="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+
+mysql -h $host -D $database -u $username -p$password -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
+
+mysql -h $host -D $database -u $username -p$password -e "UPDATE Config SET Value='$(pwd | sed "s#test##")' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
 
 
 if [ ! -z "$1" ]; then
   # Run integration tests for a sepecific module
-  echo Running integration test for module: $1;
-  ../vendor/bin/phpunit --configuration phpunit.xml ../modules/$1/test
+  echo Running integration test for module: $module;
+  ../vendor/bin/phpunit --configuration phpunit.xml ../modules/$module/test
 else
  # Run all integration tests
  ../vendor/bin/phpunit --configuration phpunit.xml --testsuite 'Loris Core Integration Tests'

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -67,7 +67,7 @@ mysql -h $host -D $database -u $username -p$password -e "UPDATE Config SET Value
 mysql -h $host -D $database -u $username -p$password -e "UPDATE Config SET Value='$(pwd | sed "s#test##")' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
 
 
-if [ ! -z "$1" ]; then
+if [ ! -z "$module" ]; then
   # Run integration tests for a sepecific module
   echo Running integration test for module: $module;
   ../vendor/bin/phpunit --configuration phpunit.xml ../modules/$module/test

--- a/test/unittests.sh
+++ b/test/unittests.sh
@@ -6,16 +6,26 @@
 #   - to run a specific unittest specify the test name and the path to test script
 #       example: bash unittests.sh 'NDB_BVL_FeedbackTest' ./unittests/NDB_BVL_FeedbackTest.php
 
-# Test databse and test config.xml have to be created before running tests. This is a one time setup.
-#   1 - create a LorisTest DB from the default schema (lori/SQL/0000-00-00-schema.sql)
+# Test database and test config.xml have to be created before running tests. This is a one time setup.
+#   1 - create a LorisTest DB from the default schema (SQL/0000-00-00-*.sql)
 #   2 - create a MySQL user SQLTestUser with password TestPassword & specify the password in the mysql commands (with option -p) below
-#   3 - Create a config.xml file in loris/test/ folder.
+#   3 - Create a config.xml file in test/ folder.
 #       Changes to make in this config.xml file:
 #       *  Database connection credentials: specify credentials to LorisTest DB which you create in step 1
 #       *  Set sandbox mode to 1: <sandbox>1</sandbox>
 #       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
 
 # set environment variable LORIS_DB_CONFIG to test config.xml file
+host="localhost"
+database="LorisTest"
+username="SQLTestUser"
+password="TestPassword"
+sed -i \
+    -e "s/%HOSTNAME%/$host/g" \
+    -e "s/%USERNAME%/$username/g" \
+    -e "s/%PASSWORD%/$password/g" \
+    -e "s/%DATABASE%/$database/g" \
+    config.xml
 export LORIS_DB_CONFIG=$(pwd)/config.xml
 
 if [ $# -eq 2 ]; then

--- a/test/unittests.sh
+++ b/test/unittests.sh
@@ -16,7 +16,7 @@
 #       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
 
 # set environment variable LORIS_DB_CONFIG to test config.xml file
-host="localhost"
+host="127.0.0.1"
 database="LorisTest"
 username="SQLTestUser"
 password="TestPassword"


### PR DESCRIPTION
Making it so that DBs can be hosted elsewhere for running tests.

Also changing the behavior of using integration.sh
In addition to optional arguments -D/-u/-p/-h/-l, you now have to specify -m [module_name] to test a module
