### PR TITLE
Removed references to Password_md5, now that everyone is on PHP 5.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,16 @@ before_script:
     - mysql LorisTest < SQL/0000-00-04-Help.sql
     - mysql LorisTest < docs/instruments/radiology_review.sql
     - mysql LorisTest -u root -e "GRANT UPDATE,INSERT,SELECT,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'localhost' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION"
-    - mysql LorisTest -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aatestpass')), Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
     - cp docs/config/config.xml project/config.xml
     - cp docs/config/config.xml test/config.xml
     - sed -i -e "s/%HOSTNAME%/127.0.0.1/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" project/config.xml
     - sed -i -e "s/%HOSTNAME%/127.0.0.1/g" -e "s/%USERNAME%/SQLTestUser/g" -e "s/%PASSWORD%/TestPassword/g" -e "s/%DATABASE%/LorisTest/g" test/config.xml
+    # Set the admin account password to a known value for testing. This needs to be done
+    # after the config.xml is setup.
+    - cd tools
+    - echo "testpass" | php ./resetpassword.php admin
+    - mysql LorisTest -e "UPDATE users SET Pending_approval='N', Password_expiry='2100-01-01' WHERE ID=1"
+    - cd ..
     - mysql LorisTest -e "UPDATE Config SET Value='$(pwd)/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
     - mysql LorisTest -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
 

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1322,7 +1322,6 @@ CREATE TABLE `users` (
   `PSCPI` enum('Y','N') NOT NULL default 'N',
   `DBAccess` varchar(10) NOT NULL default '',
   `Active` enum('Y','N') NOT NULL default 'Y',
-  `Password_md5` varchar(34) default NULL,
   `Password_hash` varchar(255) default NULL,
   `Password_expiry` date NOT NULL default '1990-04-01',
   `Pending_approval` enum('Y','N') default 'Y',
@@ -1338,8 +1337,8 @@ CREATE TABLE `users` (
 
 LOCK TABLES `users` WRITE;
 /*!40000 ALTER TABLE `users` DISABLE KEYS */;
-INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Password_md5,Pending_approval,Password_expiry)
-VALUES (1,'admin','Admin account','Admin','account','admin@localhost',0,'N','','Y','4817577f267cc8bb20c3e58b48a311b9f6','N','2016-03-30');
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expiry)
+VALUES (1,'admin','Admin account','Admin','account','admin@localhost',0,'N','','Y','N','2016-03-30');
 /*!40000 ALTER TABLE `users` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1337,8 +1337,13 @@ CREATE TABLE `users` (
 
 LOCK TABLES `users` WRITE;
 /*!40000 ALTER TABLE `users` DISABLE KEYS */;
+<<<<<<< HEAD
 INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expiry)
 VALUES (1,'admin','Admin account','Admin','account','admin@localhost',0,'N','','Y','N','2016-03-30');
