### PR TITLE
Redmine 10184 - BVL Feedback Can Only Be Changed if bvl_feedback Permission

### DIFF
--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -335,7 +335,6 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
     	// get the current bvlqc type
     	$qcStatus = $this->getBVLQCStatus();
-        $complete = $this->getVisitStatus()=='Pass' || $this->getVisitStatus()=='Fail';
 
 		foreach($this->bvlQcTypes as $type){
 			$isSelected=$type == $this->getBVLQCType();
@@ -345,7 +344,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             	$this->tpl_data['bvl_qc_type_'.$type]['icon'] = 'selected';
             }
             //If a BVLQC status is not selected, and this type is not already chosen, show the link.
-            if(!$isSelected && empty($qcStatus) && $this->tpl_data['access']['bvl_qc'] && $complete){
+            if(!$isSelected && empty($qcStatus) && $this->tpl_data['access']['bvl_qc']){
             	$this->tpl_data['bvl_qc_type_'.$type]['showlink']=true;
             }
         }
@@ -360,7 +359,6 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
     	// get the current bvlqc type
     	$qcType = $this->getBVLQCType();
-        $complete = $this->getVisitStatus()=='Pass' || $this->getVisitStatus()=='Fail';
     	
 		foreach($this->bvlQcStatuses as $status){
 			$isSelected=$status == $this->getBVLQCStatus();
@@ -370,7 +368,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             	$this->tpl_data['bvl_qc_status_'.$status]['icon'] = 'selected';
             }
             //If a BVLQC type is selected, and this status is not already chosen, show the link.
-            if(!empty($qcType) && !$isSelected && $this->tpl_data['access']['bvl_qc'] && $complete){
+            if(!empty($qcType) && !$isSelected && $this->tpl_data['access']['bvl_qc']){
             	$this->tpl_data['bvl_qc_status_'.$status]['showlink']=true;
             }
         }

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -343,7 +343,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             	$this->tpl_data['bvl_qc_type_'.$type]['icon'] = 'selected';
             }
             //If a BVLQC status is not selected, and this type is not already chosen, show the link.
-            if(!$isSelected && empty($qcStatus)){ 
+            if(!$isSelected && empty($qcStatus) && $this->tpl_data['access']['bvl_qc']){
             	$this->tpl_data['bvl_qc_type_'.$type]['showlink']=true;
             }
         }
@@ -367,7 +367,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             	$this->tpl_data['bvl_qc_status_'.$status]['icon'] = 'selected';
             }
             //If a BVLQC type is selected, and this status is not already chosen, show the link.
-            if(!empty($qcType) && !$isSelected){ 
+            if(!empty($qcType) && !$isSelected && $this->tpl_data['access']['bvl_qc']){
             	$this->tpl_data['bvl_qc_status_'.$status]['showlink']=true;
             }
         }

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -335,6 +335,8 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
     	// get the current bvlqc type
     	$qcStatus = $this->getBVLQCStatus();
+        $complete = $this->getVisitStatus()=='Pass' || $this->getVisitStatus()=='Fail';
+
 		foreach($this->bvlQcTypes as $type){
 			$isSelected=$type == $this->getBVLQCType();
 			$type=strtolower($type);
@@ -343,7 +345,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             	$this->tpl_data['bvl_qc_type_'.$type]['icon'] = 'selected';
             }
             //If a BVLQC status is not selected, and this type is not already chosen, show the link.
-            if(!$isSelected && empty($qcStatus) && $this->tpl_data['access']['bvl_qc']){
+            if(!$isSelected && empty($qcStatus) && $this->tpl_data['access']['bvl_qc'] && $complete){
             	$this->tpl_data['bvl_qc_type_'.$type]['showlink']=true;
             }
         }
@@ -358,6 +360,7 @@ Class Instrument_List_ControlPanel extends TimePoint
     {
     	// get the current bvlqc type
     	$qcType = $this->getBVLQCType();
+        $complete = $this->getVisitStatus()=='Pass' || $this->getVisitStatus()=='Fail';
     	
 		foreach($this->bvlQcStatuses as $status){
 			$isSelected=$status == $this->getBVLQCStatus();
@@ -367,7 +370,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             	$this->tpl_data['bvl_qc_status_'.$status]['icon'] = 'selected';
             }
             //If a BVLQC type is selected, and this status is not already chosen, show the link.
-            if(!empty($qcType) && !$isSelected && $this->tpl_data['access']['bvl_qc']){
+            if(!empty($qcType) && !$isSelected && $this->tpl_data['access']['bvl_qc'] && $complete){
             	$this->tpl_data['bvl_qc_status_'.$status]['showlink']=true;
             }
         }

--- a/modules/instrument_list/test/TestPlan
+++ b/modules/instrument_list/test/TestPlan
@@ -7,9 +7,8 @@ Instrument List Test Plan
 5. Verify that the meta data for the candidate/visit is correct - eg DoB, Gender, Visit Label, Visit Status, etc
 6. Verify that BVL QC flags are working and only available if has bvl_feedback permission
 7. Verify that Visit can only be set after Data Entry (and DDE if applicable) is complete and conflicts are resolved
-8. Verify that BVL QC flags should not be modifiable if Visit has not been marked Pass/Fail (i.e. completed)
-9. Verify if Current Stage is Not Started, Start Next Stage is available if valid Timepoint
-10. Verify that Send to DCC is only available after Visit is marked as Pass/Failure/Withdrawal, and that user has 'send_to_dcc' permission
-11. Verify that 'unsend_to_dcc' permission is necessary to unsend to DCC
-12. Verify that breadcrumbs work
-13. Verify that values are correct for Visit Window
+8. Verify if Current Stage is Not Started, Start Next Stage is available if valid Timepoint
+9. Verify that Send to DCC is only available after Visit is marked as Pass/Failure/Withdrawal, and that user has 'send_to_dcc' permission
+10. Verify that 'unsend_to_dcc' permission is necessary to unsend to DCC
+11. Verify that breadcrumbs work
+12. Verify that values are correct for Visit Window


### PR DESCRIPTION
Currently, if you can access the page, BVL feedback can be changed
Now you need bvl_feedback permission to change it