### PR TITLE
Readme updates - MySQL and heroku

### DIFF
--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -33,8 +33,9 @@ curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer
 ```
 
-Note that the version of PHP installed by CentOS 6.x doesn't meet the minimum requirements of many development dependencies.
-As a result, you need to either upgrade your version of PHP to 5.6 for LORIS 16.0
+Note that the default dependencies installed by CentOS 6.x may not meet the version requirements LORIS deployment or development.
+* MySQL 5.5 or lower is supported for LORIS 16.0
+* PHP 5.6 (or 5.5) is required for LORIS 16.0 - upgrade your PHP manually
 Or run composer with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
 assume you just want to get it running, so we'll run it with `--no-dev`.)
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,11 @@ This Readme covers installation of the <b>16.0</b> LORIS release on <b>Ubuntu</b
 
 Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information not included in this Readme. The [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) may also provide installation guidance not covered in the Wiki. 
 
-<b>⇾  Deploy on Heroku</b>
-As an alternative to installing LORIS on your system (per instructions below), LORIS can now be deployed on Heroku.
-Note: Your default credentials after deployment will be 'admin' as the username and your password will be the uniquely generated password used by ClearDB.
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
-
 # Prerequisites for Installation
 
  * LINUX (supported on Ubuntu 14.04 and [CentOS 6.5](https://github.com/aces/Loris/blob/16.04-dev/README.CentOS6.md)) 
  * Apache2 (libapache2-mod-php5)
- * MySQL (libmysqlclient15-dev mysql-client mysql-server)
+ * MySQL 5.5 or lower (libmysqlclient15-dev mysql-client mysql-server)
  * PHP <b>5.6</b> (php5 php5-mysql php5-gd php5-sqlite)
  * php5-json (for Debian/Ubuntu distributions)
  * Package manager (for LINUX distributions)
@@ -24,6 +19,7 @@ Note: Your default credentials after deployment will be 'admin' as the username 
 
 <b>Important:</b>
  * Only PHP <b>5.6</b> is supported for LORIS 16.0. We recommend installing/upgrading PHP using this (deprecated) PPA repository: <i>ppa:ondrej/php5-5.6 </i>
+ * MySQL 5.7 is not supported for LORIS 16.0 and will cause errors when loading LORIS.  MySQL 5.5 or lower (5.*) is recommmended.  
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information.


### PR DESCRIPTION
- Since heroku needs tweaking for 16.* : removing heroku text from main (Ubuntu) Readme for now
- MySQL 5.* but only 5.5- will work with Loris.  i.e. not MySQL 5.7. Updating both Ubuntu and CentOS readmes with this information. 