### PR TITLE
Add warning to Database->select wrapper

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -543,6 +543,11 @@ class Database
      */
     function select($query, &$result)
     {
+        error_log(
+            "LORIS's Database::select() wrappers are deprecated and will be "
+            . "removed in a future version of LORIS. Please use prepared statements "
+            . " in the Database::pselect() variety instead."
+        );
         $result = array();
 
         if (strpos(strtoupper($query), 'SELECT') !== 0


### PR DESCRIPTION
This adds a warning to the Database->select wrappers that shouldn't
be used anymore, so that people will know to update to the pselect
wrapper and we can remove them in LORIS 17.0.