### PR TITLE
tarchive_files: Add new field TarchiveSeriesID to schema (Redmine 10519)

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1107,36 +1107,6 @@ LOCK TABLES `tarchive` WRITE;
 UNLOCK TABLES;
 
 --
--- Table structure for table `tarchive_files`
---
-
-DROP TABLE IF EXISTS `tarchive_files`;
-CREATE TABLE `tarchive_files` (
-  `TarchiveFileID` int(11) NOT NULL auto_increment,
-  `TarchiveID` int(11) NOT NULL default '0',
-  `TarchiveSeriesID` INT(11) DEFAULT NULL,
-  `SeriesNumber` int(11) default NULL,
-  `FileNumber` int(11) default NULL,
-  `EchoNumber` int(11) default NULL,
-  `SeriesDescription` varchar(255) default NULL,
-  `Md5Sum` varchar(255) NOT NULL,
-  `FileName` varchar(255) NOT NULL,
-  PRIMARY KEY  (`TarchiveFileID`),
-  KEY `TarchiveID` (`TarchiveID`),
-  CONSTRAINT `tarchive_files_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE,
-  FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
---
--- Dumping data for table `tarchive_files`
---
-
-LOCK TABLES `tarchive_files` WRITE;
-/*!40000 ALTER TABLE `tarchive_files` DISABLE KEYS */;
-/*!40000 ALTER TABLE `tarchive_files` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `tarchive_series`
 --
 
@@ -1167,6 +1137,36 @@ CREATE TABLE `tarchive_series` (
 LOCK TABLES `tarchive_series` WRITE;
 /*!40000 ALTER TABLE `tarchive_series` DISABLE KEYS */;
 /*!40000 ALTER TABLE `tarchive_series` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `tarchive_files`
+--
+
+DROP TABLE IF EXISTS `tarchive_files`;
+CREATE TABLE `tarchive_files` (
+  `TarchiveFileID` int(11) NOT NULL auto_increment,
+  `TarchiveID` int(11) NOT NULL default '0',
+  `TarchiveSeriesID` INT(11) DEFAULT NULL,
+  `SeriesNumber` int(11) default NULL,
+  `FileNumber` int(11) default NULL,
+  `EchoNumber` int(11) default NULL,
+  `SeriesDescription` varchar(255) default NULL,
+  `Md5Sum` varchar(255) NOT NULL,
+  `FileName` varchar(255) NOT NULL,
+  PRIMARY KEY  (`TarchiveFileID`),
+  KEY `TarchiveID` (`TarchiveID`),
+  CONSTRAINT `tarchive_files_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE,
+  FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `tarchive_files`
+--
+
+LOCK TABLES `tarchive_files` WRITE;
+/*!40000 ALTER TABLE `tarchive_files` DISABLE KEYS */;
+/*!40000 ALTER TABLE `tarchive_files` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1124,7 +1124,7 @@ CREATE TABLE `tarchive_files` (
   PRIMARY KEY  (`TarchiveFileID`),
   KEY `TarchiveID` (`TarchiveID`),
   CONSTRAINT `tarchive_files_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE,
-  FOREIGN KEY (`tarchive_series_TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`)
+  FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1114,6 +1114,7 @@ DROP TABLE IF EXISTS `tarchive_files`;
 CREATE TABLE `tarchive_files` (
   `TarchiveFileID` int(11) NOT NULL auto_increment,
   `TarchiveID` int(11) NOT NULL default '0',
+  `TarchiveSeriesID` INT(11) DEFAULT NULL,
   `SeriesNumber` int(11) default NULL,
   `FileNumber` int(11) default NULL,
   `EchoNumber` int(11) default NULL,
@@ -1122,7 +1123,8 @@ CREATE TABLE `tarchive_files` (
   `FileName` varchar(255) NOT NULL,
   PRIMARY KEY  (`TarchiveFileID`),
   KEY `TarchiveID` (`TarchiveID`),
-  CONSTRAINT `tarchive_files_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE
+  CONSTRAINT `tarchive_files_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE,
+  FOREIGN KEY (`tarchive_series_TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1156,8 +1156,9 @@ CREATE TABLE `tarchive_files` (
   `FileName` varchar(255) NOT NULL,
   PRIMARY KEY  (`TarchiveFileID`),
   KEY `TarchiveID` (`TarchiveID`),
+  KEY `TarchiveSeriesID` (`TarchiveSeriesID`),
   CONSTRAINT `tarchive_files_ibfk_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`) ON DELETE CASCADE,
-  FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`)
+  CONSTRAINT `tarchive_files_TarchiveSeriesID_fk` FOREIGN KEY (`TarchiveSeriesID`) REFERENCES `tarchive_series` (`TarchiveSeriesID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 --

--- a/SQL/Archive/17.0/2016-07-07-AddTarchiveSeriesIDTotarchive_filesTable.sql
+++ b/SQL/Archive/17.0/2016-07-07-AddTarchiveSeriesIDTotarchive_filesTable.sql
@@ -1,2 +1,2 @@
 ALTER TABLE tarchive_files ADD `TarchiveSeriesID` INT(11) DEFAULT NULL;
-ALTER TABLE tarchive_files ADD FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`);
+ALTER TABLE tarchive_files ADD CONSTRAINT `tarchive_files_TarchiveSeriesID_fk` FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`);

--- a/SQL/Archive/17.0/2016-07-07-AddTarchiveSeriesIDTotarchive_filesTable.sql
+++ b/SQL/Archive/17.0/2016-07-07-AddTarchiveSeriesIDTotarchive_filesTable.sql
@@ -1,2 +1,2 @@
 ALTER TABLE tarchive_files ADD `TarchiveSeriesID` INT(11) DEFAULT NULL;
-ALTER TABLE tarchive_files ADD FOREIGN KEY (`tarchive_series_TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`);
+ALTER TABLE tarchive_files ADD FOREIGN KEY (`TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`);

--- a/SQL/Archive/17.0/2016-07-07-AddTarchiveSeriesIDTotarchive_filesTable.sql
+++ b/SQL/Archive/17.0/2016-07-07-AddTarchiveSeriesIDTotarchive_filesTable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tarchive_files ADD `TarchiveSeriesID` INT(11) DEFAULT NULL;
+ALTER TABLE tarchive_files ADD FOREIGN KEY (`tarchive_series_TarchiveSeriesID`) REFERENCES tarchive_series(`TarchiveSeriesID`);


### PR DESCRIPTION
This is needed because there is no way to select the proper files from tarchive_files table where there is multiple EchoTimes.

That information is stored in tarchive_series.