### PR TITLE
[Core] Fix composer install bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "phpunit/dbunit": ">=1.2",
         "facebook/webdriver" : "dev-master"
     },
+    "scripts": {
+      "pre-install-cmd": "mkdir -p project/libraries"
+    },
     "autoload" : {
         "classmap": ["project/libraries", "php/libraries", "php/exceptions"]
     }


### PR DESCRIPTION
- [x] Fix bug where `composer install` fails in projects that don't have `project/libraries` directory created.