+=======
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,CenterID,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expiry)
+VALUES (1,'admin','Admin account','Admin','account','admin@example.com',1,0,'N','','Y','N','2016-03-30');
+>>>>>>> Changed all the gmail.coms to example.coms in the user accounts tests
 /*!40000 ALTER TABLE `users` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/SQL/2016-06-08-RemovePasswordMD5.sql
+++ b/SQL/2016-06-08-RemovePasswordMD5.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN Password_md5;

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -56,7 +56,7 @@ $(document).ready(function() {
 	        <li class="error">{$k}: k{$error}</li>
 	    </ul>
     {/foreach} -->
-    <!-- <div class="row""> -->
+    <!-- <div class="row"> -->
         {if $form.errors.UserID_Group}
     	<div class="row form-group form-inline form-inline has-error">
         {else}

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -35,7 +35,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                                     'Data Coordinating Center',
                                     'admin',
                                     'Admin account',
-                                    'admin@localhost',
+                                    'admin@example.com',
                                     'Y',
                                     'N',
                                    );

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -69,7 +69,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $this->assertEquals(
             "password",
             $this->safeFindElement(
-                WebDriverBy::Name("Password_md5")
+                WebDriverBy::Name("Password_hash")
             )->getAttribute("type")
         );
         $this->assertEquals(

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -138,7 +138,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             'user_accounts',
             'UnitTester',
             'Email',
-            'newemail@gmail.com'
+            'newemail@example.com'
         );
         $this->_verifyUserModification(
             'user_accounts',
@@ -170,7 +170,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             'user_accounts/my_preferences',
             'UnitTester',
             'Email',
-            'newemail@gmail.com'
+            'newemail@example.com'
         );
     }
     /**
@@ -199,10 +199,10 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $field->sendKeys('last');
         $field = $this->safeFindElement(WebDriverBy::Name('Email'));
         $field->clear();
-        $field->sendKeys('email@gmail.com');
+        $field->sendKeys('email@example.com');
         $field = $this->safeFindElement(WebDriverBy::Name('__ConfirmEmail'));
         $field->clear();
-        $field->sendKeys('email@gmail.com');
+        $field->sendKeys('email@example.com');
         $this->safeClick(WebDriverBy::Name('SendEmail'));
         $this->safeClick(WebDriverBy::Name('fire_away'));
         $this->_accessUser('user_accounts', 'userid');
@@ -211,7 +211,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $field = $this->safeFindElement(WebDriverBy::Name('Last_name'));
         $this->assertEquals($field->getAttribute('value'), 'last');
         $field = $this->safeFindElement(WebDriverBy::Name('Email'));
-        $this->assertEquals($field->getAttribute('value'), 'email@gmail.com');
+        $this->assertEquals($field->getAttribute('value'), 'email@example.com');
     }
 
     /**

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -182,7 +182,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     {
         $this->safeGet($this->url . "/user_accounts/");
         $this->safeClick(WebDriverBy::Name('button'));
-        $field = $this->safeFindElement(WebDriverBy::Name('userID'));
+        $field = $this->safeFindElement(WebDriverBy::Name('UserID'));
         $field->clear();
         $field->sendKeys('userid');
 

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -182,7 +182,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     {
         $this->safeGet($this->url . "/user_accounts/");
         $this->safeClick(WebDriverBy::Name('button'));
-        $field = $this->safeFindElement(WebDriverBy::Name('UserID'));
+        $field = $this->safeFindElement(WebDriverBy::Name('userID'));
         $field->clear();
         $field->sendKeys('userid');
 

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -216,21 +216,8 @@ class SinglePointLogin
                . ' the passwords do not match';
         }
 
-        // Keeping the same password is not allowed
-        // 1. If we are using PHP >= 5.5 and user has a value in column
-        // Password_hash then use function password_verify to make sure that the
-        // password changed
-        // 2. If we are using PHP < 5.5 or if there is no value in column
-        // Password_hash for the user, use "old" MD5Unsalt to make sure password
-        // changed
-        if (function_exists('password_verify') && !empty($data['Password_hash'])) {
-            if (password_verify($_POST['password'], $data['Password_hash'])) {
-                $this->_lastError = 'You cannot keep the same password';
-            }
-        } else {
-            if (User::MD5Unsalt($_POST['password'], $data['Password_md5'])) {
-                $this->_lastError = 'You cannot keep the same password';
-            }
+        if (password_verify($_POST['password'], $data['Password_hash'])) {
+            $this->_lastError = 'You cannot keep the same password';
         }
 
         // if errors
@@ -413,7 +400,6 @@ class SinglePointLogin
 
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
-                        Password_md5,
                         Password_expiry,
                         Active,
                         Pending_approval,
@@ -424,29 +410,10 @@ class SinglePointLogin
         $row   = $DB->pselectRow($query, array('username' => $username));
 
         if ($row['User_count'] == 1) {
-            // validate the user
-
-            // Check if the PHP 5.5 password hashing API is available.
-            $php55 = false;
-            if (function_exists("password_verify")) {
-                $php55 = true;
-            }
-
-            // If either the password hashing isn't available, or the
-            // Password_hash column is empty, we check using Loris's old
-            // MD5Unsalt method that the passwords are equal.
-            //
-            // If there is a saved Password_hash, then we verify using the
-            // PHP 5.5+ password hashing API.
+            // validate passsword
             $oldhash = $row['Password_hash'];
-            if (((!$php55 || empty($oldhash))
-                && User::MD5Unsalt($password, $row['Password_md5']))
-                || ($php55 && password_verify($password, $oldhash))
-            ) {
-                if ($php55
-                    && (empty($oldhash)
-                    || password_needs_rehash($oldhash, PASSWORD_DEFAULT))
-                ) {
+            if (password_verify($password, $oldhash)) {
+                if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
                     $user =& User::factory($username);
                     $user->updatePassword($password);
                 }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -273,46 +273,6 @@ class User extends UserPermissions
         return true;
     }
 
-
-    /**
-     * Makes an md5 hash with a salt
-     *
-     * @param string $word The word to hash
-     *
-     * @return string
-     * @access public
-     * @static
-     */
-    static function MD5Salt($word)
-    {
-        // get a two-character hexadecimal salt from 10 to ff
-        $salt = dechex(rand(16, 255));
-
-        // return the salted md5 hash
-        return $salt . md5($salt . $word);
-    }
-
-
-    /**
-     * Checks an md5 salt
-     *
-     * @param string $word The word to compare to the hash
-     * @param string $hash The hash
-     *
-     * @return boolean
-     * @access public
-     * @static
-     */
-    static function MD5Unsalt($word, $hash)
-    {
-        // get the first two characters of the hash
-        $salt = substr($hash, 0, 2);
-
-        // return whether the hash matches the word
-        return ($salt . md5($salt . $word) == $hash);
-    }
-
-
     /**
      * Generates a random alphanumeric password
      *
@@ -443,12 +403,6 @@ class User extends UserPermissions
      */
     function updatePassword($password, $expiry = null)
     {
-        // Check if the PHP 5.5 password hashing API is available.
-        $php55 = false;
-        if (function_exists("password_verify")) {
-            $php55 = true;
-        }
-
         if (is_null($expiry)) {
             $expiry = date(
                 'Y-m-d',
@@ -458,18 +412,11 @@ class User extends UserPermissions
 
         $updateArray = array('Password_expiry' => $expiry);
 
-        // Update the appropriate password field, null the other one
-        // for security.
-        if ($php55) {
-            $updateArray['Password_hash'] = password_hash(
-                $password,
-                PASSWORD_DEFAULT
-            );
-            $updateArray['Password_MD5']  = null;
-        } else {
-            $updateArray['Password_hash'] = null;
-            $updateArray['Password_MD5']  = User::MD5Salt($password);
-        }
+        $updateArray['Password_hash'] = password_hash(
+            $password,
+            PASSWORD_DEFAULT
+        );
+        
 
         $this->update($updateArray);
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -416,7 +416,6 @@ class User extends UserPermissions
             $password,
             PASSWORD_DEFAULT
         );
-        
 
         $this->update($updateArray);
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,7 +77,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
              'Privilege'        => 0,
              'PSCPI'            => 'N',
              'Active'           => 'Y',
-             'Password_hash'    => null,
+             'Password_hash'    => password_hash("4test4", PASSWORD_DEFAULT),
              'Password_expiry'  => '2099-12-31',
              'Pending_approval' => 'N',
             )

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,7 +77,6 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
              'Privilege'        => 0,
              'PSCPI'            => 'N',
              'Active'           => 'Y',
-             'Password_md5'     => 'a601e42ba82bb37a68ca3c8b7752f2e222',
              'Password_hash'    => null,
              'Password_expiry'  => '2099-12-31',
              'Pending_approval' => 'N',

--- a/tools/resetpassword.php
+++ b/tools/resetpassword.php
@@ -1,0 +1,49 @@
+#!/usr/bin/php
+<?php
+/**
+ * This script resets a user's password. It assumes it's being
+ * run by an administer on the server and doesn't validate the
+ * user's password, just blindly resets it.
+ *
+ * PHP Version 5
+ *
+ * @category Tools
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "generic_includes.php";
+$args = $argv;
+if ($args[0] == 'php') {
+	$args = array_slice($argv, 1);
+}
+if (count($args) < 2) {
+	fwrite(STDERR, "Usage: resetpassword.php username\n");
+	fwrite(STDERR, "\nresetpassword.php will prompt for password on stdin\n");
+	exit(2);
+}
+
+$user = $args[1];
+
+$validate = $DB->pselectOne("SELECT UserID FROM users WHERE UserID=:username", array("username" => $user));
+if (empty($validate)) {
+	fwrite(STDERR, "Invalid username: $user\n");
+	exit(3);
+}
+echo "Resetting password for user: $user\n";
+echo "New password: ";
+
+// Don't echo the password being typed
+`/bin/stty -echo`;
+$newPass = trim(fgets(STDIN));
+$newHash = password_hash($newPass, PASSWORD_DEFAULT);
+`/bin/stty echo`;
+
+;
+
+// this script is assumed to be being run by an admin, since they have local
+// access to the server. There's no validation of the old password.
+$DB->update("users", array("Password_hash" => $newHash), array("UserID" => $user));
+echo "\nUpdated password for $user\n";


### PR DESCRIPTION
The minimum version requirement for LORIS 16.0 was 5.6. This means that,
by 17.0, everyone should have been running on it for a while, and the old
Password_md5 column which was only maintained for compatability with (very) old
versions of PHP that don't have access to the PHP password hashing API is
no longer needed.

This removes the column and code which was only in place as a workaround,
greatly simplifying the logic (and improving the security.)
