### PR TITLE
[Configuration] Decode HTML on login page

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -93,7 +93,7 @@ class SinglePointLogin
         $study_title       = $config->getSetting('title');
         $study_description = $config->getSetting('StudyDescription');
         $tpl_data['study_title']       = $study_title;
-        $tpl_data['study_description'] = $study_description;
+        $tpl_data['study_description'] = html_entity_decode($study_description);
         try {
             $tpl_data['study_logo'] = $config->getSetting('studylogo');
         } catch(ConfigurationException $e) {


### PR DESCRIPTION
When HTML is saved in config module, it is escaped when saving to DB (for safety purposes).
This fix unescapes it when fetching it from db and displaying on the login page.

https://redmine.cbrain.mcgill.ca/issues/11302