### PR TITLE
Update CentOS schema doc

### DIFF
--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -50,8 +50,10 @@ composer install --no-dev
 This details how to manual populate the MySQL database which is assumed
 to already exist (if not, create one before proceeding)
 
-Connect to MySQL, use your database and source the 
-`SQL/0000-00-00-schema.sql` file into it.
+Connect to MySQL, use your database and source all the files in the
+SQL/ directory of LORIS which are prefixed with `0000-00-` into it
+(ie `SQL/0000-00-00-schema.sql`, `SQL/0000-00-01-Permission.sql`, 
+`SQL/0000-00-02-Menus.sql`, etc.)
 
 There are a few settings in the Config module that LORIS currently depends
 on being updated to load correctly that must be set manually from MySQL as


### PR DESCRIPTION
The CentOS README was telling users to source the
0000-00-00-schema.sql schema file. This was outdated,
since the schema is now split into multiple files.

This pull request just updates the documentation to
reference all the 0000-00-*.sql files.

Fixes #1891