### PR TITLE
return label if static element's name is not set instead of empty string

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -688,7 +688,7 @@ class LorisForm
     function staticHTML($el)
     {
         if (empty($el['name'])) {
-            return '';
+            return $el['label'];
         }
         $val = $this->getValue($el['name']);
 


### PR DESCRIPTION
This fixes the bug where static html elements sometimes wouldn't display 