### PR TITLE
[dashboard] Fix link for Incomplete Forms

### DIFF
--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -146,9 +146,9 @@
                             {/if}
                             {if $incomplete_forms neq "" and $incomplete_forms neq 0}
                             {if $incomplete_forms_site eq "Site: all"}
-                            <a href="{$baseURL}/statistics/statistics_site/" class="list-group-item statistics">
+                            <a href="{$baseURL}/statistics/?submenu=statistics_site" class="list-group-item statistics">
                                 {else}
-                                <a href="{$baseURL}/statistics/statistics_site/?CenterID={$user_site}"
+                                <a href="{$baseURL}/statistics/?submenu=statistics_site&CenterID={$user_site}"
                                    class="list-group-item">
                                     {/if}
                                     <div class="row">

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -341,7 +341,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->_testMytaskPanelAndLink(
             ".statistics",
             "1",
-            "General Description"
+            "All Completion Statistics"
         );
         $this->resetPermissions();
     }


### PR DESCRIPTION
The Incomplete Forms panel on the dashboard now properly redirects.