### PR TITLE
Fix imaging browser navigation links

### DIFF
--- a/modules/imaging_browser/js/columnFormatter.js
+++ b/modules/imaging_browser/js/columnFormatter.js
@@ -1,45 +1,53 @@
 function formatColumn(column, cell, rowData) {
-    if (column === 'New Data') {
-        if (cell === 'new') {
-            return React.createElement(
-                'td',
-                { className: 'newdata' },
-                'NEW'
-            );
-        }
-        return React.createElement('td', null);
-    }
-    if (column === 'Links') {
-        var cellTypes = cell.split(",");
-        var cellLinks = [];
-        for (var i = 0; i < cellTypes.length; i += 1) {
+    switch (column) {
+        case 'SessionID':
+            // hide this column
+            return null;
+            break;
+        case 'New Data':
+            if (cell === 'new') {
+                return React.createElement(
+                    'td',
+                    { className: 'newdata' },
+                    'NEW'
+                );
+            }
+            return React.createElement('td', null);
+            break;
+        case 'Links':
+            var cellTypes = cell.split(",");
+            var cellLinks = [];
+            for (var i = 0; i < cellTypes.length; i += 1) {
+                cellLinks.push(React.createElement(
+                    'a',
+                    { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=" + loris.BaseURL + "/imaging_browser/" },
+                    cellTypes[i]
+                ));
+                cellLinks.push(" | ");
+            }
             cellLinks.push(React.createElement(
                 'a',
-                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] },
-                cellTypes[i]
+                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" + "&backURL=" + loris.BaseURL + "/imaging_browser/" },
+                'selected'
             ));
             cellLinks.push(" | ");
-        }
-        cellLinks.push(React.createElement(
-            'a',
-            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" },
-            'selected'
-        ));
-        cellLinks.push(" | ");
-        cellLinks.push(React.createElement(
-            'a',
-            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] },
-            'all types'
-        ));
-        return React.createElement(
-            'td',
-            null,
-            cellLinks
-        );
+            cellLinks.push(React.createElement(
+                'a',
+                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=" + loris.BaseURL + "/imaging_browser/" },
+                'all types'
+            ));
+            return React.createElement(
+                'td',
+                null,
+                cellLinks
+            );
+            break;
+        default:
+            return React.createElement(
+                'td',
+                null,
+                cell
+            );
+            break;
     }
-    return React.createElement(
-        'td',
-        null,
-        cell
-    );
 }

--- a/modules/imaging_browser/js/columnFormatter.js
+++ b/modules/imaging_browser/js/columnFormatter.js
@@ -20,20 +20,20 @@ function formatColumn(column, cell, rowData) {
             for (var i = 0; i < cellTypes.length; i += 1) {
                 cellLinks.push(React.createElement(
                     'a',
-                    { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=" + loris.BaseURL + "/imaging_browser/" },
+                    { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/" },
                     cellTypes[i]
                 ));
                 cellLinks.push(" | ");
             }
             cellLinks.push(React.createElement(
                 'a',
-                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" + "&backURL=" + loris.BaseURL + "/imaging_browser/" },
+                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" + "&backURL=/imaging_browser/" },
                 'selected'
             ));
             cellLinks.push(" | ");
             cellLinks.push(React.createElement(
                 'a',
-                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=" + loris.BaseURL + "/imaging_browser/" },
+                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=/imaging_browser/" },
                 'all types'
             ));
             return React.createElement(

--- a/modules/imaging_browser/jsx/columnFormatter.js
+++ b/modules/imaging_browser/jsx/columnFormatter.js
@@ -1,26 +1,33 @@
 function formatColumn(column, cell, rowData) {
-    if(column === 'New Data') {
-        if(cell === 'new') {
-            return <td className="newdata">NEW</td>
-        }
-        return <td></td>;
-    }
-    if(column === 'Links') {
-        var cellTypes = cell.split(",");
-        var cellLinks = []
-        for(var i = 0; i < cellTypes.length; i += 1) {
-            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i]}>{cellTypes[i]}</a>);
+    switch (column) {
+        case 'SessionID':
+            // hide this column
+            return null;
+            break;
+        case 'New Data':
+            if(cell === 'new') {
+                return <td className="newdata">NEW</td>
+            }
+            return <td></td>;
+            break;
+        case 'Links':
+            var cellTypes = cell.split(",");
+            var cellLinks = []
+            for(var i = 0; i < cellTypes.length; i += 1) {
+                cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=" + loris.BaseURL + "/imaging_browser/"}>{cellTypes[i]}</a>);
+                cellLinks.push(" | ");
+            }
+            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" + "&backURL=" + loris.BaseURL + "/imaging_browser/"}>selected</a> );
             cellLinks.push(" | ");
-
-        }
-        cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1"}>selected</a> );
-        cellLinks.push(" | ");
-        cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11]}>all types</a> );
-        return (
-                <td>
-                    {cellLinks}
-                </td>
-               );
+            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=" + loris.BaseURL + "/imaging_browser/" }>all types</a> );
+            return (
+                    <td>
+                        {cellLinks}
+                    </td>
+            );
+            break;
+        default:
+            return <td>{cell}</td>;
+            break;
     }
