### PR TITLE
Made 403 Error checking slightly stricter

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -136,6 +136,12 @@ class NDB_Client
                 // it.
                 if (!empty($_REQUEST['login'])) {
                     header("HTTP/1.1 403 Forbidden");
+                } else {
+                    // authenticate set an "Incorrect username or password"
+                    // error. We don't want it to be displayed on the login page
+                    // if they didn't just try and log in, so as a hack clear
+                    // it if $_REQUEST['login'] isn't set.
+                    $login->_lastError = '';
                 }
                 $login->clearState();
             }

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -131,7 +131,12 @@ class NDB_Client
             if ($auth === true) {
                 $error = $login->setState();
             } elseif ($auth === false) {
-                header("HTTP/1.1 403 Forbidden");
+                // only send a 403 error if they were attempting to log in,
+                // otherwise the login page returns a 403 when first accessing
+                // it.
+                if (!empty($_REQUEST['login'])) {
+                    header("HTTP/1.1 403 Forbidden");
+                }
                 $login->clearState();
             }
         }


### PR DESCRIPTION
This makes it so that LORIS will only send a 403 error if the user was
attempting to login in order to prevent the login page from returning
a 403 on first accessing the page, before they had tried entering any
username or password..

Related to #1961, but still sends the 403 error on an incorrect password.