### PR TITLE
Genomic range filter

### DIFF
--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -146,6 +146,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
                                'CNV.ValidationMethod',
                                'genome_loc.Chromosome',
                                'genome_loc.Strand',
+                               'genomic_range',
                                'gene.OfficialSymbol',
                                'gene.OfficialName',
                                'genotyping_platform.Name',
@@ -171,6 +172,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
                                'Validation_Method'  => 'CNV.ValidationMethod',
                                'Chromosome'         => 'genome_loc.Chromosome',
                                'Strand'             => 'genome_loc.Strand',
+                               'genomic_range'      => 'genomic_range',
                                'Gene_Symbol'        => 'gene.OfficialSymbol',
                                'Gene_Name'          => 'gene.OfficialName',
                                'Platform'           => 'genotyping_platform.Name',
@@ -280,6 +282,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
 
         $this->addBasicText('Chromosome', 'Chromosome:');
         $this->addBasicText('Strand', 'Strand:');
+        $this->addBasicText('genomic_range', 'Genomic Range:');
         $this->addBasicText('Gene_Symbol', 'Symbol:');
         $this->addBasicText('Gene_Name', 'Name:');
 
@@ -418,14 +421,25 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
             } elseif (strtolower(substr($field, -8)) == 'centerid'
                 || strtolower(substr($field, -10)) == 'categoryid'
                 || strtolower(substr($field, -6)) == 'gender'
-                || strtolower(substr($field, -10)) == 'chromosome'
                 || (isset($this->EqualityFilters)
                 && in_array($field, $this->EqualityFilters))
             ) {
-
                  $query .= " AND $field = :v_$prepared_key";
             } elseif ($field == "candidate.CandID") {
                 $query .= " AND $field = " . ltrim($val, '0');
+            } elseif ($field == "genomic_range") {
+                $temp_array = explode(':', $val);
+                $chr        = $temp_array[0];
+                $query     .= " AND genome_loc.Chromosome = '$chr'";
+
+                if (!empty($temp_array[1]) AND strpos($temp_array[1], '-') ) {
+                    $temp_array = explode('-', $temp_array[1]);
+                    $from       = $temp_array[0];
+                    $to         = $temp_array[1];
+                    $query     .= " AND genome_loc.Chromosome = '$chr'";
+                    $query     .= " AND genome_loc.StartLoc < $to";
+                    $query     .= " AND genome_loc.EndLoc > $from";
+                }
             } else {
                  $query .= " AND $field LIKE CONCAT('%', :v_$prepared_key, '%') ";
             }

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -449,10 +449,11 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
                     $temp_array = explode('-', $temp_array[1]);
                     $from       = $temp_array[0];
                     $to         = $temp_array[1];
-                    $query     .= " AND genome_loc.Chromosome = '$chr'";
                     $query     .= " AND genome_loc.StartLoc < $to";
                     $query     .= " AND genome_loc.EndLoc > $from";
                 }
+                $query .= " AND :v_$prepared_key IS NOT NULL";
+
             } else {
                  $query .= " AND $field LIKE CONCAT('%', :v_$prepared_key, '%') ";
             }

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -241,6 +241,13 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
 
         // CNV
