### PR TITLE
[Core] Set default JS/CSS dependencies for Loris pages

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -174,6 +174,11 @@ if (!empty($_REQUEST['sessionID'])) {
 
 //--------------------------------------------------
 
+// Set default dependencies
+$page = new NDB_Page();
+$tpl_data['jsfiles']  = $page->getJSDependencies();
+$tpl_data['cssfiles'] = $page->getCSSDependencies();
+
 // load the menu or instrument
 try {
     $caller    =& NDB_Caller::singleton();

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -174,11 +174,6 @@ if (!empty($_REQUEST['sessionID'])) {
 
 //--------------------------------------------------
 
-// Set default dependencies
-$page = new NDB_Page();
-$tpl_data['jsfiles']  = $page->getJSDependencies();
-$tpl_data['cssfiles'] = $page->getCSSDependencies();
-
 // load the menu or instrument
 try {
     $caller    =& NDB_Caller::singleton();
@@ -222,6 +217,13 @@ try {
         break;
     }
     $tpl_data['error_message'][] = $e->getMessage();
+} finally {
+    // Set dependencies if they are not set
+    if (!isset($tpl_data['jsfiles']) || !isset($tpl_data['cssfiles'])) {
+        $page = new NDB_Page();
+        $tpl_data['jsfiles']  = $page->getJSDependencies();
+        $tpl_data['cssfiles'] = $page->getCSSDependencies();
+    }
 }
 
 //--------------------------------------------------


### PR DESCRIPTION
Currently get[CSS/JS]Dependencies() is never called on "error" pages. 

1. For JS part among other things it breaks navigation menu hovers
2. For CSS part it breaks the whole layout. (example below)
![image](https://cloud.githubusercontent.com/assets/6627543/16695770/a1d43ea0-450f-11e6-857e-efcc018ac45c.png)
