### PR TITLE
Removed the double call to the baseURL when loading the css files for…

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -125,7 +125,7 @@ if (!empty($TestName)) {
         if (strpos($_SERVER['REQUEST_URI'], "main.php") === false
             && strcmp($_SERVER['REQUEST_URI'], '/') != 0
         ) {
-              $tpl_data['test_name_css'] = "$baseURL/$TestName/css/$TestName.css";
+              $tpl_data['test_name_css'] = "/$TestName/css/$TestName.css";
         } else {
               $tpl_data['test_name_css'] = "GetCSS.php?Module=$TestName";
         }


### PR DESCRIPTION
… many modules:

Error message like this for brainbrowser as an example:
Failed to load resource: the server responded with a status of 404 (Not Found)
http://mouna//http://mouna//brainbrowser/css/brainbrowser.css 
