### PR TITLE
Adding displayAllFields class variable to NDB_BVL_Instrument

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -134,6 +134,13 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     var $ValidityRequired = true;
 
+    /**
+     * True if the instrument page is being loaded by a script
+     * such as the quickform_parser where all elements should be added to form,
+     * ignoring age-dependent or other conditional display logic in the form.
+     * To be called from within individual instrument forms.
+     */
+    var $displayAllFields = false;
 
     /**
      * True if the page is being previewed from the instrument builder,
@@ -205,6 +212,11 @@ class NDB_BVL_Instrument extends NDB_Page
             // Now go ahead and instantiate it
             $obj = new $class;
             // Now go ahead and instantiate it
+        }
+
+        // if a script is loading this form without a commentID, display all fields
+        if (!isset($commentID)) {
+            $obj->displayAllFields = true;
         }
 
         // Sets up page variables such as $this->commentID and $this->form


### PR DESCRIPTION
This pull request adds a class variable to NDB_BVL_Instrument which is set to false by default, but set to true iff a null commentID is provided to the Instrument factory i.e. when an Instrument is loaded without any candidate data.
This variable is useful to add in instrument forms with conditional logic, so that scripts like the quickform_parser will read all questions in the form, and help ensure that all fields make it into the Data Dictionary and the Data Querying Tool.

Can be used to display all fields for instruments that have age-dependent or otherwise conditional display logic. Past examples of form logic include: 
- A pediatric IQ test which displays questions 1-5 only if subject age < 5 years old. 
- Adolescent development questionnaire: if female, please answer the following questions
- From a language questionnaire: Do you speak any other languages at home? If not, skip to question 20

Currently the quickform_parser script parses instrument forms without any candidate data loaded, leading to missing fields because the calculated age or gender isn't available to satisfy the form logic. 
This variable is set to true by the instrument class if an instrument form is loaded without any candidate data.  It is to be used by individual instrument forms thus: 
  `if ($candidate_age < 5 || $this->displayAllFields ) {`
      `          $this->form->addElement(...);`
 `  }`

rebased from #999 