+
+        $Base_options = array(
+                         null => 'Any',
+                         '37' => 'GRCh37',
+                        );
+        $this->addSelect('Assembly', 'Build:', $Base_options);
+
         $CNV_Type_options = array(
                              null      => 'All',
                              'gain'    => 'gain',
@@ -281,10 +288,16 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $this->addSelect('Inheritance', 'Inheritance:', $Inheritance_options);
 
         $this->addBasicText('Chromosome', 'Chromosome:');
-        $this->addBasicText('Strand', 'Strand:');
+
+        $Base_options = array(
+                         null => 'Any',
+                         'F'  => 'Forward',
+                         'R'  => 'Reverse',
+                        );
+        $this->addSelect('Strand', 'Strand:', $Base_options);
+
         $this->addBasicText('genomic_range', 'Genomic Range:');
-        $this->addBasicText('Gene_Symbol', 'Symbol:');
-        $this->addBasicText('Gene_Name', 'Name:');
+        $this->addBasicText('Gene_Symbol', 'Gene:');
 
         $DB = Database::singleton();
         $platform_results = $DB->select(

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -154,6 +154,8 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                                'genome_loc.Chromosome',
                                'genome_loc.Strand',
                                'genome_loc.StartLoc',
+                               'genome_loc.EndLoc',
+                               'genomic_range',
                                'gca.gene_name',
                                'gca.genome_build',
                                'gca.design_type',
@@ -186,6 +188,8 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                                'Platform'           => 'platform.Name',
                                'Strand'             => 'genome_loc.Strand',
                                'StartLoc'           => 'genome_loc.StartLoc',
+                               'EndLoc'             => 'genome_loc.EndLoc',
+                               'genomic_range'      => 'genomic_range',
                                'Assembly'           => 'gca.genome_build',
                                'Context'            => 'gca.island_relation',
                                'Design'             => 'gca.design_type',
@@ -280,7 +284,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         // ------------------------------------------------------------
 
         $this->addBasicText('Gene_Symbol', 'Gene:');
-        $this->addBasicText('Chromosome', 'Chromosome:');
+        $this->addBasicText('genomic_range', 'Genomic Range:');
         $Base_options = array(
                          null => 'Any',
                          '37' => 'GRCh37',
@@ -292,8 +296,6 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                          'R'  => 'Reverse',
                         );
         $this->addSelect('Strand', 'Strand:', $Base_options);
-        $this->addBasicText('StartLoc', 'From:');
-        $this->addBasicText('EndLoc', 'To:');
 
         // ------------------------------------------------------------
         // ----------------- CPG Annotations Filters --------------------
@@ -530,21 +532,39 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (in_array($field, $this->CheckboxFilters) && $val) {
                  $query .= " AND $field";
+
             } elseif (strtolower(substr($field, -8)) == 'centerid'
                 || strtolower(substr($field, -10)) == 'categoryid'
                 || (isset($this->EqualityFilters)
                 && in_array($field, $this->EqualityFilters))
             ) {
-
                  $query .= " AND $field = :v_$prepared_key";
+
             } elseif ($field == "candidate.CandID") {
                 $query .= " AND $field = " . ltrim($val, '0');
+
+            } elseif ($field == "genomic_range") {
+                $temp_array = explode(':', $val);
+                $chr        = str_replace('chr', '', $temp_array[0]);
+                $query     .= " AND genome_loc.Chromosome = '$chr'";
+
+                if (!empty($temp_array[1]) AND strpos($temp_array[1], '-') ) {
+                    $temp_array = explode('-', $temp_array[1]);
+                    $from       = $temp_array[0];
+                    $to         = $temp_array[1];
+                    $query     .= " AND genome_loc.Chromosome = '$chr'";
+                    $query     .= " AND genome_loc.StartLoc < $to";
+                    $query     .= " AND genome_loc.EndLoc > $from";
+                }
+
             } elseif ($field == "gca.probe_snp_10" && $val === 'NULL'
                 || $field == "gca.dhs" && $val === 'NULL'
             ) {
                 $query .= " AND  $field IS NULL and 'NULL' = :v_$prepared_key" ;
+
             } else {
                 $query .= " AND $field LIKE CONCAT('%', :v_$prepared_key, '%') ";
+
             }
         }
         return $query;

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -212,7 +212,6 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                                   'gca.genome_build',
                                   'gca.design_type',
                                   'genome_loc.Strand',
-                                  'gca.gene_name',
                                  );
 
         return true;
@@ -552,10 +551,11 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                     $temp_array = explode('-', $temp_array[1]);
                     $from       = $temp_array[0];
                     $to         = $temp_array[1];
-                    $query     .= " AND genome_loc.Chromosome = '$chr'";
                     $query     .= " AND genome_loc.StartLoc < $to";
                     $query     .= " AND genome_loc.EndLoc > $from";
                 }
+
+                $query .= " AND :v_$prepared_key IS NOT NULL";
 
             } elseif ($field == "gca.probe_snp_10" && $val === 'NULL'
                 || $field == "gca.dhs" && $val === 'NULL'

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -545,7 +545,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
 
             } elseif ($field == "genomic_range") {
                 $temp_array = explode(':', $val);
-                $chr        = str_replace('chr', '', $temp_array[0]);
+                $chr        = $temp_array[0];
                 $query     .= " AND genome_loc.Chromosome = '$chr'";
 
                 if (!empty($temp_array[1]) AND strpos($temp_array[1], '-') ) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -480,10 +480,10 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
                     $temp_array = explode('-', $temp_array[1]);
                     $from       = $temp_array[0];
                     $to         = $temp_array[1];
-                    $query     .= " AND genome_loc.Chromosome = '$chr'";
                     $query     .= " AND genome_loc.StartLoc < $to";
                     $query     .= " AND genome_loc.EndLoc > $from";
                 }
