### PR TITLE
Fix bug where LORIS couldn't load any pages

### DIFF
--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -62,8 +62,9 @@ class Smarty_NeuroDB extends Smarty
         // defaults, but keep them for now to ensure that Loris doesn't
         // change..
         $this->setCompileDir($paths['base']."smarty/templates_c/");
-        $this->config_dir  = $paths['base']."smarty/configs/";
-        $this->cache_dir   = $paths['base']."smarty/cache/";
+
+        $this->config_dir = $paths['base']."smarty/configs/";
+        $this->cache_dir  = $paths['base']."smarty/cache/";
 
         // Behave like smarty2 used to. This should be
         // removed after all the warnings/notices from the PHP

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -61,7 +61,7 @@ class Smarty_NeuroDB extends Smarty
         // These are probably not needed anymore and can use the smarty
         // defaults, but keep them for now to ensure that Loris doesn't
         // change..
-        $this->compile_dir = $paths['base']."smarty/templates_c/";
+        $this->setCompileDir($paths['base']."smarty/templates_c/");
         $this->config_dir  = $paths['base']."smarty/configs/";
         $this->cache_dir   = $paths['base']."smarty/cache/";
 


### PR DESCRIPTION
Smarty wasn't honouring the $this->compile_dir setting
set from Smarty_hook.class.inc, resulting in it attempting
to write to templates_c in the wrong location (the location
of the php file, generally htdocs/templates_c/) and getting
a permission denied error, causing nothing to render.
(According to @johnsaigle, this started happening after last Friday's
merges)

This updates the Smarty_hook class to use the setCompileDir()
smarty function instead of directly setting the internals,
resulting in LORIS being able to show pages again.