### PR TITLE
Add submit and hidden elements to LorisForm

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -100,7 +100,7 @@ class LorisForm
      *
      * @return &array A reference to the array that was added to $this->form
      */
-    protected function &addBase($name, $label, $attribs)
+    protected function &addBase($name, $label, $attribs = array())
     {
         $el = $this->createBase($name, $label, $attribs);
         $this->form[$name] =& $el;
@@ -163,6 +163,21 @@ class LorisForm
     {
         $el         =& $this->addBase($name, $label, $options);
         $el['type'] = 'password';
+        return $el;
+    }
+
+    /**
+     * Reimplementation of HTML_QuickForm's "addHidden" API.
+     *
+     * @param string $name    The element name.
+     * @param string $value   The element value.
+     *
+     * @return &array
+     */
+    public function addHidden($name, $value)
+    {
+        $el         =& $this->addBase($name, null, array('value' => $value));
+        $el['type'] = 'hidden';
         return $el;
     }
 
@@ -353,6 +368,9 @@ class LorisForm
             break;
         case 'advcheckbox':
             $el = $this->addCheckbox($name, $label, $options);
+            break;
+        case 'hidden':
+            $el = $this->addHidden($name, $label);
             break;
         case 'text':
         default:
@@ -797,14 +815,30 @@ class LorisForm
         if (isset($el['class'])) {
             $cls = "class=\"$el[class]\"";
         }
-        $value = $this->getValue($el['name']);
-        return "<input name=\"$el[name]\" type=\"$type\" $cls"
-            . (
-                (!empty($value) || $value === '0')
-                ? ' value="' . $this->getValue($el['value']) . '"'
-                : ''
-              )
-            .">";
+        $value = '';
+        if (isset($el['value'])) {
+            $value = "value=\"$el[value]\"";
+        }
+        return "<input name=\"$el[name]\" type=\"$type\" $cls $value>";
+    }
+
+    /**
+     * Generates the HTML to add to the page when rendered for a hidden
+     * element.
+     *
+     * @param array  $el   The element to render from $this->form
+     * @param string $type The HTML input type to user for this input
+     *                     box
+     *
+     * @return string A string of the HTML markup to render
+     */
+    function hiddenHTML($el, $type='hidden')
+    {
+        $value = '';
+        if (isset($el['value'])) {
+            $value = "value=\"$el[value]\"";
+        }
+        return "<input name=\"$el[name]\" type=\"$type\" $value>";
     }
 
     /**
@@ -1034,6 +1068,8 @@ class LorisForm
             return '';
         case 'submit':
             return $this->submitHTML($el);
+        case 'hidden':
+            return $this->hiddenHTML($el);
         }
         throw new LorisException(
             "Unsupported element type $el[type] in renderElement"

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -717,14 +717,15 @@ class LorisForm
      *
      * @return string A string of the HTML markup to render
      */
