### PR TITLE
Update readmes for 16-1

### DIFF
--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -60,7 +60,7 @@ SQL/ directory of LORIS which are prefixed with `0000-00-` into it
 `SQL/0000-00-02-Menus.sql`, etc.)
 
 There are a few settings in the Config module that LORIS currently depends
-on being updated to load correctly that must be set manually from MySQL as
+on being updated to load correctly -- these must be set manually from the MySQL commandline as
 they're normally set by the install script.
 
 ```SQL
@@ -72,10 +72,10 @@ UPDATE Config SET Value='http://localhost' WHERE ConfigID=(SELECT ID FROM Config
 Where `/var/www/loris/` is the location where LORIS is installed and assuming
 you'll be running on localhost (otherwise update host and url appropriately)
 
-Useful tip for administrators: while connected to MySQL, you can also reset the admin password:
+Set the password for the front-end _admin_ user account while connected to MySQL.
 
 ```SQL
--- Reset 'admin' front-end user account password to YOURPASSWORD
+-- Set 'admin' front-end user account password to YOURPASSWORD
 UPDATE users SET Password_md5=CONCAT('aa', MD5('aaYOURPASSWORD')) WHERE ID=1;
 ```
 
@@ -84,8 +84,8 @@ UPDATE users SET Password_md5=CONCAT('aa', MD5('aaYOURPASSWORD')) WHERE ID=1;
 Create a directory named "project" directory under the LORIS root, and copy
 the sample config.xml from `docs/config/config.xml` to `project/config.xml`
 
-Update the _<database>_ section of the config.xml to point to the database you
-just configured with an appropriate user.  (Ignore _quatuser_ and _quatpassword_ tags.)
+Update the _database_ tagset section of config.xml to point to the database you
+just configured with an appropriate user. (Ignore _quatuser_ and _quatpassword_ tags.)
 
 ## 1.3 Apache
 

--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -6,6 +6,8 @@ This document contains details on how to manually perform a basic CentOS 6.x
 install of LORIS without using the install script (as the install script
 makes some assumptions about apt-get being installed.)
 
+For details on the UNIX, MySQL and PHP accounts we recommend setting up to use with LORIS conventions, please see the GitHub wiki CentOS Install page.  
+
 It assumes you already understand basic UNIX, MySQL and Apache setup and
 settings. If you're not already comfortable troubleshooting sysadmin issues,
 you should not follow this guide.
@@ -71,7 +73,7 @@ UPDATE Config SET Value='http://localhost' WHERE ConfigID=(SELECT ID FROM Config
 Where `/var/www/loris/` is the location where LORIS is installed and assuming
 you'll be running on localhost (otherwise update host and url appropriately)
 
-While connected to MySQL, you can also reset the admin password:
+Useful tip for administrators: while connected to MySQL, you can also reset the admin password:
 
 ```SQL
 -- Reset password to YOURPASSWORD

--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -10,6 +10,7 @@ It assumes you already understand basic UNIX, MySQL and Apache setup and
 settings. If you're not already comfortable troubleshooting sysadmin issues,
 you should not follow this guide.
 
+
 # 1. System Requirements
 
 The yum packages to be installed vary from the Ubuntu packages referenced
@@ -27,22 +28,23 @@ yum install mysql
 ```
 
 PHP Composer must also be installed:
-
 ```bash
 curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer
 ```
 
 Note that the default dependencies installed by CentOS 6.x may not meet the version requirements LORIS deployment or development.
-* MySQL 5.5 or lower is supported for LORIS 16.0
-* PHP 5.6 (or 5.5) is required for LORIS 16.0 - upgrade your PHP manually
+* MySQL 5.5 or lower is supported for LORIS 16.*
+* PHP 5.6 (or 5.5) is required for LORIS 16.* - upgrade your PHP manually
 Or run composer with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
 assume you just want to get it running, so we'll run it with `--no-dev`.)
 
 ```bash
 # Will download all of LORIS's library requirements, assuming an
 # active internet connection. This must be done from the LORIS
