### PR TITLE
[Issue tracker] add categories

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2233,6 +2233,16 @@ CREATE TABLE `issues_categories` (
   UNIQUE KEY `categoryName` (`categoryName`)
 ) ENGINE=InnoDB AUTO_INCREMENT=0 DEFAULT CHARSET=utf8;
 
+INSERT INTO issues_categories (categoryName) VALUES
+    ('Behavioural Battery'), 
+    ('Behavioural Instruments'), 
+    ('Data Entry'), 
+    ('Examiners'),
+    ('Imaging'),
+    ('Technical Issue'),
+    ('User Accounts'),
+    ('Other');
+
 DROP TABLE IF EXISTS `issues`;
 CREATE TABLE `issues` (
   `issueID` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/SQL/Archive/17.0/2016-10-20_issues_categories.sql
+++ b/SQL/Archive/17.0/2016-10-20_issues_categories.sql
@@ -1,0 +1,9 @@
+INSERT INTO issues_categories (categoryName) VALUES
+    ('Behavioural Battery'),
+    ('Behavioural Instruments'),
+    ('Data Entry'),
+    ('Examiners'),
+    ('Imaging'),
+    ('Technical Issue'),
+    ('User Accounts'),
+    ('Other');


### PR DESCRIPTION
Populating default categories  for the issues_categories table, in the default schema and in a patch for existing projects.
For the recently-merged Issue Tracker module (issues_categories table was not populated in #2132 , but was supposed to be)