### PR TITLE
PatientName can now be grabbed from one place

### DIFF
--- a/modules/imaging_browser/templates/table_session_header.tpl
+++ b/modules/imaging_browser/templates/table_session_header.tpl
@@ -2,6 +2,7 @@
      <thead>
         <tr class="info">
             <th>QC Status</th>
+            <th>Patient Name</th>
             <th>PSCID</th>
             <th>DCCID</th>
             <th>Visit Label</th>
@@ -20,6 +21,7 @@
     <tbody>
         <tr>
             <td>{$subject.mriqcstatus}</td>
+            <td>{$subject.pscid}_{$subject.candid}_{$subject.visitLabel}</td>
             <td>{$subject.pscid}</td>
             <td>{$subject.candid}</td>
             <td>{$subject.visitLabel}</td>


### PR DESCRIPTION
Just added one column to the table with the full patient name to make it easier for Mantis reporting  or emailing QC updates (requested by Louis)

PR1886: https://github.com/aces/Loris/pull/1886 is identical and merged to 16.0