### PR TITLE
[Media] Upload folder info

### DIFF
--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -18,6 +18,11 @@ In order to use media module user might need one or both of the following permis
 By default, all files are uploaded under `/data/uploads/`.
 This setting is configurable in `Paths` section of `Configuration` module.
 
+>**Important:** The destination directory must have `755` permissions and `www-data` group in order for upload to work.
+Make sure to to run these commands where `data/uploads` is your upload directory:
+`chmod 755 /data/uploads/`
+`sudo chown lorisadmin:www-data /data/uploads/`
+
 ### 💯 Features
 
 1. **Browse** a list of uploaded files and related information

--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -17,7 +17,7 @@ In order to use the media module the user needs one or both of the following per
 
 >**Note**: superusers have both of the aforementioned permissions by default! 💪
 
-### Upload path
+### :file_folder: Upload path
 
 By default, all files are uploaded under `/data/uploads/`.
 *(Note this directory is not created by the Loris install script and should be manually created by the admin.)*

--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -2,31 +2,45 @@
 
 ### 📄 Overview
 
-Media module allows users to upload, browse and edit media files associated with a specific timepoint in Loris.
+Media module allows users to **upload**, **browse** and **edit** media files associated with a specific candidate timepoint in Loris.
+Any kind of data associated with a candidate timepoint can be uploaded through this module: PDFs, videos, recordings, scripts, log files, etc.
+
+
+>Note: Currently editing functionality only allows editing of certain metadata fields, such as `Comments` and `Data of Administration`.
 
 ### 🔒 Permissions
 
 In order to use media module user might need one or both of the following permissions:
 
 1. **media_read** - gives user a read-only access to media module (file browsing only)
-2. **media_write** - gives user a write access to media module (file uploading, editing and deletion)
+2. **media_write** - gives user a write access to media module (upload/delete files and edit metadata)
 
 >**Note**: superusers have both of the aforementioned permissions by default! 💪
 
 ### Default upload path
 
 By default, all files are uploaded under `/data/uploads/`.
-This setting is configurable in `Paths` section of `Configuration` module.
+The upload path is configurable in `Paths` section of `Configuration` module.
 
->**Important:** The destination directory must have `755` permissions and `www-data` group in order for upload to work.
-Make sure to to run these commands where `data/uploads` is your upload directory:
-`chmod 755 /data/uploads/`
-`sudo chown lorisadmin:www-data /data/uploads/`
+>**Important** 
+ >
+>The destination directory must have `755` permissions and `$GROUP$` group in order for upload to work. Note: group name is OS dependent. 
+>```
+>Ubuntu: $GROUP$ = www-data
+>CentOS: $GROUP$ = apache
+>```
+
+
+>Make sure to to run these commands where `/data/uploads/` is your upload directory:
+>```
+>chmod 755 /data/uploads/
+>sudo chown lorisadmin:$GROUP$ /data/uploads/
+>```
 
 ### 💯 Features
 
 1. **Browse** a list of uploaded files and related information
-2. **Edit** meta information about media files (except timepoint related data such as PSCID, Visit Label and Instrument)
+2. **Edit** metadata about media files (except timepoint related data such as PSCID, Visit Label and Instrument)
 3. **Upload** new files associated to a specific timepoint
   - PSCID, Visit Label and Instrument are required fields for all uploaded files
   - File name should always start with [PSCID]\_[Visit Label]\_[Instrument]

--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -2,15 +2,15 @@
 
 ### 📄 Overview
 
-Media module allows users to **upload**, **browse** and **edit** media files associated with a specific candidate timepoint in Loris.
+Media module allows users to **upload**, **search** and **edit** media files associated with a specific candidate timepoint in Loris.
 Any kind of data associated with a candidate timepoint can be uploaded through this module: PDFs, videos, recordings, scripts, log files, etc.
 
 
->Note: Currently editing functionality only allows editing of certain metadata fields, such as `Comments` and `Data of Administration`.
+>Note: Currently editing functionality only allows editing of certain metadata fields, such as `Comments` and `Date of Administration`.
 
 ### 🔒 Permissions
 
-In order to use media module user might need one or both of the following permissions:
+In order to use the media module the user needs one or both of the following permissions:
 
 1. **media_read** - gives user a read-only access to media module (file browsing only)
 2. **media_write** - gives user a write access to media module (upload/delete files and edit metadata)
@@ -42,6 +42,6 @@ The upload path is configurable in `Paths` section of `Configuration` module.
 1. **Browse** a list of uploaded files and related information
 2. **Edit** metadata about media files (except timepoint related data such as PSCID, Visit Label and Instrument)
 3. **Upload** new files associated to a specific timepoint
-  - PSCID, Visit Label and Instrument are required fields for all uploaded files
-  - File name should always start with [PSCID]\_[Visit Label]\_[Instrument]
-4. **Delete** files. Deleting a file hides it from the frontend, but preserves a copy in the database.
+  - PSCID, Visit Label and Site are required fields for all uploaded files
+  - File name should always start with [PSCID]\_[Visit Label]\_[Instrument] corresponding to the selection in the upload form
+4. **Delete** files. Deleting a file hides it from the frontend, but preserves a copy in the database

--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -3,7 +3,7 @@
 ### 📄 Overview
 
 Media module allows users to **upload**, **search** and **edit** media files associated with a specific candidate timepoint in Loris.
-Any kind of data associated with a candidate timepoint can be uploaded through this module: PDFs, videos, recordings, scripts, log files, etc.
+Any kind of data associated with a candidate timepoint can be uploaded through this module: PDFs, videos, recordings, scripts, log files, etc. Files can optionally be associated to a specific instrument form within a given candidate timepoint.
 
 
 >Note: Currently editing functionality only allows editing of certain metadata fields, such as `Comments` and `Date of Administration`.

--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -17,9 +17,11 @@ In order to use the media module the user needs one or both of the following per
 
 >**Note**: superusers have both of the aforementioned permissions by default! 💪
 
-### Default upload path
+### Upload path
 
 By default, all files are uploaded under `/data/uploads/`.
+*(Note this directory is not created by the Loris install script and should be manually created by the admin.)*
+
 The upload path is configurable in `Paths` section of `Configuration` module.
 
 >**Important** 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -86,9 +86,6 @@ function uploadFile()
         exit;
     }
 
-    // Make sure folder is writable
-    chmod($mediaPath, 0777);
-
     // Process posted data
     $pscid      = isset($_POST['pscid']) ? $_POST['pscid'] : null;
     $visit      = isset($_POST['visitLabel']) ? $_POST['visitLabel'] : null;


### PR DESCRIPTION
- [x] Add a note to README explaining what permission and group a directory needs to be used for uploads
- [x] Removed `chmod` from PHP as it was not working anyway

>**Note**: for `chmod` to work in PHP, the directory needs to have `www-data` owner. To set the owner as `www-data`, a `chown` needs to be executed as a superuser. Since PHP doesn't have a superuser access, none of this can be done.
