### PR TITLE
Examiner Module: fix data table bug

### DIFF
--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -55,29 +55,19 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
             $useCertification = false;
         }
 
-        // base queries
-        $query     = " FROM examiners e LEFT JOIN psc ON (e.centerID=psc.CenterID)";
-        $certQuery = " LEFT JOIN certification c ON (c.examinerID = e.examinerID) 
-            LEFT JOIN test_names tn ON (c.testID = tn.ID)";
-
-        if ($this->useCertification == '1') {
-            $query .= $certQuery;
-        }
-
-        $query .= ' WHERE 1=1';
+        // base query
+        $query = " FROM examiners e LEFT JOIN psc ON (e.centerID=psc.CenterID) WHERE
+            1=1";
 
         $user = User::singleton();
         if (!$user->hasPermission('examiner_multisite')) {
             $query .= " AND e.CenterID=" . $DB->quote($user->getData('CenterID'));
         }
 
-        if ($this->useCertification == '1') {
-            $query .= ' GROUP BY e.examinerID';
-        }
-
         // set the class variables
         $this->columns      = array(
                                'e.full_name as Examiner',
+                               'e.examinerID as ID',
                                'psc.Name as Site',
                                'e.radiologist as Radiologist',
                               );
@@ -103,15 +93,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
         // If certification is turned on, update the class variables to include
         // certification information
         if ($this->useCertification == '1') {
-            array_push(
-                $this->columns,
-                "GROUP_CONCAT(tn.Full_name SEPARATOR ', ') as Certification",
-                "e.examinerID as ID",
-                "c.pass as Pass"
-            );
             array_push($this->headers, 'Certification');
-            array_push($this->validFilters, 'tn.Full_name');
-            array_push($this->formToFilter, array('instrument' => 'tn.Full_name'));
         }
         return true;
     }
