### PR TITLE
[core] Enable project libraries override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
     #- "sh -e /etc/init.d/xvfb start"
     # Ensure node version is up to date
     - nvm install node
+    - mkdir -p project project/libraries
 
 install:
     # Install composer modules

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
         "facebook/webdriver" : "dev-master"
     },
     "autoload" : {
-        "classmap": ["php/libraries", "php/exceptions"]
+        "classmap": ["project/libraries", "php/libraries", "php/exceptions"]
     }
 }


### PR DESCRIPTION
Allows project to override libraries

The directory "project/libraries" has to exist for composer to run.