### PR TITLE
fix password expired page so that login page doesnt show

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -137,7 +137,11 @@ class NDB_Client
         if (!$login->isLoggedIn()) {
             // display login window
             //ob_end_clean();
-            $login->showLoginScreen();
+            // Check to see if passwordExpired flag is set
+            if (!$login->passwordExpired()) {
+                // If not show login page
+                $login->showLoginScreen();
+            }
             //terminate script
             return false;
         }

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -43,6 +43,11 @@ class SinglePointLogin
     var $_lastError = null;
 
     /**
+     * Defines whether a user's password has expired
+     */
+    var $_passwordExpired = false;
+
+    /**
      * Dumps the login form
      *
      * @return void
@@ -113,6 +118,9 @@ class SinglePointLogin
      */
     function showPasswordExpiryScreen()
     {
+        // Set passwordExpired flag
+        $this->_passwordExpired = true;
+
         $tpl_data['username'] = $_POST['username'];
 
         // remove logout from request
@@ -158,6 +166,17 @@ class SinglePointLogin
     function isLoggedIn()
     {
         return $this->_isLoggedIn;
+    }
+
+    /**
+     * Checks whether users password is expired
+     *
+     * @return bool
+     * @access public
+     */
+    function passwordExpired()
+    {
+        return $this->_passwordExpired;
     }
 
 
@@ -216,6 +235,8 @@ class SinglePointLogin
             return false;
         }
 
+        // Reset passwordExpired flag
+        $this->_passwordExpired = false;
         $user->updatePassword($_POST['password']);
         return true;
     }
@@ -227,6 +248,9 @@ class SinglePointLogin
      */
     function authenticate()
     {
+        // Reset passwordExpired flag
+        $this->_passwordExpired = false;
+
         // First try JWT authentication, which is cheaper and
         // doesn't involve database calls
         $headers    = getallheaders();


### PR DESCRIPTION
The expired password page showed both the page for password expired and the login page. Add a flag to say that the password expired page is being shown