### PR TITLE
Redmine 9427 - Add Radiology Review Conflicts to DQT

### DIFF
--- a/tools/CouchDB_Import_RadiologicalReview.php
+++ b/tools/CouchDB_Import_RadiologicalReview.php
@@ -68,6 +68,14 @@ class CouchDBRadiologicalReviewImporter {
         'ExtraReview_Comment' => array(
             'Description' => 'Current stage of visit',
             'Type' => "enum('Not Started','Screening','Visit','Approval','Subject','Recycling Bin')"
+        ),
+        'Conflict_Final_Extra' => array(
+            'Description' => 'Conflict between final and extra reviews',
+            'Type' => "enum('No','Yes')"
+        ),
+        'Conflict_Any' => array(
+            'Description' => 'Conflict between any reviews',
+            'Type' => "enum('No','Yes')"
         )
     );
 
@@ -120,7 +128,19 @@ class CouchDBRadiologicalReviewImporter {
             WHEN frr.PVS2=3 THEN 'Moderate' 
             WHEN frr.PVS2=4 THEN 'Marker' END as ExtraReview_PVS, 
             frr.Final_Exclusionary2 AS ExtraReview_ExclusionaryStatus,
-            frr.Final_Incidental_Findings2 AS ExtraReview_Comment
+            frr.Final_Incidental_Findings2 AS ExtraReview_Comment,
+            CASE WHEN orig.review_results <> r.final_review_results THEN 'true'
+            WHEN orig.abnormal_atypical_exclusionary <> r.final_exclusionary  THEN 'true'
+            WHEN r.Final_Review_Results <> r.Final_Review_Results2 THEN 'true'
+            WHEN r.Final_Exclusionary <> r.Final_Exclusionary2 THEN 'true'
+            WHEN r.SAS <> r.SAS2 THEN 'true'
+            WHEN r.PVS <> r.PVS2 THEN 'true'
+            ELSE 'false' END as Conflict_Final_Extra,
+            CASE WHEN r.Final_Review_Results <> r.Final_Review_Results2 THEN 'prim_second'
+            WHEN r.Final_Exclusionary <> r.Final_Exclusionary2 THEN 'prim_second'
+            WHEN r.SAS <> r.SAS2 THEN 'prim_second'
+            WHEN r.PVS <> r.PVS2 THEN 'prim_second'
+            ELSE 'false' END as Conflict_Any
             FROM final_radiological_review frr
             LEFT JOIN flag f ON (f.CommentID=frr.CommentID) 
             LEFT JOIN session s ON (s.ID=f.SessionID) 


### PR DESCRIPTION
"The field "conflict" - indicating there is a conflict between the 2 radiologists review, is missing from the DQT."