### PR TITLE
Training vimeo tab

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1888,7 +1888,7 @@ CREATE TABLE `certification_training` (
     `TestID` int(10) UNSIGNED NOT NULL,
     `Title` varchar(255) NOT NULL,
     `Content` text,
-    `TrainingType` enum('text', 'pdf', 'video', 'quiz') NOT NULL,
+    `TrainingType` enum('text', 'pdf', 'video', 'quiz', 'vimeo') NOT NULL,
     `OrderNumber` INTEGER UNSIGNED NOT NULL,
     PRIMARY KEY (`ID`),
     CONSTRAINT `FK_certification_training` FOREIGN KEY (`TestID`) REFERENCES `test_names` (`ID`)

--- a/SQL/2016-02-11-AlterTrainingTypes.sql
+++ b/SQL/2016-02-11-AlterTrainingTypes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE certification_training CHANGE TrainingType TrainingType enum('text','pdf','video','quiz', 'vimeo');

--- a/modules/training/ajax/getTabContent.php
+++ b/modules/training/ajax/getTabContent.php
@@ -68,11 +68,12 @@ if ($tabInformation['TrainingType'] == 'text') {
     );
 } else if ($tabInformation['TrainingType'] == 'vimeo') {
     $oembed_endpoint = 'http://vimeo.com/api/oembed';
-    $video_url = 'http://vimeo.com/' . $tabInformation['Content'];
+    $video_url       = 'http://vimeo.com/' . $tabInformation['Content'];
     //$json_url = $oembed_endpoint . '.json?url=' . rawurlencode($video_url);
     $video_options = '&portrait=0&autoplay=1&badge=0&byline=0&width=800';
-    $xml_url = $oembed_endpoint . '.xml?url=' . rawurlencode($video_url) . $video_options;
-    $oembed = simplexml_load_string(curl_get($xml_url));
+    $xml_url       = $oembed_endpoint . '.xml?url='
+        . rawurlencode($video_url) . $video_options;
+    $oembed        = simplexml_load_string(Curl_get($xml_url));
 
     $tabHTML = createTabHTML(
         'vimeo',
@@ -154,8 +155,15 @@ function createTabHTML($contentType, $title, $tabVariables, $type)
     return $html;
 }
 
-// Curl helper function
-function curl_get($url) {
+/**
+ * Curl helper function.
+ *
+ * @param string $url url to get
+ *
+ * @return string
+ */
+function Curl_get($url)
+{
     $curl = curl_init($url);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($curl, CURLOPT_TIMEOUT, 30);

--- a/modules/training/ajax/getTabContent.php
+++ b/modules/training/ajax/getTabContent.php
@@ -67,8 +67,8 @@ if ($tabInformation['TrainingType'] == 'text') {
         $type
     );
 } else if ($tabInformation['TrainingType'] == 'vimeo') {
-    $oembed_endpoint = 'http://vimeo.com/api/oembed';
-    $video_url       = 'http://vimeo.com/' . $tabInformation['Content'];
+    $oembed_endpoint = 'https://vimeo.com/api/oembed';
+    $video_url       = 'https://vimeo.com/' . $tabInformation['Content'];
     //$json_url = $oembed_endpoint . '.json?url=' . rawurlencode($video_url);
     $video_options = '&portrait=0&autoplay=1&badge=0&byline=0&width=800';
     $xml_url       = $oembed_endpoint . '.xml?url='

--- a/modules/training/ajax/getTabContent.php
+++ b/modules/training/ajax/getTabContent.php
@@ -69,8 +69,9 @@ if ($tabInformation['TrainingType'] == 'text') {
 } else if ($tabInformation['TrainingType'] == 'vimeo') {
     $oembed_endpoint = 'http://vimeo.com/api/oembed';
     $video_url = 'http://vimeo.com/' . $tabInformation['Content'];
-    //$json_url = $oembed_endpoint . '.json?url=' . rawurlencode($video_url) . '&width=640';
-    $xml_url = $oembed_endpoint . '.xml?url=' . rawurlencode($video_url);
+    //$json_url = $oembed_endpoint . '.json?url=' . rawurlencode($video_url);
+    $video_options = '&portrait=0&autoplay=1&badge=0&byline=0&width=800';
+    $xml_url = $oembed_endpoint . '.xml?url=' . rawurlencode($video_url) . $video_options;
     $oembed = simplexml_load_string(curl_get($xml_url));
 
     $tabHTML = createTabHTML(

--- a/modules/training/ajax/getTabContent.php
+++ b/modules/training/ajax/getTabContent.php
@@ -66,6 +66,13 @@ if ($tabInformation['TrainingType'] == 'text') {
         $instrument . '.mp4',
         $type
     );
+} else if ($tabInformation['TrainingType'] == 'vimeo') {
+    $tabHTML = createTabHTML(
+        'vimeo',
+        $tabInformation['Title'],
+        $tabInformation['Content'],
+        $type
+    );
 } else if ($tabInformation['TrainingType'] == 'quiz') {
     $tabHTML = createTabHTML(
         'quiz',
@@ -139,4 +146,5 @@ function createTabHTML($contentType, $title, $tabVariables, $type)
 
     return $html;
 }
+
 ?>

--- a/modules/training/ajax/getTabContent.php
+++ b/modules/training/ajax/getTabContent.php
@@ -67,10 +67,16 @@ if ($tabInformation['TrainingType'] == 'text') {
         $type
     );
 } else if ($tabInformation['TrainingType'] == 'vimeo') {
+    $oembed_endpoint = 'http://vimeo.com/api/oembed';
+    $video_url = 'http://vimeo.com/' . $tabInformation['Content'];
+    //$json_url = $oembed_endpoint . '.json?url=' . rawurlencode($video_url) . '&width=640';
+    $xml_url = $oembed_endpoint . '.xml?url=' . rawurlencode($video_url);
+    $oembed = simplexml_load_string(curl_get($xml_url));
+
     $tabHTML = createTabHTML(
         'vimeo',
         $tabInformation['Title'],
-        $tabInformation['Content'],
+        html_entity_decode($oembed->html),
         $type
     );
 } else if ($tabInformation['TrainingType'] == 'quiz') {
@@ -147,4 +153,14 @@ function createTabHTML($contentType, $title, $tabVariables, $type)
     return $html;
 }
 
+// Curl helper function
+function curl_get($url) {
+    $curl = curl_init($url);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, 1);
+    $return = curl_exec($curl);
+    curl_close($curl);
+    return $return;
+}
 ?>

--- a/modules/training/php/NDB_Form_training.class.inc
+++ b/modules/training/php/NDB_Form_training.class.inc
@@ -190,19 +190,5 @@ class NDB_Form_Training extends NDB_Form
             return true;
         }
     }
-
-    /**
-     * Include the column formatter required to display the feedback link colours
-     * in the training menu
-     *
-     * @return array of javascript to be inserted
-     */
-    function getJSDependencies()
-    {
-        $factory = NDB_Factory::singleton();
-        $baseURL = $factory->settings()->getBaseURL();
-        $deps    = parent::getJSDependencies();
-        return $deps;
-    }
 }
 ?>

