### PR TITLE
[Core] Fixed typo in CSS URL for automagically included test names

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -620,7 +620,7 @@ class NDB_Page
                 . "Override getCSSDependencies() instead"
             );
 
-            $files[] = $baseurl . "/$TestName/js/$TestName.css";
+            $files[] = $baseurl . "/$TestName/css/$TestName.css";
         }
 
         return $files;


### PR DESCRIPTION
GetCSSDependencies was including `js`, not `css`, in the URL.