### PR TITLE
fix table footer so that it is sticky

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -182,3 +182,14 @@ div.navbar div.container div.navbar-brand {
     color: #FFFFFF;
     background-color: #1c70b6;
 }
+
+/*
+ *  CSS for static table
+ */
+.table-footer {
+    background-color: #1c70b6;
+    color: white;
+}
+#dynamictable {
+    margin-bottom: 0px;
+}

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -193,3 +193,6 @@ div.navbar div.container div.navbar-brand {
 #dynamictable {
     margin-bottom: 0px;
 }
+.rowsPerPage {
+    color: black;
+}

--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -155,7 +155,7 @@ StaticDataTable = React.createClass({displayName: "StaticDataTable",
             );
         }
 
-        var RowsPerPageDropdown = (React.createElement("select", {onChange: this.changeRowsPerPage}, 
+        var RowsPerPageDropdown = (React.createElement("select", {className: "input-sm rowsPerPage", onChange: this.changeRowsPerPage}, 
                 React.createElement("option", null, "20"), 
                 React.createElement("option", null, "50"), 
                 React.createElement("option", null, "100"), 

--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -165,21 +165,22 @@ StaticDataTable = React.createClass({displayName: "StaticDataTable",
             )
             );
         return (
-            React.createElement("div", null, 
-                React.createElement("table", {className: "table table-hover table-primary table-bordered", id: "dynamictable"}, 
-                    React.createElement("thead", null, 
-                        React.createElement("tr", {className: "info"}, headers)
+            React.createElement("div", {className: "panel panel-primary"}, 
+                    React.createElement("table", {className: "table table-hover table-primary table-bordered", id: "dynamictable"}, 
+                        React.createElement("thead", null, 
+                            React.createElement("tr", {className: "info"}, headers)
+                        ), 
+                        React.createElement("tbody", null, 
+                            rows
+                        )
                     ), 
-                    React.createElement("tbody", null, 
-                        rows
-                    ), 
-                    React.createElement("tfoot", null, 
-                        React.createElement("tr", null, 
-                        React.createElement("td", {className: "info", colSpan: headers.length}, rows.length, " rows displayed of ", this.props.Data.length, ". (Maximum rows per page: ", RowsPerPageDropdown, ")",  
+                React.createElement("div", {className: "panel-footer table-footer"}, 
+                    React.createElement("div", {className: "row"}, 
+                        React.createElement("div", {className: "col-xs-12"}, 
+                            rows.length, " rows displayed of ", this.props.Data.length, ". (Maximum rows per page: ", RowsPerPageDropdown, ")",  
                             React.createElement("div", {className: "pull-right"}, 
                                 React.createElement(PaginationLinks, {Total: this.props.Data.length, onChangePage: this.changePage, RowsPerPage: rowsPerPage, Active: this.state.PageNumber})
                             )
- )
                         )
                     )
                 )

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -165,24 +165,25 @@ StaticDataTable = React.createClass({
             </select>
             );
         return (
-            <div>
-                <table className="table table-hover table-primary table-bordered" id="dynamictable">
-                    <thead>
-                        <tr className="info">{headers}</tr>
-                    </thead>
-                    <tbody>
-                        {rows}
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                        <td className="info" colSpan={headers.length}>{rows.length} rows displayed of {this.props.Data.length}. (Maximum rows per page: {RowsPerPageDropdown}) 
+            <div className="panel panel-primary">
+                    <table className="table table-hover table-primary table-bordered" id="dynamictable">
+                        <thead>
+                            <tr className="info">{headers}</tr>
+                        </thead>
+                        <tbody>
+                            {rows}
+                        </tbody>
+                    </table>
+                <div className="panel-footer table-footer">
+                    <div className="row">
+                        <div className="col-xs-12">
+                            {rows.length} rows displayed of {this.props.Data.length}. (Maximum rows per page: {RowsPerPageDropdown}) 
                             <div className="pull-right">
                                 <PaginationLinks Total={this.props.Data.length} onChangePage={this.changePage} RowsPerPage={rowsPerPage} Active={this.state.PageNumber} />
                             </div>
- </td>
-                        </tr>
-                    </tfoot>
-                </table>
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -155,7 +155,7 @@ StaticDataTable = React.createClass({
             );
         }
 
-        var RowsPerPageDropdown = (<select onChange={this.changeRowsPerPage}>
+        var RowsPerPageDropdown = (<select className="input-sm rowsPerPage" onChange={this.changeRowsPerPage}>
                 <option>20</option>
                 <option>50</option>
                 <option>100</option>


### PR DESCRIPTION
This makes it so that when the table is wider then the viewport the table footer is completely viewable and you don't need to scroll all the way to the right to get the paginations 