### PR TITLE
Imaging Uploader: Escape the . in uploaded filename before zip, tar, etc... Redmine 11307

### DIFF
--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -390,7 +390,7 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
                                     " PSCID: $pscid and the corresponding".
                                     " Visit-label: $visit_label which".
                                     " already exist. <br>Please refresh this page".
-                                    "to return to the Imaging Uploader module";
+                                    " to return to the Imaging Uploader module";
                 }
             }
         }

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -363,8 +363,8 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
             ///////////////////////////////////////////////////////////////////////
             $pcv  = $pscid . "_" . $candid . "_" . $visit_label;
             $pcvu = $pcv . "_";
-            if ((!preg_match("/{$pcv}.(zip|tgz|tar.gz)/", $file_name))
-                && (!preg_match("/^{$pcvu}.*(zip|tgz|tar.gz)/", $file_name))
+            if ((!preg_match("/{$pcv}\.(zip|tgz|tar.gz)/", $file_name))
+                && (!preg_match("/^{$pcvu}.*(\.(zip|tgz|tar.gz))/", $file_name))
             ) {
                     $errors[] = "File name must match " . $pcv .
                     " or begin with " . "\"". $pcvu . "\"" .


### PR DESCRIPTION
In reference to the comment of @driusan 
on: https://github.com/aces/Loris/pull/2343
about the '.' having to be escaped in the regex
