### PR TITLE
Users with multi-center affiliation: Redmine 11021

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1318,7 +1318,6 @@ CREATE TABLE `users` (
   `Country` varchar(255) default NULL,
   `Fax` varchar(255) default NULL,
   `Email` varchar(255) NOT NULL default '',
-  `CenterID` tinyint(2) unsigned default NULL,
   `Privilege` tinyint(1) NOT NULL default '0',
   `PSCPI` enum('Y','N') NOT NULL default 'N',
   `DBAccess` varchar(10) NOT NULL default '',
@@ -1331,8 +1330,6 @@ CREATE TABLE `users` (
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Email` (`Email`),
   UNIQUE KEY `UserID` (`UserID`),
-  KEY `FK_users_1` (`CenterID`),
-  CONSTRAINT `FK_users_1` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
 --
@@ -1341,8 +1338,8 @@ CREATE TABLE `users` (
 
 LOCK TABLES `users` WRITE;
 /*!40000 ALTER TABLE `users` DISABLE KEYS */;
-INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,CenterID,Privilege,PSCPI,DBAccess,Active,Password_md5,Pending_approval,Password_expiry)
-VALUES (1,'admin','Admin account','Admin','account','admin@localhost',1,0,'N','','Y','4817577f267cc8bb20c3e58b48a311b9f6','N','2016-03-30');
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Password_md5,Pending_approval,Password_expiry)
+VALUES (1,'admin','Admin account','Admin','account','admin@localhost',0,'N','','Y','4817577f267cc8bb20c3e58b48a311b9f6','N','2016-03-30');
 /*!40000 ALTER TABLE `users` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -2355,3 +2352,17 @@ CREATE TABLE `issues_watching` (
   KEY `fk_issues_watching_2` (`issueID`),
   CONSTRAINT `fk_issues_watching_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `user_psc_rel`;
+CREATE TABLE `user_psc_rel` (
+  `UserID` int(10) unsigned NOT NULL default '0',
+  `CenterID` tinyint(2) unsigned default NULL,
+  PRIMARY KEY  (`UserID`,`CenterID`),
+  KEY `FK_user_psc_rel_2` (`CenterID`),
+  CONSTRAINT `FK_user_psc_rel_2` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_user_psc_rel_1` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO user_psc_rel (UserID, CenterID) VALUES
+    (1, 1);
+
+

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2355,8 +2355,8 @@ CREATE TABLE `issues_watching` (
 
 DROP TABLE IF EXISTS `user_psc_rel`;
 CREATE TABLE `user_psc_rel` (
-  `UserID` int(10) unsigned NOT NULL default '0',
-  `CenterID` tinyint(2) unsigned default NULL,
+  `UserID` int(10) unsigned NOT NULL,
+  `CenterID` tinyint(2) unsigned NOT NULL,
   PRIMARY KEY  (`UserID`,`CenterID`),
   KEY `FK_user_psc_rel_2` (`CenterID`),
   CONSTRAINT `FK_user_psc_rel_2` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1329,7 +1329,7 @@ CREATE TABLE `users` (
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Email` (`Email`),
-  UNIQUE KEY `UserID` (`UserID`),
+  UNIQUE KEY `UserID` (`UserID`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
 
 --

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2362,7 +2362,6 @@ CREATE TABLE `user_psc_rel` (
   CONSTRAINT `FK_user_psc_rel_2` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `FK_user_psc_rel_1` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-INSERT INTO user_psc_rel (UserID, CenterID) VALUES
-    (1, 1);
+INSERT INTO user_psc_rel (UserID, CenterID) SELECT 1, CenterID FROM psc;
 
 

--- a/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
+++ b/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
@@ -1,7 +1,7 @@
-DROP TABLE IF EXISTS `user_psc_rel`;
+WARNINGS;
 CREATE TABLE `user_psc_rel` (
-  `UserID` int(10) unsigned NOT NULL default '0',
-  `CenterID` tinyint(2) unsigned default NULL,
+  `UserID` int(10) unsigned NOT NULL,
+  `CenterID` tinyint(2) unsigned NOT NULL,
   PRIMARY KEY  (`UserID`,`CenterID`),
   KEY `FK_user_psc_rel_2` (`CenterID`),
   CONSTRAINT `FK_user_psc_rel_2` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -11,11 +11,10 @@ CREATE TABLE `user_psc_rel` (
 --
 -- Dumping data for table `user_psc_site`
 --
-LOCK TABLES `user_psc_rel` WRITE, `psc` READ, `users` READ;
-/*!40000 ALTER TABLE `user_psc_rel` DISABLE KEYS */;
-INSERT INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
-/*!40000 ALTER TABLE `user_psc_rel` ENABLE KEYS */;
-UNLOCK TABLES;
+
+INSERT IGNORE INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
+-- Add admin to the user_psc_rel
+INSERT IGNORE INTO `user_psc_rel` (UserID, CenterID) SELECT 1, CenterID FROM psc;
 
 -- DROP column CenterID from the users table
 -- ALTER TABLE users DROP foreign key FK_users_1;

--- a/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
+++ b/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
@@ -11,7 +11,6 @@ CREATE TABLE `user_psc_rel` (
 --
 -- Dumping data for table `user_psc_site`
 --
-SET foreign_key_checks = 0;
 LOCK TABLES `user_psc_rel` WRITE, `psc` READ, `users` READ;
 /*!40000 ALTER TABLE `user_psc_rel` DISABLE KEYS */;
 INSERT INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
@@ -19,7 +18,6 @@ INSERT INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
 INSERT INTO `user_psc_rel` (1,1);
 /*!40000 ALTER TABLE `user_psc_rel` ENABLE KEYS */;
 UNLOCK TABLES;
-SET foreign_key_checks = 1;
 
 -- DROP column CenterID from the users table
 -- ALTER TABLE users DROP foreign key FK_users_1;

--- a/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
+++ b/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
@@ -14,8 +14,6 @@ CREATE TABLE `user_psc_rel` (
 LOCK TABLES `user_psc_rel` WRITE, `psc` READ, `users` READ;
 /*!40000 ALTER TABLE `user_psc_rel` DISABLE KEYS */;
 INSERT INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
--- Add admin to the user_psc_rel
-INSERT INTO `user_psc_rel` (1,1);
 /*!40000 ALTER TABLE `user_psc_rel` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
+++ b/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
@@ -15,6 +15,12 @@ SET foreign_key_checks = 0;
 LOCK TABLES `user_psc_rel` WRITE, `psc` READ, `users` READ;
 /*!40000 ALTER TABLE `user_psc_rel` DISABLE KEYS */;
 INSERT INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
+-- Add admin to the user_psc_rel
+INSERT INTO `user_psc_rel` (1,1);
 /*!40000 ALTER TABLE `user_psc_rel` ENABLE KEYS */;
 UNLOCK TABLES;
 SET foreign_key_checks = 1;
+
+-- DROP column CenterID from the users table
+-- ALTER TABLE users DROP foreign key FK_users_1;
+-- ALTER TABLE users DROP column `CenterID`;

--- a/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
+++ b/SQL/Archive/17.1/2016-11-21-CreateUserSitesRelTable.sql
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS `user_psc_rel`;
+CREATE TABLE `user_psc_rel` (
+  `UserID` int(10) unsigned NOT NULL default '0',
+  `CenterID` tinyint(2) unsigned default NULL,
+  PRIMARY KEY  (`UserID`,`CenterID`),
+  KEY `FK_user_psc_rel_2` (`CenterID`),
+  CONSTRAINT `FK_user_psc_rel_2` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_user_psc_rel_1` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `user_psc_site`
+--
+SET foreign_key_checks = 0;
+LOCK TABLES `user_psc_rel` WRITE, `psc` READ, `users` READ;
+/*!40000 ALTER TABLE `user_psc_rel` DISABLE KEYS */;
+INSERT INTO `user_psc_rel` (UserID, CenterID) SELECT ID, CenterID FROM users;
+/*!40000 ALTER TABLE `user_psc_rel` ENABLE KEYS */;
+UNLOCK TABLES;
+SET foreign_key_checks = 1;

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,11 +74,18 @@ Vagrant.configure("2") do |config|
 
     apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php php-mysql php-gd php-json php-xml
 
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');
+    \\\$hash = trim(file_get_contents('https://composer.github.io/installer.sig'));
+    \\\$hashed = trim(hash_file('SHA384', 'composer-setup.php'));
+    if (\\\$hashed === \\\$hash) {
+        echo 'Installer verified';
+    } else {
+        echo 'Installer corrupt (Got ' . \\\$hashed . ' want ' . \\\$hash . ')';
+        unlink('composer-setup.php');
+    }
+    echo PHP_EOL;"
     php composer-setup.php
-    php -r "unlink('composer-setup.php');"
-
+    rm composer-setup.php;
     echo "Moving composer.phar to /usr/local/bin/composer such that composer can now be used globally."
 
     mv composer.phar /usr/local/bin/composer
@@ -94,7 +101,7 @@ Vagrant.configure("2") do |config|
     chmod 777 smarty/templates_c
     chmod 777 project
 
-    sed -e "s#%LORISROOT%#/var/www/loris#g" -e "s#%LOGDIRECTORY%#/var/log/apache2/#g" < docs/config/apache2-site | sudo tee /etc/apache2/sites-available/loris.conf
+    sed -e "s#%PROJECTNAME%#loris#g" -e "s#%LORISROOT%#/var/www/loris#g" -e "s#%LOGDIRECTORY%#/var/log/apache2/#g" < docs/config/apache2-site | sudo tee /etc/apache2/sites-available/loris.conf
     sudo a2dissite 000-default
     sudo a2ensite loris.conf    
     sudo a2enmod rewrite

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,18 +74,11 @@ Vagrant.configure("2") do |config|
 
     apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php php-mysql php-gd php-json php-xml
 
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');
-    \\\$hash = trim(file_get_contents('https://composer.github.io/installer.sig'));
-    \\\$hashed = trim(hash_file('SHA384', 'composer-setup.php'));
-    if (\\\$hashed === \\\$hash) {
-        echo 'Installer verified';
-    } else {
-        echo 'Installer corrupt (Got ' . \\\$hashed . ' want ' . \\\$hash . ')';
-        unlink('composer-setup.php');
-    }
-    echo PHP_EOL;"
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+    php -r "if (hash_file('SHA384', 'composer-setup.php') === 'e115a8dc7871f15d853148a7fbac7da27d6c0030b848d9b3dc09e2a0388afed865e6a3d6b3c0fad45c48e2b5fc1196ae') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
     php composer-setup.php
-    rm composer-setup.php;
+    php -r "unlink('composer-setup.php');"
+
     echo "Moving composer.phar to /usr/local/bin/composer such that composer can now be used globally."
 
     mv composer.phar /usr/local/bin/composer
@@ -101,7 +94,7 @@ Vagrant.configure("2") do |config|
     chmod 777 smarty/templates_c
     chmod 777 project
 
-    sed -e "s#%PROJECTNAME%#loris#g" -e "s#%LORISROOT%#/var/www/loris#g" -e "s#%LOGDIRECTORY%#/var/log/apache2/#g" < docs/config/apache2-site | sudo tee /etc/apache2/sites-available/loris.conf
+    sed -e "s#%LORISROOT%#/var/www/loris#g" -e "s#%LOGDIRECTORY%#/var/log/apache2/#g" < docs/config/apache2-site | sudo tee /etc/apache2/sites-available/loris.conf
     sudo a2dissite 000-default
     sudo a2ensite loris.conf    
     sudo a2enmod rewrite

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -80,16 +80,16 @@ $tpl_data['baseurl'] = $baseURL;
 $tpl_data['study_title'] = $config->getSetting('title');
 // draw the user information table
 try {
-    $user =& User::singleton();
+    $user     =& User::singleton();
     $site_arr = $user->getData('CenterIDs');
     foreach ($site_arr as $key=>$val) {
-        $site[$key] = & Site::singleton($val);
+        $site[$key]        = & Site::singleton($val);
         $isStudySite[$key] = $site[$key]->isStudySite();
     }
-    $oneIsStudySite = in_array("1", $isStudySite);
+    $oneIsStudySite   = in_array("1", $isStudySite);
     $tpl_data['user'] = $user->getData();
-    $tpl_data['user']['permissions']   = $user->getPermissions();
-    $tpl_data['hasHelpEditPermission'] = $user->hasPermission('context_help');
+    $tpl_data['user']['permissions']          = $user->getPermissions();
+    $tpl_data['hasHelpEditPermission']        = $user->hasPermission('context_help');
     $tpl_data['user']['user_from_study_site'] = $oneIsStudySite;
 } catch(Exception $e) {
     $tpl_data['error_message'][] = "Error: " . $e->getMessage();

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -81,12 +81,16 @@ $tpl_data['study_title'] = $config->getSetting('title');
 // draw the user information table
 try {
     $user =& User::singleton();
+    $site_arr = $user->getData('SiteID');
+    foreach ($site_arr as $key=>$val) {
+        $site[$key] = & Site::singleton($val);
+        $isStudySite[$key] = $site[$key]->isStudySite();
+    }
+    $oneIsStudySite = in_array("1", $isStudySite);
     $tpl_data['user'] = $user->getData();
     $tpl_data['user']['permissions']   = $user->getPermissions();
     $tpl_data['hasHelpEditPermission'] = $user->hasPermission('context_help');
-
-    $site =& Site::singleton($user->getData('CenterID'));
-    $tpl_data['user']['user_from_study_site'] = $site->isStudySite();
+    $tpl_data['user']['user_from_study_site'] = $oneIsStudySite;
 } catch(Exception $e) {
     $tpl_data['error_message'][] = "Error: " . $e->getMessage();
 }

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -81,7 +81,7 @@ $tpl_data['study_title'] = $config->getSetting('title');
 // draw the user information table
 try {
     $user =& User::singleton();
-    $site_arr = $user->getData('CentersID');
+    $site_arr = $user->getData('CenterIDs');
     foreach ($site_arr as $key=>$val) {
         $site[$key] = & Site::singleton($val);
         $isStudySite[$key] = $site[$key]->isStudySite();

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -81,7 +81,7 @@ $tpl_data['study_title'] = $config->getSetting('title');
 // draw the user information table
 try {
     $user =& User::singleton();
-    $site_arr = $user->getData('SiteID');
+    $site_arr = $user->getData('CentersID');
     foreach ($site_arr as $key=>$val) {
         $site[$key] = & Site::singleton($val);
         $isStudySite[$key] = $site[$key]->isStudySite();

--- a/htdocs/request_account/process_new_account.php
+++ b/htdocs/request_account/process_new_account.php
@@ -159,7 +159,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         $verif_box = htmlspecialchars($_REQUEST["verif_box"], ENT_QUOTES);
         $site      = htmlspecialchars($_REQUEST["site"], ENT_QUOTES);
 
-        // check to see if verificaton code was correct
+        // check to see if verification code was correct
         // if verification code was correct send the message and show this page
         $fullname = $name." ".$lastname;
         $vals     = array(
@@ -169,7 +169,6 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
                      'Last_name'        => $lastname,
                      'Pending_approval' => 'Y',
                      'Email'            => $from,
-                     'CenterID'         => $site,
                     );
 
         if ($_REQUEST['examiner']=='on') {
@@ -177,7 +176,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             if ($_REQUEST['radiologist']=='on') {
                 $rad =1;
             }
-            //insert in DB as inactive untill account approved
+            //insert in DB as inactive until account approved
             $DB->insert(
                 'examiners',
                 array(
@@ -197,11 +196,26 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         );
 
         if ($result == 0) {
-            // insert into db only if email address if it doesnt exist
-            $DB->insert('users', $vals);
+            // insert into DB only if email address doesn't exist
+            $success = $DB->insert('users', $vals);
         }
         // Show success message even if email already exists for security reasons
         $tpl_data['success'] = true;
+
+        // Get the ID of the new user and insert into user_psc_rel
+        $user_id = $DB->pselectOne(
+            "SELECT ID FROM users WHERE Email = :VEmail",
+            array('VEmail' => $from)
+        );
+
+        $DB->insert(
+            'user_psc_rel',
+            array(
+                'UserID' => $user_id,
+                'CenterID' => $site,
+            )
+        );
+
         unset($_SESSION['tntcon']);
     }
 }

--- a/htdocs/request_account/process_new_account.php
+++ b/htdocs/request_account/process_new_account.php
@@ -211,8 +211,8 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         $DB->insert(
             'user_psc_rel',
             array(
-                'UserID' => $user_id,
-                'CenterID' => $site,
+             'UserID'   => $user_id,
+             'CenterID' => $site,
             )
         );
 

--- a/modules/candidate_list/ajax/validateProfileIDs.php
+++ b/modules/candidate_list/ajax/validateProfileIDs.php
@@ -13,9 +13,15 @@
  */
 
 $user =& User::singleton();
-$site =& Site::singleton($user->getData('CenterID'));
+//$site =& Site::singleton($user->getData('CenterID'));
+$site_arr = $user->getData('SiteID');
+foreach ($site_arr as $key=>$val) {
+    $site[$key] = & Site::singleton($val);
+    $isStudySite[$key] = $site[$key]->isStudySite();
+    }
+$oneIsStudySite = in_array("1", $isStudySite);
 if (!($user->hasPermission('access_all_profiles')
-    || ($site->isStudySite() && $user->hasPermission('data_entry')))
+    || ($oneIsStudySite && $user->hasPermission('data_entry')))
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/candidate_list/ajax/validateProfileIDs.php
+++ b/modules/candidate_list/ajax/validateProfileIDs.php
@@ -13,8 +13,7 @@
  */
 
 $user =& User::singleton();
-//$site =& Site::singleton($user->getData('CenterID'));
-$site_arr = $user->getData('SiteID');
+$site_arr = $user->getData('CentersID');
 foreach ($site_arr as $key=>$val) {
     $site[$key] = & Site::singleton($val);
     $isStudySite[$key] = $site[$key]->isStudySite();

--- a/modules/candidate_list/ajax/validateProfileIDs.php
+++ b/modules/candidate_list/ajax/validateProfileIDs.php
@@ -12,12 +12,12 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user     =& User::singleton();
 $site_arr = $user->getData('CenterIDs');
 foreach ($site_arr as $key=>$val) {
-    $site[$key] = & Site::singleton($val);
+    $site[$key]        = & Site::singleton($val);
     $isStudySite[$key] = $site[$key]->isStudySite();
-    }
+}
 $oneIsStudySite = in_array("1", $isStudySite);
 if (!($user->hasPermission('access_all_profiles')
     || ($oneIsStudySite && $user->hasPermission('data_entry')))

--- a/modules/candidate_list/ajax/validateProfileIDs.php
+++ b/modules/candidate_list/ajax/validateProfileIDs.php
@@ -13,7 +13,7 @@
  */
 
 $user =& User::singleton();
-$site_arr = $user->getData('CentersID');
+$site_arr = $user->getData('CenterIDs');
 foreach ($site_arr as $key=>$val) {
     $site[$key] = & Site::singleton($val);
     $isStudySite[$key] = $site[$key]->isStudySite();

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -33,7 +33,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        $site_arr = $user->getData('CentersID');
+        $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
             $site[$key] = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
@@ -226,7 +226,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -138,17 +138,8 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         if (!$user->hasPermission('access_all_profiles')) {
 
-            $this->query .= " AND c.CenterID=";
-            $site_arr = $user->getCenterID();
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $val;
-                }
-                else {
-                    $this->query .= $val . " OR c.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 
         //'COALESCE(pso.ID,1) AS Participant_Status',
@@ -236,12 +227,13 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = & Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
         }
 
         // SubprojectID

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -33,8 +33,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-//        $site=& Site::singleton($user->getData('SiteID'));
-        $site_arr = $user->getData('SiteID');
+        $site_arr = $user->getData('CentersID');
         foreach ($site_arr as $key=>$val) {
             $site[$key] = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
@@ -44,7 +43,6 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
         $this->tpl_data['access_all_profiles'] = $aap;
         return (
             $user->hasPermission('access_all_profiles')
-//            || ($site->isStudySite() && $user->hasPermission('data_entry'))
             || ($oneIsStudySite && $user->hasPermission('data_entry'))
 
         );
@@ -140,7 +138,6 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         if (!$user->hasPermission('access_all_profiles')) {
 
-//            $this->query .= " AND c.CenterID=" . $user->getCenterID();
             $this->query .= " AND c.CenterID=";
             $site_arr = $user->getCenterID();
             $last_key = end(array_keys($site_arr));
@@ -238,8 +235,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-//            $site =& Site::singleton($user->getData('CenterID'));
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = & Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -233,7 +233,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 
         // SubprojectID

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -32,14 +32,14 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& User::singleton();
+        $user     =& User::singleton();
         $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
-            $site[$key] = & Site::singleton($val);
+            $site[$key]        = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
         }
         $oneIsStudySite = in_array("1", $isStudySite);
-        $aap  = $user->hasPermission('access_all_profiles');
+        $aap            = $user->hasPermission('access_all_profiles');
         $this->tpl_data['access_all_profiles'] = $aap;
         return (
             $user->hasPermission('access_all_profiles')
@@ -135,10 +135,9 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             LEFT JOIN subproject sp ON (s.SubprojectID=sp.SubprojectID)
             WHERE c.Active = 'Y'";
 
-
         if (!$user->hasPermission('access_all_profiles')) {
 
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -33,12 +33,20 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
     {
         // create user object
         $user =& User::singleton();
-        $site =& Site::singleton($user->getData('CenterID'));
+//        $site=& Site::singleton($user->getData('SiteID'));
+        $site_arr = $user->getData('SiteID');
+        foreach ($site_arr as $key=>$val) {
+            $site[$key] = & Site::singleton($val);
+            $isStudySite[$key] = $site[$key]->isStudySite();
+        }
+        $oneIsStudySite = in_array("1", $isStudySite);
         $aap  = $user->hasPermission('access_all_profiles');
         $this->tpl_data['access_all_profiles'] = $aap;
         return (
             $user->hasPermission('access_all_profiles')
-            || ($site->isStudySite() && $user->hasPermission('data_entry'))
+//            || ($site->isStudySite() && $user->hasPermission('data_entry'))
+            || ($oneIsStudySite && $user->hasPermission('data_entry'))
+
         );
     }
 
@@ -129,11 +137,24 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             LEFT JOIN subproject sp ON (s.SubprojectID=sp.SubprojectID)
             WHERE c.Active = 'Y'";
 
+
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND c.CenterID=" . $user->getCenterID();
+
+//            $this->query .= " AND c.CenterID=" . $user->getCenterID();
+            $this->query .= " AND c.CenterID=";
+            $site_arr = $user->getCenterID();
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $val;
+                }
+                else {
+                    $this->query .= $val . " OR c.CenterID=";
+                }
+            }
         }
 
-                          //'COALESCE(pso.ID,1) AS Participant_Status',
+        //'COALESCE(pso.ID,1) AS Participant_Status',
         $this->group_by = 'c.CandID, psc.Name, c.PSCID, c.Gender';
         $this->order_by = 'c.PSCID ASC';
 
@@ -217,10 +238,13 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites = array();
-                $list_of_sites[$user->getData('CenterID')] = $user->getData('Site');
+//            $site =& Site::singleton($user->getData('CenterID'));
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = & Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -250,7 +250,6 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $this->query .= " AND candidate.CenterID=";
-//            $this->query .= $user->getCenterID();
             $site_arr = $user->getCenterID();
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
@@ -362,11 +361,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-/*            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $sites = array($user->getData('CenterID') => $user->getData('Site'));
-            }*/
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] =& Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -250,7 +250,17 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $this->query .= " AND candidate.CenterID=";
-            $this->query .= $user->getCenterID();
+//            $this->query .= $user->getCenterID();
+            $site_arr = $user->getCenterID();
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $val;
+                }
+                else {
+                    $this->query .= $val . " OR candidate.CenterID=";
+                }
+            }
         }
 
         $this->group_by     = '';
@@ -352,9 +362,16 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
+/*            $site =& Site::singleton($user->getData('CenterID'));
             if ($site->isStudySite()) {
                 $sites = array($user->getData('CenterID') => $user->getData('Site'));
+            }*/
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] =& Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $sites[$val] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -249,17 +249,8 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         $user = User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
-            $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getCenterID();
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $val;
-                }
-                else {
-                    $this->query .= $val . " OR candidate.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
         $this->group_by     = '';
@@ -362,12 +353,13 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] =& Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $sites = array('' => 'User All Sites') + $sites;
         }
 
         // Add form elements

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -359,7 +359,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         }
 
         // Add form elements

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -249,7 +249,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         $user = User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -352,7 +352,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -89,7 +89,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $site_arr = implode(",", $user->getCenterID());
-            $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
         $this->group_by     = '';

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -200,7 +200,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -89,7 +89,6 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $this->query .= " AND candidate.CenterID=";
-//            $this->query .= $user->getCenterID();
             $site_arr = $user->getCenterID();
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
@@ -210,11 +209,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
- /*           $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $sites = array($user->getData('CenterID') => $user->getData('Site'));
-            }*/
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] =& Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -88,17 +88,8 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
-            $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getCenterID();
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $val;
-                }
-                else {
-                    $this->query .= $val . " OR candidate.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
         }
 
         $this->group_by     = '';
@@ -210,13 +201,15 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] =& Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $sites = array('' => 'User All Sites') + $sites;
         }
+
 
         // Add form elements
         $this->addSelect('site', 'Site:', $sites);

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -89,7 +89,17 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $this->query .= " AND candidate.CenterID=";
-            $this->query .= $user->getCenterID();
+//            $this->query .= $user->getCenterID();
+            $site_arr = $user->getCenterID();
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $val;
+                }
+                else {
+                    $this->query .= $val . " OR candidate.CenterID=";
+                }
+            }
         }
 
         $this->group_by     = '';
@@ -200,9 +210,16 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
+ /*           $site =& Site::singleton($user->getData('CenterID'));
             if ($site->isStudySite()) {
                 $sites = array($user->getData('CenterID') => $user->getData('Site'));
+            }*/
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] =& Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $sites[$val] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -207,7 +207,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         }
 
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -88,7 +88,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
@@ -209,7 +209,6 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             }
             $sites = array('' => 'All User Sites') + $sites;
         }
-
 
         // Add form elements
         $this->addSelect('site', 'Site:', $sites);

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -45,8 +45,7 @@ class Create_Timepoint extends \NDB_Form
         // check user permissions
         return (
             $user->hasPermission('data_entry') &&
-  //          $user->getData('CenterID') == $candidate->getData('CenterID')
-            (in_array($candidate->getData('CenterID'), $user->getData('SiteID')))
+            (in_array($candidate->getData('CenterID'), $user->getData('CentersID')))
         );
     }
 
@@ -73,9 +72,6 @@ class Create_Timepoint extends \NDB_Form
      */
     function _process($values)
     {
-print_r("\n");
-print_r($values);
-print_r("\n");
         $success = \TimePoint::createNew(
             $this->identifier,
             $values['subprojectID'],
@@ -195,10 +191,8 @@ print_r("\n");
              // List of sites for the user
              $user = \User::singleton();
              $DB = \Database::singleton();
-             $user_list_of_sites = $user->getData('SiteID');
-             print_r ($user_list_of_sites);
+             $user_list_of_sites = $user->getData('CentersID');
              $num_sites = count($user_list_of_sites);
-             print_r ($num_sites);
 
              if ($num_sites >1) {
                  $pscLabelAdded=true;

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -41,7 +41,6 @@ class Create_Timepoint extends \NDB_Form
         $user =& \User::singleton();
 
         $candidate =& \Candidate::singleton($this->identifier);
-        print_r ($user->getData('SiteID'));
 
         // check user permissions
         return (
@@ -74,10 +73,14 @@ class Create_Timepoint extends \NDB_Form
      */
     function _process($values)
     {
+print_r("\n");
+print_r($values);
+print_r("\n");
         $success = \TimePoint::createNew(
             $this->identifier,
             $values['subprojectID'],
-            $values['visitLabel']
+            $values['visitLabel'],
+            $values['psc']
         );
 
         $this->tpl_data['success'] = true;
@@ -189,6 +192,23 @@ class Create_Timepoint extends \NDB_Form
         // label rules
         if ($visitLabelAdded) {
             $this->addRule('visitLabel', 'Visit label is required', 'required');
+             // List of sites for the user
+             $user = \User::singleton();
+             $DB = \Database::singleton();
+             $user_list_of_sites = $user->getData('SiteID');
+             print_r ($user_list_of_sites);
+             $num_sites = count($user_list_of_sites);
+             print_r ($num_sites);
+
+             if ($num_sites >1) {
+                 $pscLabelAdded=true;
+                 $psc_labelOptions = array(null => '');
+                 foreach ($user_list_of_sites as $key => $siteID) {
+                         $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
+                         $psc_labelOptions[$siteID] = $center['Name'];
+                 }
+            }
+            $this->addSelect('psc', 'Site', $psc_labelOptions);
         }
 
         $this->form->addFormRule(array(&$this, '_validate'));

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -41,11 +41,13 @@ class Create_Timepoint extends \NDB_Form
         $user =& \User::singleton();
 
         $candidate =& \Candidate::singleton($this->identifier);
+        print_r ($user->getData('SiteID'));
 
         // check user permissions
         return (
             $user->hasPermission('data_entry') &&
-            $user->getData('CenterID') == $candidate->getData('CenterID')
+  //          $user->getData('CenterID') == $candidate->getData('CenterID')
+            (in_array($candidate->getData('CenterID'), $user->getData('SiteID')))
         );
     }
 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -45,7 +45,7 @@ class Create_Timepoint extends \NDB_Form
         // check user permissions
         return (
             $user->hasPermission('data_entry') &&
-            (in_array($candidate->getData('CenterID'), $user->getData('CentersID')))
+            (in_array($candidate->getData('CenterID'), $user->getData('CenterIDs')))
         );
     }
 
@@ -191,7 +191,7 @@ class Create_Timepoint extends \NDB_Form
              // List of sites for the user
              $user = \User::singleton();
              $DB = \Database::singleton();
-             $user_list_of_sites = $user->getData('CentersID');
+             $user_list_of_sites = $user->getData('CenterIDs');
              $num_sites = count($user_list_of_sites);
 
              if ($num_sites >1) {

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -195,7 +195,7 @@ class Create_Timepoint extends \NDB_Form
              $num_sites          = count($user_list_of_sites);
 
             if ($num_sites >1) {
-                $pscLabelAdded    =true;
+                $pscLabelAdded =true;
                 $this->tpl_data['pscLabelAdded'] = true;
                 $psc_labelOptions = array(null => '');
                 foreach ($user_list_of_sites as $key => $siteID) {

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -190,17 +190,17 @@ class Create_Timepoint extends \NDB_Form
             $this->addRule('visitLabel', 'Visit label is required', 'required');
              // List of sites for the user
              $user = \User::singleton();
-             $DB = \Database::singleton();
+             $DB   = \Database::singleton();
              $user_list_of_sites = $user->getData('CenterIDs');
-             $num_sites = count($user_list_of_sites);
+             $num_sites          = count($user_list_of_sites);
 
-             if ($num_sites >1) {
-                 $pscLabelAdded=true;
-                 $psc_labelOptions = array(null => '');
-                 foreach ($user_list_of_sites as $key => $siteID) {
-                         $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
-                         $psc_labelOptions[$siteID] = $center['Name'];
-                 }
+            if ($num_sites >1) {
+                $pscLabelAdded    =true;
+                $psc_labelOptions = array(null => '');
+                foreach ($user_list_of_sites as $key => $siteID) {
+                        $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
+                        $psc_labelOptions[$siteID] = $center['Name'];
+                }
             }
             $this->addSelect('psc', 'Site', $psc_labelOptions);
         }

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -198,7 +198,11 @@ class Create_Timepoint extends \NDB_Form
                 $pscLabelAdded    =true;
                 $psc_labelOptions = array(null => '');
                 foreach ($user_list_of_sites as $key => $siteID) {
-                        $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
+                        $center = $DB->pselectRow(
+                            "SELECT CenterID as ID, Name FROM psc 
+                        WHERE CenterID =:cid",
+                            array('cid' => $siteID)
+                        );
                         $psc_labelOptions[$siteID] = $center['Name'];
                 }
             }

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -196,6 +196,7 @@ class Create_Timepoint extends \NDB_Form
 
             if ($num_sites >1) {
                 $pscLabelAdded    =true;
+                $this->tpl_data['pscLabelAdded'] = true;
                 $psc_labelOptions = array(null => '');
                 foreach ($user_list_of_sites as $key => $siteID) {
                         $center = $DB->pselectRow(

--- a/modules/create_timepoint/templates/form_create_timepoint.tpl
+++ b/modules/create_timepoint/templates/form_create_timepoint.tpl
@@ -24,6 +24,10 @@
 		<div class="col-sm-2">{$form.subprojectID.html}</div>
 	</div>
 	<div class="form-group col-sm-12">
+		<label class="col-sm-2">{$form.psc.label}</label>
+		<div class="col-sm-2">{$form.psc.html}</div>
+	</div>
+	<div class="form-group col-sm-12">
 		<label class="col-sm-2">{$form.visitLabel.label}</label>
 		<div class="col-sm-2">{$form.visitLabel.html}</div>
 	</div>

--- a/modules/create_timepoint/templates/form_create_timepoint.tpl
+++ b/modules/create_timepoint/templates/form_create_timepoint.tpl
@@ -23,10 +23,12 @@
 		<label class="col-sm-2">{$form.subprojectID.label}</label>
 		<div class="col-sm-2">{$form.subprojectID.html}</div>
 	</div>
-	<div class="form-group col-sm-12">
-		<label class="col-sm-2">{$form.psc.label}</label>
-		<div class="col-sm-2">{$form.psc.html}</div>
-	</div>
+    {if $pscLabelAdded}
+	    <div class="form-group col-sm-12">
+		    <label class="col-sm-2">{$form.psc.label}</label>
+		    <div class="col-sm-2">{$form.psc.html}</div>
+	    </div>
+    {/if}
 	<div class="form-group col-sm-12">
 		<label class="col-sm-2">{$form.visitLabel.label}</label>
 		<div class="col-sm-2">{$form.visitLabel.html}</div>

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -199,17 +199,21 @@ class NDB_Form_Dashboard extends NDB_Form
             && $user->hasPermission('user_accounts')
         ) {
             $this->tpl_data['pending_users']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM users
-		WHERE Pending_approval='Y' AND (CenterID <> 1 OR CenterID IS NULL)",
+                "SELECT COUNT(*) FROM users 
+                LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
+		        WHERE users.Pending_approval='Y' AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
                 array()
             );
             $this->tpl_data['pending_users_site'] = 'Site: all';
         } elseif ($user->hasPermission('user_accounts')) {
+            $site_arr = $user->getCenterID();
             $this->tpl_data['pending_users']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM users 
-                 WHERE Pending_approval='Y' AND CenterID=:CID",
-                array('CID' => $siteID)
-            );
+            "SELECT COUNT(*) FROM users 
+                LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
+		        WHERE users.Pending_approval='Y' AND CenterID IN (:CID)",
+                array('CID' => implode(",", $site_arr))
+           );
+
             $this->tpl_data['pending_users_site'] = 'Site: ' . $site;
         }
 

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -50,6 +50,7 @@ class NDB_Form_Dashboard extends NDB_Form
         );
 
         $siteID = $user->getCenterID();
+        print_r($siteID);
         $this->tpl_data['user_site'] = $siteID;
 
         // Welcome panel

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -201,7 +201,8 @@ class NDB_Form_Dashboard extends NDB_Form
             $this->tpl_data['pending_users']      = $DB->pselectOne(
                 "SELECT COUNT(*) FROM users 
                 LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
-		        WHERE users.Pending_approval='Y' AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
+		        WHERE users.Pending_approval='Y' 
+                AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
                 array()
             );
             $this->tpl_data['pending_users_site'] = 'Site: all';

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -50,7 +50,6 @@ class NDB_Form_Dashboard extends NDB_Form
         );
 
         $siteID = $user->getCenterID();
-        print_r($siteID);
         $this->tpl_data['user_site'] = $siteID;
 
         // Welcome panel

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -207,12 +207,12 @@ class NDB_Form_Dashboard extends NDB_Form
             $this->tpl_data['pending_users_site'] = 'Site: all';
         } elseif ($user->hasPermission('user_accounts')) {
             $site_arr = $user->getCenterID();
-            $this->tpl_data['pending_users']      = $DB->pselectOne(
-            "SELECT COUNT(*) FROM users 
+            $this->tpl_data['pending_users'] = $DB->pselectOne(
+                "SELECT COUNT(*) FROM users 
                 LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
 		        WHERE users.Pending_approval='Y' AND CenterID IN (:CID)",
                 array('CID' => implode(",", $site_arr))
-           );
+            );
 
             $this->tpl_data['pending_users_site'] = 'Site: ' . $site;
         }

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -49,7 +49,7 @@ class NDB_Form_Dashboard extends NDB_Form
             array('UserID' => $userID)
         );
 
-        $siteID = $user->getCenterID();
+        $siteID = implode(',', $user->getCenterID());
         $this->tpl_data['user_site'] = $siteID;
 
         // Welcome panel
@@ -121,7 +121,7 @@ class NDB_Form_Dashboard extends NDB_Form
 			AND s.CenterID <> 1",
                 array()
             );
-            $this->tpl_data['new_scans_site'] = 'Site: all';
+            $this->tpl_data['new_scans_site'] = 'Sites: all';
         }
 
         // Data entry conflicts
@@ -136,7 +136,7 @@ class NDB_Form_Dashboard extends NDB_Form
 			AND s.Active='Y' AND c.Active='Y'",
                     array()
                 );
-                $this->tpl_data['conflicts_site'] = 'Site: all';
+                $this->tpl_data['conflicts_site'] = 'Sites: all';
             } else {
                 $this->tpl_data['conflicts']      = $DB->pselectOne(
                     "SELECT COUNT(*) FROM conflicts_unresolved cu 
@@ -144,11 +144,11 @@ class NDB_Form_Dashboard extends NDB_Form
                      LEFT JOIN session s ON (flag.SessionID=s.ID)
 		             LEFT JOIN candidate c ON (c.CandID=s.CandID)
                      LEFT JOIN psc ON (psc.CenterID=s.CenterID) 
-                     WHERE psc.Name=:Site
+                     WHERE FIND_IN_SET(psc.CenterID, :siteID) 
 			            AND s.Active='Y' AND c.Active='Y'",
-                    array('Site' => $site)
+                    array('siteID' => $siteID)
                 );
-                $this->tpl_data['conflicts_site'] = 'Site: ' . $site;
+                $this->tpl_data['conflicts_site'] = 'Sites: ' . $site;
             }
         }
 
@@ -163,18 +163,19 @@ class NDB_Form_Dashboard extends NDB_Form
 			AND s.Active='Y' AND c.Active='Y' AND s.CenterID <> 1",
                     array()
                 );
-                $this->tpl_data['incomplete_forms_site'] = 'Site: all';
+                $this->tpl_data['incomplete_forms_site'] = 'Sites: all';
             } else {
                 $this->tpl_data['incomplete_forms']      = $DB->pselectOne(
-                    "SELECT COUNT(*) FROM flag 
+                    "SELECT COUNT(*) FROM flag
                     LEFT JOIN session s ON (flag.SessionID=s.ID)
 			LEFT JOIN candidate c ON (s.CandID=c.CandID)
                     LEFT JOIN psc ON (psc.CenterID=s.CenterID) 
-                    WHERE Data_entry='In Progress' AND psc.Name=:Site
+                    WHERE Data_entry='In Progress' 
+                    AND FIND_IN_SET(psc.CenterID, :siteID)
 			          AND s.Active='Y' AND c.Active='Y'",
-                    array('Site' => $site)
+                    array('siteID' => $siteID)
                 );
-                $this->tpl_data['incomplete_forms_site'] = 'Site: ' . $site;
+                $this->tpl_data['incomplete_forms_site'] = 'Sites: ' . $site;
             }
         }
 
@@ -191,7 +192,7 @@ class NDB_Form_Dashboard extends NDB_Form
 			AND c.Active='Y' AND s.Active='Y'",
                 array()
             );
-            $this->tpl_data['radiology_review_site'] = 'Site: all';
+            $this->tpl_data['radiology_review_site'] = 'Sites: all';
         }
 
         // Accounts pending approval
@@ -205,7 +206,7 @@ class NDB_Form_Dashboard extends NDB_Form
                 AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
                 array()
             );
-            $this->tpl_data['pending_users_site'] = 'Site: all';
+            $this->tpl_data['pending_users_site'] = 'Sites: all';
         } elseif ($user->hasPermission('user_accounts')) {
             $site_arr = $user->getCenterID();
             $this->tpl_data['pending_users'] = $DB->pselectOne(
@@ -215,7 +216,7 @@ class NDB_Form_Dashboard extends NDB_Form
                 array('CID' => implode(",", $site_arr))
             );
 
-            $this->tpl_data['pending_users_site'] = 'Site: ' . $site;
+            $this->tpl_data['pending_users_site'] = 'Sites: ' . $site;
         }
 
         // Violated scans
@@ -228,7 +229,7 @@ class NDB_Form_Dashboard extends NDB_Form
                 filter things out */
                 array()
             );
-            $this->tpl_data['violated_scans_site'] = 'Site: all';
+            $this->tpl_data['violated_scans_site'] = 'Sites: all';
         }
 
         // Document Repository Items
@@ -264,9 +265,9 @@ class NDB_Form_Dashboard extends NDB_Form
 
             // I suppose you could also base it on your query
             if ($user->hasPermission('access_all_profiles')) {
-                $this->tpl_data['issues_assigned_site'] = 'Site: all';
+                $this->tpl_data['issues_assigned_site'] = 'Sites: all';
             } else {
-                $this->tpl_data['issues_assigned_site'] = 'Site: '.
+                $this->tpl_data['issues_assigned_site'] = 'Sites: '.
                     $user->getSiteName();
             }
         }

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -212,7 +212,7 @@ class NDB_Form_Dashboard extends NDB_Form
             $this->tpl_data['pending_users'] = $DB->pselectOne(
                 "SELECT COUNT(*) FROM users 
                 LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
-		        WHERE users.Pending_approval='Y' AND CenterID IN (:CID)",
+		        WHERE users.Pending_approval='Y' AND upr.CenterID IN (:CID)",
                 array('CID' => implode(",", $site_arr))
             );
 

--- a/modules/dashboard/templates/form_dashboard.tpl
+++ b/modules/dashboard/templates/form_dashboard.tpl
@@ -145,7 +145,7 @@
                                 </a>
                             {/if}
                             {if $incomplete_forms neq "" and $incomplete_forms neq 0}
-                            {if $incomplete_forms_site eq "Site: all"}
+                            {if $incomplete_forms_site eq "Sites: all"}
                             <a href="{$baseURL}/statistics/?submenu=statistics_site" class="list-group-item statistics">
                                 {else}
                                 <a href="{$baseURL}/statistics/?submenu=statistics_site&CenterID={$user_site}"

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -47,8 +47,18 @@ class DashboardTest extends LorisIntegrationTest
              'UserID'          => 'testUser1',
              'Email'           => 'test@test.com',
              'Password'        => 'AA1234567!',
-             'CenterID'        => '1',
              'Password_expiry' => '2020-01-06',
+            )
+        );
+        $user_id = $this->DB->pselectOne(
+            "SELECT ID FROM users WHERE UserID=:test_user_id",
+            array("test_user_id" => 'testUser1')
+        );
+        $this->DB->insert(
+            "users",
+            array(
+                'UserID'          => $user_id,
+                'CenterID'        => '1',
             )
         );
         //Insert two violation scan

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -247,8 +247,8 @@ class DashboardTest extends LorisIntegrationTest
           $this->DB->insert(
               "users",
               array(
-               'ID'       => '9999991',
-               'UserID'   => 'Tester1',
+               'ID'     => '9999991',
+               'UserID' => 'Tester1',
               )
           );
           $this->DB->insert(

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -57,8 +57,8 @@ class DashboardTest extends LorisIntegrationTest
         $this->DB->insert(
             "user_psc_rel",
             array(
-                'UserID'          => $user_id,
-                'CenterID'        => '1',
+             'UserID'   => $user_id,
+             'CenterID' => '1',
             )
         );
         //Insert two violation scan

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -249,7 +249,6 @@ class DashboardTest extends LorisIntegrationTest
               array(
                'ID'       => '9999991',
                'UserID'   => 'Tester1',
-               'CenterID' => null,
               )
           );
           $this->DB->insert(

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -55,7 +55,7 @@ class DashboardTest extends LorisIntegrationTest
             array("test_user_id" => 'testUser1')
         );
         $this->DB->insert(
-            "users",
+            "user_psc_rel",
             array(
                 'UserID'          => $user_id,
                 'CenterID'        => '1',

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -101,7 +101,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
-                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
             }
         }
 

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -95,7 +95,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $list_of_sites = '';
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -95,7 +95,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $list_of_sites = '';
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -96,11 +96,12 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
             // allow only to view own site data
             $list_of_sites = '';
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
+            foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
+                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
             }
         }
 

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -94,9 +94,13 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
             if (is_array($list_of_sites)) $list_of_sites = array(null => 'Any') + $list_of_sites;
         } else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
+            $list_of_sites = '';
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = &Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -63,7 +63,7 @@ class NDB_Form_Examiner extends NDB_Form
 
             return $user->hasPermission('examiner_view')
                 && (($user->hasPermission('examiner_multisite')
-                || in_array($centerID, $user->getData('CentersID'))));
+                || in_array($centerID, $user->getData('CenterIDs'))));
         }
         return false;
     }

--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -63,7 +63,7 @@ class NDB_Form_Examiner extends NDB_Form
 
             return $user->hasPermission('examiner_view')
                 && (($user->hasPermission('examiner_multisite')
-                || in_array($centerID, $user->getData('SiteID'))));
+                || in_array($centerID, $user->getData('CentersID'))));
         }
         return false;
     }

--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -63,7 +63,7 @@ class NDB_Form_Examiner extends NDB_Form
 
             return $user->hasPermission('examiner_view')
                 && (($user->hasPermission('examiner_multisite')
-                || $user->getData('CenterID') == $centerID));
+                || in_array($centerID, $user->getData('SiteID'))));
         }
         return false;
     }

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -135,7 +135,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         }
 
         // Radiologist options

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -66,7 +66,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
 
         $user = User::singleton();
         if (!$user->hasPermission('examiner_multisite')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND e.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -66,7 +66,6 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
 
         $user = User::singleton();
         if (!$user->hasPermission('examiner_multisite')) {
-//            $query .= " AND e.CenterID=" . $DB->quote($user->getData('CenterID'));
             $query .= " AND e.CenterID=";
             $site_arr = $user->getCenterID();
             $last_key = end(array_keys($site_arr));
@@ -138,11 +137,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-/*           $site = Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $sites = array($user->getData('CenterID') => $user->getData('Site'));
-            }*/
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site_arr[$key] = Site::singleton($val);
                 if ($site_arr[$key]->isStudySite()) {

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -66,7 +66,18 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
 
         $user = User::singleton();
         if (!$user->hasPermission('examiner_multisite')) {
-            $query .= " AND e.CenterID=" . $DB->quote($user->getData('CenterID'));
+//            $query .= " AND e.CenterID=" . $DB->quote($user->getData('CenterID'));
+            $query .= " AND e.CenterID=";
+            $site_arr = $user->getCenterID();
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $query .= $val;
+                 }
+                else {
+                    $query .= $val . " OR e.CenterID=";
+                 }
+            }
         }
 
         // set the class variables
@@ -127,9 +138,16 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $site = Site::singleton($user->getData('CenterID'));
+/*           $site = Site::singleton($user->getData('CenterID'));
             if ($site->isStudySite()) {
                 $sites = array($user->getData('CenterID') => $user->getData('Site'));
+            }*/
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site_arr[$key] = Site::singleton($val);
+                if ($site_arr[$key]->isStudySite()) {
+                    $sites[$val] = $site_arr[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -128,7 +128,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -66,17 +66,8 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
 
         $user = User::singleton();
         if (!$user->hasPermission('examiner_multisite')) {
-            $query .= " AND e.CenterID=";
-            $site_arr = $user->getCenterID();
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $query .= $val;
-                 }
-                else {
-                    $query .= $val . " OR e.CenterID=";
-                 }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND e.CenterID IN (" . $site_arr . ")";
         }
 
         // set the class variables
@@ -138,12 +129,13 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site_arr[$key] = Site::singleton($val);
-                if ($site_arr[$key]->isStudySite()) {
-                    $sites[$val] = $site_arr[$key]->getCenterName();
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $sites = array('' => 'User All Sites') + $sites;
         }
 
         // Radiologist options

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -145,7 +145,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $DB   = Database::singleton();
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -146,7 +146,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -236,7 +236,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -233,7 +233,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
-                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -146,7 +146,16 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $this->query .= " AND candidate.CenterID=";
-            $this->query .= $DB->quote($user->getCenterID());
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $DB->quote($val);
+                }
+                else {
+                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
+                }
+            }
         }
 
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
@@ -227,11 +236,12 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site = Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $centerIDdata  = $user->getData('CenterID');
-                $siteData      = $user->getData('Site');
-                $list_of_sites = array($centerIDdata => $siteData);
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -145,17 +145,8 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $DB   = Database::singleton();
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $DB->quote($val);
-                }
-                else {
-                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
@@ -237,11 +228,12 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
+                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -227,7 +227,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -268,7 +268,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -274,7 +274,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
-                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -166,9 +166,17 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         $user = User::singleton();
 
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            // restrict data to own site
             $this->query .= " AND candidate.CenterID=";
-            $this->query .= $DB->quote($user->getCenterID());
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $DB->quote($val);
+                }
+                else {
+                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
+                }
+            }
         }
 
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
@@ -269,10 +277,12 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site = Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites
-                    = array($user->getData('CenterID') => $user->getData('Site'));
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -167,7 +167,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
 
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -277,7 +277,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -166,17 +166,8 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         $user = User::singleton();
 
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $DB->quote($val);
-                }
-                else {
-                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
@@ -278,11 +269,12 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
+                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -166,7 +166,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         $user = User::singleton();
 
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -186,7 +186,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -125,7 +125,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             // allow only to view own site data
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -192,7 +192,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
-                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -125,7 +125,16 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $this->query .= " AND candidate.CenterID=";
-            $this->query .= $DB->quote($user->getCenterID());
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $DB->quote($val);
+                }
+                else {
+                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
+                }
+            }
         }
 
         $this->group_by     = '';
@@ -185,11 +194,12 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site = Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $centerIDdata  = $user->getData('CenterID');
-                $siteData      = $user->getData('Site');
-                $list_of_sites = array($centerIDdata => $siteData);
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -125,7 +125,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -194,7 +194,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -124,17 +124,9 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         $DB   = Database::singleton();
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $DB->quote($val);
-                }
-                else {
-                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
-                }
-            }
+            // allow only to view own site data
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
         $this->group_by     = '';
@@ -195,11 +187,12 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
+                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -155,9 +155,17 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $DB   = Database::singleton();
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            // restrict data to own site
             $this->query .= " AND candidate.CenterID=";
-            $this->query .= $DB->quote($user->getCenterID());
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $DB->quote($val);
+                }
+                else {
+                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
+                }
+            }
         }
 
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
@@ -254,11 +262,12 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site = Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $centerIDdata  = $user->getData('CenterID');
-                $siteData      = $user->getData('Site');
-                $list_of_sites = array($centerIDdata => $siteData);
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -155,17 +155,9 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $DB   = Database::singleton();
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $DB->quote($val);
-                }
-                else {
-                    $this->query .= $DB->quote($val) . " OR candidate.CenterID=";
-                }
-            }
+            // restrict data to own site
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
         $this->order_by     = 'psc.Name, candidate.CandID DESC';
@@ -263,11 +255,12 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
+                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -260,7 +260,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
-                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
             }
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -156,7 +156,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             // restrict data to own site
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -254,7 +254,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -156,7 +156,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $this->query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -262,7 +262,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -51,8 +51,7 @@ class NDB_Form_Imaging_Browser extends NDB_Form
         // allow only to view own site data
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
 
-//        return ($user->hasPermission('imaging_browser_view_allsites') || ($user->getData('CenterID') == $timePoint->getData('CenterID') && $user->hasPermission('imaging_browser_view_site')));
-        return ($user->hasPermission('imaging_browser_view_allsites') || ((in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))) && $user->hasPermission('imaging_browser_view_site')));
+        return ($user->hasPermission('imaging_browser_view_allsites') || ((in_array($timePoint->getData('CenterID'), $user->getData('CentersID'))) && $user->hasPermission('imaging_browser_view_site')));
     }
 
     /**

--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -51,7 +51,7 @@ class NDB_Form_Imaging_Browser extends NDB_Form
         // allow only to view own site data
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
 
-        return ($user->hasPermission('imaging_browser_view_allsites') || ((in_array($timePoint->getData('CenterID'), $user->getData('CentersID'))) && $user->hasPermission('imaging_browser_view_site')));
+        return ($user->hasPermission('imaging_browser_view_allsites') || ((in_array($timePoint->getData('CenterID'), $user->getData('CenterIDs'))) && $user->hasPermission('imaging_browser_view_site')));
     }
 
     /**

--- a/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Form_imaging_browser.class.inc
@@ -51,7 +51,8 @@ class NDB_Form_Imaging_Browser extends NDB_Form
         // allow only to view own site data
         $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
 
-        return ($user->hasPermission('imaging_browser_view_allsites') || ($user->getData('CenterID') == $timePoint->getData('CenterID') && $user->hasPermission('imaging_browser_view_site')));
+//        return ($user->hasPermission('imaging_browser_view_allsites') || ($user->getData('CenterID') == $timePoint->getData('CenterID') && $user->hasPermission('imaging_browser_view_site')));
+        return ($user->hasPermission('imaging_browser_view_allsites') || ((in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))) && $user->hasPermission('imaging_browser_view_site')));
     }
 
     /**

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -38,9 +38,15 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user =& User::singleton();
 
         // allow only to view own site data
-        $site =& Site::singleton($user->getData('CenterID'));
+//        $site =& Site::singleton($user->getData('CenterID'));
+        $site_arr = $user->getData('SiteID');
+        foreach ($site_arr as $key=>$val) {
+            $site[$key] = & Site::singleton($val);
+            $isStudySite[$key] = $site[$key]->isStudySite();
+        }
+        $oneIsStudySite = in_array("1", $isStudySite);
 
-        return ($user->hasPermission('imaging_browser_view_allsites') || ($site->isStudySite() && $user->hasPermission('imaging_browser_view_site')));
+        return ($user->hasPermission('imaging_browser_view_allsites') || ($oneIsStudySite && $user->hasPermission('imaging_browser_view_site')));
     }
 
     /**
@@ -99,7 +105,18 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user =& User::singleton();
         $DB = Database::singleton();
         if (!$user->hasPermission('imaging_browser_view_allsites')) {
-            $this->query .= " AND c.CenterID=" . $DB->quote($user->getCenterID());
+            //$this->query .= " AND c.CenterID=" . $DB->quote($user->getCenterID());
+            $this->query .= " AND c.CenterID=";
+            $site_arr = $user->getCenterID();
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $val;
+                }
+                else {
+                    $this->query .= $val . " OR c.CenterID=";
+                }
+            }
         }
 
         $this->columns = array(

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -211,7 +211,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
-                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
             }
         }
 

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -216,9 +216,16 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         }
         else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
+//            $site =& Site::singleton($user->getData('CenterID'));
+//            if ($site->isStudySite()) {
+//                $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
+//            }
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = & Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -104,17 +104,8 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user =& User::singleton();
         $DB = Database::singleton();
         if (!$user->hasPermission('imaging_browser_view_allsites')) {
-            $this->query .= " AND c.CenterID=";
-            $site_arr = $user->getCenterID();
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $val;
-                }
-                else {
-                    $this->query .= $val . " OR c.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 
         $this->columns = array(
@@ -215,11 +206,12 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = & Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
                     $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
+                $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
             }
         }
 

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -38,7 +38,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user =& User::singleton();
 
         // allow only to view own site data
-        $site_arr = $user->getData('CentersID');
+        $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
             $site[$key] = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
@@ -205,7 +205,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         }
         else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -38,8 +38,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user =& User::singleton();
 
         // allow only to view own site data
-//        $site =& Site::singleton($user->getData('CenterID'));
-        $site_arr = $user->getData('SiteID');
+        $site_arr = $user->getData('CentersID');
         foreach ($site_arr as $key=>$val) {
             $site[$key] = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
@@ -105,7 +104,6 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user =& User::singleton();
         $DB = Database::singleton();
         if (!$user->hasPermission('imaging_browser_view_allsites')) {
-            //$this->query .= " AND c.CenterID=" . $DB->quote($user->getCenterID());
             $this->query .= " AND c.CenterID=";
             $site_arr = $user->getCenterID();
             $last_key = end(array_keys($site_arr));
@@ -216,11 +214,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         }
         else {
             // allow only to view own site data
-//            $site =& Site::singleton($user->getData('CenterID'));
-//            if ($site->isStudySite()) {
-//                $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
-//            }
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = & Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -496,7 +496,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SiteFilterText = $this->webDriver->findElement(
             WebDriverBy::Name("SiteID")
         )->getText();
-        $this->assertContains(trim($SiteTopMenuText[1]), $SiteFilterText);
+        $this->assertContains("All User Sites", $SiteFilterText);
 
         // With permission imaging_browser_view_allsites
         $this->setupPermissions(array('imaging_browser_view_allsites'));

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -496,7 +496,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SiteFilterText = $this->webDriver->findElement(
             WebDriverBy::Name("SiteID")
         )->getText();
-        $this->assertEquals(trim($SiteTopMenuText[1]), $SiteFilterText);
+        $this->assertContains(trim($SiteTopMenuText[1]), $SiteFilterText);
 
         // With permission imaging_browser_view_allsites
         $this->setupPermissions(array('imaging_browser_view_allsites'));

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -328,7 +328,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             return ($user->hasPermission('bvl_feedback'));
         }
         
-        return ($user->hasPermission('data_entry') && in_array($this->getData('CenterID'), $user->getData('CentersID')));
+        return ($user->hasPermission('data_entry') && in_array($this->getData('CenterID'), $user->getData('CenterIDs')));
     }
 
     function _displayBVLQCType()
@@ -457,7 +457,7 @@ Class Instrument_List_ControlPanel extends TimePoint
     	if(!$user->hasPermission('send_to_dcc')){
         	return "User does not have permission to send to DCC";
         }
-        if(!in_array($this->getData('CenterID'), $user->getData('CentersID'))){
+        if(!in_array($this->getData('CenterID'), $user->getData('CenterIDs'))){
         	return "Users must belong to the same site as the candidate to submit to DCC.";
         }
         if($this->getData('Submitted')!='N'){
@@ -529,7 +529,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         if ($user->hasPermission('unsend_to_dcc') && $this->getData('Submitted')=='Y') {
             return true;
         } elseif ($user->hasPermission('send_to_dcc')
-                  && in_array($this->getData('CenterID'), $user->getData('CentersID'))
+                  && in_array($this->getData('CenterID'), $user->getData('CenterIDs'))
                   && $this->getData('Submitted')=='N' 
                   && in_array($this->getData('Current_stage'), array('Screening', 'Visit'))
                   && !in_array($this->getData($this->getData('Current_stage')), array(null, 'In Progress'))
@@ -548,7 +548,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         $user =& User::singleton();
 
         // check user permissions
-    	if (!$user->hasPermission('data_entry') || !in_array($this->getData('CenterID'), $user->getData('CentersID'))) {
+    	if (!$user->hasPermission('data_entry') || !in_array($this->getData('CenterID'), $user->getData('CenterIDs'))) {
             return false;
         }
 		return $this->isStartable();

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -328,7 +328,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             return ($user->hasPermission('bvl_feedback'));
         }
         
-        return ($user->hasPermission('data_entry') && in_array($this->getData('CenterID'), $user->getData('SiteID')));
+        return ($user->hasPermission('data_entry') && in_array($this->getData('CenterID'), $user->getData('CentersID')));
     }
 
     function _displayBVLQCType()
@@ -457,7 +457,7 @@ Class Instrument_List_ControlPanel extends TimePoint
     	if(!$user->hasPermission('send_to_dcc')){
         	return "User does not have permission to send to DCC";
         }
-        if(!in_array($this->getData('CenterID'), $user->getData('SiteID'))){
+        if(!in_array($this->getData('CenterID'), $user->getData('CentersID'))){
         	return "Users must belong to the same site as the candidate to submit to DCC.";
         }
         if($this->getData('Submitted')!='N'){
@@ -529,7 +529,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         if ($user->hasPermission('unsend_to_dcc') && $this->getData('Submitted')=='Y') {
             return true;
         } elseif ($user->hasPermission('send_to_dcc')
-                  && in_array($this->getData('CenterID'), $user->getData('SiteID'))
+                  && in_array($this->getData('CenterID'), $user->getData('CentersID'))
                   && $this->getData('Submitted')=='N' 
                   && in_array($this->getData('Current_stage'), array('Screening', 'Visit'))
                   && !in_array($this->getData($this->getData('Current_stage')), array(null, 'In Progress'))
@@ -548,7 +548,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         $user =& User::singleton();
 
         // check user permissions
-    	if (!$user->hasPermission('data_entry') || !in_array($this->getData('CenterID'), $user->getData('SiteID'))) {
+    	if (!$user->hasPermission('data_entry') || !in_array($this->getData('CenterID'), $user->getData('CentersID'))) {
             return false;
         }
 		return $this->isStartable();

--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -328,7 +328,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             return ($user->hasPermission('bvl_feedback'));
         }
         
-        return ($user->hasPermission('data_entry') && $user->getData('CenterID') == $this->getData('CenterID'));
+        return ($user->hasPermission('data_entry') && in_array($this->getData('CenterID'), $user->getData('SiteID')));
     }
 
     function _displayBVLQCType()
@@ -457,7 +457,7 @@ Class Instrument_List_ControlPanel extends TimePoint
     	if(!$user->hasPermission('send_to_dcc')){
         	return "User does not have permission to send to DCC";
         }
-        if($user->getData('CenterID') != $this->getData('CenterID')){
+        if(!in_array($this->getData('CenterID'), $user->getData('SiteID'))){
         	return "Users must belong to the same site as the candidate to submit to DCC.";
         }
         if($this->getData('Submitted')!='N'){
@@ -529,7 +529,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         if ($user->hasPermission('unsend_to_dcc') && $this->getData('Submitted')=='Y') {
             return true;
         } elseif ($user->hasPermission('send_to_dcc')
-                  && $user->getData('CenterID') == $this->getData('CenterID')
+                  && in_array($this->getData('CenterID'), $user->getData('SiteID'))
                   && $this->getData('Submitted')=='N' 
                   && in_array($this->getData('Current_stage'), array('Screening', 'Visit'))
                   && !in_array($this->getData($this->getData('Current_stage')), array(null, 'In Progress'))
@@ -548,7 +548,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         $user =& User::singleton();
 
         // check user permissions
-    	if (!$user->hasPermission('data_entry') || $user->getData('CenterID') != $this->getData('CenterID')) {
+    	if (!$user->hasPermission('data_entry') || !in_array($this->getData('CenterID'), $user->getData('SiteID'))) {
             return false;
         }
 		return $this->isStartable();

--- a/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
+++ b/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
@@ -18,7 +18,9 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
         $candidate =& Candidate::singleton($candID);
 
         // check user permissions
-    	return ($user->hasPermission('access_all_profiles') || $user->getData('CenterID') == $candidate->getData('CenterID') || $user->getData('CenterID') == $timePoint->getData('CenterID'));
+//    	return ($user->hasPermission('access_all_profiles') || $user->getData('CenterID') == $candidate->getData('CenterID') || $user->getData('CenterID') == $timePoint->getData('CenterID'));
+        return ($user->hasPermission('access_all_profiles') || (in_array($candidate->getData('CenterID'), $user->getData('SiteID'))) || (in_array($timepoint->getData('CenterID'), $user->getData('SiteID'))));
+
     }
 
     function getControlPanel() {

--- a/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
+++ b/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
@@ -18,7 +18,7 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
         $candidate =& Candidate::singleton($candID);
 
         // check user permissions
-        return ($user->hasPermission('access_all_profiles') || (in_array($candidate->getData('CenterID'), $user->getData('CentersID'))) || (in_array($timepoint->getData('CenterID'), $user->getData('CentersID'))));
+        return ($user->hasPermission('access_all_profiles') || (in_array($candidate->getData('CenterID'), $user->getData('CenterIDs'))) || (in_array($timepoint->getData('CenterID'), $user->getData('CenterIDs'))));
 
     }
 

--- a/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
+++ b/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
@@ -18,8 +18,7 @@ class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
         $candidate =& Candidate::singleton($candID);
 
         // check user permissions
-//    	return ($user->hasPermission('access_all_profiles') || $user->getData('CenterID') == $candidate->getData('CenterID') || $user->getData('CenterID') == $timePoint->getData('CenterID'));
-        return ($user->hasPermission('access_all_profiles') || (in_array($candidate->getData('CenterID'), $user->getData('SiteID'))) || (in_array($timepoint->getData('CenterID'), $user->getData('SiteID'))));
+        return ($user->hasPermission('access_all_profiles') || (in_array($candidate->getData('CenterID'), $user->getData('CentersID'))) || (in_array($timepoint->getData('CenterID'), $user->getData('CentersID'))));
 
     }
 

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -492,11 +492,7 @@ function getIssueFields()
         $sites = Utility::getAssociativeSiteList();
     } else {
         // allow only to view own site data
-/*        $site =& Site::singleton($user->getData('CenterID'));
-        if ($site->isStudySite()) {
-            $sites[$user->getData('CenterID')] = $user->getData('Site');
-        }*/
-        $site_arr = $user->getData('SiteID');
+        $site_arr = $user->getData('CentersID');
         foreach ($site_arr as $key=>$val) {
             $site_arr[$key] = Site::singleton($val);
             if ($site_arr[$key]->isStudySite()) {

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -492,7 +492,7 @@ function getIssueFields()
         $sites = Utility::getAssociativeSiteList();
     } else {
         // allow only to view own site data
-        $site_arr = $user->getData('CentersID');
+        $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
             $site_arr[$key] = Site::singleton($val);
             if ($site_arr[$key]->isStudySite()) {

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -492,9 +492,16 @@ function getIssueFields()
         $sites = Utility::getAssociativeSiteList();
     } else {
         // allow only to view own site data
-        $site =& Site::singleton($user->getData('CenterID'));
+/*        $site =& Site::singleton($user->getData('CenterID'));
         if ($site->isStudySite()) {
             $sites[$user->getData('CenterID')] = $user->getData('Site');
+        }*/
+        $site_arr = $user->getData('SiteID');
+        foreach ($site_arr as $key=>$val) {
+            $site_arr[$key] = Site::singleton($val);
+            if ($site_arr[$key]->isStudySite()) {
+                $sites[$val] = $site_arr[$key]->getCenterName();
+            }
         }
     }
 

--- a/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
@@ -133,7 +133,8 @@ class NDB_Form_Issue_Tracker extends NDB_Form
             ['issueID' => $issueID]
         );
 
-        if (($issueData['centerID'] == $user->getData('CenterID'))
+//        if (($issueData['centerID'] == $user->getData('CenterID'))
+        if (in_array($issueData['centerID'], $user->getData('SiteID'))
             || ($user->hasPermission('access_all_profiles'))
             || (!empty($issueData['centerID']))
         ) {

--- a/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
@@ -133,8 +133,7 @@ class NDB_Form_Issue_Tracker extends NDB_Form
             ['issueID' => $issueID]
         );
 
-//        if (($issueData['centerID'] == $user->getData('CenterID'))
-        if (in_array($issueData['centerID'], $user->getData('SiteID'))
+        if (in_array($issueData['centerID'], $user->getData('CentersID'))
             || ($user->hasPermission('access_all_profiles'))
             || (!empty($issueData['centerID']))
         ) {

--- a/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
@@ -133,7 +133,7 @@ class NDB_Form_Issue_Tracker extends NDB_Form
             ['issueID' => $issueID]
         );
 
-        if (in_array($issueData['centerID'], $user->getData('CentersID'))
+        if (in_array($issueData['centerID'], $user->getData('CenterIDs'))
             || ($user->hasPermission('access_all_profiles'))
             || (!empty($issueData['centerID']))
         ) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -51,7 +51,17 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status != 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND i.centerID=" . $db->quote($user->getCenterID());
+            $this->query .= " AND i.centerID=";
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $db->quote($val);
+                }
+                else {
+                    $this->query .= $db->quote($val) . " OR i.centerID=";
+                }
+            }
         }
 
         //note that this needs to be in the same order as the headers array
@@ -163,13 +173,12 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites = array(
-                                  $user->getData('CenterID') => $user->getData(
-                                      'Site'
-                                  ),
-                                 );
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -51,17 +51,8 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status != 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $db->quote($val);
-                }
-                else {
-                    $this->query .= $db->quote($val) . " OR i.centerID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
         }
 
         //note that this needs to be in the same order as the headers array
@@ -174,12 +165,13 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             }
         } else {// allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $sites = array('' => 'User All Sites') + $sites;
         }
 
         //reporters

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -171,7 +171,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         }
 
         //reporters

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -168,10 +168,10 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
+                    $list_of_sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'All User Sites') + $sites;
+            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 
         //reporters

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -52,7 +52,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -173,7 +173,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -164,7 +164,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -51,7 +51,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status != 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -53,7 +53,17 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
             "AND i.assignee=" . $db->quote($user->getData('UserID')); //yup
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND i.centerID=" . $db->quote($user->getCenterID());
+            $this->query .= " AND i.centerID=";
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $db->quote($val);
+                }
+                else {
+                    $this->query .= $db->quote($val) . " OR i.centerID=";
+                }
+            }
         }
 
         //note that this needs to be in the same order as the headers array
@@ -162,13 +172,12 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites = array(
-                                  $user->getData('CenterID') => $user->getData(
-                                      'Site'
-                                  ),
-                                 );
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -59,8 +59,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
                     $this->query .= $db->quote($val);
-                }
-                else {
+                } else {
                     $this->query .= $db->quote($val) . " OR i.centerID=";
                 }
             }

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -54,7 +54,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -172,7 +172,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -54,8 +54,8 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('CenterIDs');
-            $last_key = end(array_keys($site_arr));
+            $site_arr     = $user->getData('CenterIDs');
+            $last_key     = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
                     $this->query .= $db->quote($val);

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -53,16 +53,8 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
             "AND i.assignee=" . $db->quote($user->getData('UserID')); //yup
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND i.centerID=";
-            $site_arr     = $user->getData('CenterIDs');
-            $last_key     = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $db->quote($val);
-                } else {
-                    $this->query .= $db->quote($val) . " OR i.centerID=";
-                }
-            }
+            $site_arr     = implode(",", $user->getData('CenterIDs'));
+            $this->query .= " AND i.centerID IN (" . $site_arr . ")";
         }
 
         //note that this needs to be in the same order as the headers array

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -54,7 +54,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -172,7 +172,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -168,7 +168,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         }
 
         //reporters

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -161,7 +161,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -51,8 +51,9 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status = 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr = implode(",", $user->getCenterID());
-            $this->query .= " AND i.CenterID IN (" . $site_arr . ")";        }
+            $site_arr     = implode(",", $user->getCenterID());
+            $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
+        }
 
         //note that this needs to be in the same order as the headers array
         $this->columns = array(

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -51,7 +51,17 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status = 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND i.centerID=" . $db->quote($user->getCenterID());
+            $this->query .= " AND i.centerID=";
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $this->query .= $db->quote($val);
+                }
+                else {
+                    $this->query .= $db->quote($val) . " OR i.centerID=";
+                }
+            }
         }
 
         //note that this needs to be in the same order as the headers array
@@ -161,14 +171,14 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $list_of_sites = array(
-                                  $user->getData('CenterID') => $user->getData(
-                                      'Site'
-                                  ),
-                                 );
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
+
         }
 
         //reporters

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -51,18 +51,8 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status = 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $this->query .= $db->quote($val);
-                }
-                else {
-                    $this->query .= $db->quote($val) . " OR i.centerID=";
-                }
-            }
-        }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND i.CenterID IN (" . $site_arr . ")";        }
 
         //note that this needs to be in the same order as the headers array
         $this->columns = array(
@@ -172,13 +162,13 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
             }
         } else {// allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-
+            $sites = array('' => 'User All Sites') + $sites;
         }
 
         //reporters

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -52,7 +52,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $this->query .= " AND i.centerID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -171,7 +171,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -73,12 +73,13 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             // allow only to view own site data
             $siteList ='';
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] =& Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $siteList[$key] = $site[$key]->getCenterName();
+                    $siteList[$val] = $site[$key]->getCenterName();
                 }
             }
+            $siteList = array('' => 'User All Sites') + $siteList;
         }
 
         $instrumentList   = [null => 'Any'];

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -71,9 +71,13 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $siteList = [$user->getData('CenterID') => $user->getData('Site')];
+            $siteList ='';
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] =& Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $siteList[$key] = $site[$key]->getCenterName();
+                }
             }
         }
 

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -136,7 +136,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $this->query = $query;
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -79,7 +79,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
                     $siteList[$val] = $site[$key]->getCenterName();
                 }
             }
-            $siteList = array('' => 'User All Sites') + $siteList;
+            $siteList = array('' => 'All User Sites') + $siteList;
         }
 
         $instrumentList   = [null => 'Any'];

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -72,7 +72,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $siteList ='';
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] =& Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -136,7 +136,8 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $this->query = $query;
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $this->query .= " AND c.CenterID=" . $user->getCenterID();
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 
         $this->group_by = '';

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -72,7 +72,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $siteList ='';
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -347,9 +347,12 @@ CONCAT_WS(''," . $DB->quote($dir_path) . ",'trashbin/',SUBSTRING_INDEX(minc_loca
             }
         } else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $sites = array($user->getData('CenterID') => $user->getData('Site'));
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $sites[$key] = $site[$key]->getCenterName();
+                }
             }
         } 
         $this->addSelect('Site', 'Site', $sites);

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -354,7 +354,7 @@ CONCAT_WS(''," . $DB->quote($dir_path) . ",'trashbin/',SUBSTRING_INDEX(minc_loca
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         } 
         $this->addSelect('Site', 'Site', $sites);
                 

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -348,12 +348,13 @@ CONCAT_WS(''," . $DB->quote($dir_path) . ",'trashbin/',SUBSTRING_INDEX(minc_loca
         } else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $sites[$key] = $site[$key]->getCenterName();
+                    $sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $sites = array('' => 'User All Sites') + $sites;
         } 
         $this->addSelect('Site', 'Site', $sites);
                 

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -347,7 +347,7 @@ CONCAT_WS(''," . $DB->quote($dir_path) . ",'trashbin/',SUBSTRING_INDEX(minc_loca
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -347,7 +347,7 @@ CONCAT_WS(''," . $DB->quote($dir_path) . ",'trashbin/',SUBSTRING_INDEX(minc_loca
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -358,7 +358,7 @@ class NDB_Menu_Filter_Form_resolved_violations extends NDB_Menu_Filter_Form
                     $sites[$val] = $site[$key]->getCenterName();
                 }
             }
-            $sites = array('' => 'User All Sites') + $sites;
+            $sites = array('' => 'All User Sites') + $sites;
         } 
         $this->addSelect('Site', 'Site', $sites);
                 

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -351,7 +351,7 @@ class NDB_Menu_Filter_Form_resolved_violations extends NDB_Menu_Filter_Form
         }
         else {
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -352,12 +352,13 @@ class NDB_Menu_Filter_Form_resolved_violations extends NDB_Menu_Filter_Form
         else {
             // allow only to view own site data
             $site_arr = $user->getData('CentersID');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                    $sites[$val] = $site[$key]->getCenterName();
                 }
             }
+            $sites = array('' => 'User All Sites') + $sites;
         } 
         $this->addSelect('Site', 'Site', $sites);
                 

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -351,9 +351,12 @@ class NDB_Menu_Filter_Form_resolved_violations extends NDB_Menu_Filter_Form
         }
         else {
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            if ($site->isStudySite()) {
-                $sites = array($user->getData('CenterID') => $user->getData('Site'));
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+                }
             }
         } 
         $this->addSelect('Site', 'Site', $sites);

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -351,7 +351,7 @@ class NDB_Menu_Filter_Form_resolved_violations extends NDB_Menu_Filter_Form
         }
         else {
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
                 if ($site[$key]->isStudySite()) {

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -122,7 +122,6 @@ class NDB_Form_new_profile extends NDB_Form
         $DB = \Database::singleton();
         $user_list_of_sites = $user->getData('CentersID');
         $num_sites = count($user_list_of_sites);
-        print_r ($num_sites);
 
         if ($num_sites >1) {
             $psc_labelOptions = array(null => '');

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -129,11 +129,11 @@ class NDB_Form_new_profile extends NDB_Form
                 $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
                 $psc_labelOptions[$siteID] = $center['Name'];
             }
+            $this->addSelect('psc', 'Site', $psc_labelOptions);
+    
+            // site rules
+            $this->addRule('psc', 'Site is required', 'required');
         }
-        $this->addSelect('psc', 'Site', $psc_labelOptions);
-
-        // site rules
-        $this->addRule('psc', 'Site is required', 'required');
 
 
         $PSCIDsettings = $config->getSetting('PSCID');

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -31,7 +31,16 @@ class NDB_Form_new_profile extends NDB_Form
         }
 
         // create the candidate
-        $candID = Candidate::createNew($user->getData('CenterID'), $dob, $edc, $values['gender'], $values['PSCID']);
+        $DB = \Database::singleton();
+        $user_list_of_sites = $user->getData('SiteID');
+        $num_sites = count($user_list_of_sites);
+
+        if ($num_sites >1) {
+            $candID = Candidate::createNew($values['psc'], $dob, $edc, $values['gender'], $values['PSCID']);
+        }
+        else {
+            $candID = Candidate::createNew($user->getData('CenterID'), $dob, $edc, $values['gender'], $values['PSCID']);
+        }
 
         // get the candidate
         $candidate =& Candidate::singleton($candID);
@@ -101,6 +110,26 @@ class NDB_Form_new_profile extends NDB_Form
 
         // gender rules
         $this->addRule('gender', 'Gender is required', 'required');
+
+        // add sites for users with more than one site affiliation
+        $user =& User::singleton();
+        $DB = \Database::singleton();
+        $user_list_of_sites = $user->getData('SiteID');
+        $num_sites = count($user_list_of_sites);
+        print_r ($num_sites);
+
+        if ($num_sites >1) {
+            $psc_labelOptions = array(null => '');
+            foreach ($user_list_of_sites as $key => $siteID) {
+                $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
+                $psc_labelOptions[$siteID] = $center['Name'];
+            }
+        }
+        $this->addSelect('psc', 'Site', $psc_labelOptions);
+
+        // site rules
+        $this->addRule('psc', 'Site is required', 'required');
+
 
         $PSCIDsettings = $config->getSetting('PSCID');
         if($PSCIDsettings['generation'] == 'user') {

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -10,7 +10,7 @@ class NDB_Form_new_profile extends NDB_Form
         // create user object
         $user =& User::singleton();
 
-        $site_arr = $user->getData('CentersID');
+        $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
             $site[$key] = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
@@ -38,14 +38,14 @@ class NDB_Form_new_profile extends NDB_Form
 
         // create the candidate
         $DB = \Database::singleton();
-        $site_arr = $user->getData('CentersID');
+        $site_arr = $user->getData('CenterIDs');
         $num_sites = count($site_arr);
 
         if ($num_sites >1) {
             $candID = Candidate::createNew($values['psc'], $dob, $edc, $values['gender'], $values['PSCID']);
         }
         else {
-            $candID = Candidate::createNew($user->getData('CentersID'), $dob, $edc, $values['gender'], $values['PSCID']);
+            $candID = Candidate::createNew($user->getData('CenterIDs'), $dob, $edc, $values['gender'], $values['PSCID']);
         }
 
         // get the candidate
@@ -120,7 +120,7 @@ class NDB_Form_new_profile extends NDB_Form
         // add sites for users with more than one site affiliation
         $user =& User::singleton();
         $DB = \Database::singleton();
-        $user_list_of_sites = $user->getData('CentersID');
+        $user_list_of_sites = $user->getData('CenterIDs');
         $num_sites = count($user_list_of_sites);
 
         if ($num_sites >1) {

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -10,12 +10,7 @@ class NDB_Form_new_profile extends NDB_Form
         // create user object
         $user =& User::singleton();
 
-/*        $site =& Site::singleton($user->getData('CenterID'));
-
-        if ($site->isStudySite() or ($site->getCenterName() == "DCC")) {
-            return $user->hasPermission('data_entry');
-        }*/
-        $site_arr = $user->getData('SiteID');
+        $site_arr = $user->getData('CentersID');
         foreach ($site_arr as $key=>$val) {
             $site[$key] = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
@@ -43,14 +38,14 @@ class NDB_Form_new_profile extends NDB_Form
 
         // create the candidate
         $DB = \Database::singleton();
-        $site_arr = $user->getData('SiteID');
+        $site_arr = $user->getData('CentersID');
         $num_sites = count($site_arr);
 
         if ($num_sites >1) {
             $candID = Candidate::createNew($values['psc'], $dob, $edc, $values['gender'], $values['PSCID']);
         }
         else {
-            $candID = Candidate::createNew($user->getData('CenterID'), $dob, $edc, $values['gender'], $values['PSCID']);
+            $candID = Candidate::createNew($user->getData('CentersID'), $dob, $edc, $values['gender'], $values['PSCID']);
         }
 
         // get the candidate
@@ -125,7 +120,7 @@ class NDB_Form_new_profile extends NDB_Form
         // add sites for users with more than one site affiliation
         $user =& User::singleton();
         $DB = \Database::singleton();
-        $user_list_of_sites = $user->getData('SiteID');
+        $user_list_of_sites = $user->getData('CentersID');
         $num_sites = count($user_list_of_sites);
         print_r ($num_sites);
 

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -12,13 +12,13 @@ class NDB_Form_new_profile extends NDB_Form
 
         $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
-            $site[$key] = & Site::singleton($val);
+            $site[$key]        = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
-            $isDCCSite[$key] = $site[$key]->getCenterName();
+            $isDCCSite[$key]   = $site[$key]->getCenterName();
         }
         $oneIsStudySite = in_array("1", $isStudySite);
-        $oneIsStudySite = in_array("DCC", $isDCCSite);
-        if ($oneIsStudySite or $isDCCSite) {
+        $oneIsDCCSite   = in_array("DCC", $isDCCSite);
+        if ($oneIsStudySite or $oneIsDCCSite) {
             return $user->hasPermission('data_entry');
         }
 
@@ -28,30 +28,37 @@ class NDB_Form_new_profile extends NDB_Form
     function _process($values)
     {
         // set up the arguments to Candidate::createNew
-        $user =& User::singleton();
+        $user   =& User::singleton();
         $config =& NDB_Config::singleton();
-        $dob = empty($values['dob1']) ? null : $values['dob1'];
+        $dob    = empty($values['dob1']) ? null : $values['dob1'];
 
-        if($config->getSetting('useEDC') == "true"){
+        if ($config->getSetting('useEDC') == "true") {
             $edc = empty($values['edc1']) ? null : $values['edc1'];
         }
 
         // create the candidate
-        $DB = \Database::singleton();
-        $site_arr = $user->getData('CenterIDs');
+        $DB        = \Database::singleton();
+        $site_arr  = $user->getData('CenterIDs');
         $num_sites = count($site_arr);
 
         if ($num_sites >1) {
-            $candID = Candidate::createNew($values['psc'], $dob, $edc, $values['gender'], $values['PSCID']);
-        }
-        else {
-            $candID = Candidate::createNew($user->getData('CenterIDs'), $dob, $edc, $values['gender'], $values['PSCID']);
+            $candID = Candidate::createNew(
+                $values['psc'],
+                $dob,
+                $edc,
+                $values['gender'],
+                $values['PSCID']
+            );
+        } else {
+            $centerIDs = $user->getData('CenterIDs');
+            $centerID  = $centerIDs[0];
+            $candID    = Candidate::createNew($centerID, $dob, $edc, $values['gender'], $values['PSCID']);
         }
 
         // get the candidate
         $candidate =& Candidate::singleton($candID);
 
-        if($config->getSetting('useProjects') == "true") {
+        if ($config->getSetting('useProjects') == "true") {
             $candidate->setData('ProjectID', $values['ProjectID']);
 
         }
@@ -59,8 +66,8 @@ class NDB_Form_new_profile extends NDB_Form
         //------------------------------------------------------------
 
         $this->tpl_data['success'] = true;
-        $this->tpl_data['candID'] = $candID;
-        $this->tpl_data['PSCID'] = $candidate->getPSCID();
+        $this->tpl_data['candID']  = $candID;
+        $this->tpl_data['PSCID']   = $candidate->getPSCID();
 
         // freeze it, just in case
         $this->form->freeze();
@@ -68,18 +75,18 @@ class NDB_Form_new_profile extends NDB_Form
 
     function new_profile()
     {
-        $config =& NDB_Config::singleton();
-        $startYear = $config->getSetting('startYear');
-        $endYear = $config->getSetting('endYear');
-        $ageMax = $config->getSetting('ageMax');
-        $ageMin = $config->getSetting('ageMin');
-        $dateOptions = array(
-                             'language'        => 'en',
-                             'format'          => 'YMd',
-                             'addEmptyOption'  => true,
-                             'minYear'         => $startYear - $ageMax,
-                             'maxYear'         => $endYear - $ageMin
-                             );
+        $config         =& NDB_Config::singleton();
+        $startYear      = $config->getSetting('startYear');
+        $endYear        = $config->getSetting('endYear');
+        $ageMax         = $config->getSetting('ageMax');
+        $ageMin         = $config->getSetting('ageMin');
+        $dateOptions    = array(
+                           'language'       => 'en',
+                           'format'         => 'YMd',
+                           'addEmptyOption' => true,
+                           'minYear'        => $startYear - $ageMax,
+                           'maxYear'        => $endYear - $ageMin,
+                          );
         $dateAttributes = ['class' => 'form-control input-sm input-date'];
 
         // add date of birth
@@ -87,12 +94,11 @@ class NDB_Form_new_profile extends NDB_Form
         $this->addBasicDate('dob2', 'Confirm Date of Birth', $dateOptions, $dateAttributes);
         $this->addRule(array('dob1', 'dob2'), 'Date of birth fields must match', 'compare');
 
-
         // date of birth rules
         $this->addRule('dob1', 'Date of Birth is required', 'required');
         $this->addRule('dob2', 'Date of Birth confirmation is required', 'required');
 
-        if($config->getSetting('useEDC') == "true"){
+        if ($config->getSetting('useEDC') == "true") {
             // add expected date of confinement
             $this->addBasicDate('edc1', 'Expected Date of Confinement', $dateOptions, $dateAttributes);
             $this->addBasicDate('edc2', 'Confirm EDC', $dateOptions, $dateAttributes);
@@ -101,7 +107,7 @@ class NDB_Form_new_profile extends NDB_Form
             $this->addRule(array('edc1', 'edc2'), 'EDC fields must match', 'compare');
         }
 
-        if($config->getSetting("useProjects") == "true") {
+        if ($config->getSetting("useProjects") == "true") {
             $projects = Utility::getProjectList();
             $projList = array('' => '');
             foreach($projects as $projectID => $projectName) {
@@ -111,7 +117,11 @@ class NDB_Form_new_profile extends NDB_Form
         }
 
         // add gender
-        $genderOptions = array('' => '', 'Male' => 'Male', 'Female' => 'Female');
+        $genderOptions = array(
+                          ''       => '',
+                          'Male'   => 'Male',
+                          'Female' => 'Female',
+                         );
         $this->addSelect('gender', 'Gender', $genderOptions);
 
         // gender rules
@@ -119,25 +129,27 @@ class NDB_Form_new_profile extends NDB_Form
 
         // add sites for users with more than one site affiliation
         $user =& User::singleton();
-        $DB = \Database::singleton();
+        $DB   = \Database::singleton();
         $user_list_of_sites = $user->getData('CenterIDs');
-        $num_sites = count($user_list_of_sites);
+        $num_sites          = count($user_list_of_sites);
 
         if ($num_sites >1) {
             $psc_labelOptions = array(null => '');
             foreach ($user_list_of_sites as $key => $siteID) {
-                $center = $DB->pselectRow("SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid", array('cid' => $siteID));
+                $center = $DB->pselectRow(
+                    "SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid",
+                    array('cid' => $siteID)
+                );
                 $psc_labelOptions[$siteID] = $center['Name'];
             }
             $this->addSelect('psc', 'Site', $psc_labelOptions);
-    
+
             // site rules
             $this->addRule('psc', 'Site is required', 'required');
         }
 
-
         $PSCIDsettings = $config->getSetting('PSCID');
-        if($PSCIDsettings['generation'] == 'user') {
+        if ($PSCIDsettings['generation'] == 'user') {
             $this->addBasicText('PSCID', 'PSCID');
         }
 
@@ -150,16 +162,14 @@ class NDB_Form_new_profile extends NDB_Form
 
         $config =& NDB_Config::singleton();
 
-        if($values['dob1'] != $values['dob2'])
-        {
+        if ($values['dob1'] != $values['dob2']) {
             $errors['dob1'] = 'Date of Birth fields must match.';
         }
-        if($config->getSetting('useEDC') == "true") {
+        if ($config->getSetting('useEDC') == "true") {
             if (strlen(implode($values['edc1'])) > 2 && !Utility::_checkDate($values['edc1'])) {
                 $errors['edc1'] = 'EDC is not a valid date';
             }
-            if($values['edc1'] != $values['edc2'])
-            {
+            if($values['edc1'] != $values['edc2']) {
                 $errors['edc1'] = 'Estimated Due date fields must match.';
             }
         }
@@ -169,24 +179,31 @@ class NDB_Form_new_profile extends NDB_Form
         }
 
         $PSCIDsettings = $config->getSetting('PSCID');
-        if($PSCIDsettings['generation'] == 'user') {
+        if ($PSCIDsettings['generation'] == 'user') {
             $db =& Database::singleton();
-            $user =& User::singleton();
-            $centerID = $user->getData('CenterID');
-            $site =& Site::singleton($centerID);
+            if(empty($values['psc'])) { // user is in only one site
+                $user      =& User::singleton();
+                $centerIDs = $user->getData('CenterIDs');
+                $centerID  = $centerIDs[0];
+                $site      =& Site::singleton($centerID);
+            } else { // user has multiple sites, so validate PSCID against the Site selected
+                $site =& Site::singleton($values['psc']);
+            }
 
-            if(empty($values['PSCID'])) {
+            if (empty($values['PSCID'])) {
                 $errors['PSCID'] = 'PSCID must be specified';
-            } elseif(!Candidate::validatePSCID($values['PSCID'], $site->getSiteAlias())) {
+            } elseif (!Candidate::validatePSCID($values['PSCID'], $site->getSiteAlias())) {
                 $errors['PSCID'] = 'PSCID does not match the required structure';
-            } elseif($db->pselectOne("SELECT count(PSCID) FROM candidate WHERE PSCID=:V_PSCID",
-                array('V_PSCID' => $values[PSCID])) > 0
+            } elseif ($db->pselectOne(
+                "SELECT count(PSCID) FROM candidate WHERE PSCID=:V_PSCID",
+                array('V_PSCID' => $values[PSCID])
+            ) > 0
             ) {
                     $errors['PSCID'] = 'PSCID has already been registered';
             }
         }
         $useProjects = $config->getSetting('useProjects');
-        if($useProjects === "true" && empty($values['ProjectID'])) {
+        if ($useProjects === "true" && empty($values['ProjectID'])) {
             $errors['ProjectID'] = "Project is required";
         }
 

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -10,9 +10,20 @@ class NDB_Form_new_profile extends NDB_Form
         // create user object
         $user =& User::singleton();
 
-        $site =& Site::singleton($user->getData('CenterID'));
+/*        $site =& Site::singleton($user->getData('CenterID'));
 
         if ($site->isStudySite() or ($site->getCenterName() == "DCC")) {
+            return $user->hasPermission('data_entry');
+        }*/
+        $site_arr = $user->getData('SiteID');
+        foreach ($site_arr as $key=>$val) {
+            $site[$key] = & Site::singleton($val);
+            $isStudySite[$key] = $site[$key]->isStudySite();
+            $isDCCSite[$key] = $site[$key]->getCenterName();
+        }
+        $oneIsStudySite = in_array("1", $isStudySite);
+        $oneIsStudySite = in_array("DCC", $isDCCSite);
+        if ($oneIsStudySite or $isDCCSite) {
             return $user->hasPermission('data_entry');
         }
 
@@ -32,8 +43,8 @@ class NDB_Form_new_profile extends NDB_Form
 
         // create the candidate
         $DB = \Database::singleton();
-        $user_list_of_sites = $user->getData('SiteID');
-        $num_sites = count($user_list_of_sites);
+        $site_arr = $user->getData('SiteID');
+        $num_sites = count($site_arr);
 
         if ($num_sites >1) {
             $candID = Candidate::createNew($values['psc'], $dob, $edc, $values['gender'], $values['PSCID']);

--- a/modules/new_profile/templates/form_new_profile.tpl
+++ b/modules/new_profile/templates/form_new_profile.tpl
@@ -44,6 +44,14 @@
 		<div class="col-sm-10">{$form.gender.html}</div>
 	</div>
 	<br><br>
+    {if $form.psc.html != ""}
+	<div class="form-group col-sm-12">
+		<label class="col-sm-2">{$form.psc.label}</label>
+		<div class="col-sm-10">{$form.psc.html}</div>
+	</div>
+	<br><br>
+    {/if}
+
     {if $form.PSCID.html != ""}
 	<div class="form-group col-sm-12">
 		<label class="col-sm-2">{$form.PSCID.label}</label>

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -61,7 +61,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileLoadsWithoutProjects() {
+    function testNewProfileLoadsWithoutProjects()
+    {
         $this->setUpConfigSetting("useProjects", "false");
 
         $this->safeGet($this->url . "/new_profile/");
@@ -82,7 +83,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileLoadsWithoutEDC() {
+    function testNewProfileLoadsWithoutEDC()
+    {
         $this->setUpConfigSetting("useEDC", "false");
 
         $this->safeGet($this->url . "/new_profile/");
@@ -109,7 +111,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileEDCDateError() {
+    function testNewProfileEDCDateError()
+    {
         $this->setUpConfigSetting("useEDC", "true");
 
         $this->webDriver->get($this->url . "/new_profile/");
@@ -120,7 +123,7 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $dates[2]->sendKeys("01/01/2015");
         $dates[3]->sendKeys("01/02/2015");
         $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $gender = $this->safeFindElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
@@ -129,7 +132,7 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         // $pscid = $this->webDriver->findElement(WebDriverBy::Name("PSCID"));
         // $pscid->sendKeys("Control");
         $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
@@ -145,7 +148,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfilePSCIDError() {
+    function testNewProfilePSCIDError()
+    {
 
         $this->markTestSkipped("Config not properly set up to test that PSCID is required");
 
@@ -170,14 +174,15 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileDoBDateError() {
+    function testNewProfileDoBDateError()
+    {
         $this->webDriver->get($this->url . "/new_profile/");
 
         $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
         $dates[0]->sendKeys("2015-01-01");
         $dates[1]->sendKeys("2015-02-01");
         $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
         sleep(2);
@@ -198,7 +203,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileCreateCandidate() {
+    function testNewProfileCreateCandidate()
+    {
 
         $this->changeStudySite();
         $this->webDriver->get($this->url . "/new_profile/");
@@ -207,12 +213,12 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $dates[0]->sendKeys("2015-01-01");
         $dates[1]->sendKeys("2015-01-01");
         $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
         $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
@@ -229,7 +235,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfilePSCIDSequential() {
+    function testNewProfilePSCIDSequential()
+    {
 
         $this->changeStudySite();
         $this->webDriver->get($this->url . "/new_profile/");
@@ -238,12 +245,12 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $dates[0]->sendKeys("2015-01-01");
         $dates[1]->sendKeys("2015-01-01");
         $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
         $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
@@ -257,12 +264,12 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $dates[0]->sendKeys("2015-01-01");
         $dates[1]->sendKeys("2015-01-01");
         $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $gender = $this->safeFindElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
         $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+            ->click();
         sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();

--- a/modules/next_stage/php/NDB_Form_next_stage.class.inc
+++ b/modules/next_stage/php/NDB_Form_next_stage.class.inc
@@ -14,7 +14,7 @@ class NDB_Form_next_stage extends NDB_Form
 
         // check user permissions
 //    	if (!$user->hasPermission('data_entry') || $user->getData('CenterID') != $timePoint->getData('CenterID')) {
-    	if (!$user->hasPermission('data_entry') || (!in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))) {
+    	if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))) {
             return false;
         }
         return $timePoint->isStartable();

--- a/modules/next_stage/php/NDB_Form_next_stage.class.inc
+++ b/modules/next_stage/php/NDB_Form_next_stage.class.inc
@@ -13,7 +13,7 @@ class NDB_Form_next_stage extends NDB_Form
         $timePoint =& TimePoint::singleton($this->identifier);
 
         // check user permissions
-    	if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('CentersID'))) {
+    	if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('CenterIDs'))) {
             return false;
         }
         return $timePoint->isStartable();

--- a/modules/next_stage/php/NDB_Form_next_stage.class.inc
+++ b/modules/next_stage/php/NDB_Form_next_stage.class.inc
@@ -13,8 +13,7 @@ class NDB_Form_next_stage extends NDB_Form
         $timePoint =& TimePoint::singleton($this->identifier);
 
         // check user permissions
-//    	if (!$user->hasPermission('data_entry') || $user->getData('CenterID') != $timePoint->getData('CenterID')) {
-    	if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))) {
+    	if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('CentersID'))) {
             return false;
         }
         return $timePoint->isStartable();

--- a/modules/next_stage/php/NDB_Form_next_stage.class.inc
+++ b/modules/next_stage/php/NDB_Form_next_stage.class.inc
@@ -13,10 +13,10 @@ class NDB_Form_next_stage extends NDB_Form
         $timePoint =& TimePoint::singleton($this->identifier);
 
         // check user permissions
-    	if (!$user->hasPermission('data_entry') || $user->getData('CenterID') != $timePoint->getData('CenterID')) {
+//    	if (!$user->hasPermission('data_entry') || $user->getData('CenterID') != $timePoint->getData('CenterID')) {
+    	if (!$user->hasPermission('data_entry') || (!in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))) {
             return false;
         }
-
         return $timePoint->isStartable();
     }
 

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -84,7 +84,7 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
         // only view their own profiles, unless they have permission to see all
         if (!($user->hasPermission('reliability_edit_all') || $user->hasPermission('access_all_profiles'))) {
             $query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             $last_key = end(array_keys($site_arr));
             foreach ($site_arr as $key=>$val) {
                 if ($key == $last_key) {
@@ -157,7 +157,7 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
             }
         }else { // this else loop is never entered as _hasAccess would have returned false
             // allow only to view own site data
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CentersID');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
             //    if ($site[$key]->isStudySite()) {

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -149,7 +149,7 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
             }
         }else { // this else loop is never entered as _hasAccess would have returned false
             // allow only to view own site data
-            $site_arr = $user->getData('CentersID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = Site::singleton($val);
             //    if ($site[$key]->isStudySite()) {

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -404,11 +404,11 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
         if($newCommentID['NewCenterID'] !== $CommentID['OldCenterID']) {
             return array('error' => "Candidates are not from the same site. Cannot swap candidates across sites.");
         }
-        elseif($user->getCenterID() != $newCommentID['NewCenterID']) {
+        elseif(!in_array($newCommentID['NewCenterID'], $user->getCenterID())) {
             $error_msg = $params_new['id_Replace']."/".$params_new['id_replaceV']." is from a different site than you. Can only swap candidates from the same site.";
             return array('error' =>$error_msg);
         }
-        elseif($user->getCenterID() != $CommentID['OldCenterID']) {
+        elseif(!in_array($CommentID['OldCenterID'], $user->getCenterID())) {
            $error_msg = $params_new['id_Replace']."/".$params_new['id_replaceV']." is from a different site than you. Can only swap candidates from the same site.";
            return array('error' => $error_msg);
 

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -156,7 +156,7 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
                     $list_of_sites[$key] = $site[$key]->getCenterName();
             //    }
             }
-            $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 
         /// hack for Visit Labels... maybe get all the real visit labels from DB?

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -83,18 +83,10 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
 
         // only view their own profiles, unless they have permission to see all
         if (!($user->hasPermission('reliability_edit_all') || $user->hasPermission('access_all_profiles'))) {
-            $query .= " AND candidate.CenterID=";
-            $site_arr = $user->getData('CentersID');
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $query .= $DB->quote($val);
-                }
-                else {
-                    $query .= $DB->quote($val) . " OR candidate.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
+
         $config=&NDB_Config::singleton();
         $useProjects = $config->getSetting("useProjects");
         // set the class variables
@@ -164,6 +156,7 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
                     $list_of_sites[$key] = $site[$key]->getCenterName();
             //    }
             }
+            $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
         }
 
         /// hack for Visit Labels... maybe get all the real visit labels from DB?

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -83,7 +83,17 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
 
         // only view their own profiles, unless they have permission to see all
         if (!($user->hasPermission('reliability_edit_all') || $user->hasPermission('access_all_profiles'))) {
-            $query .= " AND candidate.centerID = '" . $user->getData('CenterID') . "' ";
+            $query .= " AND candidate.CenterID=";
+            $site_arr = $user->getData('SiteID');
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $query .= $DB->quote($val);
+                }
+                else {
+                    $query .= $DB->quote($val) . " OR candidate.CenterID=";
+                }
+            }
         }
         $config=&NDB_Config::singleton();
         $useProjects = $config->getSetting("useProjects");
@@ -145,12 +155,15 @@ class NDB_Menu_Filter_reliability extends NDB_Menu_Filter
                 }
                 $list_of_sites = $new_list;
             }
-        }else {
+        }else { // this else loop is never entered as _hasAccess would have returned false
             // allow only to view own site data
-            $site =& Site::singleton($user->getData('CenterID'));
-            //if ($site->isStudySite()) {
-                $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));
-            //}
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = Site::singleton($val);
+            //    if ($site[$key]->isStudySite()) {
+                    $list_of_sites[$key] = $site[$key]->getCenterName();
+            //    }
+            }
         }
 
         /// hack for Visit Labels... maybe get all the real visit labels from DB?

--- a/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
+++ b/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
@@ -38,7 +38,7 @@ class NDB_Menu_Timepoint_List extends NDB_Menu
 
         // check user permissions
         if ($user->hasPermission('access_all_profiles') 
-            || (in_array($candidate->getData('CenterID'), $user->getData('CentersID')))) {
+            || (in_array($candidate->getData('CenterID'), $user->getData('CenterIDs')))) {
             return true;
         }
 

--- a/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
+++ b/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
@@ -38,7 +38,7 @@ class NDB_Menu_Timepoint_List extends NDB_Menu
 
         // check user permissions
         if ($user->hasPermission('access_all_profiles')
-            || $user->getData('CenterID') == $candidate->getData('CenterID')
+            || (in_array($candidate->getData('CenterID'), $user->getData('SiteID')))
         ) {
             return true;
         }

--- a/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
+++ b/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
@@ -37,8 +37,12 @@ class NDB_Menu_Timepoint_List extends NDB_Menu
         $candidate =& Candidate::singleton($_REQUEST['candID']);
 
         // check user permissions
-        if ($user->hasPermission('access_all_profiles') 
-            || (in_array($candidate->getData('CenterID'), $user->getData('CenterIDs')))) {
+        if ($user->hasPermission('access_all_profiles')
+            || (in_array(
+                $candidate->getData('CenterID'),
+                $user->getData('CenterIDs')
+            ))
+        ) {
             return true;
         }
 

--- a/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
+++ b/modules/timepoint_list/php/NDB_Menu_timepoint_list.class.inc
@@ -37,9 +37,8 @@ class NDB_Menu_Timepoint_List extends NDB_Menu
         $candidate =& Candidate::singleton($_REQUEST['candID']);
 
         // check user permissions
-        if ($user->hasPermission('access_all_profiles')
-            || (in_array($candidate->getData('CenterID'), $user->getData('SiteID')))
-        ) {
+        if ($user->hasPermission('access_all_profiles') 
+            || (in_array($candidate->getData('CenterID'), $user->getData('CentersID')))) {
             return true;
         }
 

--- a/modules/timepoint_list/php/TimePoint_List_ControlPanel.class.inc
+++ b/modules/timepoint_list/php/TimePoint_List_ControlPanel.class.inc
@@ -57,8 +57,7 @@ Class TimePoint_List_ControlPanel extends Candidate
     {
         $user =& User::singleton();
 
-        //$user_CenterID = $user->getData('CenterID');
-        $user_CenterID = $user->getData('SiteID');
+        $user_CenterID = $user->getData('CentersID');
         $cand_CenterID = $this->getData('CenterID');
 
         $this->tpl_data['candID'] = $this->getData('CandID');

--- a/modules/timepoint_list/php/TimePoint_List_ControlPanel.class.inc
+++ b/modules/timepoint_list/php/TimePoint_List_ControlPanel.class.inc
@@ -57,13 +57,14 @@ Class TimePoint_List_ControlPanel extends Candidate
     {
         $user =& User::singleton();
 
-        $user_CenterID = $user->getData('CenterID');
+        //$user_CenterID = $user->getData('CenterID');
+        $user_CenterID = $user->getData('SiteID');
         $cand_CenterID = $this->getData('CenterID');
 
         $this->tpl_data['candID'] = $this->getData('CandID');
 
         $this->tpl_data['isDataEntryPerson'] = $user->hasPermission('data_entry')
-              && ($user_CenterID == $cand_CenterID || $user->isUserDCC());
+              && (in_array($cand_CenterID, $user_CenterID) || $user->isUserDCC());
 
         $this->tpl_data['candidate_parameters_view']
             = $user->hasPermission('candidate_parameter_view');

--- a/modules/timepoint_list/php/TimePoint_List_ControlPanel.class.inc
+++ b/modules/timepoint_list/php/TimePoint_List_ControlPanel.class.inc
@@ -57,7 +57,7 @@ Class TimePoint_List_ControlPanel extends Candidate
     {
         $user =& User::singleton();
 
-        $user_CenterID = $user->getData('CentersID');
+        $user_CenterID = $user->getData('CenterIDs');
         $cand_CenterID = $this->getData('CenterID');
 
         $this->tpl_data['candID'] = $this->getData('CandID');

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -58,9 +58,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                 if ($this->isCreatingNewUser()) {
                     return true;
                 }
-
                 return in_array(
-                    $editor->getData('CenterID'),
+                    $editor->getData('CenterIDs'),
                     $user->getData('CenterIDs')
                 );
             }
@@ -223,9 +222,11 @@ class NDB_Form_User_Accounts extends NDB_Form
         }
 
         // multi-site UPDATE
-        $uid = $user->getData('ID');
+        $uid        = $user->getData('ID');
         $curr_sites = $values['CenterIDs'];
-        $DB->delete('user_psc_rel', array("UserID" => $uid));
+        if (!$this->isCreatingNewUser()) {
+            $DB->delete('user_psc_rel', array("UserID" => $uid));
+        }
         foreach ($curr_sites as $site) {
             $DB->insert(
                 'user_psc_rel',
@@ -236,6 +237,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             );
         }
         unset($values['CenterIDs']);
+        // END multi-site UPDATE
 
         // EXAMINER UPDATE
         $ex_curr_sites =array();

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -219,6 +219,77 @@ class NDB_Form_User_Accounts extends NDB_Form
             unset($values['Password_md5']);
         }
 
+        // multi-site UPDATE
+        $uid = $user->getData('ID');
+
+        $us_curr_sites =array();
+        $us_prev_sites =array();
+        //get sites where user is already at for compare
+        $prev_sites = $DB->pselect(
+            "
+                        SELECT CenterID
+                        FROM user_psc_rel
+                        WHERE UserID=:uid",
+            array(
+                "uid" => $uid,
+            )
+        );
+
+        foreach ($prev_sites as $row=>$center) {
+            $pr_cid = $center['CenterID'];
+            array_push($us_prev_sites, $pr_cid);
+        }
+        $curr_sites = $values['SiteID'];
+print_r($values);
+        foreach ($curr_sites as $key=>$val) {
+            //get MultiSelected CenterID
+            array_push($us_curr_sites, $val);
+            //Check if CenterID already in user_psc_rel for that user
+            $result = $DB->pselectRow(
+                "
+                          SELECT CenterID
+                          FROM user_psc_rel
+                          WHERE UserID=:uid",
+                array(
+                    "uid" => $uid,
+                )
+            );
+            // Center was not previously added
+            if (empty($result) || is_null($result) || (!(in_array($val, $us_prev_sites)))) {
+                print_r ("In empty or NOT in_array loop");
+                print_r ("\n");
+                $DB->insert(
+                    'user_psc_rel',
+                    array(
+                        'UserID'    => $uid,
+                        'CenterID'  => $val,
+                    )
+                );
+            } elseif (in_array($val, $us_prev_sites)) {
+                unset($values['CenterID'][$key]);
+            }
+        }
+        // Delete all entries from user_psc_rel in
+        // previous and not in current sites
+        $old_sites = array_diff($us_prev_sites, $us_curr_sites);
+
+        if ((!empty($old_sites)) && (!(is_null($old_sites)))) {
+            // There is some difference, so delete those in the old sites
+            foreach ($old_sites as $key=>$val) {
+                $DB->delete(
+                    'user_psc_rel',
+                    array(
+                        'CenterID'  => $val,
+                    ),
+                    array(
+                        'UserID'    => $uid,
+                    )
+                );
+            }
+        }
+        //END MULTI-SITE
+        unset($values['SiteID']);
+        print_r($values);
         // EXAMINER UPDATE
         $ex_curr_sites =array();
         $ex_prev_sites =array();
@@ -549,7 +620,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                    $editor->getData('CenterID') => $editor->getData('Site'),
                   );
         }
-        $this->addSelect('CenterID', 'Site', $siteOptions);
+        $this->addSelect('SiteID', 'Sitesss', $siteOptions, array("multiple"=>"multiple"));
 
         if ($editor->hasPermission('examiner_multisite')) {
             //get site aliases

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -59,7 +59,10 @@ class NDB_Form_User_Accounts extends NDB_Form
                     return true;
                 }
 
-                return in_array($editor->getData('CenterID'), $user->getData('CenterIDs'));
+                return in_array(
+                    $editor->getData('CenterID'),
+                    $user->getData('CenterIDs')
+                );
             }
 
             return false;
@@ -221,68 +224,16 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         // multi-site UPDATE
         $uid = $user->getData('ID');
-
-        $us_curr_sites =array();
-        $us_prev_sites =array();
-        //get sites where user is already at to compare
-        $prev_sites = $DB->pselect(
-            "           SELECT CenterID
-                        FROM user_psc_rel
-                        WHERE UserID=:uid",
-            array(
-                "uid" => $uid,
-            )
-        );
-
-        foreach ($prev_sites as $row=>$center) {
-            $pr_cid = $center['CenterID'];
-            array_push($us_prev_sites, $pr_cid);
-        }
-        $curr_sites = $values['CenterIDs'];
-        foreach ($curr_sites as $key=>$val) {
-            //get MultiSelected CenterID
-            array_push($us_curr_sites, $val);
-            //Check if CenterID already in user_psc_rel for that user
-            $result = $DB->pselectRow(
-                "         SELECT CenterID
-                          FROM user_psc_rel
-                          WHERE UserID=:uid",
+        $DB->delete('user_psc_rel', array("UserID" => $uid));
+        foreach ($curr_sites as $site) {
+            $DB->insert(
+                'user_psc_rel',
                 array(
-                    "uid" => $uid,
+                 "UserID"   => $uid,
+                 "CenterID" => $site,
                 )
             );
-            // Center was not previously added
-            if (empty($result) || is_null($result) || (!(in_array($val, $us_prev_sites)))) {
-                $DB->insert(
-                    'user_psc_rel',
-                    array(
-                        'UserID'    => $uid,
-                        'CenterID'  => $val,
-                    )
-                );
-            } elseif (in_array($val, $us_prev_sites)) {
-                unset($values['CenterID'][$key]);
-            }
         }
-        // Delete all entries from user_psc_rel in
-        // previous and not in current sites
-        $old_sites = array_diff($us_prev_sites, $us_curr_sites);
-
-        if ((!empty($old_sites)) && (!(is_null($old_sites)))) {
-            // There is some difference, so delete those in the old sites
-            foreach ($old_sites as $key=>$val) {
-                $DB->delete(
-                    'user_psc_rel',
-                    array(
-                        'CenterID'  => $val,
-                    ),
-                    array(
-                        'UserID'    => $uid,
-                    )
-                );
-            }
-        }
-        //END MULTI-SITE
         unset($values['CenterIDs']);
 
         // EXAMINER UPDATE
@@ -615,7 +566,12 @@ class NDB_Form_User_Accounts extends NDB_Form
                    $editor->getData('CenterID') => $editor->getData('Site'),
                   );
         }
-        $this->addSelect('CenterIDs', 'Sites', $siteOptions, array("multiple"=>"multiple"));
+        $this->addSelect(
+            'CenterIDs',
+            'Sites',
+            $siteOptions,
+            array('multiple' => 'multiple')
+        );
 
         if ($editor->hasPermission('examiner_multisite')) {
             //get site aliases

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -59,7 +59,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                     return true;
                 }
 
-                return in_array($editor->getData('CenterID'), $user->getData('CentersID'));
+                return in_array($editor->getData('CenterID'), $user->getData('CenterIDs'));
             }
 
             return false;
@@ -238,7 +238,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             $pr_cid = $center['CenterID'];
             array_push($us_prev_sites, $pr_cid);
         }
-        $curr_sites = $values['CentersID'];
+        $curr_sites = $values['CenterIDs'];
         foreach ($curr_sites as $key=>$val) {
             //get MultiSelected CenterID
             array_push($us_curr_sites, $val);
@@ -283,7 +283,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             }
         }
         //END MULTI-SITE
-        unset($values['CentersID']);
+        unset($values['CenterIDs']);
 
         // EXAMINER UPDATE
         $ex_curr_sites =array();
@@ -615,7 +615,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                    $editor->getData('CenterID') => $editor->getData('Site'),
                   );
         }
-        $this->addSelect('CentersID', 'Sites', $siteOptions, array("multiple"=>"multiple"));
+        $this->addSelect('CenterIDs', 'Sites', $siteOptions, array("multiple"=>"multiple"));
 
         if ($editor->hasPermission('examiner_multisite')) {
             //get site aliases

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -222,19 +222,19 @@ class NDB_Form_User_Accounts extends NDB_Form
         }
 
         // multi-site UPDATE
-        $uid        = $user->getData('ID');
-        $curr_sites = $values['CenterIDs'];
+        $uid           = $user->getData('ID');
+        $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
             $DB->delete('user_psc_rel', array("UserID" => $uid));
-        }
-        foreach ($curr_sites as $site) {
-            $DB->insert(
-                'user_psc_rel',
-                array(
-                 "UserID"   => $uid,
-                 "CenterID" => $site,
-                )
-            );
+            foreach ($us_curr_sites as $site) {
+                $DB->insert(
+                    'user_psc_rel',
+                    array(
+                     "UserID"   => $uid,
+                     "CenterID" => $site,
+                    )
+                );
+            }
         }
         unset($values['CenterIDs']);
         // END multi-site UPDATE
@@ -333,6 +333,16 @@ class NDB_Form_User_Accounts extends NDB_Form
             // insert a new user
             $success = User::insert($set);
             $user    = User::factory($set['UserID']);
+            $uid     = $user->getData('ID');
+            foreach ($us_curr_sites as $site) {
+                $DB->insert(
+                    'user_psc_rel',
+                    array(
+                     "UserID"   => $uid,
+                     "CenterID" => $site,
+                    )
+                );
+            }
         } else {
             // update the user
             $user    = User::factory($this->identifier);

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -59,7 +59,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                     return true;
                 }
 
-                return $editor->getData('CenterID') == $user->getData('CenterID');
+                return in_array($editor->getData('CenterID'), $user->getData('SiteID'));
             }
 
             return false;

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -224,6 +224,7 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         // multi-site UPDATE
         $uid = $user->getData('ID');
+        $curr_sites = $values['CenterIDs'];
         $DB->delete('user_psc_rel', array("UserID" => $uid));
         foreach ($curr_sites as $site) {
             $DB->insert(

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -59,7 +59,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                     return true;
                 }
 
-                return in_array($editor->getData('CenterID'), $user->getData('SiteID'));
+                return in_array($editor->getData('CenterID'), $user->getData('CentersID'));
             }
 
             return false;
@@ -224,10 +224,9 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         $us_curr_sites =array();
         $us_prev_sites =array();
-        //get sites where user is already at for compare
+        //get sites where user is already at to compare
         $prev_sites = $DB->pselect(
-            "
-                        SELECT CenterID
+            "           SELECT CenterID
                         FROM user_psc_rel
                         WHERE UserID=:uid",
             array(
@@ -239,15 +238,13 @@ class NDB_Form_User_Accounts extends NDB_Form
             $pr_cid = $center['CenterID'];
             array_push($us_prev_sites, $pr_cid);
         }
-        $curr_sites = $values['SiteID'];
-print_r($values);
+        $curr_sites = $values['CentersID'];
         foreach ($curr_sites as $key=>$val) {
             //get MultiSelected CenterID
             array_push($us_curr_sites, $val);
             //Check if CenterID already in user_psc_rel for that user
             $result = $DB->pselectRow(
-                "
-                          SELECT CenterID
+                "         SELECT CenterID
                           FROM user_psc_rel
                           WHERE UserID=:uid",
                 array(
@@ -256,8 +253,6 @@ print_r($values);
             );
             // Center was not previously added
             if (empty($result) || is_null($result) || (!(in_array($val, $us_prev_sites)))) {
-                print_r ("In empty or NOT in_array loop");
-                print_r ("\n");
                 $DB->insert(
                     'user_psc_rel',
                     array(
@@ -288,8 +283,8 @@ print_r($values);
             }
         }
         //END MULTI-SITE
-        unset($values['SiteID']);
-        print_r($values);
+        unset($values['CentersID']);
+
         // EXAMINER UPDATE
         $ex_curr_sites =array();
         $ex_prev_sites =array();
@@ -620,7 +615,7 @@ print_r($values);
                    $editor->getData('CenterID') => $editor->getData('Site'),
                   );
         }
-        $this->addSelect('SiteID', 'Sitesss', $siteOptions, array("multiple"=>"multiple"));
+        $this->addSelect('CentersID', 'Sites', $siteOptions, array("multiple"=>"multiple"));
 
         if ($editor->hasPermission('examiner_multisite')) {
             //get site aliases

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -52,17 +52,8 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
             WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
-            $query .= " AND user_psc_rel.CenterID=";
-            $site_arr = $user->getCenterID();
-            $last_key = end(array_keys($site_arr));
-            foreach ($site_arr as $key=>$val) {
-                if ($key == $last_key) {
-                    $query .= $val;
-                }
-                else {
-                    $query .= $val . " OR user_psc_rel.CenterID=";
-                }
-            }
+            $site_arr = implode(",", $user->getCenterID());
+            $this->query .= " AND user_psc_rel.CenterID IN (" . $site_arr . ")";
         }
 
         // set the class variables
@@ -107,8 +98,8 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
                 $site[$key] = & Site::singleton($val);
                 $list_of_sites[$val] = $site[$key]->getCenterName();
             }
+            $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
         }
-
         // add form elements
         $this->addSelect('centerID', 'Site:', $list_of_sites);
         $this->addSelect(

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -52,7 +52,6 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
             WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
-            //$query .= " AND users.CenterID = '" . $user->getData('CenterID') . "' ";
             $query .= " AND user_psc_rel.CenterID=";
             $site_arr = $user->getCenterID();
             $last_key = end(array_keys($site_arr));
@@ -103,8 +102,7 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));*/
-            $site_arr = $user->getData('SiteID');
+            $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = & Site::singleton($val);
                 $list_of_sites[$val] = $site[$key]->getCenterName();

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -98,7 +98,7 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
                 $site[$key] = & Site::singleton($val);
                 $list_of_sites[$val] = $site[$key]->getCenterName();
             }
-            $list_of_sites = array('' => 'User All Sites') + $list_of_sites;
+            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
         // add form elements
         $this->addSelect('centerID', 'Site:', $list_of_sites);

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -47,44 +47,39 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
     function _setupVariables()
     {
         $user =& User::singleton();
-
         // the base query
-        $query = " FROM users LEFT JOIN psc ON " .
-                 "(psc.CenterID = users.CenterID) WHERE 1=1 ";
+        $query = " FROM users LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
+            LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
+            WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
-            $query .= " AND users.CenterID = '" . $user->getData('CenterID') .
-                      "' ";
+            //$query .= " AND users.CenterID = '" . $user->getData('CenterID') . "' ";
+            $query .= " AND user_psc_rel.CenterID=";
+            $site_arr = $user->getCenterID();
+            $last_key = end(array_keys($site_arr));
+            foreach ($site_arr as $key=>$val) {
+                if ($key == $last_key) {
+                    $query .= $val;
+                }
+                else {
+                    $query .= $val . " OR user_psc_rel.CenterID=";
+                }
+            }
         }
 
         // set the class variables
-        $this->columns      = array(
-                               "COALESCE(psc.Name,'Not Assigned') AS PSC",
-                               'UserID AS Username',
-                               'Real_name AS Full_name',
-                               'Email',
-                               'Active',
-                               'Pending_approval',
-                              );
-        $this->query        = $query;
-        $this->order_by     = 'Username';
-        $this->validFilters = array(
-                               'users.CenterID',
-                               'users.UserID',
-                               'users.Real_name',
-                               'users.Email',
-                               'users.Active',
-                               'users.Examiner',
-                               'users.Pending_approval',
-                              );
+        $this->columns = array("COALESCE(psc.Name,'Not Assigned') AS PSC", 'users.UserID AS Username', 'Real_name AS Full_name', 'Email', 'Active', 'Pending_approval');
+        $this->query = $query;
+        $this->order_by = 'Username';
+        $this->validFilters = array('user_psc_rel.CenterID', 'users.UserID', 'users.Real_name', 'users.Email', 'users.Active', 'users.Examiner', 'users.Pending_approval');
 
         $this->formToFilter = array(
-                               'centerID'  => 'users.CenterID',
-                               'active'    => 'users.Active',
-                               'userID'    => 'users.UserID',
-                               'real_name' => 'users.Real_name',
-                               'email'     => 'users.Email',
-                               'pending'   => 'users.Pending_approval',
-                              );
+                                    'centerID' => 'user_psc_rel.CenterID',
+                                    'active' => 'users.Active',
+                                    'userID' => 'users.UserID',
+                                    'real_name' => 'users.Real_name',
+                                    'email' => 'users.Email',
+                                    'pending' => 'users.Pending_approval'
+                                    );
         return true;
     }
     /**
@@ -108,10 +103,12 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site          =& Site::singleton($user->getData('CenterID'));
-            $list_of_sites = array(
-                              $user->getData('CenterID') => $user->getData('Site'),
-                             );
+            $list_of_sites = array($user->getData('CenterID') => $user->getData('Site'));*/
+            $site_arr = $user->getData('SiteID');
+            foreach ($site_arr as $key=>$val) {
+                $site[$key] = & Site::singleton($val);
+                $list_of_sites[$val] = $site[$key]->getCenterName();
+            }
         }
 
         // add form elements

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -48,28 +48,44 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
     {
         $user =& User::singleton();
         // the base query
-        $query = " FROM users LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
+        $query = " FROM users 
+            LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
             WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND user_psc_rel.CenterID IN (" . $site_arr . ")";
         }
 
         // set the class variables
-        $this->columns = array("COALESCE(psc.Name,'Not Assigned') AS PSC", 'users.UserID AS Username', 'Real_name AS Full_name', 'Email', 'Active', 'Pending_approval');
-        $this->query = $query;
-        $this->order_by = 'Username';
-        $this->validFilters = array('user_psc_rel.CenterID', 'users.UserID', 'users.Real_name', 'users.Email', 'users.Active', 'users.Examiner', 'users.Pending_approval');
+        $this->columns      = array(
+                               "COALESCE(psc.Name,'Not Assigned') AS PSC",
+                               'users.UserID AS Username',
+                               'Real_name AS Full_name',
+                               'Email',
+                               'Active',
+                               'Pending_approval',
+                              );
+        $this->query        = $query;
+        $this->order_by     = 'Username';
+        $this->validFilters = array(
+                               'user_psc_rel.CenterID',
+                               'users.UserID',
+                               'users.Real_name',
+                               'users.Email',
+                               'users.Active',
+                               'users.Examiner',
+                               'users.Pending_approval',
+                              );
 
         $this->formToFilter = array(
-                                    'centerID' => 'user_psc_rel.CenterID',
-                                    'active' => 'users.Active',
-                                    'userID' => 'users.UserID',
-                                    'real_name' => 'users.Real_name',
-                                    'email' => 'users.Email',
-                                    'pending' => 'users.Pending_approval'
-                                    );
+                               'centerID'  => 'user_psc_rel.CenterID',
+                               'active'    => 'users.Active',
+                               'userID'    => 'users.UserID',
+                               'real_name' => 'users.Real_name',
+                               'email'     => 'users.Email',
+                               'pending'   => 'users.Pending_approval',
+                              );
         return true;
     }
     /**
@@ -95,7 +111,7 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             // allow only to view own site data
             $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
-                $site[$key] = & Site::singleton($val);
+                $site[$key]          = & Site::singleton($val);
                 $list_of_sites[$val] = $site[$key]->getCenterName();
             }
             $list_of_sites = array('' => 'All User Sites') + $list_of_sites;

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -291,10 +291,10 @@ $(document).ready(function() {
     {/if}
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
-    		{$form.CenterID.label}
+    		{$form.SiteID.label}
     	</label>	
     	<div class="col-sm-10">
-    		{$form.CenterID.html}
+    		{$form.SiteID.html}
     	</div>
     </div>
         {if $form.errors.examiner_sites}

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -291,10 +291,10 @@ $(document).ready(function() {
     {/if}
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
-    		{$form.CentersID.label}
+    		{$form.CenterIDs.label}
     	</label>	
     	<div class="col-sm-10">
-    		{$form.CentersID.html}
+    		{$form.CenterIDs.html}
     	</div>
     </div>
         {if $form.errors.examiner_sites}

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -291,10 +291,10 @@ $(document).ready(function() {
     {/if}
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
-    		{$form.SiteID.label}
+    		{$form.CentersID.label}
     	</label>	
     	<div class="col-sm-10">
-    		{$form.SiteID.html}
+    		{$form.CentersID.html}
     	</div>
     </div>
         {if $form.errors.examiner_sites}

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1084,7 +1084,7 @@ class NDB_BVL_Feedback
 
         $user =& User::singleton();
 
-        $site_arr = $user->getData('SiteID');
+        $site_arr = $user->getData('CentersID');
         foreach ($site_arr as $key=>$val) {
                 $site[$key] = & Site::singleton($val);
                 $isStudySite[$key] = $site[$key]->isStudySite();

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1084,7 +1084,7 @@ class NDB_BVL_Feedback
 
         $user =& User::singleton();
 
-        $site_arr = $user->getData('CentersID');
+        $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
                 $site[$key] = & Site::singleton($val);
                 $isStudySite[$key] = $site[$key]->isStudySite();

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1084,9 +1084,13 @@ class NDB_BVL_Feedback
 
         $user =& User::singleton();
 
-        $site =& Site::singleton($user->getData('CenterID'));
-
-        if ($site->isStudySite()) {
+        $site_arr = $user->getData('SiteID');
+        foreach ($site_arr as $key=>$val) {
+                $site[$key] = & Site::singleton($val);
+                $isStudySite[$key] = $site[$key]->isStudySite();
+        }
+        $oneIsStudySite = in_array("1", $isStudySite);
+        if ($oneIsStudySite) {
             if ($user->hasPermission('bvl_feedback')) {
                 if (($test_name === "timepoint_list")
                     || ($test_name === "instrument_list")

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -1086,7 +1086,7 @@ class NDB_BVL_Feedback
 
         $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
-                $site[$key] = & Site::singleton($val);
+                $site[$key]        = & Site::singleton($val);
                 $isStudySite[$key] = $site[$key]->isStudySite();
         }
         $oneIsStudySite = in_array("1", $isStudySite);

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -368,7 +368,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
         // make sure user belongs to same site as timepoint
         if (!$user->hasPermission('data_entry')
-            || !in_array($timePoint->getData('CenterID'), $user->getData('CentersID'))
+            || !in_array($timePoint->getData('CenterID'), $user->getData('CenterIDs'))
         ) {
             return false;
         }

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -368,7 +368,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
         // make sure user belongs to same site as timepoint
         if (!$user->hasPermission('data_entry')
-            || $user->getData('CenterID') != $timePoint->getData('CenterID')
+            || !in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))
         ) {
             return false;
         }

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -368,7 +368,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
         // make sure user belongs to same site as timepoint
         if (!$user->hasPermission('data_entry')
-            || !in_array($timePoint->getData('CenterID'), $user->getData('SiteID'))
+            || !in_array($timePoint->getData('CenterID'), $user->getData('CentersID'))
         ) {
             return false;
         }

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -368,7 +368,10 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
         // make sure user belongs to same site as timepoint
         if (!$user->hasPermission('data_entry')
-            || !in_array($timePoint->getData('CenterID'), $user->getData('CenterIDs'))
+            || !in_array(
+                $timePoint->getData('CenterID'),
+                $user->getData('CenterIDs')
+            )
         ) {
             return false;
         }

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -495,7 +495,10 @@ class NDB_Caller
         // freeze the form to prevent data entry
         if ($status->getDataEntryStatus() != 'In Progress'
             || !$user->hasPermission('data_entry')
-            || !in_array($timepoint->getData("CenterID"), $user->getData("CenterIDs"))
+            || !in_array(
+                $timepoint->getData("CenterID"),
+                $user->getData("CenterIDs")
+            )
         ) {
             if ($instrument->preview !== true && $this->DataEntry !== 'Direct') {
                 $instrument->freeze();

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -495,7 +495,7 @@ class NDB_Caller
         // freeze the form to prevent data entry
         if ($status->getDataEntryStatus() != 'In Progress'
             || !$user->hasPermission('data_entry')
-            || !in_array($timepoint->getData("CenterID"), $user->getData("CentersID"))
+            || !in_array($timepoint->getData("CenterID"), $user->getData("CenterIDs"))
         ) {
             if ($instrument->preview !== true && $this->DataEntry !== 'Direct') {
                 $instrument->freeze();

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -495,7 +495,7 @@ class NDB_Caller
         // freeze the form to prevent data entry
         if ($status->getDataEntryStatus() != 'In Progress'
             || !$user->hasPermission('data_entry')
-            || !in_array($timepoint->getData("CenterID"), $user->getData("CenterID"))
+            || !in_array($timepoint->getData("CenterID"), $user->getData("CentersID"))
         ) {
             if ($instrument->preview !== true && $this->DataEntry !== 'Direct') {
                 $instrument->freeze();

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -495,7 +495,7 @@ class NDB_Caller
         // freeze the form to prevent data entry
         if ($status->getDataEntryStatus() != 'In Progress'
             || !$user->hasPermission('data_entry')
-            || $user->getData("CenterID") != $timepoint->getData("CenterID")
+            || !in_array($timepoint->getData("CenterID"), $user->getData("CenterID"))
         ) {
             if ($instrument->preview !== true && $this->DataEntry !== 'Direct') {
                 $instrument->freeze();

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -187,11 +187,14 @@ class TimePoint
      * @param integer $candID         6 digit CandID having a timepoint created.
      * @param integer $SubprojectID   The subprojectID of the new timepoint
      * @param string  $nextVisitLabel The visit label of the timepoint being created
+     * @param string  $psc            The centre of the timepoint
      *
      * @return A new TimePoint instance.
      */
-    static function createNew($candID, $SubprojectID, $nextVisitLabel = null)
-    {
+    static function createNew($candID, $SubprojectID,
+        $nextVisitLabel = null, $psc = null
+    ) {
+
         // insert into session set CandID=$candID,
         // SubprojectID=$SubprojectID, VisitNo=nextVisitNumber(),
         // UserID=$State->getUsername(), etc...  NO Date_* are
@@ -224,12 +227,15 @@ class TimePoint
         $VisitLabel = $nextVisitLabel == null
             ? 'V' . $row['nextVisitNo']
             : $nextVisitLabel;
+        $centerID   = $psc == null
+        ? $row['CenterID']
+        : $psc;
         $insertData = array(
                        'CandID'          => $candID,
                        'SubprojectID'    => $SubprojectID,
                        'VisitNo'         => $row['nextVisitNo'],
                        'Visit_label'     => $VisitLabel,
-                       'CenterID'        => $row['CenterID'],
+                       'CenterID'        => $centerID,
                        'Current_stage'   => 'Not Started',
                        'Submitted'       => 'N',
                        'registeredBy'    => $userID,

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -56,8 +56,7 @@ class User extends UserPermissions
 
         // get user data from database
         $query = "SELECT users.*,
-            GROUP_CONCAT(psc.Name SEPARATOR '; ') AS Site,
-            psc.Name 
+            GROUP_CONCAT(psc.Name SEPARATOR '; ') AS Sites
             FROM users
             LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
@@ -215,7 +214,7 @@ class User extends UserPermissions
      */
     function getSiteName()
     {
-        return $this->userInfo['Site'];
+        return $this->userInfo['Sites'];
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -55,11 +55,27 @@ class User extends UserPermissions
         $DB =& Database::singleton();
 
         // get user data from database
-        $query = "SELECT users.*, psc.Name AS Site FROM users
-            LEFT JOIN psc ON (users.centerID=psc.CenterID)
-            WHERE users.UserID = :UID";
+//        $query = "SELECT users.*, psc.Name AS Site FROM users
+//            LEFT JOIN psc ON (users.centerID=psc.CenterID)
+//            WHERE users.UserID = :UID";
+        $query = "SELECT users.*,
+            GROUP_CONCAT(psc.Name SEPARATOR '; ') AS Site,
+            psc.Name 
+            FROM users
+            LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
+            LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
+            WHERE users.UserID = :UID
+            GROUP BY users.ID";
 
         $row = $DB->pselectRow($query, array('UID' => $username));
+
+        // get user sites
+        $user_centerID_query =  $DB->pselect("SELECT CenterID FROM user_psc_rel upr 
+                        WHERE upr.UserID= :UID", array('UID' => $row['ID']));
+
+        foreach ($user_centerID_query as $key=>$val){
+            $user_cid[$key]=$val['CenterID'];
+        }
 
         // Get examiner information
         $examiner_check = $DB->pselect(
@@ -86,6 +102,7 @@ class User extends UserPermissions
         }
         // store user data in object property
         $row['examiner'] =$examiner_info;
+        $row['SiteID']=$user_cid;
         $obj->userInfo   = $row;
         return $obj;
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -56,7 +56,7 @@ class User extends UserPermissions
 
         // get user data from database
         $query = "SELECT users.*,
-            GROUP_CONCAT(psc.Name SEPARATOR '; ') AS Sites
+            GROUP_CONCAT(psc.Name SEPARATOR ';') AS Sites
             FROM users
             LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -225,8 +225,10 @@ class User extends UserPermissions
      */
     function getCenterID()
     {
-        return $this->userInfo['CenterID'];
+//        return $this->userInfo['CenterID'];
+        return $this->userInfo['SiteID'];
     }
+
 
     /**
      * Unknown what this does. Maybe it should be removed?

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -99,7 +99,7 @@ class User extends UserPermissions
         }
         // store user data in object property
         $row['examiner'] =$examiner_info;
-        $row['CentersID']   =$user_cid;
+        $row['CenterIDs']   =$user_cid;
         $obj->userInfo   =$row;
         return $obj;
     }
@@ -222,7 +222,7 @@ class User extends UserPermissions
      */
     function getCenterID()
     {
-        return $this->userInfo['CentersID'];
+        return $this->userInfo['CenterIDs'];
     }
 
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -67,11 +67,14 @@ class User extends UserPermissions
         $row = $DB->pselectRow($query, array('UID' => $username));
 
         // get user sites
-        $user_centerID_query =  $DB->pselect("SELECT CenterID FROM user_psc_rel upr 
-                        WHERE upr.UserID= :UID", array('UID' => $row['ID']));
+        $user_centerID_query =  $DB->pselect(
+            "SELECT CenterID FROM user_psc_rel upr 
+                        WHERE upr.UserID= :UID",
+            array('UID' => $row['ID'])
+        );
 
-        foreach ($user_centerID_query as $key=>$val){
-            $user_cid[$key]=$val['CenterID'];
+        foreach ($user_centerID_query as $key=>$val) {
+            $user_cid[$key] =$val['CenterID'];
         }
 
         // Get examiner information
@@ -98,9 +101,9 @@ class User extends UserPermissions
             }
         }
         // store user data in object property
-        $row['examiner'] =$examiner_info;
-        $row['CenterIDs']   =$user_cid;
-        $obj->userInfo   =$row;
+        $row['examiner']  =$examiner_info;
+        $row['CenterIDs'] =$user_cid;
+        $obj->userInfo    =$row;
         return $obj;
     }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -55,9 +55,6 @@ class User extends UserPermissions
         $DB =& Database::singleton();
 
         // get user data from database
-//        $query = "SELECT users.*, psc.Name AS Site FROM users
-//            LEFT JOIN psc ON (users.centerID=psc.CenterID)
-//            WHERE users.UserID = :UID";
         $query = "SELECT users.*,
             GROUP_CONCAT(psc.Name SEPARATOR '; ') AS Site,
             psc.Name 
@@ -102,8 +99,8 @@ class User extends UserPermissions
         }
         // store user data in object property
         $row['examiner'] =$examiner_info;
-        $row['SiteID']=$user_cid;
-        $obj->userInfo   = $row;
+        $row['CentersID']   =$user_cid;
+        $obj->userInfo   =$row;
         return $obj;
     }
 
@@ -225,8 +222,7 @@ class User extends UserPermissions
      */
     function getCenterID()
     {
-//        return $this->userInfo['CenterID'];
-        return $this->userInfo['SiteID'];
+        return $this->userInfo['CentersID'];
     }
 
 

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -161,7 +161,7 @@
                         </li>
                         <li>
                             <p class="navbar-text">
-                                &nbsp;&nbsp;  Site: {$user.Site} &nbsp;
+                                &nbsp;&nbsp;  Sites: {$user.Sites} &nbsp;
                             </p>
                         </li>
                         <li class="dropdown">

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -74,7 +74,6 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
              'First_name'       => 'Unit',
              'Last_name'        => 'Tester',
              'Email'            => 'tester@example.com',
-             'CenterID'         => 1,
              'Privilege'        => 0,
              'PSCPI'            => 'N',
              'Active'           => 'Y',
@@ -82,6 +81,14 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
              'Password_hash'    => null,
              'Password_expiry'  => '2099-12-31',
              'Pending_approval' => 'N',
+            )
+        );
+
+        $this->DB->insert(
+            "user_psc_rel",
+            array(
+                'UserID'    => 999990,
+                'CenterID'  => 1,
             )
         );
 
@@ -295,7 +302,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
     function changeStudySite()
     {
         $this->DB->insert("psc", array("CenterID" => 99, "Alias" => "BBQ"));
-        $this->DB->update("users", array("CenterID" => 99), array("ID" => 999990));
+        $this->DB->update("user_psc_rel", array("CenterID" => 99), array("UserID" => 999990));
     }
 
     /**
@@ -305,7 +312,7 @@ abstract class LorisIntegrationTest extends PHPUnit_Framework_TestCase
      */
     function resetStudySite()
     {
-        $this->DB->update("users", array("CenterID" => 1), array("ID" => 999990));
+        $this->DB->update("user_psc_rel", array("CenterID" => 1), array("UserID" => 999990));
         $this->DB->delete("psc", array("CenterID" => 99));
     }
 


### PR DESCRIPTION
Main changes:
- Dropping the column CenterID in the users table (commented out for now in the mysql patch), and moving this information to a new table: user_psc_rel
- User Accounts module now allows for multi-site selection from the dropdown menu
- Creation of a new candidate now requires a site selection if the user has multi-site affiliation
- Creation of a timepoint also would have an additional dropdown menu for site selection when the user has multiple sites (another redmine task, Redmine 11009, but it made sense to add it here, I think!)
- Filters dropdown across all modules now get populated with the multiple sites of the user (with an additional option: 'User All Sites'; as a parallel to the 'All' option when user has the 'all-site' permission); perhaps not the right thing to do?
- IsStudySite() complicates things (I think) if the user has some sites which are StudySites and others which are not. I opted for the option that if at least one of the sites is a study site, then return true (perhaps makes no sense, other suggestions?)
- Next to the User logged on, now the "Sites: " field is populated with *all* the sites the user belongs to, semi-column separated. Any better alternative/suggestion? 
- Request account now writes the appropriate data into the user_psc_rel table, but it **does not allow a multi-select for the users when they request an account**
- Admin was added by default to **all sites** as per @xlecours suggestion

Changes still needed:
- API
- All test plans 
- Test cases for automated tests to account for the fact that users can be multi-sited
- Dashboard: "Incomplete Forms" link takes us to a submenu of statistics that does not currently allow multi centers in its Request; (http://localhost/statistics/?submenu=statistics_site&CenterID=1,21,53); so this link will not display results for centers 1, 21 and 53



