### PR TITLE
Remove codecov from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,3 @@ script:
 
     # Run unit tests to make sure functions still do what they should.
     - vendor/bin/phpunit --configuration test/phpunit.xml --coverage-clover=coverage.xml
-
-after_success:
-    - bash <(curl -s https://codecov.io/bash)

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -461,7 +461,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
      *
      * @return WebDriverElement the element found.
      */
-    function safeFindElement(WebDriverBy $by, $waitPeriod=1)
+    function safeFindElement(WebDriverBy $by, $waitPeriod=15)
     {
         $wait = new WebDriverWait($this->webDriver, $waitPeriod);
         $wait->until(


### PR DESCRIPTION
The CodeCov reports aren't working very well, and create false negatives with pull requests "failing" because they didn't pass the code coverage tests, even though they're set to not be required.

This removes the code from the Travis.yml.