### PR TITLE
imaging browser: false will show as caveat if selected (Redmine 10517)

### DIFF
--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -34,7 +34,7 @@
                       "Selected" : "{if $files[file].Selected}{$files[file].Selected}{/if}",
                       "SelectedOptions" : {$selected_options|json_encode},
 
-                      "Caveat" : "{if $files[file].Caveat}{$files[file].Caveat}{/if}",
+                      "Caveat" : "{$files[file].Caveat}",
                       "SNR" : "{if $files[file].SNR}{$files[file].SNR}{/if}",
                       'HeaderInfo' : {
                           'XStep' : "{$files[file].Xstep}",


### PR DESCRIPTION
False would not show as selected caveat.  Now does as well as true shows as true and null or nothing shows as nothing.