### PR TITLE
[Dashboard] Load custom CSS

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -376,6 +376,22 @@ class NDB_Form_Dashboard extends NDB_Form
         }
     }
 
+    /**
+     * Include additional CSS files:
+     *  1. dashboard.css
+     *
+     * @return array of css to be included
+     */
+    function getCSSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getCSSDependencies();
+        return array_merge(
+            $deps,
+            [$baseURL . "/dashboard/css/dashboard.css"]
+        );
+    }
 
     /**
      * Add dependency on D3 and C3 javascript libraries


### PR DESCRIPTION
Dashboard was still relying on autoloading, so all the custom CSS was not loading anymore on 17.0.

- [x] Added getCSSDependencies();

Before | After
----- | -----
![image](https://cloud.githubusercontent.com/assets/6627543/18069516/c14e8f86-6e15-11e6-9c86-fbc4065f3c2c.png) | ![image](https://cloud.githubusercontent.com/assets/6627543/18069564/0013cf60-6e16-11e6-8787-a268e6868bce.png)



