### PR TITLE
Scrolling to missing first name does not work on add user page.

### DIFF
--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -1,6 +1,6 @@
 <br />
-{literal}
 <script type="text/javascript" src="{$baseurl}/js/invalid_form_scroll.js"></script>
+{literal}
 <script>
 
 $(document).ready(function() {


### PR DESCRIPTION
When you create a new user and do not enter its first name, there will be an error popup saying that the field is required but the popup is partly hidden underneath the LORIS menu bar. Fix for Redmine ticket #9769.
