### PR TITLE
Adding back missing user site variable to Dashboard

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -36,6 +36,7 @@ class NDB_Form_Dashboard extends NDB_Form
         $DB     = Database::singleton();
         $user   = User::singleton();
         $config = NDB_Config::singleton();
+        $site   = $user->getSiteName();
 
         $userID     = $user->getUsername();
         $last_login = $DB->pselectOne(


### PR DESCRIPTION
At some point the user site variable got deleted from the dashboard code. It was used in a few queries, and therefore messed with the task panel (only in the situation where the user does not have access_all_profiles permission).