-    return <td>{cell}</td>;
 }

--- a/modules/imaging_browser/jsx/columnFormatter.js
+++ b/modules/imaging_browser/jsx/columnFormatter.js
@@ -14,12 +14,12 @@ function formatColumn(column, cell, rowData) {
             var cellTypes = cell.split(",");
             var cellLinks = []
             for(var i = 0; i < cellTypes.length; i += 1) {
-                cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=" + loris.BaseURL + "/imaging_browser/"}>{cellTypes[i]}</a>);
+                cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/"}>{cellTypes[i]}</a>);
                 cellLinks.push(" | ");
             }
-            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" + "&backURL=" + loris.BaseURL + "/imaging_browser/"}>selected</a> );
+            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1" + "&backURL=/imaging_browser/"}>selected</a> );
             cellLinks.push(" | ");
-            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=" + loris.BaseURL + "/imaging_browser/" }>all types</a> );
+            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=/imaging_browser/" }>all types</a> );
             return (
                     <td>
                         {cellLinks}

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -146,7 +146,8 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             'New_Data',
             'T1_Passed',
             'T2_Passed',
-            'Links'
+            'Links',
+            'sessionID'
         );
        
         $this->validFilters = array(
@@ -174,6 +175,17 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $this->searchKeyword    = array();
         
         $this->tpl_data['numTimepoints'] = 0;
+
+        // This variable will be used by the columnFormatter javascript
+        // to set the default hidden columns in the data table.
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array_map(
+                function ($header) {
+                        return ucwords(str_replace('_', ' ', $header));
+                },
+                array('sessionID')
+            )
+        );
     }
 
     /**
@@ -350,6 +362,32 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             }
         }
         return $query;
+    }
+
+    /**
+     * Converts this menu filter to an array of the form
+     *
+     * Headers => (string array)
+     * Data => (array of arrays of row data)
+     *
+     * @note overloaded function
+     *         Overloading this method to create a list of sessionID that
+     *         will be used for the Navigation Links in  the viewSession
+     *         page.
+     *
+     * @return associative array
+     */
+    function toArray()
+    {
+        $bob   = parent::toArray();
+        $index = array_search('SessionID', $bob['Headers']);
+        if ($index !== false) {
+            $_SESSION['State']->setProperty(
+                'mriSessionsListed',
+                array_column($bob['Data'], $index)
+            );
+        }
+        return $bob;
     }
 
     function getJSDependencies() {

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -379,15 +379,15 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
      */
     function toArray()
     {
-        $bob   = parent::toArray();
-        $index = array_search('SessionID', $bob['Headers']);
+        $data   = parent::toArray();
+        $index = array_search('SessionID', $data['Headers']);
         if ($index !== false) {
             $_SESSION['State']->setProperty(
                 'mriSessionsListed',
-                array_column($bob['Data'], $index)
+                array_column($data['Data'], $index)
             );
         }
-        return $bob;
+        return $data;
     }
 
     function getJSDependencies() {

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -281,42 +281,6 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
     }
 
     /**
-     * Setup table rows for the template
-     *
-     * @param int $count number
-     *
-     * @return null
-     */
-
-    function _setDataTableRows($count)
-    {
-        // print out
-        $x = 0;
-        foreach ($this->list as $item) {
-            //count column
-            $this->tpl_data['items'][$x][0]['value'] = $x + $count;
-
-            //print out data rows
-            $i = 1;
-            foreach ($item as $key => $val) {
-                if ($key == 'sessionID') {
-                    $this->tpl_data['items'][$x]['sessionID'] = $val;
-                    $filtered_sessionIDs[] = $val;
-                    continue;
-                }
-                $this->tpl_data['items'][$x][$i]['name'] = $key;
-                $this->tpl_data['items'][$x][$i]['value'] = $val;
-                $i++;
-            }
-            $x++;
-        }
-        $this->tpl_data['numTimepoints'] = $this->TotalItems; //$x;
-        $_SESSION['State']->setProperty(
-	    'mriSessionsListed', $filtered_sessionIDs
-        );
-        return true;
-    }
-    /**
      * Overwrites the function to add a customized filter
      * for Pending and New
      *

--- a/modules/imaging_browser/templates/menu_imaging_browser.tpl
+++ b/modules/imaging_browser/templates/menu_imaging_browser.tpl
@@ -9,7 +9,9 @@
     }
 </script>
 {/literal}
-
+<script>
+    loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
+</script>
 <div class="row">
 <div class="col-sm-9">
 <div class="panel panel-primary">


### PR DESCRIPTION
- Adding backURL in the columnFormater
- Setting the $_SESSION mriSessionsListed property in a overridden toArray function for the viewSession Navigation Links to appear.
- Using a switch control structure in the columnFormater for efficiency.
- Removing _setDataTableRows no-longer-used-function