### PR TITLE
Fix instrument control panel status links parameters

### DIFF
--- a/smarty/templates/instrumentstatus_controlpanel.tpl
+++ b/smarty/templates/instrumentstatus_controlpanel.tpl
@@ -16,7 +16,7 @@
     <li>
         <img src="{$baseurl}/images/{$administration[item].icon|default:'default'}.gif" alt="" border="0" width="12" height="12" />
     {if $access.administration and $administration[item].showlink}
-        <a href="?commentID={$commentID}&setAdministration={$administration[item].label}">{$administration[item].label}</a>
+        <a href="?commentID={$commentID}&sessionID={$sessionID}&setAdministration={$administration[item].label}">{$administration[item].label}</a>
     {else}
         {$administration[item].label}
     {/if}
@@ -31,7 +31,7 @@
     <li>
         <img src="{$baseurl}/images/{$validity[item].icon|default:'default'}.gif" alt="" border="0" width="12" height="12" />
     {if $access.validity and $validity[item].showLink}
-        <a href="?commentID={$commentID}&setValidity={$validity[item].label}">{$validity[item].label}</a>
+        <a href="?commentID={$commentID}&sessionID={$sessionID}&setValidity={$validity[item].label}">{$validity[item].label}</a>
     {else}
         {$validity[item].label}
     {/if}
@@ -45,7 +45,7 @@
     <li>
         <img src="{$baseurl}/images/{$data_entry[item].icon|default:'default'}.gif" alt="" border="0" width="12" height="12" />
     {if $access.data_entry and $data_entry[item].showlink}
-        <a href="?commentID={$commentID}&setDataEntry={$data_entry[item].label}">{$data_entry[item].label}</a>
+        <a href="?commentID={$commentID}&sessionID={$sessionID}&setDataEntry={$data_entry[item].label}">{$data_entry[item].label}</a>
     {else}
         {$data_entry[item].label}
     {/if}


### PR DESCRIPTION
missing sessionID in URL causing 500 error on setAdministration, setValidity and setDataEntry.
The timepoint could not be instantiated in the NDB_Caller class.

`PHP Fatal error:  Call to a member function getData() on null in /var/www/loris/php/libraries/NDB_Caller.class.inc on line 443`