### PR TITLE
Redmine 10146 - Remove 'ignored' conflicts from Conflict Resolver

### DIFF
--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -123,6 +123,7 @@ function detectIgnoreColumns($instruments)
 function defaultIgnoreColumns() {
     $db =& Database::singleton();
 
+<<<<<<< HEAD
     if ($this->confirm) {
         foreach ($this->defaultFields as $field) {
             $defaultQuery = "DELETE FROM conflicts_unresolved WHERE FieldName = '$field'";
@@ -141,6 +142,9 @@ function defaultIgnoreColumns() {
         }
     }
 }
+=======
+    foreach ($instrumentFields as $field => $instr) {
+>>>>>>> print conflicts to be removed
 
 /*
  * Prints the instrument-specific ignore columns to be removed
@@ -160,10 +164,24 @@ function ignoreColumn($instrument, $instrumentFields) {
         foreach ($instrumentFields as $field => $instr) {
             $query = "SELECT TableName, FieldName, Value1, Value2 FROM conflicts_unresolved 
           WHERE TableName = '$instrument' AND FieldName = '$field'";
+<<<<<<< HEAD
             $ignoreColumn = $db->pselectOne($query, array());
             echo "TableName, FieldName, Value1, Value2: ";
             print_r($ignoreColumn);
             echo  "\n";
+=======
+        $ignoreColumn = $db->pselectOne($query, array());
+
+        if (!empty($ignoreColumn)) {
+            $query = "SELECT TableName, CommentId1, Value1, CommentId2, Value2 FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
+            $conflictsToRemove = $db->pselect($query, array());
+            print_r($conflictsToRemove);
+
+            if ($confirm) {
+                $query = "DELETE FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
+                $db->run($query);
+            }
+>>>>>>> print conflicts to be removed
         }
     }
 }

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -123,7 +123,6 @@ function detectIgnoreColumns($instruments)
 function defaultIgnoreColumns() {
     $db =& Database::singleton();
 
-<<<<<<< HEAD
     if ($this->confirm) {
         foreach ($this->defaultFields as $field) {
             $defaultQuery = "DELETE FROM conflicts_unresolved WHERE FieldName = '$field'";
@@ -142,9 +141,6 @@ function defaultIgnoreColumns() {
         }
     }
 }
-=======
-    foreach ($instrumentFields as $field => $instr) {
->>>>>>> print conflicts to be removed
 
 /*
  * Prints the instrument-specific ignore columns to be removed
@@ -164,24 +160,10 @@ function ignoreColumn($instrument, $instrumentFields) {
         foreach ($instrumentFields as $field => $instr) {
             $query = "SELECT TableName, FieldName, Value1, Value2 FROM conflicts_unresolved 
           WHERE TableName = '$instrument' AND FieldName = '$field'";
-<<<<<<< HEAD
             $ignoreColumn = $db->pselectOne($query, array());
             echo "TableName, FieldName, Value1, Value2: ";
             print_r($ignoreColumn);
             echo  "\n";
-=======
-        $ignoreColumn = $db->pselectOne($query, array());
-
-        if (!empty($ignoreColumn)) {
-            $query = "SELECT TableName, FieldName, CommentId1, Value1, CommentId2, Value2 FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
-            $conflictsToRemove = $db->pselect($query, array());
-            print_r($conflictsToRemove);
-
-            if ($confirm) {
-                $query = "DELETE FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
-                $db->run($query);
-            }
->>>>>>> print conflicts to be removed
         }
     }
 }

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -167,3 +167,5 @@ function ignoreColumn($instrument, $instrumentFields) {
         }
     }
 }
+
+?>

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -173,7 +173,7 @@ function ignoreColumn($instrument, $instrumentFields) {
         $ignoreColumn = $db->pselectOne($query, array());
 
         if (!empty($ignoreColumn)) {
-            $query = "SELECT TableName, CommentId1, Value1, CommentId2, Value2 FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
+            $query = "SELECT TableName, FieldName, CommentId1, Value1, CommentId2, Value2 FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
             $conflictsToRemove = $db->pselect($query, array());
             print_r($conflictsToRemove);
 

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -94,8 +94,8 @@ function detectIgnoreColumns($instruments)
 
         $file = "../project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
         if (file_exists($file)) {
-        include $file;
-        $instance =& NDB_BVL_Instrument::factory($instrument, null, null);
+            include $file;
+            $instance =& NDB_BVL_Instrument::factory($instrument, null, null);
 
             $DDEIgnoreFields = $instance->_doubleDataEntryDiffIgnoreColumns;
 

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -94,8 +94,8 @@ function detectIgnoreColumns($instruments)
 
         $file = "../project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
         if (file_exists($file)) {
-            include $file;
-            $instance =& NDB_BVL_Instrument::factory($instrument, null, null);
+        include $file;
+        $instance =& NDB_BVL_Instrument::factory($instrument, null, null);
 
             $DDEIgnoreFields = $instance->_doubleDataEntryDiffIgnoreColumns;
 
@@ -167,5 +167,3 @@ function ignoreColumn($instrument, $instrumentFields) {
         }
     }
 }
-
-?>

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -28,26 +28,31 @@ require_once "TimePoint.class.inc";
  
 if ((count($argv)<2) || (count($argv)>6)) {
 
-    echo "Usage: php detect_conflicts.php -i Instrument -t Timepoint\n";
-    echo "Example: php detect_conflicts.php -i bdi -t 3month \n";
+    echo "Usage: php detect_conflicts.php -i [instrument] -t [timepoint]\n";
+    echo "Example: php detect_conflicts.php -i bdi -t 3month \n\n";
 
-    echo "OR";
-    echo "Usage: php detect_conflicts.php -i Instrument \n";
-    echo "Example: php detect_conflicts.php bdi \n";
+    echo "Usage: php detect_conflicts.php -i [instrument] \n";
+    echo "Example: php detect_conflicts.php -i bdi \n\n";
 
-    echo "to insert the conflicts into conflicts_unresovled table type -c -i \n";
-    echo "to remove all/re-insert the conflicts into
-            conflicts_unresovled table type -m \n";
-    echo "to run the script for all the instruments
-            simply type -i all \n";
+    echo "Usage: php detect_conflicts.php -r [instrument/all] [-y to confirm]\n";
+    echo "Example: php detect_conflicts.php -r all -y\n";
+    echo "Example: php detect_conflicts.php -r bdi -y \n\n";
+
+    echo "to insert the conflicts into conflicts_unresolved table type -c -i \n";
+    echo "to remove all/re-insert the conflicts into conflicts_unresolved table type -m \n";
+    echo "to run the script for all the instruments simply type -i all \n";
+    echo "to remove ignored conflicts type -r\n\n";
     echo "NOTE: ONLY THE FAILED VISITS ARE EXCLUDED BY THIS SCRIPT \n";
     die();
 }
 
 // parse the options
-$opts = getopt("m:i:t:c");
+$opts = getopt("m:i:t:r:c:y");
 $change = false;
 $change_all = false;
+$confirm = false;
+$delete_ignored_conflicts = false;
+$instrument_ignored = null;
 $instrument = null;
 $visit_label = null;
 
@@ -56,18 +61,23 @@ if (!is_array($opts)) {
     exit(1);
 }
 
-/// IF it's an instrument
-if ($opts['i']!=null) {
+// if it's an instrument
+if (array_key_exists('i', $opts) && $opts['i']!=null) {
     $instrument = $opts['i'];
 }
 
 // if it's an visit
-if ($opts['t'] !=null) {
+if (array_key_exists('t', $opts) && $opts['t'] !=null) {
     $visit_label = $opts['t'];
 }
 
-// Set the variables $change and $chage_all
+// if ignored but existing conflicts should be included
+if (array_key_exists('r', $opts) && $opts['r'] !=null) {
+    $delete_ignored_conflicts = true;
+    $instrument_ignored[0] = $opts['r'];
+}
 
+// Set the variables $change and $change_all
 if (array_key_exists('c', $opts)) {
     $change = true;
 }
@@ -75,9 +85,14 @@ if (array_key_exists('c', $opts)) {
 if (array_key_exists('m', $opts)) {
     $change_all = true;
 }
+
+if (array_key_exists('y', $opts)) {
+    $confirm = true;
+}
+print_r($opts);
   
-if ($change && $change_all) {
-    $die("Choose either Change (-c) or remove and re-insert all conflicts (-m)");
+if (($change && $change_all) || ($delete_ignored_conflicts && ($change || $change_all))) {
+    $die("Choose either Change (-c) or remove and re-insert all conflicts (-m) or remove ignored conflicts (-r)");
 }
 
 /// Initialization
@@ -93,122 +108,151 @@ $detected_conflicts = array();
 $current_conflicts = array();
 $conflicts_to_be_excluded = array();
 
-
-// Check to see if the variable instrument is set
-if (($instrument=='all') ||($instrument=='All')) {
-
-    $Factory       = NDB_Factory::singleton();
-    $DB            = $Factory->Database(); //=& Database::singleton();
-    $instruments_q = $DB->pselect(
-        "SELECT Test_name FROM test_names",
-        array()
-    );
-
-    $instruments   = array();
-
-    foreach ($instruments_q as $row) {
-        if (isset($row['Test_name'])) {
-            $instruments[$row['Test_name']] =$row['Test_name'];
-        }
+if ($delete_ignored_conflicts) {
+    if ($instrument_ignored[0] == "all") {
+        $instrument_ignored = $ddeInstruments;
     }
-
-} else {
-    $instruments = array($instrument=>$instrument);
-}
-foreach ($instruments as $instrument) {
-    if (isset($instrument)) {
-
-        include_once $paths['base'].
-            "project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
-
-        print  "instrument is $instrument \n";
-
-        //Run the script for all the instruments
-        $commentids = getCommentIDs($instrument, $visit_label);
-
-        
-         //check to make sure that the commentids are set
-        if (isset($commentids)) {
-            //get the current conflicts
-            $current_conflicts =getCurrentUnresolvedConflicts(
-                $instrument, $visit_label
-            );
-            $detected_conflicts = detectConflicts(
-                $instrument, $commentids, $current_conflicts
-            );
-
-            $new_conflicts = getNewConflicts(
-                $current_conflicts, $detected_conflicts
-            );
-            $conflicts_to_be_excluded = detectConflictsTobeExcluded(
-                $instrument, $commentids, $current_conflicts
-            );
-            /**
-            * Only Create report for the  confliclits
-            1) that should be inserted into the conflicts_unresolved table
-            2) that should be deleted from the conflicts_unresolved table
-            */
-            if ((!$change)&&(!$change_all)) {
-
-                //just show the conflicts
-                print "This will only display the conflicts needed to
-                be inserted \n";
-                print "To re-create the conflict, run this script with 
-                -c option \n";
-                if ((empty($new_conflicts)) && empty($conflicts_to_be_excluded)) {
-                    print "No new conflicts or current conflicts to be
-                removed are detected for instrument $instrument \n";
-                } else {
-                    writeCSV(
-                        $new_conflicts, $dataDir, $instrument, $visit_label,
-                        "Conflicts_to_be_inserted"
-                    );
-                    writeCSV(
-                        $conflicts_to_be_excluded, $dataDir, $instrument,
-                        $visit_label, "Conflicts_to_be_removed"
-                    );
-                }
-            }
-            /**
-            * Only insert those conflicts which are new and are not currently
-            * in the conflict_uresolved
-            * 1)remove/clear the existing conflicts
-            * 2) And then re-create the conflicts
-            */
-
-            ///if the instrument is not provided, run it only for all the instruments
-            if ($change) {
-                if ((empty($new_conflicts)) || (!isset($new_conflicts))) {
-                    die("There are No new conflicts to be inserted ");
-                }
-                foreach ($new_conflicts as $conflict) {
-                    if (($conflict!=null)&&(!empty($conflict))) {
-                        ConflictDetector::clearConflictsForInstance(
-                            $conflict['CommentId1']
-                        ); ///clear the conflicts
-                    }
-                }
-                //////re-insert them into the table
-                ConflictDetector::recordUnresolvedConflicts($new_conflicts);
-            }
-
-
-            /**
-            * Remove all the current conflicts for the givent instrument/visit_label
-            * And re-insert them
-            */
-            if ($change_all) {
-                foreach ($commentids as $cid) {
-                    ConflictDetector::clearConflictsForInstance($cid['CommentID']);
-                    $diff=ConflictDetector::detectConflictsForCommentIds(
-                        $test_name, $cid['CommentID'], $cid['DDECommentID']
-                    );
-                    ConflictDetector::recordUnresolvedConflicts($diff);
-                }
-            }
+    if (isset($instrument_ignored)) {
+        if ($confirm) {
+            echo "Removing ignored conflicts\n\n";
+        }
+        else {
+            echo "Detecting ignored conflicts\n\n";
+        }
+        detectIgnoreColumns($instrument_ignored, $confirm);
+        if ($confirm) {
+            echo "Finished.\n\n";
+        }
+        else {
+            echo "\n\nRun this tool again with the argument '-y' to ".
+                "perform the changes\n\n";
         }
     } else {
-        die("the instrument is not set or there are no commentids \n");
+        echo "No DDE instruments found to remove ignored columns.";
+    }
+}
+else {
+
+    // Check to see if the variable instrument is set
+    if (($instrument=='all') ||($instrument=='All')) {
+
+        $Factory       = NDB_Factory::singleton();
+        $DB            = $Factory->Database(); //=& Database::singleton();
+        $instruments_q = $DB->pselect(
+            "SELECT Test_name FROM test_names",
+            array()
+        );
+
+        $instruments   = array();
+
+        foreach ($instruments_q as $row) {
+            if (isset($row['Test_name'])) {
+                $instruments[$row['Test_name']] =$row['Test_name'];
+            }
+        }
+
+    } else {
+        $instruments = array($instrument=>$instrument);
+    }
+
+    foreach ($instruments as $instrument) {
+        if (isset($instrument)) {
+
+            include_once $paths['base'] .
+                "project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
+
+            print  "instrument is $instrument \n";
+
+            //Run the script for all the instruments
+            $commentids = getCommentIDs($instrument, $visit_label);
+
+
+            //check to make sure that the commentids are set
+            if (isset($commentids)) {
+                //get the current conflicts
+                $current_conflicts = getCurrentUnresolvedConflicts(
+                    $instrument, $visit_label
+                );
+                $detected_conflicts = detectConflicts(
+                    $instrument, $commentids, $current_conflicts
+                );
+
+                $new_conflicts = getNewConflicts(
+                    $current_conflicts, $detected_conflicts
+                );
+                $conflicts_to_be_excluded = detectConflictsTobeExcluded(
+                    $instrument, $commentids, $current_conflicts
+                );
+                /**
+                 * Only Create report for the  confliclits
+                 * 1) that should be inserted into the conflicts_unresolved table
+                 * 2) that should be deleted from the conflicts_unresolved table
+                 */
+                if ((!$change) && (!$change_all)) {
+
+                    //just show the conflicts
+                    print "This will only display the conflicts needed to
+                be inserted \n";
+                    print "To re-create the conflict, run this script with 
+                -c option \n";
+                    if ((empty($new_conflicts)) && empty($conflicts_to_be_excluded)) {
+                        print "No new conflicts or current conflicts to be
+                removed are detected for instrument $instrument \n";
+                    } else {
+                        writeCSV(
+                            $new_conflicts, $dataDir, $instrument, $visit_label,
+                            "Conflicts_to_be_inserted"
+                        );
+                        writeCSV(
+                            $conflicts_to_be_excluded, $dataDir, $instrument,
+                            $visit_label, "Conflicts_to_be_removed"
+                        );
+                    }
+                }
+                /**
+                 * Only insert those conflicts which are new and are not currently
+                 * in the conflict_uresolved
+                 * 1)remove/clear the existing conflicts
+                 * 2) And then re-create the conflicts
+                 */
+
+                ///if the instrument is not provided, run it only for all the instruments
+                if ($change) {
+                    if ((empty($new_conflicts)) || (!isset($new_conflicts))) {
+                        die("There are No new conflicts to be inserted ");
+                    }
+                    foreach ($new_conflicts as $conflict) {
+                        if (($conflict != null) && (!empty($conflict))) {
+                            ConflictDetector::clearConflictsForInstance(
+                                $conflict['CommentId1']
+                            ); ///clear the conflicts
+                        }
+                    }
+                    //////re-insert them into the table
+                    ConflictDetector::recordUnresolvedConflicts($new_conflicts);
+                }
+
+
+                /**
+                 * Remove all the current conflicts for the givent instrument/visit_label
+                 * And re-insert them
+                 */
+                if ($change_all) {
+                    foreach ($commentids as $cid) {
+                        ConflictDetector::clearConflictsForInstance($cid['CommentID']);
+                        $diff = ConflictDetector::detectConflictsForCommentIds(
+                            $test_name, $cid['CommentID'], $cid['DDECommentID']
+                        );
+                        ConflictDetector::recordUnresolvedConflicts($diff);
+                    }
+                }
+
+
+            }
+
+        } else {
+            die("the instrument is not set or there are no commentids \n");
+        }
     }
 }
 
@@ -503,4 +547,69 @@ function findConflict($conflict,$conflicts)
     }
     return false;
 }
