### PR TITLE
User account not editable after any successful edit/add operation

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -306,7 +306,6 @@ class NDB_Form_User_Accounts extends NDB_Form
         }
 
         $this->tpl_data['success'] = true;
-        $this->form->freeze();
     }
 
     /**


### PR DESCRIPTION
The user account form would become non editable after either a new user was added or modifications were made to an existing account. This commit leaves the form editable in all cases.