### PR TITLE
Fix for REDMINE ticket #10915: log viewer window on MRI uploader page is too small

### DIFF
--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -639,5 +639,15 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
         );
     }
 
+    function getCSSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getCSSDependencies();
+        return array_merge(
+            $deps,
+            [$baseURL . "/imaging_uploader/css/imaging_uploader.css"]
+        );
+    }
 }
 ?>

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -639,6 +639,12 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
         );
     }
 
+    /**
+     * Include additional CSS files:
+     *  imaging_uploader.css
+     *
+     * @return array of css to be inserted
+     */
     function getCSSDependencies()
     {
         $factory = NDB_Factory::singleton();

--- a/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
+++ b/modules/imaging_uploader/templates/menu_imaging_uploader.tpl
@@ -157,7 +157,7 @@
                             <label class="col-sm-4 col-md-4">
                                 Logs to display:
                             </label>
-                            <div class="col-sm-4 col-md-4">
+                            <div class="col-sm-5 col-md-5">
                                 {$form.LogType.html}
                             </div>
                         </div>


### PR DESCRIPTION
The log viewer table, which was fine in 16.1 apparently, is now very small and practically unusable. 
The fix: class NDB_Menu_Filter_imaging_uploader.class.inc now implements getCSSDependencies so it is displayed as it should be. 