### PR TITLE
Instrument List Baseurl fix 

### DIFF
--- a/modules/instrument_list/templates/instrument_list_controlpanel.tpl
+++ b/modules/instrument_list/templates/instrument_list_controlpanel.tpl
@@ -2,7 +2,8 @@
 	<ul class="controlPanel">
 	    	<li>
 		{if $access.next_stage}
-                        <img src="{$baseurl}/images/open.gif" alt="" border="0" width="12" height="12" />&nbsp;<a href="{baseurl}/next_stage/?candID={$candID}&sessionID={$sessionID}&identifier={$sessionID}">Start {$next_stage} Stage</a>
+                        <img src="{$baseurl}/images/open.gif" alt="" border="0" width="12" height="12" />&nbsp;<a
+				href="{$baseurl}/next_stage/?candID={$candID}&sessionID={$sessionID}&identifier={$sessionID}">Start {$next_stage} Stage</a>
 {else}
                         <img src="{$baseurl}/images/locked.gif" alt="" border="0" width="12" height="12" />&nbsp;Start Next Stage
 {/if}


### PR DESCRIPTION
Missing "$" in $baseurl

Page was not loading

![image](https://cloud.githubusercontent.com/assets/11700445/14584597/3beb6a3e-041c-11e6-906b-9499c6e9a5d4.png)
