### PR TITLE
[SQL] Add uniqueness constraint on permission names

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -5,7 +5,7 @@
 DROP TABLE IF EXISTS `permissions`;
 CREATE TABLE `permissions` (
   `permID` int(10) unsigned NOT NULL auto_increment,
-  `code` varchar(255) NOT NULL default '',
+  `code` varchar(255) NOT NULL default '' UNIQUE,
   `description` varchar(255) NOT NULL default '',
   `categoryID` int(10) DEFAULT NULL,
   PRIMARY KEY  (`permID`)

--- a/SQL/2016-07-06-UniquePermissionname.sql
+++ b/SQL/2016-07-06-UniquePermissionname.sql
@@ -1,1 +1,15 @@
+CREATE TEMPORARY TABLE `new_permissions` (   `permID` int(10) unsigned NOT NULL auto_increment,   `code` varchar(255) NOT NULL default '' UNIQUE,   `description` varchar(255) NOT NULL default '',   `categoryID` int(10) DEFAULT NULL,   PRIMARY KEY  (`permID`) ) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8;
+
+INSERT INTO new_permissions SELECT permID, code, description, categoryID FROM permissions WHERE permID IN (select MIN(permID) from permissions GROUP BY code);
+
+UPDATE IGNORE user_perm_rel a LEFT JOIN permissions b ON a.permID = b.permID LEFT JOIN new_permissions c ON b.code = c.code SET a.permID = c.permID WHERE b.permID <> c.permID;
+
+DELETE FROM permissions WHERE permID not in (select permID from new_permissions);
+
+DELETE FROM user_perm_rel WHERE permID NOT IN (SELECT permID from new_permissions);
+
+UPDATE IGNORE LorisMenuPermissions a LEFT JOIN permissions b ON a.PermID = b.permID LEFT JOIN new_permissions c ON b.code = c.code SET a.PermID = c.permID WHERE b.permID <> c.permID;
+
+DELETE FROM LorisMenuPermissions WHERE PermID NOT IN (SELECT permID from new_permissions);
+
 ALTER TABLE permissions ADD CONSTRAINT code_name UNIQUE (code);

--- a/SQL/2016-07-06-UniquePermissionname.sql
+++ b/SQL/2016-07-06-UniquePermissionname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE permissions ADD CONSTRAINT code_name UNIQUE (code);


### PR DESCRIPTION
This updates the permissions table to have a unique key constraint
on the `code` column, so that future patches which add a new permission
can just do an INSERT IGNORE without worrying about affecting existing
installations which already have the permission code setup, potentially
with a different id.