### PR TITLE
LORIS Web Based DB Install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ script:
       done
 
     # Run PHPCS on the entire libraries directory.
-    - vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries php/exceptions
+    - vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries php/exceptions php/installer
     - vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php htdocs
 
     # Run PHPCS on some scripts

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
     Download the latest release from the [releases page](https://github.com/aces/Loris/releases) and
     extract it to `/var/www/$projectname`
 
-3. Run installer script to install core code, libraries, and MySQL schema (see LORIS Setup Schematic). The script will prompt for information, including usernames and folders which it will create automatically.
+3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
 
     For more information, please read the [Install Script wiki page](https://github.com/aces/Loris/wiki/Install-Script).
 
@@ -73,8 +73,7 @@ LORIS requires Apache's mod_rewrite module to rewrite its URLs. Enable this modu
     sudo service apache2 reload
     ```
 
-5. Go to http://localhost to verify that the LORIS core database has been successfully installed. Congratulations!
-Log in with the username "admin" and the password you supplied for this user while running the Install script.
+5. Go to http://localhost/installdb.php and follow the instructions to finalize LORIS installation.
 
     _Note_: Apache config files will be installed as *.conf, per Ubuntu 14.04. If running an earlier version of Ubuntu, rename these files, then run the following commands. After, restart Apache.
 
@@ -83,18 +82,8 @@ Log in with the username "admin" and the password you supplied for this user whi
     sudo a2dissite default
     sudo a2ensite $projectname
     ```
-6. Note that the default Loris setup assumes that Loris is running on localhost. If this
-is not the case, you'll have to manually update the URL and Host config variables in the
-ConfigSettings table by running the following SQL commands from a MySQL prompt:
 
-    ```SQL
-    UPDATE Config SET Value='$yourURL' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url');
-    UPDATE Config SET Value='$yourHostname' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='host');
-    ```
-
-    Make sure that `$yourURL` above contains the "http://" or "https://" and `$yourHostname` does not. If your server is only being accessed from localhost, you can skip this step.
-
-7. Follow the [Setup Guide in the LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) to complete your post-installation setup and configuration, and for more documentation.
+6. Follow the [Setup Guide in the LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) to complete your post-installation setup and configuration, and for more documentation.
 
 # Community
 Please feel free to subscribe to the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) to ask any LORIS-related questions.

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * This file represents the main entry point into the Loris installer.
+ *
+ * It should only be accessed the first time LORIS is installed.
+ *
+ * Since it's written in PHP, obviously Apache and PHP are required to be
+ * set up before accessing this page. Nonetheless, it will verify all
+ * of the dependencies on the server being installed, create required
+ * accounts, and source the schema. Users can either user the NeuroDebian,
+ * or Docker packages or set them up themselves depending on their experience.
+ *
+ * The user must have also already run `composer install` before accessing
+ * this page, because the vendor/autoload.php file is required to load smarty.
+ *
+ * It does the following:
+ *    1. Check if LORIS is already installed (there's a config.xml
+ *       setup), and if so bail to ensure it doesn't affect an
+ *       existing system.
+ *    2. Check that the external dependencies are installed (PHP version,
+ *       MySQL, etc) and check their versions (if possible.)
+ *    3. Prompt for the admin MySQL account to use for setup
+ *    4. Check that the LORIS database doesn't already exist
+ *    5. Prompt for (and create) the non-root MySQL user
+ *    5a. Prompt for and update the LORIS frontend admin account username
+ *       and password at the same time.
+ *    6. Create the database, MySQL user, source the schema, and
+ *       reset the admin username and password in the users table
+ *    7. Write the config.xml if possible. If the directory isn't
+ *       writable, print the content that should go there and ask
+ *       the user to manually create the file.
+ *
+ * PHP Version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+// the installer directory doesn't get autoloaded by composer, so we
+// need to manually require this.
+require_once __DIR__ . "/../php/installer/Installer.class.inc";
+
+// Since LORIS isn't configured yet, these classes from the php/
+// directory won't work. We need stubs for the installer to use, and
+// they need to have the same name so that composer doesn't try and
+// autoload the ones that we can't use which try to access config.xml.
+// We don't need to implement all the functionality, just enough for
+// smarty to use when it gets autoloaded.
+require_once __DIR__ . "/../php/installer/Database.class.inc";
+require_once __DIR__ . "/../php/installer/NDB_Config.class.inc";
+
+$installer = new Installer("../project");
+
+// Check the dependencies of this script.
+if ($installer->CheckPreconditionsValid() === false) {
+    $err = $installer->GetLastError();
+    if ($err == "") {
+        $err = "Unknown error checking LORIS install preconditions. Sorry.";
+    }
+    echo $err;
+    exit(2);
+}
+
+// Check the dependencies of LORIS
+if ($installer->CheckSystemDependenciesValid() == false) {
+    $err = $installer->GetLastError();
+    if ($err == "") {
+        $err = "Unknown error checking system dependencies.";
+    }
+    echo $err;
+    exit(3);
+}
+
+require_once __DIR__ . "/../vendor/autoload.php";
+
+ini_set('default_charset', 'utf-8');
+// Create an output buffer to capture console output, separately from the
+// gzip handler.
+//ob_start('ob_gzhandler');
+ob_start();
+$tpl_data = array();
+
+// Page 1: Help, prompt server, root username, root password
+// Page 2: 1. Connect with username/password
+// 	2. Check has required permissions -- abort if not
+//	 3. Source schema
+// Page 3: Help, prompt for new username/password (include defaults)
+// Page 4: 1. Check if user exists -- if so, error, if not create
+//	 2. Update config.xml if write access, otherwise download copy
+switch($_POST['formname']) {
+case 'validaterootaccount':
+    // This will connect to MySQL, check the permissions of the
+    // account provided, check that the database doesn't already
+    // exist, and create the database.
+    if ($installer->CreateMySQLDB($_POST) === false) {
+        $tpl_data['error'] = $installer->GetLastError();
+        $tpl_data['Page']  = "";
+        break;
+    }
+    if ($installer->SourceSchema($_POST) === false) {
+        $tpl_data['error'] = $installer->GetLastError();
+        $tpl_data['Page']  = "";
+        break;
+    }
+    if ($installer->UpdateBaseConfig($_POST) === false) {
+        $tpl_data['error'] = $installer->GetLastError();
+        $tpl_data['Page']  = "";
+        break;
+    }
+
+    $tpl_data['Page'] = "MySQLUserPrompt";
+    break;
+case 'createmysqlaccount':
+    if ($installer->CreateMySQLAccount($_POST) === false) {
+        $tpl_data['error'] = $installer->GetLastError();
+        $tpl_data['Page']  = "MySQLUserPrompt";
+        break;
+    }
+
+    if ($installer->ResetFrontEndAdmin($_POST) === false) {
+        $tpl_data['error'] = $installer->GetLastError();
+        $tpl_data['Page']  = "MySQLUserPrompt";
+        break;
+    }
+
+    if ($installer->ConfigWritable()) {
+        if ($installer->WriteConfig($_POST) === false) {
+            $tpl_data['error'] = $installer->GetLastError();
+            $tpl_data['Page']  = "MySQLUserPrompt";
+            break;
+        }
+        $tpl_data['configfile'] = $installer->GetBaseDir() . "/project/config.xml";
+    } else {
+        $tpl_data['configlocation'] = $installer->GetBaseDir()
+                 . "/project/config.xml";
+        $tpl_data['configcontent']  = htmlspecialchars(
+            $installer->GetConfigContent($_POST)
+        );
+    }
+    $tpl_data['Page'] = "Done";
+    break;
+}
+$tpl_data['console'] = htmlspecialchars(ob_get_contents());
+
+// Set up some special smarty variables that are required on different
+// pages
+if ($tpl_data['Page'] == 'MySQLUserPrompt') {
+    $tpl_data['SamplePassword']  = User::newPassword(16);
+    $tpl_data['SamplePassword2'] = User::newPassword(16);
+} else if ($tpl_data['Page'] == "Done") {
+    $tpl_data['lorisurl'] = $installer->getBaseURL();
+}
+// end ob_start that captures console output. The Smarty hook
+// needs to be able to write to the client.
+ob_end_clean();
+
+/**
+ * Sets a tpl variable based on a request parameter.
+ * Used to persist form elements between requests in case of error.
+ *
+ * @param string $name The request parameter to add to a smarty variable
+ *
+ * @return none
+ */
+function tplvar($name)
+{
+    global $tpl_data;
+    if (isset($_REQUEST[$name])) {
+        $tpl_data[$name] = $_REQUEST[$name];
+    } else {
+        $tpl_data[$name] = '';
+    }
+}
+tplvar("dbhost");
+tplvar("dbadminuser");
+tplvar("dbadminpassword");
+tplvar("dbname");
+tplvar("lorismysqluser");
+tplvar("lorismysqlpassword");
+tplvar("frontenduser");
+tplvar("frontendpassword");
+$smarty = new Smarty_NeuroDB;
+$smarty->assign($tpl_data);
+$smarty->display('install.tpl');
+
+//ob_end_flush();
+?>

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -7,7 +7,7 @@
  * Since it's written in PHP, obviously Apache and PHP are required to be
  * set up before accessing this page. Nonetheless, it will verify all
  * of the dependencies on the server being installed, create required
- * accounts, and source the schema. Users can either user the NeuroDebian,
+ * accounts, and source the schema. Users can either use the NeuroDebian,
  * or Docker packages or set them up themselves depending on their experience.
  *
  * The user must have also already run `composer install` before accessing

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -90,7 +90,7 @@ $tpl_data = array();
 // Page 3: Help, prompt for new username/password (include defaults)
 // Page 4: 1. Check if user exists -- if so, error, if not create
 //	 2. Update config.xml if write access, otherwise download copy
-switch($_POST['formname']) {
+switch(isset($_POST['formname']) ? $_POST['formname'] : '') {
 case 'validaterootaccount':
     // This will connect to MySQL, check the permissions of the
     // account provided, check that the database doesn't already

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -1,0 +1,215 @@
+<?php
+/**
+ * The Installer Database class is like the LORIS database class, except it
+ * at the time of the installer the config.xml doesn't exist, so it can't
+ * connect using the connection info from there, so this class does the
+ * minimal amount that's necessary to bootstrap the installation.
+ *
+ * PHP Version 5
+ *
+ * @category Installer
+ * @package  Installer
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * The Installer Database class is like the LORIS database class, except it
+ * at the time of the installer the config.xml doesn't exist, so it can't
+ * connect using the connection info from there, so this class does the
+ * minimal amount that's necessary to bootstrap the installation.
+ *
+ * @category Installer
+ * @package  Installer
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Database
+{
+    public $PDO;
+
+    /**
+     * Returns one and only one Database object.
+     *
+     * @return Database
+     */
+    public static function singleton()
+    {
+        static $DB = null;
+        if (is_null($DB)) {
+            $DB = new Database;
+        }
+        return $DB;
+    }
+
+    /**
+     * This wrapper connects differently than the normal database wrapper.
+     * Instead of connecting to a database, it will connect to the server,
+     * check that the user has create user and create privileges, make sure
+     * the database doesn't already exist, and if so create it and use it.
+     * If any of these conditions fail, it's an error.
+     * This is because this wrapper is only used to connect from the install
+     * script, so we want to ensure that the preconditions for the install
+     * script are satisfied while we're connecting. This will only happen
+     * once.
+     *
+     * @param string $database     The database to be created
+     * @param string $username     The username to connect as
+     * @param string $password     The password to connect with
+     * @param string $host         The hostname that the SQL server is running
+     *                             on.
+     * @param bool   $trackChanges Unused. For signature compatibility with the
+     *                             "real" Database class.
+     *
+     * @return bool true on success, false on failure.
+     */
+    public function connectAndCreate(
+        $database,
+        $username,
+        $password,
+        $host,
+        $trackChanges = true
+    ) {
+        try {
+            $this->PDO = new PDO(
+                "mysql:host=$host;charset=UTF8",
+                $username,
+                $password
+            );
+            $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+
+            $userperms = $this->PDO->query(
+                "SELECT
+                   Create_user_priv, Create_priv
+                 FROM `mysql`.`user`
+                 WHERE CONCAT(user, '@', host)=CURRENT_USER"
+            );
+
+            $userperms = $userperms->fetchall(PDO::FETCH_ASSOC);
+
+            if (count($userperms) != 1) {
+                $this->lastErr = "Error retrieving user permissions for $username.";
+                return false;
+            }
+
+            $userperms = $userperms[0];
+            if ($userperms['Create_priv'] != 'Y') {
+                $this->lastErr = "User does not have create "
+                . "privileges.";
+                return false;
+            }
+            if ($userperms['Create_user_priv'] != 'Y') {
+                $this->lastErr = "Specified user can not create new "
+                ." user for LORIS to connect as.";
+                return false;
+            }
+
+            $dbexists = $this->PDO->query("SHOW DATABASES LIKE '$database'")
+                ->fetch(PDO::FETCH_ASSOC);
+            // this needs to be !empty, because otherwise if there's
+            // no results returned count($dbexists) == 1 when no
+            // results are returned, because the result isn't an array
+            // Something to do with how the Countable interface is
+            // implemented in PHP..
+            if (!empty($dbexists)) {
+                $this->lastErr = "Database $database already exists."
+                . " Can only install new databases.";
+                return false;
+            }
+
+            $this->PDO->exec("CREATE DATABASE $database");
+            $this->PDO->exec("USE $database");
+            return true;
+        } catch(Exception $e) {
+            return false;
+        }
+        // should be inaccessible, but include it just in case we
+        // somehow get here.
+        return false;
+    }
+
+    /**
+     * This connects to a database, but doesn't try to create it if it doesn't
+     * already exist.
+     *
+     * @param string $database     The database to be created
+     * @param string $username     The username to connect as
+     * @param string $password     The password to connect with
+     * @param string $host         The hostname that the SQL server is running
+     *                             on.
+     * @param bool   $trackChanges Unused. For signature compatibility with the
+     *                             "real" Database class.
+     *
+     * @return bool true on success, false on failure.
+     */
+    public function connect(
+        $database,
+        $username,
+        $password,
+        $host,
+        $trackChanges = true
+    ) {
+        if ($this->isConnected() === true) {
+            return true;
+        }
+        try {
+             $this->PDO = new PDO(
+                 "mysql:host=$host;dbname=$database;charset=UTF8",
+                 $username,
+                 $password
+             );
+             $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+             return true;
+        } catch(Exception $e) {
+            $this->lastErr = "Exceptional error connecting to the database "
+            . $database . ".";
+            return false;
+        }
+
+        // Unreachable
+        return false;
+    }
+
+    /**
+     * Returns true if this Database instance is connected to a database.
+     *
+     * @return bool
+     */
+    public function isConnected()
+    {
+        try {
+            if (!$this->PDO) {
+                return false;
+            }
+            $this->PDO->query("SELECT 'x'");
+            return true;
+        } catch(Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Prepares a query to run.
+     *
+     * @param string $query The SQL query to be prepared
+     *
+     * @return PDOStatement of prepared statement
+     */
+    public function prepare($query)
+    {
+        return $this->PDO->prepare($query);
+    }
+
+    /**
+     * Stub to prevent PHP from crashing if something autloads and tries
+     * to call pselect
+     *
+     * @return the empty array
+     */
+    public function pselect()
+    {
+        return array();
+    }
+}

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -178,15 +178,15 @@ class Installer
     function createMySQLDB($values)
     {
         if (preg_match(
-             '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
-             $values['dbname']
+            '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
+            $values['dbname']
         ) == false
         ) {
-		$this->_lastErr = "Database name must only contain letters, "
-			. "numbers and underscores and must be at least 2 "
+            $this->_lastErr = "Database name must only contain letters, "
+            . "numbers and underscores and must be at least 2 "
                         . "characters long.";
-		return false;
-	}
+            return false;
+        }
         $DB = Database::singleton();
         if ($DB->connectAndCreate(
             $values['dbname'],

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -1,0 +1,594 @@
+<?php
+/**
+ * The Installer class handles all the logic used by the installdb.php
+ * script under htdocs. It's put in a class for testability (even if there
+ * aren't currently any tests for it.) and to keep installdb.php neat.
+ *
+ * PHP Version 5.5+
+ *
+ * @category Installer
+ * @package  Installer
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * The Installer class handles all the logic used by the installdb.php
+ * script under htdocs. It's put in a class for testability (even if there
+ * aren't currently any tests for it.) and to keep installdb.php neat.
+ *
+ * @category Installer
+ * @package  Installer
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Installer
+{
+
+    private $_lastErr;
+
+    /**
+     * Get the last error that occured in this install process.
+     *
+     * @return string
+     */
+    function getLastError()
+    {
+        return $this->_lastErr;
+    }
+
+    /**
+     * Checks that all the preconditions that this script depends upon are
+     * met.
+     *
+     * @return bool if the script is in an environment where it can proceed
+     */
+    public function checkPreconditionsValid()
+    {
+        // Check if config.xml already exists
+        if ($this->_configXMLExists()) {
+            $this->_lastErr = "LORIS appears to already be installed"
+            . " (project/config.xml already exists.)\n"
+            . "Can not install LORIS on top of existing"
+            . " LORIS installation.\n"
+            . "Aborting.";
+            return false;
+        }
+
+        // Check that we have access to the schema files
+        if ($this->_schemaFilesExist() == false) {
+            $this->_lastErr = "LORIS database schema appears to be missing.\n"
+            . "Please verify your LORIS installation and try again.";
+            return false;
+        }
+
+        // Check that the user ran composer, so we can provide a friendlier
+        // error than "autoload.php not found" when the script requires
+        // it.
+        if ($this->_checkComposerRan() == false) {
+            $this->_lastErr = "Must run `composer install` before accessing this"
+            . " page.\n"
+            . "Please see instructions in README.md";
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Check that config.xml file exists.
+     *
+     * @return bool
+     */
+    private function _configXMLExists()
+    {
+        if (file_exists(__DIR__ . "/../../project/config.xml")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check that all schema files are accessible.
+     *
+     * @return bool
+     */
+    private function _schemaFilesExist()
+    {
+        return file_exists(__DIR__ . "/../../SQL/0000-00-00-schema.sql")
+        && file_exists(__DIR__ . "/../../SQL/0000-00-01-Permission.sql")
+        && file_exists(__DIR__ . "/../../SQL/0000-00-02-Menus.sql")
+        && file_exists(__DIR__ . "/../../SQL/0000-00-03-ConfigTables.sql")
+        && file_exists(__DIR__ . "/../../SQL/0000-00-04-Help.sql")
+        && file_exists(__DIR__ . "/../../SQL/0000-00-99-indexes.sql");
+    }
+
+    /**
+     * Check that composer has already been run by.
+     *
+     * @return true if composer has been run
+     */
+    private function _checkComposerRan()
+    {
+        return file_exists(__DIR__ . "/../../vendor/autoload.php");
+    }
+
+    /**
+     * Check that the system being installed on meets all LORIS dependencies
+     * which can be checked.
+     *
+     * @return true if system is dependable.
+     */
+    public function checkSystemDependenciesValid()
+    {
+        // Check PHP version is supported.
+        if (PHP_MAJOR_VERSION <= 4
+            || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 6)
+        ) {
+            $this->_lastErr = "PHP version 5.6 or higher is required to run "
+            . "LORIS. $PHP_RELEASE_VERSION is not supported.";
+            return false;
+        }
+
+        // Check that some standard PHP packages which are removed in Debian
+        // without a special package installed are available.
+        if (function_exists('json_encode') == false) {
+            $this->_lastErr = "json functions do not appear to be accessible in your"
+            . " PHP installation. If you're running on Debian or Ubuntu, please"
+            . " ensure you've installed the php-json package.";
+            return false;
+        }
+
+        // Check that the PDO is able to connect to MySQL.
+        try {
+            // and check that the MySQL driver is available.
+            $drivers = PDO::getAvailableDrivers();
+            if (in_array("mysql", $drivers) == false) {
+                $this->_lastErr = "You do not appear to have MySQL support"
+                . " available in PHP. Aborting.\n"
+                . " Please check your system dependencies and try again.";
+                return false;
+            }
+        } catch (Exception $e) {
+            $this->_lastErr = "You do not appear to have PDO support in your "
+            . "version of PHP, which is required to access the database.";
+            return false;
+        }
+
+        // Check that the smarty templates_c directory is writable.
+        if (is_writable(__DIR__ . "/../../smarty/templates_c") == false) {
+            $this->_lastErr = "Web server can not write to template cache "
+            . "directory.\n"
+            . "Please ensure the LORIS/smarty/templaces_c directory is writable by"
+            . " your web server and try again.";
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Connects to a database server and creates a MySQL database, after
+     * verifying that it doesn't already exist.
+     *
+     * @param array $values The POSTed values for the database to be created.
+     *
+     * @return true on success, false on error.
+     */
+    function createMySQLDB($values)
+    {
+        if (preg_match(
+             '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
+             $values['dbname']
+        ) == false
+        ) {
+		$this->_lastErr = "Database name must only contain letters, "
+			. "numbers and underscores and must be at least 2 "
+                        . "characters long.";
+		return false;
+	}
+        $DB = Database::singleton();
+        if ($DB->connectAndCreate(
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) == false
+        ) {
+            if (!empty($DB->lastErr)) {
+                $this->_lastErr = $DB->lastErr;
+            } else {
+                $this->_lastErr = "Could not connect to MySQL server "
+                . "and create database with credentials provided.";
+            }
+            return false;
+
+        }
+        return true;
+    }
+
+    /**
+     * Source the LORIS schema files into the database.
+     *
+     * @param array $values The POSTed values from the client.
+     *
+     * @return true on success, false on failure.
+     */
+    function sourceSchema($values)
+    {
+        $DB = Database::singleton();
+        if ($DB->connect(
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) == false
+        ) {
+            if (!empty($DB->lastErr)) {
+                $this->_lastErr = $DB->lastErr;
+            } else {
+                $this->_lastErr = "Could not connect to MySQL server "
+                ."with credentials provided.";
+            }
+            return false;
+
+        }
+
+        if ($this->_sourceSchemaFile($DB, "00-schema.sql") == false) {
+            return false;
+        };
+        if ($this->_sourceSchemaFile($DB, "01-Permission.sql") == false) {
+            return false;
+        };
+        if ($this->_sourceSchemaFile($DB, "02-Menus.sql") == false) {
+            return false;
+        };
+        if ($this->_sourceSchemaFile($DB, "03-ConfigTables.sql") == false) {
+            return false;
+        };
+        if ($this->_sourceSchemaFile($DB, "04-Help.sql") == false) {
+            return false;
+        };
+        if ($this->_sourceSchemaFile($DB, "99-indexes.sql") == false) {
+            return false;
+        };
+        return true;
+    }
+
+    /**
+     * Returns the base directory of LORIS
+     *
+     * @return string of LORIS install base directory
+     */
+    function getBaseDir()
+    {
+        return preg_replace("#php/installer$#", "", __DIR__);
+
+    }
+
+    /**
+     * Get the Base URL that this LORIS instance appears to be installed under
+     * by checking the URL that the user is accessing.
+     *
+     * @return string the LORIS base URL.
+     */
+    function getBaseURL()
+    {
+        // This is apparently the most reliable way to figure out if
+        // the requery is over http or https.. $_SERVER[REQUEST_SCHEME]
+        // is not reliable.
+        $RequestScheme = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on'
+                            ? 'https' : 'http';
+
+        return $RequestScheme . '://' . $_SERVER['HTTP_HOST']
+            . preg_replace("#/installdb.php#", "", $_SERVER['REQUEST_URI']);
+
+    }
+    /**
+     * Updates the basic config files required by LORIS.
+     *
+     * @param array $values The values from the POST request.
+     *
+     * @return true on success, false on error
+     */
+    function updateBaseConfig($values)
+    {
+        $DB = Database::singleton();
+        if ($DB->connect(
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) == false
+        ) {
+            if (!empty($DB->lastErr)) {
+                $this->_lastErr = $DB->lastErr;
+            } else {
+                $this->_lastErr = "Could not connect to MySQL server "
+                . "with credentials provided.";
+            }
+            return false;
+
+        }
+
+        // get the LORIS base path, based on what we know about where
+        // this file is located.
+        $basepath = $this->GetBaseDir();
+        // Assume the database name is the same as the project name,
+        // in order to not need to prompt.
+        $datadir = "/data/$values[dbname]/data/";
+
+        $this->_updateConfig($DB, "base", $basepath);
+        $this->_updateConfig($DB, "DownloadPath", $basepath);
+
+        $this->_updateConfig($DB, "imagePath", $datadir);
+        $this->_updateConfig($DB, "data", $datadir);
+        $this->_updateConfig($DB, "mincPath", $datadir);
+        $this->_updateConfig($DB, "MRICodePath", $datadir);
+
+        // Update the host based and URL based on the location that
+        // this request is coming from.
+        $this->_updateConfig($DB, "host", $_SERVER['HTTP_HOST']);
+        $this->_updateConfig($DB, "url", $this->getBaseURL());
+
+        // Generate a new secret key for JWT tokens. We don't really care
+        // what it is, as long as the server always uses the same one to
+        // validate tokens. So we use the new user password code to generate a
+        // really long password and use that as the key.
+        $this->_updateConfig($DB, "JWTKey", User::newPassword(64));
+    }
+
+    /**
+     * Updates a config setting in the database.
+     *
+     * @param Database $DB      A database handler. Must already be connected.
+     * @param string   $setting The setting name to be updated.
+     * @param string   $value   The value to set $setting to.
+     *
+     * @return none
+     */
+    private function _updateConfig($DB, $setting, $value)
+    {
+        $prepared = $DB->prepare(
+            "UPDATE Config SET Value=:q_val WHERE
+				ConfigID=(SELECT ID FROM ConfigSettings 
+					WHERE Name=:q_sett)"
+        );
+        $prepared->execute(['q_val' => $value, 'q_sett' => $setting]);
+    }
+
+    /**
+     * Runs all statements in the file.
+     *
+     * @param Database $DB   A database handler. Must already be connected.
+     * @param string   $file The file to source into the database that $DB
+     *                       is connected to.
+     *
+     * @return true on success, false on failure.
+     */
+    private function _sourceSchemaFile($DB, $file)
+    {
+        $sqls = file_get_contents(__DIR__ . "/../../SQL/0000-00-$file");
+        if ($DB->PDO->exec($sqls) === false) {
+            $this->_lastErr = "Unknown error sourcing schema file. $file";
+            return false;
+        }
+        return true;
+
+    }
+
+    /**
+     * Creates a non-privileged MySQL account for based on the parameters
+     * in $values.
+     *
+     * @param array $values An associative array of request parameters.
+     *                      Must have keys for dbname, dbadminuser,
+     *                      dbadminpassword, dbhost, lorismysqluser, and
+     *                      lorismysqlpassword
+     *
+     * @return true on success, false on error
+     */
+    function createMySQLAccount($values)
+    {
+        $DB = Database::singleton();
+        if ($DB->connect(
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) == false
+        ) {
+            if (!empty($DB->lastErr)) {
+                $this->_lastErr = $DB->lastErr;
+            } else {
+                $this->_lastErr = "Could not connect to MySQL server "
+                . "with credentials provided.";
+            }
+            return false;
+        }
+
+        // This script is being run by the web server, so get the host
+        // that the current user is connect from to be the host of the
+        // new user, since the new user is also going to be used from
+        // the same web server so should have the same address.
+        $connectHost = $DB->PDO->query(
+            "SELECT host FROM `mysql`.`user`
+		WHERE CONCAT(user, '@', host)=CURRENT_USER"
+        )->fetch(PDO::FETCH_ASSOC);
+
+        if (!is_array($connectHost) || empty($connectHost['host'])) {
+            // This should never happen. It would mean that the user
+            // that we ran the query from isn't connected..
+            $this->_lastErr = "Could not retrieve hostname for MySQL user";
+            return false;
+        }
+
+        $connectHost = $connectHost['host'];
+
+        $userExistsQ = $DB->prepare(
+            "SELECT 'x' FROM mysql.user 
+			WHERE user=:q_user AND host=:q_host"
+        );
+        $userExistsQ->execute(
+            [
+             'q_user' => $values['lorismysqluser'],
+             'q_host' => $connectHost,
+            ]
+        );
+        $results    = $userExistsQ->fetchAll(PDO::FETCH_ASSOC);
+        $userExists = false;
+
+        $quotedUser = $DB->PDO->quote($values['lorismysqluser']) .
+        '@' . $DB->PDO->quote($connectHost);
+
+        if (!empty($results)) {
+            // There is already a user for this username@hostname.
+            // Try connecting to see if the MySQL password matches.
+            // (the MySQL Password() function has been deprecated,
+            // so we can't rely on it to select a hash from the mysql.user
+            // table and compare.)
+            try {
+                $test = new PDO(
+                    "mysql:host=$values[dbhost];dbname=$values[dbname];charset=UTF8",
+                    $values['lorismysqluser'],
+                    $values['lorismysqlpassword']
+                );
+
+                // the user already exists and the password is valid.
+                // we don't need to go any further than this.
+                return true;
+            } catch(Exception $e) {
+                // the user already exists but we couldn't connect as it.
+                $this->_lastErr = "MySQL user $quotedUser already exists and "
+                . " password does not match or it does not"
+                . " have access to the $values[dbname]"
+                . " database.";
+                return false;
+            }
+        }
+
+        // The user does not exist and needs to be created
+        $DB->PDO->exec(
+            "CREATE USER IF NOT EXISTS $quotedUser IDENTIFIED BY " .
+            $DB->PDO->quote($values['lorismysqlpassword'])
+        );
+        $DB->PDO->exec(
+            "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES 
+			ON `$values[dbname]`.* TO $quotedUser"
+        );
+        return true;
+    }
+
+    /**
+     * Resets the username and password of the front end admin user.
+     *
+     * @param array $values an associative array. Must have keys for
+     *                      dbname, dbadminuser, dbadminpassword, dbhost,
+     *                      frontenduser, and frontendpassword
+     *
+     * @return true on success
+     */
+    function resetFrontEndAdmin($values)
+    {
+        if (empty($values['dbname'])
+            || empty($values['dbadminuser'])
+            || empty($values['dbadminpassword'])
+            || empty($values['dbhost'])
+            || empty($values['frontenduser'])
+            || empty($values['frontendpassword'])
+        ) {
+            $this->_lastErr = "All entries must be provided.";
+            return false;
+        }
+        $DB = Database::singleton();
+        if ($DB->connect(
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) == false
+        ) {
+            if (!empty($DB->lastErr)) {
+                $this->_lastErr = $DB->lastErr;
+            } else {
+                $this->_lastErr = "Could not connect to MySQL server "
+                . "with credentials provided.";
+            }
+            return false;
+        }
+
+        $stmt = $DB->prepare(
+            "UPDATE users SET UserID=:q_userID, Password_hash=:q_password, "
+            . "   Password_expiry=DATE_FORMAT(DATE_ADD(CURRENT_TIMESTAMP, "
+            . "                     INTERVAL 30 DAY), '%Y-%m-%d')"
+            . " WHERE ID=1"
+        );
+        return $stmt->execute(
+            [
+             'q_userID'   => $values['frontenduser'],
+             'q_password' => password_hash(
+                 $values['frontendpassword'],
+                 PASSWORD_DEFAULT
+             ),
+            ]
+        );
+    }
+
+    /**
+     * Returns whether or not the config.xml file should be writable.
+     *
+     * @return true if the file should be writable.
+     */
+    function configWritable()
+    {
+        // config.xml doesn't exist when this is called, so check if the
+        // directory is writable, since is_writable returns false for a
+        // file that doesn't exist.
+        return is_writable(__DIR__ . "/../../project");
+    }
+
+    /**
+     * Returns the XML for a valid configuration based on the parameters passed.
+     *
+     * @param array $values An associative array with keys for dbhost,
+     *                      lorismysqluser, lorismysqlpassword, and dbname
+     *
+     * @return true on success, false if there were any problems.
+     */
+    function getConfigContent($values)
+    {
+        $contents = file_get_contents(__DIR__ . "/../../docs/config/config.xml");
+        return str_replace(
+            [
+             '%HOSTNAME%',
+             '%USERNAME%',
+             '%PASSWORD%',
+             '%DATABASE%',
+            ],
+            [
+             $values['dbhost'],
+             $values['lorismysqluser'],
+             $values['lorismysqlpassword'],
+             $values['dbname'],
+            ],
+            $contents
+        );
+    }
+
+    /**
+     * Writes the config.xml file, based on the parameters passed in $values.
+     * $values should match the $_POST parameter on the last page of the
+     * installer
+     *
+     * @param array $values An associative array with keys for dbhost,
+     *                      lorismysqluser, lorismysqlpassword, and dbname
+     *
+     * @return true
+     */
+    function writeConfig($values)
+    {
+        $contents = $this->getConfigContent($values);
+        file_put_contents(__DIR__ . "/../../project/config.xml", $contents);
+        return true;
+    }
+}

--- a/php/installer/NDB_Config.class.inc
+++ b/php/installer/NDB_Config.class.inc
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This NDB_Config class is a stub that gets autoloaded by the LORIS installer.
+ * At the time of installation, the config.xml isn't setup yet, so the real
+ * NDB_Config class will fail if it gets autoloaded. Smarty tries to use
+ * NDB_Config, and the installer uses smarty, so this is required to make things
+ * not crash.
+ *
+ * PHP Version 5.4+
+ *
+ * @category Installer
+ * @package  Installer
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * This NDB_Config class is a stub that gets autoloaded by the LORIS installer.
+ * At the time of installation, the config.xml isn't setup yet, so the real
+ * NDB_Config class will fail if it gets autoloaded. Smarty tries to use
+ * NDB_Config, and the installer uses smarty, so this is required to make things
+ * not crash.
+ *
+ * PHP Version 5.4+
+ *
+ * @category Installer
+ * @package  Installer
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NDB_Config
+{
+    /**
+     * Returns a single NDB_Config object.
+     *
+     * @return NDB_Config
+     */
+    public static function singleton()
+    {
+        static $cfg = null;
+        if (is_null($cfg)) {
+            $cfg = new NDB_Config();
+        }
+        return $cfg;
+    }
+
+
+    /**
+     * Get a setting used by the installer.
+     *
+     * @param string $setting The setting to retrieve. Must be "paths".
+     *
+     * @return mixed the setting value
+     */
+    public function getSetting($setting)
+    {
+        // the base path is used by smarty, so calculate it relative
+        // to the current directory. Nothing else needs to be supported.
+        if ($setting == "paths") {
+            return [
+                    "base" => __DIR__ . "/../../",
+                   ];
+        }
+        return null;
+    }
+}
+

--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -1,0 +1,165 @@
+<html>
+	<head>
+	{* installdb.php is in the root directory, so we know these relative
+	   links should work. Load in the base LORIS bootstrap CSS
+	*}
+		<link rel="stylesheet" href="bootstrap/css/bootstrap.min.css">
+		<link rel="stylesheet" href="bootstrap/css/custom-css.css">
+
+		<title>Loris SQL Installer</title>
+	</head>
+    <body>
+	<div class="container">
+		<div class="page-header">
+			<h1>LORIS Installer{if $PageName}: {$PageName}{/if}</h1>
+		</div>
+		{if $error}<div class="alert alert-danger error">{$error}</div>{/if}
+		{if $console}<div class="alert alert-warning console"><pre>{$console}</pre></div>{/if}
+		<div>
+		{* Default page is at the end in the else statement. The rest of
+		   the pages are in the order that the user goes through them *}
+		{if $Page == "MySQLUserPrompt"}
+			<p>
+			   Successfully created MySQL database and sourced the schema.
+			   Now, we need to create a non-administer MySQL username for LORIS to use.
+			   This user will be created if it does not already exist.
+			</p>
+			<p>
+			   This username and password will be saved to the LORIS config
+			   file, so it's best to make sure you're using a unique password.
+			</p>
+			<p>
+			   If you're feeling uninspired, here's a randomly generated password:
+				<code>{$SamplePassword}</code>.
+			</p>
+			<p>
+			   We also need to set the username and password for the default
+			   <em>LORIS</em> admin account. This is the account that you will
+			   use to login to the LORIS frontend. Here's another password that
+			   you can user for that account if you don't have something else
+			   in mind: <code>{$SamplePassword2}</code>.
+			</p>
+		<form method="post">
+			<fieldset>
+				<legend>LORIS MySQL User</legend>
+			<div>
+				<label for="lorisuser">Username: <input type="text" name="lorismysqluser" placeholder="ie. lorisuser" value="{$lorismysqluser}">
+			</div>
+			<div>
+				<label for="lorispassword">Password: <input type="password" value="{$lorismysqlpassword}" name="lorismysqlpassword" placeholder="ie. LORISISTHEBEST!!!1">
+			</div>
+			</fieldset>
+			<fieldset>
+				<legend>LORIS Front End Admin</legend>
+			<div>
+				<label for="lorisuser">Username: <input type="text" name="frontenduser" placeholder="ie. myname" value="{$frontenduser}">
+			</div>
+			<div>
+				<label for="lorisuser">Password: <input type="password" name="frontendpassword" placeholder="ie. LORISISSTILLTHEBEST!!1" value="{$frontendpassword}">
+			</div>
+			</fieldset>
+			<input type="hidden" name="formname"        value="createmysqlaccount" />
+			<input type="hidden" name="dbname"          value="{$dbname}" />
+			<input type="hidden" name="dbhost"          value="{$dbhost}" />
+			<input type="hidden" name="dbadminuser"     value="{$dbadminuser}" />
+			<input type="hidden" name="dbadminpassword" value="{$dbadminpassword}" />
+			<div>
+				<input type="submit" />
+			</div>
+		</form>
+	{elseif $Page == "Done"}
+		{if $configfile}
+			<h2>Congratulations! You're done</h2>
+			<p>Wrote LORIS config file to {$configfile}.</p>
+		{else}
+			<h2>Almost done!</h2>
+			<p>The LORIS username was configured, but the web server
+			   wasn't able to write to the file {$configlocation}.</p>
+			<p>Please copy and paste the following into that file
+			   on the server in which this web server is running or
+			   contact your system administer for help:</p>
+			<div>
+				<code><pre>{$configcontent}</pre></code>
+			</div>
+		{/if}
+			<p>
+			  {if $configfile}
+				You should now be able to
+			  {else}
+				After that you should be able to
+			  {/if} access LORIS by visiting
+			  <a href="{$lorisurl}">{$lorisurl}</a> and logging in
+			  with the front end admin username and password you
+			  configured on the previous page.
+			</p>
+	{else}
+		{* Default Page *}
+		<p>Welcome to the LORIS installer.</p>
+		<p>This module is the last step in installing LORIS, before
+		proceeding to do your study configuration.</p>
+		<p>This installer will set up the default users, create the SQL
+		database and load the LORIS database schema, set up some basic
+		server configuration, and reset the default LORIS username and
+		password.
+		<p>In order to proceed you'll need the following information:
+		<ul>
+			<li>A MySQL hostname that you'll be installing
+			    LORIS on, which is accessible from this server.</li>
+			<li>A MySQL root username and password on that server which
+			    has permissions to create databases, tables, and users
+			    (this username and password will not be saved, but is
+			    only used for installing LORIS.)</li>
+			<li>The database name for LORIS to use. It's best to name
+			    your databases after the project being hosted, but if
+			    you're unsure it's safe to use the default value of
+			    "LORIS". This database must <strong>not</strong> already
+			    exist in MySQL.</li>
+		</ul></p>
+		<p>Let's get started.</p>
+		<form method="post">
+			<fieldset>
+				<legend>MySQL Connection Information</legend>
+			<div>
+				<div class="col-md-2">
+					<label for="serverhost">Server Hostname:</label>
+				</div>
+				<div class="col-md-10">
+					<input id="serverhost" value="{$dbhost}" type="text" name="dbhost" placeholder="ie. localhost">
+				</div>
+			</div>
+			<div>
+				<div class="col-md-2">
+					<label for="serveruser">Admin Username:</label>
+				</div>
+				<div class="col-md-10">
+					<input id="serveruser" value="{$dbadminuser}" name="dbadminuser" type="text" placeholder="ie. root">
+				</div>
+			</div>
+			<div>
+				<div class="col-md-2">
+					<label for="serverpassword">Admin Password:</label>
+				</div>
+				<div class="col-md-10">
+					<input id="serverpassword" value="{$dbadminpassword}" type="password" name="dbadminpassword" placeholder="ie. LORISISTHEBEST!!!1">
+				</div>
+			</div>
+			<div>
+				<div class="col-md-2">
+					<label for="dbname">Database name:</label>
+				</div>
+				<div class="col-md-10">
+					<input id="dbname" value="{if $dbname}{$dbname}{else}LORIS{/if}" type="text" name="dbname">
+				</div>
+			</div>
+			</fieldset>
+			<input type="hidden" name="formname" value="validaterootaccount" />
+			<div class="col-md-2">&nbsp;</div>
+			<div class="col-md-10">
+				<input class="btn btn-submit btn-default" type="submit" />
+			</div>
+		</form>
+	{/if}
+    </div>
+	</div>
+    </body>
+</html>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -56,7 +56,11 @@
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".inc">../php</directory>
+            <directory suffix=".inc">../php/libraries</directory>
+            <!-- CodeCov crashes because installer/ has classes with the same
+                 name as libraries/, so for now we only cover libraries and
+                 exceptions under php/ -->
+            <directory suffix=".inc">../php/exceptions</directory>
             <!--directory suffix=".php">../htdocs</directory-->
             <directory suffix=".inc">../modules/*/php</directory>
             <!--directory>../modules/dashboard/ajax/</directory-->

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -101,33 +101,8 @@ Please ensure you have the following information ready (if applicable):
   1) Your project directory name.   
      (Will be used to modify the paths for Imaging data in the generated
      config.xml file for LORIS, and may also be used to automatically
-     create/install apache config files.)
-
-  2) MySQL Database name. 
-     If an empty database has not already been created for your project, 
-     choose a simple name such as "LORIS" or "Abc_Def"
-
-  3) Hostname for the machine running MySQL server where the database
-     is or will be located.
-
-  4) A new MySQL username that the LORIS system will use to connect
-     to this server and database to perform frontend-backend transactions.  
-     This script will ask to create this user. 
-     Recommended: "lorisuser"
-
-  5) Host address of this machine - from which LORIS system will be connecting 
-     (Where Apache is installed)
-
-  6) A new password for the "lorisuser" MySQL username
-
-  7) Another new password for the 'admin' frontend Loris user account.
-     This 'admin' account will be the superuser Loris' web-accessible platform.
-
-  8) Credentials of an existing MySQL account with root or superuser privileges, 
-     capable of creating the database, or installing the schema, 
-     or creating users on the given database. 
-     This will only be used to create the database, install the schema, 
-     and/or create and grant privileges to the "lorisuser" MySQL user. 
+     create/install apache config files.) If unsure, a default like "LORIS"
+     should be acceptable.
 
 Please also consult the Loris WIKI on GitHub for more information on these 
 Install Script input parameters.
@@ -167,17 +142,11 @@ if [ -f ../project/config.xml ]; then
     exit 2;
 fi
 
-# Check that we're running in the proper directory structure.
-if [ ! -f ../SQL/0000-00-00-schema.sql ] ; then
-    echo "Could not find schema file; make sure the current directory is in tools/ under the distribution."
-    exit 2
-fi
-
 # Create some subdirectories, if needed.
 mkdir -p ../project ../project/data ../project/libraries ../project/instruments ../project/templates ../project/tables_sql ../project/modules ../smarty/templates_c
 
 # Setting 777 permissions for templates_c
-chmod 777 ../smarty/templates_c
+chmod 770 ../smarty/templates_c
 
 # Changing group to 'www-data' or 'apache' to give permission to create directories in Document Repository module
 # Detecting distribution
@@ -191,10 +160,20 @@ fi
 
 if [ $os_distro = "Ubuntu" ]; then
     sudo chown www-data.www-data ../modules/document_repository/user_uploads
+    sudo chown www-data.www-data ../smarty/templates_c
+    # Make Apache the group for project directory, so that the web based install
+    # can write the config.xml file.
+    sudo chgrp www-data ../project
+    sudo chmod 770 ../project
 elif [ $os_distro = "CentOS" ]; then
     sudo chown apache.apache ../modules/document_repository/user_uploads
+    sudo chown apache.apache ../smarty/templates_c
+    # Make Apache the group for project directory, so that the web based install
+    # can write the config.xml file.
+    sudo chgrp apache ../project
+    sudo chmod 770 ../project
 else
-    echo "$os_distro Linux distribution detected. We currently do not support this. Please manually chown/chgrp the user_uploads directory in ../modules/document_repository to the web server"
+    echo "$os_distro Linux distribution detected. We currently do not support this. Please manually chown/chgrp the user_uploads directory in ../modules/document_repository to the web server and ../smarty/templates_c"
 fi
 
 
@@ -210,240 +189,6 @@ if [ -d logs ]; then
         echo "$os_distro Linux distribution detected. We currently do not support this. Please manually set the permissions for user_uploads directory in ../modules/document_repository"
     fi
 fi
-
-
-while [ "$mysqldb" == "" ]; do
-	read -p "What is the database name? " mysqldb
-	echo $mysqldb | tee -a $LOGFILE > /dev/null
-	case $mysqldb in
-		"" )
-			read -p "What is the database name? " mysqldb
-			continue;;
-		* )
-			break;;
-	esac
-done;
-
-while [ "$mysqlhost" == "" ]; do
-        read -p "Database host? " mysqlhost
-	echo $mysqlhost | tee -a $LOGFILE > /dev/null
-       	case $mysqlhost in
-               	"" )
-                       	read -p "Database host? " mysqlhost
-                       	continue;;
-                * )
-       	                break;;
-        esac
-done;
-
-while [ "$mysqluser" == "" ]; do
-        read -p "What MySQL user will LORIS connect as? (Recommended: lorisuser)" mysqluser
-	echo $mysqluser | tee -a $LOGFILE > /dev/null
-       	case $mysqluser in
-               	"" )
-                       	read -p "What MySQL user will LORIS connect as? (Recommended: lorisuser)" mysqluser
-                       	continue;;
-                * )
-       	                break;;
-       	esac
-done;
-
-while [ "$mysqluserhost" == "" ]; do
-        read -p "What is the host from which MySQL user '$mysqluser' will connect? (Where Loris' Apache is hosted)" mysqluserhost
-        echo $mysqluserhost | tee -a $LOGFILE > /dev/null
-        case $mysqluserhost in
-                "" )
-                        read -p "What is the host from which MySQL user '$mysqluser' will connect? (Where Loris' Apache is hosted)" mysqluserhost
-                        continue;;
-                * )
-                        break;;
-        esac
-done;
-
-stty -echo
-
-while true; do
-        read -p "Choose a password for MySQL user '$mysqluser'? " mysqlpass
-	echo ""
-        read -p "Re-enter the password to check for accuracy: " mysqlpass2
-	if [[ "$mysqlpass" == "$mysqlpass2" ]] ; then
-	        break;
-	fi
-	echo ""
-	echo "Passwords did not match. Please try again.";
-done;
-
-stty echo ; echo ""
-stty -echo
-
-while true; do
-        read -p "Choose a different password for the front-end LORIS 'admin' user account: " lorispass
-        echo ""
-        read -p "Re-enter the password to check for accuracy: " lorispass2
-        if [[ "$lorispass" == "$lorispass2" ]] ; then
-                break;
-        fi
-	echo ""
-	echo "Passwords did not match. Please try again.";
-done;
-
-stty echo ; echo ""
-
-while [ "$mysqlrootuser" == "" ]; do
-       	read -p "Existing root or admin-level MySQL username: " mysqlrootuser
-	echo $mysqlrootuser | tee -a $LOGFILE > /dev/null
-       	case $mysqlrootuser in
-               	"" )
-                       	read -p "Existing root MySQL username: " mysqlrootuser
-                       	continue;;
-                * )
-       	                break;;
-       	esac
-done;
-
-stty -echo
-
-while true; do
-        read -p "MySQL password for user '$mysqlrootuser': " mysqlrootpass
-        echo ""
-        read -p "Re-enter the password to check for accuracy: " mysqlrootpass2
-        if [[ "$mysqlrootpass" == "$mysqlrootpass2" ]] ; then
-                break;
-        fi
-	echo ""
-	echo "Passwords did not match. Please try again.";
-done;
-
-stty echo
-
-echo ""
-while true; do
-    read -p "Would you like to automatically create the MySQL database for LORIS? [yn] " yn
-    echo $yn | tee -a $LOGFILE > /dev/null
-    case $yn in
-        [Yy]* )
-            while true; do
-                echo ""
-                echo "Attempting to create the MySQL database '$mysqldb' ..."
-                result=$(echo "CREATE DATABASE $mysqldb" | mysql -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1);
-                if [[ $result == *1044* ]] || [[ $result == *1045* ]]; then
-                    echo "Could not connect to database with the credential provided for '$mysqlrootuser' - Please try again.";
-                    read -p "Existing root MySQL username: " mysqlrootuser
-                    echo $mysqlrootuser | tee -a $LOGFILE > /dev/null
-                    stty -echo
-                    while true; do
-                        read -p "MySQL password for user '$mysqlrootuser': " mysqlrootpass
-                        echo ""
-                        read -p "Re-enter the password to check for accuracy: " mysqlrootpass2
-                        if [[ "$mysqlrootpass" == "$mysqlrootpass2" ]] ; then
-                            break;
-                        fi
-                        echo ""
-                        echo "Passwords did not match. Please try again.";
-                     done;
-                     stty echo
-                # Needed for mysql version > 5.6
-                elif [[ $result == *password* ]] && [[ $result != *1007* ]] ; then
-                    echo "Warning: Using a password on the command line interface can be insecure.";
-                    break;
-                elif [[ $result == *1007* ]] ; then
-                    echo "Could not create the database $mysqldb. A database with the name $mysqldb already exists.";
-                    read -p "Choose a different database name: " mysqldb
-                elif [[ $result != '' ]]; then
-                    echo "Could not create the database with the user '$mysqlrootuser' provided.";
-                    exit 1;
-                else
-                    break;
-                fi
-            done;
-            break;;
-        [Nn]* )
-            echo "Not creating MySQL database for LORIS."
-            break;;
-         * ) echo "Please enter 'y' or 'n'."
-    esac
-done;
-
-
-while true; do
-    read -p "Would you like to automatically create and grant privileges to MySQL user '$mysqluser'@'$mysqluserhost'? [yn] " yn
-    echo $yn | tee -a $LOGFILE > /dev/null
-    case $yn in
-        [Yy]* )
-            echo ""
-            echo "Attempting to create and grant privileges to MySQL user '$mysqluser'@'$mysqluserhost' ..."
-            echo "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON $mysqldb.* TO '$mysqluser'@'$mysqluserhost' IDENTIFIED BY '$mysqlpass' WITH GRANT OPTION" | mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A > /dev/null 2>&1
-            MySQLError=$?;
-            if [ $MySQLError -ne 0 ] ; then
-                echo "Could not connect to database with $mysqlrootuser user provided.";
-                exit 1;
-            fi
-            break;;
-        [Nn]* )
-            echo "Not creating and granting privileges to MySQL user '$mysqluser'@'$mysqluserhost'."
-            break;;
-         * ) echo "Please enter 'y' or 'n'."
-    esac
-done;
-
-
-while true; do
-    read -p "Would you like to automatically create/populate database tables from schema? [yn] " yn
-    echo $yn | tee -a $LOGFILE > /dev/null
-    case $yn in
-        [Yy]* )
-            echo ""
-            echo "Creating/populating database tables from schema."
-            echo ""
-            mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-00-schema.sql
-            mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-01-Permission.sql
-            mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-02-Menus.sql
-            mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-03-ConfigTables.sql
-            mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-04-Help.sql
-            mysql $mysqldb -h$mysqlhost --user=$mysqlrootuser --password="$mysqlrootpass" -A 2>&1 < ../SQL/0000-00-99-indexes.sql
-            echo "Updating Loris admin user's password."
-            pw_expiry=$(date --date="6 month" +%Y-%m-%d)
-            echo "Updating admin password reset date to be $pw_expiry"
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE users SET Password_MD5=CONCAT('aa', MD5('aa$lorispass')), Password_expiry='$pw_expiry', Pending_approval='N' WHERE ID=1"
-            break;;
-        [Nn]* )
-            echo "Not creating/populating database tables from schema."
-            break;;
-         * ) echo "Please enter 'y' or 'n'."
-    esac
-done;
-
-
-echo ""
-echo "Creating config file."
-sed -e "s/%HOSTNAME%/$mysqlhost/g" \
-    -e "s/%USERNAME%/$mysqluser/g" \
-    -e "s/%PASSWORD%/$mysqlpass/g" \
-    -e "s/%DATABASE%/$mysqldb/g" \
-    < ../docs/config/config.xml > ../project/config.xml
-
-
-while true; do
-    read -p "Would you like to automatically populate database config? [yn] " yn
-    echo $yn | tee -a $LOGFILE > /dev/null
-    case $yn in
-        [Yy]* )
-            echo ""
-            echo "Populating database config."
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$RootDir/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='$RootDir/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='DownloadPath')"
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$projectname/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='imagePath')"
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$projectname/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='data')"
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$projectname/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='mincPath')"
-            mysql $mysqldb -h$mysqlhost --user=$mysqluser --password="$mysqlpass" -A -e "UPDATE Config SET Value='/data/$projectname/data/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
-            break;;
-        [Nn]* )
-            echo "Not populating database config."
-            break;;
-         * ) echo "Please enter 'y' or 'n'."
-    esac
-done;
-
 
 echo ""
 # Install external libraries using composer

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -145,7 +145,7 @@ fi
 # Create some subdirectories, if needed.
 mkdir -p ../project ../project/data ../project/libraries ../project/instruments ../project/templates ../project/tables_sql ../project/modules ../smarty/templates_c
 
-# Setting 777 permissions for templates_c
+# Setting 770 permissions for templates_c
 chmod 770 ../smarty/templates_c
 
 # Changing group to 'www-data' or 'apache' to give permission to create directories in Document Repository module


### PR DESCRIPTION
This removes all parts of sourcing the schema and updating the config from the
install.sh script and moves it into a friendlier web based installer, where more
error checking and validation can be easily done. Since it's web based, the web
server and PHP need to already be installed and run (as does composer, since it
uses smarty) and the install.sh script can not yet be completely removed.

Being web based, we also have more information that can be deduced instead of
prompted for, such as the hostname/URL (we can just check the hostname that the
user is accessing the install page from) or the host for the MySQL username
(which we can assume is the same as the admin MySQL user creating the database,
since the install script is connecting from the same place as LORIS.)

The API secret token is also now randomly generated when installing the
database, since it doesn't matter what it is as long as the server is always
using the same key to generate and authenticate tokens, and this is easier to
do in PHP than it was in a shell script.