### PR TITLE
Install and Readme tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ before contributing is probably sign up for the [LORIS developers' mailing list]
 
 Pull requests should be based on and sent to the VERSIONNUMBER-dev branch of the version that you are targeting. The master branch is reserved for stable releases.
 
-Your current version number can be found in the VERSION file under the LORIS root (as of version 15.10).
+Your current version number can be found in the VERSION file under the LORIS root.
 
 ## Code Contributions
 
@@ -22,6 +22,7 @@ If you'd like to contribute code, here are some things to keep in mind.
   If you have questions, feel free to mail the mailing list.
 * Add your new tests to get auto-run by Travis in the .travis.yml to make sure that
   other people don't accidentally break your module.
+* Check out our Coding Standards in the [docs/ directory](https://github.com/aces/Loris/tree/master/docs) and also our [Code Review Checklist](https://github.com/aces/Loris/wiki/Code-Review-Checklist) in the [GitHub Wiki](https://github.com/aces/Loris/wiki)
 * Try and make sure you run PHP codesniffer using the standards file in
   docs/LorisCS.xml before sending any pull request, otherwise the Loris tests may
   fail and we won't be able to merge your pull request.
@@ -30,9 +31,9 @@ If you'd like to contribute code, here are some things to keep in mind.
   in a non-backwards-compatible way, document it in your pull request description and
   tag it with "Caveat For Existing Projects" so that we know that the change needs
   to be mentioned in release notes. Non-backwards-compatible changes should be sent
-  to the next major release(eg. 16.X -> 17.0) while backwards-compatible changes should
-  be sent to the next minor release(eg. 16.1.0 -> 16.2.0) and backwards-compatible bug
-  fixes should be sent to the next minor release update(eg. 16.1.0 -> 16.1.1)
+  to the next major release (e.g. 17.X -> 18.0) while backwards-compatible changes should
+  be sent to the next minor release (e.g. 17.1.0 -> 17.2.0) and backwards-compatible bug
+  fixes should be sent to the next minor release update (e.g. 17.1.0 -> 17.1.1)
 
 ## Ways To Get Started
 
@@ -41,10 +42,6 @@ started, some ideas to get you started:
 
 * You can browse some of our public [Issues](https://github.com/aces/Loris/issues)
 * You can run PHP CodeSniffer on modules that haven't had it run yet.
-* You can go through modules and convert any old SQL statements to prepared
-  statements
-* You can go through modules and remove old PEAR exception handling (PEAR::isError
-  calls) since we now use PHP5 exceptions
 * You can help improve our documentation if you find any parts of it confusing or
   lacking
 * You can try and track down any bugs

--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -34,8 +34,8 @@ sudo mv composer.phar /usr/local/bin/composer
 ```
 
 Note that the default dependencies installed by CentOS 6.x may not meet the version requirements LORIS deployment or development.
-* MySQL 5.5 or lower is supported for LORIS 16.*
-* PHP 5.6 (or 5.5) is required for LORIS 16.* - upgrade your PHP manually
+* MySQL 5.7 is recommended for LORIS 17.*
+* PHP 7 is recommended for LORIS 17.* - upgrade your PHP manually
 Or run composer with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
 assume you just want to get it running, so we'll run it with `--no-dev`.)
 
@@ -45,13 +45,14 @@ assume you just want to get it running, so we'll run it with `--no-dev`.)
 # root directory that you downloaded and extracted LORIS into.
 # Expect this step to print scary warning messages 
 # about downloading and installing dependencies. 
+# It may be necessary to create the project/libraries/ directory before running composer install 
 composer install --no-dev
 ```
 
 ## 1.1 MySQL
 
-This details how to manual populate the MySQL database which is assumed
-to already exist (if not, create one before proceeding)
+This details how to set up accounts and manually populate the MySQL database  
+which is assumed to already exist (if not, create one before proceeding)
 
 Connect to MySQL, use your database and source all the files in the
 SQL/ directory of LORIS which are prefixed with `0000-00-` into it
@@ -71,6 +72,11 @@ UPDATE Config SET Value='http://localhost' WHERE ConfigID=(SELECT ID FROM Config
 Where `/var/www/loris/` is the location where LORIS is installed and assuming
 you'll be running on localhost (otherwise update host and url appropriately)
 
+Create a new MySQL back-end user (recommended: _lorisuser_) that will perform all transactions coming from the front-end, with the following privileges:
+```mysql 
+     GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON $mysqldb.* TO 'lorisuser'@'$mysqlhost' IDENTIFIED BY '$newPassword' WITH GRANT OPTION; 
+```
+
 Set the password for the front-end _admin_ user account while connected to MySQL.
 
 ```SQL
@@ -84,7 +90,7 @@ Create a directory named "project" directory under the LORIS root, and copy
 the sample config.xml from `docs/config/config.xml` to `project/config.xml`
 
 Update the _database_ tagset section of config.xml to point to the database you
-just configured with an appropriate user. (Ignore _quatuser_ and _quatpassword_ tags.)
+just configured with the _lorisuser_ credential created in step 1.1. (Ignore _quatuser_ and _quatpassword_ tags.)
 
 ## 1.3 Apache
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#LORIS Neuroimaging Platform [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=16.1-dev)](https://travis-ci.org/aces/Loris)
+#LORIS Neuroimaging Platform [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=17.0-dev)](https://travis-ci.org/aces/Loris)
 
 LORIS (Longitudinal Online Research and Imaging System) is a web-based data and project management software for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
@@ -9,26 +9,23 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/17.0-dev)
 <hr>
 
-This Readme covers installation of the <b>17.0</b> LORIS development branch on <b>Ubuntu</b>.
-([CentOS Readme also available](https://github.com/aces/Loris/blob/16.1-dev/README.CentOS6.md)).
-
-If you are looking to install a stable release, please consult the [Releases page](https://github.com/aces/Loris/releases) and the Readme for the last stable release.
+This Readme covers installation of the <b>17.0</b> LORIS release on <b>Ubuntu</b>.
+([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).
 
 Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information not included in this Readme. The [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) may also provide installation guidance not covered in the Wiki. 
 
 # Prerequisites for Installation
 
- * LINUX (supported on Ubuntu 14.04 and [CentOS 6.5](https://github.com/aces/Loris/blob/16.1-dev/README.CentOS6.md))
+ * LINUX (supported on Ubuntu 14+ and [CentOS 6.5](https://github.com/aces/Loris/blob/16.1-dev/README.CentOS6.md))
  * Apache2 (libapache2-mod-php5)
- * MySQL 5.5 or lower (libmysqlclient15-dev mysql-client mysql-server)
- * PHP <b>5.6</b> (php5 php5-mysql php5-gd php5-sqlite)
+ * MySQL 5.7 (libmysqlclient15-dev mysql-client mysql-server)
+ * PHP <b>7</b> (php5 php5-mysql php5-gd php5-sqlite)
  * php5-json (for Debian/Ubuntu distributions)
  * Package manager (for LINUX distributions)
  * Composer : should be run with --no-dev option
 
 <b>Important:</b>
- * Only PHP <b>5.6</b> is supported for LORIS 16.1. We recommend installing/upgrading PHP using this (deprecated) PPA repository: <i>ppa:ondrej/php5-5.6 </i>
- * MySQL 5.7 is not supported for LORIS 16.1 and will cause errors when loading LORIS.  MySQL 5.5 or lower (5.*) is recommmended.  
+ * If you are upgrading your LORIS, you'll also want to upgrade to both PHP 7 and MySQL 5.7, since these dependency versions were not supported in the last release. 
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Install-Script) for more information.


### PR DESCRIPTION
Install script changes, based on recent user feedback:
* clearly suggest that MySQL root credential be used if known, to help novice users (P.Bermudez)
* Give users the choice of providing another URL (S.Milot) instead of default http://localhost

CentOS installation readme: 
* provide the command to create MySQL lorisuser account with appropriate permissions
