### PR TITLE
Fix path for composer in install.sh (Redmine #11110)

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -72,10 +72,14 @@ else
     exit 2;
 fi
 
-if [[ -n $(which composer) ]] || [[ -x ../composer ]]; then
+if [[ -n $(which composer) ]]; then
     echo ""
     echo "PHP Composer appears to be installed."
     composer_scr="composer install --no-dev"
+elif [[ -x ../composer ]]; then
+    echo ""
+    echo "PHP Composer appears to be installed."
+    composer_scr="./composer install --no-dev"
 else
     echo "PHP Composer does not appear to be installed. Attempting to install now..."
     curl -sS https://getcomposer.org/installer | php


### PR DESCRIPTION
Fixes a small bug in install.sh which can cause composer install to fail. See Redmine #11110