### PR TITLE
Remove GitHub PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-Make sure you send your pull request to the right VERSIONNUMBER-dev branch.
-It's still possible to change it afterwards and if you are not sure which branch to send to, please consult the CONTRIBUTING.md.
-
-Please also make sure to indicate in the pull request title the general domain in which your pull request pertains to.
-For example, "[Core] Adding CentOS support to Install Script" or "[Document Repository] Adding functionality to group files under Categories".
-
-Also set appropriate Labels and Milestones as you see fit. Assignee is usually set to whoever may be the right person to test your pull request.


### PR DESCRIPTION
Make sure you send your pull request to the right VERSIONNUMBER-dev branch.
It's still possible to change it afterwards and if you are not sure which branch to send to, please consult the CONTRIBUTING.md.

Please also make sure to indicate in the pull request title the general domain in which your pull request pertains to.
For example, "[Core] Adding CentOS support to Install Script" or "[Document Repository] Adding functionality to group files under Categories".

Also set appropriate Labels and Milestones as you see fit. Assignee is usually set to whoever may be the right person to test your pull request.

It's annoying and not very helpful feature of GitHub
as currently implemented, I think it's better for people
to stick to writing a description.