### PR TITLE
Imaging Browser: 'No data selected' message becomes 'No data available' (Redmine #10492)

### DIFF
--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -71,6 +71,6 @@
    </div> <!-- closing panel-body div-->
 </div>
 {else}
-    <h3>No data selected</h3>
+    <h3>No data available</h3>
 </div>
 {/if}


### PR DESCRIPTION
Clarifying this error message to better indicate that there is no imaging data associated to the given candidate-timepoint.  
The current error message ("No data selected") is confusing to users who arrive at the ImagingBrowser:ViewSession page from links in the RadiologicalReview or Stats module.  