### PR TITLE
Imaging Browser - add 'all' as option to scan types

### DIFF
--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -251,7 +251,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
                  JOIN files f ON (f.AcquisitionProtocolID=mri.ID)",
                  array()
         );
-        $scan_types[''] = '';
+        $scan_types = $allAr;
         foreach ($types_q as $row) {
             $type                   = $row['Scan_type'];
             $scan_types[$row['ID']] = $type;


### PR DESCRIPTION
For consistency, 'sequence type' filter should have 'all' like all other filters in this module (and not just a blank space)

![selection_299](https://cloud.githubusercontent.com/assets/11700445/15368670/0ad49d68-1cfd-11e6-8016-8ace7b2e5f5c.png)
