### PR TITLE
Updated dashboard queries to exclude DCC and cancelled candidates

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -94,7 +94,11 @@ class NDB_Form_Dashboard extends NDB_Form
 
         // Charts
         $this->tpl_data['total_scans'] = $DB->pselectOne(
-            "SELECT COUNT(*) FROM files f",
+            "SELECT COUNT(*) FROM files f
+		LEFT JOIN session s ON (s.ID=f.SessionID)
+		LEFT JOIN candidate c ON (s.CandID=c.CandID)
+		WHERE s.Active='Y' AND c.Active='Y'
+			AND s.CenterID <> 1",
             array()
         );
 
@@ -107,7 +111,10 @@ class NDB_Form_Dashboard extends NDB_Form
                  FROM files f 
                  LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID)
                  LEFT JOIN session s ON (s.ID=f.SessionID)
-                 WHERE fqc.QCStatus IS NULL",
+		LEFT JOIN candidate c ON (s.CandID=c.CandID)
+                 WHERE fqc.QCStatus IS NULL
+			AND s.Active='Y' AND c.Active='Y'
+			AND s.CenterID <> 1",
                 array()
             );
             $this->tpl_data['new_scans_site'] = 'Site: all';
@@ -117,7 +124,12 @@ class NDB_Form_Dashboard extends NDB_Form
         if ($user->hasPermission('conflict_resolver')) {
             if ($user->hasPermission('access_all_profiles')) {
                 $this->tpl_data['conflicts']      = $DB->pselectOne(
-                    "SELECT COUNT(*) FROM conflicts_unresolved",
+                    "SELECT COUNT(*) FROM conflicts_unresolved cu
+                    LEFT JOIN flag ON (cu.CommentId1=flag.CommentID) 
+                     LEFT JOIN session s ON (flag.SessionID=s.ID)
+			LEFT JOIN candidate c ON (s.CandID=c.CandID)
+                      WHERE s.CenterID <> 1
+			AND s.Active='Y' AND c.Active='Y'",
                     array()
                 );
                 $this->tpl_data['conflicts_site'] = 'Site: all';
@@ -125,9 +137,11 @@ class NDB_Form_Dashboard extends NDB_Form
                 $this->tpl_data['conflicts']      = $DB->pselectOne(
                     "SELECT COUNT(*) FROM conflicts_unresolved cu 
                      LEFT JOIN flag ON (cu.CommentId1=flag.CommentID) 
-                     LEFT JOIN session s ON (flag.SessionID=s.ID) 
+                     LEFT JOIN session s ON (flag.SessionID=s.ID)
+		     LEFT JOIN candidate c ON (c.CandID=s.CandID)
                      LEFT JOIN psc ON (psc.CenterID=s.CenterID) 
-                     WHERE psc.Name=:Site",
+                     WHERE psc.Name=:Site
+			s.Active='Y' AND c.Active='Y'",
                     array('Site' => $site)
                 );
                 $this->tpl_data['conflicts_site'] = 'Site: ' . $site;
@@ -138,16 +152,21 @@ class NDB_Form_Dashboard extends NDB_Form
         if ($user->hasPermission('data_entry')) {
             if ($user->hasPermission('access_all_profiles')) {
                 $this->tpl_data['incomplete_forms']      = $DB->pselectOne(
-                    "SELECT COUNT(*) FROM flag WHERE Data_entry='In Progress'",
+                    "SELECT COUNT(*) FROM flag
+			LEFT JOIN session s ON (s.ID=flag.SessionID)
+			LEFT JOIN candidate c ON (s.CandID=c.CandID)
+		     WHERE flag.Data_entry='In Progress' AND s.Active='Y' AND c.Active='Y' AND s.CenterID <> 1",
                     array()
                 );
                 $this->tpl_data['incomplete_forms_site'] = 'Site: all';
             } else {
                 $this->tpl_data['incomplete_forms']      = $DB->pselectOne(
                     "SELECT COUNT(*) FROM flag 
-                    LEFT JOIN session s ON (flag.SessionID=s.ID) 
+                    LEFT JOIN session s ON (flag.SessionID=s.ID)
+			LEFT JOIN candidate c ON (s.CandID=c.CandID)
                     LEFT JOIN psc ON (psc.CenterID=s.CenterID) 
-                    WHERE Data_entry='In Progress' AND psc.Name=:Site",
+                    WHERE Data_entry='In Progress' AND psc.Name=:Site
+			s.Active='Y' AND c.Active='Y'",
                     array('Site' => $site)
                 );
                 $this->tpl_data['incomplete_forms_site'] = 'Site: ' . $site;
@@ -159,8 +178,12 @@ class NDB_Form_Dashboard extends NDB_Form
             && $user->hasPermission('view_final_radiological_review')
         ) {
             $this->tpl_data['radiology_review']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM final_radiological_review f 
-                WHERE Review_Done IS NULL",
+                "SELECT COUNT(*) FROM final_radiological_review f
+			LEFT JOIN flag fg ON (fg.CommentID=f.CommentID)
+			LEFT JOIN session s ON (s.ID=fg.SessionID)
+			LEFT JOIN candidate c ON (c.CandID=s.CandID)
+                WHERE Review_Done IS NULL
+			AND c.Active='Y' AND s.Active='Y'",
                 array()
             );
             $this->tpl_data['radiology_review_site'] = 'Site: all';
@@ -171,7 +194,7 @@ class NDB_Form_Dashboard extends NDB_Form
             && $user->hasPermission('user_accounts')
         ) {
             $this->tpl_data['pending_users']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM users WHERE Pending_approval='Y'",
+                "SELECT COUNT(*) FROM users WHERE Pending_approval='Y' AND CenterID <> 1",
                 array()
             );
             $this->tpl_data['pending_users_site'] = 'Site: all';
@@ -187,7 +210,10 @@ class NDB_Form_Dashboard extends NDB_Form
         // Violated scans
         if ($user->hasPermission('violated_scans_view_allsites')) {
             $this->tpl_data['violated_scans']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM mri_protocol_violated_scans",
+                "SELECT COUNT(*) FROM mri_protocol_violated_scans
+			LEFT JOIN candidate c USING (CandID)
+		WHERE COALESCE(c.CenterID, 0) <> 1", /* include null CenterIDs so we don't accidentally
+						    filter things out */
                 array()
             );
             $this->tpl_data['violated_scans_site'] = 'Site: all';
@@ -224,7 +250,7 @@ class NDB_Form_Dashboard extends NDB_Form
         $DB = Database::singleton();
         $totalRecruitment = $DB->pselectOne(
             "SELECT COUNT(*) FROM candidate c
-             WHERE c.Active='Y' AND c.Entity_type='Human' AND c.CenterID!=1",
+             WHERE c.Active='Y' AND c.Entity_type='Human' AND c.CenterID <> 1",
             array()
         );
         return $totalRecruitment;
@@ -244,7 +270,7 @@ class NDB_Form_Dashboard extends NDB_Form
             "SELECT COUNT(*)
              FROM candidate c
              WHERE c.Active='Y' AND c.ProjectID=:PID AND c.Entity_type='Human'
-             AND c.CenterID!=1",
+             AND c.CenterID <> 1",
             array('PID' => $projectID)
         );
         return $totalRecruitment;
@@ -264,7 +290,7 @@ class NDB_Form_Dashboard extends NDB_Form
             "SELECT COUNT(c.CandID)
              FROM candidate c
              WHERE c.Gender=:Gender AND c.Active='Y' AND c.Entity_type='Human'
-             AND c.CenterID!=1",
+             AND c.CenterID <> 1",
             array('Gender' => $gender)
         );
         return $total;
