### PR TITLE
Redmine 10099 - DDE Stats now exclude non-DDE instruments 

### DIFF
--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -159,6 +159,12 @@ class NDB_Form_statistics extends NDB_Form
             }
         }
         // DDE STATS
+        $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
+        if ($ddeInstruments != null) {
+            $ddeInstrumentCriteria = implode("' OR f.Test_name='", $ddeInstruments);
+            $ddeInstrumentCriteria = "AND (f.Test_name ='" . $ddeInstrumentCriteria . "') ";
+        }
+
         $DB->select("SELECT s.CenterID, 
                 f.Data_Entry as Data_Entry, 
                 s.visit_label as VLabel,
@@ -168,9 +174,7 @@ class NDB_Form_statistics extends NDB_Form
                 AND s.Current_stage <> 'Recycling Bin'
                 AND f.CommentID LIKE 'DDE%' 
                 AND c.Active='Y' 
-                AND (f.Test_name NOT LIKE '%parameter%' 
-                    AND f.Test_name NOT LIKE '%radiological%' 
-                    AND f.Test_name NOT LIKE '%vineland%')
+                AND $ddeInstrumentCriteria
                 $ExtraProject_Criteria
                 GROUP BY s.CenterID, VLabel, f.Data_Entry ORDER BY c.PSCID;",
             $result);

