### PR TITLE
Source the MINC tools path for brainbrowser

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -163,4 +163,8 @@
             <permission>sampleInstrument2PermissionName</permission>
         </instrument>
     </instrumentPermissions>
+
+    <!-- MINC TOOLS PATH -->
+    <MINCToolsPath>%MINCTOOLSPATH%</MINCToolsPath>
+
 </config>

--- a/modules/brainbrowser/ajax/minc.php
+++ b/modules/brainbrowser/ajax/minc.php
@@ -18,6 +18,7 @@
 ini_set('default_charset', 'utf-8');
 require_once "Utility.class.inc";
 require_once "NDB_Config.class.inc";
+require_once "MincEnv.php.inc";
 
 $headers = array();
 

--- a/modules/brainbrowser/php/MincEnv.php.inc
+++ b/modules/brainbrowser/php/MincEnv.php.inc
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Get the MINC tools path for bin, lib, and pipeline
+ *
+ * If the minc_headers request parameter is set, it will return a JSON object
+ * representing the headers necessary to render the file. If raw_data is set,
+ * it will return a byte array of the raw data for brainbrowser to display.
+ *
+ * PHP Version 5
+ *
+ * @category Imaging
+ * @package  Loris/Modules/BrainBrowser
+ * @author   Loris Team <loris@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * Get the MINC tools path for bin, lib, and pipeline
+ *
+ * @category Imaging
+ * @package  Loris/Modules/BrainBrowser
+ * @author   Loris Team <loris@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+require_once "NDB_Config.class.inc";
+
+$config    =& NDB_Config::singleton();
+$minc_path = $config->getSetting("MINCToolsPath");
+
+putenv("PATH=" . $minc_path . "bin:" . $minc_path . "pipeline:" . getenv("PATH"));
+putenv("LD_LIBRARY_PATH=" . getenv("LD_LIBRARY_PATH") . ":" . $minc_path . "lib");
+
+?>

--- a/test/config.xml
+++ b/test/config.xml
@@ -194,4 +194,8 @@
             <permission>sampleInstrument2PermissionName</permission>
         </instrument>
     </instrumentPermissions>
+
+    <!-- MINC TOOLS PATH -->
+    <MINCToolsPath>%MINCTOOLSPATH%</MINCToolsPath>
+
 </config>

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -513,4 +513,15 @@ else
     exit 1
 fi
 
+echo ""
+# Add MINC tools path
+echo "Adding the following MINC tools path:"
+MINC_TOOLKIT_DIR=`which mincheader|sed s#bin/mincheader##`
+
+sed -e "s#%MINCTOOLSPATH%#$MINC_TOOLKIT_DIR#g" \
+    < ../docs/config/config.xml > ../project/config.xml
+
+echo "$MINC_TOOLKIT_DIR"
+
+echo ""
 echo "Installation complete."

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -513,15 +513,4 @@ else
     exit 1
 fi
 
-echo ""
-# Add MINC tools path
-echo "Adding the following MINC tools path:"
-MINC_TOOLKIT_DIR=`which mincheader|sed s#bin/mincheader##`
-
-sed -e "s#%MINCTOOLSPATH%#$MINC_TOOLKIT_DIR#g" \
-    < ../docs/config/config.xml > ../project/config.xml
-
-echo "$MINC_TOOLKIT_DIR"
-
-echo ""
 echo "Installation complete."


### PR DESCRIPTION
This gets the MINC tools path from the config.xml file.
CHANGES REQUIRED TO THE CONFIG.XML FILE for existing projects:
Add the following lines (where /opt/minc/ is where the MINC tools are installed in the example below; replace with the appropriate path):
    <!-- MINC TOOLS PATH -->
    < MINCToolsPath >/opt/minc/< /MINCToolsPath >

Related to Loris-MRI Pull request 125:
https://github.com/aces/Loris-MRI/pull/125