### PR TITLE
Only use htmlspecialchars on non-null values in Database class

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -271,7 +271,7 @@ class Database
     {
         $retVal = array();
         foreach ($set as $key => $val) {
-            $retVal[$key] = htmlspecialchars($val);
+            $retVal[$key] = is_null($val) ? null : htmlspecialchars($val);
         }
         return $retVal;
     }


### PR DESCRIPTION
If you don't do that, nulls are transformed into '' (empty strings), which can have undesirable consequences.