### PR TITLE
View Slices in brainbrowser: security error messages

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -103,7 +103,8 @@ class NDB_Client
             "Content-Security-Policy: "
             . "default-src 'self' 'unsafe-inline'; "
             . "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
-            . "font-src 'self' data:"
+            . "font-src 'self' data:; "
+            . "img-src 'self' data:"
         );
         // start php session
         session_start();


### PR DESCRIPTION
this extra line is needed for brainbrowser.loris.js, line 473:
img.src = canvas.toDataURL();