--- a/modules/training/php/NDB_Form_training.class.inc
+++ b/modules/training/php/NDB_Form_training.class.inc
@@ -202,14 +202,6 @@ class NDB_Form_Training extends NDB_Form
         $factory = NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
         $deps    = parent::getJSDependencies();
-        print_r($baseURL);
-        print_r($deps);
-        /*return array_merge(
-            $deps,
-            array(
-                $baseURL . "/training/js/training.js",
-            )
-        );*/
         return $deps;
     }
 }

--- a/modules/training/php/NDB_Form_training.class.inc
+++ b/modules/training/php/NDB_Form_training.class.inc
@@ -190,5 +190,27 @@ class NDB_Form_Training extends NDB_Form
             return true;
         }
     }
+
+    /**
+     * Include the column formatter required to display the feedback link colours
+     * in the training menu
+     *
+     * @return array of javascript to be inserted
+     */
+    function getJSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        print_r($baseURL);
+        print_r($deps);
+        /*return array_merge(
+            $deps,
+            array(
+                $baseURL . "/training/js/training.js",
+            )
+        );*/
+        return $deps;
+    }
 }
 ?>

--- a/modules/training/templates/training.tpl
+++ b/modules/training/templates/training.tpl
@@ -22,6 +22,8 @@
         {include file='training_pdf.tpl' filename=$tabVariables}
     {elseif $contentType=='video'}
         {include file='training_video.tpl' filename=$tabVariables}
