### PR TITLE
Escape reserved XML characters before writing config.xml

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -587,7 +587,13 @@ class Installer
      */
     function writeConfig($values)
     {
-        $contents = $this->getConfigContent($values);
+        $escapedValues = array_map(
+            function ($val) {
+                return htmlspecialchars($val, ENT_XML1, 'ISO-8859-1');
+            },
+            $values
+        );
+        $contents = $this->getConfigContent($escapedValues);
         file_put_contents(__DIR__ . "/../../project/config.xml", $contents);
         return true;
     }


### PR DESCRIPTION
Config fields containing XML reserved characters (", <, >, & ') weren't being escaped and were causing PHP to throw an error when parsing.

See Redmine #11136