### PR TITLE
Fixing final radiological review task link on the Dashboard

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -154,7 +154,9 @@ class NDB_Form_Dashboard extends NDB_Form
         }
 
         // Final radiological review
-        if ($user->hasPermission('edit_final_radiological_review') && $user->hasPermission('view_final_radiological_review')) {
+        if ($user->hasPermission('edit_final_radiological_review')
+            && $user->hasPermission('view_final_radiological_review')
+        ) {
             $this->tpl_data['radiology_review']      = $DB->pselectOne(
                 "SELECT COUNT(*) FROM final_radiological_review f 
                 WHERE Review_Done IS NULL",

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -154,7 +154,7 @@ class NDB_Form_Dashboard extends NDB_Form
         }
 
         // Final radiological review
-        if ($user->hasPermission('edit_final_radiological_review')) {
+        if ($user->hasPermission('edit_final_radiological_review') && $user->hasPermission('view_final_radiological_review')) {
             $this->tpl_data['radiology_review']      = $DB->pselectOne(
                 "SELECT COUNT(*) FROM final_radiological_review f 
                 WHERE Review_Done IS NULL",


### PR DESCRIPTION
Link to the final radiological review module from the dashboard was not working is you only had the `edit_final_radiological_review` permission and not the `view_final_radiological_review`