### PR TITLE
[CORE] add check to ProjectList in Utilities

### DIFF
--- a/htdocs/api/v0.0.1/APIBase.php
+++ b/htdocs/api/v0.0.1/APIBase.php
@@ -33,6 +33,7 @@ abstract class APIBase
     var $AllowedMethods = [];
     var $AutoHandleRequestDelegation = true;
     var $HTTPMethod;
+    var $config;
 
     var $Factory;
     var $Headers;
@@ -82,6 +83,8 @@ abstract class APIBase
         }
 
         $this->DB = $this->Factory->database();
+
+        $this->config = \NDB_Config::singleton();
 
         if ($this->AutoHandleRequestDelegation) {
             $this->handleRequest();

--- a/htdocs/api/v0.0.1/APIBase.php
+++ b/htdocs/api/v0.0.1/APIBase.php
@@ -84,7 +84,7 @@ abstract class APIBase
 
         $this->DB = $this->Factory->database();
 
-        $this->config = \NDB_Config::singleton();
+        $this->config = $this->Factory->config();
 
         if ($this->AutoHandleRequestDelegation) {
             $this->handleRequest();

--- a/htdocs/api/v0.0.1/APIBase.php
+++ b/htdocs/api/v0.0.1/APIBase.php
@@ -33,7 +33,6 @@ abstract class APIBase
     var $AllowedMethods = [];
     var $AutoHandleRequestDelegation = true;
     var $HTTPMethod;
-    var $config;
 
     var $Factory;
     var $Headers;
@@ -83,8 +82,6 @@ abstract class APIBase
         }
 
         $this->DB = $this->Factory->database();
-
-        $this->config = $this->Factory->config();
 
         if ($this->AutoHandleRequestDelegation) {
             $this->handleRequest();

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -266,13 +266,20 @@ class Utility
     {
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
-        // get the list of projects
-        $projects = $DB->pselect("SELECT * FROM Project", array());
-        $project  = array();
-        foreach ($projects as $row) {
-            $project[$row['ProjectID']] = $row['Name'];
+
+        $config      =& NDB_Config::singleton();
+        $useProjects = $config->getSetting('useProjects');
+
+        if ($useProjects) {
+            // get the list of projects
+            $projects = $DB->pselect("SELECT * FROM Project", array());
+            $project  = array();
+            foreach ($projects as $row) {
+                $project[$row['ProjectID']] = $row['Name'];
+            }
+            return $project;
         }
-        return $project;
+        return array();
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -756,7 +756,7 @@ class Utility
     {
         $Factory       = NDB_Factory::singleton();
         $DB            = $Factory->Database();
-        $config        =& NDB_Config::singleton();
+        $config        = $Factory->config();
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names",
             array()

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -267,7 +267,7 @@ class Utility
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $config      =& NDB_Config::singleton();
+        $config      = $factory->config();
         $useProjects = $config->getSetting('useProjects');
 
         if ($useProjects) {
@@ -756,7 +756,7 @@ class Utility
     {
         $Factory       = NDB_Factory::singleton();
         $DB            = $Factory->Database();
-        $config        = $Factory->config();
+        $config        =& NDB_Config::singleton();
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names",
             array()


### PR DESCRIPTION
In statistics: little bug fix 
call to Utility::getProjectList() should preceded by a check that useProjects Config setting is true.

Otherwise Utility::getProjectList() throws an error if there is no Projects tagset defined in config.xml 
For existing projects that don't use multiple projects within Loris, it shouldn't be mandatory to have a meaningless set of <Projects> tags just so as not to throw this error

