### PR TITLE
[Sample instruments] removed deprecated addRule checkdate

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_radiology_review.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_radiology_review.class.inc
@@ -106,8 +106,6 @@ class NDB_BVL_Instrument_radiology_review extends NDB_BVL_Instrument
 
      	$this->form->addRule('Date_taken', 'Date of Administration is required', 'required');
 
-        $this->form->addRule('Date_taken', 'Date of Administration is invalid', 'checkdate');
-
         $this->form->addRule('Examiner', 'Examiner is required', 'required');
     }
 }


### PR DESCRIPTION
Removed deprecated sample addRule() using checkdate
Among the sample instruments, this appeared only in the sample Radiological Review instrument. 
