### PR TITLE
[Core] Fix Access Profile LorisMenu permissions

### DIFF
--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -72,8 +72,6 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
 
 -- Access Profile
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
-    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Access Profile';
-INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='Access Profile';
 
 -- Reliability

--- a/SQL/Archive/2016-10-02-FixAccessProfilePermissions.sql
+++ b/SQL/Archive/2016-10-02-FixAccessProfilePermissions.sql
@@ -1,0 +1,2 @@
+DELETE FROM LorisMenuPermissions WHERE MenuID=(SELECT ID FROM LorisMenu WHERE Label='Access Profile' AND Parent=1) AND PermID=(SELECT PermID FROM permissions WHERE code='data_entry');
+


### PR DESCRIPTION
I think users should be able to access 'Access Profile' if they have the access_all_profiles permission, regardless of whether they have data_entry permission or not.

Also, we don't have a way to 'OR' LorisMenu permissions.