### PR TITLE
Disable submit button in start next stage once clicked

### DIFF
--- a/modules/next_stage/templates/form_next_stage.tpl
+++ b/modules/next_stage/templates/form_next_stage.tpl
@@ -33,7 +33,7 @@
     </div>
     {/if}
     <div class="form-group row">
-        <div class="col-sm-offset-2 col-sm-4 col-md-3"><input class="btn btn-primary col-xs-12" type="submit" name="fire_away" value="Start {$stage}" /></div>
+        <div class="col-sm-offset-2 col-sm-4 col-md-3"><input class="btn btn-primary col-xs-12" type="submit" name="fire_away" value="Start {$stage}" onClick="this.form.submit(); this.disabled=true;"/></div>
     </div>
 
     {$form.hidden}


### PR DESCRIPTION
Quick fix to stop Start Next Stage button from being clicked twice and causing an error.
@ridz1208 can you text this and see if this is what you want? My local sandbox is to fast to submit, and I can't actually get the error you are seeing.