### PR TITLE
Fixed SQL Error

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -881,7 +881,7 @@ class Utility
         //$database = $config->getSetting('database');
         $query    = "SELECT count(*)
             FROM {$table_name}
-            WHERE {$column} is NULL;";
+            WHERE {$column} is NULL";
         $DB       =& Database::singleton();
         $num_null = $DB->pselectOne(
             $query,


### PR DESCRIPTION
The query from the Utility class wasn't correct, since the pselectOne
adds an implicit LIMIT 1, the query generated was
	SELECT count(\*) FROM ...; LIMIT 1
instead of
	SELECT count(\*) FROM ... LIMIT 1