### PR TITLE
[Instruments] replaced deprecated call_user_method by call_user_func

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_TEMPLATE.class.inc
@@ -55,7 +55,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
     */
     function _setupForm(){
        if(preg_match("/<TEST_NAME>(_page[0-9]+)/",$this->page,$matches)){
-            call_user_method($matches[1], $this);
+            call_user_func(array($this, $matches[1]));
         } else {
             $this->_main();
         }


### PR DESCRIPTION
This function call needs an array to replicate existing functionality.