### PR TITLE
[Core] Remove autoloading for CSS dependencies

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -603,25 +603,10 @@ class NDB_Page
         $www     = $config->getSetting('www');
         $baseurl = $www['url'];
 
-        $paths = $config->getSetting("paths");
-
-        $TestName = $this->name;
-
         $files = array(
                   $baseurl . "/bootstrap/css/bootstrap.min.css",
                   $baseurl . "/bootstrap/css/custom-css.css",
                  );
-
-        if (file_exists($paths['base'] . "modules/$TestName/css/$TestName.css")) {
-            error_log(
-                "WARNING: Relying on $TestName.css getting automatically loaded will"
-                . " soon be removed. "
-                . "Override getCSSDependencies() instead"
-            );
-
-            $files[] = $baseurl . "/$TestName/css/$TestName.css";
-        }
-
         return $files;
     }
 


### PR DESCRIPTION
Since autoloading (and corresponding warning) were removed for `getJSDependencies()`, they should probably be removed from `getCSSDependencies()`