### PR TITLE
Send Direction Cosines as additional header parameters to brainbrowser

### DIFF
--- a/modules/brainbrowser/ajax/minc.php
+++ b/modules/brainbrowser/ajax/minc.php
@@ -50,6 +50,7 @@ function extractDimension($dimension, $minc_file)
             'start'        => exec("mincinfo -attval $dimension:start $minc_file"),
             'space_length' => exec("mincinfo -dimlength $dimension $minc_file"),
             'step'         => exec("mincinfo -attval $dimension:step $minc_file"),
+	    'dir_cosines'  => explode(" ",exec("mincinfo -attval $dimension:direction_cosines $minc_file"))
            );
 }
 

--- a/modules/brainbrowser/ajax/minc.php
+++ b/modules/brainbrowser/ajax/minc.php
@@ -50,7 +50,12 @@ function extractDimension($dimension, $minc_file)
             'start'        => exec("mincinfo -attval $dimension:start $minc_file"),
             'space_length' => exec("mincinfo -dimlength $dimension $minc_file"),
             'step'         => exec("mincinfo -attval $dimension:step $minc_file"),
-	    'dir_cosines'  => explode(" ",exec("mincinfo -attval $dimension:direction_cosines $minc_file"))
+            'dir_cosines'  => explode(
+                " ",
+                exec(
+                    "mincinfo -attval $dimension:direction_cosines $minc_file"
+                )
+            ),
            );
 }
 


### PR DESCRIPTION
I think this is necessary when calling brainbrowser.
@cmadjar, if you have a minc file which has direction cosine header information different from (1,0,0; 0,1,0; 0,0,1); you will see the difference (compared to when you load the minc file in Register for example).
@samirdas, @jstirling91 
milestone set to 16.1?