### PR TITLE
[Core] Load minified files on production only

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -580,7 +580,8 @@ class NDB_Page
                   $baseurl . '/js/jquery/jquery-1.11.0.min.js',
                   $baseurl . '/js/helpHandler.js',
                   $baseurl . '/js/modernizr/modernizr.min.js',
-                  $baseurl . '/js/react-with-addons-0.13.3.min.js',
+                  // Only load minified file on production, not sandboxes
+                  $baseurl . '/js/react-with-addons-0.13.3' . $min . '.js',
                   $baseurl . '/js/jquery/jquery-ui-1.10.4.custom.min.js',
                   $baseurl . '/js/jquery.dynamictable.js',
                   $baseurl . '/js/jquery.fileupload.js',


### PR DESCRIPTION
This feature was accidentally deleted during some of the rebases.

Brough it back with a clear comment explaining its functionality