+                $query .= " AND :v_$prepared_key IS NOT NULL";
 
             } else {
                  $query .= " AND $field LIKE CONCAT('%', :v_$prepared_key, '%') ";

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -161,6 +161,9 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
                                'SNP.ExonicFunction',
                                'genome_loc.Chromosome',
                                'genome_loc.Strand',
+                               'genome_loc.StartLoc',
+                               'genome_loc.EndLoc',
+                               'genome_loc.Strand',
                                'gene.OfficialSymbol',
                                'gene.OfficialName',
                                'genotyping_platform.Name',
@@ -191,6 +194,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
                 'Exonic_Function'     => 'SNP.ExonicFunction',
                 'Chromosome'          => 'genome_loc.Chromosome',
                 'Gene_Symbol'         => 'gene.OfficalSymbol',
+                'genomic_range'       => 'genomic_range',
                 'Platform'            => 'genotyping_platform.Name',
                );
 
@@ -259,6 +263,13 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
 
         // SNP
+
+        $Base_options = array(
+                         null => 'Any',
+                         '37' => 'GRCh37',
+                        );
+        $this->addSelect('Assembly', 'Build:', $Base_options);
+
         $this->addBasicText('rsID', 'rsID:');
         $this->addBasicText('SNP_Name', 'Name:');
         $this->addBasicText('SNP_Description', 'Description:');
@@ -306,9 +317,15 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $this->addBasicText('Genotype_Quality', 'Genotype Quality:');
         $this->addBasicText('Exonic_Function', 'Exonic Function:');
 
-        $this->addBasicText('Chromosome', 'Chromosome:');
-        $this->addBasicText('Strand', 'Strand:');
-        $this->addBasicText('Gene_Symbol', 'Symbol:');
+        $Base_options = array(
+                         null => 'Any',
+                         'F'  => 'Forward',
+                         'R'  => 'Reverse',
+                        );
+        $this->addSelect('Strand', 'Strand:', $Base_options);
+
+        $this->addBasicText('genomic_range', 'Genomic Range:');
+        $this->addBasicText('Gene_Symbol', 'Gene:');
         $this->addBasicText('Gene_Name', 'Name:');
 
         $DB = Database::singleton();
@@ -454,6 +471,20 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
                  $query .= " AND $field = :v_$prepared_key";
             } elseif ($field == "candidate.CandID") {
                 $query .= " AND $field = " . ltrim($val, '0');
+            } elseif ($field == "genomic_range") {
+                $temp_array = explode(':', $val);
+                $chr        = str_replace('chr', '', $temp_array[0]);
+                $query     .= " AND genome_loc.Chromosome = '$chr'";
+
+                if (!empty($temp_array[1]) AND strpos($temp_array[1], '-') ) {
+                    $temp_array = explode('-', $temp_array[1]);
+                    $from       = $temp_array[0];
+                    $to         = $temp_array[1];
+                    $query     .= " AND genome_loc.Chromosome = '$chr'";
+                    $query     .= " AND genome_loc.StartLoc < $to";
+                    $query     .= " AND genome_loc.EndLoc > $from";
+                }
+
             } else {
                  $query .= " AND $field LIKE CONCAT('%', :v_$prepared_key, '%') ";
             }

--- a/modules/genomic_browser/templates/menu_cnv_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cnv_browser.tpl
@@ -76,40 +76,40 @@
               <div class="form-group col-sm-5">
                 <div class="panel panel-primary">
                   <div class="panel-heading" onclick="hideFilterGene();">
-                    Gene Filters
+                    Genomic Range Filters 
                     <span class="glyphicon glyphicon-chevron-down pull-right" style="display:none" id="down-gene"></span>
                     <span class="glyphicon glyphicon-chevron-up pull-right" id="up-gene"></span>
                   </div>
                   <div class="panel-body" id="panel-body-gene">
 	            <div class="row">
                       <div class="form-group col-sm-12">
-                        <label class="col-sm-12 col-md-2">
+                        <label class="col-sm-12 col-md-1" data-toggle="tooltip" data-placement="top" title="HUGO Gene Nomenclature Committee ID ex: PINK1">
         		  {$form.Gene_Symbol.label}
                         </label>
                         <div class="col-sm-12 col-md-3">
         	          {$form.Gene_Symbol.html}
 		        </div>
