### PR TITLE
Correct order of files in Imaging Uploader Progress column when Success

### DIFF
--- a/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
+++ b/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
@@ -203,7 +203,7 @@
                             {if $items[item][piece].value}
                                 <td nowrap="nowrap">
                                         {if {$items[item][piece].value} eq 'Success'}
-                                            {$items[item][piece].value} ({$items[item][10].value} out of {$items[item][11].value})
+                                            {$items[item][piece].value} ({$items[item][11].value} out of {$items[item][10].value})
                                         {else}
                                             {$items[item][piece].value}
                                         {/if}


### PR DESCRIPTION
Success (X out of Y) where X is the number of MincInserted column and Y is the number of MIncCreated column (not the other way around!)