@@ -286,7 +312,7 @@ class NDB_Form_Dashboard extends NDB_Form
             "SELECT COUNT(c.CandID)
              FROM candidate c
              WHERE c.Gender=:Gender AND c.Active='Y' AND c.ProjectID=:PID
-             AND c.Entity_type='Human' AND c.CenterID!=1",
+             AND c.Entity_type='Human' AND c.CenterID <> 1",
             array(
              'Gender' => $gender,
              'PID'    => $projectID,

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -155,7 +155,8 @@ class NDB_Form_Dashboard extends NDB_Form
                     "SELECT COUNT(*) FROM flag
 			LEFT JOIN session s ON (s.ID=flag.SessionID)
 			LEFT JOIN candidate c ON (s.CandID=c.CandID)
-		     WHERE flag.Data_entry='In Progress' AND s.Active='Y' AND c.Active='Y' AND s.CenterID <> 1",
+		     WHERE flag.Data_entry='In Progress'
+			AND s.Active='Y' AND c.Active='Y' AND s.CenterID <> 1",
                     array()
                 );
                 $this->tpl_data['incomplete_forms_site'] = 'Site: all';
@@ -194,7 +195,8 @@ class NDB_Form_Dashboard extends NDB_Form
             && $user->hasPermission('user_accounts')
         ) {
             $this->tpl_data['pending_users']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM users WHERE Pending_approval='Y' AND CenterID <> 1",
+                "SELECT COUNT(*) FROM users
+		WHERE Pending_approval='Y' AND CenterID <> 1",
                 array()
             );
             $this->tpl_data['pending_users_site'] = 'Site: all';
@@ -209,11 +211,12 @@ class NDB_Form_Dashboard extends NDB_Form
 
         // Violated scans
         if ($user->hasPermission('violated_scans_view_allsites')) {
-            $this->tpl_data['violated_scans']      = $DB->pselectOne(
+            $this->tpl_data['violated_scans'] = $DB->pselectOne(
                 "SELECT COUNT(*) FROM mri_protocol_violated_scans
 			LEFT JOIN candidate c USING (CandID)
-		WHERE COALESCE(c.CenterID, 0) <> 1", /* include null CenterIDs so we don't accidentally
-						    filter things out */
+		WHERE COALESCE(c.CenterID, 0) <> 1",
+                /* include null CenterIDs so we don't accidentally
+                filter things out */
                 array()
             );
             $this->tpl_data['violated_scans_site'] = 'Site: all';


### PR DESCRIPTION
Candidates (or sessions) with Active='N' aren't real candidates,
they should effectively be considered deleted.

On top of that, DCC candidates are usually "fake" candidates used
for testing or mocking instruments.

This removes them from the stats on the dashboard.