-                        <label class="col-sm-12 col-md-2">
-        	          {$form.Gene_Name.label}
+                        <label class="col-sm-12 col-md-2" data-toggle="tooltip" data-placement="top" title="Genome Reference Consortium ID">
+        	          {$form.Assembly.label}
                         </label>
-                        <div class="col-sm-12 col-md-5">
-        	          {$form.Gene_Name.html}
+                        <div class="col-sm-12 col-md-3">
+        	          {$form.Assembly.html}
 		        </div>
 		      </div>
 	            </div>
 	            <div class="row">
                       <div class="form-group col-sm-12">
-                        <label class="col-sm-12 col-md-3">
-      		          {$form.Chromosome.label}
+                        <label class="col-sm-12 col-md-1">
+      		          {$form.Strand.label}
                         </label>
                         <div class="col-sm-12 col-md-2">
-        	          {$form.Chromosome.html}
+        	          {$form.Strand.html}
 		        </div>
                         <label class="col-sm-12 col-md-3">
-        	          {$form.Platform.label}
+        	          {$form.genomic_range.label}
                         </label>
-                        <div class="col-sm-12 col-md-4">
-        	          {$form.Platform.html}
+                        <div class="col-sm-12 col-md-6">
+        	          {$form.genomic_range.html}
 		        </div>
 		      </div>
 	            </div>

--- a/modules/genomic_browser/templates/menu_cpg_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cpg_browser.tpl
@@ -86,20 +86,14 @@
                         <label class="col-sm-12 col-md-1" data-toggle="tooltip" data-placement="top" title="HUGO Gene Nomenclature Committee ID ex: PINK1">
                           {$form.Gene_Symbol.label}
                         </label>
-                        <div class="col-sm-12 col-md-2">
+                        <div class="col-sm-12 col-md-3">
                           {$form.Gene_Symbol.html}
                         </div>
-                        <label class="col-sm-12 col-md-1" data-toggle="tooltip" data-placement="top" title="Genome Reference Consortium ID">
+                        <label class="col-sm-12 col-md-2" data-toggle="tooltip" data-placement="top" title="Genome Reference Consortium ID">
                           {$form.Assembly.label}
                         </label>
                         <div class="col-sm-12 col-md-3">
                           {$form.Assembly.html}
-                        </div>
-                        <label class="col-sm-12 col-md-2" data-toggle="tooltip" data-placement="top" title="Chromosome number or symbole">
-                          {$form.Chromosome.label}
-                        </label>
-                        <div class="col-sm-12 col-md-2">
-                          {$form.Chromosome.html}
                         </div>
                       </div>
                     </div>
@@ -111,17 +105,11 @@
                         <div class="col-sm-12 col-md-2">
                           {$form.Strand.html}
                         </div>
-                        <label class="col-sm-12 col-md-1" data-toggle="tooltip" data-placement="top" title="Start location on the genome">
-                          {$form.StartLoc.label}
+                        <label class="col-sm-12 col-md-3" data-toggle="tooltip" data-placement="top" title="ex: chr14:68341139-69341267">
+                          {$form.genomic_range.label}
                         </label>
-                        <div class="col-sm-12 col-md-3">
-                          {$form.StartLoc.html}
-                        </div>
-                        <label class="col-sm-12 col-md-1" data-toggle="tooltip" data-placement="top" title="End location on the genome">
-                          {$form.EndLoc.label}
-                        </label>
-                        <div class="col-sm-12 col-md-3">
-                          {$form.EndLoc.html}
+                        <div class="col-sm-12 col-md-6">
+                          {$form.genomic_range.html}
                         </div>
                       </div>
                     </div>

--- a/modules/genomic_browser/templates/menu_cpg_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cpg_browser.tpl
@@ -76,7 +76,7 @@
               <div class="form-group col-sm-5">
                 <div class="panel panel-primary">
                   <div class="panel-heading" onclick="hideFilterGene();">
-                    Genomic range Filters
+                    Genomic Range Filters
                     <span class="glyphicon glyphicon-chevron-down pull-right" style="display:none" id="down-gene"></span>
                     <span class="glyphicon glyphicon-chevron-up pull-right" id="up-gene"></span>
                   </div>

--- a/modules/genomic_browser/templates/menu_snp_browser.tpl
+++ b/modules/genomic_browser/templates/menu_snp_browser.tpl
@@ -76,40 +76,40 @@
               <div class="form-group col-sm-5">
                 <div class="panel panel-primary">
                   <div class="panel-heading" onclick="hideFilterGene();">
