### PR TITLE
Move the Acknowledgement tab to Tools

### DIFF
--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -15,8 +15,7 @@ INSERT INTO LorisMenu (Label, OrderNumber) VALUES
      ('Imaging', 3), 
      ('Reports', 4), 
      ('Tools', 5), 
-     ('Admin', 6),
-     ('Acknowledgements', 7);
+     ('Admin', 6);
 
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
     ('New Profile', 'new_profile/', (SELECT ID FROM LorisMenu as L WHERE Label='Candidate'), 1),
@@ -46,7 +45,8 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Data Team Helper', 'data_team_helper/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 4),
     ('Instrument Builder', 'instrument_builder/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 5),
     ('Genomic Browser', 'genomic_browser/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 6),
-    ('Data Release', 'data_release/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 7);
+    ('Data Release', 'data_release/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 7),
+    ('Acknowledgements', 'acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 8);
 
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
     ('User Accounts', 'user_accounts/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 1),
@@ -56,8 +56,6 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Configuration', 'configuration/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 5),
     ('Server Processes Manager', 'server_processes_manager/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 6);
 
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
-    ('Acknowledgements','acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Acknowledgements'), 1);
 
 CREATE TABLE LorisMenuPermissions (
     MenuID integer unsigned REFERENCES LorisMenu(ID),

--- a/SQL/Archive/16.0/2016-06-08-MoveAcknowledgementsMenu.sql
+++ b/SQL/Archive/16.0/2016-06-08-MoveAcknowledgementsMenu.sql
@@ -1,2 +1,9 @@
+DELETE FROM LorisMenuPermissions WHERE MenuID IN (SELECT ID FROM LorisMenu WHERE Label='Acknowledgements'); 
 DELETE FROM LorisMenu WHERE Label='Acknowledgements'; -- deletes both top level and subitem
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES ('Acknowledgements','acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 8);
+
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
+    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='acknowledgements_view' AND m.Label='Acknowledgements';
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
+    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='acknowledgements_edit' AND m.Label='Acknowledgements';
+

--- a/SQL/Archive/16.0/2016-06-08-MoveAcknowledgementsMenu.sql
+++ b/SQL/Archive/16.0/2016-06-08-MoveAcknowledgementsMenu.sql
@@ -1,0 +1,2 @@
+DELETE FROM LorisMenu WHERE Label='Acknowledgements'; -- deletes both top level and subitem
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES ('Acknowledgements','acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 8);

--- a/SQL/Release_patches/15.10_To_16.0_upgrade.sql
+++ b/SQL/Release_patches/15.10_To_16.0_upgrade.sql
@@ -97,8 +97,7 @@ CREATE TABLE `acknowledgements` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO LorisMenu (Label, OrderNumber) VALUES ('Acknowledgements', 7);
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES ('Acknowledgements','/acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Acknowledgements'), 1);
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES ('Acknowledgements','/acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 8);
 
 INSERT INTO permissions (code,description,categoryID) VALUES ('acknowledgements_view','View Acknowledgements',2);
 INSERT INTO permissions (code,description,categoryID) VALUES ('acknowledgements_edit','Edit Acknowledgements',2);


### PR DESCRIPTION
This one module has a top level menu item to itself, and since the
name was so long it was causing the menu to wrap on lower screen
resolutions.

This moves the Acknowledgements item to the "Tools" menu and
gets rid of the top level menu, so that it fits on tablets and
lower resolution screens.