### PR TITLE
Dynamic log display of the MRI pipeline results for a scan.

### DIFF
--- a/SQL/2016-01-22-CurrentlyProcessedRenamedInMRIUploadTable.sql
+++ b/SQL/2016-01-22-CurrentlyProcessedRenamedInMRIUploadTable.sql
@@ -1,2 +1,2 @@
 ALTER TABLE mri_upload CHANGE `Processed` `InsertionComplete` tinyint(1) NOT NULL DEFAULT '0';
-ALTER TABLE mri_upload CHANGE `CurrentlyProcessed` `Inserting` tinyint(1) NOT NULL DEFAULT '0';
+ALTER TABLE mri_upload CHANGE `CurrentlyProcessed` `Inserting` tinyint(1) DEFAULT NULL;

--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Ajax script used to get the progress of an MRI pipeline run for a specific MRI
+ * scan. The upload progress for a scan (identified by its uploadId) consists of:
+ *   - Value of column Inserting in table mri_upload for the upload ID.
+ *   - Value of column InsertionComplete in table mri_upload for the upload ID.
+ *   - The notifications in table notification_spool for that scan (if script
+ *     argument summary is true, only those with verbose == 'N' are returned,
+ *     otherwise they are all returned).
+ *
+ * PHP Version 5
+ *
+ * @category Documentation
+ * @package  Main
+ * @author   Nicolas Brossard <justinkat@gmail.com>
+ * @license  Loris license
+ * @link     https://www.github.com/Jkat/Loris-Trunk/
+ */
+
+// Get LORIS user issuing the request
+$user =& User::singleton();
+if (!$user->hasPermission('imaging_uploader')) {
+    header("HTTP/1.1 403 Forbidden");
+    exit;
+}
+
+set_include_path(
+    get_include_path().":../../project/libraries:../../php/libraries:"
+);
+require_once "NDB_Client.class.inc";
+require_once "NDB_Config.class.inc";
+
+$client = new NDB_Client();
+$client->initialize("../../project/config.xml");
+
+$config = NDB_Config::singleton();
+
+// create Database object
+$DB =& Database::singleton();
+
+// return bad request if uploadId is not in POST argument list
+// or if it is not a number
+if (empty($_POST['uploadId']) || !is_numeric($_POST['uploadId'])) {
+    header("HTTP/1.1 400 Bad Request");
+    exit;
+} else {
+    $uploadId = $_POST['uploadId'];
+}
+
+// return bad request if summary is not in POST argument list
+// of if it is neither 'true' nor 'false'
+if (empty($_POST['summary'])
+    || ($_POST['summary'] != 'true' && $_POST['summary'] != 'false')
+) {
+    header("HTTP/1.1 400 Bad Request");
+    exit;
+} else {
+    $summary = $_POST['summary'] == 'true';
+}
+
+// Fetch columns Inserting and InsertionComplete from table mri_upload
+$query = "SELECT Inserting, InsertionComplete 
+          FROM mri_upload
+          WHERE UploadId =:uploadId";
+
+$row       = $DB->pselectRow(
+    $query,
+    array('uploadId' => $uploadId)
+);
+$inserting = $row['Inserting'];
+$insertionComplete = $row['InsertionComplete'];
+
+// Get notifications from table notification_spool. Only get those with
+// Verbose == 'N' if summary is set to true
+$query = "SELECT NotificationID, TimeSpooled, Error, Verbose, Message 
+          FROM notification_spool
+          WHERE ProcessID = :processId";
+if ($summary) {
+    $query .= " AND Verbose = 'N'";
+}
+
+$notifications = $DB->pselect(
+    $query,
+    array('processId' => $uploadId)
+);
+
+// Return JSON object encapsulating the response
+print json_encode(
+    array(
+     'inserting'         => $inserting,
+     'insertionComplete' => $insertionComplete,
+     'notifications'     => $notifications,
+    )
+);
+
+?>

--- a/modules/imaging_uploader/css/imaging_uploader.css
+++ b/modules/imaging_uploader/css/imaging_uploader.css
@@ -46,3 +46,21 @@ progress[aria-valuenow]:before  {
   text-align: center;
   padding-top: 4px;
 }
