### PR TITLE
Imaging Browser: Selected no longer shows up as Array: Redmine 11190

### DIFF
--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -30,7 +30,7 @@
 
                       'HasQCPerm': {if $has_qc_permission}true{else}false{/if},
                       'FileNew'  : {if $files[file].New}true{else}false{/if},
-                      "Selected" : "{$files[file].Selected}",
+                      "Selected" : "{if $files[file].Selected}{$files[file].Selected}{/if}",
 
                       "Caveat" : "{$files[file].Caveat}",
                       "SNR" : "{if $files[file].SNR}{$files[file].SNR}{/if}",


### PR DESCRIPTION
Without the Edit QC Permission; if the file was not the in the files_qcstatus table, Selected appeared as 'Array'. 

Before:
![array](https://cloud.githubusercontent.com/assets/15198379/19566935/0d917332-96ba-11e6-8a42-15ae9e84d618.png)

After:
![selectednoarray](https://cloud.githubusercontent.com/assets/15198379/19566938/11982eee-96ba-11e6-826f-41cb9d663b4c.png)