--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -160,12 +160,17 @@ class NDB_Form_statistics extends NDB_Form
         }
         // DDE STATS
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
-        $ddeInstrumentCriteria = "";
-        if ($ddeInstruments != null) {
-            $ddeInstrumentCriteria = implode("' OR f.Test_name='", $ddeInstruments);
-            $ddeInstrumentCriteria = "AND (f.Test_name ='" . $ddeInstrumentCriteria . "') ";
+        $ddeInstrumentsQuoted = array();
+        foreach ($ddeInstruments as $ddeInstrument) {
+            array_push($ddeInstrumentsQuoted, $DB->quote($ddeInstrument));
         }
 
+        $ddeInstrumentCriteria = "";
+        if ($ddeInstruments != null) {
+            $ddeInstrumentCriteria = implode(" OR f.Test_name=", $ddeInstrumentsQuoted);
+            $ddeInstrumentCriteria = "AND (f.Test_name =" . $ddeInstrumentCriteria . ") ";
+        }
+        
         $DB->select("SELECT s.CenterID, 
                 f.Data_Entry as Data_Entry, 
                 s.visit_label as VLabel,

--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -174,7 +174,7 @@ class NDB_Form_statistics extends NDB_Form
                 AND s.Current_stage <> 'Recycling Bin'
                 AND f.CommentID LIKE 'DDE%' 
                 AND c.Active='Y' 
-                AND $ddeInstrumentCriteria
+                $ddeInstrumentCriteria
                 $ExtraProject_Criteria
                 GROUP BY s.CenterID, VLabel, f.Data_Entry ORDER BY c.PSCID;",
             $result);

--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -160,6 +160,7 @@ class NDB_Form_statistics extends NDB_Form
         }
         // DDE STATS
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
+        $ddeInstrumentCriteria = "";
         if ($ddeInstruments != null) {
             $ddeInstrumentCriteria = implode("' OR f.Test_name='", $ddeInstruments);
             $ddeInstrumentCriteria = "AND (f.Test_name ='" . $ddeInstrumentCriteria . "') ";

--- a/modules/statistics/php/NDB_Menu_statistics_dd_site.class.inc
+++ b/modules/statistics/php/NDB_Menu_statistics_dd_site.class.inc
@@ -27,7 +27,7 @@ class NDB_Menu_statistics_dd_site extends NDB_Menu_statistics_site
         $statisticsConfig = $config->getSetting('statistics');
         $excluded_measures = array($statisticsConfig['excludedMeasures']);
 
-        $key = array_search($var, $excluded_measures); 
+        $key = array_search($var, $excluded_measures);
         foreach ($excluded_measures as $key=>$val) {
             if (in_array($var, $val) || $var == $val) {
                 return false;
@@ -37,11 +37,10 @@ class NDB_Menu_statistics_dd_site extends NDB_Menu_statistics_site
     }
 
     function __construct() {
-        $this->instruments = Utility::getAllInstruments();
+        $this->instruments = Utility::getAllDDEInstruments();
         foreach($this->instruments as $k=>$v) {
             $this->instruments[$k] = $k;
         }
-       
         $this->instruments = array_filter($this->instruments, array(&$this, 'notexcluded'));
     }
 
@@ -49,25 +48,36 @@ class NDB_Menu_statistics_dd_site extends NDB_Menu_statistics_site
         $this->_checkCriteria($centerID, $projectID);
         $DB =& Database::singleton();
 
-        return $DB->pselectOne("SELECT count(s.CandID)  FROM session s, candidate c, flag f, {$instrument} i WHERE 
-                s.ID=f.SessionID AND f.CommentID=i.CommentID 
-                AND s.CandID=c.CandID  
-                AND s.Active='Y' 
+        $this->__construct();
+        if (!in_array($instrument, $this->instruments)) {
+            return 0;
+        }
+
+        return $DB->pselectOne("SELECT count(s.CandID)  FROM session s, candidate c, flag f, {$instrument} i WHERE
+                s.ID=f.SessionID AND f.CommentID=i.CommentID
+                AND s.CandID=c.CandID
+                AND s.Active='Y'
                 AND s.Current_stage <> 'Recycling Bin'
                 $this->query_criteria
-                AND f.Data_entry='Complete' AND f.Administration='All' 
+                AND f.Data_entry='Complete' AND f.Administration='All'
                 AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID", $this->query_vars);
     }
 
     function _GetResults($centerID, $projectID, $instrument) {
         $this->_checkCriteria($centerID, $projectID);
         $DB =& Database::singleton();
-        $result = $DB->pselect("SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID, lower(s.Visit_label) as Visit_label  FROM session s, candidate c, flag f, {$instrument} i 
-                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID AND 
-                s.CandID=c.CandID  AND s.Active='Y' 
+
+        $this->__construct();
+        if (!in_array($instrument, $this->instruments)) {
+            return null;
+        }
+
+        $result = $DB->pselect("SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID, lower(s.Visit_label) as Visit_label  FROM session s, candidate c, flag f, {$instrument} i
+                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID AND
+                s.CandID=c.CandID  AND s.Active='Y'
                 $this->query_criteria
                 AND s.Current_stage <> 'Recycling Bin'
-                AND (f.Data_entry is NULL OR f.Data_entry<>'Complete') AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID", $this->query_vars); 
+                AND (f.Data_entry is NULL OR f.Data_entry<>'Complete') AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID", $this->query_vars);
             return $result;
     }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -42,9 +42,9 @@ class Utility
      */
     static function isErrorX($data, $code=null)
     {
-        throw new LorisException(
-            "Utility::isErrorX has been deprecated. Use PHP5 exceptions instead."
-        );
+//        throw new LorisException(
+//            "Utility::isErrorX has been deprecated. Use PHP5 exceptions instead."
+//        );
     }
 
     /**
@@ -739,6 +739,33 @@ class Utility
         return $instruments;
     }
 
+    /**
+     * Get a list of instruments installed in Loris.
+     *
+     * @return Associative array of the form Test_name => Full Description
+     * @note   Arguably, this should be a static function in NDB_BVL_Instrument
+     */
+    static function getAllDDEInstruments()
+    {
+        $Factory       = NDB_Factory::singleton();
+        $DB            = $Factory->Database();
+        $config =& NDB_Config::singleton();
+        $instruments_q = $DB->pselect(
+            "SELECT Test_name,Full_name FROM test_names",
+            array()
+        );
+        $doubleDataEntryInstruments = $config->getSetting('DoubleDataEntryInstruments');
+
+        $instruments   = array();
+        foreach ($instruments_q as $row) {
+            if (isset($row['Test_name']) && isset($row['Full_name'])) {
+                if (in_array($row['Test_name'], $doubleDataEntryInstruments)) {
+                    $instruments[$row['Test_name']] = $row['Full_name'];
+                }
+            }
+        }
+        return $instruments;
+    }
 
     /**
      * Gets a list of all instruments where are administered as direct data

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -740,7 +740,7 @@ class Utility
     }
 
     /**
-     * Get a list of instruments installed in Loris.
+     * Get a list of DDE instruments installed in Loris.
      *
      * @return Associative array of the form Test_name => Full Description
      * @note   Arguably, this should be a static function in NDB_BVL_Instrument

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -42,9 +42,9 @@ class Utility
      */
     static function isErrorX($data, $code=null)
     {
-//        throw new LorisException(
-//            "Utility::isErrorX has been deprecated. Use PHP5 exceptions instead."
-//        );
+        throw new LorisException(
+            "Utility::isErrorX has been deprecated. Use PHP5 exceptions instead."
+        );
     }
 
     /**
@@ -749,14 +749,16 @@ class Utility
     {
         $Factory       = NDB_Factory::singleton();
         $DB            = $Factory->Database();
-        $config =& NDB_Config::singleton();
+        $config        =& NDB_Config::singleton();
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names",
             array()
         );
-        $doubleDataEntryInstruments = $config->getSetting('DoubleDataEntryInstruments');
+        $doubleDataEntryInstruments = $config->getSetting(
+            'DoubleDataEntryInstruments'
+        );
 
-        $instruments   = array();
+        $instruments = array();
         foreach ($instruments_q as $row) {
             if (isset($row['Test_name']) && isset($row['Full_name'])) {
                 if (in_array($row['Test_name'], $doubleDataEntryInstruments)) {

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ *
+ * This script removes the 'ignored' fields from the Conflict Resolver table.
+ * Should be run after any fields are added to the _doubleDataEntryDiffIgnoreColumns
+ * after the instrument has been completed.
+ *
+ * It has two modes:
+ *     regular mode -> Prints the conflicts to be removed, but does not remove them.
+ *
+ *     confirm mode -> Actually removes the conflicts.
+ *
+ * Usage: php assign_missing_instrument.php [Test_name] [confirm]
+ *
+ * Example: php delete_ignored_conflicts.php tsi
+ * (Will use regular mode and print the obsolete conflicts)
+ *
+ * Example: php delete_ignored_conflicts.php tsi confirm
+ * (Will use confirm mode and remove obsolete tsi conflicts)
+ *
+ * Example: php delete_ignored_conflicts.php confirm
+ * (Will use confirm mode and remove all obsolete conflicts)
+ *
+ */
+
+set_include_path(get_include_path().":../project/libraries:../php/libraries:");
+//
+//require_once __DIR__ . "/../vendor/autoload.php";
+//require_once "NDB_Client.class.inc";
+//require_once "Utility.class.inc";
+//require_once "Database.class.inc";
+
+//$client = new NDB_Client();
+//$client->makeCommandLine();
+//$client->initialize('../project/config.xml');
+
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "NDB_Client.class.inc";
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize();
+
+$config        =& NDB_Config::singleton();
+
+// Meta fields that should be removed
+$defaultFields = array(
+    'CommentID', 'UserID', 'Testdate', 'Window_Difference',
+    'Candidate_Age', 'Data_entry_completion_status'
+);
+
+$instruments = array();
+$instrumentSpecified = false;
+
+$confirm = false;
+if ((isset($argv[1]) && $argv[1] === "confirm")
+    || (isset($argv[2]) && $argv[2] === "confirm")) {
+    $confirm = true;
+}
+
+if (!empty($argv[1]) && $argv[1]!="confirm") {
+    $instruments[0] = $argv[1];
+    $instrumentSpecified = true;
+} else {
+    $instruments = $config->getSetting('DoubleDataEntryInstruments');
+}
+
+if (isset($instruments)) {
+    detectIgnoreColumns($instruments);
+    echo "Done.";
+}
+else {
+    echo "No instruments found";
+}
+
+if ($confirm === false) {
+    echo "\n\nRun this tool again with the argument 'confirm' to ".
+        "perform the changes\n\n";
+}
+
+/**
+ * Populates the DDE ignore fields for each instrument and runs
+ * the ignoreColumn function on the instrument for the given fields
+ * @param $instruments
+ * @throws Exception
+ */
+function detectIgnoreColumns($instruments)
+{
+    $instrumentFields = array();
+
+    foreach ($instruments as $instrument) {
+
+        echo "Checking DDE ignore fields for " . $instrument . "\n";
+
+        $file = "../project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
+        if (file_exists($file)) {
+        include $file;
+        $instance =& NDB_BVL_Instrument::factory($instrument, null, null);
+
+            $DDEIgnoreFields = $instance->_doubleDataEntryDiffIgnoreColumns;
+
+            if ($DDEIgnoreFields != null) {
+                foreach ($DDEIgnoreFields as $key => $DDEField) {
+                    if (!in_array($DDEField, $this->defaultFields)) {
+                        $instrumentFields = array_merge($instrumentFields, array($DDEField => $instrument));
+                    }
+                }
+            } else {
+                echo "No DDE ignore fields found for " . $instrument . "\n";
+            }
+            if (!$this->instrumentSpecified) {
+                defaultIgnoreColumns();
+            }
+            ignoreColumn($instrument, $instrumentFields);
+        }
+    }
+}
+
+/*
+ * Prints the default ignore columns to be removed
+ * Removes the fields if confirmation is set
+ */
+function defaultIgnoreColumns() {
+    $db =& Database::singleton();
+
+    if ($this->confirm) {
+        foreach ($this->defaultFields as $field) {
+            $defaultQuery = "DELETE FROM conflicts_unresolved WHERE FieldName = '$field'";
+            $changes = $db->run($defaultQuery);
+            echo $changes . "\n";
+        }
+    }
+    else {
+        foreach ($this->defaultFields as $field) {
+            $defaultQuery = "SELECT TableName, FieldName, Value1, Value2 
+          FROM conflicts_unresolved WHERE FieldName = '$field'";
+            $defaultColumn = $db->pselectOne($defaultQuery, array());
+            echo "TableName, FieldName, Value1, Value2: ";
+            print_r($defaultColumn);
+            echo "\n";
+        }
+    }
+}
+
+/*
+ * Prints the instrument-specific ignore columns to be removed
+ * Removes the fields if confirmation is set
+ */
+function ignoreColumn($instrument, $instrumentFields) {
+    $db =& Database::singleton();
+
+    if ($this->confirm) {
+        foreach ($instrumentFields as $field => $instr) {
+            $query = "DELETE FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
+            $changes = $db->run($query);
+            echo $changes . "\n";
+        }
+    }
+    else {
+        foreach ($instrumentFields as $field => $instr) {
+            $query = "SELECT TableName, FieldName, Value1, Value2 FROM conflicts_unresolved 
+          WHERE TableName = '$instrument' AND FieldName = '$field'";
+            $ignoreColumn = $db->pselectOne($query, array());
+            echo "TableName, FieldName, Value1, Value2: ";
+            print_r($ignoreColumn);
+            echo  "\n";
+        }
+    }
+}
+
+?>


### PR DESCRIPTION
If DDE was previously used for those instruments, comment ids like 'DDE%' are created and are included in the stats

Now the stats check the config for the DDE instruments