### PR TITLE
removing study_consent and study_consent_withdrawal filters from where clause

### DIFF
--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -123,7 +123,7 @@ class CouchDBDemographicsImporter {
             $EDCFields = ", c.EDC as EDC";
             $fieldsInQuery .= $EDCFields;
         }
-        $concatQuery = $fieldsInQuery . $tablesToJoin . " WHERE s.Active='Y' AND c.Active='Y' AND ps.study_consent='yes' AND (COALESCE(ps.study_consent_withdrawal,'0000-00-00') = '0000-00-00') AND c.PSCID <> 'scanner'";
+        $concatQuery = $fieldsInQuery . $tablesToJoin . " WHERE s.Active='Y' AND c.Active='Y' AND c.PSCID <> 'scanner'";
         return $concatQuery;
     }
 


### PR DESCRIPTION
DQT users of Demographics will have to pro-actively filter for study consent to only use data where consent was not removed.