### PR TITLE
Fix bug where project modules couldn't override CSS

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -123,7 +123,9 @@ $paths = $config->getSetting('paths');
 if (!empty($TestName)) {
     // Get CSS for a module
     $base = $paths['base'];
-    if (file_exists($base . "modules/$TestName/css/$TestName.css")) {
+    if (file_exists($base . "modules/$TestName/css/$TestName.css")
+        || file_exists($base . "project/modules/$TestName/css/$TestName.css")
+    ) {
         if (strpos($_SERVER['REQUEST_URI'], "main.php") === false
             && strcmp($_SERVER['REQUEST_URI'], '/') != 0
         ) {


### PR DESCRIPTION
The main.php file was only checking for the existence of
$base/modules/$testname/css/$testname.css and not
$base/project/modules/$testname/css/$testname.css when
deciding if the template should automatically add the
module's CSS file.

This just adds a check for the existence of either file,
the GetCSS.php was already properly handling both cases.