### PR TITLE
403 denial code should not happen when a page loads properly. removing

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -131,7 +131,6 @@ class NDB_Client
             if ($auth === true) {
                 $error = $login->setState();
             } elseif ($auth === false) {
-                header("HTTP/1.1 403 Forbidden");
                 $login->clearState();
             }
         }


### PR DESCRIPTION
The 403 status code is defined here https://en.wikipedia.org/wiki/List_of_HTTP_status_codes:

> 403 Forbidden: The request was a valid request, but the server is refusing to respond to it. 403 error semantically means "unauthorized", i.e. the user does not have the necessary permissions for the resource.

We were issuing this code on the normally loading login/logout page. It is not a semantically correct use of the code. Testing and monitoring tools rely on correct use of http codes.
