### PR TITLE
Make DICOM Archive site list consistent

### DIFF
--- a/modules/dicom_archive/php/NDB_Menu_Filter_dicom_archive.class.inc
+++ b/modules/dicom_archive/php/NDB_Menu_Filter_dicom_archive.class.inc
@@ -169,7 +169,7 @@ class NDB_Menu_Filter_Dicom_Archive extends NDB_Menu_Filter
     function _setFilterForm()
     {
         $list_of_sites = array('' => 'All');
-        $sitesList = Utility::getSiteList(false);
+        $sitesList = Utility::getSiteList();
 
         foreach ($sitesList as $key=>$value) {
             $list_of_sites[$key]= $value;


### PR DESCRIPTION
The DICOM Archive module is including all sites in the site filter
dropdown, while every other module only includes study sites. This
updates the criteria to only include study sites for consistency
across LORIS.