### PR TITLE
[Schema] Add DEFAULT CURRENT_TIMESTAMP to data_entry_date

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1555,7 +1555,7 @@ CREATE TABLE participant_status (
         UserID varchar(255) default NULL,
         Examiner varchar(255) default NULL,
         entry_staff varchar(255) default NULL,
-        data_entry_date timestamp NOT NULL,
+        data_entry_date timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
         participant_status integer DEFAULT NULL REFERENCES participant_status_options(ID),
         participant_suboptions integer DEFAULT NULL REFERENCES participant_status_options(ID),
         reason_specify text default NULL,

--- a/SQL/Archive/17.0/2016-10-24-ParticipantStatus_add_data_entry_date_default.sql
+++ b/SQL/Archive/17.0/2016-10-24-ParticipantStatus_add_data_entry_date_default.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `participant_status` 
+CHANGE COLUMN `data_entry_date` `data_entry_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
In MySQL 5.7+ inserting in a timestamp NOT NULL column will raise an error when the DEFAULT value is not explicit in the table definition.

Related to: https://github.com/aces/Loris/pull/2296