### PR TITLE
[Brainbrowser] Bring back jQuery UI

### DIFF
--- a/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
+++ b/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
@@ -84,6 +84,7 @@ class NDB_Form_Brainbrowser extends NDB_Form
         return array_merge(
             $deps,
             [
+             $baseURL . "/css/loris-jquery/jquery-ui-1.10.4.custom.min.css",
              $baseURL . "/brainbrowser/css/volume-viewer-demo.css",
              $baseURL . "/brainbrowser/css/brainbrowser.css",
             ]

--- a/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
+++ b/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
@@ -70,9 +70,9 @@ class NDB_Form_Brainbrowser extends NDB_Form
 
     /**
      * Include additional CSS files:
-     *  1. brainbrowser.css
+     *  1. jQuery UI
      *  2. volume-viewer-demo.css
-     *  3. surface-viewer-demo.css
+     *  3. brainbrowser.css
      *
      * @return array of javascript to be inserted
      */

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -338,6 +338,28 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
     }
 
     /**
+     * Include additional CSS files:
+     *  1. brainbrowser.css
+     *  2. volume-viewer-demo.css
+     *  3. surface-viewer-demo.css
+     *
+     * @return array of javascript to be inserted
+     */
+    function getCSSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getCSSDependencies();
+        return array_merge(
+            $deps,
+            [
+                $baseURL . "/css/loris-jquery/jquery-ui-1.10.4.custom.min.css",
+                $baseURL . "/document_repository/css/document_repository.css"
+            ]
+        );
+    }
+
+    /**
      * Include the column formatter required to display the feedback link colours
      * in the candidate_list menu
      *
@@ -355,6 +377,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
             )
         );
     }
+
 }
 
 ?>

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -339,9 +339,8 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
     /**
      * Include additional CSS files:
-     *  1. brainbrowser.css
-     *  2. volume-viewer-demo.css
-     *  3. surface-viewer-demo.css
+     *  1. jQuery UI
+     *  2. document_repository.css
      *
      * @return array of javascript to be inserted
      */


### PR DESCRIPTION
- [x] Include jQuery UI CSS file in brain browser and document repository

>After removing jQuery UI dependency it was found that brain browser still uses some of the jQuery UI CSS. To ensure that no other modules are broken, I searched for 'ui-' across the whole project and found some references to 'ui-' classes in document repository as well.
