### PR TITLE
Disable configuration fields in front-end if they are overridden in the config.xml

### DIFF
--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -6,7 +6,7 @@
  *
  * @category Behavioural
  * @package  Main
- * @author   Olga Tsibulevskaya <olgatsib@gmail.com>
+ * @author   Tara Campbell <tara.campbell@mail.mcill.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris-Trunk
 */
@@ -18,7 +18,7 @@
  *
  * @category Behavioural
  * @package  Main
- * @author   Olga Tsibulevskaya <olgatsib@gmail.com>
+ * @author   Tara Campbell <tara.campbell@mail.mcill.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris-Trunk
 */
@@ -61,16 +61,6 @@ class NDB_Form_Configuration extends NDB_Form
             array()
         );
 
-        // Check whether any setting is overwritten in the config.xml
-        // Add this info to the array so form entries can be disabled in front end
-        foreach ($configs as &$setting) {
-            if ($config->settingExistsInXML($setting['Name'])) {
-                $setting['Disabled'] = 'Yes';
-            } else {
-                $setting['Disabled'] = 'No';
-            }
-        }
-
         // add values
         foreach ($configs as &$tag) {
             $value = $this->DB->pselect(
@@ -81,6 +71,24 @@ class NDB_Form_Configuration extends NDB_Form
                 foreach ($value as $subvalue) {
                     $tag['Value'][$subvalue['ID']] = $subvalue['Value'];
                 }
+            }
+        }
+
+        // Check whether any setting is overwritten in the config.xml
+        // Add this info to the array so form entries can be disabled in front end
+        // Update the value for the setting to the value from the config.xml
+        foreach ($configs as &$setting) {
+            try {
+                $valueFromXML = $config->getSettingFromXML($setting['Name']);
+                unset($setting['Value']);
+                if (!is_array($valueFromXML)) {
+                    $setting['Value'][0] = $valueFromXML;
+                } else {
+                    $setting['Value'] = $valueFromXML;
+                }
+                $setting['Disabled'] = 'Yes';
+            } catch (ConfigurationException $e) {
+                $setting['Disabled'] = 'No';
             }
         }
 

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -62,7 +62,7 @@ class NDB_Form_Configuration extends NDB_Form
         );
 
         // Check whether any setting is overwritten in the config.xml
-        // Add this info to the array so form entries can be disabled in the front end
+        // Add this info to the array so form entries can be disabled in front end
         foreach ($configs as &$setting) {
             if ($config->settingExistsInXML($setting['Name'])) {
                 $setting['Disabled'] = 'Yes';

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -104,8 +104,6 @@ class NDB_Form_Configuration extends NDB_Form
             $tree[$node['Parent']]['Children'][] = &$node;
         }
 
-
-
         $instruments = Utility::getAllInstruments();
         $instruments = array_merge(array('' => ''), $instruments);
         $useProjects = $config->getSetting("useProjects");

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -62,14 +62,14 @@ class NDB_Form_Configuration extends NDB_Form
         );
 
         // add values
