### PR TITLE
Removing implicit group_by

### DIFF
--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -123,7 +123,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
             $this->query .= $DB->quote($user->getCenterID());
         }
 
-        $this->group_by     = 'candidate.CandID';
+        $this->group_by     = '';
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
         $this->validFilters = array(
                                'candidate.CenterID',


### PR DESCRIPTION
MySQL 5.7 compliance for `incompatible with sql_mode=only_full_group_by` error