### PR TITLE
Update imaging uploader test plan

### DIFF
--- a/modules/imaging_uploader/test/TestPlan
+++ b/modules/imaging_uploader/test/TestPlan
@@ -3,7 +3,8 @@
                                     
 1. Check that you have access to the MRI upload page if you have either the mri_upload or superuser permission.
 2. Check that when accessing the MRI Upload page, the search result table displays all the uploads done for all users.
-3. Check that the visit label combo box contains all the possible visit labels (taken from Visit_Windows mySQL table).
+3. Check that the visit label combo box contains all the possible visit labels (taken from the active entries for any
+   candidate from the session table).
 4. Try uploading an invalid file (a .jpg or .txt) with syntactically correct CandID, PSCID and visit labels. Make sure
    an appropriate message is displayed in the Console Output at the top of the page.
 5. Upload a tar.gz file that is not a valid DICOM archive and specify syntactically correct CandID, PSCID and visit 

--- a/modules/imaging_uploader/test/TestPlan
+++ b/modules/imaging_uploader/test/TestPlan
@@ -3,8 +3,8 @@
                                     
 1. Check that you have access to the MRI upload page if you have either the mri_upload or superuser permission.
 2. Check that when accessing the MRI Upload page, the search result table displays all the uploads done for all users.
-3. Check that the visit label combo box contains all the possible visit labels (taken from the active entries for any
-   candidate from the session table).
+3. Check that the visit label combo box contains all the possible visit labels (taken from the Visit_label column 
+   in the session table for any Active candidate).
 4. Try uploading an invalid file (a .jpg or .txt) with syntactically correct CandID, PSCID and visit labels. Make sure
    an appropriate message is displayed in the Console Output at the top of the page.
 5. Upload a tar.gz file that is not a valid DICOM archive and specify syntactically correct CandID, PSCID and visit 


### PR DESCRIPTION
The dropdown options for the imaging uploader VisitLabel are taken from the session table Visit_label column (for Active candidates).
This probably requires more higher level changes (?) but until then the documentation needs to be updated (more to come from @christinerogers, redmine 8906)