### PR TITLE
Fix typo in 'Project' table name that causes a loading issue on candidate_list module 

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -124,7 +124,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
             LEFT JOIN participant_status_options pso
                 ON (ps.participant_status=pso.ID)
-            LEFT JOIN project p ON (c.ProjectID=p.ProjectID)
+            LEFT JOIN Project p ON (c.ProjectID=p.ProjectID)
             LEFT JOIN subproject sp ON (s.SubprojectID=sp.SubprojectID)
             WHERE c.Entity_type = 'Human' AND c.Active = 'Y'";
 


### PR DESCRIPTION
* Fixed an error where candidate list would not load because of a mistake in the SQL table name.