### PR TITLE
[Core] Fix typo in StaticDataTable

### DIFF
--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -30,7 +30,7 @@ var StaticDataTable = React.createClass({
         // Init modulePrefs for current module
         if (modulePrefs[loris.TestName] === undefined) {
             modulePrefs[loris.TestName] = {};
-            modulePrefs[loris.TestName].rowsPerPage = this.state.rowsPerPage;
+            modulePrefs[loris.TestName].rowsPerPage = this.state.RowsPerPage;
         }
 
         // Set rows per page

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -28,7 +28,7 @@ var StaticDataTable = React.createClass({
         // Init modulePrefs for current module
         if (modulePrefs[loris.TestName] === undefined) {
           modulePrefs[loris.TestName] = {};
-          modulePrefs[loris.TestName].rowsPerPage = this.state.rowsPerPage;
+          modulePrefs[loris.TestName].rowsPerPage = this.state.RowsPerPage;
         }
 
         // Set rows per page


### PR DESCRIPTION
Fixed a typo that would break StaticDataTable until a number of rows is selected on a fresh Loris install