### PR TITLE
Default path for MRIUploadIncomingPath

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -141,7 +141,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "%LORISROOT%" FROM ConfigSetting
 INSERT INTO Config (ConfigID, Value) SELECT ID, "tools/logs/" FROM ConfigSettings WHERE Name="log";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSettings WHERE Name="IncomingPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/bin/mri/" FROM ConfigSettings WHERE Name="MRICodePath";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/MRI-Upload/" FROM ConfigSettings WHERE Name="MRIUploadIncomingPath";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSettings WHERE Name="MRIUploadIncomingPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/Genomic-Data/" FROM ConfigSettings WHERE Name="GenomicDataPath";
 
 -- default gui settings

--- a/SQL/2016-03-10-DefaultMRIUploadPath.sql
+++ b/SQL/2016-03-10-DefaultMRIUploadPath.sql
@@ -1,0 +1,1 @@
+INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSettings WHERE Name="MRIUploadIncomingPath"

--- a/SQL/2016-03-10-DefaultMRIUploadPath.sql
+++ b/SQL/2016-03-10-DefaultMRIUploadPath.sql
@@ -1,1 +1,1 @@
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSettings WHERE Name="MRIUploadIncomingPath"
+UPDATE Config AS c, ConfigSettings AS cs SET c.value="/data/incoming/" WHERE c.ConfigID=cs.ID AND cs.Name="MRIUploadIncomingPath";

--- a/SQL/2016-03-10-DefaultMRIUploadPath.sql
+++ b/SQL/2016-03-10-DefaultMRIUploadPath.sql
@@ -1,1 +1,1 @@
-UPDATE Config AS c, ConfigSettings AS cs SET c.value="/data/incoming/" WHERE c.ConfigID=cs.ID AND cs.Name="MRIUploadIncomingPath";
+UPDATE Config AS c, ConfigSettings AS cs SET c.value="/data/incoming/" WHERE c.ConfigID=cs.ID AND c.Value="/PATH/TO/MRI-Upload/" AND cs.Name="MRIUploadIncomingPath";


### PR DESCRIPTION
Set default to /data/incoming (like what we have in the installation scripts) to prevent imaging_uploader from uploading to /tmp/