-                    Gene Filters
+                    Genomic Range Filters
                     <span class="glyphicon glyphicon-chevron-down pull-right" style="display:none" id="down-gene"></span>
                     <span class="glyphicon glyphicon-chevron-up pull-right" id="up-gene"></span>
                   </div>
                   <div class="panel-body" id="panel-body-gene">
                     <div class="row">
                       <div class="form-group col-sm-12">
-                        <label class="col-sm-12 col-md-2">
+                        <label class="col-sm-12 col-md-1">
                           {$form.Gene_Symbol.label}
                         </label>
                         <div class="col-sm-12 col-md-3">
                           {$form.Gene_Symbol.html}
                         </div>
                         <label class="col-sm-12 col-md-2">
-                          {$form.Gene_Name.label}
+                          {$form.Assembly.label}
                         </label>
-                        <div class="col-sm-12 col-md-5">
-                          {$form.Gene_Name.html}
+                        <div class="col-sm-12 col-md-3">
+                          {$form.Assembly.html}
                         </div>
                       </div>
                     </div>
                     <div class="row">
                       <div class="form-group col-sm-12">
-                        <label class="col-sm-12 col-md-3">
-                          {$form.Chromosome.label}
+                        <label class="col-sm-12 col-md-1">
+                          {$form.Strand.label}
                         </label>
                         <div class="col-sm-12 col-md-2">
-                          {$form.Chromosome.html}
+                          {$form.Strand.html}
                         </div>
                         <label class="col-sm-12 col-md-3">
-                          {$form.Platform.label}
+                          {$form.genomic_range.label}
                         </label>
-                        <div class="col-sm-12 col-md-4">
-                          {$form.Platform.html}
+                        <div class="col-sm-12 col-md-6">
+                          {$form.genomic_range.html}
                         </div>
                       </div>
                     </div>
@@ -206,6 +206,12 @@
                         </label>
                     	<div class="col-sm-12 col-md-2">
         		  {$form.Genotype_Quality.html}
+			</div>
+                        <label class="col-sm-12 col-md-2">
+        		  {$form.Platform.label}
+                        </label>
+                    	<div class="col-sm-12 col-md-2">
+        		  {$form.Platform.html}
 			</div>
 		      </div>
 		    </div>

--- a/modules/genomic_browser/tools/HumanMethylation450k_annotations_to_sql.py
+++ b/modules/genomic_browser/tools/HumanMethylation450k_annotations_to_sql.py
@@ -38,8 +38,8 @@ with open(annotation_file, 'r') as f:
             continue
 
         sys.stdout.write("INSERT IGNORE INTO genome_loc (Chromosome, EndLoc, StartLoc, Strand) VALUES\n")
-        sys.stdout.write("  ('" + line["CHR"] + "'," + line["MAPINFO"] + "," + line["MAPINFO"] + ",'" + line["Strand"] + "');\n")
-        genome_loc_subquery = "(SELECT GenomeLocID FROM genome_loc WHERE Chromosome = '" + line["CHR"] + "' AND StartLoc = " + line["MAPINFO"] + " AND EndLoc = " + line["MAPINFO"] + ")"
+        sys.stdout.write("  ('chr" + line["CHR"] + "'," + line["MAPINFO"] + "," + line["MAPINFO"] + ",'" + line["Strand"] + "');\n")
+        genome_loc_subquery = "(SELECT GenomeLocID FROM genome_loc WHERE Chromosome = 'chr" + line["CHR"] + "' AND StartLoc = " + line["MAPINFO"] + " AND EndLoc = " + line["MAPINFO"] + ")"
 
         sys.stdout.write("INSERT IGNORE INTO genomic_cpg_annotation (cpg_name, location_id, address_id_a, probe_seq_a, address_id_b, probe_seq_b, design_type, color_channel, genome_build, probe_snp_10, gene_name, gene_acc_num, gene_group, island_loc, island_relation, fantom_promoter_loc, dmr, enhancer, hmm_island_loc, reg_feature_loc, reg_feature_group, dhs, platform_id) VALUES\n")
 


### PR DESCRIPTION
Using the [chr#:startLoc-endLoc] notation to search for elements along the genome inside or overlaping this genomic_range.

ex: chr14:20000200-35000000 will look for elements on the chromosome 14 starting from the position 20000200 to the position 35000000.

For now, the implicite assembly (genome build) is GRCh37 (hg19)