### PR TITLE
[Schema] Adds candID to issues_history's fieldChanged enum

### DIFF
--- a/SQL/Archive/17.0/2016-10-26-IssuesHistory_add_candID_to_fieldChanged_enum.sql
+++ b/SQL/Archive/17.0/2016-10-26-IssuesHistory_add_candID_to_fieldChanged_enum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `issues_history`
+  CHANGE COLUMN `fieldChanged` `fieldChanged` enum('assignee','status','comment','sessionID','centerID','title','category','module','lastUpdatedBy','priority','candID') NOT NULL DEFAULT 'comment';


### PR DESCRIPTION
Bug fix for the Issue Tracker - new module for 17.0: 
The [original patch](https://github.com/aces/Loris/blob/17.0-dev/SQL/Archive/17.0/2016-08-19-IssueTracker.sql#L74) committed with this module missed a `candID` value in an enum in the issues_history table. 
The default schema (0000*.sql) change [correctly included this value](https://github.com/aces/Loris/blob/17.0-dev/SQL/0000-00-00-schema.sql#L2284) in the [original PR](https://github.com/aces/Loris/pull/2132) - only the patch for existing projects was [missing this value](https://github.com/aces/Loris/blob/17.0-dev/SQL/Archive/17.0/2016-08-19-IssueTracker.sql#L74).

(RM11315)