+    {elseif $contentType=='vimeo'}
+        {include file='training_vidmo.tpl' filename=$tabVariables}
     {elseif $contentType=='quiz'}
         {include file='training_quiz.tpl' questions=$tabVariables}
     {/if}
@@ -43,6 +45,8 @@
     {if $contentType=='text' or $contentType=='pdf'}
         I have completed reading this section of the training module.
     {elseif $contentType=='video'}
+        I have completed watching this section of the training module.
+    {elseif $contentType=='vimeo'}
         I have completed watching this section of the training module.
     {elseif $contentType=='quiz'}
         Submit your answers to the quiz. If any answers are incorrect, you will be prompted to repeat the certification training.

--- a/modules/training/templates/training.tpl
+++ b/modules/training/templates/training.tpl
@@ -5,6 +5,8 @@
             Please read the following:
         {elseif $contentType=='video'}
             Please watch the following:
+        {elseif $contentType=='vimeo'}
+            Please watch the following:
         {elseif $contentType=='quiz'}
             Please complete the quiz below in order to receive certification:
         {/if}
@@ -23,7 +25,7 @@
     {elseif $contentType=='video'}
         {include file='training_video.tpl' filename=$tabVariables}
     {elseif $contentType=='vimeo'}
-        {include file='training_vidmo.tpl' filename=$tabVariables}
+        {include file='training_vimeo.tpl' filename=$tabVariables}
     {elseif $contentType=='quiz'}
         {include file='training_quiz.tpl' questions=$tabVariables}
     {/if}

--- a/modules/training/templates/training_vimeo.tpl
+++ b/modules/training/templates/training_vimeo.tpl
@@ -1,0 +1,6 @@
+<div>
+    <iframe src="https://player.vimeo.com/video/{$vimeo_id}"
+            <!--width="600" height="338" frameborder="0"-->
+            webkitAllowFullScreen mozallowfullscreen allowFullScreen>
+    </iframe>
+</div>

--- a/modules/training/templates/training_vimeo.tpl
+++ b/modules/training/templates/training_vimeo.tpl
@@ -1,6 +1,3 @@
 <div>
-    <iframe src="https://player.vimeo.com/video/{$vimeo_id}"
-            <!--width="600" height="338" frameborder="0"-->
-            webkitAllowFullScreen mozallowfullscreen allowFullScreen>
-    </iframe>
+    {$tabVariables}
 </div>

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -103,6 +103,7 @@ class NDB_Client
             "Content-Security-Policy: "
             . "default-src 'self' 'unsafe-inline'; "
             . "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+            . "frame-src https://player.vimeo.com/; "
             . "font-src 'self' data:"
         );
         // start php session


### PR DESCRIPTION
Adds a new tab type to the training module, to display a Vimeo video player
that streams from our vimeo account.
Requires the addition of a CSP exception to permit streaming from here: https://player.vimeo.com/
To use, simply add a record to the certification_training table with TrainingType='vimeo' and Content= the id of your vimeo video, e.g. 7100569.