### PR TITLE
[Brainbrowser] Reactify brainbrowser page (Redmine #9893)

### DIFF
--- a/modules/brainbrowser/css/brainbrowser.css
+++ b/modules/brainbrowser/css/brainbrowser.css
@@ -35,16 +35,6 @@ body {
   border-top-right-radius: 4px;
 }
 
-#sync-volumes-wrapper {
-  margin-right: 10px;
-}
-
-#capture-slices, #sync-volumes {
-  font-size: 12px;
-  margin: 0;
-  line-height: 2;
-}
-
 .volume-container {
   display: block;
   margin-bottom: 15px;
@@ -154,13 +144,6 @@ body {
 
 .play-btn:focus { outline: 0; }
 
-.panel-size {
-  color: #fff;
-  background-color: #064785;
-  border-color: #053a6d;
-  font-weight: bold;
-}
-
 .overlay-viewer-display {
   float: right;
 }
@@ -180,3 +163,19 @@ body {
   text-transform: uppercase;
 }
 
+.brainbrowser-wrapper .global-controls .control {
+  color: #fff;
+  background-color: #064785;
+  border: 1px solid #053a6d;
+  font-weight: 500;
+  height: 35px;
+  padding: 5px 10px;
+  border-radius: 5px;
+  margin-right: 10px;
+  outline: 0 !important;
+}
+
+.brainbrowser-wrapper .global-controls .control:active,
+.brainbrowser-wrapper .global-controls .control.isChecked {
+  background-color: #042d54;
+}

--- a/modules/brainbrowser/js/Brainbrowser.js
+++ b/modules/brainbrowser/js/Brainbrowser.js
@@ -26,7 +26,7 @@ var BrainBrowser = React.createClass({
     var modulePrefs = JSON.parse(localStorage.getItem('modulePrefs'));
     var panelSize = this.state.defaultPanelSize;
 
-    if (modulePrefs !== undefined) {
+    if (modulePrefs !== null) {
       this.modulePrefs = modulePrefs; // make prefs accesible within component
       if (modulePrefs[loris.TestName].panelSize !== undefined) {
         panelSize = modulePrefs[loris.TestName].panelSize;
@@ -100,11 +100,6 @@ var BrainBrowser = React.createClass({
               className: 'control',
               value: this.state.panelSize,
               onChange: this.handleChange },
-            React.createElement(
-              'option',
-              { value: '' },
-              'Choose Panel Size'
-            ),
             React.createElement(
               'option',
               { value: '-1' },

--- a/modules/brainbrowser/js/Brainbrowser.js
+++ b/modules/brainbrowser/js/Brainbrowser.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/* exported RBrainBrowser */
+
+/**
+ * Brainbrowser Page.
+ *
+ * Renders Brainbrowser main page
+ *
+ * @author Alex Ilea
+ * @version 1.0.0
+ *
+ * */
+var BrainBrowser = React.createClass({
+  displayName: 'BrainBrowser',
+
+
+  getInitialState: function getInitialState() {
+    return {
+      defaultPanelSize: 300
+    };
+  },
+
+  componentDidMount: function componentDidMount() {
+    // Retrieve module preferences and set panelSize
+    var modulePrefs = JSON.parse(localStorage.getItem('modulePrefs'));
+    var panelSize = this.state.defaultPanelSize;
+
+    if (modulePrefs !== undefined) {
+      this.modulePrefs = modulePrefs; // make prefs accesible within component
+      if (modulePrefs[loris.TestName].panelSize !== undefined) {
+        panelSize = modulePrefs[loris.TestName].panelSize;
+      }
+    }
+
+    this.setState({
+      panelSize: panelSize
+    });
+  },
+
+  handleChange: function handleChange(e) {
+    var value = e.target.value;
+    var modulePrefs = {};
+
+    if (value === "") {
+      value = this.state.defaultPanelSize;
+    }
+
+    if (this.modulePrefs) {
+      modulePrefs = this.modulePrefs;
+    } else {
+      modulePrefs[loris.TestName] = {};
+    }
+
+    // Save panelSize in localStorage
+    modulePrefs[loris.TestName].panelSize = value;
+    localStorage.setItem('modulePrefs', JSON.stringify(modulePrefs));
+    this.setState({
+      panelSize: value
+    });
+  },
+
+  render: function render() {
+    var options = {
+      100: '100 Pixels',
+      200: '200 Pixels',
+      256: '256 Pixels',
+      300: '300 Pixels (Default)',
+      400: '400 Pixels',
+      500: '500 Pixels',
+      600: '600 Pixels',
+      700: '700 Pixels',
+      800: '800 Pixels',
+      900: '900 Pixels',
+      1000: '1000 Pixels'
+    };
+
+    return React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'div',
+        { id: 'brainbrowser-wrapper', className: 'brainbrowser-wrapper' },
+        React.createElement(
+          'div',
+          { id: 'global-controls', className: 'global-controls' },
+          React.createElement(
+            'button',
+            { id: 'sync-volumes', className: 'control' },
+            'Sync Volumes'
+          ),
+          React.createElement(
+            'button',
+            { id: 'reset-view', className: 'control' },
+            'Reset View'
+          ),
+          React.createElement(
+            'select',
+            { id: 'panel-size',
+              className: 'control',
+              value: this.state.panelSize,
+              onChange: this.handleChange },
+            React.createElement(
+              'option',
+              { value: '' },
+              'Choose Panel Size'
+            ),
+            React.createElement(
+              'option',
+              { value: '-1' },
+              'Auto'
+            ),
+            Object.keys(options).map(function (option) {
+              return React.createElement(
+                'option',
+                { value: option, key: option },
+                options[option]
+              );
+            })
+          )
+        )
+      ),
+      React.createElement('div', { id: 'brainbrowser', className: 'brainbrowser' }),
+      React.createElement(
+        'div',
+        { id: 'loading', className: 'loading-message' },
+        'Loading...'
+      )
+    );
+  }
+
+});
+
+var RBrainBrowser = React.createFactory(BrainBrowser);

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -58,10 +58,11 @@ $(function() {
     });
 
     // Should cursors in all panels be synchronized?
-    $("#sync-volumes").change(function() {
-      var synced = $(this).is(":checked");
-
-      viewer.synced = synced;
+    var isChecked = false;
+    $("#sync-volumes").click(function() {
+      isChecked = !isChecked;
+      $(this).toggleClass('isChecked');
+      viewer.synced = isChecked;
     });
 
     // Reset button

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -843,7 +843,14 @@ $(function() {
     ////////////////////////////////////////
     // Set the size of slice display panels.
     ////////////////////////////////////////
-    viewer.setDefaultPanelSize(256, 256);
+
+    // Use the size from dropdown as deafault size
+    var panelSize = Number.parseInt($("#panel-size").val(), 10);
+
+    // If not a real size, set to default value
+    if (panelSize < 0) { panelSize = 300; }
+
+    viewer.setDefaultPanelSize(panelSize, panelSize);
 
     ///////////////////
     // Start rendering.

--- a/modules/brainbrowser/jsx/Brainbrowser.js
+++ b/modules/brainbrowser/jsx/Brainbrowser.js
@@ -22,7 +22,7 @@ var BrainBrowser = React.createClass({
     var modulePrefs = JSON.parse(localStorage.getItem('modulePrefs'));
     var panelSize = this.state.defaultPanelSize;
 
-    if (modulePrefs !== undefined) {
+    if (modulePrefs !== null) {
       this.modulePrefs = modulePrefs; // make prefs accesible within component
       if (modulePrefs[loris.TestName].panelSize !== undefined) {
         panelSize = modulePrefs[loris.TestName].panelSize;
@@ -81,7 +81,6 @@ var BrainBrowser = React.createClass({
                     className="control"
                     value={this.state.panelSize}
                     onChange={this.handleChange}>
-              <option value="">Choose Panel Size</option>
               <option value="-1">Auto</option>
               {Object.keys(options).map(function(option) {
                 return (

--- a/modules/brainbrowser/jsx/Brainbrowser.js
+++ b/modules/brainbrowser/jsx/Brainbrowser.js
@@ -1,0 +1,102 @@
+/* exported RBrainBrowser */
+
+/**
+ * Brainbrowser Page.
+ *
+ * Renders Brainbrowser main page
+ *
+ * @author Alex Ilea
+ * @version 1.0.0
+ *
+ * */
+var BrainBrowser = React.createClass({
+
+  getInitialState: function() {
+    return {
+      defaultPanelSize: 300
+    };
+  },
+
+  componentDidMount: function() {
+    // Retrieve module preferences and set panelSize
+    var modulePrefs = JSON.parse(localStorage.getItem('modulePrefs'));
+    var panelSize = this.state.defaultPanelSize;
+
+    if (modulePrefs !== undefined) {
+      this.modulePrefs = modulePrefs; // make prefs accesible within component
+      if (modulePrefs[loris.TestName].panelSize !== undefined) {
+        panelSize = modulePrefs[loris.TestName].panelSize;
+      }
+    }
+
+    this.setState({
+      panelSize: panelSize
+    });
+  },
+
+  handleChange: function(e) {
+    var value = e.target.value;
+    var modulePrefs = {};
+
+    if (value === "") {
+      value = this.state.defaultPanelSize;
+    }
+
+    if (this.modulePrefs) {
+      modulePrefs = this.modulePrefs;
+    } else {
+      modulePrefs[loris.TestName] = {};
+    }
+
+    // Save panelSize in localStorage
+    modulePrefs[loris.TestName].panelSize = value;
+    localStorage.setItem('modulePrefs', JSON.stringify(modulePrefs));
+    this.setState({
+      panelSize: value
+    });
+  },
+
+  render: function() {
+    var options = {
+      100: '100 Pixels',
+      200: '200 Pixels',
+      256: '256 Pixels',
+      300: '300 Pixels (Default)',
+      400: '400 Pixels',
+      500: '500 Pixels',
+      600: '600 Pixels',
+      700: '700 Pixels',
+      800: '800 Pixels',
+      900: '900 Pixels',
+      1000: '1000 Pixels'
+    };
+
+    return (
+      <div>
+        <div id="brainbrowser-wrapper" className="brainbrowser-wrapper">
+          <div id="global-controls" className="global-controls">
+            <button id="sync-volumes" className="control">Sync Volumes</button>
+            <button id="reset-view" className="control">Reset View</button>
+            <select id="panel-size"
+                    className="control"
+                    value={this.state.panelSize}
+                    onChange={this.handleChange}>
+              <option value="">Choose Panel Size</option>
+              <option value="-1">Auto</option>
+              {Object.keys(options).map(function(option) {
+                return (
+                  <option value={option} key={option}>{options[option]}</option>
+                );
+              })}
+            </select>
+          </div>
+        </div>
+        <div id="brainbrowser" className="brainbrowser"></div>
+        <div id="loading" className="loading-message">Loading...</div>
+      </div>
+    );
+  }
+
+});
+
+var RBrainBrowser = React.createFactory(BrainBrowser);

--- a/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
+++ b/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
@@ -59,6 +59,7 @@ class NDB_Form_Brainbrowser extends NDB_Form
         return array_merge(
             $deps,
             array(
+             $baseURL . "/brainbrowser/js/Brainbrowser.js",
              $baseURL . "/brainbrowser/js/jquery.mousewheel.min.js",
              $baseURL . "/brainbrowser/js/three.min.js",
              $baseURL . "/brainbrowser/js/brainbrowser.volume-viewer.min.js",

--- a/modules/brainbrowser/templates/form_brainbrowser.tpl
+++ b/modules/brainbrowser/templates/form_brainbrowser.tpl
@@ -175,39 +175,11 @@
 </script>
 {/literal}
 
-<div id="brainbrowser-wrapper" class="brainbrowser-wrapper">
-    <div id="global-controls" class="clearfix">
-        <span id="sync-volumes-wrapper" class="clickable">
-            <input type="checkbox" class="button ui-helper-hidden-accessible" id="sync-volumes">
-            <label for="sync-volumes" id="sync-volumes" class="clickable btn btn-sm btn-primary">Sync Volumes</label>
-        </span>
-
-        <span id="reset-wrapper" class="clickable">
-            <input type="button" class="button ui-helper-hidden-accessible" id="reset-view">
-            <label for="reset-view" id="reset-view" class="clickable btn btn-sm btn-primary">Reset View</label>
-        </span>
-
-        <div class="btn-group">
-            <select id="panel-size" class="form-control panel-size clickable">
-                <option value="256" selected>Choose Panel Size</option>
-                <option value="-1">Auto</option>
-                <option value="100">100 Pixels</option>
-                <option value="200">200 Pixels</option>
-                <option value="256">256 Pixels (Default)</option>
-                <option value="300">300 Pixels</option>
-                <option value="400">400 Pixels</option>
-                <option value="500">500 Pixels</option>
-                <option value="600">600 Pixels</option>
-                <option value="700">700 Pixels</option>
-                <option value="800">800 Pixels</option>
-                <option value="900">900 Pixels</option>
-                <option value="1000">1000 Pixels</option>
-            </select>
-        </div>
-    </div>
+<div id="brainbrowserPage">
+  {* React component is inserted here *}
 </div>
 
-<div id="brainbrowser" class="brainbrowser"></div>
-
-<div id="loading" class="loading-message">Loading...</div>
-
+<script>
+  var brainBrowserPage = RBrainBrowser();
+  React.render(brainBrowserPage, document.getElementById('brainbrowserPage'));
+</script>


### PR DESCRIPTION
- [x] Render HTML within `Brainbrowser` page react component
- [x] Refactor and simplify HTML for global controls
- [x] Save selected panel size in component state and local storage

>**Note**: this PR addresses requests to make default panel size bigger and to remember user selection across page reloads.
