### PR TITLE
[Core] Removing changelogs file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,0 @@
-# Current changelogs
-Please refer to the Github [Releases](https://github.com/aces/Loris/releases) page.


### PR DESCRIPTION
We don't need this anymore. I think we have enough resources pointing to the Releases at this point.