### PR TITLE
Remove deprecated implicit testname.js loading from 17.0

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -568,20 +568,6 @@ class NDB_Page
                   $baseurl . '/bootstrap/js/bootstrap.min.js',
                   $baseurl . '/js/components/react.breadcrumb.js',
                  );
-        if (file_exists($paths['base'] . "modules/$TestName/js/$TestName.js")) {
-            error_log(
-                "WARNING: Relying on $TestName.js getting automatically loaded will"
-                . " soon be removed. "
-                . "Override getJSDependencies() instead"
-            );
-
-            if (strpos($_SERVER['REQUEST_URI'], "main.php") === false
-            ) {
-                $files[] = $baseurl . "/$TestName/js/$TestName.js";
-            } else {
-                $files[] = $baseurl . "/GetJS.php?Module=$TestName";
-            }
-        }
         return $files;
     }
 }


### PR DESCRIPTION
There's been a warning since (at least?) 15.10 telling people to use
getJSDependencies instead of relying on testname.js automatically
getting loaded to load module javascript files and claiming the feature
will be removed in a future release.

This removes the feature (and warning message) in the next
backwards incompatible release.