@@ -174,6 +156,38 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
      */
     function _setDataTableRows($count)
     {
+        $DB = Database::singleton();
+
+        if ($this->useCertification == '1') {
+
+            // For each examiner, build the certification column
+            foreach ($this->list as &$examiner) {
+                $examinerID = $examiner['ID'];
+
+                // Grab their certifications from the database
+                $certifications = $DB->pselect(
+                    "SELECT tn.Full_name FROM certification c
+                     LEFT JOIN test_names tn ON (tn.ID=c.testID) 
+                     WHERE c.examinerID=:EID AND c.pass='certified'",
+                    array('EID' => $examinerID)
+                );
+
+                if (empty($certifications)) {
+                    $examiner['Certification'] = 'None';
+                } else {
+                    foreach ($certifications as $certification) {
+                        if (end($certifications) == $certification) {
+                            $examiner['Certification'] .= " " .
+                                $certification['Full_name'];
+                        } else {
+                            $examiner['Certification'] .= $certification['Full_name']
+                                . ", ";
+                        }
+                    }
+                }
+            }
+        }
+
         $x = 0;
         foreach ($this->list as $item) {
             //count column
@@ -182,22 +196,24 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
             //print out data rows
             $i = 1;
             foreach ($item as $key => $val) {
-                if ($key == 'Examiner') {
-                    $this->tpl_data['items'][$x][$i]['ID'] = $item['ID'];
-                }
-
-                if ($key == 'Radiologist') {
-                    $this->tpl_data['items'][$x][$i]['name'] = $key;
-                    if ($val == 1) {
-                        $this->tpl_data['items'][$x][$i]['value'] = 'Yes';
-                    } else {
-                        $this->tpl_data['items'][$x][$i]['value'] = 'No';
+                if ($key != 'ID') {
+                    if ($key == 'Examiner') {
+                        $this->tpl_data['items'][$x][$i]['ID'] = $item['ID'];
                     }
-                } else if ($key != 'ID' && $key != 'Pass') {
-                    $this->tpl_data['items'][$x][$i]['name']  = $key;
-                    $this->tpl_data['items'][$x][$i]['value'] = $val;
+
+                    if ($key == 'Radiologist') {
+                        $this->tpl_data['items'][$x][$i]['name'] = $key;
+                        if ($val == 1) {
+                            $this->tpl_data['items'][$x][$i]['value'] = 'Yes';
+                        } else {
+                            $this->tpl_data['items'][$x][$i]['value'] = 'No';
+                        }
+                    } else {
+                        $this->tpl_data['items'][$x][$i]['name']  = $key;
+                        $this->tpl_data['items'][$x][$i]['value'] = $val;
+                    }
+                    $i++;
                 }
-                $i++;
             }
             $x++;
         }

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -59,11 +59,11 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
         $query     = " FROM examiners e LEFT JOIN psc ON (e.centerID=psc.CenterID)";
         $certQuery = " LEFT JOIN certification c ON (c.examinerID = e.examinerID) 
             LEFT JOIN test_names tn ON (c.testID = tn.ID)";
-        
+
         if ($this->useCertification == '1') {
             $query .= $certQuery;
         }
-        
+
         $query .= ' WHERE 1=1';
 
         $user = User::singleton();
@@ -174,8 +174,6 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
      */
     function _setDataTableRows($count)
     {
-        $DB = Database::singleton();
-
         $x = 0;
         foreach ($this->list as $item) {
             //count column

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -59,16 +59,20 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
         $query     = " FROM examiners e LEFT JOIN psc ON (e.centerID=psc.CenterID)";
         $certQuery = " LEFT JOIN certification c ON (c.examinerID = e.examinerID) 
             LEFT JOIN test_names tn ON (c.testID = tn.ID)";
-
+        
         if ($this->useCertification == '1') {
             $query .= $certQuery;
         }
-
+        
         $query .= ' WHERE 1=1';
 
         $user = User::singleton();
         if (!$user->hasPermission('examiner_multisite')) {
             $query .= " AND e.CenterID=" . $DB->quote($user->getData('CenterID'));
+        }
+
+        if ($this->useCertification == '1') {
+            $query .= ' GROUP BY e.examinerID';
         }
 
         // set the class variables
@@ -101,9 +105,9 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
         if ($this->useCertification == '1') {
             array_push(
                 $this->columns,
-                'tn.Full_name as Certification',
-                'e.examinerID as ID',
-                'c.pass as Pass'
+                "GROUP_CONCAT(tn.Full_name SEPARATOR ', ') as Certification",
+                "e.examinerID as ID",
+                "c.pass as Pass"
             );
             array_push($this->headers, 'Certification');
             array_push($this->validFilters, 'tn.Full_name');
@@ -170,52 +174,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
      */
     function _setDataTableRows($count)
     {
-        // Code from old certification module
-
-        if ($this->useCertification == '1') {
-            $IDs        = array();
-            $duplicates = array();
-            $i          = 0;
-
-            foreach ($this->list as $li) {
-                $id            = $li['ID'];
-                $certification = $li['Certification'];
-
-                $str           = explode(' ', $certification);
-                $certification = $str[0];
-
-                if (array_key_exists($id, $IDs)) {
-                    if ($li['Pass'] == 'certified') {
-                        if ($IDs[$id] == 'none') {
-                            $IDs[$id] = $certification;
-                        } else {
-                            $IDs[$id] .= ", " . $certification;
-                        }
-                    }
-                    array_push($duplicates, $i);
-                } else {
-                    if ($li['Pass'] == 'certified') {
-                        $IDs[$id] = $certification;
-                    } else {
-                        $IDs[$id] = "none";
-                    }
-                }
-                $i++;
-            }
-
-            // create concatenated list of certifications for each examiner
-            foreach ($this->list as &$l) {
-                if (array_key_exists($l['ID'], $IDs)) {
-                    $l['Certification'] = $IDs[$l['ID']];
-                }
-            }
-
-            $list =& $this->list;
-            foreach ($duplicates as $k=>$v) {
-                unset($list[$v]);
-
-            }
-        }
+        $DB = Database::singleton();
 
         $x = 0;
         foreach ($this->list as $item) {

--- a/modules/examiner/templates/menu_examiner.tpl
+++ b/modules/examiner/templates/menu_examiner.tpl
@@ -104,13 +104,19 @@
             {section name=item loop=$items}
             <tr>
                 {section name=piece loop=$items[item]}
-                    <td>
-                        {if $items[item][piece].name == "Examiner" and $certification == "1"}
+                    {if $items[item][piece].name == "Examiner" and $certification == "1"}
+                        <td nowrap="nowrap">
                             <a href="{$baseurl}/examiner/editExaminer/?identifier={$items[item][piece].ID}">{$items[item][piece].value}</a>
-                        {else}
+                        </td>
+                    {elseif $items[item][piece].name == "Site"}
+                        <td nowrap="nowrap">
                             {$items[item][piece].value}
-                        {/if}
-                    </td>
+                        </td>
+                    {else}
+                        <td>
+                            {$items[item][piece].value}
+                        </td>
+                    {/if}
                 {/section}
             </tr>
             {sectionelse}


### PR DESCRIPTION
The examiner module (when using certification) previously pulled each certification for a given examiner from the database as an individual row. These rows where then concatenated to make one row per examiner.

Some code changes broke this process, and row numbering and display was broken. Tried to fix this by doing the concat in the MySQL query itself, but this broke the menu filter :( Now I am adding it in the `_setDataTableRows` function - not the best solution but works for now.

As you can see in CCNA - we have our max rows set to 25, but only 4 are appearing on this first page (because there are 25 total certifications between these 4 examiners):
<img width="844" alt="screen shot 2016-07-29 at 11 45 45 am" src="https://cloud.githubusercontent.com/assets/5473436/17244439/1f74f1ba-5582-11e6-8d25-14146dd0cee1.png">


Data table should be React-ified at some point...