-# root directory that you downloaded and extracted LORIS into
+# root directory that you downloaded and extracted LORIS into.
+# Expect this step to print scary warning messages 
+# about downloading and installing dependencies. 
 composer install --no-dev
 ```
 

--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -6,12 +6,11 @@ This document contains details on how to manually perform a basic CentOS 6.x
 install of LORIS without using the install script (as the install script
 makes some assumptions about apt-get being installed.)
 
-For details on the UNIX, MySQL and PHP accounts we recommend setting up to use with LORIS conventions, please see the GitHub wiki CentOS Install page.  
-
 It assumes you already understand basic UNIX, MySQL and Apache setup and
 settings. If you're not already comfortable troubleshooting sysadmin issues,
 you should not follow this guide.
 
+For further details on the install process including LORIS nomenclature for recommended UNIX, MySQL and front-end user accounts, please see the LORIS GitHub Wiki CentOS Install page.  
 
 # 1. System Requirements
 
@@ -76,7 +75,7 @@ you'll be running on localhost (otherwise update host and url appropriately)
 Useful tip for administrators: while connected to MySQL, you can also reset the admin password:
 
 ```SQL
--- Reset password to YOURPASSWORD
+-- Reset 'admin' front-end user account password to YOURPASSWORD
 UPDATE users SET Password_md5=CONCAT('aa', MD5('aaYOURPASSWORD')) WHERE ID=1;
 ```
 
@@ -85,8 +84,8 @@ UPDATE users SET Password_md5=CONCAT('aa', MD5('aaYOURPASSWORD')) WHERE ID=1;
 Create a directory named "project" directory under the LORIS root, and copy
 the sample config.xml from `docs/config/config.xml` to `project/config.xml`
 
-Update the database section of the config.xml to point to the database you
-just configured with an appropriate user.
+Update the _<database>_ section of the config.xml to point to the database you
+just configured with an appropriate user.  (Ignore _quatuser_ and _quatpassword_ tags.)
 
 ## 1.3 Apache
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 LORIS (Longitudinal Online Research and Imaging System) is a web-based data and project management software for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
+<hr>
+NEW <b>⇾  Try LORIS on Heroku</b> before installing it on your system<br>
+Deploy and log in with username <i>admin</i> and the password that's set up during deployment via ClearDB.
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/16.1-dev)
+<hr>
+
 This Readme covers installation of the <b>16.1</b> LORIS development branch on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/16.1-dev/README.CentOS6.md)).
 If you are looking to install a stable release, please consult the [Releases page](https://github.com/aces/Loris/releases) and the Readme for the last stable release.
 
 Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information not included in this Readme. The [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) may also provide installation guidance not covered in the Wiki. 
-
-<b>⇾  Deploy on Heroku</b>
-As an alternative to installing LORIS on your system (per instructions below), LORIS can now be deployed on Heroku.
-Note: Your default credentials after deployment will be 'admin' as the username and your password will be the uniquely generated password used by ClearDB.
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/16.1-dev)
 
 # Prerequisites for Installation
 
@@ -24,8 +25,8 @@ Note: Your default credentials after deployment will be 'admin' as the username 
  * Composer : should be run with --no-dev option
 
 <b>Important:</b>
- * Only PHP <b>5.6</b> is supported for LORIS 16.0. We recommend installing/upgrading PHP using this (deprecated) PPA repository: <i>ppa:ondrej/php5-5.6 </i>
- * MySQL 5.7 is not supported for LORIS 16.0 and will cause errors when loading LORIS.  MySQL 5.5 or lower (5.*) is recommmended.  
+ * Only PHP <b>5.6</b> is supported for LORIS 16.1. We recommend installing/upgrading PHP using this (deprecated) PPA repository: <i>ppa:ondrej/php5-5.6 </i>
+ * MySQL 5.7 is not supported for LORIS 16.1 and will cause errors when loading LORIS.  MySQL 5.5 or lower (5.*) is recommmended.  
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information.


### PR DESCRIPTION
small updates to Ubuntu and CentOS readmes, for 16.1 release
- main (ubuntu) Readme now recommends trying Loris on heroku
- CentOS Readme updated with clarifications suggested by @steve-yeg #1926 
