### PR TITLE
Remove 'stage' from Get Battery Function

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -324,8 +324,7 @@ class NDB_BVL_Battery
             AND LEFT(f.CommentID, 3) != 'DDE'";
 
         if (!is_null($stage)) {
-            $query         .= " AND t.Test_name=b.Test_name AND b.Stage=:stg";
-            $qparams['stg'] = $stage;
+            $query         .= " AND t.Test_name=b.Test_name";
 
             if (!is_null($SubprojectID)) {
                 $query .= " AND (

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -324,7 +324,7 @@ class NDB_BVL_Battery
             AND LEFT(f.CommentID, 3) != 'DDE'";
 
         if (!is_null($stage)) {
-            $query         .= " AND t.Test_name=b.Test_name";
+            $query .= " AND t.Test_name=b.Test_name";
 
             if (!is_null($SubprojectID)) {
                 $query .= " AND (


### PR DESCRIPTION
In cases where the candidate has multiple stages (i.e. Staging and Visit), current_stage is set to multiple stages but only one is queried in getBatteryVerbose, so the appropriate instruments do not show up in the instrument list.