### PR TITLE
Genomic browser - CPG color 

### DIFF
--- a/modules/genomic_browser/css/genomic_browser.css
+++ b/modules/genomic_browser/css/genomic_browser.css
@@ -29,6 +29,21 @@
    margin-left: 2px;
    margin-top: 7px;
    margin-bottom: 7px;
-
 }
 
+/* 
+  Color coding Methylation-tab aacording to the display convention of 
+  the wgEncodeHaibMethyl450 track at the UCSC Genome-Browser
+*/
+td.cpgOrange, td.cpgOrange a {
+  color: orange;
+}
+td.cpgPurple, td.cpgPurple a {
+  color: purple;
+}
+td.cpgBlue, td.cpgBlue a{
+  color: blue;
+}
+td.cpgBlack, td.cpgBlack a {
+  color: black;
+}

--- a/modules/genomic_browser/js/cpgColumnFormatter.js
+++ b/modules/genomic_browser/js/cpgColumnFormatter.js
@@ -1,4 +1,26 @@
 
+function getClassColor(methylationLevel) {
+    var className = '';
+    var level = parseFloat(methylationLevel);
+    // Color coding of cpg link follow display convention of the wgEncodeHaibMethyl450 track
+    // at the UCSC Genome-Browser
+    switch (true) {
+       case ( methylationLevel >= 0.6):
+           className = 'cpgOrange';
+           break;
+       case ( methylationLevel > 0.2):
+           className = 'cpgPurple';
+           break;
+       case ( methylationLevel > 0):
+           className = 'cpgBlue';
+           break;
+       default:
+           className = 'cpgBlack';
+           break;
+    }
+    return className;
+}
+
 function formatColumn(column, cell, rowData) {
     reactElement = null;
     if (-1 == loris.hiddenHeaders.indexOf(column)) {
@@ -21,15 +43,25 @@ function formatColumn(column, cell, rowData) {
                 var startLoc = parseInt(genomicLocation) - 1000,
                     endLoc   = parseInt(genomicLocation) + 1000;
                 
+                var className = getClassColor(rowData[8]);
+
                 var url = "http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=" + chr + ":" + startLoc + "-" + endLoc;
                 reactElement = React.createElement(
                     "td",
-                    null,
+                    {className: className},
                     React.createElement(
                         "a",
                         { href: url , target: '_blank'},
                         cell
                     )
+                );
+                break;
+            case 'Beta Value':
+                var className = getClassColor(rowData[8]);
+                reactElement = React.createElement(
+                    "td",
+                    {className: className},
+                    cell
                 );
                 break;
             case 'Gene':


### PR DESCRIPTION
This add colouring to the methylation tab cpg_name and beta_value columns.
The colouring follow the diplay convention for the methylation450k probe track at the UCS Genome Browser.