### PR TITLE
examiner: Could not reset certification to N/A (Redmine: 10612)

### DIFF
--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -186,7 +186,7 @@ class NDB_Form_Examiner extends NDB_Form
                 $oldVal  = $oldVals['new'];
                 $oldDate = $oldVals['new_date'];
 
-                $oldCertification = $DB->pselect(
+                $oldCertification = $DB->pselectRow(
                     "SELECT pass, date_cert, comment
                      FROM certification
                      WHERE examinerID=:EID AND testID=:TID",


### PR DESCRIPTION
Was failing because pselect returns arrays of array instead of the expected array