### PR TITLE
DQT moving study consent & study consent withdrawal from where clause to fields drop down

### DIFF
--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -123,7 +123,7 @@ class CouchDBDemographicsImporter {
             $EDCFields = ", c.EDC as EDC";
             $fieldsInQuery .= $EDCFields;
         }
-        $concatQuery = $fieldsInQuery . $tablesToJoin . " WHERE s.Active='Y' AND c.Active='Y' AND ps.study_consent='yes' AND (COALESCE(ps.study_consent_withdrawal,'0000-00-00') = '0000-00-00') AND c.PSCID <> 'scanner'";
+        $concatQuery = $fieldsInQuery . $tablesToJoin . " WHERE s.Active='Y' AND c.Active='Y' AND c.PSCID <> 'scanner'";
         return $concatQuery;
     }
 

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -77,7 +77,7 @@ class CouchDBDemographicsImporter {
         ),
         'Study_consent' => array(
             'Description' => 'Study Consent',
-            'Type' => "int(10)",
+            'Type' => "enum('yes','no','not_answered')",
         ),
         'Study_consent_withdrawal' => array(
             'Description' => 'Study Consent Withdrawal Date',

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -74,6 +74,14 @@ class CouchDBDemographicsImporter {
         'Status_comments' => array(
             'Description' => 'Participant status comments',
             'Type' => "text",
+        ),
+        'Study_consent' => array(
+            'Description' => 'Study Consent',
+            'Type' => "int(10)",
+        ),
+        'Study_consent_withdrawal' => array(
+            'Description' => 'Study Consent Withdrawal Date',
+            'Type' => "varchar(255)",
         )
     );
 
@@ -111,7 +119,7 @@ class CouchDBDemographicsImporter {
 
     function _generateQuery() {
         $config = NDB_Config::singleton();
-        $fieldsInQuery = "SELECT c.CandID, c.PSCID, s.Visit_label, s.SubprojectID, p.Alias as Site, c.Gender, s.Current_stage, CASE WHEN s.Visit='Failure' THEN 'Failure' WHEN s.Screening='Failure' THEN 'Failure' WHEN s.Visit='Withdrawal' THEN 'Withdrawal' WHEN s.Screening='Withdrawal' THEN 'Withdrawal' ELSE 'Neither' END as Failure, c.ProjectID, c.flagged_caveatemptor as CEF, c.flagged_caveatemptor as CEF, c_o.Description as CEF_reason, c.flagged_other as CEF_comment, pc_comment.Value as Comment, COALESCE(pso.Description,'Active') as Status, ps.participant_suboptions as Status_reason, ps.reason_specify as Status_comments";
+        $fieldsInQuery = "SELECT c.CandID, c.PSCID, s.Visit_label, s.SubprojectID, p.Alias as Site, c.Gender, s.Current_stage, CASE WHEN s.Visit='Failure' THEN 'Failure' WHEN s.Screening='Failure' THEN 'Failure' WHEN s.Visit='Withdrawal' THEN 'Withdrawal' WHEN s.Screening='Withdrawal' THEN 'Withdrawal' ELSE 'Neither' END as Failure, c.ProjectID, c.flagged_caveatemptor as CEF, c.flagged_caveatemptor as CEF, c_o.Description as CEF_reason, c.flagged_other as CEF_comment, pc_comment.Value as Comment, COALESCE(pso.Description,'Active') as Status, ps.participant_suboptions as Status_reason, ps.reason_specify as Status_comments, ps.study_consent as Study_consent, COALESCE(ps.study_consent_withdrawal,'0000-00-00') AS Study_consent_withdrawal";
         $tablesToJoin = " FROM session s JOIN candidate c USING (CandID) LEFT JOIN psc p ON (p.CenterID=s.CenterID) LEFT JOIN caveat_options c_o ON (c_o.ID=c.flagged_reason) LEFT JOIN parameter_candidate AS pc_comment ON (pc_comment.CandID=c.CandID) AND pc_comment.ParameterTypeID=(SELECT ParameterTypeID FROM parameter_type WHERE Name='candidate_comment') LEFT JOIN participant_status ps ON (ps.CandID=c.CandID) LEFT JOIN participant_status_options pso ON (pso.ID=ps.participant_status)";
         // If proband fields are being used, add proband information into the query
         if ($config->getSetting("useProband") === "true") {


### PR DESCRIPTION
DQT users of Demographics will have to pro-actively filter for study consent to only use data where consent was not removed.
