### PR TITLE
Mike examiner fix

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -530,7 +530,7 @@ class NDB_Menu_Filter extends NDB_Menu
             }
         }
 
-        if ( isset($this->searchKeyword)
+        if (isset($this->searchKeyword)
             && is_array($this->searchKeyword)
             && count($this->searchKeyword) > 0
             && !empty($this->searchKey['keyword'])

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -530,7 +530,8 @@ class NDB_Menu_Filter extends NDB_Menu
             }
         }
 
-        if (is_array($this->searchKeyword)
+        if ( isset($this->searchKeyword)
+            && is_array($this->searchKeyword)
             && count($this->searchKeyword) > 0
             && !empty($this->searchKey['keyword'])
         ) {


### PR DESCRIPTION
while resolving the examiner issue ted brought up here https://redmine.cbrain.mcgill.ca/issues/10527. I have encountered the following error message. 
```
NDB_Menu_Filter_Form_Examiner::$searchKeyword in /var/www/loris/php/libraries/NDB_Menu_Filter.class.inc on line 533, referer: https://132.206.37.107/examiner/
Undefined property: NDB_Menu_Filter_Form_Examiner::$searchKeyword in /var/www/loris/php/libraries/NDB_Menu_Filter.class.inc on line 533, referer: https://132.206.37.107/examiner/
Undefined variable: baseurl in /var/www/loris/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc on line 301, referer: https://132.206.37.107/examiner/
Undefined property: NDB_Menu_Filter_Form_Examiner::$searchKeyword in /var/www/loris/php/libraries/NDB_Menu_Filter.class.inc on line 533, referer: https://132.206.37.107/examiner/
Undefined property: NDB_Menu_Filter_Form_Examiner::$searchKeyword in /var/www/loris/php/libraries/NDB_Menu_Filter.class.inc on line 533, referer: https://132.206.37.107/examiner/

```
This is because `searchKeyword` variable was suppose to be instantiated dynamically but somehow it wasn't. @driusan  introduced the variable in this commit https://github.com/aces/Loris/commit/a4a44724f9adf97a460a49a00eea79b50707ea6a  to replace `searchKey` variable. 

`searchKeyword` is now checked before used. 