### PR TITLE
[Core] Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
   "presets": [
-    "react",
-    "es2015"
+    "react"
   ]
 }


### PR DESCRIPTION
- [x] Remove ES2015 from babel to avoid compilation errors in incompatible modules

>Note: the feature could be brought back when all modules will be updated to use strict mode