### PR TITLE
Timepoint creation: add site dropdown when creating the visit: Redmine 11009

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -182,15 +182,15 @@ class Create_Timepoint extends \NDB_Form
         // label rules
         if ($visitLabelAdded) {
             $this->addRule('visitLabel', 'Visit label is required', 'required');
-	    // List of sites
-            $list_of_sites = \Utility::getSiteList();
+            // List of sites
+            $list_of_sites    = \Utility::getSiteList();
             $psc_labelOptions = array(null => '');
-            foreach($list_of_sites as $psc => $siteAlias) {
+            foreach ($list_of_sites as $psc => $siteAlias) {
                     $psc_labelOptions[$psc] = $siteAlias;
             }
             $this->addSelect('psc', 'Site', $psc_labelOptions);
             $this->addRule('psc', 'Site Alias is required', 'required');
-            $this->_setDefaults(array("psc"=>$this->psc));
+            $this->_setDefaults(array("psc" => $this->psc));
         }
 
         $this->form->addFormRule(array(&$this, '_validate'));

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -75,7 +75,8 @@ class Create_Timepoint extends \NDB_Form
         $success = \TimePoint::createNew(
             $this->identifier,
             $values['subprojectID'],
-            $values['visitLabel']
+            $values['visitLabel'],
+            $values['psc']
         );
 
         $this->tpl_data['success'] = true;
@@ -181,6 +182,15 @@ class Create_Timepoint extends \NDB_Form
         // label rules
         if ($visitLabelAdded) {
             $this->addRule('visitLabel', 'Visit label is required', 'required');
+	    // List of sites
+            $list_of_sites = \Utility::getSiteList();
+            $psc_labelOptions = array(null => '');
+            foreach($list_of_sites as $psc => $siteAlias) {
+                    $psc_labelOptions[$psc] = $siteAlias;
+            }
+            $this->addSelect('psc', 'Site', $psc_labelOptions);
+            $this->addRule('psc', 'Site Alias is required', 'required');
+            $this->_setDefaults(array("psc"=>$this->psc));
         }
 
         $this->form->addFormRule(array(&$this, '_validate'));

--- a/modules/create_timepoint/templates/form_create_timepoint.tpl
+++ b/modules/create_timepoint/templates/form_create_timepoint.tpl
@@ -27,6 +27,10 @@
 		<label class="col-sm-2">{$form.visitLabel.label}</label>
 		<div class="col-sm-2">{$form.visitLabel.html}</div>
 	</div>
+	<div class="form-group col-sm-12">
+		<label class="col-sm-2">{$form.psc.label}</label>
+		<div class="col-sm-2">{$form.psc.html}</div>
+	</div>
 
 	<div class="form-group col-sm-12">
 		<div class="col-sm-2 col-sm-offset-2"><input class="btn btn-primary col-sm-12" name="fire_away" value="Create Time Point" type="submit" /></div>

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -187,11 +187,14 @@ class TimePoint
      * @param integer $candID         6 digit CandID having a timepoint created.
      * @param integer $SubprojectID   The subprojectID of the new timepoint
      * @param string  $nextVisitLabel The visit label of the timepoint being created
+     * @param string  $psc            The centre of the timepoint
      *
      * @return A new TimePoint instance.
      */
-    static function createNew($candID, $SubprojectID, $nextVisitLabel = null)
-    {
+    static function createNew($candID, $SubprojectID,
+        $nextVisitLabel = null, $psc = null
+    ) {
+
         // insert into session set CandID=$candID,
         // SubprojectID=$SubprojectID, VisitNo=nextVisitNumber(),
         // UserID=$State->getUsername(), etc...  NO Date_* are
@@ -224,12 +227,15 @@ class TimePoint
         $VisitLabel = $nextVisitLabel == null
             ? 'V' . $row['nextVisitNo']
             : $nextVisitLabel;
+        $centerID   = $psc == null
+        ? $row['CenterID']
+        : $psc;
         $insertData = array(
                        'CandID'          => $candID,
                        'SubprojectID'    => $SubprojectID,
                        'VisitNo'         => $row['nextVisitNo'],
                        'Visit_label'     => $VisitLabel,
-                       'CenterID'        => $row['CenterID'],
+                       'CenterID'        => $centerID,
                        'Current_stage'   => 'Not Started',
                        'Submitted'       => 'N',
                        'registeredBy'    => $userID,


### PR DESCRIPTION
Requires a site selection when creating the timepoint (so that the session table can be populated with the CenterID of the site administering the visit).
Currently, all sites are populated. This feature will be changed to populate only centres that the user creating the timepoint is affiliated with (when users are allowed multi-centres: a feature to be implemented; redmine 11021)