### PR TITLE
Image Browser: Number of Volumes now show up in the Header Info of the Image Panel (Redmine 10727)

### DIFF
--- a/modules/imaging_browser/js/ImagePanel.js
+++ b/modules/imaging_browser/js/ImagePanel.js
@@ -212,7 +212,7 @@ ImagePanelHeadersTable = React.createClass({
                 React.createElement(
                     'td',
                     { className: 'col-xs-2' },
-                    this.props.HeaderInfo.Time,
+                    this.props.HeaderInfo.NumVolumes,
                     ' volumes'
                 ),
                 React.createElement(

--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -92,7 +92,7 @@ ImagePanelHeadersTable = React.createClass({
                 </tr>
                 <tr>
                     <th className="col-xs-2 info">Number of volumes</th>
-                    <td className="col-xs-2">{this.props.HeaderInfo.Time} volumes</td>
+                    <td className="col-xs-2">{this.props.HeaderInfo.NumVolumes} volumes</td>
 
                     <th className="col-xs-2 info">Pipeline</th>
                     <td className="col-xs-2">{this.props.HeaderInfo.Pipeline}</td>


### PR DESCRIPTION
this.props.HeaderInfo.NumVolumes instead of this.props.HeaderInfo.Time as this is how it is called in the template file form_viewSession.tpl