### PR TITLE
Using rowData and rowHeaders mapping

### DIFF
--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -191,7 +191,7 @@ StaticDataTable = React.createClass({
                     data = "Unknown";
                 }
                 if (this.props.getFormattedCell) {
-                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx]);
+                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx], this.props.Headers);
                     curRow.push({ data });
                 } else {
                     curRow.push(React.createElement(
@@ -309,5 +309,3 @@ StaticDataTable = React.createClass({
 });
 
 RStaticDataTable = React.createFactory(StaticDataTable);
-
-//# sourceMappingURL=StaticDataTable.js.map

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -167,7 +167,7 @@ StaticDataTable = React.createClass({
                     data = "Unknown";
                 }
                 if (this.props.getFormattedCell) {
-                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx]);
+                    data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[i].RowIdx], this.props.Headers);
                     curRow.push({data});
                 } else {
                     curRow.push(<td>{data}</td>);

--- a/modules/imaging_browser/js/columnFormatter.js
+++ b/modules/imaging_browser/js/columnFormatter.js
@@ -1,48 +1,58 @@
-function formatColumn(column, cell, rowData) {
-    if (column === 'SessionID') {
-        return null;
-    }
-    if (column === 'New Data') {
-        if (cell === 'new') {
-            return React.createElement(
-                'td',
-                { className: 'newdata' },
-                'NEW'
-            );
+function formatColumn(column, cell, rowData, rowHeaders) {
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {
+        // If this column is not a hidden one
+
+        // Create the mapping between rowHeaders and rowData in a row object.
+        var row = {};
+        rowHeaders.forEach(function (header, index) {
+            row[header] = rowData[index];
+        }, this);
+
+        if (column === 'New Data') {
+            if (cell === 'new') {
+                return React.createElement(
+                    'td',
+                    { className: 'newdata' },
+                    'NEW'
+                );
+            }
+            return React.createElement('td', null);
         }
-        return React.createElement('td', null);
-    }
-    if (column === 'Links') {
-        var cellTypes = cell.split(",");
-        var cellLinks = [];
-        for (var i = 0; i < cellTypes.length; i += 1) {
+
+        if (column === 'Links') {
+            var cellTypes = cell.split(",");
+            var cellLinks = [];
+            for (var i = 0; i < cellTypes.length; i += 1) {
+                cellLinks.push(React.createElement(
+                    'a',
+                    { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/" },
+                    cellTypes[i]
+                ));
+                cellLinks.push(" | ");
+            }
             cellLinks.push(React.createElement(
                 'a',
-                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/" },
-                cellTypes[i]
+                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/" },
+                'selected'
             ));
             cellLinks.push(" | ");
+            cellLinks.push(React.createElement(
+                'a',
+                { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/" },
+                'all types'
+            ));
+            return React.createElement(
+                'td',
+                null,
+                cellLinks
+            );
         }
-        cellLinks.push(React.createElement(
-            'a',
-            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1&backURL=/imaging_browser/" },
-            'selected'
-        ));
-        cellLinks.push(" | ");
-        cellLinks.push(React.createElement(
-            'a',
-            { href: loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=/imaging_browser/" },
-            'all types'
-        ));
+
         return React.createElement(
             'td',
             null,
-            cellLinks
+            cell
         );
     }
-    return React.createElement(
-        'td',
-        null,
-        cell
-    );
+    return null;
 }

--- a/modules/imaging_browser/jsx/columnFormatter.js
+++ b/modules/imaging_browser/jsx/columnFormatter.js
@@ -1,29 +1,39 @@
-function formatColumn(column, cell, rowData) {
-    if(column === 'SessionID') {
-        return null;
-    }
-    if(column === 'New Data') {
-        if(cell === 'new') {
-            return <td className="newdata">NEW</td>
-        }
-        return <td></td>;
-    }
-    if(column === 'Links') {
-        var cellTypes = cell.split(",");
-        var cellLinks = []
-        for(var i = 0; i < cellTypes.length; i += 1) {
-            cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/"}>{cellTypes[i]}</a>);
-            cellLinks.push(" | ");
+function formatColumn(column, cell, rowData, rowHeaders) {
+    if (-1 == loris.hiddenHeaders.indexOf(column)) {    
+        // If this column is not a hidden one
 
+        // Create the mapping between rowHeaders and rowData in a row object.
+        var row = {};
+        rowHeaders.forEach(function (header, index) {
+            row[header] = rowData[index];
+        }, this);
+
+        if(column === 'New Data') {
+            if(cell === 'new') {
+                return <td className="newdata">NEW</td>
+            }
+            return <td></td>;
         }
-        cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&selectedOnly=1&backURL=/imaging_browser/"}>selected</a> );
-        cellLinks.push(" | ");
-        cellLinks.push(<a href={loris.BaseURL + "/imaging_browser/viewSession/?sessionID=" + rowData[11] + "&backURL=/imaging_browser/"}>all types</a> );
-        return (
-                <td>
-                    {cellLinks}
-                </td>
-               );
+
+        if(column === 'Links') {
+            var cellTypes = cell.split(",");
+            var cellLinks = []
+            for(var i = 0; i < cellTypes.length; i += 1) {
+                cellLinks.push(<a href={loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&outputType=" + cellTypes[i] + "&backURL=/imaging_browser/"}>{cellTypes[i]}</a>);
+                cellLinks.push(" | ");
+    
+            }
+            cellLinks.push(<a href={loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&selectedOnly=1&backURL=/imaging_browser/"}>selected</a> );
+            cellLinks.push(" | ");
+            cellLinks.push(<a href={loris.BaseURL + "imaging_browser/viewSession/?sessionID=" + row.SessionID + "&backURL=/imaging_browser/"}>all types</a> );
+            return (
+                    <td>
+                        {cellLinks}
+                    </td>
+                   );
+        }
+
+        return <td>{cell}</td>;
     }
-    return <td>{cell}</td>;
+    return null;
 }


### PR DESCRIPTION
Now send the headers to the getFormattedCell function.
I think we should only send the index, the rowData and the headers but having the current header (column) does not hurt that much.

For this to work, each columnFormater.js script need to add the additionnal parameter and contain the following mapping function.

`function formatColumn(column, cell, rowData, rowHeaders) {`

        var row = {};
        rowHeaders.forEach(function (header, index) {
            row[header] = rowData[index];
        }, this);

Values are now available as row.PSCID , row.MyDynamicColumn, ...



Side note, I am also using the following lines to having dynamic column showing in the table

modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc:
`$this->tpl_data['hiddenHeaders'] = json_encode(`

modules/genomic_browser/templates/menu_genomic_browser.tpl:
`loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };`

modules/genomic_browser/jsx/profileColumnFormatter.jsx:
`if (-1 == loris.hiddenHeaders.indexOf(column)) {`

Also, fix a bug in the navigation links where the leading slash was causing the hostname to be removed in the MRINavigation::_splitURL() function.