### PR TITLE
[Core] LorisMenuPermissions missing DROP table if exists

### DIFF
--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -58,6 +58,7 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Configuration', 'configuration/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 5),
     ('Server Processes Manager', 'server_processes_manager/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 6);
 
+DROP TABLE IF EXISTS `LorisMenuPermissions`;
 
 CREATE TABLE LorisMenuPermissions (
     MenuID integer unsigned REFERENCES LorisMenu(ID),


### PR DESCRIPTION
Just in conformity, LorisMenuPermissions was missing DROP table if exists
