### PR TITLE
removes errors "integrity constraint violation" because of history table

### DIFF
--- a/tools/data_dictionary_builder.php
+++ b/tools/data_dictionary_builder.php
@@ -58,6 +58,9 @@ $client->makeCommandLine();
 $client->initialize($configFile);
 $DB = Database::singleton();
 
+//Setting trackchanges to false because getting error messages
+$DB->_trackChanges = false;
+
 // define which configuration file we're using for this installation
 //Get the entries we already have in the DB
 getColumns(


### PR DESCRIPTION
Because this script is running from the shell, there is no users logged in to populate the userid of the history table.