### PR TITLE
re-add the capability of overriding a class in project/libraries

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -108,7 +108,8 @@ class NDB_Caller
             // Only supports Menu_Filters and Forms.
             // Modules can not have instruments or reliability.
             set_include_path(
-                "$ModuleDir/php:"
+                $base . "project/libraries:"
+                . "$ModuleDir/php:"
                 . get_include_path()
             );
 


### PR DESCRIPTION
For all existing projects that override the specific module php in project/libraries this will allow them to keep the override as opposed to having to create a full module override.

According to #1404 this should not be allowed and all current projects should redesign their project directory