### PR TITLE
[DICOM Archive] BaseURL bugfix

### DIFF
--- a/modules/dicom_archive/templates/menu_dicom_archive.tpl
+++ b/modules/dicom_archive/templates/menu_dicom_archive.tpl
@@ -3,7 +3,7 @@
   loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
   var dicomArchivePage = RDicomArchive({
     "Sites": {$Sites|@json_encode},
-    "DataURL": "{$baseurl}/dicom_archive/?format=json",
+    "DataURL": loris.BaseURL + "/dicom_archive/?format=json",
     "getFormattedCell": formatColumn,
     "Module": "dicom_archive"
   });


### PR DESCRIPTION
Following the update of `dicom_archive` to the new module structure, `$baseurl` is never set on backend anymore. As a workaround using JS version now

- [x] Use JS baseURL