### PR TITLE
This is for the notification spool table messaging in Loris-MRI

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -694,6 +694,7 @@ CREATE TABLE `notification_spool` (
   `TimeSpooled` datetime DEFAULT NULL,
   `Message` text,
   `Error` enum('Y','N') default NULL,
+  `Verbose` enum('Y','N') DEFAULT NULL;
   `Sent` enum('N','Y') NOT NULL default 'N',
   `CenterID` tinyint(2) unsigned default NULL,
   `Origin` varchar(255) DEFAULT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -694,7 +694,7 @@ CREATE TABLE `notification_spool` (
   `TimeSpooled` datetime DEFAULT NULL,
   `Message` text,
   `Error` enum('Y','N') default NULL,
-  `Verbose` enum('Y','N') DEFAULT NULL,
+  `Verbose` enum('Y','N') NOT NULL DEFAULT 'N',
   `Sent` enum('N','Y') NOT NULL default 'N',
   `CenterID` tinyint(2) unsigned default NULL,
   `Origin` varchar(255) DEFAULT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -694,7 +694,7 @@ CREATE TABLE `notification_spool` (
   `TimeSpooled` datetime DEFAULT NULL,
   `Message` text,
   `Error` enum('Y','N') default NULL,
-  `Verbose` enum('Y','N') DEFAULT NULL;
+  `Verbose` enum('Y','N') DEFAULT NULL,
   `Sent` enum('N','Y') NOT NULL default 'N',
   `CenterID` tinyint(2) unsigned default NULL,
   `Origin` varchar(255) DEFAULT NULL,

--- a/SQL/2016-02-25-AddVerboseFlagToNotificationSpoolTable.sql
+++ b/SQL/2016-02-25-AddVerboseFlagToNotificationSpoolTable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notification_spool add Verbose enum('Y','N') DEFAULT NULL;

--- a/SQL/2016-02-25-AddVerboseFlagToNotificationSpoolTable.sql
+++ b/SQL/2016-02-25-AddVerboseFlagToNotificationSpoolTable.sql
@@ -1,1 +1,1 @@
-ALTER TABLE notification_spool add Verbose enum('Y','N') DEFAULT NULL;
+ALTER TABLE notification_spool add Verbose enum('Y','N') NOT NULL DEFAULT 'N';


### PR DESCRIPTION
Adding a verbose flag to the notification spool table to flag messages:
Verbose = 'Y' will be an elaborate set of messages as outputted by the imaging preprocessing pipeline
Verbose = 'N' will represent the end result of executing the few major steps in the pipeline

Related to:
https://github.com/aces/Loris-MRI/pull/104
and
https://github.com/aces/dicom-archive-tools/pull/31