### PR TITLE
[dashboard] Add a custom message if a user has never logged in

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -53,11 +53,11 @@ class NDB_Form_Dashboard extends NDB_Form
         $this->tpl_data['user_site'] = $siteID;
 
         // Welcome panel
-        $this->tpl_data['username']            = $user->getFullname();
+        $this->tpl_data['username'] = $user->getFullname();
         if ($last_login) {
-            $this->tpl_data['last_login']      = $last_login;
+            $this->tpl_data['last_login'] = $last_login;
         } else {
-            $this->tpl_data['last_login']      = "...never. Welcome!";
+            $this->tpl_data['last_login'] = "...never. Welcome!";
         }
         $this->tpl_data['project_description']
             = $config->getSetting('projectDescription');

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -54,7 +54,11 @@ class NDB_Form_Dashboard extends NDB_Form
 
         // Welcome panel
         $this->tpl_data['username']            = $user->getFullname();
-        $this->tpl_data['last_login']          = $last_login;
+        if ($last_login) {
+            $this->tpl_data['last_login']      = $last_login;
+        } else {
+            $this->tpl_data['last_login']      = "...never. Welcome!";
+        }
         $this->tpl_data['project_description']
             = $config->getSetting('projectDescription');
         $dashboard_links = $config->getExternalLinks('dashboard');


### PR DESCRIPTION
Previously, if a user had never logged in, there was a blank space after "Last login:".

This adds a custom message that is displayed to the user on their first login. 

[Redmine #11276]