### PR TITLE
fix query in getting number of accounts needing approval

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -196,7 +196,7 @@ class NDB_Form_Dashboard extends NDB_Form
         ) {
             $this->tpl_data['pending_users']      = $DB->pselectOne(
                 "SELECT COUNT(*) FROM users
-		WHERE Pending_approval='Y' AND CenterID <> 1",
+		WHERE Pending_approval='Y' AND (CenterID <> 1 OR CenterID IS NULL)",
                 array()
             );
             $this->tpl_data['pending_users_site'] = 'Site: all';


### PR DESCRIPTION
The query was excluding any accounts where the site was set to null