### PR TITLE
Add Quickform For Instruments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
     # Install composer modules
     - composer install
+    - pear install HTML_QuickForm
     - phpenv rehash
 
     # Install jslint

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -170,7 +170,7 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     static function factory($instrument, $commentID, $page, $guarantee_exists = true)
     {
-        //include_once 'HTML/QuickForm.php';
+        include_once 'HTML/QuickForm.php';
         $class = "NDB_BVL_Instrument_$instrument";
 
         // Make sure the instrument class has been included/required!


### PR DESCRIPTION
The instruments in LORIS are still using QuickForm, but it cant be installed by composer without breaking PHP7.

This includes it from the instrument class factory, so that it gets included when using instruments, but isn't going to break PHP7 under Travis.