### PR TITLE
Fix for REDMINE ticket 10936: no colours in the Progress column of the MRI upload table

### DIFF
--- a/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
+++ b/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
@@ -201,7 +201,7 @@
                     {section name=piece loop=$items[item]}
                         {if $items[item][piece].name eq 'Progress'}
                             {if $items[item][piece].value}
-                                <td nowrap="nowrap">
+                                <td nowrap="nowrap" bgcolor="{$items[item][piece].bgcolor}">
                                         {if {$items[item][piece].value} eq 'Success'}
                                             {$items[item][piece].value} ({$items[item][11].value} out of {$items[item][10].value})
                                         {else}
@@ -233,7 +233,7 @@
                                 <td nowrap="nowrap"> </td>
                             {/if}
                         {else}
-                            <td nowrap="nowrap" bgcolor="{$items[item][piece].bgcolor}">
+                            <td nowrap="nowrap">
                                 {$items[item][piece].value}
                             </td>
                         {/if}

--- a/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
+++ b/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
@@ -201,7 +201,7 @@
                     {section name=piece loop=$items[item]}
                         {if $items[item][piece].name eq 'Progress'}
                             {if $items[item][piece].value}
-                                <td nowrap="nowrap" bgcolor="{$items[item][piece].bgcolor}">
+                                <td nowrap="nowrap" style="background-color:{$items[item][piece].bgcolor}">
                                         {if {$items[item][piece].value} eq 'Success'}
                                             {$items[item][piece].value} ({$items[item][11].value} out of {$items[item][10].value})
                                         {else}


### PR DESCRIPTION
The colours that used to be there in the MRI upload table somehow disappeared. When the progress value is 'In Progress', the value should be displayed with a yellow background colour. When the progress value is 'Failure', the background colour should be red.