### PR TITLE
[Imaging Browser] Ordering of scans in imaging browser - Louis request (Redmine 9894)

### DIFF
--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -145,7 +145,7 @@ class NDB_Form_Imaging_Browser extends NDB_Form
             WHERE SessionID=:SID AND (AcquisitionProtocolID IS NULL 
             OR AcquisitionProtocolID not in (1, 2, 3, 52)) 
             AND PendingStaging=0 $extra_where_string 
-            ORDER BY files.OutputType, files.File",
+            ORDER BY files.OutputType, files.AcquisitionProtocolID, files.File",
             array(
                 'SID' => $this->sessionID,
             )


### PR DESCRIPTION
This ordering puts T1 and T2 first in most studies.  Making the ordering more predictive.
