### PR TITLE
[Scripts] Fix recreate conflicts script

### DIFF
--- a/tools/recreate_conflicts.php
+++ b/tools/recreate_conflicts.php
@@ -12,9 +12,8 @@
  */
 
 require_once __DIR__ . "/../vendor/autoload.php";
-require_once "../php/libraries/NDB_Client.class.inc";
-require_once "../php/libraries/NDB_Config.class.inc";
-require_once "../php/libraries/ConflictDetector.class.inc";
+require_once __DIR__ . "/../vendor/autoload.php";
+set_include_path(get_include_path().":".__DIR__."/../project/libraries:".":".__DIR__."/../php/libraries:");
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize();
@@ -45,16 +44,17 @@ if (empty($argv[1]) || $argv[1] == 'help') {
 }
 
 /**
-* Get cmd-line arguments
-*/
+ * Get cmd-line arguments
+ */
 // get $action argument
 $action         = $argv[1];
-$ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 
 if ($action=='all') {
     $allInstruments = Utility::getAllInstruments();
+    $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 } else {
     $allInstruments = array($action => $action);
+    $ddeInstruments = array($action => $action);
 }
 // clear the unresolved conflicts for all the instruments
 foreach ($allInstruments as $instrument=>$Full_name) {
@@ -70,11 +70,12 @@ foreach ($allInstruments as $instrument=>$Full_name) {
                                            AND c.Active='Y'",
         array('testname' => $instrument)
     );
-    
+
     foreach ($clear_conflicts as $conflict) {
         ConflictDetector::clearConflictsForInstance($conflict['CommentID']);
     }
 }
+
 foreach ($ddeInstruments as $test) {
     $instruments = $db->pselect(
         "SELECT CommentID, Test_name, CONCAT('DDE_',
@@ -95,7 +96,7 @@ foreach ($ddeInstruments as $test) {
         // If the instrument requires double data entry, check that DDE is also done
         if (in_array($instrument['Test_name'], $ddeInstruments)) {
             print "Recreating conflicts for " . $instrument['Test_name'] .
-                   ':'. $instrument['CommentID'] . "\n";
+                ':'. $instrument['CommentID'] . "\n";
             $diff = ConflictDetector::detectConflictsForCommentIds(
                 $instrument['Test_name'],
                 $instrument['CommentID'],

--- a/tools/recreate_conflicts.php
+++ b/tools/recreate_conflicts.php
@@ -12,7 +12,6 @@
  */
 
 require_once __DIR__ . "/../vendor/autoload.php";
-require_once __DIR__ . "/../vendor/autoload.php";
 set_include_path(get_include_path().":".__DIR__."/../project/libraries:".":".__DIR__."/../php/libraries:");
 $client = new NDB_Client();
 $client->makeCommandLine();


### PR DESCRIPTION
It was breaking on multiple instruments that required other files
Also, it was recreating conflicts for all DDE instruments instead of the one specified