### PR TITLE
[Dashboard] Place recruitmentLineChart in global scope

### DIFF
--- a/modules/dashboard/js/dashboard-helper.js
+++ b/modules/dashboard/js/dashboard-helper.js
@@ -237,7 +237,7 @@ $.ajax({
     type: 'post',
     success: function(data) {
         var recruitmentLineData = formatLineData(data);
-        var recruitmentLineChart = c3.generate({
+        recruitmentLineChart = c3.generate({
             bindto: '#recruitmentChart',
             data: {
                 x: 'x',


### PR DESCRIPTION
The rest of the charts are available in the global scope. This fact is relied on when a chart is selected from the dropdown (to call .resize() on it)

See Redmine #11277