### PR TITLE
Readme dependencies update for 16.0

### DIFF
--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -1,6 +1,6 @@
 #LORIS CentOS 6.x Notes
 
-Note that the README in LORIS assumes that LORIS is being run on Ubuntu.
+Note that the main README in LORIS assumes that LORIS is being run on Ubuntu.
 
 This document contains details on how to manually perform a basic CentOS 6.x
 install of LORIS without using the install script (as the install script
@@ -33,10 +33,9 @@ curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer
 ```
 
-Note that the version of PHP installed by CentOS 6.x is approximately 600 years
-old, and doesn't meet the minimum requirements of many development dependencies.
-As a result, you need to either upgrade your version of PHP or run composer
-with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
+Note that the version of PHP installed by CentOS 6.x doesn't meet the minimum requirements of many development dependencies.
+As a result, you need to either upgrade your version of PHP to 5.6 for LORIS 16.0
+Or run composer with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
 assume you just want to get it running, so we'll run it with `--no-dev`.)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #LORIS Neuroimaging Platform
 
-LORIS is a web-accessible database solution for neuroimaging, providing a secure infrastructure to automate the flow of clinical data for complex multi-site neuroimaging studies.
+LORIS (Longitudinal Online Research and Imaging System) is a web-based data and project management software for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
 This Readme covers installation of the <b>16.0</b> LORIS release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/16.04-dev/README.CentOS6.md))
@@ -14,16 +14,16 @@ Note: Your default credentials after deployment will be 'admin' as the username 
 
 # Prerequisites for Installation
 
- * LINUX (supported on Ubuntu 14.04 and CentOS 6.5) or Mac OS X (tested for Mavericks - OS X 10.9)
+ * LINUX (supported on Ubuntu 14.04 and [CentOS 6.5](https://github.com/aces/Loris/blob/16.04-dev/README.CentOS6.md)) 
  * Apache2 (libapache2-mod-php5)
  * MySQL (libmysqlclient15-dev mysql-client mysql-server)
- * PHP 5.3+ (php5 php5-mysql php5-gd php5-sqlite)
- * PEAR (php-pear)
+ * PHP <b>5.6</b> (php5 php5-mysql php5-gd php5-sqlite)
  * php5-json (for Debian/Ubuntu distributions)
  * Package manager (for LINUX distributions)
- * Composer
+ * Composer : should be installed with --no-dev option
 
-<b>Important:</b> Composer should be installed with --no-dev option.  
+<b>Important:</b>Only PHP 5.6 is supported for LORIS 16.0  Composer should be installed with --no-dev option unless you are an active LORIS developer. 
+
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information.
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Note: Your default credentials after deployment will be 'admin' as the username 
  * PHP <b>5.6</b> (php5 php5-mysql php5-gd php5-sqlite)
  * php5-json (for Debian/Ubuntu distributions)
  * Package manager (for LINUX distributions)
- * Composer : should be installed with --no-dev option
+ * Composer : should be run with --no-dev option
 
-<b>Important:</b>Only PHP 5.6 is supported for LORIS 16.0  Composer should be installed with --no-dev option unless you are an active LORIS developer. 
+<b>Important:</b>Only PHP 5.6 is supported for LORIS 16.0  Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information.
 


### PR DESCRIPTION
Updating dependencies -- PHP 5.6 only is important for 16.0
Both CentOS and Ubuntu 