### PR TITLE
Removed internal state from several input components

### DIFF
--- a/htdocs/js/components/Form.js
+++ b/htdocs/js/components/Form.js
@@ -178,32 +178,9 @@ var SelectElement = React.createClass({
       }
     };
   },
-  componentDidMount: function componentDidMount() {
-    if (this.props.value) {
-      this.setState({
-        value: this.props.value
-      });
-    }
-  },
-  componentWillReceiveProps: function componentWillReceiveProps() {
-    if (this.props.hasError) {
-      this.setState({
-        hasError: this.props.hasError
-      });
-    }
-  },
-  getInitialState: function getInitialState() {
-    var value = this.props.multiple ? [] : '';
-    return {
-      value: value,
-      hasError: false
-    };
-  },
   handleChange: function handleChange(e) {
     var value = e.target.value;
     var options = e.target.options;
-    var hasError = false;
-    var isEmpty = value === "";
 
     // Multiple values
     if (this.props.multiple && options.length > 1) {
@@ -213,18 +190,7 @@ var SelectElement = React.createClass({
           value.push(options[i].value);
         }
       }
-      isEmpty = value.length > 1;
     }
-
-    // Check for errors
-    if (this.props.required && isEmpty) {
-      hasError = true;
-    }
-
-    this.setState({
-      value: value,
-      hasError: hasError
-    });
 
     this.props.onUserInput(this.props.name, value);
   },
