### PR TITLE
Default testdate instrument table

### DIFF
--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -64,7 +64,7 @@ foreach($instruments AS $instrument){
                 $output .= "`CommentID` varchar(255) NOT NULL default '',\n
                             `UserID` varchar(255) default NULL,\n
                             `Examiner` varchar(255) default NULL,\n
-                            `Testdate` timestamp NOT NULL,\n
+                            `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP,\n
                             `Data_entry_completion_status` enum('Incomplete','Complete') NOT NULL default 'Incomplete',\n";
             break;
 

--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -64,7 +64,7 @@ foreach($instruments AS $instrument){
                 $output .= "`CommentID` varchar(255) NOT NULL default '',\n
                             `UserID` varchar(255) default NULL,\n
                             `Examiner` varchar(255) default NULL,\n
-                            `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP,\n
+                            `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n
                             `Data_entry_completion_status` enum('Incomplete','Complete') NOT NULL default 'Incomplete',\n";
             break;
 

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -47,7 +47,7 @@ foreach($instruments AS $instrument){
                 $output.="`CommentID` varchar(255) NOT NULL default '',
                           `UserID` varchar(255) default NULL,
                           `Examiner` varchar(255) default NULL,
-                          `Testdate` timestamp NOT NULL,
+                          `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP,
                           `Data_entry_completion_status` enum('Incomplete','Complete') NOT NULL default 'Incomplete',\n";
             break;
             case "page":

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -47,7 +47,7 @@ foreach($instruments AS $instrument){
                 $output.="`CommentID` varchar(255) NOT NULL default '',
                           `UserID` varchar(255) default NULL,
                           `Examiner` varchar(255) default NULL,
-                          `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP,
+                          `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                           `Data_entry_completion_status` enum('Incomplete','Complete') NOT NULL default 'Incomplete',\n";
             break;
             case "page":


### PR DESCRIPTION
Safer to be explicit

For existing project, upgrading mysql to version 5.6+ might set the explicit_defaults_for_timestamp option to ON. Inserting in a `timestamp NOT NULL` column will raise an error when the DEFAULT value is not explicit in the table definition (existing instrument table). The solution is to ALTER those tables by adding DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP for those columns.