### PR TITLE
Imaging Uploader: Uploaded file can be PSCID_CandID_VL or PSCID_CandID_VL_*: Redmine 11186

### DIFF
--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -356,14 +356,19 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
             }
 
             ///////////////////////////////////////////////////////////////////////
-            ////////////// Make sure the file name matches the format   ///////////
-            /////////// $candid and $visit_label can be of variable length ////////
+            ///////////    Make sure the file name matches the format   ///////////
+            ///////////         $pscid_$candid_$visit_label             ///////////
+            ///////////              OR starts with                     ///////////
+            ///////////         $pscid_$candid_$visit_label_            ///////////
             ///////////////////////////////////////////////////////////////////////
-            $pcv = "{$pscid}_{$candid}_{$visit_label}";
-            if (!preg_match("/^{$pcv}.*(zip|tgz|tar.gz)/", $file_name)) {
-                $errors[] = "File name must begin with " .
-                "\"". $pscid ."_". $candid ."_". $visit_label . "\"" .
-                " and have the extension of .tgz, tar.gz or .zip";
+            $pcv  = $pscid . "_" . $candid . "_" . $visit_label;
+            $pcvu = $pcv . "_";
+            if ((!preg_match("/{$pcv}.(zip|tgz|tar.gz)/", $file_name))
+                && (!preg_match("/^{$pcvu}.*(zip|tgz|tar.gz)/", $file_name))
+            ) {
+                    $errors[] = "File name must match " . $pcv .
+                    " or begin with " . "\"". $pcvu . "\"" .
+                    ", and have the extension of .tgz, tar.gz or .zip";
             }
 
             ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In Loris v16.x, we allowed uploader to upload a filename that starts with PSCID_CandID_VL; in this pull request, we add the underscore at the end of the visit label if we were to allow extra suffix at the end of the filename (not adding the underscore could have implications on the Visit_Label interpretation on the Loris-MRI side, and _potentially_ logging the candidate into MRICandidateErrors table with the error: Visit Label does not exist).