@@ -253,7 +219,7 @@ var SelectElement = React.createClass({
     }
 
     // Add error message
-    if (this.state.hasError) {
+    if (this.props.hasError || this.props.required && !this.props.value) {
       errorMessage = React.createElement(
         'span',
         null,
@@ -281,7 +247,7 @@ var SelectElement = React.createClass({
             multiple: multiple,
             className: 'form-control',
             id: this.props.label,
-            value: this.state.value,
+            value: this.props.value,
             onChange: this.handleChange,
             required: required,
             disabled: disabled
@@ -332,20 +298,7 @@ var TextareaElement = React.createClass({
       }
     };
   },
-  getInitialState: function getInitialState() {
-    return {
-      value: ''
-    };
-  },
-  componentDidMount: function componentDidMount() {
-    if (this.props.value) {
-      this.setState({ value: this.props.value });
-    }
-  },
   handleChange: function handleChange(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function render() {
@@ -380,7 +333,7 @@ var TextareaElement = React.createClass({
           className: 'form-control',
           name: this.props.name,
           id: this.props.id,
-          value: this.state.value,
+          value: this.props.value,
           required: required,
           disabled: disabled,
           onChange: this.handleChange
@@ -406,11 +359,6 @@ var TextboxElement = React.createClass({
     required: React.PropTypes.bool,
     onUserInput: React.PropTypes.func
   },
-  getInitialState: function getInitialState() {
-    return {
-      value: ''
-    };
-  },
   getDefaultProps: function getDefaultProps() {
     return {
       name: '',
@@ -424,17 +372,7 @@ var TextboxElement = React.createClass({
       }
     };
   },
-  componentDidMount: function componentDidMount() {
-    if (this.props.value) {
-      this.setState({
-        value: this.props.value
-      });
-    }
-  },
   handleChange: function handleChange(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function render() {
@@ -468,7 +406,7 @@ var TextboxElement = React.createClass({
           className: 'form-control',
           name: this.props.name,
           id: this.props.id,
-          value: this.state.value,
+          value: this.props.value,
           required: required,
           disabled: disabled,
           onChange: this.handleChange
@@ -509,20 +447,7 @@ var DateElement = React.createClass({
       }
     };
   },
-  getInitialState: function getInitialState() {
-    return {
-      value: ''
-    };
-  },
-  componentDidMount: function componentDidMount() {
-    if (this.props.value) {
-      this.setState({ value: this.props.value });
-    }
-  },
   handleChange: function handleChange(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function render() {
@@ -559,7 +484,7 @@ var DateElement = React.createClass({
           min: this.props.minYear,
           max: this.props.maxYear,
           onChange: this.handleChange,
-          value: this.state.value,
+          value: this.props.value,
           required: required,
           disabled: disabled
         })
@@ -586,11 +511,6 @@ var NumericElement = React.createClass({
     required: React.PropTypes.bool,
     onUserInput: React.PropTypes.func
   },
-  getInitialState: function getInitialState() {
-    return {
-      value: ''
-    };
-  },
   getDefaultProps: function getDefaultProps() {
     return {
       name: '',
@@ -606,17 +526,7 @@ var NumericElement = React.createClass({
       }
     };
   },
-  componentDidMount: function componentDidMount() {
-    if (this.props.value) {
-      this.setState({
-        value: this.props.value
-      });
-    }
-  },
   handleChange: function handleChange(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function render() {
@@ -969,9 +879,6 @@ var ButtonElement = React.createClass({
     label: React.PropTypes.string,
     type: React.PropTypes.string,
     onUserInput: React.PropTypes.func
-  },
-  getInitialState: function getInitialState() {
-    return {};
   },
   getDefaultProps: function getDefaultProps() {
     return {

--- a/htdocs/js/components/Form.js
+++ b/htdocs/js/components/Form.js
@@ -164,7 +164,7 @@ var SelectElement = React.createClass({
       name: '',
       options: {},
       label: '',
-      value: null,
+      value: undefined,
       id: '',
       class: '',
       multiple: false,
@@ -178,6 +178,7 @@ var SelectElement = React.createClass({
       }
     };
   },
+
   handleChange: function handleChange(e) {
     var value = e.target.value;
     var options = e.target.options;
@@ -219,7 +220,7 @@ var SelectElement = React.createClass({
     }
 
     // Add error message
-    if (this.props.hasError || this.props.required && !this.props.value) {
+    if (this.props.hasError || this.props.required && this.props.value === "") {
       errorMessage = React.createElement(
         'span',
         null,

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -157,7 +157,7 @@ var SelectElement = React.createClass({
       name: '',
       options: {},
       label: '',
-      value: null,
+      value: undefined,
       id: '',
       class: '',
       multiple: false,
@@ -171,6 +171,7 @@ var SelectElement = React.createClass({
       }
     };
   },
+
   handleChange: function(e) {
     var value = e.target.value;
     var options = e.target.options;
@@ -208,7 +209,7 @@ var SelectElement = React.createClass({
     }
 
     // Add error message
-    if (this.props.hasError || (this.props.required && !this.props.value)) {
+    if (this.props.hasError || (this.props.required && this.props.value === "")) {
       errorMessage = <span>{this.props.errorMessage}</span>;
       elementClass = 'row form-group has-error';
     }

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -171,32 +171,9 @@ var SelectElement = React.createClass({
       }
     };
   },
-  componentDidMount: function() {
-    if (this.props.value) {
-      this.setState({
-        value: this.props.value
-      });
-    }
-  },
-  componentWillReceiveProps: function() {
-    if (this.props.hasError) {
-      this.setState({
-        hasError: this.props.hasError
-      });
-    }
-  },
-  getInitialState: function() {
-    var value = this.props.multiple ? [] : '';
-    return {
-      value: value,
-      hasError: false
-    };
-  },
   handleChange: function(e) {
     var value = e.target.value;
     var options = e.target.options;
-    var hasError = false;
-    var isEmpty = (value === "");
 
     // Multiple values
     if (this.props.multiple && options.length > 1) {
@@ -206,18 +183,7 @@ var SelectElement = React.createClass({
           value.push(options[i].value);
         }
       }
-      isEmpty = (value.length > 1);
     }
-
-    // Check for errors
-    if (this.props.required && isEmpty) {
-      hasError = true;
-    }
-
-    this.setState({
-      value: value,
-      hasError: hasError
-    });
 
     this.props.onUserInput(this.props.name, value);
   },
@@ -242,7 +208,7 @@ var SelectElement = React.createClass({
     }
 
     // Add error message
-    if (this.state.hasError) {
+    if (this.props.hasError || (this.props.required && !this.props.value)) {
       errorMessage = <span>{this.props.errorMessage}</span>;
       elementClass = 'row form-group has-error';
     }
@@ -259,7 +225,7 @@ var SelectElement = React.createClass({
             multiple={multiple}
             className="form-control"
             id={this.props.label}
-            value={this.state.value}
+            value={this.props.value}
             onChange={this.handleChange}
             required={required}
             disabled={disabled}
@@ -307,20 +273,7 @@ var TextareaElement = React.createClass({
       }
     };
   },
-  getInitialState: function() {
-    return {
-      value: ''
-    };
-  },
-  componentDidMount: function() {
-    if (this.props.value) {
-      this.setState({value: this.props.value});
-    }
-  },
   handleChange: function(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function() {
@@ -346,7 +299,7 @@ var TextareaElement = React.createClass({
             className="form-control"
             name={this.props.name}
             id={this.props.id}
-            value={this.state.value}
+            value={this.props.value}
             required={required}
             disabled={disabled}
             onChange={this.handleChange}
@@ -372,11 +325,6 @@ var TextboxElement = React.createClass({
     required: React.PropTypes.bool,
     onUserInput: React.PropTypes.func
   },
-  getInitialState: function() {
-    return {
-      value: ''
-    };
-  },
   getDefaultProps: function() {
     return {
       name: '',
@@ -390,17 +338,7 @@ var TextboxElement = React.createClass({
       }
     };
   },
-  componentDidMount: function() {
-    if (this.props.value) {
-      this.setState({
-        value: this.props.value
-      });
-    }
-  },
   handleChange: function(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function() {
@@ -425,7 +363,7 @@ var TextboxElement = React.createClass({
             className="form-control"
             name={this.props.name}
             id={this.props.id}
-            value={this.state.value}
+            value={this.props.value}
             required={required}
             disabled={disabled}
             onChange={this.handleChange}
@@ -465,20 +403,7 @@ var DateElement = React.createClass({
       }
     };
   },
-  getInitialState: function() {
-    return {
-      value: ''
-    };
-  },
-  componentDidMount: function() {
-    if (this.props.value) {
-      this.setState({value: this.props.value});
-    }
-  },
   handleChange: function(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function() {
@@ -506,7 +431,7 @@ var DateElement = React.createClass({
             min={this.props.minYear}
             max={this.props.maxYear}
             onChange={this.handleChange}
-            value={this.state.value}
+            value={this.props.value}
             required={required}
             disabled={disabled}
           />
@@ -532,11 +457,6 @@ var NumericElement = React.createClass({
     required: React.PropTypes.bool,
     onUserInput: React.PropTypes.func
   },
-  getInitialState: function() {
-    return {
-      value: ''
-    };
-  },
   getDefaultProps: function() {
     return {
       name: '',
@@ -552,17 +472,7 @@ var NumericElement = React.createClass({
       }
     };
   },
-  componentDidMount: function() {
-    if (this.props.value) {
-      this.setState({
-        value: this.props.value
-      });
-    }
-  },
   handleChange: function(e) {
-    this.setState({
-      value: e.target.value
-    });
     this.props.onUserInput(this.props.name, e.target.value);
   },
   render: function() {
@@ -852,9 +762,6 @@ var ButtonElement = React.createClass({
     label: React.PropTypes.string,
     type: React.PropTypes.string,
     onUserInput: React.PropTypes.func
-  },
-  getInitialState: function() {
-    return {};
   },
   getDefaultProps: function() {
     return {

--- a/modules/candidate_parameters/js/familyInfo.js
+++ b/modules/candidate_parameters/js/familyInfo.js
@@ -148,7 +148,7 @@ var FamilyInfo = React.createClass({
 
     return React.createElement(
       'div',
-      { 'class': 'row' },
+      { className: 'row' },
       React.createElement(
         'div',
         { className: alertClass, role: 'alert', ref: 'alert-message' },
@@ -179,7 +179,8 @@ var FamilyInfo = React.createClass({
           onUserInput: this.setFormData,
           ref: 'FamilyCandID',
           disabled: disabled,
-          required: false
+          required: false,
+          value: this.state.formData.FamilyCandID
         }),
         React.createElement(SelectElement, {
           label: 'Relation Type',
@@ -188,7 +189,8 @@ var FamilyInfo = React.createClass({
           onUserInput: this.setFormData,
           ref: 'Relationship_type',
           disabled: disabled,
-          required: relationshipRequired
+          required: relationshipRequired,
+          value: this.state.formData.Relationship_type
         }),
         addButton
       )

--- a/modules/candidate_parameters/jsx/familyInfo.js
+++ b/modules/candidate_parameters/jsx/familyInfo.js
@@ -146,7 +146,7 @@ var FamilyInfo = React.createClass({
     }
 
     return (
-        <div class="row">
+        <div className="row">
           <div className={alertClass} role="alert" ref="alert-message">
             {alertMessage}
           </div>
@@ -175,6 +175,7 @@ var FamilyInfo = React.createClass({
               ref="FamilyCandID"
               disabled={disabled}
               required={false}
+              value={this.state.formData.FamilyCandID}
             />
             <SelectElement
               label="Relation Type"
@@ -184,6 +185,7 @@ var FamilyInfo = React.createClass({
               ref="Relationship_type"
               disabled={disabled}
               required={relationshipRequired}
+              value={this.state.formData.Relationship_type}
             />
             {addButton}
           </FormElement>

--- a/modules/media/js/editForm.js
+++ b/modules/media/js/editForm.js
@@ -184,14 +184,14 @@ var MediaEditForm = function (_React$Component) {
             maxYear: '2017',
             onUserInput: this.setFormData,
             ref: 'dateTaken',
-            value: this.state.mediaData.dateTaken
+            value: this.state.formData.dateTaken
           }),
           React.createElement(TextareaElement, {
             name: 'comments',
             label: 'Comments',
             onUserInput: this.setFormData,
             ref: 'comments',
-            value: this.state.mediaData.comments
+            value: this.state.formData.comments
           }),
           React.createElement(FileElement, {
             name: 'file',
@@ -201,7 +201,7 @@ var MediaEditForm = function (_React$Component) {
             disabled: true,
             ref: 'file',
             label: 'Uploaded file',
-            value: this.state.mediaData.fileName
+            value: this.state.formData.fileName
           }),
           React.createElement(SelectElement, {
             name: 'hideFile',
@@ -210,7 +210,7 @@ var MediaEditForm = function (_React$Component) {
             options: ["No", "Yes"],
             onUserInput: this.setFormData,
             ref: 'hideFile',
-            value: this.state.mediaData.hideFile
+            value: this.state.formData.hideFile
           }),
           React.createElement(ButtonElement, { label: 'Update File' })
         )

--- a/modules/media/js/uploadForm.js
+++ b/modules/media/js/uploadForm.js
@@ -161,7 +161,8 @@ var MediaUploadForm = function (_React$Component) {
             onUserInput: this.setFormData,
             ref: 'pscid',
             hasError: false,
-            required: true
+            required: true,
+            value: this.state.formData.pscid
           }),
           React.createElement(SelectElement, {
             name: 'visitLabel',
@@ -169,7 +170,8 @@ var MediaUploadForm = function (_React$Component) {
             options: this.state.Data.visits,
             onUserInput: this.setFormData,
             ref: 'visitLabel',
-            required: true
+            required: true,
+            value: this.state.formData.visitLabel
           }),
           React.createElement(SelectElement, {
             name: 'forSite',
@@ -177,14 +179,16 @@ var MediaUploadForm = function (_React$Component) {
             options: this.state.Data.sites,
             onUserInput: this.setFormData,
             ref: 'forSite',
-            required: true
+            required: true,
+            value: this.state.formData.forSite
           }),
           React.createElement(SelectElement, {
             name: 'instrument',
             label: 'Instrument',
             options: this.state.Data.instruments,
             onUserInput: this.setFormData,
-            ref: 'instrument'
+            ref: 'instrument',
+            value: this.state.formData.instrument
           }),
           React.createElement(DateElement, {
             name: 'dateTaken',
@@ -192,13 +196,15 @@ var MediaUploadForm = function (_React$Component) {
             minYear: '2000',
             maxYear: '2017',
             onUserInput: this.setFormData,
-            ref: 'dateTaken'
+            ref: 'dateTaken',
+            value: this.state.formData.dateTaken
           }),
           React.createElement(TextareaElement, {
             name: 'comments',
             label: 'Comments',
             onUserInput: this.setFormData,
-            ref: 'comments'
+            ref: 'comments',
+            value: this.state.formData.comments
           }),
           React.createElement(FileElement, {
             name: 'file',

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -156,14 +156,14 @@ class MediaEditForm extends React.Component {
             maxYear="2017"
             onUserInput={this.setFormData}
             ref="dateTaken"
-            value={this.state.mediaData.dateTaken}
+            value={this.state.formData.dateTaken}
           />
           <TextareaElement
             name="comments"
             label="Comments"
             onUserInput={this.setFormData}
             ref="comments"
-            value={this.state.mediaData.comments}
+            value={this.state.formData.comments}
           />
           <FileElement
             name="file"
@@ -173,7 +173,7 @@ class MediaEditForm extends React.Component {
             disabled={true}
             ref="file"
             label="Uploaded file"
-            value={this.state.mediaData.fileName}
+            value={this.state.formData.fileName}
           />
           <SelectElement
             name="hideFile"
@@ -182,7 +182,7 @@ class MediaEditForm extends React.Component {
             options={["No", "Yes"]}
             onUserInput={this.setFormData}
             ref="hideFile"
-            value={this.state.mediaData.hideFile}
+            value={this.state.formData.hideFile}
           />
           <ButtonElement label="Update File"/>
         </FormElement>

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -126,6 +126,7 @@ class MediaUploadForm extends React.Component {
             ref="pscid"
             hasError={false}
             required={true}
+            value={this.state.formData.pscid}
           />
           <SelectElement
             name="visitLabel"
@@ -134,6 +135,7 @@ class MediaUploadForm extends React.Component {
             onUserInput={this.setFormData}
             ref="visitLabel"
             required={true}
+            value={this.state.formData.visitLabel}
           />
           <SelectElement
             name="forSite"
@@ -142,6 +144,7 @@ class MediaUploadForm extends React.Component {
             onUserInput={this.setFormData}
             ref="forSite"
             required={true}
+            value={this.state.formData.forSite}
           />
           <SelectElement
             name="instrument"
@@ -149,6 +152,7 @@ class MediaUploadForm extends React.Component {
             options={this.state.Data.instruments}
             onUserInput={this.setFormData}
             ref="instrument"
+            value={this.state.formData.instrument}
           />
           <DateElement
             name="dateTaken"
@@ -157,12 +161,14 @@ class MediaUploadForm extends React.Component {
             maxYear="2017"
             onUserInput={this.setFormData}
             ref="dateTaken"
+            value={this.state.formData.dateTaken}
           />
           <TextareaElement
             name="comments"
             label="Comments"
             onUserInput={this.setFormData}
             ref="comments"
+            value={this.state.formData.comments}
           />
           <FileElement
             name="file"


### PR DESCRIPTION
These components were duplicating/mirroring state when they could use props instead. This change gives us a single source of truth for state and is more in line with the React idiom of preferring [controlled components](https://facebook.github.io/react/docs/forms.html#controlled-components) to uncontrolled ones.