### PR TITLE
Update some outdated parts of CodingStandards document

### DIFF
--- a/docs/CodingStandards
+++ b/docs/CodingStandards
@@ -15,30 +15,26 @@ gg=G
 In emacs:
 ? (C-x C-c, vi filename?)
 
-PHP: 
-- for control structures, opening curly bracket should be on the same line as statement with a space before the curly bracket, closing bracket should be aligned with opening of statement. 
-    if (x) {
-        things go here;
-    }
-- An exception to this is class definitions and class function definitions, which may have the bracket on the proceeding line:
-
-class NDB_BVL_Foo extends NDB_Bar 
-{
-    definition goes here
-}
-
-Instead of using PEAR::isError, use Utility::isErrorX. It does the same thing, but avoids errors about PEAR::isError not being static in newer versions of PHP.
+PHP:
+- Ensure formatting meets Loris style guidelines by running phpcs with the LorisCS.xml
+  configuration file which accompanies these guidelines. You can run the tool
+  with the command `vendor/bin/phpcs --standard=docs/LorisCS.xml [file]` for any
+  files you've modified or added. For new modules, ensure that PHPCS has been
+  run on the module directory and add the module to travis.yml
 
 HTML:
-- HTML should never be mixed with code. HTML should go into a template and be rendered using a templating library (smarty for PHP)
-- General formatting rules about indentation applies for each tag embedded inside another tag of HTML
+- HTML should never be mixed with code. HTML should go into a template and be
+  rendered using a templating library (smarty for PHP)
+- General formatting rules about indentation applies for each tag embedded inside
+  another tag of HTML
 <div>
     <span>foo</span>
 </div>
 
 Javascript: 
-- Javascript should never be mixed with HTML or PHP code. Javascript should go into htdocs/JS/modules/ (Loris automatically includes the js file in that directory with the same name as Test_name, if it exists as of https://github.com/aces/Loris-Trunk/commit/8065fb265705298cb801d0e2f373d75e51d3cf29)
-- Any newly written Javascript should pass JSLint with default options, since those enforce the coding standards adopted by the general Javascript community
+- Javascript should never be mixed with HTML or PHP code. Javascript should go into
+  `modules/js`
+- Any newly written Javascript should pass ESLint with default options.
 
 SQL:
 - prepared statements ($db->pselect() rather than $db->select()) MUST be used for any statements which involve user input. You must never use string concatenation to create an SQL statement such as "SELECT abc FROM table WHERE field1='" + $_REQUEST['val'] + '"' as this is a serious security hole.
@@ -47,7 +43,7 @@ SQL:
 - SQL keywords should be capitalized
 
 Git:
-- Any changes should be done on a branch based on aces/master and contain only the changes which are applicable for that branch. (ie don't merge master back into your branch, and don't include commits that are unrelated) so that if someone merges the branch into their repository, they only get that branch's changes. In particular, so pull requests merge the proper code.
+- Any changes should be done on a branch based on the current development branch and contain only the changes which are applicable for that branch. (ie don't merge master back into your branch, and don't include commits that are unrelated) so that if someone merges the branch into their repository, they only get that branch's changes. In particular, so pull requests merge the proper code.
 - Commits should be atomic (self contained) and contain the changes and only the changes described by the commit message. The commit message should be a sentence that describes the goal of the change as a whole, for seeing the details of what code changed we have diff.
 - Don't try to correct unrelated code in the same commit, even if it violates these coding standards, that should be done in a separate branch/commit with a message such as "Fixed coding standard violations". In particular, don't try to fix whitespace since that is likely to cause conflicts even if you don't have any real (code) changes to those lines.
 - ALWAYS do a diff before commiting (after doing "git add file1 file2" when you're planning on doing git commit, you can use git diff --staged to see a diff of what will be commited). Ensure that nothing unexpected is included (such as whitespace changes. If using an external diff tool such as kdiff3, ensure your tool is whitespace sensitive)


### PR DESCRIPTION
- The PHP section is more or less deprecated in favour of PHPCS, and
  we now use eslint instead of jslint.
- The parts about where to put javascript were outdated and predated the
  existence of modules (and also referenced a deprecated/removed feature..)