### PR TITLE
Redmine 10097 - Prevent Entering Candidate as Own Sibling

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -737,7 +737,11 @@ class NDB_Form_candidate_parameters extends NDB_Form
             $active_family[] = $relative['CandID'];    
         }
         if (in_array($cand, $active_family)){
-            $errors['FamilyMemberID'] = 'CandID already entered as Sibling';    
+            $errors['FamilyMemberID'] = 'CandID already entered as sibling';
+        }
+        $CandID = $this->identifier;
+        if ($CandID == $cand) {
+            $errors['FamilyMemberID'] = 'Cannot enter candidate as own sibling';
         }
         if (empty($values['relation_type'])) {
             $errors['relation_type'] = 'Please specify relationship type';    


### PR DESCRIPTION
Candidate Parameters Test Plan:
27. Enter the candidate's DCCID as the family member ID. Enter a relationship type. Make sure that an error appears.