### PR TITLE
Downgrade eslint-config-google to 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
     # Install ESLint and plugins
     - npm -g install eslint
-    - npm -g install eslint-config-google
+    - npm -g install eslint-config-google@0.6.0
     - npm -g install eslint-plugin-react
 
     # Download a Selenium Web Driver release


### PR DESCRIPTION
Because we were doing a plain `npm -g install` in travis.yml it picked up the latest version of eslint-config-google which contained eslint rule changes.

This is a temporary fix. travis.yml should be referencing package.json when installing so we can have a single source of truth for node dependency versions.