### PR TITLE
[CouchDB] make MRI_Importer runnable and fix select warning

### DIFF
--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -165,7 +165,7 @@ class FeedbackMRI
                       FROM feedback_mri_comments
                   WHERE ".$this->_buildWhere();
 
-        $DB->select($query, $result);
+        $result = $DB->pselect($query, array());
 
         // build the output array
         if (is_array($result)) {

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -1,8 +1,6 @@
 <?php
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once 'generic_includes.php';
-require_once 'CouchDB.class.inc';
-require_once 'Database.class.inc';
 
 /**
  * Wrapper around CouchDB MRI functions

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -1,4 +1,8 @@
 <?php
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once 'generic_includes.php';
+require_once 'CouchDB.class.inc';
+require_once 'Database.class.inc';
 
 /**
  * Wrapper around CouchDB MRI functions
@@ -545,4 +549,10 @@ class CouchDBMRIImporter
             }
         }
     }
+}
+
+// Don't run if we're doing the unit tests; the unit test will call run.
+if(!class_exists('UnitTestCase')) {
+    $Runner = new CouchDBMRIImporter();
+    $Runner->run();
 }


### PR DESCRIPTION
1. Change a select to pselect

2. Add the proper require_once and runner to make it runnable.

`
php CouchDB_MRI_Importer.php`