### PR TITLE
Fix for Remine ticket #10927: the server processes files are deleted only if the pipeline's exit code is 0.

### DIFF
--- a/modules/server_processes_manager/php/MriUploadServerProcess.class.inc
+++ b/modules/server_processes_manager/php/MriUploadServerProcess.class.inc
@@ -177,6 +177,18 @@ class MriUploadServerProcess extends AbstractServerProcess
     {
         return self::PROCESS_TYPE;
     }
+
+    /**
+     * Whether $outfile, $_errfile and $_exitCodeFile should be deleted once the
+     * process is finished. These files will be deleted only if the pipeline
+     * executed successfully (i.e. with exit code 0).
+     *
+     * @return boolean true if the files should be deleted, false otherwise
+     */
+    public function deleteProcessFiles()
+    {
+        return !is_null($exitCode) && is_numeric($exitCode) && $exitCode == 0;
+    }
 }
 
 ?>

--- a/modules/server_processes_manager/php/MriUploadServerProcess.class.inc
+++ b/modules/server_processes_manager/php/MriUploadServerProcess.class.inc
@@ -187,6 +187,8 @@ class MriUploadServerProcess extends AbstractServerProcess
      */
     public function deleteProcessFiles()
     {
+        $exitCode = parent::getExitCode();
+
         return !is_null($exitCode) && is_numeric($exitCode) && $exitCode == 0;
     }
 }


### PR DESCRIPTION
This should facilitate debugging in some cases.