### PR TITLE
Remove IF NOT EXISTS syntax from Installer class (not compatible with…

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -469,12 +469,13 @@ class Installer
 
         // The user does not exist and needs to be created
         $DB->PDO->exec(
-            "CREATE USER IF NOT EXISTS $quotedUser IDENTIFIED BY " .
+            "CREATE USER $quotedUser IDENTIFIED BY " .
             $DB->PDO->quote($values['lorismysqlpassword'])
         );
+
         $DB->PDO->exec(
-            "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES 
-			ON `$values[dbname]`.* TO $quotedUser"
+            "GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES
+            ON `$values[dbname]`.* TO $quotedUser"
         );
         return true;
     }


### PR DESCRIPTION
… MySQL < 5.7).

"CREATE USER IF NOT EXISTS" syntax only works in MySQL 5.7. In MySQL < 5.7 the user will get created but is unable to authenticate using the intended password. Instead, allow GRANT to implicitly create the account.

See Redmine #11148