-        foreach ($configs as &$tag) {
+        foreach ($configs as &$setting) {
             $value = $this->DB->pselect(
                 "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
-                array('ID' => $tag{'ID'})
+                array('ID' => $setting{'ID'})
             );
             if ($value) {
                 foreach ($value as $subvalue) {
-                    $tag['Value'][$subvalue['ID']] = $subvalue['Value'];
+                    $setting['Value'][$subvalue['ID']] = $subvalue['Value'];
                 }
             }
         }
@@ -79,14 +79,16 @@ class NDB_Form_Configuration extends NDB_Form
         // Update the value for the setting to the value from the config.xml
         foreach ($configs as &$setting) {
             try {
-                $valueFromXML = $config->getSettingFromXML($setting['Name']);
-                unset($setting['Value']);
-                if (!is_array($valueFromXML)) {
-                    $setting['Value'][0] = $valueFromXML;
-                } else {
-                    $setting['Value'] = $valueFromXML;
+                if ($setting['Parent'] != null) {
+                    $valueFromXML = $config->getSettingFromXML($setting['Name']);
+                    unset($setting['Value']);
+                    if (!is_array($valueFromXML)) {
+                        $setting['Value'][0] = $valueFromXML;
+                    } else {
+                        $setting['Value'] = $valueFromXML;
+                    }
+                    $setting['Disabled'] = 'Yes';
                 }
-                $setting['Disabled'] = 'Yes';
             } catch (ConfigurationException $e) {
                 $setting['Disabled'] = 'No';
             }
@@ -101,6 +103,8 @@ class NDB_Form_Configuration extends NDB_Form
         foreach ($configs as &$node) {
             $tree[$node['Parent']]['Children'][] = &$node;
         }
+
+
 
         $instruments = Utility::getAllInstruments();
         $instruments = array_merge(array('' => ''), $instruments);

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -61,6 +61,16 @@ class NDB_Form_Configuration extends NDB_Form
             array()
         );
 
+        // Check whether any setting is overwritten in the config.xml
+        // Add this info to the array so form entries can be disabled in the front end
+        foreach ($configs as &$setting) {
+            if ($config->settingExistsInXML($setting['Name'])) {
+                $setting['Disabled'] = 'Yes';
+            } else {
+                $setting['Disabled'] = 'No';
+            }
+        }
+
         // add values
         foreach ($configs as &$tag) {
             $value = $this->DB->pselect(

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -44,53 +44,89 @@ class NDB_Form_Configuration extends NDB_Form
      */
     function configuration()
     {
-
         $config =& NDB_Config::singleton();
 
+        $instruments = Utility::getAllInstruments();
+        $instruments = array_merge(array('' => ''), $instruments);
+
+        $this->tpl_data['useProjects']     = $config->getSetting("useProjects");
+        $this->tpl_data['parentMenuItems'] = $this->_getParentConfigLabels();
+        $this->tpl_data['config']          = $this->_getConfigSettingTree();
+        $this->tpl_data['instruments']     = $instruments;
+        $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
+
+    }
+
+    /**
+     * Gets an array of the top level configuration items
+     * This is used to create the configuration setting category menu
+     *
+     * @return array of parent config items
+     */
+    function _getParentConfigLabels()
+    {
         $this->DB = Database::singleton();
 
-        $parentMenuItems = $this->DB->pselect(
+        $parentConfigItems = $this->DB->pselect(
             "SELECT Label, Name 
              FROM ConfigSettings 
              WHERE Parent IS NULL AND Visible=1 ORDER BY OrderNumber",
             array()
         );
 
+        return $parentConfigItems;
+    }
+
+    /**
+     * Returns an array of configuration settings in a tree format.
+     * The array contains all of the settings that are in config table
+     * in the database. However, if the value if overridden in the config.xml,
+     * the value for that setting is replaced with the value from the config.xml
+     *
+     * @return array of config settings
+     */
+    function _getConfigSettingTree()
+    {
+        $config =& NDB_Config::singleton();
+
+        // Get the names and meta-information for the config settings in the database
         $configs = $this->DB->pselect(
             "SELECT * FROM ConfigSettings WHERE Visible=1 ORDER BY OrderNumber",
             array()
         );
-
-        // add values
-        foreach ($configs as &$setting) {
-            $value = $this->DB->pselect(
-                "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
-                array('ID' => $setting{'ID'})
-            );
-            if ($value) {
-                foreach ($value as $subvalue) {
-                    $setting['Value'][$subvalue['ID']] = $subvalue['Value'];
-                }
-            }
-        }
 
         // Check whether any setting is overwritten in the config.xml
         // Add this info to the array so form entries can be disabled in front end
         // Update the value for the setting to the value from the config.xml
         foreach ($configs as &$setting) {
             try {
+                $setting['Disabled'] = 'Yes';
                 if ($setting['Parent'] != null) {
                     $valueFromXML = $config->getSettingFromXML($setting['Name']);
-                    unset($setting['Value']);
                     if (!is_array($valueFromXML)) {
                         $setting['Value'][0] = $valueFromXML;
                     } else {
                         $setting['Value'] = $valueFromXML;
                     }
-                    $setting['Disabled'] = 'Yes';
                 }
             } catch (ConfigurationException $e) {
                 $setting['Disabled'] = 'No';
+            }
+        }
+
+        // Now check for config settings from the database for the fields not
+        // overridden in the config.xml
+        foreach ($configs as &$setting) {
+            if ($setting['Disabled'] == 'No') {
+                $value = $this->DB->pselect(
+                    "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
+                    array('ID' => $setting{'ID'})
+                );
+                if ($value) {
+                    foreach ($value as $subvalue) {
+                        $setting['Value'][$subvalue['ID']] = $subvalue['Value'];
+                    }
+                }
             }
         }
 
@@ -104,16 +140,7 @@ class NDB_Form_Configuration extends NDB_Form
             $tree[$node['Parent']]['Children'][] = &$node;
         }
 
-        $instruments = Utility::getAllInstruments();
-        $instruments = array_merge(array('' => ''), $instruments);
-        $useProjects = $config->getSetting("useProjects");
-
-        $this->tpl_data['useProjects']     = $useProjects;
-        $this->tpl_data['parentMenuItems'] = $parentMenuItems;
-        $this->tpl_data['config']          = $configs;
-        $this->tpl_data['instruments']     = $instruments;
-        $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
-
+        return $configs;
     }
 
     /**

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -1,23 +1,23 @@
 {function name=createRadio}
     {if $v eq "1" || $v eq "0"}
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="1" {if $v eq "1"}checked{/if}>Yes
+        <input type="radio" name="{$k}" value="1" {if $v eq "1"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
     </label>
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="0" {if $v eq "0"}checked{/if}>No
+        <input type="radio" name="{$k}" value="0" {if $v eq "0"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
     </label>
     {else if $v eq "true" || $v eq "false"}
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="true" {if $v eq "true"}checked{/if}>Yes
+        <input type="radio" name="{$k}" value="true" {if $v eq "true"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
     </label>
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="false" {if $v eq "false"}checked{/if}>No
+        <input type="radio" name="{$k}" value="false" {if $v eq "false"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
     </label>
     {/if}
 {/function}
 
 {function name=createInstrument}
-    <select class="form-control" name="{$k}">
+    <select class="form-control" name="{$k}" {if $d eq "Yes"}disabled{/if}>
         {foreach from=$instruments key=name item=label}
             <option {if $v eq $name}selected{/if} value="{$name}">{$label}</option>
         {/foreach}
@@ -25,15 +25,15 @@
 {/function}
 
 {function name=createEmail}
-    <input class="form-control" type="email" name="{$k}" value="{$v}">
+    <input class="form-control" type="email" name="{$k}" value="{$v}" {if $d eq "Yes"}disabled{/if}>
 {/function}
 
 {function name=createTextArea}
-    <textarea class="form-control" rows="4" name="{$k}">{$v}</textarea>
+    <textarea class="form-control" rows="4" name="{$k}" {if $d eq "Yes"}disabled{/if}>{$v}</textarea>
 {/function}
 
 {function name=createText}
-    <input type="text" class="form-control" name="{$k}" value="{$v}">
+    <input type="text" class="form-control" name="{$k}" value="{$v}" {if $d eq "Yes"}disabled{/if}>
 {/function}
 
 {function name=printConfigItem}
@@ -63,15 +63,15 @@
     {foreach from=$node['Value'] key=k item=v}
         {if $node['AllowMultiple'] == 1}<div class="input-group entry">{/if}
         {if $node['DataType'] eq 'boolean'}
-            {call createRadio k=$k v=$v}
+            {call createRadio k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'instrument'}
-            {call createInstrument k=$k v=$v}
+            {call createInstrument k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'email'}
-            {call createEmail k=$k v=$v}
+            {call createEmail k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
-            {call createTextArea k=$k v=$v}
+            {call createTextArea k=$k v=$v d=$node['Disabled']}
         {else}
-            {call createText k=$k v=$v}
+            {call createText k=$k v=$v d=$node['Disabled']}
         {/if}
         {if $node['AllowMultiple'] == 1}
             <div class="input-group-btn">

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -50,7 +50,7 @@
             {call name=printForm node=$node}
         {/if}
         {if $node['AllowMultiple'] == 1}
-            <button class="btn btn-success add" id="{$node['ID']}" type="button">
+            <button class="btn btn-success add" id="{$node['ID']}" type="button" {if $node['Disabled'] eq "Yes"}disabled{/if}>
                 <span class="glyphicon glyphicon-plus"></span> Add field
             </button>
         {/if}
@@ -75,7 +75,7 @@
         {/if}
         {if $node['AllowMultiple'] == 1}
             <div class="input-group-btn">
-                <button class="btn btn-danger btn-remove" type="button" name="remove-{$k}">
+                <button class="btn btn-danger btn-remove" type="button" name="remove-{$k}" {if $node['Disabled'] eq "Yes"}disabled{/if}>
                     <span class="glyphicon glyphicon-remove"></span>&nbsp;
                 </button>
             </div>
@@ -85,17 +85,17 @@
         {if $node['AllowMultiple'] == 1}<div class="input-group entry">{/if}
         {assign var=id value={"add-"|cat:$node['ID']} }
         {if $node['DataType'] eq 'instrument'}
-            {call createInstrument k=$id}
+            {call createInstrument k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'email'}
-            {call createEmail k=$id}
+            {call createEmail k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
-            {call createTextArea k=$id}
+            {call createTextArea k=$id d=$node['Disabled']}
         {else}
-            {call createText k=$id}
+            {call createText k=$id d=$node['Disabled']}
         {/if}
         {if $node['AllowMultiple'] == 1}
             <div class="input-group-btn">
-                <button class="btn btn-danger btn-remove remove-new" type="button">
+                <button class="btn btn-danger btn-remove remove-new" type="button" {if $node['Disabled'] eq "Yes"}disabled{/if}>
                     <span class="glyphicon glyphicon-remove"></span>&nbsp;
                 </button>
             </div>

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -388,6 +388,47 @@ class NDB_Config
     }
 
     /**
+     * Checks whether a config setting exists in the config.xml
+     *
+     * @param string $name The name of the XML node to check.
+     *
+     * @return boolean Whether or not the node exists in the xml
+     */
+    function settingExistsInXML($name)
+    {
+        if (class_exists("User") && isset($_SESSION['State'])) {
+            if (empty($this->_siteSettings)) {
+                // merge site and study settings
+                $this->mergeSettings();
+            }
+
+            // look at the merged site settings
+            $settingsArray =& $this->_siteSettings;
+        } else {
+            // by default, look at the raw settings
+            $settingsArray =& $this->_settings;
+        }
+
+        // loop over the settings, and find the node
+        foreach ($settingsArray AS $key=>$value) {
+            // see if they want the top level node
+            if ($key == $name) {
+                return true;
+            }
+
+            // Look inside the top level node
+            // is_array is called before the isset check. This is done to
+            // fix an undesirable feature of isset: it would sometimes
+            // return true is $value was not an array (see isset PHP doc)
+            // in PHP <= 5.3. This behavior was changed for PHP > 5.3.
+            if (is_array($value) && isset($value[$name])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
     * Gets a setting by name
     *
     * @param string $name The name of the setting to retrieve

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -388,47 +388,6 @@ class NDB_Config
     }
 
     /**
-     * Checks whether a config setting exists in the config.xml
-     *
-     * @param string $name The name of the XML node to check.
-     *
-     * @return boolean Whether or not the node exists in the xml
-     */
-    function settingExistsInXML($name)
-    {
-        if (class_exists("User") && isset($_SESSION['State'])) {
-            if (empty($this->_siteSettings)) {
-                // merge site and study settings
-                $this->mergeSettings();
-            }
-
-            // look at the merged site settings
-            $settingsArray =& $this->_siteSettings;
-        } else {
-            // by default, look at the raw settings
-            $settingsArray =& $this->_settings;
-        }
-
-        // loop over the settings, and find the node
-        foreach ($settingsArray AS $key=>$value) {
-            // see if they want the top level node
-            if ($key == $name) {
-                return true;
-            }
-
-            // Look inside the top level node
-            // is_array is called before the isset check. This is done to
-            // fix an undesirable feature of isset: it would sometimes
-            // return true is $value was not an array (see isset PHP doc)
-            // in PHP <= 5.3. This behavior was changed for PHP > 5.3.
-            if (is_array($value) && isset($value[$name])) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
     * Gets a setting by name
     *
     * @param string $name The name of the setting to retrieve


### PR DESCRIPTION
This pull request, at an html-level, stops users from editing config fields that are overridden in the config.xml. It shows the value of the setting from the config.xml for reference. It looks something like this (host in this case is not editable):

<img width="815" alt="screen shot 2016-03-10 at 2 45 48 pm" src="https://cloud.githubusercontent.com/assets/5473436/13671577/f0507154-e6d0-11e5-9e23-bceb0efa7c8a.png">

Config names have to be unique right now. I have to work on checking the parent node so that subnode names can be repeated.