### PR TITLE
[Core] Add trailling slash to Loris URL

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -27,5 +27,10 @@
  RewriteRule ^([a-zA-Z_-]+)/static/([a-zA-Z0-9_.-/]+)$ GetStatic.php?Module=$1&file=$2
  RewriteRule ^([a-zA-Z_-]+)/ajax/([a-zA-Z0-9_.-]+)$ AjaxHelper.php?Module=$1&script=$2 [QSA]
  RewriteRule ^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)/$ main.php?test_name=$1&subtest=$2 [QSA]
+
+ # Add trailing slash to all links except those that contain spefied extensions
+ RewriteCond %{REQUEST_URI} !\.(php|js|css|html?|jpg|gif|png|mov|swf)$
+ RewriteRule ^(.*)([^/])$ https://%{HTTP_HOST}/$1$2/ [L,R=301]
+
 </IfModule>
 

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -28,9 +28,9 @@
  RewriteRule ^([a-zA-Z_-]+)/ajax/([a-zA-Z0-9_.-]+)$ AjaxHelper.php?Module=$1&script=$2 [QSA]
  RewriteRule ^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)/$ main.php?test_name=$1&subtest=$2 [QSA]
 
- # Add trailing slash to all links except those that contain spefied extensions
- RewriteCond %{REQUEST_URI} !\.(php|js|css|html?|jpg|gif|png|mov|swf)$
- RewriteRule ^(.*)([^/])$ https://%{HTTP_HOST}/$1$2/ [L,R=301]
+ # Add trailing slash to all directories
+ RewriteCond %{REQUEST_FILENAME} !-f
+ RewriteRule ^(.*[^/])$ /$1/ [L,R=301]
 
 </IfModule>
 


### PR DESCRIPTION
- [x] Add trailing slash to Loris URL ~~automatically~~ automagically

>Currently, if user does not add trailing slash at the end of the URL, an error page is shown instead of the module page. This is an attempt to fix this annoyance.