### PR TITLE
[Core] Pagination Links bugfix

### DIFF
--- a/htdocs/js/components/PaginationLinks.js
+++ b/htdocs/js/components/PaginationLinks.js
@@ -1,108 +1,110 @@
-'use strict';
+"use strict";
+
+/* exported RPaginationLinks */
 
 var PaginationLinks = React.createClass({
-    displayName: 'PaginationLinks',
+  displayName: "PaginationLinks",
 
-    mixins: [React.addons.PureRenderMixin],
-    propTypes: {
-        onChangePage: React.PropTypes.func,
-        Total: React.PropTypes.number.isRequired
-    },
-    getDefaultProps: function getDefaultProps() {
-        return {
-            'RowsPerPage': 10,
-            'Active': 1
-        };
-    },
-    changePage: function changePage(i) {
-        var that = this;
-        return function (evt) {
-            // Don't jump to the top of the page
-            evt.preventDefault();
+  mixins: [React.addons.PureRenderMixin],
+  propTypes: {
+    onChangePage: React.PropTypes.func,
+    Total: React.PropTypes.number.isRequired
+  },
+  getDefaultProps: function getDefaultProps() {
+    return {
+      RowsPerPage: 10,
+      Active: 1
+    };
+  },
+  changePage: function changePage(i) {
+    var that = this;
+    return function (evt) {
+      // Don't jump to the top of the page
+      evt.preventDefault();
 
-            if (that.props.onChangePage) {
-                that.props.onChangePage(i);
-            }
-        };
-    },
-    render: function render() {
-        var rowsPerPage = this.props.RowsPerPage;
-        var pageLinks = [];
-        var classList;
-        var lastPage = Math.ceil(this.props.Total / rowsPerPage);
-        var startPage = Math.max(1, this.props.Active - 3);
-        var lastShownPage = Math.min(this.props.Active + 3, lastPage);
+      if (that.props.onChangePage) {
+        that.props.onChangePage(i);
+      }
+    };
+  },
+  render: function render() {
+    var rowsPerPage = this.props.RowsPerPage;
+    var pageLinks = [];
+    var classList;
+    var lastPage = Math.ceil(this.props.Total / rowsPerPage);
+    var startPage = Math.max(1, this.props.Active - 3);
+    var lastShownPage = Math.min(this.props.Active + 3, lastPage);
 
-        if (this.props.Total === 0) {
-            return React.createElement('div', null);
-        }
-        if (this.props.Total < this.props.RowsPerPage) {
-            return React.createElement('div', null);
-        }
-
-        if (lastShownPage - startPage <= 7) {
-            lastShownPage = startPage + 6;
-            if (lastShownPage > lastPage) {
-                lastShownPage = lastPage;
-                startPage = lastPage - 6;
-            }
-        }
-
-        if (startPage > 1) {
-            pageLinks.push(React.createElement(
-                'li',
-                { onClick: this.changePage(1) },
-                React.createElement(
-                    'a',
-                    { href: '#' },
-                    '«'
-                )
-            ));
-        }
-        if (startPage < 1) {
-            startPage = 1;
-        }
-        if (lastShownPage < 1) {
-            lastShownPage = 1;
-        }
-
-        // If there is only 1 page, don't display pagination links
-        if (startPage === lastShownPage) {
-            return React.createElement('div', null);
-        }
-
-        for (var i = startPage; i <= lastShownPage; i += 1) {
-            classList = '';
-            if (this.props.Active == i) {
-                classList = "active";
-            }
-            pageLinks.push(React.createElement(
-                'li',
-                { onClick: this.changePage(i), className: classList },
-                React.createElement(
-                    'a',
-                    { href: '#' },
-                    i
-                )
-            ));
-        }
-        if (lastShownPage !== lastPage) {
-            pageLinks.push(React.createElement(
-                'li',
-                { onClick: this.changePage(lastPage) },
-                React.createElement(
-                    'a',
-                    { href: '#' },
-                    '»'
-                )
-            ));
-        }
-        return React.createElement(
-            'ul',
-            { className: 'pagination pagination-table' },
-            pageLinks
-        );
+    if (this.props.Total === 0) {
+      return React.createElement("div", null);
     }
+    if (this.props.Total < this.props.RowsPerPage) {
+      return React.createElement("div", null);
+    }
+
+    if (lastShownPage - startPage <= 7) {
+      lastShownPage = startPage + 6;
+      if (lastShownPage > lastPage) {
+        lastShownPage = lastPage;
+        startPage = lastPage - 6;
+      }
+    }
+
+    if (startPage > 1) {
+      pageLinks.push(React.createElement(
+        "li",
+        { onClick: this.changePage(1) },
+        React.createElement(
+          "a",
+          { href: "#" },
+          "«"
+        )
+      ));
+    }
+    if (startPage < 1) {
+      startPage = 1;
+    }
+    if (lastShownPage < 1) {
+      lastShownPage = 1;
+    }
+
+    // If there is only 1 page, don't display pagination links
+    if (startPage === lastShownPage) {
+      return React.createElement("div", null);
+    }
+
+    for (var i = startPage; i <= lastShownPage; i += 1) {
+      classList = '';
+      if (this.props.Active === i) {
+        classList = "active";
+      }
+      pageLinks.push(React.createElement(
+        "li",
+        { onClick: this.changePage(i), className: classList },
+        React.createElement(
+          "a",
+          { href: "#" },
+          i
+        )
+      ));
+    }
+    if (lastShownPage !== lastPage) {
+      pageLinks.push(React.createElement(
+        "li",
+        { onClick: this.changePage(lastPage) },
+        React.createElement(
+          "a",
+          { href: "#" },
+          "»"
+        )
+      ));
+    }
+    return React.createElement(
+      "ul",
+      { className: "pagination pagination-table" },
+      pageLinks
+    );
+  }
 });
 
 var RPaginationLinks = React.createFactory(PaginationLinks);

--- a/htdocs/js/components/PaginationLinks.js
+++ b/htdocs/js/components/PaginationLinks.js
@@ -1,6 +1,6 @@
-//var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
+'use strict';
 
-PaginationLinks = React.createClass({
+var PaginationLinks = React.createClass({
     displayName: 'PaginationLinks',
 
     mixins: [React.addons.PureRenderMixin],
@@ -8,13 +8,13 @@ PaginationLinks = React.createClass({
         onChangePage: React.PropTypes.func,
         Total: React.PropTypes.number.isRequired
     },
-    getDefaultProps: function () {
+    getDefaultProps: function getDefaultProps() {
         return {
             'RowsPerPage': 10,
             'Active': 1
         };
     },
-    changePage: function (i) {
+    changePage: function changePage(i) {
         var that = this;
         return function (evt) {
             // Don't jump to the top of the page
@@ -25,7 +25,7 @@ PaginationLinks = React.createClass({
             }
         };
     },
-    render: function () {
+    render: function render() {
         var rowsPerPage = this.props.RowsPerPage;
         var pageLinks = [];
         var classList;
@@ -65,6 +65,12 @@ PaginationLinks = React.createClass({
         if (lastShownPage < 1) {
             lastShownPage = 1;
         }
+
+        // If there is only 1 page, don't display pagination links
+        if (startPage === lastShownPage) {
+            return React.createElement('div', null);
+        }
+
         for (var i = startPage; i <= lastShownPage; i += 1) {
             classList = '';
             if (this.props.Active == i) {
@@ -99,4 +105,4 @@ PaginationLinks = React.createClass({
     }
 });
 
-RPaginationLinks = React.createFactory(PaginationLinks);
+var RPaginationLinks = React.createFactory(PaginationLinks);

--- a/jsx/PaginationLinks.js
+++ b/jsx/PaginationLinks.js
@@ -1,6 +1,4 @@
-//var PureRenderMixin = require('react/addons').addons.PureRenderMixin;
-
-PaginationLinks = React.createClass({
+var PaginationLinks = React.createClass({
     mixins: [React.addons.PureRenderMixin],
     propTypes: {
         onChangePage: React.PropTypes.func,
@@ -57,6 +55,12 @@ PaginationLinks = React.createClass({
         if(lastShownPage < 1) {
             lastShownPage = 1;
         }
+
+        // If there is only 1 page, don't display pagination links
+        if (startPage === lastShownPage) {
+          return <div />;
+        }
+
         for(var i = startPage; i <= lastShownPage; i += 1) {
             classList = '';
             if(this.props.Active == i) {
@@ -75,4 +79,4 @@ PaginationLinks = React.createClass({
     }
 });
 
-RPaginationLinks = React.createFactory(PaginationLinks);
+var RPaginationLinks = React.createFactory(PaginationLinks);

--- a/jsx/PaginationLinks.js
+++ b/jsx/PaginationLinks.js
@@ -1,82 +1,92 @@
+/* exported RPaginationLinks */
+
 var PaginationLinks = React.createClass({
-    mixins: [React.addons.PureRenderMixin],
-    propTypes: {
-        onChangePage: React.PropTypes.func,
-        Total: React.PropTypes.number.isRequired
-    },
-    getDefaultProps: function() {
-        return {
-            'RowsPerPage' : 10,
-            'Active' : 1
-        }
-    },
-    changePage: function(i) {
-        var that = this;
-        return function(evt) {
-            // Don't jump to the top of the page
-            evt.preventDefault();
+  mixins: [React.addons.PureRenderMixin],
+  propTypes: {
+    onChangePage: React.PropTypes.func,
+    Total: React.PropTypes.number.isRequired
+  },
+  getDefaultProps: function() {
+    return {
+      RowsPerPage: 10,
+      Active: 1
+    };
+  },
+  changePage: function(i) {
+    var that = this;
+    return function(evt) {
+      // Don't jump to the top of the page
+      evt.preventDefault();
 
-            if(that.props.onChangePage) {
-                that.props.onChangePage(i);
-            }
-        };
-    },
-    render: function() {
-        var rowsPerPage = this.props.RowsPerPage;
-        var pageLinks = [];
-        var classList;
-        var lastPage = Math.ceil(this.props.Total / rowsPerPage);
-        var startPage = Math.max(1, this.props.Active-3);
-        var lastShownPage = Math.min(this.props.Active+3, lastPage);
+      if (that.props.onChangePage) {
+        that.props.onChangePage(i);
+      }
+    };
+  },
+  render: function() {
+    var rowsPerPage = this.props.RowsPerPage;
+    var pageLinks = [];
+    var classList;
+    var lastPage = Math.ceil(this.props.Total / rowsPerPage);
+    var startPage = Math.max(1, this.props.Active - 3);
+    var lastShownPage = Math.min(this.props.Active + 3, lastPage);
 
-        if(this.props.Total === 0) {
-            return <div />;
-        }
-        if(this.props.Total < this.props.RowsPerPage) {
-            return <div />;
-        }
+    if (this.props.Total === 0) {
+      return <div />;
+    }
+    if (this.props.Total < this.props.RowsPerPage) {
+      return <div />;
+    }
 
-        if((lastShownPage - startPage) <= 7) {
-            lastShownPage = startPage + 6;
-            if(lastShownPage > lastPage) {
-                lastShownPage = lastPage;
-                startPage = lastPage - 6
-            }
+    if ((lastShownPage - startPage) <= 7) {
+      lastShownPage = startPage + 6;
+      if (lastShownPage > lastPage) {
+        lastShownPage = lastPage;
+        startPage = lastPage - 6;
+      }
+    }
 
-        }
-
-
-        if(startPage > 1) {
-            pageLinks.push(<li onClick={this.changePage(1)}><a href="#">&laquo;</a></li>);
-        }
-        if(startPage < 1) {
-            startPage = 1;
-        }
-        if(lastShownPage < 1) {
-            lastShownPage = 1;
-        }
+    if (startPage > 1) {
+      pageLinks.push(
+        <li onClick={this.changePage(1)}><a href="#">&laquo;</a></li>
+      );
+    }
+    if (startPage < 1) {
+      startPage = 1;
+    }
+    if (lastShownPage < 1) {
+      lastShownPage = 1;
+    }
 
         // If there is only 1 page, don't display pagination links
-        if (startPage === lastShownPage) {
-          return <div />;
-        }
+    if (startPage === lastShownPage) {
+      return <div />;
+    }
 
-        for(var i = startPage; i <= lastShownPage; i += 1) {
-            classList = '';
-            if(this.props.Active == i) {
-                classList = "active";
-            }
-            pageLinks.push(<li onClick={this.changePage(i)} className={classList}><a href="#">{i}</a></li>);
-        }
-        if(lastShownPage !== lastPage) {
-        pageLinks.push(<li onClick={this.changePage(lastPage)}><a href="#">&raquo;</a></li>);
-        }
-        return (
+    for (var i = startPage; i <= lastShownPage; i += 1) {
+      classList = '';
+      if (this.props.Active === i) {
+        classList = "active";
+      }
+      pageLinks.push(
+        <li onClick={this.changePage(i)} className={classList}>
+          <a href="#">{i}</a>
+        </li>
+      );
+    }
+    if (lastShownPage !== lastPage) {
+      pageLinks.push(
+        <li onClick={this.changePage(lastPage)}>
+          <a href="#">&raquo;</a>
+        </li>
+      );
+    }
+    return (
             <ul className="pagination pagination-table">
                 {pageLinks}
             </ul>
         );
-    }
+  }
 });
 
 var RPaginationLinks = React.createFactory(PaginationLinks);


### PR DESCRIPTION
**Example of the edge case bug**

![image](https://cloud.githubusercontent.com/assets/6627543/17703199/e4655382-639e-11e6-8072-92390fcee8d1.png)

>If number of rows to display is set to 20, and there is exactly 20 search results, a pagination link will be added although it is not necessary and it can't be used.

>**[Click Here](https://github.com/aces/Loris/pull/2113/commits/3565f7974fe61e013eec976bda2bb5d4cb86f3a2?w=1#diff-40a94d299d0b4c2349f4ec172abe306f)** to see relevant changes