### PR TITLE
Do not reset view in brainbrowser when Synching volumes

### DIFF
--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -46,10 +46,6 @@ $(function() {
     // Should cursors in all panels be synchronized?
     $("#sync-volumes").change(function() {
       var synced = $(this).is(":checked");
-      if (synced) {
-        viewer.resetDisplays();
-        viewer.redrawVolumes();
-      }
 
       viewer.synced = synced;
     });

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -50,6 +50,12 @@ $(function() {
       viewer.synced = synced;
     });
 
+    // Reset button
+    $("#reset-view").click(function() {
+      viewer.resetDisplays();
+      viewer.redrawVolumes();
+    });
+
     // This will create an image of all the display panels
     // currently being shown in the viewer.
     $("#screenshot").click(function() {

--- a/modules/brainbrowser/templates/form_brainbrowser.tpl
+++ b/modules/brainbrowser/templates/form_brainbrowser.tpl
@@ -178,6 +178,11 @@
                 <label for="sync-volumes" id="sync-volumes" class="clickable btn btn-sm btn-primary">Sync Volumes</label>
             </span>
 
+            <span id="reset-wrapper" class="clickable">
+                <input type="button" class="button ui-helper-hidden-accessible" id="reset-view">
+                <label for="reset-view" id="reset-view" class="clickable btn btn-sm btn-primary">Reset View</label>
+            </span>
+
             <div class="btn-group">
                 <select id="panel-size" class="form-control panel-size clickable">
                     <option value="256" SELECTED>Choose Panel Size</option>


### PR DESCRIPTION
Can only be tested with PR 1556
(https://github.com/aces/Loris/pull/1556) as otherwise brainbrowser will not launch.
