### PR TITLE
Fix static column index in columnFormater.js

### DIFF
--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -191,7 +191,7 @@ StaticDataTable = React.createClass({
                     data = "Unknown";
                 }
                 if (this.props.getFormattedCell) {
-                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx]);
+                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx], this.props.Headers);
                     curRow.push({ data });
                 } else {
                     curRow.push(React.createElement(
@@ -309,5 +309,3 @@ StaticDataTable = React.createClass({
 });
 
 RStaticDataTable = React.createFactory(StaticDataTable);
-
-//# sourceMappingURL=StaticDataTable.js.map

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -167,7 +167,7 @@ StaticDataTable = React.createClass({
                     data = "Unknown";
                 }
                 if (this.props.getFormattedCell) {
-                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx]);
+                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx], this.props.Headers);
                     curRow.push({data});
                 } else {
                     curRow.push(<td>{data}</td>);

--- a/modules/imaging_browser/js/columnFormatter.js
+++ b/modules/imaging_browser/js/columnFormatter.js
@@ -1,48 +1,70 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'SessionID') {
-        return null;
-    }
-    if (column === 'New Data') {
-        if (cell === 'new') {
-            return React.createElement(
-                'td',
-                { className: 'newdata' },
-                'NEW'
-            );
+function formatColumn(column, cell, rowData, rowHeaders) {
+    reactElement = null;
+
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+
+        var row = {};
+        rowHeaders.forEach(function (header, index) {
+            row[header] = rowData[index];
+        }, this);
+
+        switch (column) {
+            case 'New Data':
+                if (cell === 'new') {
+                    reactElement = React.createElement(
+                        'td',
+                        { className: 'newdata' },
+                        'NEW'
+                    );
+                } else {
+                    reactElement = React.createElement('td', null);
+                }
+                break;
+            case 'Links':
+                // 11 = SessionID
+                var cellTypes = cell.split(",");
+                var cellLinks = cellTypes.map(function (current, index) {
+                    return React.createElement(
+                        'span',
+                        null,
+                        React.createElement(
+                            'a',
+                            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + current + "&backURL=/imaging_browser/" },
+                            current
+                        ),
+                        ' | '
+                    );
+                }, this);
+                cellLinks.push(React.createElement(
+                    'span',
+                    null,
+                    React.createElement(
+                        'a',
+                        { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/" },
+                        'selected'
+                    ),
+                    ' | '
+                ));
+                cellLinks.push(React.createElement(
+                    'a',
+                    { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/" },
+                    'all types'
+                ));
+                reactElement = React.createElement(
+                    'td',
+                    null,
+                    cellLinks
+                );
+                console.log(row);
+                break;
+            default:
+                reactElement = React.createElement(
+                    'td',
+                    null,
+                    cell
+                );
+                break;
         }
-        return React.createElement('td', null);
     }
-    if (column === 'Links') {
-        var cellTypes = cell.split(",");
-        var cellLinks = [];
-        for (var i = 0; i < cellTypes.length; i += 1) {
-            cellLinks.push(React.createElement(
-                'a',
-                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/" },
-                cellTypes[i]
-            ));
-            cellLinks.push(" | ");
-        }
-        cellLinks.push(React.createElement(
-            'a',
-            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1&backURL=/imaging_browser/" },
-            'selected'
-        ));
-        cellLinks.push(" | ");
-        cellLinks.push(React.createElement(
-            'a',
-            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=/imaging_browser/" },
-            'all types'
-        ));
-        return React.createElement(
-            'td',
-            null,
-            cellLinks
-        );
-    }
-    return React.createElement(
-        'td',
-        null,
-        cell
-    );
+    return reactElement;
 }

--- a/modules/imaging_browser/js/columnFormatter.js
+++ b/modules/imaging_browser/js/columnFormatter.js
@@ -29,7 +29,7 @@ function formatColumn(column, cell, rowData, rowHeaders) {
                         null,
                         React.createElement(
                             'a',
-                            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + current + "&backURL=/imaging_browser/" },
+                            { href: loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + current + "&backURL=/imaging_browser/" },
                             current
                         ),
                         ' | '
@@ -40,14 +40,14 @@ function formatColumn(column, cell, rowData, rowHeaders) {
                     null,
                     React.createElement(
                         'a',
-                        { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/" },
+                        { href: loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/" },
                         'selected'
                     ),
                     ' | '
                 ));
                 cellLinks.push(React.createElement(
                     'a',
-                    { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/" },
+                    { href: loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/" },
                     'all types'
                 ));
                 reactElement = React.createElement(

--- a/modules/imaging_browser/jsx/columnFormatter.js
+++ b/modules/imaging_browser/jsx/columnFormatter.js
@@ -20,10 +20,10 @@ function formatColumn(column, cell, rowData, rowHeaders) {
                 // 11 = SessionID 
                 var cellTypes = cell.split(",");
                 var cellLinks = cellTypes.map(function (current, index) {
-                    return <span><a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + current + "&backURL=/imaging_browser/"}>{current}</a> | </span>;
+                    return <span><a href={loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + current + "&backURL=/imaging_browser/"}>{current}</a> | </span>;
                 }, this);
-                cellLinks.push(<span><a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/"}>selected</a> | </span>);
-                cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/"}>all types</a>);
+                cellLinks.push(<span><a href={loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/"}>selected</a> | </span>);
+                cellLinks.push(<a href={loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/"}>all types</a>);
                 reactElement = <td>{cellLinks}</td>;
 console.log(row);
                 break;

--- a/modules/imaging_browser/jsx/columnFormatter.js
+++ b/modules/imaging_browser/jsx/columnFormatter.js
@@ -1,29 +1,36 @@
-function formatColumn(column, cell, rowData) {
-    if(column === 'SessionID') {
-        return null;
-    }
-    if(column === 'New Data') {
-        if(cell === 'new') {
-            return <td className="newdata">NEW</td>
-        }
-        return <td></td>;
-    }
-    if(column === 'Links') {
-        var cellTypes = cell.split(",");
-        var cellLinks = []
-        for(var i = 0; i < cellTypes.length; i += 1) {
-            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/"}>{cellTypes[i]}</a>);
-            cellLinks.push(" | ");
+function formatColumn(column, cell, rowData, rowHeaders) {
+    reactElement = null;
 
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+
+        var row = {};
+        rowHeaders.forEach(function(header, index) {
+            row[header] = rowData[index];
+        }, this);
+
+        switch (column) {
+            case 'New Data':
+                if(cell === 'new') {
+                     reactElement = <td className="newdata">NEW</td>;
+                } else {
+                     reactElement = <td></td>;
+                }
+                break;
+            case 'Links':
+                // 11 = SessionID 
+                var cellTypes = cell.split(",");
+                var cellLinks = cellTypes.map(function (current, index) {
+                    return <span><a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + current + "&backURL=/imaging_browser/"}>{current}</a> | </span>;
+                }, this);
+                cellLinks.push(<span><a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/"}>selected</a> | </span>);
+                cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/"}>all types</a>);
+                reactElement = <td>{cellLinks}</td>;
+console.log(row);
+                break;
+            default:
+                reactElement = <td>{cell}</td>;
+                break;
         }
-        cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1&backURL=/imaging_browser/"}>selected</a> );
-        cellLinks.push(" | ");
-        cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=/imaging_browser/"}>all types</a> );
-        return (
-                <td>
-                    {cellLinks}
-                </td>
-               );
     }
-    return <td>{cell}</td>;
+    return reactElement;
 }


### PR DESCRIPTION
Now send the headers to the getFormattedCell function.
I think we should only send the index, the rowData and the headers but having the current header (column) does not hurt that much.

For this to work, each columnFormater.js script need to add the additionnal parameter and contain the following mapping function.

`function formatColumn(column, cell, rowData, rowHeaders) {`
```
        var row = {};
        rowHeaders.forEach(function (header, index) {
            row[header] = rowData[index];
        }, this);
```

Values are now available as row.PSCID , row.MyDynamicColumn, ...