-?>
+
+
+
+
+
+/**
+ * Populates the DDE ignore fields for each instrument and runs
+ * the ignoreColumn function on the instrument for the given fields
+ * @param $instruments
+ * @throws Exception
+ */
+function detectIgnoreColumns($instruments, $confirm)
+{
+    $instrumentFields = array();
+
+    foreach ($instruments as $instrument) {
+        $file = "../project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
+        if (file_exists($file)) {
+            include_once $file;
+            $commentids = getCommentIDs($instrument, null);
+            $instance =& NDB_BVL_Instrument::factory($instrument, $commentids[0]['CommentID'], null);
+            $DDEIgnoreFields = $instance->_doubleDataEntryDiffIgnoreColumns;
+
+            if ($DDEIgnoreFields != null) {
+                foreach ($DDEIgnoreFields as $key => $DDEField) {
+                    $instrumentFields = array_merge($instrumentFields, array($DDEField => $instrument));
+                }
+            } else {
+                echo "No DDE ignore fields found for " . $instrument;
+            }
+            ignoreColumn($instrument, $instrumentFields, $confirm);
+        }
+        else {
+            echo $file . " was not found.\n";
+        }
+    }
+}
+
+
+/*
+ * Prints the instrument-specific ignore columns to be removed
+ * Removes the fields if confirmation is set
+ */
+function ignoreColumn($instrument, $instrumentFields, $confirm) {
+    $db =& Database::singleton();
+
+    foreach ($instrumentFields as $field => $instr) {
+
+
+        $query = "SELECT TableName, FieldName, Value1, Value2 FROM conflicts_unresolved 
+          WHERE TableName = '$instrument' AND FieldName = '$field'";
+        $ignoreColumn = $db->pselectOne($query, array());
+
+        if (!empty($ignoreColumn)) {
+            $query = "SELECT TableName, FieldName, CommentId1, Value1, CommentId2, Value2 FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
+            $conflictsToRemove = $db->pselect($query, array());
+            print_r($conflictsToRemove);
+
+            if ($confirm) {
+                $query = "DELETE FROM conflicts_unresolved WHERE TableName = '$instrument' AND FieldName = '$field'";
+                $db->run($query);
+            }
+        }
+    }
+    echo "\n";
+}


### PR DESCRIPTION
When fields are added to the _doubleDataEntryDiffIgnoreColumns in an instrument after data entry has already been completed, the conflicts are not removed from the conflict resolver module.

This script removes those conflicts.