### PR TITLE
[Issue Tracker] Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ script:
     - vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/candidate_parameters/ajax
     - vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/dicom_archive
     - vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/create_timepoint
+    - vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/issue_tracker
 
     # Run JSLINT on specific scripts
     - jslint htdocs/js/jquery.dynamictable.js

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -70,7 +70,7 @@ function editIssue()
 
     foreach ($fields as $field) {
         $value = $_POST[$field];
-        if (strcmp($_POST[$field], "null") == 0) {
+        if ($_POST[$field] === "null") {
             $value = NULL;
         }
         if (isset($field)) {
@@ -78,7 +78,7 @@ function editIssue()
         }
     }
     foreach ($fieldsToValidateFirst as $vField) {
-        if (isset($_POST[$vField]) && strcmp($_POST[$vField], "null") != 0) {
+        if (isset($_POST[$vField]) && $_POST[$vField] !== "null") {
             $validateValues[$vField] = $_POST[$vField];
         }
     }

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -569,7 +569,7 @@ WHERE (u.CenterID=:CenterID) OR (u.CenterID=:DCC)",
                   );
 
     $unorgCategories = $db->pselect(
-        "SELECT categoryNameFROM issues_categories",
+        "SELECT categoryName FROM issues_categories",
         []
     );
     $categories      = [];

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -71,7 +71,7 @@ function editIssue()
     foreach ($fields as $field) {
         $value = $_POST[$field];
         if ($_POST[$field] === "null") {
-            $value = NULL;
+            $value = null;
         }
         if (isset($field)) {
             $issueValues[$field] = $value;

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -147,14 +147,20 @@ function editIssue()
 
     //adding others from multiselect to watching table.
     if (isset($_POST['othersWatching'])) {
-        $othersNowWatching = explode(',', $_POST['othersWatching']);
-        foreach ($othersNowWatching as $userWatching) {
-            if ($userWatching) { //cause sometimes it sends null
-                $nowWatching = array(
-                                'userID'  => $userWatching,
-                                'issueID' => $issueID,
-                               );
-                $db->replace('issues_watching', $nowWatching);
+
+        // Clear the list of current watchers
+        $db->delete('issues_watching', [
+            'issueID' => $issueID
+        ]);
+
+        // Add new watchers (if any)
+        $usersWatching = explode(',', $_POST['othersWatching']);
+        foreach ($usersWatching as $usersWatching) {
+            if ($usersWatching) {
+                $db->insert('issues_watching', [
+                    'userID'  => $usersWatching,
+                    'issueID' => $issueID
+                ]);
             }
         }
     }

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -71,9 +71,9 @@ function editIssue()
     foreach ($fields as $field) {
         $value = $_POST[$field];
         if (strcmp($_POST[$field], "null") == 0) {
-            $value = null;
+            $value = NULL;
         }
-        if (isset($field) && isset($value)) {
+        if (isset($field)) {
             $issueValues[$field] = $value;
         }
     }

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -49,24 +49,24 @@ if ($_SERVER['REQUEST_METHOD'] === "GET") {
  */
 function editIssue()
 {
-    $db =& Database::singleton();
+    $db   =& Database::singleton();
     $user =& User::singleton();
 
-    $issueValues = array();
+    $issueValues    = array();
     $validateValues = array();
-    $fields = array(
-        'assignee',
-        'status',
-        'priority',
-        'centerID',
-        'title',
-        'category',
-        'module',
-    );
+    $fields         = array(
+                       'assignee',
+                       'status',
+                       'priority',
+                       'centerID',
+                       'title',
+                       'category',
+                       'module',
+                      );
     $fieldsToValidateFirst = array(
-        'PSCID',
-        'visitLabel',
-    );
+                              'PSCID',
+                              'visitLabel',
+                             );
 
     foreach ($fields as $field) {
         $value = $_POST[$field];
@@ -86,8 +86,7 @@ function editIssue()
     $issueID = $_POST['issueID'];
     $issueValues['lastUpdatedBy'] = $user->getData('UserID');
 
-    //this whole validation thing really needs some best practice love
-    $validatedInput = validateInput($validateValues, $issueID);
+    $validatedInput = validateInput($validateValues);
     if ($validatedInput['isValidSubmission']) {
         if (array_key_exists('sessionID', $validatedInput)) {
             $issueValues['sessionID'] = $validatedInput['sessionID'];
@@ -102,7 +101,7 @@ function editIssue()
     if (!empty($issueID) || $issueID != 0) {
         $db->update('issues', $issueValues, ['issueID' => $issueID]);
     } else {
-        $issueValues['reporter'] = $user->getData('UserID');
+        $issueValues['reporter']    = $user->getData('UserID');
         $issueValues['dateCreated'] = date('Y-m-d H:i:s');
         $db->insert('issues', $issueValues);
         $issueID = $db->getLastInsertId();
@@ -113,35 +112,35 @@ function editIssue()
     //adding comment in now that I have an issueID for both new and old.
     if ($_POST['comment'] != null) {
         $commentValues = array(
-            'issueComment' => $_POST['comment'],
-            'addedBy' => $user->getData('UserID'),
-            'issueID' => $issueID,
-        );
+                          'issueComment' => $_POST['comment'],
+                          'addedBy'      => $user->getData('UserID'),
+                          'issueID'      => $issueID,
+                         );
         $db->insert('issues_comments', $commentValues);
     }
 
     //adding new assignee to watching
     if (isset($issueValues['assignee'])) {
         $nowWatching = array(
-            'userID' => $issueValues['assignee'],
-            'issueID' => $issueID,
-        );
+                        'userID'  => $issueValues['assignee'],
+                        'issueID' => $issueID,
+                       );
         $db->replace('issues_watching', $nowWatching);
     }
 
     //adding editor to the watching table unless they don't want to be added.
     if ($_POST['watching'] == 'Yes') {
         $nowWatching = array(
-            'userID' => $user->getData('UserID'),
-            'issueID' => $issueID,
-        );
+                        'userID'  => $user->getData('UserID'),
+                        'issueID' => $issueID,
+                       );
         $db->replace('issues_watching', $nowWatching);
     } else if ($_POST['watching'] == "No") {
         $db->delete(
             'issues_watching',
             array(
-                'issueID' => $issueID,
-                'userID' => $user->getData('UserID'),
+             'issueID' => $issueID,
+             'userID'  => $user->getData('UserID'),
             )
         );
     }
@@ -152,9 +151,9 @@ function editIssue()
         foreach ($othersNowWatching as $userWatching) {
             if ($userWatching) { //cause sometimes it sends null
                 $nowWatching = array(
-                    'userID' => $userWatching,
-                    'issueID' => $issueID,
-                );
+                                'userID'  => $userWatching,
+                                'issueID' => $issueID,
+                               );
                 $db->replace('issues_watching', $nowWatching);
             }
         }
@@ -164,120 +163,94 @@ function editIssue()
     emailUser($issueID, $issueValues['assignee']);
 
     return array(
-        'isValidSubmission' => true,
-        'issueID' => $issueID,
-    );
+            'isValidSubmission' => true,
+            'issueID'           => $issueID,
+           );
 }
 
-//also make this better
 /**
- * Validates those fields that need it
- * Currently PSCID and visitLabel as fk to session
+ * Validate PSCID and Visit Label
  *
- * @param array $validateValues values to be validated
- * @param int $issueID issue ID
+ * @param array $values  values to be validated
+ * @param int   $issueID issue ID
  *
  * @throws DatabaseException
  *
  * @return array success with values, or error with message.
  */
-function validateInput($validateValues, $issueID)
+function validateInput($values)
 {
-    $db =& Database::singleton();
-    $user =& User::singleton();
+    $db     =& Database::singleton();
+    $result = [
+               'PSCID'             => (isset($values['PSCID']) ? $values['PSCID'] : null),
+               'visit'             => (isset($values['visitLabel']) ? $values['visitLabel'] : null),
+               'candID'            => null,
+               'sessionID'         => null,
+               'isValidSubmission' => true,
+               'invalidMessage'    => null,
+              ];
 
-    $old = null;
-    if ($issueID) {
-        $old = $db->pSelect(
-            "SELECT c.PSCID, s.Visit_label from candidate c 
-LEFT JOIN issues i ON (i.candID = c.CandID) 
-LEFT JOIN session s ON (i.sessionID = s.ID) 
-WHERE i.issueID=:issueID",
-            array('issueID' => $issueID)
-        );//inner join because you only want if it has these values.
+    // If both are set, return SessionID and CandID
+    if (isset($result['PSCID']) && isset($result['visit'])) {
+        $session = $db->pSelect(
+            "SELECT s.ID as sessionID, c.candID as candID FROM candidate c 
+            INNER JOIN session s on (c.CandID = s.CandID) 
+            WHERE c.PSCID=:PSCID and s.Visit_label=:visitLabel",
+            [
+             'PSCID'      => $result['PSCID'],
+             'visitLabel' => $result['visit'],
+            ]
+        );
+
+        if (isset($session[0]['sessionID'])) {
+            $result['sessionID'] = $session[0]['sessionID'];
+            $result['candID']    = $session[0]['candID'];
+        } else {
+            $result['isValidSubmission'] = false;
+            $result['invalidMessage']    =
+                "PSCID and Visit Label do not match a valid candidate session!";
+        }
+
+        return $result;
     }
 
-    $oldPSCID = $old[0]['PSCID'];
-    $oldVisitLabel = $old['Visit_label'];
-    if ((isset($validateValues['visitLabel']) && $oldPSCID)
-        || (isset($validateValues['PSCID']) && $oldVisitLabel)
-    ) {
-        $PSCID = $oldPSCID;
-        $visitLabel = $oldVisitLabel;
-        if (isset($validateValues['PSCID'])) {
-            $PSCID = $validateValues['PSCID'];
+    // If only PSCID is set, return CandID
+    if (isset($result['PSCID'])) {
+        $query  = "SELECT CandID FROM candidate WHERE PSCID=:PSCID";
+        $params = ['PSCID' => $result['PSCID']];
+
+        $user =& User::singleton();
+        if (!$user->hasPermission('access_all_profiles')) {
+            $params['CenterID'] = $user->getCenterID();
+            $query .= " AND CenterID=:CenterID";
         }
-        if (isset($validateValues['visitLabel'])) {
-            $visitLabel = $validateValues['visitLabel'];
-        }
-        $isValidSession = $db->pSelectOne(
-            "SELECT s.ID FROM candidate c 
-INNER JOIN session s on (c.CandID = s.CandID) 
-WHERE c.PSCID=:PSCID and s.Visit_label=:visitLabel",
-            array(
-                'PSCID' => $PSCID,
-                'visitLabel' => $visitLabel,
-            )
-        );
-        if (!$isValidSession) {
-            return array(
-                'isValidSubmission' => false,
-                'invalidMessage' => 'PSCID and Visit Label '
-                    . 'do not match a valid candidate session',
-            );
-        } else if (!isset($validateValues['PSCID'])) {
-            return array(
-                'isValidSubmission' => true,
-                'sessionID' => $isValidSession,
-            );
-        }
-        //return here ^ if you're not evaluating a new PSCID.
-        //Otherwise you need to go onto the else if below
-        //To check that the user has permissions on that PSCID
-    } else if (isset($validateValues['PSCID'])) {
-        if ($user->hasPermission('access_all_profiles')) {
-            $isValidCandidate = $db->pSelectOne(
-                "SELECT CandID FROM candidate WHERE PSCID=:PSCID",
-                array(
-                    'PSCID' => $validateValues['PSCID'],
-                )
-            );
+
+        $candidate = $db->pSelectOne($query, $params);
+        if ($candidate) {
+            $result['candID'] = $candidate;
         } else {
-            $isValidCandidate = $db->pSelectOne(
-                "SELECT CandID FROM candidate WHERE PSCID=:PSCID
-                 AND CenterID=:CenterID",
-                array(
-                    'PSCID' => $validateValues['PSCID'],
-                    'CenterID' => $user->getCenterID()
-                )
-            );
+            $result['isValidSubmission'] = false;
+            $result['invalidMessage']    = "PSCID does not match a valid candidate!";
         }
-        if (!$isValidCandidate) {
-            return array(
-                'isValidSubmission' => false,
-                'invalidMessage' => 'PSCID does not match a valid candidate',
-            );
-        } else {
-            return array(
-                'isValidSubmission' => true,
-                'candID' => $isValidCandidate,
-            );
-        }
-    } else if (isset($validateValues['visitLabel'])) {
-        return array(
-            'isValidSubmission' => false,
-            'invalidMessage' => 'A Visit Label must be accompanied by a PSCID',
-        );
-    } else {
-        return array('isValidSubmission' => true);
-    } //phew
+
+        return $result;
+    }
+
+    // If only visit label is set, return an error
+    if (isset($result['visit'])) {
+        $result['isValidSubmission'] = false;
+        $result['invalidMessage']    = "A Visit Label must be accompanied by a PSCID";
+        return $result;
+    }
+
+    return $result;
 }
 
 /**
  * Puts updated fields into the issues_history table.
  *
- * @param array $issueValues the new values
- * @param string $issueID the issue ID
+ * @param array  $issueValues the new values
+ * @param string $issueID     the issue ID
  *
  * @throws DatabaseException
  *
@@ -286,12 +259,12 @@ WHERE c.PSCID=:PSCID and s.Visit_label=:visitLabel",
 function updateHistory($issueValues, $issueID)
 {
     $user =& User::singleton();
-    $db =& Database::singleton();
+    $db   =& Database::singleton();
     $undesiredFields = array(
-        'lastUpdatedBy',
-        'reporter',
-        'dateCreated'
-    );
+                        'lastUpdatedBy',
+                        'reporter',
+                        'dateCreated',
+                       );
 
     foreach ($issueValues as $key => $value) {
         if (in_array($key, $undesiredFields)) {
@@ -299,11 +272,11 @@ function updateHistory($issueValues, $issueID)
         }
         if (!empty($value)) { //check that all kinds of nulls are being dealt with
             $changedValues = [
-                'newValue' => $value,
-                'fieldChanged' => $key,
-                'issueID' => $issueID,
-                'addedBy' => $user->getData('UserID'),
-            ];
+                              'newValue'     => $value,
+                              'fieldChanged' => $key,
+                              'issueID'      => $issueID,
+                              'addedBy'      => $user->getData('UserID'),
+                             ];
             $db->insert('issues_history', $changedValues);
         }
     }
@@ -312,7 +285,7 @@ function updateHistory($issueValues, $issueID)
 /**
  * Will keep track of comment edit history
  *
- * @param int $issueCommentID the comment that is being edited
+ * @param int    $issueCommentID  the comment that is being edited
  * @param string $newCommentValue the new comment
  *
  * @throws DatabaseException
@@ -322,13 +295,13 @@ function updateHistory($issueValues, $issueID)
 function updateCommentHistory($issueCommentID, $newCommentValue)
 {
     $user =& User::singleton();
-    $db =& Database::singleton();
+    $db   =& Database::singleton();
 
     $changedValue = array(
-        'issueCommentID' => $issueCommentID,
-        'newValue' => $newCommentValue,
-        'editedBy' => $user->getData('UserID'),
-    );
+                     'issueCommentID' => $issueCommentID,
+                     'newValue'       => $newCommentValue,
+                     'editedBy'       => $user->getData('UserID'),
+                    );
 
     $db->insert('issues_comments_history', $changedValue);
 }
@@ -346,8 +319,10 @@ function getWatching($issueID)
 {
     $db =& Database::singleton();
 
-    $watching = $db->pselect("SELECT userID from issues_watching WHERE issueID=:issueID",
-        array('issueID' => $issueID));
+    $watching = $db->pselect(
+        "SELECT userID from issues_watching WHERE issueID=:issueID",
+        array('issueID' => $issueID)
+    );
 
     $whoIsWatching = array();
     foreach ($watching as $watcher) {
@@ -392,7 +367,7 @@ function getComments($issueID)
                 "SELECT Name FROM psc WHERE CenterID=:centerID",
                 array('centerID' => $comment['newValue'])
             );
-            $comment['newValue'] = $site;
+            $comment['newValue']     = $site;
             $comment['fieldChanged'] = 'site';
             continue;
         } else if ($comment['fieldChanged'] === 'candID') {
@@ -400,11 +375,11 @@ function getComments($issueID)
                 "SELECT PSCID FROM candidate WHERE CandID=:candID",
                 array('candID' => $comment['newValue'])
             );
-            $comment['newValue'] = $PSCID;
+            $comment['newValue']     = $PSCID;
             $comment['fieldChanged'] = 'PSCID';
             continue;
         } else if ($comment['fieldChanged'] === 'sessionID') {
-            $visitLabel = $db->pselectOne(
+            $visitLabel          = $db->pselectOne(
                 "SELECT Visit_label FROM session WHERE ID=:sessionID",
                 array('sessionID' => $comment['newValue'])
             );
@@ -443,20 +418,22 @@ function display_comments($issueID)
 function emailUser($issueID, $changed_assignee)
 {
     $user =& User::singleton();
-    $db =& Database::singleton();
+    $db   =& Database::singleton();
     //not sure if this is necessary
     $factory = NDB_Factory::singleton();
     $baseurl = $factory->settings()->getBaseURL();
 
-    $title = $db->pSelectOne("SELECT title FROM issues 
+    $title = $db->pSelectOne(
+        "SELECT title FROM issues 
         WHERE issueID=:issueID",
-        array('issueID' => $issueID));
+        array('issueID' => $issueID)
+    );
 
-    $msg_data['url'] = $baseurl .
+    $msg_data['url']         = $baseurl .
         "/issue_tracker/edit/?backURL=/issue_tracker/&issueID=" . $issueID;
-    $msg_data['issueID'] = $issueID;
+    $msg_data['issueID']     = $issueID;
     $msg_data['currentUser'] = $user->getUsername();
-    $msg_data['title'] = $title;
+    $msg_data['title']       = $title;
 
     if (isset($changed_assignee)) {
         $issue_change_emails_assignee = $db->pselect(
@@ -464,11 +441,11 @@ function emailUser($issueID, $changed_assignee)
             "FROM users u WHERE u.UserID=:assignee
             AND u.UserID<>:currentUser",
             array(
-                'assignee' => $changed_assignee,
-                'currentUser' => $user->getUserName()
+             'assignee'    => $changed_assignee,
+             'currentUser' => $user->getUserName(),
             )
         );
-        $msg_data['firstname'] = $issue_change_emails_assignee[0]['firstname'];
+        $msg_data['firstname']        = $issue_change_emails_assignee[0]['firstname'];
 
         Email::send(
             $issue_change_emails_assignee[0]['Email'],
@@ -484,15 +461,15 @@ function emailUser($issueID, $changed_assignee)
         "FROM users u INNER JOIN issues_watching w ON (w.userID = u.userID) WHERE ".
         "w.issueID=:issueID AND u.UserID<>:uid AND u.UserID<>:assignee",
         array(
-            'issueID' => $issueID,
-            'uid' => $user->getUsername(),
-            'assignee' => $changed_assignee
+         'issueID'  => $issueID,
+         'uid'      => $user->getUsername(),
+         'assignee' => $changed_assignee,
         )
     );
 
-    $msg_data['url'] = $baseurl .
+    $msg_data['url']         = $baseurl .
         "/issue_tracker/edit/?backURL=/issue_tracker/&issueID=" . $issueID;
-    $msg_data['issueID'] = $issueID;
+    $msg_data['issueID']     = $issueID;
     $msg_data['currentUser'] = $user->getUsername();
 
     foreach ($issue_change_emails as $email) {
@@ -510,7 +487,7 @@ function emailUser($issueID, $changed_assignee)
 function getIssueFields()
 {
 
-    $db =& Database::singleton();
+    $db   =& Database::singleton();
     $user =& User::singleton();
 
     //get field options
@@ -534,13 +511,17 @@ function getIssueFields()
         );
     } else {
         $CenterID = $user->getCenterID();
-        $DCCID = $db->pselectOne("SELECT CenterID from psc where Name='DCC'",
-            array());
+        $DCCID    = $db->pselectOne(
+            "SELECT CenterID from psc where Name='DCC'",
+            array()
+        );
         $assignee_expanded = $db->pselect(
             "SELECT u.Real_name, u.UserID FROM users u 
 WHERE (u.CenterID=:CenterID) OR (u.CenterID=:DCC)",
-            array('CenterID' => $CenterID,
-                'DCC' => $DCCID)
+            array(
+             'CenterID' => $CenterID,
+             'DCC'      => $DCCID,
+            )
         );
     }
 
@@ -562,34 +543,36 @@ WHERE (u.CenterID=:CenterID) OR (u.CenterID=:DCC)",
     //can't set to closed if not developer.
     if ($user->hasPermission('issue_tracker_developer')) {
         $statuses = array(
-            'new' => 'New',
-            'acknowledged' => 'Acknowledged',
-            'assigned' => 'Assigned',
-            'feedback' => 'Feedback',
-            'resolved' => 'Resolved',
-            'closed' => 'Closed',
-        );
+                     'new'          => 'New',
+                     'acknowledged' => 'Acknowledged',
+                     'assigned'     => 'Assigned',
+                     'feedback'     => 'Feedback',
+                     'resolved'     => 'Resolved',
+                     'closed'       => 'Closed',
+                    );
     } else {
         $statuses = array(
-            'new' => 'New',
-            'acknowledged' => 'Acknowledged',
-            'assigned' => 'Assigned',
-            'feedback' => 'Feedback',
-            'resolved' => 'Resolved',
-        );
+                     'new'          => 'New',
+                     'acknowledged' => 'Acknowledged',
+                     'assigned'     => 'Assigned',
+                     'feedback'     => 'Feedback',
+                     'resolved'     => 'Resolved',
+                    );
     }
 
     $priorities = array(
-        'low' => 'Low',
-        'normal' => 'Normal',
-        'high' => 'High',
-        'urgent' => 'Urgent',
-        'immediate' => 'Immediate',
-    );
+                   'low'       => 'Low',
+                   'normal'    => 'Normal',
+                   'high'      => 'High',
+                   'urgent'    => 'Urgent',
+                   'immediate' => 'Immediate',
+                  );
 
-    $unorgCategories = $db -> pselect( "SELECT categoryName
-        FROM issues_categories", []);
-    $categories = [];
+    $unorgCategories = $db->pselect(
+        "SELECT categoryNameFROM issues_categories",
+        []
+    );
+    $categories      = [];
     foreach ($unorgCategories as $r_row) {
         $categoryName = $r_row['categoryName'];
         if ($categoryName) {
@@ -597,8 +580,7 @@ WHERE (u.CenterID=:CenterID) OR (u.CenterID=:DCC)",
         }
     }
 
-
-    $modules = array();
+    $modules          = array();
     $modules_expanded = $db->pselect(
         "SELECT DISTINCT Label, ID FROM LorisMenu 
 WHERE Parent IS NOT NULL ORDER BY Label ",
@@ -611,7 +593,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
     //Now get issue values
     $issueData = null;
     if (!empty($_GET['issueID'])) { //if an existing issue
-        $issueID = $_GET['issueID'];
+        $issueID   = $_GET['issueID'];
         $issueData = $db->pselectRow(
             "SELECT i.*, c.PSCID, s.Visit_label as visitLabel FROM issues as i " .
             "LEFT JOIN candidate c ON (i.candID=c.CandID)" .
@@ -620,38 +602,41 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
             array('issueID' => $issueID)
         );
         $issueData['commentHistory'] = getComments($issueID);
-        $issueData['whoIsWatching'] = getWatching($issueID);
-        $issueData['desc'] = $db->pSelectOne("SELECT issueComment 
+        $issueData['whoIsWatching']  = getWatching($issueID);
+        $issueData['desc']           = $db->pSelectOne(
+            "SELECT issueComment 
 FROM issues_comments WHERE issueID=:issueID 
-ORDER BY dateAdded", array('issueID' => $issueID));
+ORDER BY dateAdded",
+            array('issueID' => $issueID)
+        );
     } else { //just setting the default values
-        $issueData['reporter'] = $user->getData('UserID');
-        $issueData['dateCreated'] = date('Y-m-d H:i:s');
-        $issueData['centerID'] = $user->getData('CenterID');
-        $issueData['status'] = "new";
-        $issueData['priority'] = "normal";
-        $issueData['issueID'] = 0; //TODO: this is dumb
-        $issueData['title'] = null;
-        $issueData['lastUpdate'] = null;
-        $issueData['PSCID'] = null;
-        $issueData['assignee'] = null;
-        $issueData['history'] = null;
-        $issueData['watching'] = null;
-        $issueData['visitLabel'] = null;
-        $issueData['category'] = null;
+        $issueData['reporter']      = $user->getData('UserID');
+        $issueData['dateCreated']   = date('Y-m-d H:i:s');
+        $issueData['centerID']      = $user->getData('CenterID');
+        $issueData['status']        = "new";
+        $issueData['priority']      = "normal";
+        $issueData['issueID']       = 0; //TODO: this is dumb
+        $issueData['title']         = null;
+        $issueData['lastUpdate']    = null;
+        $issueData['PSCID']         = null;
+        $issueData['assignee']      = null;
+        $issueData['history']       = null;
+        $issueData['watching']      = null;
+        $issueData['visitLabel']    = null;
+        $issueData['category']      = null;
         $issueData['lastUpdatedBy'] = null;
     }
 
     $isWatching = $db->pselectOne(
         "SELECT * FROM issues_watching WHERE issueID=:issueID AND userID=:userID",
         array(
-            'issueID' => $issueID,
-            'userID' => $user->getData('UserID'),
+         'issueID' => $issueID,
+         'userID'  => $user->getData('UserID'),
         )
     );
 
     $issueData['watching'] = $isWatching;
-    $issueData['comment'] = null;
+    $issueData['comment']  = null;
 
     if ($issueData['reporter'] == $user->getData('UserID')) {
         $isOwnIssue = true;
@@ -660,19 +645,19 @@ ORDER BY dateAdded", array('issueID' => $issueID));
     }
 
     $result = [
-        'assignees' => $assignees,
-        'sites' => $sites,
-        'statuses' => $statuses,
-        'priorities' => $priorities,
-        'categories' => $categories,
-        'modules' => $modules,
-        'otherWatchers' => $otherWatchers,
-        'issueData' => $issueData,
-        'hasEditPermission' => $user->hasPermission(
-            'issue_tracker_developer'
-        ),
-        'isOwnIssue' => $isOwnIssue,
-    ];
+               'assignees'         => $assignees,
+               'sites'             => $sites,
+               'statuses'          => $statuses,
+               'priorities'        => $priorities,
+               'categories'        => $categories,
+               'modules'           => $modules,
+               'otherWatchers'     => $otherWatchers,
+               'issueData'         => $issueData,
+               'hasEditPermission' => $user->hasPermission(
+                   'issue_tracker_developer'
+               ),
+               'isOwnIssue'        => $isOwnIssue,
+              ];
 
     return $result;
 }

--- a/modules/issue_tracker/js/editIssue.js
+++ b/modules/issue_tracker/js/editIssue.js
@@ -66,7 +66,7 @@ var CollapsibleComment = React.createClass({
         { className: "col-sm-9" },
         React.createElement(
           "div",
-          { className: "btn btn-primary padding",
+          { className: "btn btn-primary",
             onClick: this.toggleCollapsed,
             "data-toggle": "collapse",
             "data-target": "#comment-history",

--- a/modules/issue_tracker/js/editIssue.js
+++ b/modules/issue_tracker/js/editIssue.js
@@ -142,32 +142,32 @@ var IssueEditForm = React.createClass({
     if (this.state.isNewIssue) {
       headerText = "Create New Issue";
     } else {
-      headerText = "Edit Issue #" + this.state.issueData.issueID;
+      headerText = "Edit Issue #" + this.state.formData.issueID;
     }
 
     var lastUpdateValue = " ";
     if (this.state.isNewIssue) {
       lastUpdateValue = "Never!";
     } else {
-      lastUpdateValue = this.state.issueData.lastUpdate;
+      lastUpdateValue = this.state.formData.lastUpdate;
     }
 
     var lastUpdatedByValue = " ";
     if (this.state.isNewIssue) {
       lastUpdatedByValue = "No-one!";
     } else {
-      lastUpdatedByValue = this.state.issueData.lastUpdatedBy;
+      lastUpdatedByValue = this.state.formData.lastUpdatedBy;
     }
 
     var dateCreated = " ";
     if (this.state.isNewIssue) {
       dateCreated = "Sometime Soon!";
     } else {
-      dateCreated = this.state.issueData.dateCreated;
+      dateCreated = this.state.formData.dateCreated;
     }
 
     var isWatching = "";
-    if (this.state.issueData.watching) {
+    if (this.state.formData.watching) {
       isWatching = "Yes";
     } else {
       isWatching = "No";
@@ -191,11 +191,11 @@ var IssueEditForm = React.createClass({
       commentHistory = React.createElement(
         "div",
         { "class": "form-group" },
-        " "
+        "\xA0"
       );
     } else {
       commentHistory = React.createElement(CollapsibleComment, {
-        commentHistory: this.state.issueData.commentHistory
+        commentHistory: this.state.formData.commentHistory
       });
     }
 
@@ -263,7 +263,7 @@ var IssueEditForm = React.createClass({
               name: "reporter",
               label: "Reporter: ",
               ref: "reporter",
-              text: this.state.issueData.reporter
+              text: this.state.formData.reporter
             })
           )
         )
@@ -279,7 +279,7 @@ var IssueEditForm = React.createClass({
             name: "description",
             label: "Description",
             ref: "description",
-            text: this.state.issueData.desc
+            text: this.state.formData.desc
           })
         )
       );
@@ -319,7 +319,7 @@ var IssueEditForm = React.createClass({
                 label: "Title",
                 onUserInput: this.setFormData,
                 ref: "title",
-                value: this.state.issueData.title,
+                value: this.state.formData.title,
                 disabled: !hasEditPermission,
                 required: true
               })
@@ -336,7 +336,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "assignee",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.assignee,
+                value: this.state.formData.assignee,
                 required: true
               })
             ),
@@ -351,7 +351,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "centerID",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.centerID
+                value: this.state.formData.centerID
               })
             ),
             React.createElement(
@@ -365,7 +365,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "status",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.status // todo: edit this so the
+                value: this.state.formData.status // todo: edit this so the
                 // options are different if
                 // the user doesn't have
                 // permission
@@ -383,7 +383,7 @@ var IssueEditForm = React.createClass({
                 ref: "priority",
                 required: false,
                 disabled: !hasEditPermission,
-                value: this.state.issueData.priority
+                value: this.state.formData.priority
               })
             ),
             React.createElement(
@@ -397,7 +397,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "category",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.category
+                value: this.state.formData.category
               })
             ),
             React.createElement(
@@ -411,7 +411,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "module",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.module
+                value: this.state.formData.module
               })
             ),
             React.createElement(
@@ -423,7 +423,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "PSCID",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.PSCID
+                value: this.state.formData.PSCID
               })
             ),
             React.createElement(
@@ -435,7 +435,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "visitLabel",
                 disabled: !hasEditPermission,
-                value: this.state.issueData.visitLabel
+                value: this.state.formData.visitLabel
               })
             ),
             React.createElement(
@@ -462,7 +462,7 @@ var IssueEditForm = React.createClass({
                 onUserInput: this.setFormData,
                 ref: "watching",
                 multiple: true,
-                value: this.state.issueData.whoIsWatching
+                value: this.state.formData.whoIsWatching
               })
             ),
             React.createElement(
@@ -527,37 +527,16 @@ var IssueEditForm = React.createClass({
         });
         return xhr;
       },
-
       success: function success(data) {
         if (!data.issueData.issueID) {
           that.setState({ isNewIssue: true });
         }
 
-        var formData = {
-          issueID: data.issueData.issueID,
-          title: data.issueData.title,
-          lastUpdate: data.issueData.lastUpdate,
-          centerID: data.issueData.centerID,
-          PSCID: data.issueData.PSCID,
-          reporter: data.issueData.reporter,
-          assignee: data.issueData.assignee,
-          status: data.issueData.status,
-          priority: data.issueData.priority,
-          watching: data.issueData.watching,
-          visitLabel: data.issueData.visitLabel,
-          dateCreated: data.issueData.dateCreated,
-          category: data.issueData.category,
-          lastUpdatedBy: data.issueData.lastUpdatedBy,
-          history: data.issueData.history,
-          comment: data.issueData.comment,
-          otherWatchers: data.issueData.whoIsWatching
-        };
-
         that.setState({
           Data: data,
           isLoaded: true,
           issueData: data.issueData,
-          formData: formData
+          formData: data.issueData
         });
 
         that.setState({
@@ -584,7 +563,6 @@ var IssueEditForm = React.createClass({
     var myFormData = this.state.formData;
     var formRefs = this.refs;
     var formData = new FormData();
-    var issueData = this.state.issueData;
 
     // Validate the form
     if (!this.isValidForm(formRefs, myFormData)) {
@@ -592,12 +570,10 @@ var IssueEditForm = React.createClass({
     }
 
     for (var key in myFormData) {
-      if (myFormData[key] !== "" && myFormData[key] !== issueData[key]) {
+      if (myFormData[key] !== "") {
         formData.append(key, myFormData[key]);
       }
     }
-
-    formData.append('issueID', this.state.Data.issueData.issueID);
 
     $.ajax({
       type: 'POST',

--- a/modules/issue_tracker/jsx/editIssue.js
+++ b/modules/issue_tracker/jsx/editIssue.js
@@ -125,32 +125,32 @@ var IssueEditForm = React.createClass({
     if (this.state.isNewIssue) {
       headerText = "Create New Issue";
     } else {
-      headerText = "Edit Issue #" + this.state.issueData.issueID;
+      headerText = "Edit Issue #" + this.state.formData.issueID;
     }
 
     var lastUpdateValue = " ";
     if (this.state.isNewIssue) {
       lastUpdateValue = "Never!";
     } else {
-      lastUpdateValue = this.state.issueData.lastUpdate;
+      lastUpdateValue = this.state.formData.lastUpdate;
     }
 
     var lastUpdatedByValue = " ";
     if (this.state.isNewIssue) {
       lastUpdatedByValue = "No-one!";
     } else {
-      lastUpdatedByValue = this.state.issueData.lastUpdatedBy;
+      lastUpdatedByValue = this.state.formData.lastUpdatedBy;
     }
 
     var dateCreated = " ";
     if (this.state.isNewIssue) {
       dateCreated = "Sometime Soon!";
     } else {
-      dateCreated = this.state.issueData.dateCreated;
+      dateCreated = this.state.formData.dateCreated;
     }
 
     var isWatching = "";
-    if (this.state.issueData.watching) {
+    if (this.state.formData.watching) {
       isWatching = "Yes";
     } else {
       isWatching = "No";
@@ -174,7 +174,7 @@ var IssueEditForm = React.createClass({
       commentHistory = <div class="form-group">&nbsp;</div>;
     } else {
       commentHistory = <CollapsibleComment
-          commentHistory={this.state.issueData.commentHistory}
+          commentHistory={this.state.formData.commentHistory}
         />;
     }
 
@@ -233,7 +233,7 @@ var IssueEditForm = React.createClass({
                   name="reporter"
                   label={"Reporter: "}
                   ref="reporter"
-                  text={this.state.issueData.reporter}
+                  text={this.state.formData.reporter}
                 />
               </div>
             </div>
@@ -247,7 +247,7 @@ var IssueEditForm = React.createClass({
                 name="description"
                 label="Description"
                 ref="description"
-                text={this.state.issueData.desc}
+                text={this.state.formData.desc}
               />
             </div>
           </div>
@@ -278,7 +278,7 @@ var IssueEditForm = React.createClass({
                     label="Title"
                     onUserInput={this.setFormData}
                     ref="title"
-                    value={this.state.issueData.title}
+                    value={this.state.formData.title}
                     disabled={!hasEditPermission}
                     required={true}
                   />
@@ -295,7 +295,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="assignee"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.assignee}
+                    value={this.state.formData.assignee}
                     required={true}
                   />
                 </div>
@@ -308,7 +308,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="centerID"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.centerID}
+                    value={this.state.formData.centerID}
                   />
                 </div>
 
@@ -321,7 +321,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="status"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.status} // todo: edit this so the
+                    value={this.state.formData.status} // todo: edit this so the
                                                         // options are different if
                                                         // the user doesn't have
                                                         // permission
@@ -337,7 +337,7 @@ var IssueEditForm = React.createClass({
                     ref="priority"
                     required={false}
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.priority}
+                    value={this.state.formData.priority}
                   />
                 </div>
 
@@ -350,7 +350,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="category"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.category}
+                    value={this.state.formData.category}
                   />
                 </div>
                 <div class="row">
@@ -362,7 +362,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="module"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.module}
+                    value={this.state.formData.module}
                   />
                 </div>
 
@@ -373,7 +373,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="PSCID"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.PSCID}
+                    value={this.state.formData.PSCID}
                   />
                 </div>
                 <div class="row">
@@ -383,7 +383,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="visitLabel"
                     disabled={!hasEditPermission}
-                    value={this.state.issueData.visitLabel}
+                    value={this.state.formData.visitLabel}
                   />
                 </div>
 
@@ -408,7 +408,7 @@ var IssueEditForm = React.createClass({
                     onUserInput={this.setFormData}
                     ref="watching"
                     multiple={true}
-                    value={this.state.issueData.whoIsWatching}
+                    value={this.state.formData.whoIsWatching}
                   />
                 </div>
 
@@ -455,71 +455,42 @@ var IssueEditForm = React.createClass({
 
     var dataURL = this.props.DataURL;
 
-    $.ajax(
-        dataURL,
-      {
-        dataType: 'json',
-        xhr: function() {
-          var xhr = new window.XMLHttpRequest();
-          xhr.addEventListener(
+    $.ajax(dataURL, {
+      dataType: 'json',
+      xhr: function() {
+        var xhr = new window.XMLHttpRequest();
+        xhr.addEventListener(
               "progress",
               function(evt) {
-                that.setState(
-                  {
-                    loadedData: evt.loaded
-                  }
-                );
+                that.setState({
+                  loadedData: evt.loaded
+                });
               }
             );
-          return xhr;
-        },
-
-        success: function(data) {
-          if (!data.issueData.issueID) {
-            that.setState({isNewIssue: true});
-          }
-
-          var formData = {
-            issueID: data.issueData.issueID,
-            title: data.issueData.title,
-            lastUpdate: data.issueData.lastUpdate,
-            centerID: data.issueData.centerID,
-            PSCID: data.issueData.PSCID,
-            reporter: data.issueData.reporter,
-            assignee: data.issueData.assignee,
-            status: data.issueData.status,
-            priority: data.issueData.priority,
-            watching: data.issueData.watching,
-            visitLabel: data.issueData.visitLabel,
-            dateCreated: data.issueData.dateCreated,
-            category: data.issueData.category,
-            lastUpdatedBy: data.issueData.lastUpdatedBy,
-            history: data.issueData.history,
-            comment: data.issueData.comment,
-            otherWatchers: data.issueData.whoIsWatching
-          };
-
-          that.setState(
-            {
-              Data: data,
-              isLoaded: true,
-              issueData: data.issueData,
-              formData: formData
-            }
-            );
-
-          that.setState(
-            {
-              error: "finished success"
-            }
-            );
-        },
-        error: function(data, errorCode, errorMsg) {
-          that.setState({
-            error: errorMsg
-          });
+        return xhr;
+      },
+      success: function(data) {
+        if (!data.issueData.issueID) {
+          that.setState({isNewIssue: true});
         }
+
+        that.setState({
+          Data: data,
+          isLoaded: true,
+          issueData: data.issueData,
+          formData: data.issueData
+        });
+
+        that.setState({
+          error: "finished success"
+        });
+      },
+      error: function(data, errorCode, errorMsg) {
+        that.setState({
+          error: errorMsg
+        });
       }
+    }
       );
   },
 
@@ -535,7 +506,6 @@ var IssueEditForm = React.createClass({
     var myFormData = this.state.formData;
     var formRefs = this.refs;
     var formData = new FormData();
-    var issueData = this.state.issueData;
 
       // Validate the form
     if (!this.isValidForm(formRefs, myFormData)) {
@@ -543,25 +513,22 @@ var IssueEditForm = React.createClass({
     }
 
     for (var key in myFormData) {
-      if (myFormData[key] !== "" && myFormData[key] !== issueData[key]) {
+      if (myFormData[key] !== "") {
         formData.append(key, myFormData[key]);
       }
     }
 
-    formData.append('issueID', this.state.Data.issueData.issueID);
-
-    $.ajax(
-      {
-        type: 'POST',
-        url: self.props.action,
-        data: formData,
-        cache: false,
-        dataType: 'json',
-        contentType: false,
-        processData: false,
-        xhr: function() {
-          var xhr = new window.XMLHttpRequest();
-          xhr.upload.addEventListener(
+    $.ajax({
+      type: 'POST',
+      url: self.props.action,
+      data: formData,
+      cache: false,
+      dataType: 'json',
+      contentType: false,
+      processData: false,
+      xhr: function() {
+        var xhr = new window.XMLHttpRequest();
+        xhr.upload.addEventListener(
               "progress",
               function(evt) {
                 if (evt.lengthComputable) {
@@ -575,47 +542,43 @@ var IssueEditForm = React.createClass({
               },
               false
             );
-          return xhr;
-        },
+        return xhr;
+      },
 
-        success: function(data) {
-          if (!data.isValidSubmission) {
-            self.setState(
-              {
-                errorMessage: data.invalidMessage,
-                submissionResult: "invalid"
-              }
-              );
-            self.showAlertMessage();
-            return;
-          }
-
-          self.setState(
-            {
-              submissionResult: "success",
-              issueID: data.issueID
-            }
-            );
-          self.getDataAndChangeState();
+      success: function(data) {
+        if (!data.isValidSubmission) {
+          self.setState({
+            errorMessage: data.invalidMessage,
+            submissionResult: "invalid"
+          });
           self.showAlertMessage();
-
-          if (self.state.isNewIssue) {
-            setTimeout(function() {
-              window.location.assign('/issue_tracker');
-            }, 2000);
-          }
-        },
-        error: function(err) {
-          console.error(err);
-          self.setState(
-            {
-              submissionResult: "error"
-            }
-            );
-          self.showAlertMessage();
+          return;
         }
 
+        self.setState({
+          submissionResult: "success",
+          issueID: data.issueID
+        });
+        self.getDataAndChangeState();
+        self.showAlertMessage();
+
+        if (self.state.isNewIssue) {
+          setTimeout(function() {
+            window.location.assign('/issue_tracker');
+          }, 2000);
+        }
+      },
+      error: function(err) {
+        console.error(err);
+        self.setState(
+          {
+            submissionResult: "error"
+          }
+            );
+        self.showAlertMessage();
       }
+
+    }
       );
   },
 

--- a/modules/issue_tracker/jsx/editIssue.js
+++ b/modules/issue_tracker/jsx/editIssue.js
@@ -50,7 +50,7 @@ var CollapsibleComment = React.createClass({
     return (
       <div className="row form-group">
         <div className="col-sm-9">
-          <div className="btn btn-primary padding"
+          <div className="btn btn-primary"
                onClick={this.toggleCollapsed}
                data-toggle="collapse"
                data-target="#comment-history"

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -39,7 +39,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
     {
 
         $user =& User::singleton();
-        $db = Database::singleton();
+        $db   = Database::singleton();
 
         $this->query = " FROM issues as i " .
             "LEFT JOIN candidate c ON (i.candID=c.CandID) " .
@@ -56,81 +56,84 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
 
         //note that this needs to be in the same order as the headers array
         $this->columns = array(
-            'i.issueID as Issue_ID',
-            'i.title as Title',
-            'l.Label as Module',
-            'i.category as Category',
-            'i.reporter as Reporter',
-            'i.assignee as Assignee',
-            'i.status as Status',
-            'i.priority as Priority',
-            'p.Name as Site',
-            'c.PSCID as PSCID',
-            's.Visit_label as Visit_Label',
-            'i.lastUpdate as Last_Update',
-        );
+                          'i.issueID as Issue_ID',
+                          'i.title as Title',
+                          'l.Label as Module',
+                          'i.category as Category',
+                          'i.reporter as Reporter',
+                          'i.assignee as Assignee',
+                          'i.status as Status',
+                          'i.priority as Priority',
+                          'p.Name as Site',
+                          'c.PSCID as PSCID',
+                          's.Visit_label as Visit_Label',
+                          'i.lastUpdate as Last_Update',
+                         );
 
         $this->order_by = 'i.issueID DESC';
         $this->group_by = 'i.issueID';
 
         //NDB filter will remove underscores
         $this->headers = array(
-            'Issue_ID',
-            'Title',
-            'Module',
-            'Category',
-            'Reporter',
-            'Assignee',
-            'Status',
-            'Priority',
-            'Site',
-            'PSCID',
-            'Visit_Label',
-            'Last_Update',
-        );
+                          'Issue_ID',
+                          'Title',
+                          'Module',
+                          'Category',
+                          'Reporter',
+                          'Assignee',
+                          'Status',
+                          'Priority',
+                          'Site',
+                          'PSCID',
+                          'Visit_Label',
+                          'Last_Update',
+                         );
 
         $this->validFilters = array(
-            'i.issueID',
-            'l.Label',
-            'i.category',
-            'c.PSCID',
-            's.Visit_label',
-            'i.reporter',
-            'i.assignee',
-            'i.centerID',
-            'w.userID',
-            'i.projectID',
-            'i.status',
-            'i.priority',
-            'keyword',
-            'minDate',
-            'maxDate',
-        );
+                               'i.issueID',
+                               'l.Label',
+                               'i.category',
+                               'c.PSCID',
+                               's.Visit_label',
+                               'i.reporter',
+                               'i.assignee',
+                               'i.centerID',
+                               'w.userID',
+                               'i.projectID',
+                               'i.status',
+                               'i.priority',
+                               'keyword',
+                               'minDate',
+                               'maxDate',
+                              );
 
         $this->formToFilter = array(
-            'issueID' => 'i.issueID',
-            'category' => 'i.category',
-            'module' => 'l.Label',
-            'PSCID' => 'c.PSCID',
-            'visitLabel' => 's.Visit_label',
-            'reporter' => 'i.reporter',
-            'assignee' => 'i.assignee',
-            'site' => 'i.centerID',
-            'projectID' => 'i.projectID',
-            'status' => 'i.status',
-            'priority' => 'i.priority',
-            'keyword' => 'ic.issueComment',
-            'minDate' => 'minDate',
-            'maxDate' => 'maxDate',
-            $user->getData('UserID') => 'watching',
-        );
+                               'issueID'                => 'i.issueID',
+                               'category'               => 'i.category',
+                               'module'                 => 'l.Label',
+                               'PSCID'                  => 'c.PSCID',
+                               'visitLabel'             => 's.Visit_label',
+                               'reporter'               => 'i.reporter',
+                               'assignee'               => 'i.assignee',
+                               'site'                   => 'i.centerID',
+                               'projectID'              => 'i.projectID',
+                               'status'                 => 'i.status',
+                               'priority'               => 'i.priority',
+                               'keyword'                => 'ic.issueComment',
+                               'minDate'                => 'minDate',
+                               'maxDate'                => 'maxDate',
+                               $user->getData('UserID') => 'watching',
+                              );
 
         $this->EqualityFilters = array(
-            'i.issueID',
-            'i.centerID',
-            'i.status',
-        );
-        $this->searchKeyword = array('ic.issueComment', 'i.title');
+                                  'i.issueID',
+                                  'i.centerID',
+                                  'i.status',
+                                 );
+        $this->searchKeyword   = array(
+                                  'ic.issueComment',
+                                  'i.title',
+                                 );
     }
 
     /**
@@ -141,7 +144,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
     function _setFilterForm()
     {
         $user =& User::singleton();
-        $db = Database::singleton();
+        $db   = Database::singleton();
 
         //sites
         if ($user->hasPermission('access_all_profiles')) {
@@ -153,15 +156,15 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             $site =& Site::singleton($user->getData('CenterID'));
             if ($site->isStudySite()) {
                 $list_of_sites = array(
-                    $user->getData('CenterID') => $user->getData(
-                        'Site'
-                    ),
-                );
+                                  $user->getData('CenterID') => $user->getData(
+                                      'Site'
+                                  ),
+                                 );
             }
         }
 
         //reporters
-        $reporters = array('' => 'All');
+        $reporters         = array('' => 'All');
         $reporter_expanded = $db->pselect(
             "SELECT u.UserID, u.Real_name FROM issues i " .
             "INNER JOIN users u ON(i.assignee=u.UserID)",
@@ -172,7 +175,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
         }
 
         //assignees
-        $assignees = array('' => 'All');
+        $assignees         = array('' => 'All');
         $assignee_expanded = $db->pselect(
             "SELECT u.UserID, u.Real_name FROM issues i " .
             "INNER JOIN users u ON(i.assignee=u.UserID)",
@@ -188,33 +191,36 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
 WHERE Parent IS NOT NULL ORDER BY Label",
             []
         );
-        $modules = $this->reorganizeQueryResults(
+        $modules          = $this->reorganizeQueryResults(
             $modules_expanded,
             'Label'
         );
 
         $priorities = array(
-            '' => 'All',
-            'low' => 'Low',
-            'normal' => 'Normal',
-            'high' => 'High',
-            'urgent' => 'Urgent',
-            'immediate' => 'Immediate',
-        );
+                       ''          => 'All',
+                       'low'       => 'Low',
+                       'normal'    => 'Normal',
+                       'high'      => 'High',
+                       'urgent'    => 'Urgent',
+                       'immediate' => 'Immediate',
+                      );
 
         $statuses = array(
-            '' => 'All',
-            'new' => 'New',
-            'acknowledged' => 'Acknowledged',
-            'feedback' => 'Feedback',
-            'assigned' => 'Assigned',
-            'resolved' => 'Resolved',
-            'closed' => 'Closed',
-        );
+                     ''             => 'All',
+                     'new'          => 'New',
+                     'acknowledged' => 'Acknowledged',
+                     'feedback'     => 'Feedback',
+                     'assigned'     => 'Assigned',
+                     'resolved'     => 'Resolved',
+                     'closed'       => 'Closed',
+                    );
 
-        $unorgCategories = $db -> pselect( "SELECT categoryName
-        FROM issues_categories", []);
-        $categories = array('' => "All");
+        $unorgCategories = $db -> pselect(
+            "SELECT categoryName
+        FROM issues_categories",
+            []
+        );
+        $categories      = array('' => "All");
         foreach ($unorgCategories as $r_row) {
             $categoryName = $r_row['categoryName'];
             if ($categoryName) {
@@ -223,25 +229,25 @@ WHERE Parent IS NOT NULL ORDER BY Label",
         }
 
         $dateOptions = array(
-            'language' => 'en',
-            'format' => 'YMdHis',
-            'addEmptyOption' => true,
-        );
+                        'language'       => 'en',
+                        'format'         => 'YMdHis',
+                        'addEmptyOption' => true,
+                       );
 
         $this->addBasicText(
             'keyword',
             'Keyword',
             array(
-                "size" => 10,
-                "maxlength" => 50,
+             "size"      => 10,
+             "maxlength" => 50,
             )
         );
         $this->addBasicText(
             'issueID',
             'Issue ID',
             array(
-                "size" => 10,
-                "maxlength" => 25,
+             "size"      => 10,
+             "maxlength" => 25,
             )
         );
         $this->addSelect('module', 'Module', $modules);
@@ -250,16 +256,16 @@ WHERE Parent IS NOT NULL ORDER BY Label",
             'PSCID',
             'PSCID',
             array(
-                "size" => 10,
-                "maxlength" => 25,
+             "size"      => 10,
+             "maxlength" => 25,
             )
         );
         $this->addBasicText(
             'visitLabel',
             'Visit Label',
             array(
-                'size' => "5",
-                "maxlength" => "15",
+             'size'      => "5",
+             "maxlength" => "15",
             )
         );
         $this->addSelect('site', 'Site', $list_of_sites);
@@ -280,14 +286,14 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      * for watching and include closed
      *
      * @param string $prepared_key filter key
-     * @param string $field filter field
-     * @param string $val filter value
+     * @param string $field        filter field
+     * @param string $val          filter value
      *
      * @return null
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
-        $user =& User::singleton();
+        $user  =& User::singleton();
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (($field != 'w.userID')
@@ -331,7 +337,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      */
     function toArray()
     {
-        $data = parent::toArray();
+        $data  = parent::toArray();
         $index = array_search('Issue ID', $data['Headers']);
         if ($index !== false) {
             $_SESSION['State']->setProperty(
@@ -346,8 +352,8 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      * Utility function to re-organize query results for selects.
      * Key and value are equal.
      *
-     * @param array $queryResult query result
-     * @param string $key key needed to extract appropriate result column
+     * @param array  $queryResult query result
+     * @param string $key         key needed to extract appropriate result column
      *
      * @return array
      */

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -107,21 +107,21 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                               );
 
         $this->formToFilter = array(
-                               'issueID'    => 'i.issueID',
-                               'category'   => 'i.category',
-                               'module'     => 'l.Label',
-                               'PSCID'      => 'c.PSCID',
-                               'visitLabel' => 's.Visit_label',
-                               'reporter'   => 'i.reporter',
-                               'site'       => 'i.centerID',
-                               'watching'   => 'w.userID',
-                               'projectID'  => 'i.projectID',
-                               'status'     => 'i.status',
-                               'priority'   => 'i.priority',
-                               'keyword'    => 'ic.issueComment',
-                               'minDate'    => 'minDate',
-                               'maxDate'    => 'maxDate',
-            $user->getData('UserID') => 'watching',
+                               'issueID'                => 'i.issueID',
+                               'category'               => 'i.category',
+                               'module'                 => 'l.Label',
+                               'PSCID'                  => 'c.PSCID',
+                               'visitLabel'             => 's.Visit_label',
+                               'reporter'               => 'i.reporter',
+                               'site'                   => 'i.centerID',
+                               'watching'               => 'w.userID',
+                               'projectID'              => 'i.projectID',
+                               'status'                 => 'i.status',
+                               'priority'               => 'i.priority',
+                               'keyword'                => 'ic.issueComment',
+                               'minDate'                => 'minDate',
+                               'maxDate'                => 'maxDate',
+                               $user->getData('UserID') => 'watching',
                               );
 
         $this->EqualityFilters = array(
@@ -129,7 +129,10 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                                   'i.centerID',
                                   'i.status',
                                  );
-        $this->searchKeyword   = array('ic.issueComment', 'i.title');
+        $this->searchKeyword   = array(
+                                  'ic.issueComment',
+                                  'i.title',
+                                 );
     }
 
     /**
@@ -160,7 +163,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
         }
 
         //reporters
-        $reporters = array('' => 'All');
+        $reporters         = array('' => 'All');
         $reporter_expanded = $db->pselect(
             "SELECT u.UserID, u.Real_name FROM issues i " .
             "INNER JOIN users u ON(i.assignee=u.UserID)",
@@ -169,7 +172,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
         foreach ($reporter_expanded as $r_row) {
             $reporters[$r_row['UserID']] = $r_row['Real_name'];
         }
-        
+
         //modules
         $modules_expanded = $db->pselect(
             "SELECT DISTINCT Label, ID FROM LorisMenu 
@@ -200,9 +203,12 @@ WHERE Parent IS NOT NULL ORDER BY Label",
                      'closed'       => 'Closed',
                     );
 
-        $unorgCategories = $db -> pselect( "SELECT categoryName
-        FROM issues_categories", []);
-        $categories = array('' => "All");
+        $unorgCategories = $db -> pselect(
+            "SELECT categoryName
+        FROM issues_categories",
+            []
+        );
+        $categories      = array('' => "All");
         foreach ($unorgCategories as $r_row) {
             $categoryName = $r_row['categoryName'];
             if ($categoryName) {
@@ -274,7 +280,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
-        $user =& User::singleton();
+        $user  =& User::singleton();
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (($field != 'w.userID')

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -39,7 +39,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
     {
 
         $user =& User::singleton();
-        $db = Database::singleton();
+        $db   = Database::singleton();
 
         $this->query = " FROM issues as i " .
             "LEFT JOIN candidate c ON (i.candID=c.CandID) " .
@@ -56,79 +56,82 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
 
         //note that this needs to be in the same order as the headers array
         $this->columns = array(
-            'i.issueID as Issue_ID',
-            'i.title as Title',
-            'l.Label as Module',
-            'i.category as Category',
-            'i.reporter as Reporter',
-            'i.assignee as Assignee',
-            'i.status as Status',
-            'i.priority as Priority',
-            'p.Name as Site',
-            'c.PSCID as PSCID',
-            's.Visit_label as Visit_Label',
-            'i.lastUpdate as Last_Update',
-        );
+                          'i.issueID as Issue_ID',
+                          'i.title as Title',
+                          'l.Label as Module',
+                          'i.category as Category',
+                          'i.reporter as Reporter',
+                          'i.assignee as Assignee',
+                          'i.status as Status',
+                          'i.priority as Priority',
+                          'p.Name as Site',
+                          'c.PSCID as PSCID',
+                          's.Visit_label as Visit_Label',
+                          'i.lastUpdate as Last_Update',
+                         );
 
         $this->order_by = 'i.issueID DESC';
         $this->group_by = 'i.issueID';
 
         //NDB filter will remove underscores
         $this->headers = array(
-            'Issue_ID',
-            'Title',
-            'Module',
-            'Category',
-            'Reporter',
-            'Assignee',
-            'Status',
-            'Priority',
-            'Site',
-            'PSCID',
-            'Visit_Label',
-            'Last_Update',
-        );
+                          'Issue_ID',
+                          'Title',
+                          'Module',
+                          'Category',
+                          'Reporter',
+                          'Assignee',
+                          'Status',
+                          'Priority',
+                          'Site',
+                          'PSCID',
+                          'Visit_Label',
+                          'Last_Update',
+                         );
 
         $this->validFilters = array(
-            'i.issueID',
-            'l.Label',
-            'i.category',
-            'c.PSCID',
-            's.Visit_label',
-            'i.reporter',
-            'i.assignee',
-            'i.centerID',
-            'w.userID',
-            'i.projectID',
-            'i.priority',
-            'keyword',
-            'minDate',
-            'maxDate'
-        );
+                               'i.issueID',
+                               'l.Label',
+                               'i.category',
+                               'c.PSCID',
+                               's.Visit_label',
+                               'i.reporter',
+                               'i.assignee',
+                               'i.centerID',
+                               'w.userID',
+                               'i.projectID',
+                               'i.priority',
+                               'keyword',
+                               'minDate',
+                               'maxDate',
+                              );
 
         $this->formToFilter = array(
-            'issueID' => 'i.issueID',
-            'category' => 'i.category',
-            'module' => 'l.Label',
-            'PSCID' => 'c.PSCID',
-            'visitLabel' => 's.Visit_label',
-            'reporter' => 'i.reporter',
-            'assignee' => 'i.assignee',
-            'site' => 'i.centerID',
-            'watching' => 'w.userID',
-            'projectID' => 'i.projectID',
-            'priority' => 'i.priority',
-            'keyword' => 'ic.issueComment',
-            'minDate' => 'minDate',
-            'maxDate' => 'maxDate',
-            $user->getData('UserID') => 'watching'
-        );
+                               'issueID'                => 'i.issueID',
+                               'category'               => 'i.category',
+                               'module'                 => 'l.Label',
+                               'PSCID'                  => 'c.PSCID',
+                               'visitLabel'             => 's.Visit_label',
+                               'reporter'               => 'i.reporter',
+                               'assignee'               => 'i.assignee',
+                               'site'                   => 'i.centerID',
+                               'watching'               => 'w.userID',
+                               'projectID'              => 'i.projectID',
+                               'priority'               => 'i.priority',
+                               'keyword'                => 'ic.issueComment',
+                               'minDate'                => 'minDate',
+                               'maxDate'                => 'maxDate',
+                               $user->getData('UserID') => 'watching',
+                              );
 
         $this->EqualityFilters = array(
-            'i.issueID',
-            'i.centerID',
-        );
-        $this->searchKeyword = array('ic.issueComment', 'i.title');
+                                  'i.issueID',
+                                  'i.centerID',
+                                 );
+        $this->searchKeyword   = array(
+                                  'ic.issueComment',
+                                  'i.title',
+                                 );
     }
 
     /**
@@ -139,7 +142,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
     function _setFilterForm()
     {
         $user =& User::singleton();
-        $db = Database::singleton();
+        $db   = Database::singleton();
 
         //sites
         if ($user->hasPermission('access_all_profiles')) {
@@ -151,15 +154,15 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
             $site =& Site::singleton($user->getData('CenterID'));
             if ($site->isStudySite()) {
                 $list_of_sites = array(
-                    $user->getData('CenterID') => $user->getData(
-                        'Site'
-                    ),
-                );
+                                  $user->getData('CenterID') => $user->getData(
+                                      'Site'
+                                  ),
+                                 );
             }
         }
 
         //reporters
-        $reporters = array('' => 'All');
+        $reporters         = array('' => 'All');
         $reporter_expanded = $db->pselect(
             "SELECT u.UserID, u.Real_name FROM issues i " .
             "INNER JOIN users u ON(i.assignee=u.UserID)",
@@ -170,7 +173,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
         }
 
         //assignees
-        $assignees = array('' => 'All');
+        $assignees         = array('' => 'All');
         $assignee_expanded = $db->pselect(
             "SELECT u.UserID, u.Real_name FROM issues i " .
             "INNER JOIN users u ON(i.assignee=u.UserID)",
@@ -186,23 +189,26 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
 WHERE Parent IS NOT NULL ORDER BY Label ",
             []
         );
-        $modules = $this->reorganizeQueryResults(
+        $modules          = $this->reorganizeQueryResults(
             $modules_expanded,
             'Label'
         );
 
         $priorities = array(
-            '' => 'All',
-            'low' => 'Low',
-            'normal' => 'Normal',
-            'high' => 'High',
-            'urgent' => 'Urgent',
-            'immediate' => 'Immediate',
-        );
+                       ''          => 'All',
+                       'low'       => 'Low',
+                       'normal'    => 'Normal',
+                       'high'      => 'High',
+                       'urgent'    => 'Urgent',
+                       'immediate' => 'Immediate',
+                      );
 
-        $unorgCategories = $db -> pselect( "SELECT categoryName
-        FROM issues_categories", []);
-        $categories = array('' => "All");
+        $unorgCategories = $db -> pselect(
+            "SELECT categoryName
+        FROM issues_categories",
+            []
+        );
+        $categories      = array('' => "All");
         foreach ($unorgCategories as $r_row) {
             $categoryName = $r_row['categoryName'];
             if ($categoryName) {
@@ -211,25 +217,25 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
         }
 
         $dateOptions = array(
-            'language' => 'en',
-            'format' => 'YMdHis',
-            'addEmptyOption' => true,
-        );
+                        'language'       => 'en',
+                        'format'         => 'YMdHis',
+                        'addEmptyOption' => true,
+                       );
 
         $this->addBasicText(
             'keyword',
             'Keyword',
             array(
-                "size" => 10,
-                "maxlength" => 50,
+             "size"      => 10,
+             "maxlength" => 50,
             )
         );
         $this->addBasicText(
             'issueID',
             'Issue ID',
             array(
-                "size" => 10,
-                "maxlength" => 25,
+             "size"      => 10,
+             "maxlength" => 25,
             )
         );
         $this->addSelect('module', 'Module', $modules);
@@ -238,16 +244,16 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
             'PSCID',
             'PSCID',
             array(
-                "size" => 10,
-                "maxlength" => 25,
+             "size"      => 10,
+             "maxlength" => 25,
             )
         );
         $this->addBasicText(
             'visitLabel',
             'Visit Label',
             array(
-                'size' => "5",
-                "maxlength" => "15",
+             'size'      => "5",
+             "maxlength" => "15",
             )
         );
         $this->addSelect('site', 'Site', $list_of_sites);
@@ -267,14 +273,14 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
      * for watching and include closed
      *
      * @param string $prepared_key filter key
-     * @param string $field filter field
-     * @param string $val filter value
+     * @param string $field        filter field
+     * @param string $val          filter value
      *
      * @return null
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
-        $user =& User::singleton();
+        $user  =& User::singleton();
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (($field != 'w.userID')
@@ -319,7 +325,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
      */
     function toArray()
     {
-        $data = parent::toArray();
+        $data  = parent::toArray();
         $index = array_search('Issue ID', $data['Headers']);
         if ($index !== false) {
             $_SESSION['State']->setProperty(
@@ -335,8 +341,8 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
      * Utility function to re-organize query results for selects.
      * Key and value are equal.
      *
-     * @param array $queryResult query result
-     * @param string $key key needed to extract appropriate result column
+     * @param array  $queryResult query result
+     * @param string $key         key needed to extract appropriate result column
      *
      * @return array
      */

--- a/modules/issue_tracker/php/issue_tracker_ControlPanel.class.inc
+++ b/modules/issue_tracker/php/issue_tracker_ControlPanel.class.inc
@@ -33,7 +33,7 @@ class Issue_Tracker_ControlPanel
     var $issueID;
 
     /**
-     * Sets up the isssueID
+     * Sets up the issueID
      *
      * @param int $issueID current issueID
      *
@@ -52,7 +52,11 @@ class Issue_Tracker_ControlPanel
     function _hasAccess()
     {
         $user =& User::singleton();
-        return $user->hasPermission('issue_tracker_can_assign');
+        if ($user->hasPermission('issue_tracker_reporter') ||
+            $user->hasPermission('issue_tracker_developer')) {
+                return true;
+        }
+        return false;
     }
 
     /**

--- a/modules/issue_tracker/php/issue_tracker_ControlPanel.class.inc
+++ b/modules/issue_tracker/php/issue_tracker_ControlPanel.class.inc
@@ -52,8 +52,9 @@ class Issue_Tracker_ControlPanel
     function _hasAccess()
     {
         $user =& User::singleton();
-        if ($user->hasPermission('issue_tracker_reporter') ||
-            $user->hasPermission('issue_tracker_developer')) {
+        if ($user->hasPermission('issue_tracker_reporter')
+            || $user->hasPermission('issue_tracker_developer')
+        ) {
                 return true;
         }
         return false;


### PR DESCRIPTION
This PR addresses Redmine 11187 and Redmine 11050 plus fixed bugs found along the way

- [x] Make sure all form fields are submitted (even the empty ones), otherwise can't reset values
- [x] Add extra validation on PHP side to check for "null" strings as POST requests are made using standard form data.
- [x] Make sure visitLabel is displayed 
- [x] Remove duplicated issueData object, and use formData everywhere instead
- [x] Make categories save-able (given issues_categories is properly populated aka another issue)
- [x] Rewrite PSCID/Visit Label validation with a much simple/more understandable code
- [x] Clear/reinsert users watching on every update
- [x] Fixed isWatching field not saving properly
- [x] Fixed comment button to correspond to comment section display state
- [x] Fixed comment ordering to show the most recent first
- [x] Prevent multiple form submission when quickly pressing `submit issues` button
- [x] Removed unused display_comments functions in EditIssue.php
- [x] Run PHPCS & add to Travis


### [Click Here](https://github.com/aces/Loris/pull/2307/files?w=1) for diff without space changes 