### PR TITLE
DQT php max vars

### DIFF
--- a/modules/dataquery/js/react.app.js
+++ b/modules/dataquery/js/react.app.js
@@ -639,10 +639,10 @@ DataQueryApp = React.createClass({
                 DocTypes.push(category);
                 // Split the sessions to be queried into subqueries so that they don't exceed the defualt
                 // php defualt setting for maximum variables allowed in a single request
-                for (var j = 0; j < sessionInfo.length; j += 999) {
+                for (var j = 0; j < sessionInfo.length; j += 400) {
                     // keep track of the number of requests waiting for a response
                     semaphore++;
-                    sectionedSessions = sessionInfo.slice(j, j + 999);
+                    sectionedSessions = sessionInfo.slice(j, j + 400);
                     $.ajax({
                         type: "POST",
                         url: loris.BaseURL + "/AjaxHelper.php?Module=dataquery&script=retrieveCategoryDocs.php",

--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -606,10 +606,10 @@ DataQueryApp = React.createClass({
                 DocTypes.push(category);
                 // Split the sessions to be queried into subqueries so that they don't exceed the defualt
                 // php defualt setting for maximum variables allowed in a single request
-                for(var j = 0; j < sessionInfo.length; j += 999){
+                for(var j = 0; j < sessionInfo.length; j += 400){
                     // keep track of the number of requests waiting for a response
                     semaphore++;
-                    sectionedSessions = sessionInfo.slice(j, j+999);
+                    sectionedSessions = sessionInfo.slice(j, j+400);
                     $.ajax({
                         type: "POST",
                         url: loris.BaseURL + "/AjaxHelper.php?Module=dataquery&script=retrieveCategoryDocs.php",


### PR DESCRIPTION
Lower the block size of data being sent to backend to prevent data loss. The block size was larger then the php default max_input_vars so data was lost in POST