### PR TITLE
[Instrument Builder] Prevent duplicate names in uploaded files

### DIFF
--- a/modules/instrument_builder/js/react.instrument_builder.js
+++ b/modules/instrument_builder/js/react.instrument_builder.js
@@ -62,7 +62,7 @@ var LoadPane = React.createClass({
 						React.createElement(
 							'span',
 							{ 'aria-hidden': 'true' },
-							'×'
+							'\xD7'
 						)
 					),
 					React.createElement(
@@ -83,7 +83,7 @@ var LoadPane = React.createClass({
 						React.createElement(
 							'span',
 							{ 'aria-hidden': 'true' },
-							'×'
+							'\xD7'
 						)
 					),
 					React.createElement(
@@ -415,8 +415,17 @@ var BuildPane = React.createClass({
 	// Load in a group of elements, replacing any that
 	// were already present
 	loadElements: function (elements) {
+
+		// Populate existing DB names
+		var elContent = elements[this.state.currentPage].Elements;
+		var elNames = {};
+		elContent.forEach(function (el) {
+			elNames[el.Name] = "";
+		});
+
 		this.setState({
-			Elements: elements
+			Elements: elements,
+			elementDBNames: elNames
 		});
 	},
 	// Set the element editing flag to true to render the element
@@ -482,6 +491,7 @@ var BuildPane = React.createClass({
 	},
 	// Add a new question to the page's elements
 	addQuestion: function (element) {
+
 		if (element.Name && element.Name in this.state.elementDBNames) {
 			// If the DB name already exists return false.
 			return false;

--- a/modules/instrument_builder/jsx/react.instrument_builder.js
+++ b/modules/instrument_builder/jsx/react.instrument_builder.js
@@ -327,13 +327,22 @@ var BuildPane = React.createClass({
 	 		elementDBNames : {}
 	 	};
 	},
-	// Load in a group of elements, replacing any that
-	// were already present
-	loadElements: function(elements) {
-		this.setState({
-			Elements: elements
-		});
-	},
+  // Load in a group of elements, replacing any that
+  // were already present
+  loadElements: function(elements) {
+
+    // Populate existing DB names
+    var elContent = elements[this.state.currentPage].Elements;
+    var elNames = {};
+    elContent.forEach(function(el) {
+       elNames[el.Name] = "";
+    });
+
+    this.setState({
+      Elements: elements,
+      elementDBNames: elNames
+    });
+  },
 	// Set the element editing flag to true to render the element
 	// as an AddQuestion object. Increase the number of editing to
 	// disable drag and drop
@@ -396,6 +405,7 @@ var BuildPane = React.createClass({
 	},
 	// Add a new question to the page's elements
 	addQuestion: function(element){
+
 		if (element.Name && element.Name in this.state.elementDBNames){
 			// If the DB name already exists return false.
 			return false;


### PR DESCRIPTION
- [x] Fix check for duplicate names in uploaded LISNT files (Redmine 10707)

Description of the problem:

When a LINST file is uploaded, the build tab gets populated with fields of this file. Adding a new field with an existing name is not prevented.

The fix in this PR checks for duplicate entries added in the Build tab after loading a file, hence preventing duplicate names.