### PR TITLE
LorisForm updates: Dates (addGroupRule) and deprecated registerRule() 

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_radiology_review.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_radiology_review.class.inc
@@ -106,7 +106,6 @@ class NDB_BVL_Instrument_radiology_review extends NDB_BVL_Instrument
 
      	$this->form->addRule('Date_taken', 'Date of Administration is required', 'required');
 
-        $this->form->registerRule('checkdate', 'callback', '_checkDate');
         $this->form->addRule('Date_taken', 'Date of Administration is invalid', 'checkdate');
 
         $this->form->addRule('Examiner', 'Examiner is required', 'required');

--- a/docs/instruments/NDB_BVL_Instrument_radiology_review.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_radiology_review.class.inc
@@ -104,7 +104,7 @@ class NDB_BVL_Instrument_radiology_review extends NDB_BVL_Instrument
         $examiners = $this->_getExaminerNames();
         $this->form->addElement('select', 'Examiner', 'Radiologist', $examiners);
 
-     	$this->form->addGroupRule('Date_taken', 'Date of Administration is required', 'required');
+     	$this->form->addRule('Date_taken', 'Date of Administration is required', 'required');
 
         $this->form->registerRule('checkdate', 'callback', '_checkDate');
         $this->form->addRule('Date_taken', 'Date of Administration is invalid', 'checkdate');

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -381,8 +381,6 @@ class NDB_Reliability extends NDB_Form
           $examiners = $this->_getExaminerNames();
           $this->addSelect('Examiner', 'Reliability Coder', $examiners);
 
-          $this->form->registerRule('checkdate', 'callback', '_checkDate');
-
           $this->addSelect(
               'invalid',
               '<font color="red">Mark as invalid</font>',


### PR DESCRIPTION
This PR cleans up all instances of dates using addGroupRule, and registerRule() deprecated function calls in the codebase. 

Updated sample Radiology Review instrument in docs/ : 
* replaced addGroupRule() with addRule() since dates in LorisForm are now one element (string) not a group of elements (array)
* removed registerRule() call (now deprecated in LorisForm)

NDB_Reliability update: 
* removed registerRule() call (now deprecated in LorisForm)


