### PR TITLE
Added getCSSDependencies to parallel getJSDependencies

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -193,7 +193,8 @@ try {
     }
 
     if (isset($caller->page)) {
-        $tpl_data['jsfiles'] = $caller->page->getJSDependencies();
+        $tpl_data['jsfiles']  = $caller->page->getJSDependencies();
+        $tpl_data['cssfiles'] = $caller->page->getCSSDependencies();
     }
 
     $tpl_data['workspace'] = $workspace;

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -586,5 +586,44 @@ class NDB_Page
         }
         return $files;
     }
+
+
+    /**
+     * Returns an ordered list of CSS dependencies that this page depends
+     * on.  These will get loaded into the template in order, so that
+     * interdependent files can be included in the correct order.
+     *
+     * @return array of strings with URLs to retrieve CSS resources
+     */
+    function getCSSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $config  = $factory->config();
+
+        $www     = $config->getSetting('www');
+        $baseurl = $www['url'];
+
+        $paths = $config->getSetting("paths");
+
+        $TestName = $this->name;
+
+        $files = array(
+                  $baseurl . "/bootstrap/css/bootstrap.min.css",
+                  $baseurl . "/bootstrap/css/custom-css.css",
+                 );
+
+        if (file_exists($paths['base'] . "modules/$TestName/css/$TestName.css")) {
+            error_log(
+                "WARNING: Relying on $TestName.css getting automatically loaded will"
+                . " soon be removed. "
+                . "Override getCSSDependencies() instead"
+            );
+
+            $files[] = $baseurl . "/$TestName/js/$TestName.css";
+        }
+
+        return $files;
+    }
+
 }
 ?>

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -24,14 +24,9 @@
    
         <link type="text/css" href="{$baseurl}/css/loris-jquery/jquery-ui-1.10.4.custom.min.css" rel="Stylesheet" />
 
-        <!-- Latest compiled and minified CSS -->
-        <link rel="stylesheet" href="{$baseurl}/bootstrap/css/bootstrap.min.css">
-        <link rel="stylesheet" href="{$baseurl}/bootstrap/css/custom-css.css">
-
-        <!-- Module-specific CSS -->
-        {if $test_name_css}
-            <link rel="stylesheet" href="{$baseurl}/{$test_name_css}" type="text/css" />
-        {/if}
+	{section name=cssfile loop=$cssfiles}
+		<link rel="stylesheet" href="{$cssfiles[cssfile]}">
+	{/section}
 
         <title>
             {$study_title}


### PR DESCRIPTION
This makes it easier for modules to add custom CSS.

This should just rework how the code works, not what it does and should be backwards compatible.