### PR TITLE
[Media] Update SQL table structure

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE `acknowledgements` (
 
 --
 -- Dumping data for table `acknowledgements`
--- 
+--
 
 LOCK TABLES `acknowledgements` WRITE;
 /*!40000 ALTER TABLE `acknowledgements` DISABLE KEYS */;
@@ -102,9 +102,9 @@ CREATE TABLE `caveat_options` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- 
+--
 -- Dumping data for table `caveat_options`
--- 
+--
 
 LOCK TABLES `caveat_options` WRITE;
 /*!40000 ALTER TABLE `caveat_options` DISABLE KEYS */;
@@ -268,7 +268,7 @@ CREATE TABLE `feedback_bvl_type` (
 
 LOCK TABLES `feedback_bvl_type` WRITE;
 /*!40000 ALTER TABLE `feedback_bvl_type` DISABLE KEYS */;
-INSERT INTO `feedback_bvl_type` VALUES 
+INSERT INTO `feedback_bvl_type` VALUES
     (1,'Input','Input Errors'),
     (2,'Scoring','Scoring Errors');
 /*!40000 ALTER TABLE `feedback_bvl_type` ENABLE KEYS */;
@@ -293,13 +293,13 @@ CREATE TABLE `feedback_mri_comment_types` (
 
 LOCK TABLES `feedback_mri_comment_types` WRITE;
 /*!40000 ALTER TABLE `feedback_mri_comment_types` DISABLE KEYS */;
-INSERT INTO `feedback_mri_comment_types` VALUES 
+INSERT INTO `feedback_mri_comment_types` VALUES
     (1,'Geometric distortion','volume','a:2:{s:5:\"field\";s:20:\"Geometric_distortion\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"Good\";i:2;s:4:\"Fair\";i:3;s:4:\"Poor\";i:4;s:12:\"Unacceptable\";}}'),
     (2,'Intensity artifact','volume','a:2:{s:5:\"field\";s:18:\"Intensity_artifact\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"Good\";i:2;s:4:\"Fair\";i:3;s:4:\"Poor\";i:4;s:12:\"Unacceptable\";}}'),
     (3,'Movement artifact','volume','a:2:{s:5:\"field\";s:30:\"Movement_artifacts_within_scan\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"None\";i:2;s:15:\"Slight Movement\";i:3;s:12:\"Poor Quality\";i:4;s:12:\"Unacceptable\";}}'),
     (4,'Packet movement artifact','volume','a:2:{s:5:\"field\";s:31:\"Movement_artifacts_between_packets\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"None\";i:2;s:15:\"Slight Movement\";i:3;s:12:\"Poor Quality\";i:4;s:12:\"Unacceptable\";}}'),
     (5,'Coverage','volume','a:2:{s:5:\"field\";s:8:\"Coverage\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"Good\";i:2;s:4:\"Fair\";i:3;s:5:\"Limit\";i:4;s:12:\"Unacceptable\";}}'),	    (6,'Overall','volume',''),
-    (7,'Subject','visit',''),	
+    (7,'Subject','visit',''),
     (8,'Dominant Direction Artifact (DWI ONLY)','volume','a:2:{s:5:"field";s:14:"Color_Artifact";s:6:"values";a:5:{i:0;s:0:"";i:1;s:4:"Good";i:2;s:4:"Fair";i:3;s:4:"Poor";i:4;s:12:"Unacceptable";}}'),
     (9,'Entropy Rating (DWI ONLY)','volume','a:2:{s:5:"field";s:7:"Entropy";s:6:"values";a:5:{i:0;s:0:"";i:1;s:10:"Acceptable";i:2;s:10:"Suspicious";i:3;s:12:"Unacceptable";i:4;s:13:"Not Available";}}');
 /*!40000 ALTER TABLE `feedback_mri_comment_types` ENABLE KEYS */;
@@ -325,7 +325,7 @@ CREATE TABLE `feedback_mri_predefined_comments` (
 
 LOCK TABLES `feedback_mri_predefined_comments` WRITE;
 /*!40000 ALTER TABLE `feedback_mri_predefined_comments` DISABLE KEYS */;
-INSERT INTO `feedback_mri_predefined_comments` VALUES 
+INSERT INTO `feedback_mri_predefined_comments` VALUES
 	(1,2,'missing slices'),
 	(2,2,'reduced dynamic range due to bright artifact/pixel'),
 	(3,2,'slice to slice intensity differences'),
@@ -445,7 +445,7 @@ CREATE TABLE `files` (
   `SourcePipeline` varchar(255),
   `PipelineDate` date,
   `SourceFileID` int(10) unsigned DEFAULT '0',
-  `ProcessProtocolID` int(11) unsigned, 
+  `ProcessProtocolID` int(11) unsigned,
   `Caveat` tinyint(1) default NULL,
   `TarchiveSource` int(11) default NULL,
   PRIMARY KEY  (`FileID`),
@@ -658,7 +658,7 @@ CREATE TABLE `mri_scan_type` (
 
 LOCK TABLES `mri_scan_type` WRITE;
 /*!40000 ALTER TABLE `mri_scan_type` DISABLE KEYS */;
-INSERT INTO `mri_scan_type` VALUES 
+INSERT INTO `mri_scan_type` VALUES
     (40,'fMRI'),
     (41,'flair'),
     (44,'t1'),
@@ -674,7 +674,7 @@ INSERT INTO `mri_scan_type` VALUES
     (54,'cocosco_cls'),
     (55,'clean_cls'),
     (56,'em_cls'),
-    (57,'seg'),	
+    (57,'seg'),
     (58,'white_matter'),
     (59,'gray_matter'),
     (60,'csf_matter'),
@@ -763,7 +763,7 @@ CREATE TABLE `notification_types` (
 
 LOCK TABLES `notification_types` WRITE;
 /*!40000 ALTER TABLE `notification_types` DISABLE KEYS */;
-INSERT INTO `notification_types` (Type,private,Description) VALUES 
+INSERT INTO `notification_types` (Type,private,Description) VALUES
     ('mri new study',0,'New studies processed by the MRI upload handler'),
     ('mri new series',0,'New series processed by the MRI upload handler'),
     ('mri upload handler emergency',1,'MRI upload handler emergencies'),
@@ -773,7 +773,7 @@ INSERT INTO `notification_types` (Type,private,Description) VALUES
     ('visual bvl qc',0,'Timepoints selected for visual QC'),
     ('mri qc status',0,'MRI QC Status change');
 
-INSERT INTO notification_types (Type,private,Description) VALUES 
+INSERT INTO notification_types (Type,private,Description) VALUES
     ('minc insertion',1,'Insertion of the mincs into the mri-table'),
     ('tarchive loader',1,'calls specific Insertion Scripts'),
     ('tarchive validation',1,'Validation of the dicoms After uploading'),
@@ -891,7 +891,7 @@ CREATE TABLE `parameter_type` (
 
 LOCK TABLES `parameter_type` WRITE;
 /*!40000 ALTER TABLE `parameter_type` DISABLE KEYS */;
-INSERT INTO `parameter_type` VALUES 
+INSERT INTO `parameter_type` VALUES
 	(2,'Geometric_distortion','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
 	(3,'Intensity_artifact','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
 	(4,'Movement_artifacts_within_scan','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
@@ -953,18 +953,18 @@ UNLOCK TABLES;
 -- ADDing Meta-data Visit_label , candidate_label and candidate_dob
 --
 
-INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition) 
+INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition)
 VALUES ('candidate_label','text','Identifier_of_candidate',null,null,'PSCID','candidate',null,1,null);
-INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition) 
+INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition)
 VALUES ('Visit_label','varchar(255)','Visit_label',null,null,'visit_label','session',null,1,null);
-INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition) 
+INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition)
 VALUES  ('candidate_dob','date','Candidate_Dob',null,null,'DoB','candidate',null,1,null);
 
 INSERT INTO parameter_type_category (Name, type) VALUES('Identifiers', 'Metavars');
 
-INSERT INTO parameter_type_category_rel (ParameterTypeID,ParameterTypeCategoryID) 
-SELECT pt.ParameterTypeID,ptc.ParameterTypeCategoryID 
-FROM parameter_type pt,parameter_type_category ptc 
+INSERT INTO parameter_type_category_rel (ParameterTypeID,ParameterTypeCategoryID)
+SELECT pt.ParameterTypeID,ptc.ParameterTypeCategoryID
+FROM parameter_type pt,parameter_type_category ptc
 WHERE ptc.Name='Identifiers' AND pt.Name IN ('candidate_label', 'Visit_label','candidate_dob');
 
 
@@ -1501,9 +1501,9 @@ CREATE TABLE participant_status_options (
         Required boolean default NULL,
         parentID int(10) default NULL,
         PRIMARY KEY  (ID),
-        UNIQUE KEY ID (ID) 
+        UNIQUE KEY ID (ID)
 );
-INSERT INTO `participant_status_options` VALUES 
+INSERT INTO `participant_status_options` VALUES
 	(1,'Active',0,NULL),
 	(2,'Refused/Not Enrolled',0,NULL),
 	(3,'Ineligible',0,NULL),
@@ -1532,7 +1532,7 @@ CREATE TABLE participant_status (
         study_consent_date date default NULL,
         study_consent_withdrawal date default NULL,
         PRIMARY KEY  (ID),
-        UNIQUE KEY ID (ID) 
+        UNIQUE KEY ID (ID)
 );
 
 
@@ -1935,7 +1935,7 @@ CREATE TABLE `CNV` (
 --
 -- Table structure for table `GWAS`
 -- Genomic Browser module
--- 
+--
 DROP TABLE IF EXISTS `GWAS`;
 CREATE TABLE `GWAS` (
   `GWASID` int unsigned NOT NULL AUTO_INCREMENT,
@@ -2021,7 +2021,7 @@ CREATE TABLE `genomic_cpg_annotation` (
   `cpg_name` varchar(100) NOT NULL,
   `location_id` bigint(20) NOT NULL,
   `address_id_a` int unsigned NULL,
-  `probe_seq_a` varchar(100) NULL, 
+  `probe_seq_a` varchar(100) NULL,
   `address_id_b` int unsigned NULL,
   `probe_seq_b` varchar(100) NULL,
   `design_type` varchar(20) NULL,
@@ -2032,7 +2032,7 @@ CREATE TABLE `genomic_cpg_annotation` (
   `gene_acc_num` text NULL,
   `gene_group` text NULL,
   `island_loc` varchar(100) NULL,
-  `island_relation` enum ('island', 'n_shelf', 'n_shore', 's_shelf', 's_shore') NULL, 
+  `island_relation` enum ('island', 'n_shelf', 'n_shore', 's_shelf', 's_shore') NULL,
   `fantom_promoter_loc`varchar(100) NULL,
   `dmr` enum ('CDMR', 'DMR', 'RDMR') NULL,
   `enhancer` tinyint(1) NULL,
@@ -2118,7 +2118,7 @@ DROP TABLE IF EXISTS ExternalLinkTypes;
 CREATE TABLE ExternalLinkTypes (
     LinkTypeID int NOT NULL AUTO_INCREMENT PRIMARY KEY,
     LinkType varchar(255)
-);  
+);
 INSERT INTO ExternalLinkTypes (LinkType)
     VALUES ('FooterLink'),
            ('StudyLinks'),
@@ -2132,7 +2132,7 @@ CREATE TABLE ExternalLinks (
     LinkURL varchar(255) NOT NULL,
     FOREIGN KEY (LinkTypeID) REFERENCES ExternalLinkTypes(LinkTypeID)
 );
-INSERT INTO ExternalLinks (LinkTypeID, LinkText, LinkURL) VALUES 
+INSERT INTO ExternalLinks (LinkTypeID, LinkText, LinkURL) VALUES
     (1,  'Loris Website', 'http://www.loris.ca'),
     (1,  'GitHub', 'https://github.com/aces/Loris'),
     (2,  'Loris Website', 'http://www.loris.ca'),
@@ -2165,3 +2165,21 @@ CREATE TABLE `data_release_permissions` (
  CONSTRAINT `FK_userid` FOREIGN KEY (`userid`) REFERENCES `users` (`ID`),
  CONSTRAINT `FK_data_release_id` FOREIGN KEY (`data_release_id`) REFERENCES `data_release` (`id`)
 );
+
+DROP TABLE IF EXISTS `media`;
+CREATE TABLE `media` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `session_id` int(10) unsigned NOT NULL,
+  `instrument` varchar(255) DEFAULT NULL,
+  `date_taken` date DEFAULT NULL,
+  `comments` text,
+  `file_name` varchar(255) NOT NULL,
+  `file_type` varchar(255) DEFAULT NULL,
+  `data_dir` varchar(255) NOT NULL,
+  `uploaded_by` varchar(255) DEFAULT NULL,
+  `hide_file` tinyint(1) DEFAULT '0',
+  `date_uploaded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
+  FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -17,7 +17,7 @@ CREATE TABLE `permissions` (
 
 LOCK TABLES `permissions` WRITE;
 /*!40000 ALTER TABLE `permissions` DISABLE KEYS */;
-INSERT INTO `permissions` VALUES 
+INSERT INTO `permissions` VALUES
     (1,'superuser','There can be only one Highlander','1'),
     (2,'user_accounts','User management','2'),
     (3,'user_accounts_multisite','Across all sites create and edit users','2'),
@@ -60,10 +60,10 @@ INSERT INTO `permissions` VALUES
     (40,'imaging_uploader','Imaging Uploader','2'),
     (41,'acknowledgements_view','View Acknowledgements','2'),
     (42,'acknowledgements_edit','Edit Acknowledgements','2'),
-    (43,'dataquery_view','View Data Query Tool','2');
-
-INSERT INTO `permissions` (code, description, categoryID) VALUES
-    ('genomic_data_manager', 'Manage the genomic files', 2);
+    (43,'dataquery_view','View Data Query Tool','2'),
+    (44,'genomic_data_manager','Manage the genomic files','2'),
+    (45,'media_write','Media files: Uploading/Downloading/Editing','2'),
+    (46,'media_read','Media files: Browsing','2');
 
 /*!40000 ALTER TABLE `permissions` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -9,32 +9,33 @@ CREATE TABLE LorisMenu (
     OrderNumber integer
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO LorisMenu (Label, OrderNumber) VALUES 
-     ('Candidate', 1), 
-     ('Clinical', 2), 
-     ('Imaging', 3), 
-     ('Reports', 4), 
-     ('Tools', 5), 
+INSERT INTO LorisMenu (Label, OrderNumber) VALUES
+     ('Candidate', 1),
+     ('Clinical', 2),
+     ('Imaging', 3),
+     ('Reports', 4),
+     ('Tools', 5),
      ('Admin', 6);
 
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('New Profile', 'new_profile/', (SELECT ID FROM LorisMenu as L WHERE Label='Candidate'), 1),
     ('Access Profile', 'candidate_list/', (SELECT ID FROM LorisMenu as L WHERE Label='Candidate'), 2);
 
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Reliability', 'reliability/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 1),
     ('Conflict Resolver', 'conflict_resolver/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 2),
     ('Examiner', 'examiner/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 3),
-    ('Training', 'training/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 4);
+    ('Training', 'training/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 4),
+    ('Media', 'media/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 5);
 
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Radiological Reviews', 'final_radiological_review/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 1),
     ('DICOM Archive', 'dicom_archive/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 2),
     ('Imaging Browser', 'imaging_browser/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 3),
     ('MRI Violated Scans', 'mri_violations/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 4),
     ('Imaging Uploader', 'imaging_uploader/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 5);
 
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Statistics', 'statistics/', (SELECT ID FROM LorisMenu as L WHERE Label='Reports'), 1),
     ('Data Query Tool', 'dataquery/', (SELECT ID FROM LorisMenu as L WHERE Label='Reports'), 2);
 
@@ -48,7 +49,7 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Data Release', 'data_release/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 7),
     ('Acknowledgements', 'acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 8);
 
-INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES 
+INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('User Accounts', 'user_accounts/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 1),
     ('Survey Module', 'survey_accounts/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 2),
     ('Help Editor', 'help_editor/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 3),
@@ -63,49 +64,49 @@ CREATE TABLE LorisMenuPermissions (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT="If a user has ANY of the permissions for a module it will show up in their menu bar";
 
 -- New Profile permission
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='New Profile';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='New Profile';
 
--- Access Profile 
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+-- Access Profile
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Access Profile';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='Access Profile';
 
 -- Reliability
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='user_accounts' AND m.Label='Reliability';
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='reliability_edit_all' AND m.Label='Reliability';
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='Reliability';
 
 -- Conflict Resolver
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='conflict_resolver' AND m.Label='Conflict Resolver';
 
 -- Examiner
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_site' AND m.Label='Examiner';
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_multisite' AND m.Label='Examiner';
 
 -- Training
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='training' AND m.Label='Training';
 
 -- Radiological Reviews
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='edit_final_radiological_review' AND m.Label='Radiological Reviews';
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='view_final_radiological_review' AND m.Label='Radiological Reviews';
 
 -- DICOM Archive
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='dicom_archive_view_allsites' AND m.Label='DICOM Archive';
-    
+
 -- Imaging Browser
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='imaging_browser_view_site' AND m.Label='Imaging Browser';
@@ -113,11 +114,11 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='imaging_browser_view_allsites' AND m.Label='Imaging Browser';
 
 -- MRI Violated Scans
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='violated_scans_view_allsites' AND m.Label='MRI Violated Scans';
 
 -- MRI Upload
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='imaging_uploader' AND m.Label='Imaging Uploader';
 
 -- Statistics
@@ -125,57 +126,57 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Statistics';
 
 -- Data Query Tool
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_dict_view' AND m.Label='Data Query Tool';
 
 -- Data Dictionary
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_dict_view' AND m.Label='Data Dictionary';
 
 -- Document Repository
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='document_repository_view' AND m.Label='Document Repository';
 
 -- Data Integrity Flag
-INSERT INTO LorisMenuPermissions (MenuID, PermID) SELECT m.ID, p.PermID 
+INSERT INTO LorisMenuPermissions (MenuID, PermID) SELECT m.ID, p.PermID
     FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_integrity_flag' AND m.Label='Data Integrity Flag';
 
 -- Data Team Helper
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_team_helper' AND m.Label='Data Team Helper';
 
--- Instrument Builder 
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+-- Instrument Builder
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='instrument_builder' AND m.Label='Instrument Builder';
 
--- Genomic Browser 
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+-- Genomic Browser
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='genomic_browser_view_site' AND m.Label='Genomic Browser';
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='genomic_browser_view_allsites' AND m.Label='Genomic Browser';
 
 -- User Accounts
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='user_accounts' AND m.Label='User Accounts';
 
 -- Survey Module
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='user_accounts' AND m.Label='Survey Module';
 
 -- Help Editor
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='context_help' AND m.Label='Help Editor';
 
 -- Instrument Manager
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='superuser' AND m.Label='Instrument Manager';
 
 -- Configuration
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='config' AND m.Label='Configuration';
 
 -- Server Processes Manager
-INSERT INTO LorisMenuPermissions (MenuID, PermID) 
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='server_processes_manager' AND m.Label='Server Processes Manager';
 
 -- Acknowledgement Generator

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -48,7 +48,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ImagingUploaderAutoLaunch', "Allows running the ImagingUpload pre-processing scripts", 1, 0, 'boolean', ID, 'ImagingUploader Auto Launch',21 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'citation_policy', 'Citation Policy for Acknowledgements module', 1, 0, 'textarea', ID, 'Citation Policy', 22 FROM ConfigSettings WHERE Name="study";
 
-
 -- paths
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('paths', 'Specify directories where LORIS-related files are stored or created. Take care when editing these fields as changing them incorrectly can cause certain modules to lose functionality.', 1, 0, 'Paths', 2);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'imagePath', 'Path to images for display in Imaging Browser (e.g. /data/$project/data/) ', 1, 0, 'text', ID, 'Images', 9 FROM ConfigSettings WHERE Name="paths";
@@ -62,6 +61,8 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MRICodePath', 'Path to directory where Loris-MRI (git) code is installed', 1, 0, 'text', ID, 'LORIS-MRI code', 6 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MRIUploadIncomingPath', '"Path to the Directory of Uploaded Scans', 1, 0, 'text', ID, 'MRI-Upload Directory', 7 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'GenomicDataPath', 'Path to Genomic data files', 1, 0, 'text', ID, 'Genomic Data Path', 8 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT
+  'mediaPath', 'Path to uploaded media files', 1, 0, 'text', ID, 'Media', 9 FROM ConfigSettings WHERE Name="paths";
 
 -- gui
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
@@ -145,6 +146,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSet
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/bin/mri/" FROM ConfigSettings WHERE Name="MRICodePath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSettings WHERE Name="MRIUploadIncomingPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/Genomic-Data/" FROM ConfigSettings WHERE Name="GenomicDataPath";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSettings WHERE Name="mediaPath";
 
 -- default gui settings
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";

--- a/SQL/Archive/16.1/2016-06-27-Media.sql
+++ b/SQL/Archive/16.1/2016-06-27-Media.sql
@@ -7,21 +7,20 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES ('Media', 'media
 -- Add 'media' table
 CREATE TABLE IF NOT EXISTS `media` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `pscid` varchar(255) NOT NULL DEFAULT '',
-  `visit_label` varchar(255) NOT NULL DEFAULT '',
+  `session_id` int(10) unsigned NOT NULL,
   `instrument` varchar(255) DEFAULT NULL,
-  `for_site` int(2) DEFAULT NULL,
   `date_taken` date DEFAULT NULL,
   `comments` text,
-  `file_name` varchar(255) DEFAULT NULL,
+  `file_name` varchar(255) NOT NULL,
   `file_type` varchar(255) DEFAULT NULL,
-  `file_size` bigint(20) unsigned DEFAULT NULL,
-  `data_dir` varchar(255) DEFAULT NULL,
+  `data_dir` varchar(255) NOT NULL,
   `uploaded_by` varchar(255) DEFAULT NULL,
   `hide_file` tinyint(1) DEFAULT '0',
   `date_uploaded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-);
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
+  FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Add user permissions

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -112,17 +112,23 @@ function uploadFile()
 
     $userID = $user->getData('UserID');
 
+
+    $sessionID = $db->pselectOne("SELECT s.ID as session_id FROM candidate c LEFT JOIN session s USING(CandID) WHERE c.PSCID = :v_pscid AND s.Visit_label = :v_visit_label AND s.CenterID = :v_center_id",
+        [
+            'v_pscid'       => $pscid,
+            'v_visit_label' => $visit,
+            'v_center_id'   => $site
+        ]
+    );
+
     // Build insert query
     $query = [
-              'pscid'         => $pscid,
-              'visit_label'   => $visit,
+              'session_id'    => $sessionID,
               'instrument'    => $instrument,
-              'for_site'      => $site,
               'date_taken'    => $dateTaken,
               'comments'      => $comments,
               'file_name'     => $fileName,
               'file_type'     => $fileType,
-              'file_size'     => $fileSize,
               'data_dir'      => $mediaPath,
               'uploaded_by'   => $userID,
               'hide_file'     => 0,

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -98,7 +98,7 @@ function uploadFile()
     $comments   = isset($_POST['comments']) ? $_POST['comments'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES) || !isset($pscid) || !isset($visit)) {
+    if (!isset($_FILES) || !isset($pscid) || !isset($visit) || !isset($site)) {
         showError("Please fill in all required fields!");
 
         return;

--- a/modules/media/js/editForm.js
+++ b/modules/media/js/editForm.js
@@ -162,6 +162,7 @@ var MediaEditForm = React.createClass({
           options: this.state.Data.sites,
           onUserInput: this.setFormData,
           ref: 'for_site',
+          disabled: true,
           value: this.state.mediaData.for_site
         }),
         React.createElement(DateElement, {

--- a/modules/media/js/editForm.js
+++ b/modules/media/js/editForm.js
@@ -148,6 +148,15 @@ var MediaEditForm = React.createClass({
           value: this.state.mediaData.visit_label
         }),
         React.createElement(SelectElement, {
+          name: 'for_site',
+          label: 'Site',
+          options: this.state.Data.sites,
+          onUserInput: this.setFormData,
+          ref: 'for_site',
+          disabled: true,
+          value: this.state.mediaData.for_site
+        }),
+        React.createElement(SelectElement, {
           name: 'instrument',
           label: 'Instrument',
           options: this.state.Data.instruments,
@@ -155,15 +164,6 @@ var MediaEditForm = React.createClass({
           ref: 'instrument',
           disabled: true,
           value: this.state.mediaData.instrument
-        }),
-        React.createElement(SelectElement, {
-          name: 'for_site',
-          label: 'For Site',
-          options: this.state.Data.sites,
-          onUserInput: this.setFormData,
-          ref: 'for_site',
-          disabled: true,
-          value: this.state.mediaData.for_site
         }),
         React.createElement(DateElement, {
           name: 'date_taken',

--- a/modules/media/js/uploadForm.js
+++ b/modules/media/js/uploadForm.js
@@ -253,7 +253,8 @@ var MediaUploadForm = React.createClass({
       success: function (data) {
         $("#file-progress").addClass('hide');
         self.setState({
-          uploadResult: "success"
+          uploadResult: "success",
+          formData: {} // reset form data after successful file upload
         });
 
         // Trigger an update event to update all observers (i.e DataTable)

--- a/modules/media/js/uploadForm.js
+++ b/modules/media/js/uploadForm.js
@@ -133,19 +133,19 @@ var MediaUploadForm = React.createClass({
           required: true
         }),
         React.createElement(SelectElement, {
+          name: 'for_site',
+          label: 'Site',
+          options: this.state.Data.sites,
+          onUserInput: this.setFormData,
+          ref: 'for_site',
+          required: true
+        }),
+        React.createElement(SelectElement, {
           name: 'instrument',
           label: 'Instrument',
           options: this.state.Data.instruments,
           onUserInput: this.setFormData,
-          ref: 'instrument',
-          required: true
-        }),
-        React.createElement(SelectElement, {
-          name: 'for_site',
-          label: 'For Site',
-          options: this.state.Data.sites,
-          onUserInput: this.setFormData,
-          ref: 'for_site'
+          ref: 'instrument'
         }),
         React.createElement(DateElement, {
           name: 'date_taken',

--- a/modules/media/js/uploadForm.js
+++ b/modules/media/js/uploadForm.js
@@ -336,6 +336,13 @@ var MediaUploadForm = React.createClass({
    * @param value
    */
   setFormData: function (formElement, value) {
+
+    // Only display visits and sites available for the current pscid
+    if (formElement === "pscid") {
+      this.state.Data.visits = this.state.Data.sessionData[value].visits;
+      this.state.Data.sites = this.state.Data.sessionData[value].sites;
+    }
+
     var formData = this.state.formData;
     formData[formElement] = value;
 

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -131,6 +131,15 @@ var MediaEditForm = React.createClass({
             value={this.state.mediaData.visit_label}
           />
           <SelectElement
+            name="for_site"
+            label="Site"
+            options={this.state.Data.sites}
+            onUserInput={this.setFormData}
+            ref="for_site"
+            disabled={true}
+            value={this.state.mediaData.for_site}
+          />
+          <SelectElement
             name="instrument"
             label="Instrument"
             options={this.state.Data.instruments}
@@ -138,15 +147,6 @@ var MediaEditForm = React.createClass({
             ref="instrument"
             disabled={true}
             value={this.state.mediaData.instrument}
-          />
-          <SelectElement
-            name="for_site"
-            label="For Site"
-            options={this.state.Data.sites}
-            onUserInput={this.setFormData}
-            ref="for_site"
-            disabled={true}
-            value={this.state.mediaData.for_site}
           />
           <DateElement
             name="date_taken"

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -145,6 +145,7 @@ var MediaEditForm = React.createClass({
             options={this.state.Data.sites}
             onUserInput={this.setFormData}
             ref="for_site"
+            disabled={true}
             value={this.state.mediaData.for_site}
           />
           <DateElement

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -120,19 +120,19 @@ var MediaUploadForm = React.createClass({
             required={true}
           />
           <SelectElement
+            name="for_site"
+            label="Site"
+            options={this.state.Data.sites}
+            onUserInput={this.setFormData}
+            ref="for_site"
+            required={true}
+          />
+          <SelectElement
             name="instrument"
             label="Instrument"
             options={this.state.Data.instruments}
             onUserInput={this.setFormData}
             ref="instrument"
-            required={true}
-          />
-          <SelectElement
-            name="for_site"
-            label="For Site"
-            options={this.state.Data.sites}
-            onUserInput={this.setFormData}
-            ref="for_site"
           />
           <DateElement
             name="date_taken"

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -244,7 +244,8 @@ var MediaUploadForm = React.createClass({
       success: function(data) {
         $("#file-progress").addClass('hide');
         self.setState({
-          uploadResult: "success"
+          uploadResult: "success",
+          formData: {} // reset form data after successful file upload
         });
 
         // Trigger an update event to update all observers (i.e DataTable)

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -328,6 +328,13 @@ var MediaUploadForm = React.createClass({
    * @param value
    */
   setFormData: function(formElement, value) {
+
+    // Only display visits and sites available for the current pscid
+    if (formElement === "pscid") {
+      this.state.Data.visits = this.state.Data.sessionData[value].visits;
+      this.state.Data.sites =  this.state.Data.sessionData[value].sites;
+    }
+
     var formData = this.state.formData;
     formData[formElement] = value;
 

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -30,7 +30,6 @@ require_once 'NDB_Menu_Filter.class.inc';
  */
 class NDB_Menu_Filter_Media extends NDB_Menu_Filter
 {
-    public $centerIDMap;
     public $hasWritePermission = false;
 
     /**
@@ -76,9 +75,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             // allow only to view own site data
             $site =& Site::singleton($user->getData('CenterID'));
             if ($site->isStudySite()) {
-                $siteList = [
-                             $user->getData('CenterID') => $user->getData('Site'),
-                            ];
+                $siteList = [$user->getData('CenterID') => $user->getData('Site')];
             }
         }
 
@@ -104,21 +101,13 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
     }
 
     /**
-     * Build media list
+     * Build a list of media to display in Data Table
      *
      * @return bool
      * @throws DatabaseException
      */
     function _setupVariables()
     {
-        $db =& Database::singleton();
-
-        // create the centerID map
-//        $pscRows = $db->pselect("SELECT CenterID, Name FROM psc", []);
-//        foreach ($pscRows as $row) {
-//            $this->centerIDMap[$row['CenterID']] = $row['Name'];
-//        }
-
         // the base query
         $query  = " FROM media m LEFT JOIN session s ON m.session_id = s.ID";
         $query .= " WHERE m.hide_file = FALSE";
@@ -129,14 +118,15 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
                'm.file_name',
                '(SELECT PSCID from candidate WHERE CandID=s.CandID) as pscid',
                's.Visit_label as visit_label',
-               '(SELECT Full_name FROM test_names WHERE Test_name=m.instrument) as instrument',
+               '(SELECT Full_name FROM test_names WHERE Test_name=m.instrument)',
                '(SELECT name FROM psc WHERE CenterID=s.CenterID) as site',
                'm.uploaded_by',
                'm.date_taken',
                'substring(m.comments, 1, 50) as comments',
                'm.date_uploaded',
                's.CandID as cand_id',
-               's.ID as session_id'
+               's.ID as session_id',
+               'm.id',
               ];
 
         $this->query = $query;

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -114,39 +114,35 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $db =& Database::singleton();
 
         // create the centerID map
-        $pscRows = $db->pselect("SELECT CenterID, Name FROM psc", []);
-        foreach ($pscRows as $row) {
-            $this->centerIDMap[$row['CenterID']] = $row['Name'];
-        }
+//        $pscRows = $db->pselect("SELECT CenterID, Name FROM psc", []);
+//        foreach ($pscRows as $row) {
+//            $this->centerIDMap[$row['CenterID']] = $row['Name'];
+//        }
 
         // the base query
-        $query  = " FROM media v"; // left join candidate c using(pscid) ";
-        $query .= " WHERE (v.hide_file=false OR v.hide_file IS NULL)";
+        $query  = " FROM media m LEFT JOIN session s ON m.session_id = s.ID";
+        $query .= " WHERE m.hide_file = FALSE";
 
         // set the class variables
         $this->columns
             = [
-               'v.file_name',
-               'v.pscid',
-               'v.visit_label',
-               '(SELECT Full_name FROM test_names WHERE Test_name=v.instrument)',
-               '(SELECT name FROM psc WHERE CenterID=v.for_site)',
-               'v.uploaded_by',
-               'v.date_taken',
-               'substring(v.comments, 1, 50) as comments',
-               'v.date_uploaded',
-               // candidate id
-               "(SELECT CandID FROM candidate WHERE PSCID=v.pscid) as candID",
-                // sessiod id
-               "(SELECT ID FROM session WHERE CandID=(SELECT CandID FROM candidate ".
-               "WHERE PSCID=v.pscid) AND Visit_label=v.visit_label)",
-               'v.id',
+               'm.file_name',
+               '(SELECT PSCID from candidate WHERE CandID=s.CandID) as pscid',
+               's.Visit_label as visit_label',
+               '(SELECT Full_name FROM test_names WHERE Test_name=m.instrument) as instrument',
+               '(SELECT name FROM psc WHERE CenterID=s.CenterID) as site',
+               'm.uploaded_by',
+               'm.date_taken',
+               'substring(m.comments, 1, 50) as comments',
+               'm.date_uploaded',
+               's.CandID as cand_id',
+               's.ID as session_id'
               ];
 
         $this->query = $query;
 
         $this->group_by = '';
-        $this->order_by = 'v.instrument';
+        $this->order_by = 'm.instrument';
         $this->headers  = [
                            'File Name',
                            'PSCID',
@@ -170,22 +166,22 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         }
 
         $this->validFilters = [
-                               'v.pscid',
-                               'v.instrument',
-                               'v.data_dir',
-                               'v.for_site',
-                               'v.visit_label',
-                               'v.uploaded_by',
+                               'm.pscid',
+                               'm.instrument',
+                               'm.data_dir',
+                               'm.for_site',
+                               'm.visit_label',
+                               'm.uploaded_by',
                               ];
         $this->formToFilter = [
-                               'file_name'     => 'v.file_name',
-                               'data_dir'      => 'v.data_dir',
-                               'instrument'    => 'v.instrument',
-                               'pscid'         => 'v.pscid',
-                               'for_site'      => 'v.for_site',
-                               'uploaded_by'   => 'v.uploaded_by',
-                               'visit_label'   => 'v.visit_label',
-                               'date_uploaded' => 'v.date_uploaded',
+                               'file_name'     => 'm.file_name',
+                               'data_dir'      => 'm.data_dir',
+                               'instrument'    => 'm.instrument',
+                               'pscid'         => 'm.pscid',
+                               'for_site'      => 'm.for_site',
+                               'uploaded_by'   => 'm.uploaded_by',
+                               'visit_label'   => 'm.visit_label',
+                               'date_uploaded' => 'm.date_uploaded',
                                'comments'      => 'comments',
                               ];
 


### PR DESCRIPTION
- [x] Update SQL to use `session_id` instead of `pscid`, `visit_label` and `for_site`
- [x] Add foreign keys to `session_id` and `instrument` to enforce relational table structure
- [x] Clean some dead code
- [x] Selecting associated `Instrument` is now optional
- [x] Options under `Visit Label` and  `For Site` dropdown are now dynamically updated based on selected `PSCID`
- [x] `Site` is no longer editable as it is attached to the session 
- [x] Found and fixed a bug where form data was not reset after multiple subsequent file uploads

> To see changes without spaces **[click here](https://github.com/aces/Loris/pull/2037/files?w=1)**