+
+.upload-logs-table-summary {
+  width: 95%;
+  height:130px;
+  background: #E8E8E8;
+  resize: vertical;
+  margin-left:30px;
+  padding: 5px;
+}
+
+.upload-logs-table-detailed {
+  width: 95%;
+  height:400px;
+  background: #E8E8E8;
+  resize: vertical;
+  margin-left:30px;
+  padding: 5px;
+}

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -60,9 +60,14 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
     function _setupVariables()
     {
 
+        $progressSelectPart = "IF(ISNULL(Inserting), 'Not Started',"
+            . "IF(Inserting=1, 'In Progress...', "
+            . "IF(InsertionComplete=0, 'Failure', 'Success'))) as Progress";
+
         // set the class variables
         $this->columns = array(
                           'UploadID',
+                          $progressSelectPart,
                           's.CandID',
                           'c.PSCID',
                           's.Visit_label',
@@ -135,6 +140,25 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
             'Are these Phantom Scans:',
             $phantom_options
         );
+
+        $this->addSelect(
+            'LogType',
+            '',
+            array(
+             'summary'  => 'Summary',
+             'detailed' => 'Detailed',
+            )
+        );
+
+        $this->form->addTextArea(
+            'UploadLogs',
+            '',
+            array(
+             'class' => 'upload-logs-table',
+             'id'    => 'mri_upload_logs',
+            )
+        );
+
         ///////////////////////////////////////////////////////////////////////
         //////////////////Upload-related Error messages ///////////////////////
         ///////////////////////////////////////////////////////////////////////
@@ -149,13 +173,50 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
         }
         return true;
     }
-     /**
-      * Returns true if the _saveFile has successfully
-      * completed
-      *
-      * @param array $values the array of values from the form
-      *
-      * @return true on success, false othewise
+
+
+    /**
+     * Overrides the default setDataTableRows to assign the background colour
+     * to the progress column
+     *
+     * @param integer $count The number of rows in the table
+     *
+     * @return true on success
+     */
+    function _setDataTableRows($count)
+    {
+        $x = 0;
+        foreach ($this->list as $item) {
+            //count column
+            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
+
+            //print out data rows
+            $i = 1;
+            foreach ($item as $key => $val) {
+                $itemi          =& $this->tpl_data['items'][$x][$i];
+                $itemi['name']  = $key;
+                $itemi['value'] = $val;
+                if ($key == 'Progress' && $val == 'Failure') {
+                    $itemi['bgcolor'] =  '#E4A09E';
+                } elseif ($key == 'Progress' && $val == 'In Progress...') {
+                    $itemi['bgcolor'] =  '#F3F781';
+                }
+                $i++;
+            }
+
+            $x++;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if the _saveFile has successfully
+     * completed
+     *
+     * @param array $values the array of values from the form
+     *
+     * @return true on success, false othewise
      */
     function _process($values)
     {

--- a/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
+++ b/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
@@ -144,6 +144,32 @@
 </table>
 *}
 
+<div class="row">
+    <div class="col-sm-10 col-md-8">
+        <div class="panel panel-primary">
+            <div class="panel-heading" onclick="hideFilter();">
+                Upload process logs
+            </div>
+            <div class="panel-body" id="panel-body">
+
+                    <div class="row">
+                        <div class="form-group col-sm-5">
+                            <label class="col-sm-4 col-md-4">
+                                Logs to display:
+                            </label>
+                            <div class="col-sm-4 col-md-4">
+                                {$form.LogType.html}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        {$form.UploadLogs.html}
+                    </div>
+             </div>
+        </div>
+   </div>
+</div>
+        
 <!--  title table with pagination -->
 <table border="0" valign="bottom" width="100%">
 <tr>
@@ -153,7 +179,7 @@
 </table>
 
 <div class="row">
-    <table class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
+    <table id="mri_upload_table" class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
         <thead>
             <tr class="info">
                 <th nowrap="nowrap">


### PR DESCRIPTION
Improvements to the imaging uploader page:

- Added a column to the MRI upload table for the upload progress (MRI pipeline run status)
- Added click event handler to the MRI upload table: this handler will update the contents of the logs sub-panel (see below).
- Added a sub panel to show the notifications (logs) issued by the MRI pipeline during an upload. The contents are dynamic and updated by regularly polling the server. Two types of logs can be displayed: summary (Verbose = 'N' in notification_spool table) or detailed (Verbose value does not matter).