### PR TITLE
Fixed 500 Error on Help Editor Form

### DIFF
--- a/modules/help_editor/php/NDB_Form_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Form_help_editor.class.inc
@@ -11,6 +11,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
+require_once __DIR__ . "/HelpFile.class.inc";
 /**
  * A class for holding a set of functions to add/update content 
  * for all modules


### PR DESCRIPTION
The NDB_Form_help_editor was using a file, HelpFile.class.inc
from the module directory, but not requiring it. Since it isn't
in php/libraries, it isn't autoloaded, and this was resulting
in a 500 error.

This just adds the require_once to make the form load.