### PR TITLE
[DQT] Typo fix: Longitudial selected filter

### DIFF
--- a/modules/dataquery/js/react.app.js
+++ b/modules/dataquery/js/react.app.js
@@ -739,7 +739,7 @@ DataQueryApp = React.createClass({
                 Identifiers.push(session);
             }
         } else {
-            // Displaying the data in the longitudial way
+            // Displaying the data in the longitudinal way
 
             var Visits = {},
                 visit,
@@ -877,7 +877,7 @@ DataQueryApp = React.createClass({
         }));
 
         // Define the data displayed type and add the view data tab
-        var displayType = this.state.grouplevel === 0 ? "Cross-sectional" : "Longitudial";
+        var displayType = this.state.grouplevel === 0 ? "Cross-sectional" : "Longitudinal";
         tabs.push(React.createElement(ViewDataTabPane, {
             TabId: "ViewData",
             Fields: this.state.fields,

--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -705,7 +705,7 @@ DataQueryApp = React.createClass({
                 Identifiers.push(session);
             }
         } else {
-            // Displaying the data in the longitudial way
+            // Displaying the data in the longitudinal way
 
             var Visits = {},
                 visit, identifier, temp, colHeader, index, instrument, fieldSplit;
@@ -836,7 +836,7 @@ DataQueryApp = React.createClass({
         );
 
         // Define the data displayed type and add the view data tab
-        var displayType = (this.state.grouplevel === 0) ? "Cross-sectional" : "Longitudial";
+        var displayType = (this.state.grouplevel === 0) ? "Cross-sectional" : "Longitudinal";
         tabs.push(<ViewDataTabPane
                 TabId="ViewData"
                 Fields={this.state.fields}


### PR DESCRIPTION
In the Data Query Tool, when Longitudinal display mode (vs. cross-sectional) is selected,
the displayed value is "Longitudial" (missing an n)