### PR TITLE
Simplified CentOS install Readme

### DIFF
--- a/README.CentOS6.md
+++ b/README.CentOS6.md
@@ -1,21 +1,22 @@
 #LORIS CentOS 6.x Notes
 
+This document contains supplemental details on how to perform a basic CentOS 6.x install of LORIS.
 Note that the main README in LORIS assumes that LORIS is being run on Ubuntu.
+As of Loris 17.0, the install script and web-based install steps as described in the main (Ubuntu) readme are applicable to CentOS installs. 
 
-This document contains details on how to manually perform a basic CentOS 6.x
-install of LORIS without using the install script (as the install script
-makes some assumptions about apt-get being installed.)
-
-It assumes you already understand basic UNIX, MySQL and Apache setup and
+This Readme assumes you already understand basic UNIX, MySQL and Apache setup and
 settings. If you're not already comfortable troubleshooting sysadmin issues,
 you should not follow this guide.
 
-For further details on the install process including LORIS nomenclature for recommended UNIX, MySQL and front-end user accounts, please see the LORIS GitHub Wiki CentOS Install page.  
+For further details on the install process, please see the LORIS GitHub Wiki CentOS Install page.  
 
-# 1. System Requirements
+# System Requirements
 
-The yum packages to be installed vary from the Ubuntu packages referenced
-in the LORIS README
+Default dependencies installed by CentOS 6.x may not meet the version requirements LORIS deployment or development.
+* MySQL 5.7 is supported for LORIS 17.*
+* PHP 7 is supported for LORIS 17.* - upgrade your PHP manually
+
+The yum packages to be installed vary from any Ubuntu packages referenced in the LORIS README.
 
 The following should be installed with yum:
  
@@ -33,11 +34,7 @@ curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer
 ```
 
-Note that the default dependencies installed by CentOS 6.x may not meet the version requirements LORIS deployment or development.
-* MySQL 5.7 is supported for LORIS 17.*
-* PHP 7 is supported for LORIS 17.* - upgrade your PHP manually
-Or run composer with the `--no-dev` option. (Upgrading PHP is preferred, but for now we'll
-assume you just want to get it running, so we'll run it with `--no-dev`.)
+If you just want to get Loris running and upgrade your PHP later, run composer with the `--no-dev` option. 
 
 ```bash
 # Will download all of LORIS's library requirements, assuming an
@@ -49,64 +46,22 @@ assume you just want to get it running, so we'll run it with `--no-dev`.)
 composer install --no-dev
 ```
 
-## 1.1 MySQL
-
-This details how to set up accounts and manually populate the MySQL database  
-which is assumed to already exist (if not, create one before proceeding)
-
-Connect to MySQL, use your database and source all the files in the
-SQL/ directory of LORIS which are prefixed with `0000-00-` into it
-(ie `SQL/0000-00-00-schema.sql`, `SQL/0000-00-01-Permission.sql`, 
-`SQL/0000-00-02-Menus.sql`, etc.)
-
-There are a few settings in the Config module that LORIS currently depends
-on being updated to load correctly -- these must be set manually from the MySQL commandline as
-they're normally set by the install script.
-
-```SQL
-UPDATE Config SET Value='/var/www/loris/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base');
-UPDATE Config SET Value='localhost' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='host');
-UPDATE Config SET Value='http://localhost' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url');
-```
-
-Where `/var/www/loris/` is the location where LORIS is installed and assuming
-you'll be running on localhost (otherwise update host and url appropriately)
-
-Create a new MySQL back-end user (recommended: _lorisuser_) that will perform all transactions coming from the front-end, with the following privileges:
-```mysql 
-     GRANT UPDATE,INSERT,SELECT,DELETE,CREATE TEMPORARY TABLES ON $mysqldb.* TO 'lorisuser'@'$mysqlhost' IDENTIFIED BY '$newPassword' WITH GRANT OPTION; 
-```
-
-Set the password for the front-end _admin_ user account while connected to MySQL.
-
-```SQL
--- Set 'admin' front-end user account password to YOURPASSWORD
-UPDATE users SET Password_hash=NULL, Password_md5=concat('aa',MD5('aaYOURPASSWORD')) WHERE ID=1;
-```
-
-## 1.2 Config.xml
-
-Create a directory named "project" directory under the LORIS root, and copy
-the sample config.xml from `docs/config/config.xml` to `project/config.xml`
-
-Update the _database_ tagset section of config.xml to point to the database you
-just configured with the _lorisuser_ credential created in step 1.1. (Ignore _quatuser_ and _quatpassword_ tags.)
-
-## 1.3 Apache
+## Apache configuration
 
 A sample apache configuration file is in `docs/config/apache2-site`. 
-You can copy this file to the apache configuration directory (`/etc/httpd/conf.d/`), adding the appropriate suffix:
+The install script will ask if you want to automatically create/install apache config files.
+To perform this step manually, copy the sample file to the apache configuration directory (`/etc/httpd/conf.d/`), and add the `.conf` file extension:
 
 ```bash
 cp docs/config/apache-site /etc/httpd/conf.d/apache-site.conf
 ```
 
-Update the paths and settings in this new file as appropriate for your server, ensuring that all placeholders (`%LORISROOT%`, `%PROJECTNAME%`, `%LOGDIRECTORY%`) are populated. Ensure that the DocumentRoot is pointing to the htdocs/ directory under your LORIS root (usually `/var/www/loris/htdocs`).
+Ensure that paths and settings in this new file are populated appropriately for your server, e.g. replacing placeholders such as `%LORISROOT%`, `%PROJECTNAME%`, `%LOGDIRECTORY%`. Ensure that the DocumentRoot is pointing to the htdocs/ directory under your LORIS root (usually `/var/www/loris/htdocs`).
 
-You'll have to create a `smarty/templates_c/` directory under the LORIS
-root and assure that it's writable by Apache.
+Also ensure that your new `smarty/templates_c/` directory under the LORIS
+root is writable by Apache.
 
-## 1.4 Last steps
+## SELinux
 
 Finally, SELinux will block MySQL connections from PHP. For now, we'll 
 disable SELinux (though on a production server you should learn how to
@@ -122,10 +77,7 @@ service httpd stop
 service httpd start
 ```
 
-At this point, you should be able to log in to LORIS
-at http://localhost/ using the username "admin" and the password that
-you set in section 1.1. Further configuration can be done using the
-LORIS configuration module.
+Further configuration can be done using the LORIS configuration module.
 
 If there are any errors or you get a blank page, you'll have to troubleshoot
 based on the errors in your apache error log (by default


### PR DESCRIPTION
Many of the manual steps previously necessary for CentOS installation are now covered by install.sh and the new web-based install process.  
