### PR TITLE
Optimize imaging browser queries

### DIFF
--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -52,44 +52,23 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
     function _setupVariables()
     {
         $NewDataSubquery = "CASE 
-            COALESCE((
-                SELECT MIN(QCLastChangeTime) 
-                FROM files LEFT JOIN files_qcstatus 
-                USING(FileID) 
-                WHERE files.SessionID=s.ID 
-                AND OutputType='native' 
-                AND AcquisitionProtocolID not in (1, 2, 3, 52) 
-                GROUP BY QCLastChangeTime 
-                ORDER BY QCLastChangeTime limit 1
-            ), 'new')
+            COALESCE(nd.QCLastChangeTime, 'new')
             WHEN 'new' THEN 'new' 
             WHEN '' THEN 'new'
             ELSE ''
             END";
         $T1PassSubquery = "CASE 
-            COALESCE((
-                SELECT MIN(files_qcstatus.QCStatus+0) 
-                FROM files JOIN files_qcstatus 
-                USING (FileID) 
-                WHERE files.SessionID=s.ID AND files.AcquisitionProtocolID=44 and (files_qcstatus.QCStatus=1 or files_qcstatus.QCStatus=2)
-                GROUP BY files.SessionID), '')
+            COALESCE(t1pass.T1QC, '') 
             WHEN '' THEN ''
             WHEN 1 THEN 'Passed'
             WHEN 2 THEN 'Failed'
-            END
-            ";
+            END";
         $T2PassSubquery = "CASE 
-            COALESCE((
-                SELECT MIN(files_qcstatus.QCStatus+0) 
-                FROM files JOIN files_qcstatus 
-                USING (FileID) 
-                WHERE files.SessionID=s.ID AND files.AcquisitionProtocolID=45 and (files_qcstatus.QCStatus=1 or files_qcstatus.QCStatus=2)
-                GROUP BY files.SessionID), '')
+            COALESCE(t2pass.T2QC, '') 
             WHEN '' THEN ''
             WHEN 1 THEN 'Passed'
             WHEN 2 THEN 'Failed'
-            END
-            ";
+            END";
 
         $PendingFailSubquery = "
             CASE s.MRIQCStatus
@@ -107,6 +86,9 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             JOIN files f ON (f.SessionID=s.ID) 
             LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID) 
             JOIN mri_acquisition_dates md ON (md.SessionID=s.ID)
+            LEFT JOIN (SELECT files.SessionID, MIN(QCLastChangeTime) as QCLastChangeTime FROM files LEFT JOIN files_qcstatus USING (FileID) WHERE OutputType='native' AND AcquisitionProtocolID NOT IN (1, 2, 3, 52) GROUP BY files.SessionID) nd ON (nd.SessionID=f.SessionID)
+            LEFT JOIN (SELECT files.SessionID, MIN(files_qcstatus.QCStatus+0) as T1QC FROM files JOIN files_qcstatus USING (FileID) WHERE files.AcquisitionProtocolID=44 AND files_qcstatus.QCStatus IN (1, 2) GROUP BY files.SessionID) t1pass ON (t1pass.SessionID=f.SessionID)
+            LEFT JOIN (SELECT files.SessionID, MIN(files_qcstatus.QCStatus+0) as T2QC FROM files JOIN files_qcstatus USING (FileID) WHERE files.AcquisitionProtocolID=45 AND files_qcstatus.QCStatus IN (1, 2) GROUP BY files.SessionID) t2pass ON (t2pass.SessionID=f.SessionID)
             WHERE 
             f.PendingStaging=0 AND 
             f.FileType='mnc' AND 


### PR DESCRIPTION
The imaging_browser menu was using 3 dependent subselects, causing it to take
unnecessary amounts of time when run on large data sets (such as IBIS).

This updates the code to use a JOIN instead of a subselect, significantly
increasing the speed of the imaging_browser.