### PR TITLE
Searching for users with Site='Not assigned' doesn't make sense anymore.

### DIFF
--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -50,7 +50,7 @@ class NDB_Menu_Filter_user_accounts extends NDB_Menu_Filter
         if ($user->hasPermission('user_accounts_multisite')) {
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites =& Utility::getSiteList(false);
-            if(is_array($list_of_sites)) $list_of_sites = array('' => 'All',0=>'Not Assigned') + $list_of_sites;
+            if(is_array($list_of_sites)) $list_of_sites = array('' => 'All') + $list_of_sites;
         }
         else {
             // allow only to view own site data


### PR DESCRIPTION
This feature was added in the past but does not make sense anymore as you have to assign a site to every user when they are created (the search would always return 'No results'....)