-    function groupHTML($el)
+    function groupHTML(&$el)
     {
         $retVal = '';
-        foreach ($el['elements'] as $element) {
+        foreach ($el['elements'] as &$element) {
             if (isset($el['options']['prefix_wrapper'])) {
                 $retVal .= $el['options']['prefix_wrapper'];
             }
-            $retVal .= $this->renderElement($element);
+            $element['html'] = $this->renderElement($element);
+            $retVal .= $element['html'];
             if (isset($el['options']['postfix_wrapper'])) {
                 $retVal .= $el['options']['postfix_wrapper'];
             }
@@ -1006,7 +1007,7 @@ class LorisForm
      *
      * @return string the HTML for the given element.
      */
-    function renderElement($el)
+    function renderElement(&$el)
     {
         switch($el['type']) {
         case 'date':

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -81,6 +81,9 @@ class LorisForm
         if (isset($attribs['required']) && $attribs['required'] === true) {
             $el['required'] = true;
         }
+        if (isset($attribs['align'])) {
+            $el['align'] = $attribs['align'];
+        }
 
         return $el;
     }
@@ -346,7 +349,7 @@ class LorisForm
             $el = $this->addPassword($name, $label, $options);
             break;
         case 'header':
-            $el = $this->addHeader($name, $label);
+            $el = $this->addHeader($name, $label, $options);
             break;
         case 'advcheckbox':
             $el = $this->addCheckbox($name, $label, $options);
@@ -1046,7 +1049,17 @@ class LorisForm
      */
     function headerHTML($el)
     {
-        return "<h2>$el[label]</h2>";
+        $cls   = '';
+        $align = '';
+
+        if (isset($el['class'])) {
+            $cls = "class=\"$el[class]\"";
+        }
+        if (isset($el['align'])) {
+            $align = "align=\"$el[align]\"";
+        }
+
+        return "<h2 $cls $align>$el[label]</h2>";
     }
 
     /**

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -381,6 +381,29 @@ class LorisForm
     }
 
     /**
+     * Reimplementation of HTML_QuickForm's createSubmit function.
+     *
+     * Creates a text element that can be added to the page but
+     * does not itself add the element.
+     *
+     * @param string $elname  The name of the element to be added to
+     *                        the form
+     * @param string $value   The value of the element to be added to
+     *                        the form
+     * @param array  $attribs An array of extra HTML attributes to be
+     *                        added to this element.
+     *
+     * @return array of the form that can be added to $this->form
+     */
+    function createSubmit($elname, $value, $attribs = array())
+    {
+        $attribs['value'] = $value;
+        $el         =& $this->createBase($elname, null, $attribs);
+        $el['type'] = 'submit';
+        return $el;
+    }
+
+    /**
      * Reimplementation of HTML_QuickForm's createTextArea function.
      *
      * Creates a text element that can be added to the page but
@@ -755,6 +778,32 @@ class LorisForm
     }
 
     /**
+     * Generates the HTML to add to the page when rendered for a submit
+     * element.
+     *
+     * @param array  $el   The element to render from $this->form
+     * @param string $type The HTML input type to user for this input
+     *                     box
+     *
+     * @return string A string of the HTML markup to render
+     */
+    function submitHTML($el, $type='submit')
+    {
+        $cls      = '';
+        if (isset($el['class'])) {
+            $cls = "class=\"$el[class]\"";
+        }
+        $value = $this->getValue($el['name']);
+        return "<input name=\"$el[name]\" type=\"$type\" $cls"
+            . (
+                (!empty($value) || $value === '0')
+                ? ' value="' . $this->getValue($el['value']) . '"'
+                : ''
+              )
+            .">";
+    }
+
+    /**
      * Generates the HTML to add to the page when a file is
      * added to the form.
      *
@@ -979,6 +1028,8 @@ class LorisForm
             return $this->headerHTML($el);
         case 'page':
             return '';
+        case 'submit':
+            return $this->submitHTML($el);
         }
         throw new LorisException(
             "Unsupported element type $el[type] in renderElement"
@@ -1251,6 +1302,8 @@ class LorisForm
             return $this->createText($elname, $label, $options, $attribs);
         case 'select':
             return $this->createSelect($elname, $label, $options, $attribs);
+        case 'submit':
+            return $this->createSubmit($elname, $label, $options);
         case 'static':
             /* Label seems to usually be the wrong attribute for static
              * elements?

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1427,7 +1427,7 @@ class LorisForm
     function getSubmitValues()
     {
         $retVal = array();
-        $this->getGroupValues(array_keys($_REQUEST), $retVal);
+        $this->getGroupValues(array_keys($_POST), $retVal);
         return $retVal;
     }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -169,8 +169,8 @@ class LorisForm
     /**
      * Reimplementation of HTML_QuickForm's "addHidden" API.
      *
-     * @param string $name    The element name.
-     * @param string $value   The element value.
+     * @param string $name  The element name.
+     * @param string $value The element value.
      *
      * @return &array
      */
@@ -742,8 +742,10 @@ class LorisForm
             if (isset($el['options']['prefix_wrapper'])) {
                 $retVal .= $el['options']['prefix_wrapper'];
             }
+
             $element['html'] = $this->renderElement($element);
-            $retVal .= $element['html'];
+            $retVal         .= $element['html'];
+
             if (isset($el['options']['postfix_wrapper'])) {
                 $retVal .= $el['options']['postfix_wrapper'];
             }
@@ -811,7 +813,7 @@ class LorisForm
      */
     function submitHTML($el, $type='submit')
     {
-        $cls      = '';
+        $cls = '';
         if (isset($el['class'])) {
             $cls = "class=\"$el[class]\"";
         }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -170,7 +170,6 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     static function factory($instrument, $commentID, $page, $guarantee_exists = true)
     {
-        include_once 'HTML/QuickForm.php';
         $class = "NDB_BVL_Instrument_$instrument";
 
         // Make sure the instrument class has been included/required!
@@ -424,7 +423,6 @@ class NDB_BVL_Instrument extends NDB_Page
         $this->form->setDefaults($defaults);
 
         if ($this->DataEntryType == 'DirectEntry') {
-            $renderer = new HTML_QuickForm_Renderer_Default();
             if (isset($this->testName)) {
                 $renderer->setFormTemplate(
                     "<form{attributes}>

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -243,8 +243,8 @@ class NDB_Page
      * Adds a hidden element to the current page. Note if the hidden element
      * needs a value it should be added to the defaults.
      *
-     * @param string $name      The name of the hidden element to add
-     * @param array  $value     The value of the hidden element to add
+     * @param string $name  The name of the hidden element to add
+     * @param array  $value The value of the hidden element to add
      *
      * @return none
      */

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -243,15 +243,14 @@ class NDB_Page
      * Adds a hidden element to the current page. Note if the hidden element
      * needs a value it should be added to the defaults.
      *
-     * @param string $label      The label to attach to the element
-     * @param array  $attributes List of HTML attributes to add to the
-     *                           element
+     * @param string $name      The name of the hidden element to add
+     * @param array  $value     The value of the hidden element to add
      *
      * @return none
      */
-    function addHidden($label, $attributes=null)
+    function addHidden($name, $value=null)
     {
-        $this->form->addElement('hidden', $label, $attributes);
+        $this->form->addElement('hidden', $name, $value);
     }
 
     /**

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -14,7 +14,11 @@
 	{assign var="inTable" value="FALSE"}
 	{foreach from=$form.elements item=element}
 		{if $element.name neq mainError}
-			{if $element.name eq lorisSubHeader}
+			{if $element.type eq header}
+				<div class="col-xs-12">
+					{$element.html}
+				</div>
+			{elseif $element.name eq lorisSubHeader}
 				<div class="col-xs-12">
 					{$element.label}
 				</div>


### PR DESCRIPTION
This pull request add the ability to create a submit element and add a hidden element to LorisForm. Along with add attributes to the Header element.

It also modifies the group element HTML render function to attach the HTML for each children to the child element itself as opposed to just rendering the HTML for the entire group. This makes the HTML renderer behave more similar to the renderer used with QuickForm in instruments. 