### PR TITLE
[Imaging Browser] MRI Violation Link (Redmine #9528)

### DIFF
--- a/modules/imaging_browser/js/ImagePanel.js
+++ b/modules/imaging_browser/js/ImagePanel.js
@@ -421,12 +421,12 @@ ImagePanelQCCaveatSelector = React.createClass({
     displayName: 'ImagePanelQCCaveatSelector',
 
     render: function () {
-
-        console.log(this.props.Caveat, this.props.SeriesUID);
         // Link caveat to MRI Violations if set true
         var mriViolationsLink = null;
         if (this.props.SeriesUID && this.props.Caveat === "1") {
-            mriViolationsLink = '/mri_violations/?' + 'submenu=mri_protocol_check_violations&SeriesUID=' + this.props.SeriesUID + '&filter=true';
+            mriViolationsLink = '/mri_violations/?' +
+              'submenu=mri_protocol_check_violations&SeriesUID=' +
+              this.props.SeriesUID + '&filter=true';
         }
 
         return React.createElement(ImageQCDropdown, {

--- a/modules/imaging_browser/js/ImagePanel.js
+++ b/modules/imaging_browser/js/ImagePanel.js
@@ -295,7 +295,24 @@ ImagePanelHeadersTable = React.createClass({
 ImageQCDropdown = React.createClass({
     displayName: 'ImageQCDropdown',
 
+
     render: function () {
+        var label = React.createElement(
+            'label',
+            null,
+            this.props.Label
+        );
+        if (this.props.url) {
+            label = React.createElement(
+                'label',
+                null,
+                React.createElement(
+                    'a',
+                    { href: this.props.url },
+                    this.props.Label
+                )
+            );
+        }
         var dropdown;
         if (this.props.editable) {
             var options = [];
@@ -326,11 +343,7 @@ ImageQCDropdown = React.createClass({
         return React.createElement(
             'div',
             { className: 'row' },
-            React.createElement(
-                'label',
-                null,
-                this.props.Label
-            ),
+            label,
             dropdown
         );
     }
@@ -340,11 +353,11 @@ ImageQCStatic = React.createClass({
 
     render: function () {
         var staticInfo;
-            staticInfo = React.createElement(
-                'div',
-                { className: 'col-xs-12' },
-                this.props.defaultValue
-            );
+        staticInfo = React.createElement(
+            'div',
+            { className: 'col-xs-12' },
+            this.props.defaultValue
+        );
         return React.createElement(
             'div',
             { className: 'row' },
@@ -408,6 +421,14 @@ ImagePanelQCCaveatSelector = React.createClass({
     displayName: 'ImagePanelQCCaveatSelector',
 
     render: function () {
+
+        console.log(this.props.Caveat, this.props.SeriesUID);
+        // Link caveat to MRI Violations if set true
+        var mriViolationsLink = null;
+        if (this.props.SeriesUID && this.props.Caveat === "1") {
+            mriViolationsLink = '/mri_violations/?' + 'submenu=mri_protocol_check_violations&SeriesUID=' + this.props.SeriesUID + '&filter=true';
+        }
+
         return React.createElement(ImageQCDropdown, {
             Label: 'Caveat',
             FormName: 'caveat',
@@ -418,7 +439,8 @@ ImagePanelQCCaveatSelector = React.createClass({
                 "1": "True",
                 "0": "False"
             },
-            defaultValue: this.props.Caveat
+            defaultValue: this.props.Caveat,
+            url: mriViolationsLink
         });
     }
 });
@@ -457,7 +479,8 @@ ImagePanelQCPanel = React.createClass({
             React.createElement(ImagePanelQCCaveatSelector, {
                 FileID: this.props.FileID,
                 HasQCPerm: this.props.HasQCPerm,
-                Caveat: this.props.Caveat
+                Caveat: this.props.Caveat,
+                SeriesUID: this.props.SeriesUID
             }),
             React.createElement(ImagePanelQCSNRValue, {
                 FileID: this.props.FileID,
@@ -620,7 +643,8 @@ ImagePanelBody = React.createClass({
                         Caveat: this.props.Caveat,
                         SelectedOptions: this.props.SelectedOptions,
                         Selected: this.props.Selected,
-                        SNR: this.props.SNR
+                        SNR: this.props.SNR,
+                        SeriesUID: this.props.SeriesUID
                     })
                 )
             ),
@@ -695,7 +719,8 @@ ImagePanel = React.createClass({
                     XMLProtocol: this.props.XMLProtocol,
                     XMLReport: this.props.XMLReport,
                     NrrdFile: this.props.NrrdFile,
-                    OtherTimepoints: this.props.OtherTimepoints
+                    OtherTimepoints: this.props.OtherTimepoints,
+                    SeriesUID: this.props.SeriesUID
                 })
             )
         );

--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -121,7 +121,12 @@ ImagePanelHeadersTable = React.createClass({
     }
 });
 ImageQCDropdown = React.createClass({
+
     render: function() {
+        var label = <label>{this.props.Label}</label>;
+        if (this.props.url) {
+          label = <label><a href={this.props.url}>{this.props.Label}</a></label>;
+        }
         var dropdown;
         if(this.props.editable) {
             var options = [];
@@ -147,7 +152,7 @@ ImageQCDropdown = React.createClass({
         }
         return (
             <div className="row">
-                <label>{this.props.Label}</label>
+                {label}
                 {dropdown}
             </div>
         );
@@ -207,6 +212,15 @@ ImagePanelQCSelectedSelector = React.createClass({
 });
 ImagePanelQCCaveatSelector = React.createClass({
     render: function () {
+
+        // Link caveat to MRI Violations if set true
+        var mriViolationsLink = null;
+        if (this.props.SeriesUID && this.props.Caveat === "1") {
+          mriViolationsLink = '/mri_violations/?' +
+            'submenu=mri_protocol_check_violations&SeriesUID=' +
+            this.props.SeriesUID + '&filter=true';
+        }
+
         return (
             <ImageQCDropdown
                 Label="Caveat"
@@ -219,8 +233,9 @@ ImagePanelQCCaveatSelector = React.createClass({
                         "1" : "True",
                         "0" : "False"
                     }
-                } 
+                }
                 defaultValue={this.props.Caveat}
+                url={mriViolationsLink}
             />
         );
     }
@@ -258,6 +273,7 @@ ImagePanelQCPanel = React.createClass({
                     FileID={this.props.FileID}
                     HasQCPerm={this.props.HasQCPerm}
                     Caveat={this.props.Caveat}
+                    SeriesUID={this.props.SeriesUID}
                 />
                 <ImagePanelQCSNRValue
                     FileID={this.props.FileID}
@@ -300,7 +316,7 @@ ImageQCCommentsButton = React.createClass({
         };
         return (
             <a className="btn btn-default"
-                href="#noID" 
+                href="#noID"
                 onClick={this.openWindowHandler}
                 >
                     <span className="text-default">
@@ -343,10 +359,10 @@ ImageDownloadButtons = React.createClass({
     render: function() {
         return (
             <div className="row mri-second-row-panel col-xs-12">
-                <ImageQCCommentsButton FileID={this.props.FileID} 
+                <ImageQCCommentsButton FileID={this.props.FileID}
                     BaseURL={this.props.BaseURL}
                 />
-                <DownloadButton FileName={this.props.Fullname} 
+                <DownloadButton FileName={this.props.Fullname}
                     Label="Download Minc"
                     BaseURL={this.props.BaseURL}
                 />
@@ -354,11 +370,11 @@ ImageDownloadButtons = React.createClass({
                     BaseURL={this.props.BaseURL}
                     Label="Download XML Protocol"
                 />
-                <DownloadButton FileName={this.props.XMLReport} 
+                <DownloadButton FileName={this.props.XMLReport}
                     BaseURL={this.props.BaseURL}
                     Label="Download XML Report"
                 />
-                <DownloadButton FileName={this.props.NrrdFile} 
+                <DownloadButton FileName={this.props.NrrdFile}
                     BaseURL={this.props.BaseURL}
                     Label="Download NRRD"
                 />
@@ -395,6 +411,7 @@ ImagePanelBody = React.createClass({
                                 SelectedOptions={this.props.SelectedOptions}
                                 Selected={this.props.Selected}
                                 SNR={this.props.SNR}
+                                SeriesUID={this.props.SeriesUID}
                             />
                          </div>
                     </div>
@@ -434,7 +451,7 @@ ImagePanel = React.createClass({
         return (
             <div className="col-xs-12 col-md-6">
                 <div className="panel panel-default">
-                <ImagePanelHeader 
+                <ImagePanelHeader
                     FileID={this.props.FileID}
                     Filename={this.props.Filename}
                     QCStatus={this.props.QCStatus}
@@ -443,7 +460,7 @@ ImagePanel = React.createClass({
                     Expanded={!this.state.BodyCollapsed}
                     HeadersExpanded={!this.state.HeadersCollapsed}
                 />
-                {this.state.BodyCollapsed ? '' : 
+                {this.state.BodyCollapsed ? '' :
                     <ImagePanelBody
                         BaseURL={this.props.BaseURL}
 
@@ -452,7 +469,7 @@ ImagePanel = React.createClass({
                         Checkpic={this.props.Checkpic}
                         HeadersExpanded={!this.state.HeadersCollapsed}
 
-                        HeaderInfo={this.props.HeaderInfo} 
+                        HeaderInfo={this.props.HeaderInfo}
 
                         FileNew={this.props.FileNew}
                         HasQCPerm={this.props.HasQCPerm}
@@ -467,6 +484,7 @@ ImagePanel = React.createClass({
                         XMLReport={this.props.XMLReport}
                         NrrdFile={this.props.NrrdFile}
                         OtherTimepoints={this.props.OtherTimepoints}
+                        SeriesUID={this.props.SeriesUID}
                     /> }
                 </div>
             </div>

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -18,7 +18,6 @@
    <div class="panel-body">
       {section name=file loop=$files}
           <div id="image-{$files[file].FileID}"></div>
-
           <script>
           React.render(
                   RImagePanel({
@@ -63,7 +62,8 @@
                       "XMLProtocol" : "{$files[file].XMLprotocol}",
                       "XMLReport" : "{$files[file].XMLreport}",
                       "NrrdFile" : "{$files[file].NrrdFile}",
-                      "OtherTimepoints" : "{$files[file].OtherTimepoints}"
+                      "OtherTimepoints" : "{$files[file].OtherTimepoints}",
+                      "SeriesUID": "{$files[file].SeriesUID}"
                   }),
                   document.getElementById("image-{$files[file].FileID}" )
                   );


### PR DESCRIPTION
- [x] Make `Caveat` label link to MRI violations, when caveat is set to true.

>This functionality was present in 15.10, but was apparently forgotten when form was reactified.
**[Click here](https://github.com/aces/Loris/blob/15.10-dev/modules/imaging_browser/templates/form_viewSession.tpl)** to see the old version.