### PR TITLE
[Installer] Updated Vagrantfile to be more robust     

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,13 +84,13 @@ Vagrant.configure("2") do |config|
     mv composer.phar /usr/local/bin/composer
 
     # For testing pull request before it gets merged
-    # git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
+    git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
     # Use the latest LORIS release.
-    git clone -b master https://github.com/driusan/Loris /var/www/loris
+    # git clone -b master https://github.com/driusan/Loris /var/www/loris
     cd /var/www/loris
     /usr/local/bin/composer install --no-dev
 
-    mkdir -p project smarty/templates_c
+    mkdir -p project/libraries smarty/templates_c
     chmod 777 smarty/templates_c
     chmod 777 project
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,11 +72,8 @@ Vagrant.configure("2") do |config|
     sudo add-apt-repository ppa:ondrej/php
     sudo apt-get -q update
 
-    apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php5.6 php5.6-mysql php5.6-gd php5.6-json php5.6-xml
+    apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php php-mysql php-gd php-json php-xml
 
-    # LORIS needs PHP 5.6 until QuickForm is completely replaced :(
-    a2dismod php7.0 && a2enmod php5.6 && service apache2 restart
-    ln -sfn /usr/bin/php5.6 /etc/alternatives/php
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
     php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
     php composer-setup.php
@@ -86,7 +83,10 @@ Vagrant.configure("2") do |config|
 
     mv composer.phar /usr/local/bin/composer
 
-    git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
+    # For testing pull request before it gets merged
+    # git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
+    # Use the latest LORIS release.
+    git clone -b master https://github.com/driusan/Loris /var/www/loris
     cd /var/www/loris
     /usr/local/bin/composer install --no-dev
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.49.10"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -37,7 +37,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  # config.vm.synced_folder ".", "/var/www/loris"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -65,13 +65,18 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-    apt-get update
+    PASSWORD=`date | md5sum | cut -c1-12`
+    sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password $PASSWORD"
+    sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $PASSWORD"
 
-    sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password password loris'
-    sudo debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password loris'
+    sudo add-apt-repository ppa:ondrej/php
+    sudo apt-get -q update
 
-    apt-get install -y libapache2-mod-php5 libmysqlclient15-dev mysql-client mysql-server php5 php5-mysql php5-gd php5-sqlite php5-json
+    apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php5.6 php5.6-mysql php5.6-gd php5.6-json php5.6-xml
 
+    # LORIS needs PHP 5.6 until QuickForm is completely replaced :(
+    a2dismod php7.0 && a2enmod php5.6 && service apache2 restart
+    ln -sfn /usr/bin/php5.6 /etc/alternatives/php
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
     php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
     php composer-setup.php
@@ -81,9 +86,33 @@ Vagrant.configure("2") do |config|
 
     mv composer.phar /usr/local/bin/composer
 
-    echo "MySQL was installed with root password 'loris'. You must change this for security reasons."
+    git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
+    cd /var/www/loris
+    /usr/local/bin/composer install --no-dev
+
+    mkdir -p project smarty/templates_c
+    chmod 777 smarty/templates_c
+    chmod 777 project
+
+    sed -e "s#%LORISROOT%#/var/www/loris#g" -e "s#%LOGDIRECTORY%#/var/log/apache2/#g" < docs/config/apache2-site | sudo tee /etc/apache2/sites-available/loris.conf
+    sudo a2dissite 000-default
+    sudo a2ensite loris.conf    
+    sudo a2enmod rewrite
+    sudo a2enmod headers
+
+    sudo service apache2 restart
+
+    echo "MySQL was installed with root password '$PASSWORD'"
+
+    echo "Even though the password was randomly generated, it was not generated in a cryptographically secure way and you should"
+
+    echo "change it soon. For now, it can be used to complete the installation of LORIS on this VM."
 
     echo "Please follow the README on GitHub to complete your installation."
+
+    echo "Please visit http://192.168.49.10/installdb.php to complete the LORIS install."
+
+    echo "When prompted for the MySQL host use \"127.0.0.1\" with admin username \"root\" and the password above."
   SHELL
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-    PASSWORD=`date | md5sum | cut -c1-12`
+    PASSWORD=`date | md5sum | cut -c1-12` 
     sudo debconf-set-selections <<< "mysql-server mysql-server/root_password password $PASSWORD"
     sudo debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $PASSWORD"
 
@@ -84,9 +84,9 @@ Vagrant.configure("2") do |config|
     mv composer.phar /usr/local/bin/composer
 
     # For testing pull request before it gets merged
-    git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
+    # git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
     # Use the latest LORIS release.
