### PR TITLE
Fix permission with AJAX scripts

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -29,8 +29,9 @@ require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
-$client->initialize("../project/config.xml");
-
+if ($client->initialize("../project/config.xml") == false) {
+    return false;
+}
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -28,7 +28,9 @@ require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
-$client->initialize("../project/config.xml");
+if ($client->initialize("../project/config.xml") == false) {
+    return false;
+}
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -32,7 +32,9 @@ require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
-$client->initialize("../project/config.xml");
+if ($client->initialize("../project/config.xml") == false) {
+    return false;
+}
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();

--- a/htdocs/GetStatic.php
+++ b/htdocs/GetStatic.php
@@ -33,7 +33,9 @@ require_once __DIR__ . "/../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
-$client->initialize("../project/config.xml");
+if ($client->initialize("../project/config.xml") == false) {
+    return false;
+}
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -33,7 +33,9 @@ require_once __DIR__ . "/../../../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
-$client->initialize("../../../project/config.xml");
+if ($client->initialize("../../../project/config.xml") == false) {
+    return false;
+}
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();


### PR DESCRIPTION
The return value of $client->initialize wasn't checked, resulting in data being sent to the client even if they weren't logged in.

(This is a bugfix backported to 16.1 for existing projects.)