### PR TITLE
[Image Uploader] fix naming convention check

### DIFF
--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -358,13 +358,11 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
             ///////////////////////////////////////////////////////////////////////
             ////////////// Make sure the file name matches the format   ///////////
             ///////////////////////////////////////////////////////////////////////
-            if (($file_name != $pscid."_". $candid ."_". $visit_label . ".zip")
-                && ($file_name != $pscid."_". $candid ."_". $visit_label . ".tgz")
-                && ($file_name != $pscid."_". $candid ."_". $visit_label . ".tar.gz")
-            ) {
+            if (substr($file_name, 0, 18) !== $pscid ."_". $candid ."_". $visit_label)
+            {
                 $errors[] = "Make sure the file name matches this format:  " .
                 "\"". $pscid ."_". $candid ."_". $visit_label .
-                ".(tgz or tar.gz or .zip)\"";
+                " plus extra stuff in you need it and .(tgz or tar.gz or .zip)\"";
             }
 
             ///////////////////////////////////////////////////////////////////////

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -357,9 +357,10 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
 
             ///////////////////////////////////////////////////////////////////////
             ////////////// Make sure the file name matches the format   ///////////
+            /////////// $candid and $visit_label can be of variable length ////////
             ///////////////////////////////////////////////////////////////////////
-            if (substr($file_name, 0, 18) !== $pscid ."_". $candid ."_". $visit_label)
-            {
+            $pcv = "{$pscid}_{$candid}_{$visit_label}";
+            if (preg_match("/^{$pcv}.*(zip|tgz|tar.gz)/", $file_name)) {
                 $errors[] = "Make sure the file name matches this format:  " .
                 "\"". $pscid ."_". $candid ."_". $visit_label .
                 " plus extra stuff in you need it and .(tgz or tar.gz or .zip)\"";

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -361,9 +361,9 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
             ///////////////////////////////////////////////////////////////////////
             $pcv = "{$pscid}_{$candid}_{$visit_label}";
             if (preg_match("/^{$pcv}.*(zip|tgz|tar.gz)/", $file_name)) {
-                $errors[] = "Make sure the file name matches this format:  " .
-                "\"". $pscid ."_". $candid ."_". $visit_label .
-                " plus extra stuff in you need it and .(tgz or tar.gz or .zip)\"";
+                $errors[] = "File name must begin with " .
+                "\"". $pscid ."_". $candid ."_". $visit_label . "\"" .
+                " and have the extension of .tgz, tar.gz or .zip";
             }
 
             ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previous name was too strict.  

- Could not upload a second scan set for same visit.
- Could not include RES or HOS to separate scanners.
