### PR TITLE
Redmine 10083 - Timepoint List Permissions

### DIFF
--- a/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
+++ b/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
@@ -14,7 +14,8 @@ class NDB_Menu_timepoint_list extends NDB_Menu
         $candidate =& Candidate::singleton($_REQUEST['candID']);
 
         // check user permissions
-    	if ($user->hasPermission('access_all_profiles') || $user->getData('CenterID') == $candidate->getData('CenterID')) {
+    	if ($user->hasPermission('access_all_profiles') || ($user->hasPermission('data_entry') && $user->getData
+        ('CenterID') == $candidate->getData('CenterID'))) {
             return true;
         }
 


### PR DESCRIPTION
User can only access timepoint list if access_all_profiles or data_entry for user's site