-    # git clone -b master https://github.com/aces/Loris /var/www/loris
+    git clone -b master https://github.com/aces/Loris /var/www/loris
     cd /var/www/loris
     mkdir -p project/libraries smarty/templates_c
     /usr/local/bin/composer install --no-dev

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,11 +86,11 @@ Vagrant.configure("2") do |config|
     # For testing pull request before it gets merged
     git clone -b VagrantUp https://github.com/driusan/Loris /var/www/loris
     # Use the latest LORIS release.
-    # git clone -b master https://github.com/driusan/Loris /var/www/loris
+    # git clone -b master https://github.com/aces/Loris /var/www/loris
     cd /var/www/loris
+    mkdir -p project/libraries smarty/templates_c
     /usr/local/bin/composer install --no-dev
 
-    mkdir -p project/libraries smarty/templates_c
     chmod 777 smarty/templates_c
     chmod 777 project
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "74f6a7d62205738b3633a84577f3c105",
-    "content-hash": "f0c1bbcca2ca5ba0536616727c6d3cf7",
+    "hash": "e4974305d0eca3e4b2dcd82e2d06b2b9",
+    "content-hash": "372f4a88b3cab0928f9645701be8067f",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -1144,16 +1144,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.11",
+            "version": "v2.8.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
+                "reference": "0ceab136f43ed9d3e97b3eea32a7855dc50c121d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0ceab136f43ed9d3e97b3eea32a7855dc50c121d",
+                "reference": "0ceab136f43ed9d3e97b3eea32a7855dc50c121d",
                 "shasum": ""
             },
             "require": {
@@ -1189,7 +1189,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 01:57:56"
+            "time": "2016-07-17 09:06:15"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -5,6 +5,7 @@
         "This file is @generated automatically"
     ],
     "hash": "74f6a7d62205738b3633a84577f3c105",
+    "content-hash": "f0c1bbcca2ca5ba0536616727c6d3cf7",
     "packages": [
         {
             "name": "firebase/php-jwt",

--- a/docs/config/apache2-site
+++ b/docs/config/apache2-site
@@ -18,13 +18,13 @@
 
 	DirectoryIndex main.php index.html
 
-	ErrorLog %LOGDIRECTORY%/error.log
+	ErrorLog %LOGDIRECTORY%/loris-error.log
 
 	# Possible values include: debug, info, notice, warn, error, crit,
 	# alert, emerg.
 	LogLevel warn
 
-	CustomLog %LOGDIRECTORY%/access.log combined
+	CustomLog %LOGDIRECTORY%/loris-access.log combined
 	ServerSignature Off
 
 	#SSLEngine Off  # change to On to enable, after updating cert paths below

--- a/docs/config/apache2-site
+++ b/docs/config/apache2-site
@@ -18,13 +18,13 @@
 
 	DirectoryIndex main.php index.html
 
-	ErrorLog %LOGDIRECTORY%/%PROJECTNAME%-error.log
+	ErrorLog %LOGDIRECTORY%/error.log
 
 	# Possible values include: debug, info, notice, warn, error, crit,
 	# alert, emerg.
 	LogLevel warn
 
-	CustomLog %LOGDIRECTORY%/%PROJECTNAME%-access.log combined
+	CustomLog %LOGDIRECTORY%/access.log combined
 	ServerSignature Off
 
 	#SSLEngine Off  # change to On to enable, after updating cert paths below

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -178,15 +178,15 @@ class Installer
     function createMySQLDB($values)
     {
         if (preg_match(
-             '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
-             $values['dbname']
+            '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
+            $values['dbname']
         ) == false
         ) {
-		$this->_lastErr = "Database name must only contain letters, "
-			. "numbers and underscores and must be at least 2 "
+            $this->_lastErr = "Database name must only contain letters, "
+            . "numbers and underscores and must be at least 2 "
                         . "characters long.";
-		return false;
-	}
+            return false;
+        }
         $DB = Database::singleton();
         if ($DB->connectAndCreate(
             $values['dbname'],

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -178,15 +178,15 @@ class Installer
     function createMySQLDB($values)
     {
         if (preg_match(
-            '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
-            $values['dbname']
+             '/^[a-zA-Z]+[a-zA-Z0-9_]*$/',
+             $values['dbname']
         ) == false
         ) {
-            $this->_lastErr = "Database name must only contain letters, "
-            . "numbers and underscores and must be at least 2 "
+		$this->_lastErr = "Database name must only contain letters, "
+			. "numbers and underscores and must be at least 2 "
                         . "characters long.";
-            return false;
-        }
+		return false;
+	}
         $DB = Database::singleton();
         if ($DB->connectAndCreate(
             $values['dbname'],


### PR DESCRIPTION
This begins the process of moving the vagrant install process to do a complete LORIS install of all dependencies. Apache is now configured on the vagrant VM, the password is no longer hardcoded, and the user is directed to the web based installer in #2010 .