### PR TITLE
Reactified genomic browser

### DIFF
--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -59,10 +59,9 @@ StaticDataTable = React.createClass({
             'PageNumber': 1
         });
     },
-    downloadCSV: function() {
+    downloadCSV: function () {
         var headers = this.props.Fields,
             csvworker = new Worker(loris.BaseURL + '/js/workers/savecsv.js');
-
 
         csvworker.addEventListener('message', function (e) {
             var dataURL, dataDate, link;
@@ -216,39 +215,93 @@ StaticDataTable = React.createClass({
             ));
         }
 
-<<<<<<< HEAD
-        var RowsPerPageDropdown = (
-            React.createElement("select", {className: "input-sm perPage", onChange: this.changeRowsPerPage}, 
-                React.createElement("option", null, "20"), 
-                React.createElement("option", null, "50"), 
-                React.createElement("option", null, "100"), 
-                React.createElement("option", null, "1000"), 
-                React.createElement("option", null, "5000"), 
-                React.createElement("option", null, "10000")
+        var RowsPerPageDropdown = React.createElement(
+            "select",
+            { className: "input-sm perPage", onChange: this.changeRowsPerPage },
+            React.createElement(
+                "option",
+                null,
+                "20"
+            ),
+            React.createElement(
+                "option",
+                null,
+                "50"
+            ),
+            React.createElement(
+                "option",
+                null,
+                "100"
+            ),
+            React.createElement(
+                "option",
+                null,
+                "1000"
+            ),
+            React.createElement(
+                "option",
+                null,
+                "5000"
+            ),
+            React.createElement(
+                "option",
+                null,
+                "10000"
             )
-            );
-        return (
-            React.createElement("div", {className: "panel panel-primary"}, 
-                    React.createElement("table", {className: "table table-hover table-primary table-bordered", id: "dynamictable"}, 
-                        React.createElement("thead", null, 
-                            React.createElement("tr", {className: "info"}, headers)
-                        ), 
-                        React.createElement("tbody", null, 
-                            rows
-                        )
-                    ), 
-                React.createElement("div", {className: "panel-footer table-footer"}, 
-                    React.createElement("div", {className: "row"}, 
-                        React.createElement("div", {className: "col-xs-12"}, 
-                            React.createElement("div", {className: "col-xs-12 footerText"}, 
-                                rows.length, " rows displayed of ", this.props.Data.length, ". (Maximum rows per page: ", RowsPerPageDropdown, ")"
-                            ), 
-                            React.createElement("div", {className: "col-xs-6"}, 
-                                React.createElement("button", {className: "btn btn-primary downloadCSV", onClick: this.downloadCSV}, "Download Table as CSV")
-                            ), 
-                            React.createElement("div", {className: "pull-right"}, 
-                                React.createElement(PaginationLinks, {Total: this.props.Data.length, onChangePage: this.changePage, RowsPerPage: rowsPerPage, Active: this.state.PageNumber})
+        );
+        return React.createElement(
+            "div",
+            { className: "panel panel-primary" },
+            React.createElement(
+                "table",
+                { className: "table table-hover table-primary table-bordered", id: "dynamictable" },
+                React.createElement(
+                    "thead",
+                    null,
+                    React.createElement(
+                        "tr",
+                        { className: "info" },
+                        headers
+                    )
+                ),
+                React.createElement(
+                    "tbody",
+                    null,
+                    rows
+                )
+            ),
+            React.createElement(
+                "div",
+                { className: "panel-footer table-footer" },
+                React.createElement(
+                    "div",
+                    { className: "row" },
+                    React.createElement(
+                        "div",
+                        { className: "col-xs-12" },
+                        React.createElement(
+                            "div",
+                            { className: "col-xs-12 footerText" },
+                            rows.length,
+                            " rows displayed of ",
+                            this.props.Data.length,
+                            ". (Maximum rows per page: ",
+                            RowsPerPageDropdown,
+                            ")"
+                        ),
+                        React.createElement(
+                            "div",
+                            { className: "col-xs-6" },
+                            React.createElement(
+                                "button",
+                                { className: "btn btn-primary downloadCSV", onClick: this.downloadCSV },
+                                "Download Table as CSV"
                             )
+                        ),
+                        React.createElement(
+                            "div",
+                            { className: "pull-right" },
+                            React.createElement(PaginationLinks, { Total: this.props.Data.length, onChangePage: this.changePage, RowsPerPage: rowsPerPage, Active: this.state.PageNumber })
                         )
                     )
                 )

--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -1,4 +1,6 @@
-StaticDataTable = React.createClass({displayName: "StaticDataTable",
+StaticDataTable = React.createClass({
+    displayName: "StaticDataTable",
+
     mixins: [React.addons.PureRenderMixin],
     propTypes: {
         Headers: React.PropTypes.array.isRequired,
@@ -8,54 +10,54 @@ StaticDataTable = React.createClass({displayName: "StaticDataTable",
         // func(ColumnName, CellData, EntireRowData)
         getFormattedCell: React.PropTypes.func
     },
-    componentDidMount: function() {
+    componentDidMount: function () {
         if (jQuery.fn.DynamicTable) {
-            if(this.props.freezeColumn) {
-                $("#dynamictable").DynamicTable({"freezeColumn" : this.props.freezeColumn});
+            if (this.props.freezeColumn) {
+                $("#dynamictable").DynamicTable({ "freezeColumn": this.props.freezeColumn });
             } else {
                 $("#dynamictable").DynamicTable();
             }
         }
     },
-    getInitialState: function() {
+    getInitialState: function () {
         return {
-            'PageNumber' : 1,
-            'SortColumn' : -1,
-            'SortOrder' : 'ASC',
-            'RowsPerPage' : 20
+            'PageNumber': 1,
+            'SortColumn': -1,
+            'SortOrder': 'ASC',
+            'RowsPerPage': 20
         };
     },
-    getDefaultProps: function() {
+    getDefaultProps: function () {
         return {
             Headers: [],
             Data: {},
             RowNumLabel: 'No.'
         };
     },
-    changePage: function(pageNo) {
+    changePage: function (pageNo) {
         this.setState({
             PageNumber: pageNo
         });
     },
-    setSortColumn: function(colNumber) {
+    setSortColumn: function (colNumber) {
         that = this;
-        return function(e) {
-            if(that.state.SortColumn === colNumber) {
+        return function (e) {
+            if (that.state.SortColumn === colNumber) {
                 that.setState({
-                    'SortOrder' : that.state.SortOrder === 'ASC' ? 'DESC' : 'ASC'
+                    'SortOrder': that.state.SortOrder === 'ASC' ? 'DESC' : 'ASC'
                 });
             } else {
                 that.setState({
                     SortColumn: colNumber
                 });
             }
-        }
+        };
     },
-    changeRowsPerPage: function(val) {
-       this.setState({
-           'RowsPerPage' : val.target.value,
-           'PageNumber' : 1
-       });
+    changeRowsPerPage: function (val) {
+        this.setState({
+            'RowsPerPage': val.target.value,
+            'PageNumber': 1
+        });
     },
     downloadCSV: function() {
         var headers = this.props.Fields,
@@ -83,31 +85,51 @@ StaticDataTable = React.createClass({displayName: "StaticDataTable",
             identifiers: this.props.RowNameMap
         });
     },
-    render: function() {
+    render: function () {
         if (this.props.Data == null) {
-            return (
-                React.createElement("div", {
+            return React.createElement(
+                "div",
+                {
                     className: "alert alert-info no-result-found-panel"
-                }, 
-                    React.createElement("strong", null, "No result found.")
+                },
+                React.createElement(
+                    "strong",
+                    null,
+                    "No result found."
                 )
             );
         }
         var rowsPerPage = this.state.RowsPerPage;
-        var headers = [React.createElement("th", {onClick: this.setSortColumn(-1)}, this.props.RowNumLabel)];
-        for(var i = 0; i < this.props.Headers.length; i += 1) {
-            if(this.props.Headers[i] == this.props.freezeColumn){
-                headers.push(React.createElement("th", {id: this.props.freezeColumn, onClick: this.setSortColumn(i)}, this.props.Headers[i]));
-            }else {
-                headers.push(React.createElement("th", {onClick: this.setSortColumn(i)}, this.props.Headers[i]));
+        var headers = [React.createElement(
+            "th",
+            { onClick: this.setSortColumn(-1) },
+            this.props.RowNumLabel
+        )];
+        for (var i = 0; i < this.props.Headers.length; i += 1) {
+
+            if (typeof loris.briefHeaders === "undefined" || !(loris.brief && -1 == loris.briefHeaders.indexOf(this.props.Headers[i]))) {
+                if (this.props.Headers[i] == this.props.freezeColumn) {
+                    headers.push(React.createElement(
+                        "th",
+                        { id: this.props.freezeColumn, onClick: this.setSortColumn(i) },
+                        this.props.Headers[i]
+                    ));
+                } else {
+                    headers.push(React.createElement(
+                        "th",
+                        { onClick: this.setSortColumn(i) },
+                        this.props.Headers[i]
+                    ));
+                }
             }
         }
         var rows = [];
         var curRow = [];
-        var index = [], that = this;
+        var index = [],
+            that = this;
 
-        if(this.state.SortColumn >= 0) {
-            for(var i = 0; i < this.props.Data.length; i += 1) {
+        if (this.state.SortColumn >= 0) {
+            for (var i = 0; i < this.props.Data.length; i += 1) {
                 var val = this.props.Data[i][this.state.SortColumn];
 
                 if (parseInt(val, 10) == val) {
@@ -119,68 +141,82 @@ StaticDataTable = React.createClass({displayName: "StaticDataTable",
                 }
 
                 if (this.props.RowNameMap) {
-                    index.push({ RowIdx: i, Value: val, Content: this.props.RowNameMap[i]});
+                    index.push({ RowIdx: i, Value: val, Content: this.props.RowNameMap[i] });
                 } else {
-                    index.push({ RowIdx: i, Value: val, Content: i+1 });
+                    index.push({ RowIdx: i, Value: val, Content: i + 1 });
                 }
             }
-            index.sort(function(a, b) {
-                if(that.state.SortOrder === 'ASC') {
+            index.sort(function (a, b) {
+                if (that.state.SortOrder === 'ASC') {
                     // Sort by value
-                    if(a.Value < b.Value) return -1;
-                    if(a.Value > b.Value) return 1;
+                    if (a.Value < b.Value) return -1;
+                    if (a.Value > b.Value) return 1;
 
                     // If all values are equal, sort by rownum
-                    if(a.RowIdx < b.RowIdx) { return -1; }
-                    if(a.RowIdx > b.RowIdx) { return 1; }
+                    if (a.RowIdx < b.RowIdx) {
+                        return -1;
+                    }
+                    if (a.RowIdx > b.RowIdx) {
+                        return 1;
+                    }
                 } else {
                     // Sort by value
-                    if(a.Value < b.Value) return 1;
-                    if(a.Value > b.Value) return -1;
+                    if (a.Value < b.Value) return 1;
+                    if (a.Value > b.Value) return -1;
 
                     // If all values are equal, sort by rownum
-                    if(a.RowIdx < b.RowIdx) { return 1; }
-                    if(a.RowIdx > b.RowIdx) { return -1; }
+                    if (a.RowIdx < b.RowIdx) {
+                        return 1;
+                    }
+                    if (a.RowIdx > b.RowIdx) {
+                        return -1;
+                    }
                 }
                 // They're equal..
                 return 0;
-
             });
         } else {
-            for(var i = 0; i < this.props.Data.length; i += 1) {
+            for (var i = 0; i < this.props.Data.length; i += 1) {
                 if (this.props.RowNameMap) {
-                    index.push({ RowIdx: i, Content: this.props.RowNameMap[i]});
+                    index.push({ RowIdx: i, Content: this.props.RowNameMap[i] });
                 } else {
-                    index.push({ RowIdx: i, Content: i+1});
+                    index.push({ RowIdx: i, Content: i + 1 });
                 }
             }
         }
-        for(var i = (rowsPerPage*(this.state.PageNumber-1));
-                (i < this.props.Data.length) && (rows.length < rowsPerPage);
-                i += 1) {
+        for (var i = rowsPerPage * (this.state.PageNumber - 1); i < this.props.Data.length && rows.length < rowsPerPage; i += 1) {
             curRow = [];
 
-            for(var j = 0; j < this.props.Headers.length; j += 1) {
-                if(this.props.Data[index[i].RowIdx]) {
+            for (var j = 0; j < this.props.Headers.length; j += 1) {
+                if (this.props.Data[index[i].RowIdx]) {
                     data = this.props.Data[index[i].RowIdx][j];
                 } else {
                     data = "Unknown";
                 }
                 if (this.props.getFormattedCell) {
                     data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx]);
-                    curRow.push({data});
+                    curRow.push({ data });
                 } else {
-                    curRow.push(React.createElement("td", null, data));
+                    curRow.push(React.createElement(
+                        "td",
+                        null,
+                        data
+                    ));
                 }
             }
-            rows.push(
-                React.createElement("tr", {colSpan: headers.length}, 
-                    React.createElement("td", null, index[i].Content), 
-                    curRow
-                )
-            );
+            rows.push(React.createElement(
+                "tr",
+                { colSpan: headers.length },
+                React.createElement(
+                    "td",
+                    null,
+                    index[i].Content
+                ),
+                curRow
+            ));
         }
 
+<<<<<<< HEAD
         var RowsPerPageDropdown = (
             React.createElement("select", {className: "input-sm perPage", onChange: this.changeRowsPerPage}, 
                 React.createElement("option", null, "20"), 

--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -107,7 +107,7 @@ StaticDataTable = React.createClass({
         )];
         for (var i = 0; i < this.props.Headers.length; i += 1) {
 
-            if (typeof loris.briefHeaders === "undefined" || !(loris.brief && -1 == loris.briefHeaders.indexOf(this.props.Headers[i]))) {
+            if (typeof loris.hiddenHeaders === "undefined" || -1 == loris.hiddenHeaders.indexOf(this.props.Headers[i])) {
                 if (this.props.Headers[i] == this.props.freezeColumn) {
                     headers.push(React.createElement(
                         "th",

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -97,7 +97,7 @@ StaticDataTable = React.createClass({
         var headers = [<th onClick={this.setSortColumn(-1)}>{this.props.RowNumLabel}</th>];
         for(var i = 0; i < this.props.Headers.length; i += 1) {
  
-            if ( typeof loris.briefHeaders === "undefined" || !(loris.brief && -1 == loris.briefHeaders.indexOf(this.props.Headers[i])) ) {
+            if ( typeof loris.hiddenHeaders === "undefined" || -1 == loris.hiddenHeaders.indexOf(this.props.Headers[i]) ) {
                 if(this.props.Headers[i] == this.props.freezeColumn){
                     headers.push(<th id={this.props.freezeColumn} onClick={this.setSortColumn(i)}>{this.props.Headers[i]}</th>);
                 }else {

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -96,10 +96,13 @@ StaticDataTable = React.createClass({
         var rowsPerPage = this.state.RowsPerPage;
         var headers = [<th onClick={this.setSortColumn(-1)}>{this.props.RowNumLabel}</th>];
         for(var i = 0; i < this.props.Headers.length; i += 1) {
-            if(this.props.Headers[i] == this.props.freezeColumn){
-                headers.push(<th id={this.props.freezeColumn} onClick={this.setSortColumn(i)}>{this.props.Headers[i]}</th>);
-            }else {
-                headers.push(<th onClick={this.setSortColumn(i)}>{this.props.Headers[i]}</th>);
+ 
+            if ( typeof loris.briefHeaders === "undefined" || !(loris.brief && -1 == loris.briefHeaders.indexOf(this.props.Headers[i])) ) {
+                if(this.props.Headers[i] == this.props.freezeColumn){
+                    headers.push(<th id={this.props.freezeColumn} onClick={this.setSortColumn(i)}>{this.props.Headers[i]}</th>);
+                }else {
+                    headers.push(<th onClick={this.setSortColumn(i)}>{this.props.Headers[i]}</th>);
+                }
             }
         }
         var rows = [];

--- a/modules/genomic_browser/js/cnvColumnFormatter.js
+++ b/modules/genomic_browser/js/cnvColumnFormatter.js
@@ -1,0 +1,20 @@
+function formatColumn(column, cell, rowData) {
+    if (column === 'PSCID') {
+        var url = loris.BaseURL + "/" + rowData[1] + "/";
+        return React.createElement(
+            "td",
+            null,
+            React.createElement(
+                "a",
+                { href: url },
+                cell
+            )
+        );
+    }
+    return React.createElement(
+        "td",
+        null,
+        cell
+    );
+}
+

--- a/modules/genomic_browser/js/cnvColumnFormatter.js
+++ b/modules/genomic_browser/js/cnvColumnFormatter.js
@@ -1,20 +1,28 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'PSCID') {
-        var url = loris.BaseURL + "/" + rowData[1] + "/";
-        return React.createElement(
-            "td",
-            null,
-            React.createElement(
-                "a",
-                { href: url },
-                cell
-            )
-        );
-    }
-    return React.createElement(
-        "td",
-        null,
-        cell
-    );
-}
 
+function formatColumn(column, cell, rowData) {
+    reactElement = null;
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+        switch (column) {
+            case 'PSCID':
+                var url = loris.BaseURL + "/" + rowData[1] + "/";
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url },
+                        cell
+                    )
+                );
+                break;
+            default:
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    cell
+                );
+                break;
+        }
+    }
+    return reactElement;
+}

--- a/modules/genomic_browser/js/cpgColumnFormatter.js
+++ b/modules/genomic_browser/js/cpgColumnFormatter.js
@@ -15,6 +15,51 @@ function formatColumn(column, cell, rowData) {
                     )
                 );
                 break;
+            case 'Cpg Name':
+                var chr = rowData[9];
+                var genomicLocation = rowData[11];
+                var startLoc = parseInt(genomicLocation) - 1000,
+                    endLoc   = parseInt(genomicLocation) + 1000;
+                
+                var url = "http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=" + chr + ":" + startLoc + "-" + endLoc;
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url , target: '_blank'},
+                        cell
+                    )
+                );
+                break;
+            case 'Gene':
+            case 'Accession Number':
+            case 'Island Loc':
+                if( cell != null) {
+                    links = cell.split(';').map( function (e) {
+                        var url = "http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=" + e;
+                        return React.createElement(
+                            "a",
+                            { href: url , target: '_blank'},
+                            e + " " 
+                        )
+                    });
+                } else {
+                    links = React.createElement(
+                        "a",
+                        null,
+                        " "
+                    );
+                }
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    links
+                );
+                break;
+            case 'DHS':
+            case 'Enhancer':
+                cell = (cell == '1') ? 'Yes' : null;
             default:
                 reactElement = React.createElement(
                     "td",

--- a/modules/genomic_browser/js/cpgColumnFormatter.js
+++ b/modules/genomic_browser/js/cpgColumnFormatter.js
@@ -1,0 +1,20 @@
+function formatColumn(column, cell, rowData) {
+    if (column === 'PSCID') {
+        var url = loris.BaseURL + "/" + rowData[1] + "/";
+        return React.createElement(
+            "td",
+            null,
+            React.createElement(
+                "a",
+                { href: url },
+                cell
+            )
+        );
+    }
+    return React.createElement(
+        "td",
+        null,
+        cell
+    );
+}
+

--- a/modules/genomic_browser/js/cpgColumnFormatter.js
+++ b/modules/genomic_browser/js/cpgColumnFormatter.js
@@ -1,20 +1,28 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'PSCID') {
-        var url = loris.BaseURL + "/" + rowData[1] + "/";
-        return React.createElement(
-            "td",
-            null,
-            React.createElement(
-                "a",
-                { href: url },
-                cell
-            )
-        );
-    }
-    return React.createElement(
-        "td",
-        null,
-        cell
-    );
-}
 
+function formatColumn(column, cell, rowData) {
+    reactElement = null;
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+        switch (column) {
+            case 'PSCID':
+                var url = loris.BaseURL + "/" + rowData[1] + "/";
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url },
+                        cell
+                    )
+                );
+                break;
+            default:
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    cell
+                );
+                break;
+        }
+    }
+    return reactElement;
+}

--- a/modules/genomic_browser/js/gwasColumnFormatter.js
+++ b/modules/genomic_browser/js/gwasColumnFormatter.js
@@ -1,0 +1,20 @@
+function formatColumn(column, cell, rowData) {
+    if (column === 'PSCID') {
+        var url = loris.BaseURL + "/" + rowData[1] + "/";
+        return React.createElement(
+            "td",
+            null,
+            React.createElement(
+                "a",
+                { href: url },
+                cell
+            )
+        );
+    }
+    return React.createElement(
+        "td",
+        null,
+        cell
+    );
+}
+

--- a/modules/genomic_browser/js/gwasColumnFormatter.js
+++ b/modules/genomic_browser/js/gwasColumnFormatter.js
@@ -1,20 +1,28 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'PSCID') {
-        var url = loris.BaseURL + "/" + rowData[1] + "/";
-        return React.createElement(
-            "td",
-            null,
-            React.createElement(
-                "a",
-                { href: url },
-                cell
-            )
-        );
-    }
-    return React.createElement(
-        "td",
-        null,
-        cell
-    );
-}
 
+function formatColumn(column, cell, rowData) {
+    reactElement = null;
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+        switch (column) {
+            case 'PSCID':
+                var url = loris.BaseURL + "/" + rowData[1] + "/";
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url },
+                        cell
+                    )
+                );
+                break;
+            default:
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    cell
+                );
+                break;
+        }
+    }
+    return reactElement;
+}

--- a/modules/genomic_browser/js/profileColumnFormatter.js
+++ b/modules/genomic_browser/js/profileColumnFormatter.js
@@ -2,6 +2,8 @@
 function formatColumn(column, cell, rowData) {
     reactElement = null;
     if (-1 == loris.hiddenHeaders.indexOf(column)) {
+        var params = [];
+        console.log(column)
         switch (column) {
             case 'PSCID':
                 var url = loris.BaseURL + "/" + rowData[1] + "/";
@@ -22,18 +24,37 @@ function formatColumn(column, cell, rowData) {
                     loris.subprojectList[cell]
                 );
                 break;
+
+            // Links columns. They all use the loris.loadFilteredMenuClickHandler
+            // but with distinctive parameters.
             case 'Files':
-                var url = loris.BaseURL + "/genomic_browser/viewGenomicFile/?candID=" + rowData[1] + "/";
+		if (0 == params.length) {
+                    params = ['genomic_browser&submenu=viewGenomicFile', {'candID': rowData[1]}];
+                }
+            case 'SNPs':
+		if (0 == params.length) {
+                    params = ['genomic_browser&submenu=snp_browser', {'DCCID': rowData[1], 'filter': "Show Data"}];
+                }
+            case 'CNVs':
+		if (0 == params.length) {
+                    params = ['genomic_browser&submenu=cnv_browser', {'DCCID': rowData[1], 'filter': "Show Data"}];
+                }
+            case 'CPGs':
+		if (0 == params.length) {
+                    params = ['genomic_browser&submenu=cpg_browser', {'DCCID': rowData[1], 'filter': "Show Data"}];
+                }
+                console.log(params);
                 reactElement = React.createElement(
                     "td",
                     null,
                     React.createElement(
-                        "span",
-                        {onClick: loris.loadFilteredMenuClickHandler('genomic_browser&submenu=viewGenomicFile', {'candID': rowData[1]}) },
+                        "a",
+                        {onClick: loris.loadFilteredMenuClickHandler(params[0], params[1]) },
                         cell
                     )
                 );
                 break;
+            
             default:
                 reactElement = React.createElement(
                     "td",

--- a/modules/genomic_browser/js/profileColumnFormatter.js
+++ b/modules/genomic_browser/js/profileColumnFormatter.js
@@ -15,6 +15,25 @@ function formatColumn(column, cell, rowData) {
                     )
                 );
                 break;
+            case 'Subproject':
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    loris.subprojectList[cell]
+                );
+                break;
+            case 'Files':
+                var url = loris.BaseURL + "/genomic_browser/viewGenomicFile/?candID=" + rowData[1] + "/";
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "span",
+                        {onClick: loris.loadFilteredMenuClickHandler('genomic_browser&submenu=viewGenomicFile', {'candID': rowData[1]}) },
+                        cell
+                    )
+                );
+                break;
             default:
                 reactElement = React.createElement(
                     "td",

--- a/modules/genomic_browser/js/profileColumnFormatter.js
+++ b/modules/genomic_browser/js/profileColumnFormatter.js
@@ -1,0 +1,20 @@
+function formatColumn(column, cell, rowData) {
+    if (column === 'PSCID') {
+        var url = loris.BaseURL + "/" + rowData[1] + "/";
+        return React.createElement(
+            "td",
+            null,
+            React.createElement(
+                "a",
+                { href: url },
+                cell
+            )
+        );
+    }
+    return React.createElement(
+        "td",
+        null,
+        cell
+    );
+}
+

--- a/modules/genomic_browser/js/profileColumnFormatter.js
+++ b/modules/genomic_browser/js/profileColumnFormatter.js
@@ -1,8 +1,7 @@
 
 function formatColumn(column, cell, rowData) {
     reactElement = null;
-    if ( !(loris.brief && -1 == loris.briefHeaders.indexOf(column)) ) {
-
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
         switch (column) {
             case 'PSCID':
                 var url = loris.BaseURL + "/" + rowData[1] + "/";
@@ -25,6 +24,5 @@ function formatColumn(column, cell, rowData) {
                 break;
         }
     }
-
     return reactElement;
 }

--- a/modules/genomic_browser/js/profileColumnFormatter.js
+++ b/modules/genomic_browser/js/profileColumnFormatter.js
@@ -1,20 +1,30 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'PSCID') {
-        var url = loris.BaseURL + "/" + rowData[1] + "/";
-        return React.createElement(
-            "td",
-            null,
-            React.createElement(
-                "a",
-                { href: url },
-                cell
-            )
-        );
-    }
-    return React.createElement(
-        "td",
-        null,
-        cell
-    );
-}
 
+function formatColumn(column, cell, rowData) {
+    reactElement = null;
+    if ( !(loris.brief && -1 == loris.briefHeaders.indexOf(column)) ) {
+
+        switch (column) {
+            case 'PSCID':
+                var url = loris.BaseURL + "/" + rowData[1] + "/";
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url },
+                        cell
+                    )
+                );
+                break;
+            default:
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    cell
+                );
+                break;
+        }
+    }
+
+    return reactElement;
+}

--- a/modules/genomic_browser/js/profileColumnFormatter.js
+++ b/modules/genomic_browser/js/profileColumnFormatter.js
@@ -3,7 +3,6 @@ function formatColumn(column, cell, rowData) {
     reactElement = null;
     if (-1 == loris.hiddenHeaders.indexOf(column)) {
         var params = [];
-        console.log(column)
         switch (column) {
             case 'PSCID':
                 var url = loris.BaseURL + "/" + rowData[1] + "/";
@@ -43,7 +42,6 @@ function formatColumn(column, cell, rowData) {
 		if (0 == params.length) {
                     params = ['genomic_browser&submenu=cpg_browser', {'DCCID': rowData[1], 'filter': "Show Data"}];
                 }
-                console.log(params);
                 reactElement = React.createElement(
                     "td",
                     null,

--- a/modules/genomic_browser/js/snpColumnFormatter.js
+++ b/modules/genomic_browser/js/snpColumnFormatter.js
@@ -1,20 +1,30 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'PSCID') {
-        var url = loris.BaseURL + "/" + rowData[1] + "/";
-        return React.createElement(
-            "td",
-            null,
-            React.createElement(
-                "a",
-                { href: url },
-                cell
-            )
-        );
-    }
-    return React.createElement(
-        "td",
-        null,
-        cell
-    );
-}
 
+function formatColumn(column, cell, rowData) {
+    reactElement = null;
+console.log(column);
+console.log(loris.hiddenHeaders.indexOf(column));
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+        switch (column) {
+            case 'PSCID':
+                var url = loris.BaseURL + "/" + rowData[1] + "/";
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url },
+                        cell
+                    )
+                );
+                break;
+            default:
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    cell
+                );
+                break;
+        }
+    }
+    return reactElement;
+}

--- a/modules/genomic_browser/js/snpColumnFormatter.js
+++ b/modules/genomic_browser/js/snpColumnFormatter.js
@@ -1,0 +1,20 @@
+function formatColumn(column, cell, rowData) {
+    if (column === 'PSCID') {
+        var url = loris.BaseURL + "/" + rowData[1] + "/";
+        return React.createElement(
+            "td",
+            null,
+            React.createElement(
+                "a",
+                { href: url },
+                cell
+            )
+        );
+    }
+    return React.createElement(
+        "td",
+        null,
+        cell
+    );
+}
+

--- a/modules/genomic_browser/js/snpColumnFormatter.js
+++ b/modules/genomic_browser/js/snpColumnFormatter.js
@@ -15,6 +15,18 @@ function formatColumn(column, cell, rowData) {
                     )
                 );
                 break;
+            case 'RsID':
+                var url = "http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=" + cell;
+                reactElement = React.createElement(
+                    "td",
+                    null,
+                    React.createElement(
+                        "a",
+                        { href: url, target: '_blank' },
+                        cell
+                    )
+                );
+                break;
             default:
                 reactElement = React.createElement(
                     "td",

--- a/modules/genomic_browser/js/snpColumnFormatter.js
+++ b/modules/genomic_browser/js/snpColumnFormatter.js
@@ -1,8 +1,6 @@
 
 function formatColumn(column, cell, rowData) {
     reactElement = null;
-console.log(column);
-console.log(loris.hiddenHeaders.indexOf(column));
     if (-1 == loris.hiddenHeaders.indexOf(column)) {
         switch (column) {
             case 'PSCID':

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -32,10 +32,8 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
     /**
      * Variables to enable special filter behaviour -
      * Show brief results or show full results (all available fields)
-     * used in (overridden) _addValidFilters function below
      */
     var $_displayBrief = true;  // default: display only Brief results
-    var $_briefFields  = array(); // which fields to display
 
     /**
      * Overloading this method to allow access to site users (own site only)
@@ -68,17 +66,23 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
                           'candidate.Gender',
                           'cohort.SubprojectID as Subproject',
                           'DATE_FORMAT(candidate.DoB,\'%Y-%m-%d\') AS DoB',
-                          'candidate.ExternalID as externalID',
+                          'candidate.ExternalID as ExternalID',
                           'genome_loc.Chromosome as Chromosome',
                           'genome_loc.Strand as Strand',
                           'genome_loc.StartLoc as StartLoc',
                           'genome_loc.EndLoc as EndLoc',
                           'genome_loc.Size as Size',
+                          'CONCAT(
+                              genome_loc.Chromosome, 
+                              ":",
+                              genome_loc.StartLoc,
+                              "-",
+                              genome_loc.EndLoc
+                           ) as Location',
                           'gene.OfficialSymbol as Gene_Symbol',
                           'gene.OfficialName as Gene_Name',
-                          'genotyping_platform.Name as Platform',
-                          'CNV.Type as CNV_Type',
                           'CNV.Description as CNV_Description',
+                          'CNV.Type as CNV_Type',
                           'CNV.CopyNumChange as Copy_Num_Change',
                           'CNV.EventName as Event_Name',
                           'CNV.Common_CNV as Common_CNV',
@@ -87,22 +91,37 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
                           'CNV.ArrayReport as Array_Report',
                           'CNV.Markers as Markers',
                           'CNV.ValidationMethod as Validation_Method',
+                          'genotyping_platform.Name as Platform',
                          );
 
-        $this->_briefFields = array(
-                               'DCCID',
-                               'PSCID',
-                               'Subproject',
-                               'Chromosome',
-                               'StartLoc',
-                               'Size',
-                               'Gene_Name',
-                               'Platform',
-                               'CNV_Type',
-                               'CNV_Description',
-                               'Copy_Num_Change',
-                               'Common_CNV',
-                              );
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array(
+                 'PSC',
+                 'DCCID',
+                 'Subproject',
+                 'DoB',
+                 'ExternalID',
+                 'Chromosome',
+                 'Strand',
+                 'StartLoc',
+                 'EndLoc',
+                 'Size',
+                 'Event_Name',
+                 'Gene_Symbol',
+                 'Gene_Name',
+                 'Platform',
+                 'Array_Report',
+                 'Markers',
+                 'Validation_Method',
+                )
+            )
+        );
 
         $this->query = " FROM candidate
             LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -325,88 +325,6 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
     }
 
     /**
-     * Function _setDataTableRows
-     *
-     * @param string $count number of data
-     *
-     * @note   overloaded function
-     * @return bool
-     */
-    function _setDataTableRows($count)
-    {
-        // create user object
-        $user           = User::singleton();
-        $subprojectlist = Utility::getSubprojectList();
-
-        $this->tpl_data['resultcount']  = $this->TotalItems;
-        $this->tpl_data['displayBrief'] = $this->_displayBrief;
-
-        // re-set headers if Brief; if full, gets set by _setDataTable()
-        if ($this->_displayBrief) {
-            $this->headers = array(); // re-initialize i.e. wipe
-            foreach ($this->_briefFields as $col) {
-                 $this->headers[] = $col;
-            }
-
-            // copy column headings to new array, then replace
-            $colCount     = 0; //  column counter
-            $maxCols      = sizeof($this->tpl_data['headers']); //limit
-            $briefHeaders = array();  // reset
-            foreach ($this->headers as $header) {
-                $found = false;
-                while ($colCount < $maxCols && !$found ) {
-                    // copy entire tpl_data element
-                    // including displayName and fieldOrder
-                    if ($this->tpl_data['headers'][$colCount]['name'] == $header) {
-                        $found          = true;
-                        $briefHeaders[] = $this->tpl_data['headers'][$colCount];
-                    }
-                    $colCount++;
-                } // iterate to check for next elt, starting from here
-            }
-            // When done, replace tpl_data headers
-            $this->tpl_data['headers'] = $briefHeaders;
-        }
-
-        $x = 0;
-        foreach ($this->list as $item) {
-            //count column
-            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
-
-            //print out data rows
-            $i = 1;
-            foreach ($item as $key => $val) {
-                if ($this->_displayBrief && !in_array($key, $this->_briefFields)) {
-                    continue;  // loop without incrementing $i
-                }
-
-                //Show the URL to the timepoint list on PSCID field
-                if ($key == 'PSCID' && $user->hasPermission('access_all_profiles')) {
-                    $this->tpl_data['items'][$x][$i]['DCCID']
-                        = str_pad($item['DCCID'], 6, '0', STR_PAD_LEFT);
-                }
-                $this->tpl_data['items'][$x][$i]['name']  = $key;
-                $this->tpl_data['items'][$x][$i]['value'] = $val;
-
-                if ($key=='Subproject' ) {
-                    if (is_null($val)) {
-                        $this->tpl_data['items'][$x][$i]['value'] = null;
-                    } else {
-                        $this->tpl_data['items'][$x][$i]['value']
-                            = $subprojectlist[$val];
-                    }
-                }
-                $i++;
-            }
-            $x++;
-        }
-        $this->tpl_data['resultcount']   = $this->TotalItems;
-        $this->tpl_data['displayFilter'] = $this->_displayBrief;
-
-        return true;
-    }
-
-    /**
      * Adds filters
      * This function overrides filters to enable display of brief/full results
      *
@@ -459,6 +377,26 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
             }
         }
         return $query;
+    }
+
+    /**
+     * Include the column formatter required to display the feedback link colours
+     * in the candidate_list menu
+     *
+     * @return array of javascript to be inserted
+     */
+    function getJSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            array(
+             $baseURL . "/genomic_browser/js/genomic_browser.js",
+             $baseURL . "/genomic_browser/js/cnvColumnFormatter.js",
+            )
+        );
     }
 
 }

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -29,7 +29,7 @@ require_once 'NDB_Menu_Filter.class.inc';
 class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
 {
 
-    var $AjaxModule = true;
+    var $AjaxModule = false;
 
     /**
      * Variables to enable special filter behaviour -
@@ -404,113 +404,6 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
     }
 
     /**
-     * Function _setDataTableRows
-     *
-     * @param string $count number of data
-     *
-     * @note   overloaded function
-     * @return bool
-     */
-    function _setDataTableRows($count)
-    {
-        // create user object
-        $user           = User::singleton();
-        $subprojectlist = Utility::getSubprojectList();
-
-        $this->tpl_data['resultcount']  = $this->TotalItems;
-        $this->tpl_data['displayBrief'] = $this->_displayBrief;
-        // re-set headers if Brief; if full, gets set by _setDataTable()
-        if ($this->_displayBrief) {
-            $this->headers = array(); // re-initialize i.e. wipe
-            foreach ($this->_briefFields as $col) {
-                $this->headers[] = $col;
-            }
-
-            // copy column headings to new array, then replace
-            $colCount     = 0; // column counter
-            $maxCols      = sizeof($this->tpl_data['headers']); //limit
-            $briefHeaders = array();  // reset
-            foreach ($this->headers as $header) {
-                $found = false;
-                while ($colCount < $maxCols && !$found ) {
-                    // copy entire tpl_data element
-                    // including displayName and fieldOrder
-                    if ($this->tpl_data['headers'][$colCount]['name'] == $header) {
-                        $found          = true;
-                        $briefHeaders[] = $this->tpl_data['headers'][$colCount];
-                    }
-                    $colCount++;
-                } // iterate to check for next elt, starting from here
-            }
-            // When done, replace tpl_data headers
-            $this->tpl_data['headers'] = $briefHeaders;
-        }
-
-        $x = 0;
-        foreach ($this->list as $item) {
-            //count column
-            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
-
-            //print out data rows
-            $i = 1;
-            foreach ($item as $key => $val) {
-
-                if ($this->_displayBrief && !in_array($key, $this->_briefFields)) {
-                    continue;  // no increment to $i
-                }
-
-                //Show the URL to the timepoint list on PSCID field
-                if ($key == 'PSCID' && $user->hasPermission('access_all_profiles')) {
-                    $this->tpl_data['items'][$x][$i]['DCCID'] = $item['DCCID'];
-                }
-                $this->tpl_data['items'][$x][$i]['name']  = $key;
-                $this->tpl_data['items'][$x][$i]['value'] = $val;
-
-                if ($key=='Subproject') {
-                    if (is_null($val)) {
-                        $this->tpl_data['items'][$x][$i]['value'] = null;
-                    } else {
-                        $this->tpl_data['items'][$x][$i]['value']
-                            = $subprojectlist[$val];
-                    }
-                }
-
-                if ($key=='Gene') {
-
-                    $gene    = strtok($val, ';');
-                    $acc_num = strtok($item['Accession_number'], ';');
-
-                    $this->tpl_data['items'][$x][$i]['value']   = $gene;
-                    $this->tpl_data['items'][$x][$i]['acc_num'] = $acc_num;
-                }
-
-                if ($key=='Accession_number') {
-
-                    $acc_num = strtok($val, ';');
-
-                    $this->tpl_data['items'][$x][$i]['value'] = $acc_num;
-                }
-                if ($key=='cpg_name') {
-
-                    $startLoc = $item['StartLoc'] - 500;
-                    $endLoc   = $item['StartLoc'] + 500;
-                    $position = 'Chr'.$item['Chromosome'].':'.$startLoc.'-'.$endLoc;
-
-                    $this->tpl_data['items'][$x][$i]['value']    = $val;
-                    $this->tpl_data['items'][$x][$i]['assembly'] = $item['Assembly'];
-                    $this->tpl_data['items'][$x][$i]['position'] = $position;
-                }
-                $i++;
-            }
-            $x++;
-        }
-        $this->tpl_data['resultcount']   = $this->TotalItems;
-        $this->tpl_data['displayFilter'] = $this->_displayBrief;
-
-        return true;
-    }
-
-    /**
      * Adds filters
      * This function overrides filters to enable display of brief/full results
      *
@@ -588,6 +481,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
             $deps,
             array(
              $baseURL . "/genomic_browser/js/genomic_browser.js",
+             $baseURL . "/genomic_browser/js/cpgColumnFormatter.js",
             )
         );
     }

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -34,10 +34,8 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
     /**
      * Variables to enable special filter behaviour -
      * Show brief results or show full results (all available fields)
-     * used in (overridden) _addValidFilters function below
      */
     var $_displayBrief = true;  // default: display only Brief results
-    var $_briefFields  = array(); // which fields to display
 
     /**
      * Overloading this method to allow access to site users (own site only)
@@ -101,18 +99,44 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                                 'platform.Name as Platform',
                                );
 
-        $this->_briefFields = array(
-                               'DCCID',
-                               'PSCID',
-                               'Subproject',
-                               'cpg_name',
-                               'Beta_value',
-                               'Chromosome',
-                               'Gene',
-                              );
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array(
+                 'PSC',
+                 'DCCID',
+                 'Subproject',
+                 'DoB',
+                 'Sample',
+                 'StartLoc',
+                 'Probe_Loc_A',
+                 'Probe_Seq_A',
+                 'Probe_Loc_B',
+                 'Probe_Seq_B',
+                 'Design',
+                 'Color',
+                 'Assembly',
+                 'SNP_10',
+                 'Accession_number',
+                 'Gene_Grp',
+                 'Island_Loc',
+                 'Context',
+                 'Fantom_Prom',
+                 'DMR',
+                 'Enhancer',
+                 'HMM_Island',
+                 'Reg_Feature_Loc',
+                 'Reg_Feature_Grp',
+                 'DHS',
+                 'Platform',
+                )
+            )
+        );
 
-        // Chromosome from genome_loc table
-        // INNER JOIN on table.
         // If a candidate has no CPG records, they will not appear.
         $this->query = " FROM candidate
             LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -28,8 +28,11 @@ require_once 'NDB_Menu_Filter.class.inc';
 */
 class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
 {
+
+    var $AjaxModule = true;
+
     /**
- * Variables to enable special filter behaviour -
+     * Variables to enable special filter behaviour -
      * Show brief results or show full results (all available fields)
      * used in (overridden) _addValidFilters function below
      */

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -38,7 +38,6 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
      * used in (overridden) _addValidFilters function below
      */
     var $_displayBrief = true;  // default: display only Brief results
-    var $_briefFields  = array(); // which fields to display
 
     /**
      * Overloading this method to allow access to site users (own site only)
@@ -78,17 +77,16 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
                           'M.CPGCount as CPGs',
                          );
 
-        $this->_briefFields = array(
-                               'DCCID',
-                               'PSCID',
-                               'Files',
-                               'SNPs',
-                               'CNVs',
-                               'CPGs',
-                              );
-
-        // This variable will be used by the collumnFormatter javascript.
-        $this->tpl_data['briefHeaders'] = json_encode($this->_briefFields);
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array(
+             'PSC',
+             'DCCID',
+             'Subproject',
+             'DoB',
+            )
+        );
 
         $this->query = " FROM candidate
             LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -87,6 +87,9 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
                                'CPGs',
                               );
 
+        // This variable will be used by the collumnFormatter javascript.
+        $this->tpl_data['briefHeaders'] = json_encode($this->_briefFields);
+
         $this->query = " FROM candidate
             LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID
                 from session s GROUP BY s.CandID) AS cohort
@@ -221,116 +224,6 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
                                  'full'  => 'All fields',
                                 );
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
-
-        return true;
-    }
-
-    /**
-     * Function _setDataTableRows
-     *
-     * @param string $count number of data
-     *
-     * @note   overloaded function
-     * @return bool
-     */
-    function _setDataTableRows($count)
-    {
-        // create user object
-        $user           = User::singleton();
-        $subprojectlist = Utility::getSubprojectList();
-
-        $config = NDB_Config::singleton();
-        $this->tpl_data['genomicDataPath'] = $config->getSetting('GenomicDataPath');
-
-        $this->tpl_data['resultcount']  = $this->TotalItems;
-        $this->tpl_data['displayBrief'] = $this->_displayBrief;
-
-        // re-set headers if Brief; if full, gets set by _setDataTable()
-        if ($this->_displayBrief) {
-            $this->headers = array(); // re-initialize i.e. wipe
-            foreach ($this->_briefFields as $col) {
-                $this->headers[] = $col;
-            }
-            // Note this includes an extra column: Total Filesets
-
-            // copy column headings to new array, then replace
-            $colCount     = 0; //  column counter
-            $maxCols      = sizeof($this->tpl_data['headers']); //limit
-            $briefHeaders = array();  // reset
-            foreach ($this->headers as $header) {
-                // special case: insert header for a derived column
-                if ($header == "Total_Filesets") {
-                    $headerArray = array(
-                                    "name"        => $header,
-                                    "displayName" => "All Filesets",
-                                    "fieldOrder"  => "ASC",
-                                   );
-
-                    $this->tpl_data['headers'][$colCount] = $headerArray;
-                    $briefHeaders[] = $headerArray;
-                    $colCount++; // increment and continue processing
-                    continue;
-                }
-
-                $found = false;
-                while ($colCount < $maxCols && !$found ) {
-                    // copy entire tpl_data element
-                    // including displayName and fieldOrder
-                    if ($this->tpl_data['headers'][$colCount]['name'] == $header) {
-                        $found          = true;
-                        $briefHeaders[] = $this->tpl_data['headers'][$colCount];
-                    }
-                    $colCount++;
-                } // iterate to check for next elt, starting from here
-            }
-            // When done, replace tpl_data headers
-            $this->tpl_data['headers'] = $briefHeaders;
-        }
-
-        $x = 0;
-        foreach ($this->list as $item) {
-            //calculate row number
-            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
-
-            //print out data rows
-            $i = 1;
-            foreach ($item as $key => $val) {
-                if ($this->_displayBrief && !in_array($key, $this->_briefFields)) {
-                    continue;  // loop without incrementing $i
-                }
-
-                //Show the URL to the timepoint list on PSCID field
-                if ($key == 'PSCID' && $user->hasPermission('access_all_profiles')) {
-                    $this->tpl_data['items'][$x][$i]['DCCID']
-                        = str_pad($item['DCCID'], 6, '0', STR_PAD_LEFT);
-                }
-
-                $this->tpl_data['items'][$x][$i]['name']  = $key;
-                $this->tpl_data['items'][$x][$i]['value'] = $val;
-
-                // Print '' if no data
-                if ($key=='Files' || $key == 'SNPs'
-                    || $key == 'CNVs' || $key == 'CPGs'
-                ) {
-                    if (is_null($val) || $val === '0') {
-                        $this->tpl_data['items'][$x][$i]['value'] = '';
-                    }
-                }  // if is_numeric, set = $val
-
-                if ($key=='Subproject' ) {
-                    if (is_null($val)) {
-                        $this->tpl_data['items'][$x][$i]['value'] = null;
-                    } else {
-                        $this->tpl_data['items'][$x][$i]['value']
-                            = $subprojectlist[$val];
-                    }
-                }
-                $i++;
-            }
-            $x++;
-        }
-        $this->tpl_data['resultcount']   = $this->TotalItems;
-        $this->tpl_data['displayFilter'] = $this->_displayBrief;
 
         return true;
     }

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -31,6 +31,7 @@ require_once 'NDB_Menu_Filter.class.inc';
 */
 class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
 {
+    var $AjaxModule = false;
     /**
      * Variables to enable special filter behaviour -
      * Show brief results or show full results (all available fields)
@@ -387,5 +388,23 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         return $query;
     }
 
+    /**
+     * Include the column formatter required to display the feedback link colours
+     * in the candidate_list menu
+     *
+     * @return array of javascript to be inserted
+     */
+    function getJSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            array(
+             $baseURL . "/genomic_browser/js/profileColumnFormatter.js",
+            )
+        );
+    }
 }
 ?>

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -80,11 +80,16 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            array(
-             'PSC',
-             'DCCID',
-             'Subproject',
-             'DoB',
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array(
+                 'PSC',
+                 'DCCID',
+                 'externalID',
+                 'DoB',
+                )
             )
         );
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_file_uploader.class.inc
@@ -54,21 +54,28 @@ class NDB_Menu_Filter_Genomic_File_Uploader extends NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $this->_displayBrief = !(isset($_REQUEST['format']));
-        $this->columns       = array(
-                                'GenomicFileID',
-                                'FileName',
-                                'Description',
-                                'FileType',
-                                'Date_inserted',
-                                'InsertedByUserID',
-                                'Caveat',
-                                'Notes',
-                               );
+        $this->columns = array(
+                          'GenomicFileID',
+                          'FileName',
+                          'Description',
+                          'FileType',
+                          'Date_inserted',
+                          'InsertedByUserID',
+                          'Caveat',
+                          'Notes',
+                         );
 
-        // Chromosome from genome_loc table
-        // INNER JOIN on table.
-        // If a candidate has no CPG records, they will not appear.
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array()
+            )
+        );
+
         $this->query = " FROM genomic_files WHERE 1=1 ";
 
         $this->validFilters = array(

--- a/modules/genomic_browser/php/NDB_Menu_Filter_gwas_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_gwas_browser.class.inc
@@ -161,82 +161,6 @@ class NDB_Menu_Filter_GWAS_Browser extends NDB_Menu_Filter
     }
 
     /**
-     * Function _setDataTableRows
-     *
-     * @param string $count number of data
-     *
-     * @note   overloaded function
-     * @return bool
-     */
-    function _setDataTableRows($count)
-    {
-        // create user object
-        $user           = User::singleton();
-        $subprojectlist = Utility::getSubprojectList();
-
-        $this->tpl_data['resultcount']  = $this->TotalItems;
-        $this->tpl_data['displayBrief'] = $this->_displayBrief;
-
-        // re-set headers if Brief; if full, gets set by _setDataTable()
-        if ($this->_displayBrief) {
-            $this->headers = array(); // re-initialize i.e. wipe
-            foreach ($this->_briefFields as $col) {
-                $this->headers[] = $col;
-            }
-
-            // copy column headings to new array, then replace
-            $colCount     = 0; // column counter
-            $maxCols      = sizeof($this->tpl_data['headers']); //limit
-            $briefHeaders = array();  // reset
-            foreach ($this->headers as $header) {
-                $found = false;
-                while ($colCount < $maxCols && !$found ) {
-                    // copy entire tpl_data element
-                    // including displayName and fieldOrder
-                    if ($this->tpl_data['headers'][$colCount]['name'] == $header) {
-                        $found          = true;
-                        $briefHeaders[] = $this->tpl_data['headers'][$colCount];
-                    }
-                    $colCount++;
-                } // iterate to check for next elt, starting from here
-            }
-            // When done, replace tpl_data headers
-            $this->tpl_data['headers'] = $briefHeaders;
-        }
-
-        $x = 0;
-        foreach ($this->list as $item) {
-            //count column
-            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
-
-            //print out data rows
-            $i = 1;
-            foreach ($item as $key => $val) {
-
-                if ($this->_displayBrief && !in_array($key, $this->_briefFields)) {
-                    continue;  // no increment to $i
-                }
-
-                //Show the URL to the timepoint list on PSCID field
-                if ($key == 'SNP_ID'
-                    && $user->hasPermission('access_all_profiles')
-                ) {
-                    $this->tpl_data['items'][$x][$i]['SNP_ID'] = $item['SNP_ID'];
-                }
-                $this->tpl_data['items'][$x][$i]['name']  = $key;
-                $this->tpl_data['items'][$x][$i]['value'] = $val;
-
-                $i++;
-            }
-            $x++;
-        }
-        $this->tpl_data['resultcount']   = $this->TotalItems;
-        $this->tpl_data['displayFilter'] = $this->_displayBrief;
-
-        return true;
-    }
-
-    /**
      * Adds filters
      * This function overrides filters to enable display of brief/full results
      *
@@ -275,6 +199,26 @@ class NDB_Menu_Filter_GWAS_Browser extends NDB_Menu_Filter
             }
         }
         return $query;
+    }
+
+    /**
+     * Include the column formatter required to display the feedback link colours
+     * in the candidate_list menu
+     *
+     * @return array of javascript to be inserted
+     */
+    function getJSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            array(
+             $baseURL . "/genomic_browser/js/genomic_browser.js",
+             $baseURL . "/genomic_browser/js/gwasColumnFormatter.js",
+            )
+        );
     }
 
 }

--- a/modules/genomic_browser/php/NDB_Menu_Filter_gwas_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_gwas_browser.class.inc
@@ -34,10 +34,8 @@ class NDB_Menu_Filter_GWAS_Browser extends NDB_Menu_Filter
     /**
      * Variables to enable special filter behaviour -
      * Show brief results or show full results (all available fields)
-     * used in (overridden) _addValidFilters function below
      */
     var $_displayBrief = true;  // default: display only Brief results
-    var $_briefFields  = array(); // which fields to display
 
     /**
      * Overloading this method to allow access to site users (own site only)
@@ -75,17 +73,16 @@ class NDB_Menu_Filter_GWAS_Browser extends NDB_Menu_Filter
                           'GWAS.Pvalue AS P_value',
                          );
 
-        $this->_briefFields = array(
-                               'SNP_ID',
-                               'Chromosome',
-                               'Position_BP',
-                               'Major_Allele',
-                               'Minor_Allele',
-                               'MAF',
-                               'Estimate',
-                               'StdErr',
-                               'P_value',
-                              );
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array()
+            )
+        );
 
         // $this->query = " FROM GWAS ";
         $this->query = " FROM GWAS

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -34,10 +34,8 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
     /**
      * Variables to enable special filter behaviour -
      * Show brief results or show full results (all available fields)
-     * used in (overridden) _addValidFilters function below
      */
     var $_displayBrief = true;  // default: display only Brief results
-    var $_briefFields  = array(); // which fields to display
 
     /**
      * Overloading this method to allow access to site users (own site only)
@@ -96,19 +94,38 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
                           'SNP.ExonicFunction as Exonic_Function',
                          );
 
-        $this->_briefFields = array(
-                               'DCCID',
-                               'PSCID',
-                               'Subproject',
-                               'Chromosome',
-                               'StartLoc',
-                               'Gene_Name',
-                               'Platform',
-                               'rsID',
-                               'SNP_Name',
-                               'SNP_Description',
-                               'Function_Prediction',
-                              );
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array(
+                 'PSC',
+                 'DCCID',
+                 'Subproject',
+                 'DoB',
+                 'externalID',
+                 'Chromosome',
+                 'Strand',
+                 'StartLoc',
+                 'EndLoc',
+                 'Size',
+                 'Gene_Symbol',
+                 'Gene_Name',
+                 'Platform',
+                 'SNP_Name',
+                 'SNP_Description',
+                 'External_Source',
+                 'Array_Report',
+                 'Markers',
+                 'Validation_Method',
+                 'Validated',
+                 'Genotype_Quality',
+                )
+            )
+        );
 
         // Chromosome from genome_loc table
         // INNER JOIN on SNP_candidate_rel table. //##

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -353,89 +353,6 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
     }
 
     /**
-     * Function _setDataTableRows
-     *
-     * @param string $count number of data
-     *
-     * @note   overloaded function
-     * @return bool
-     */
-    function _setDataTableRows($count)
-    {
-        // create user object
-        $user           = User::singleton();
-        $subprojectlist = Utility::getSubprojectList();
-
-        $this->tpl_data['resultcount']  = $this->TotalItems;
-        $this->tpl_data['displayBrief'] = $this->_displayBrief;
-
-        // re-set headers if Brief; if full, gets set by _setDataTable()
-        if ($this->_displayBrief) {
-            $this->headers = array(); // re-initialize i.e. wipe
-            foreach ($this->_briefFields as $col) {
-                $this->headers[] = $col;
-            }
-
-            // copy column headings to new array, then replace
-            $colCount     = 0; // column counter
-            $maxCols      = sizeof($this->tpl_data['headers']); //limit
-            $briefHeaders = array();  // reset
-            foreach ($this->headers as $header) {
-                $found = false;
-                while ($colCount < $maxCols && !$found ) {
-                    // copy entire tpl_data element
-                    // including displayName and fieldOrder
-                    if ($this->tpl_data['headers'][$colCount]['name'] == $header) {
-                        $found          = true;
-                        $briefHeaders[] = $this->tpl_data['headers'][$colCount];
-                    }
-                    $colCount++;
-                } // iterate to check for next elt, starting from here
-            }
-            // When done, replace tpl_data headers
-            $this->tpl_data['headers'] = $briefHeaders;
-        }
-
-        $x = 0;
-        foreach ($this->list as $item) {
-            //count column
-            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
-
-            //print out data rows
-            $i = 1;
-            foreach ($item as $key => $val) {
-
-                if ($this->_displayBrief && !in_array($key, $this->_briefFields)) {
-                    continue;  // no increment to $i
-                }
-
-                //Show the URL to the timepoint list on PSCID field
-                if ($key == 'PSCID' && $user->hasPermission('access_all_profiles')) {
-                    $this->tpl_data['items'][$x][$i]['DCCID']
-                        = str_pad($item['DCCID'], 6, '0', STR_PAD_LEFT);
-                }
-                $this->tpl_data['items'][$x][$i]['name']  = $key;
-                $this->tpl_data['items'][$x][$i]['value'] = $val;
-
-                if ($key=='Subproject') {
-                    if (is_null($val)) {
-                        $this->tpl_data['items'][$x][$i]['value'] = null;
-                    } else {
-                        $this->tpl_data['items'][$x][$i]['value']
-                            = $subprojectlist[$val];
-                    }
-                }
-                $i++;
-            }
-            $x++;
-        }
-        $this->tpl_data['resultcount']   = $this->TotalItems;
-        $this->tpl_data['displayFilter'] = $this->_displayBrief;
-
-        return true;
-    }
-
-    /**
      * Adds filters
      * This function overrides filters to enable display of brief/full results
      *
@@ -490,6 +407,26 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
             }
         }
         return $query;
+    }
+
+    /**
+     * Include the column formatter required to display the feedback link colours
+     * in the candidate_list menu
+     *
+     * @return array of javascript to be inserted
+     */
+    function getJSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            array(
+             $baseURL . "/genomic_browser/js/genomic_browser.js",
+             $baseURL . "/genomic_browser/js/snpColumnFormatter.js",
+            )
+        );
     }
 
 }

--- a/modules/genomic_browser/templates/menu_cnv_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cnv_browser.tpl
@@ -1,3 +1,6 @@
+<script>
+    loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
+</script>
 <div class="col-sm-12">
   <div class="row">
     <div id="tabs"> 
@@ -227,6 +230,9 @@
   <div id="datatable"></div>
 </div>
 <script>
+if (document.getElementsByName('Show_Brief_Results')[0].value != "brief") {
+    loris.hiddenHeaders = [];
+}
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?submenu=cnv_browser&format=json",

--- a/modules/genomic_browser/templates/menu_cnv_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cnv_browser.tpl
@@ -218,71 +218,21 @@
       </div>
     </div>
   </div>
-  <div class="row">
-  <!-- title table with pagination -->
-    <table id="LogEntries" border="0" valign="bottom" width="100%">
-      <tr>
-      <!-- title -->
-        {if {$resultcount} != '' }
-          <td class="controlpanelsection">Variants found: <strong>{$resultcount}</strong> total</td>
-                    <a href="{$baseurl}/{$csvUrl}" download="{$csvFile}.csv">
-                      [ Download as CSV ]
-                    </a><br>
-        {else}
-          <td>No variants found. </td>
-        {/if}
-        <!-- display pagination links -->
-        {if $resultcount != '' && $resultcount > 25 }
-	  <td align="right">Pages:&nbsp;&nbsp;&nbsp; {$page_links}</td>
-        {/if}
-      </tr>
-    </table>
-    <!-- start data table -->
-    <table  class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
-      <thead>
-        <tr class="info">
-          <th>No.</th>
-          <!-- print out column headings - quick & dirty hack -->
-          {section name=header loop=$headers}
-            <th><a href="{$baseurl}/genomic_browser/?submenu=cnv_browser&filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">{$headers[header].displayName}</a></th>
-          {/section}
-        </tr>
-      </thead>
-      <tbody>
-        {section name=item loop=$items}
-        <tr>
-        <!-- print out data rows -->
-          {section name=piece loop=$items[item]}
-            {if $items[item][piece].bgcolor != ''}
-              <td style="background-color:{$items[item][piece].bgcolor}">
-            {else}
-              <td>
-            {/if}
-            {if $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
-              {assign var="PSCID" value=$items[item][piece].value}
-               <a href="{$baseurl}/{$items[item][piece].DCCID}/">{$items[item][piece].value}</a>
-            {elseif $items[item][piece].name == "Chromosome"}
-              {assign var="chromValue" value=$items[item][piece].value}
-              {$chromValue} 
-            {elseif $items[item][piece].name == "StartLoc"}
-              {assign var="startLocValue" value=$items[item][piece].value}
-              <!--{assign var="sizeValue" value=$items[item]["Size"].name}-->
-              {$startLocValue} 
-            {elseif $items[item][piece].name == "Size"}
-              {assign var="sizeValue" value=$items[item][piece].value}
-              {assign var="endLocValue" value=$startLocValue+$sizeValue}
-              <a href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{$chromValue}%3A{$startLocValue}-{$endLocValue}" target="_blank">{$sizeValue}</a>
-              <!--a href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{$chromValue}%3A{$startLocValue}-{$endLocValue}" target="_blank">{$startLocValue} + {$sizeValue} : {$endLocValue}</a-->
-            {else}
-              {$items[item][piece].value}
-            {/if}
-            </td>
-          {/section}
-          </tr>
-        {/section}
-      </tbody>
-      <!-- end data table -->
-    </table>
-  </div>
+  <table border="0" valign="bottom" width="100%">
+    <tr>
+      <!-- display pagination links -->
+      <td align="left" id="pageLinks"></td>
+    </tr>
+  </table>
+  <div id="datatable"></div>
 </div>
-<br>
+<script>
+
+var table = RDynamicDataTable({
+    "DataURL" : "{$baseurl}/genomic_browser/?submenu=cnv_browser&format=json",
+    "getFormattedCell" : formatColumn,
+});
+
+React.render(table, document.getElementById("datatable"));
+</script>
+

--- a/modules/genomic_browser/templates/menu_cpg_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cpg_browser.tpl
@@ -1,3 +1,6 @@
+<script>
+    loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
+</script>
 <div class="col-sm-12">
   <div class="row">
     <div id="tabs">
@@ -238,6 +241,9 @@
   <div id="datatable"></div>
 </div>
 <script>
+if (document.getElementsByName('Show_Brief_Results')[0].value != "brief") {
+    loris.hiddenHeaders = [];
+}
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?submenu=cpg_browser&format=json",

--- a/modules/genomic_browser/templates/menu_cpg_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cpg_browser.tpl
@@ -229,62 +229,20 @@
       </div>
     </div>
   </div> <!-- end row containing all filters-->
-  <div class="row">
-    <!-- title table with pagination -->
-    <table border="0" valign="bottom" width="100%"><tr>
-      <!-- title -->
-      {if {$resultcount} != '' }
-        <td class="controlpanelsection">Results found: <strong>{$resultcount}</strong> total</td>
-          <a href="{$baseurl}/{$csvUrl}" download="{$csvFile}.csv">Download all fields as CSV</a>
-      {else}
-        <td>No variants found. </td>
-      {/if} 
+  <table border="0" valign="bottom" width="100%">
+    <tr>
       <!-- display pagination links -->
-      {if {$resultcount} != '' && $resultcount > 25}  
-        <td align="right">Pages:&nbsp;&nbsp;&nbsp; {$page_links}</td>
-      {/if}
+      <td align="left" id="pageLinks"></td>
     </tr>
-    </table>
-<!-- start data table -->
-    <table  class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
-      <thead>
-        <tr class="info">
-          <th>No.</th>
-          <!-- print out column headings - quick & dirty hack -->
-          {section name=header loop=$headers}
-            <th><a href="{$baseurl}/genomic_browser/?submenu=cpg_browser&filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">{$headers[header].displayName}</a></th>
-          {/section}
-        </tr>
-      </thead>
-      <tbody>
-        {section name=item loop=$items}
-          <tr>
-        <!-- print out data rows -->
-          {section name=piece loop=$items[item]}
-            {if $items[item][piece].bgcolor != ''}
-              <td style="background-color:{$items[item][piece].bgcolor}">
-            {elseif $items[item][piece].name == "Date_of_Birth" OR $items[item][piece].name == "Date_Collected"}
-              <td style="white-space: nowrap">
-            {else}
-              <td>
-            {/if}
-            {if $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
-              {assign var="PSCID" value=$items[item][piece].value}
-              <a href="{$baseurl}/{$items[item][piece].DCCID}/">{$items[item][piece].value}</a>
-            {elseif $items[item][piece].value != "" AND $items[item][piece].name == "cpg_name"}
-              <a title="UCSC Genome Browser" href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position={$items[item][piece].position}" target="_blank">{$items[item][piece].value}</a>
-            {elseif $items[item][piece].value != "" AND $items[item][piece].name == "Gene"}
-              <a title="UCSC Genome Browser" href="http://genome.ucsc.edu/cgi-bin/hgTracks?org=human&position={$items[item][piece].acc_num}" target="_blank">{$items[item][piece].value}</a>
-            {else}
-              {$items[item][piece].value}
-            {/if }
-            </td>
-          {/section}
-        </tr>
-        {/section}
-      </tbody>
-      <!-- end data table -->
-    </table>
-  </div>
+  </table>
+  <div id="datatable"></div>
 </div>
-<br>
+<script>
+
+var table = RDynamicDataTable({
+    "DataURL" : "{$baseurl}/genomic_browser/?submenu=cpg_browser&format=json",
+    "getFormattedCell" : formatColumn,
+});
+
+React.render(table, document.getElementById("datatable"));
+</script>

--- a/modules/genomic_browser/templates/menu_genomic_browser.tpl
+++ b/modules/genomic_browser/templates/menu_genomic_browser.tpl
@@ -158,6 +158,9 @@
   <div id="datatable"></div>
 </div>
 <script>
+loris.brief = document.getElementsByName('Show_Brief_Results')[0].value == "brief";
+
+loris.briefHeaders = {(empty($briefHeaders))? [] : $briefHeaders };
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?format=json",

--- a/modules/genomic_browser/templates/menu_genomic_browser.tpl
+++ b/modules/genomic_browser/templates/menu_genomic_browser.tpl
@@ -161,9 +161,21 @@
   <div id="datatable"></div>
 </div>
 <script>
+
 if (document.getElementsByName('Show_Brief_Results')[0].value != "brief") {
     loris.hiddenHeaders = [];
 }
+
+{literal}
+loris.subprojectList = {};
+Array.from(document.getElementsByName('SubprojectID')[0].children).forEach(
+    function (o) {
+        if (o.value !== "") {
+            loris.subprojectList[o.value] = o.label;
+        }
+    }
+);
+{/literal}
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?format=json",

--- a/modules/genomic_browser/templates/menu_genomic_browser.tpl
+++ b/modules/genomic_browser/templates/menu_genomic_browser.tpl
@@ -1,3 +1,6 @@
+<script>
+    loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
+</script>
 <div class="col-sm-12">
   <div class="row">
     <div id="tabs"> 
@@ -158,15 +161,14 @@
   <div id="datatable"></div>
 </div>
 <script>
-loris.brief = document.getElementsByName('Show_Brief_Results')[0].value == "brief";
-
-loris.briefHeaders = {(empty($briefHeaders))? [] : $briefHeaders };
+if (document.getElementsByName('Show_Brief_Results')[0].value != "brief") {
+    loris.hiddenHeaders = [];
+}
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?format=json",
     "getFormattedCell" : formatColumn,
     "freezeColumn" : "PSCID"
 });
-
 React.render(table, document.getElementById("datatable"));
 </script>

--- a/modules/genomic_browser/templates/menu_genomic_browser.tpl
+++ b/modules/genomic_browser/templates/menu_genomic_browser.tpl
@@ -149,77 +149,21 @@
       </div>
     </div>
   </div>
-  <div class="row">
-  <!-- title table with pagination -->
-    <table id="LogEntries" border="0" valign="bottom" width="100%">
-      <tr>
-      <!-- title -->
-        {if {$resultcount} != '' }
-          <td class="controlpanelsection">Profiles found: <strong>{$resultcount}</strong> total</td>
-                              <a href="{$baseurl}/{$csvUrl}" download="{$csvFile}.csv">
-                                                    [ Download as CSV ]
-                                                                        </a><br>
-        {else}
-          <td>No results found. </td>
-        {/if}
-        <!-- display pagination links -->
-        {if $resultcount != '' && $resultcount > 25 }
-	  <td align="right">Pages:&nbsp;&nbsp;&nbsp; {$page_links}</td>
-        {/if}
-      </tr>
-    </table>
-    <!-- start data table -->
-    <table  class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
-      <thead>
-        <tr class="info">
-          <th>No.</th>
-          <!-- print out column headings - quick & dirty hack -->
-          {section name=header loop=$headers}
-            <th><a href="{$baseurl}/genomic_browser/?filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">{$headers[header].displayName}</a></th>
-          {/section}
-        </tr>
-      </thead>
-      <tbody>
-        {section name=item loop=$items}
-        <tr>
-        <!-- print out data rows -->
-          {section name=piece loop=$items[item]}
-            {if $items[item][piece].bgcolor != ''}
-              <td style="background-color:{$items[item][piece].bgcolor}">
-            {else}
-              <td>
-            {/if}
-            {if $items[item][piece].name == "DCCID"}
-              {assign var="CandID" value=$items[item][piece].value}
-              {$CandID}
-            {elseif $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
-              {assign var="PSCID" value=$items[item][piece].value}
-               <a href="{$baseurl}/{$items[item][piece].DCCID}/">{$items[item][piece].value}</a>
-
-            {elseif $items[item][piece].value eq ""}
-              -
-              {* just print a dash if no value available*}
-            {elseif $items[item][piece].name eq "Files" } 
-               <a href="{$baseurl}/genomic_browser/viewGenomicFile/?candID={$CandID}">
-                   <b>({$items[item][piece].value})</b> &nbsp;&nbsp;View
-                   <span class="glyphicon glyphicon-eye-open"></span>
-               </a>
-            {elseif $items[item][piece].name eq "SNPs" }
-                 <a href="{$baseurl}/genomic_browser/?submenu=snp_browser" class="snp_link" data-pscid="{$PSCID}" >{$items[item][piece].value}</a>
-            {elseif $items[item][piece].name eq "CNVs" }
-                 <a href="#" class="cnv_link" data-pscid="{$PSCID}" >{$items[item][piece].value}</a>
-            {elseif $items[item][piece].name eq "CPGs" }
-                 <a href="#" class="cpg_link" data-pscid="{$PSCID}" >{$items[item][piece].value}</a>
-            {else}
-              {$items[item][piece].value}
-            {/if}
-            </td>
-          {/section}
-          </tr>
-        {/section}
-      </tbody>
-      <!-- end data table -->
-    </table>
-  </div>
+  <table border="0" valign="bottom" width="100%">
+    <tr>
+      <!-- display pagination links -->
+      <td align="left" id="pageLinks"></td>
+    </tr>
+  </table>
+  <div id="datatable"></div>
 </div>
-<br>
+<script>
+
+var table = RDynamicDataTable({
+    "DataURL" : "{$baseurl}/genomic_browser/?format=json",
+    "getFormattedCell" : formatColumn,
+    "freezeColumn" : "PSCID"
+});
+
+React.render(table, document.getElementById("datatable"));
+</script>

--- a/modules/genomic_browser/templates/menu_gwas_browser.tpl
+++ b/modules/genomic_browser/templates/menu_gwas_browser.tpl
@@ -129,72 +129,21 @@
       </div>
     </div>
   </div> <!-- end row containing all filters-->
-  <div class="row">
-    <!-- title table with pagination -->
-    <table border="0" valign="bottom" width="100%"><tr>
-      <!-- title -->
-      {if {$resultcount} != '' }
-        <td class="controlpanelsection">Results found: <strong>{$resultcount}</strong> total</td>
-                            <a href="{$baseurl}/{$csvUrl}" download="{$csvFile}.csv">
-                                                  [ Download as CSV ]
-                                                                      </a><br><br>
-      {else}
-        <td>No results found. </td>
-      {/if} 
+  <table border="0" valign="bottom" width="100%">
+    <tr>
       <!-- display pagination links -->
-      {if {$resultcount} != '' && $resultcount > 25}  
-        <td align="right">Pages:&nbsp;&nbsp;&nbsp; {$page_links}</td>
-      {/if}
+      <td align="left" id="pageLinks"></td>
     </tr>
-    </table>
-<!-- start data table -->
-    <table  class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
-      <thead>
-        <tr class="info">
-          <th>No.</th>
-          <!-- print out column headings - quick & dirty hack -->
-          {section name=header loop=$headers}
-            <th>
-               <a href="{$baseurl}/genomic_browser/?submenu=gwas_browser&filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">
-                   {if $headers[header].displayName == "P Value"}
-                       P-value Trend
-                   {else}
-                       {$headers[header].displayName}
-                   {/if}
-               </a>
-            </th>
-          {/section}
-        </tr>
-      </thead>
-      <tbody>
-        {section name=item loop=$items}
-          <tr>
-        <!-- print out data rows -->
-          {section name=piece loop=$items[item]}
-            {if $items[item][piece].bgcolor != ''}
-              <td style="background-color:{$items[item][piece].bgcolor}">
-            {else}
-              <td>
-            {/if}
-            {if $items[item][piece].SNP_ID != "" AND $items[item][piece].name == "SNP_ID"}
-              {assign var="SNP_ID" value=$items[item][piece].value}
-              <a href="{$baseurl}/genomic_browser/?submenu=snp_browser&rsID={$items[item][piece].SNP_ID}">{$items[item][piece].value}</a>
-            {elseif $items[item][piece].name == "Chromosome"}
-              {assign var="chromValue" value=$items[item][piece].value}
-              {$chromValue} 
-            {elseif $items[item][piece].name == "Position_BP"}
-              {assign var="startLocValue" value=$items[item][piece].value}
-              <a href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{$chromValue}%3A{$startLocValue}-{$startLocValue}" target="_blank">{$startLocValue}</a>
-            {else}
-              {$items[item][piece].value}
-            {/if }
-            </td>
-          {/section}
-        </tr>
-        {/section}
-      </tbody>
-      <!-- end data table -->
-    </table>
-  </div>
+  </table>
+  <div id="datatable"></div>
 </div>
-<br>
+<script>
+
+var table = RDynamicDataTable({
+    "DataURL" : "{$baseurl}/genomic_browser/?submenu=gwas_browser&format=json",
+    "getFormattedCell" : formatColumn,
+});
+
+React.render(table, document.getElementById("datatable"));
+</script>
+

--- a/modules/genomic_browser/templates/menu_gwas_browser.tpl
+++ b/modules/genomic_browser/templates/menu_gwas_browser.tpl
@@ -1,3 +1,6 @@
+<script>
+    loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
+</script>
 <div class="col-sm-12">
   <div class="row">
     <div id="tabs">
@@ -138,6 +141,10 @@
   <div id="datatable"></div>
 </div>
 <script>
+
+if (document.getElementsByName('Show_Brief_Results')[0].value != "brief") {
+    loris.hiddenHeaders = [];
+}
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?submenu=gwas_browser&format=json",

--- a/modules/genomic_browser/templates/menu_snp_browser.tpl
+++ b/modules/genomic_browser/templates/menu_snp_browser.tpl
@@ -1,3 +1,6 @@
+<script>
+    loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
+</script>
 <div class="col-sm-12">
   <div class="row">
     <div id="tabs">
@@ -260,6 +263,9 @@
   <div id="datatable"></div>
 </div>
 <script>
+if (document.getElementsByName('Show_Brief_Results')[0].value != "brief") {
+    loris.hiddenHeaders = [];
+}
 
 var table = RDynamicDataTable({
     "DataURL" : "{$baseurl}/genomic_browser/?submenu=snp_browser&format=json",

--- a/modules/genomic_browser/templates/menu_snp_browser.tpl
+++ b/modules/genomic_browser/templates/menu_snp_browser.tpl
@@ -251,64 +251,21 @@
       </div>
     </div>
   </div> <!-- end row containing all filters-->
-  <div class="row">
-    <!-- title table with pagination -->
-    <table border="0" valign="bottom" width="100%"><tr>
-      <!-- title -->
-      {if {$resultcount} != '' }
-        <td class="controlpanelsection">Variants found: <strong>{$resultcount}</strong> total</td>
-                            <a href="{$baseurl}/{$csvUrl}" download="{$csvFile}.csv">
-                                                  [ Download as CSV ]
-                                                                      </a><br><br>
-      {else}
-        <td>No variants found. </td>
-      {/if} 
+  <table border="0" valign="bottom" width="100%">
+    <tr>
       <!-- display pagination links -->
-      {if {$resultcount} != '' && $resultcount > 25}  
-        <td align="right">Pages:&nbsp;&nbsp;&nbsp; {$page_links}</td>
-      {/if}
+      <td align="left" id="pageLinks"></td>
     </tr>
-    </table>
-<!-- start data table -->
-    <table  class ="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
-      <thead>
-        <tr class="info">
-          <th>No.</th>
-          <!-- print out column headings - quick & dirty hack -->
-          {section name=header loop=$headers}
-            <th><a href="{$baseurl}/genomic_browser/?submenu=snp_browser&filter[order][field]={$headers[header].name}&filter[order][fieldOrder]={$headers[header].fieldOrder}">{$headers[header].displayName}</a></th>
-          {/section}
-        </tr>
-      </thead>
-      <tbody>
-        {section name=item loop=$items}
-          <tr>
-        <!-- print out data rows -->
-          {section name=piece loop=$items[item]}
-            {if $items[item][piece].bgcolor != ''}
-              <td style="background-color:{$items[item][piece].bgcolor}">
-            {else}
-              <td>
-            {/if}
-            {if $items[item][piece].DCCID != "" AND $items[item][piece].name == "PSCID"}
-              {assign var="PSCID" value=$items[item][piece].value}
-              <a href="{$baseurl}/{$items[item][piece].DCCID}/">{$items[item][piece].value}</a>
-            {elseif $items[item][piece].name == "Chromosome"}
-              {assign var="chromValue" value=$items[item][piece].value}
-              {$chromValue} 
-            {elseif $items[item][piece].name == "StartLoc"}
-              {assign var="startLocValue" value=$items[item][piece].value}
-              <a href="https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{$chromValue}%3A{$startLocValue}-{$startLocValue}" target="_blank">{$startLocValue}</a>
-            {else}
-              {$items[item][piece].value}
-            {/if }
-            </td>
-          {/section}
-        </tr>
-        {/section}
-      </tbody>
-      <!-- end data table -->
-    </table>
-  </div>
+  </table>
+  <div id="datatable"></div>
 </div>
-<br>
+<script>
+
+var table = RDynamicDataTable({
+    "DataURL" : "{$baseurl}/genomic_browser/?submenu=snp_browser&format=json",
+    "getFormattedCell" : formatColumn,
+});
+
+React.render(table, document.getElementById("datatable"));
+</script>
+

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -734,9 +734,12 @@ class NDB_Menu_Filter extends NDB_Menu
             },
             $this->headers
         );
+
+        $MappedData = array();
         foreach ($data as $row) {
             $MappedData[] = array_values($row);
         }
+
         return array(
                 'Headers' => $headers,
                 'Data'    => $MappedData,


### PR DESCRIPTION
This is to fix the pagination links that were using PEAR::Pager 

All the tabs now use The DynamicDataTable React component that contains a Pagination feature.

The show brief-fields feature is now using a hiddanHeaders veriable passed from the php class the the loris javascript object via the templates.

All the column content is now managed in the <tab_name>ColumnFormatter.js script instead of the php _setDataTableRows function.