### PR TITLE
[CORE] Change MyISAM to INNODB Script

### DIFF
--- a/tools/Engine_Change_MyISAM_to_INNODB.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Script exporting Update statements to remove 0000-00-00 values
+ * and replace them by NULL
+ *
+ * PHP Version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Various <example@example.com>
+ * @license  Loris license
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+set_include_path(get_include_path().":".__DIR__."/../project/libraries:".":".__DIR__."/../php/libraries:");
+require_once __DIR__ . "/../../vendor/autoload.php";
+//require_once "NDB_Config.class.inc";
+
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize(__DIR__."/../project/config.xml");
+$config = NDB_Config::singleton();
+
+$db =& Database::singleton();
+$database = $config->getSetting('database');
+
+$base = $config->getSetting('base');
+$db->_trackChanges = false;
+
+$filename = __DIR__ . "/../project/tables_sql/change_MyISQM_to_INNODB.sql";
+$output = "";
+$output .="SET FOREIGN_KEY_CHECKS=0; \n";
+
+echo "\n#################################################################\n\n".
+    "This script will create ALTER TABLE statements to change any table in the ".
+    "database with a MyISAM engine to use INNODB. \nThe output file is ".
+    "tables_sql/change_MyISQM_to_INNODB.sql and includes foreign key ".
+    "checks disabling and re-enabling.\n".
+    "\n#################################################################\n\n";
+
+$database_name= $database['database'];
+
+$table_names = $db->pselect("
+                      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+                      WHERE TABLE_SCHEMA =:dbn 
+                        AND ENGINE = 'MyISAM'",
+    array("dbn"=>$database['database'])
+);
+
+foreach ($table_names as $key=>$table)
+{
+    $output .= "ALTER TABLE `".$table["TABLE_NAME"]."` ENGINE=INNODB;\n";
+}
+$output .="SET FOREIGN_KEY_CHECKS=1; \n";
+$fp=fopen($filename, "w");
+fwrite($fp, $output);
+fclose($fp);
+
+?>

--- a/tools/Engine_Change_MyISAM_to_INNODB_allTables.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB_allTables.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Script exporting Update statements to remove 0000-00-00 values
- * and replace them by NULL
+ * Script changing all table engines in the database to InnoDB
  *
  * PHP Version 5
  *

--- a/tools/Engine_Change_MyISAM_to_INNODB_allTables.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB_allTables.php
@@ -12,39 +12,39 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 set_include_path(get_include_path().":".__DIR__."/../project/libraries:".":".__DIR__."/../php/libraries:");
-require_once __DIR__ . "/../../vendor/autoload.php";
-//require_once "NDB_Config.class.inc";
+require_once __DIR__ . "/../vendor/autoload.php";
 
+// Base variables
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__."/../project/config.xml");
 $config = NDB_Config::singleton();
-
 $db =& Database::singleton();
 $database = $config->getSetting('database');
 
-$base = $config->getSetting('base');
-$db->_trackChanges = false;
-
-$filename = __DIR__ . "/../project/tables_sql/change_MyISQM_to_INNODB.sql";
-$output = "";
-$output .="SET FOREIGN_KEY_CHECKS=0; \n";
 
 echo "\n#################################################################\n\n".
     "This script will create ALTER TABLE statements to change any table in the ".
-    "database with a MyISAM engine to use INNODB. \nThe output file is ".
+    "DATABASE with a MyISAM engine to use INNODB. \nThe output file is ".
     "tables_sql/change_MyISQM_to_INNODB.sql and includes foreign key ".
     "checks disabling and re-enabling.\n".
     "\n#################################################################\n\n";
 
-$database_name= $database['database'];
 
+// SETUP INPUT from Database table schema
 $table_names = $db->pselect("
-                      SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+                      SELECT TABLE_NAME 
+                      FROM INFORMATION_SCHEMA.TABLES
                       WHERE TABLE_SCHEMA =:dbn 
                         AND ENGINE = 'MyISAM'",
     array("dbn"=>$database['database'])
 );
+//END INPUT
+
+// SETUP OUTPUT to file in project/tables_sql/change_MyISQM_to_INNODB_allTables.sql
+$filename = __DIR__ . "/../project/tables_sql/change_MyISQM_to_INNODB_allTables.sql";
+$output = "";
+$output .="SET FOREIGN_KEY_CHECKS=0; \n";
 
 foreach ($table_names as $key=>$table)
 {
@@ -54,5 +54,4 @@ $output .="SET FOREIGN_KEY_CHECKS=1; \n";
 $fp=fopen($filename, "w");
 fwrite($fp, $output);
 fclose($fp);
-
 ?>

--- a/tools/Engine_Change_MyISAM_to_INNODB_allTables.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB_allTables.php
@@ -41,16 +41,17 @@ $table_names = $db->pselect("
 );
 //END INPUT
 
-// SETUP OUTPUT to file in project/tables_sql/change_MyISQM_to_INNODB_allTables.sql
-$filename = __DIR__ . "/../project/tables_sql/change_MyISQM_to_INNODB_allTables.sql";
+// SETUP OUTPUT to file in project/tables_sql/change_MyISAM_to_INNODB_allTables.sql
+$filename = __DIR__ . "/../project/tables_sql/change_MyISAM_to_INNODB_allTables.sql";
 $output = "";
+$output .="SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS; \n";
 $output .="SET FOREIGN_KEY_CHECKS=0; \n";
 
 foreach ($table_names as $key=>$table)
 {
     $output .= "ALTER TABLE `".$table["TABLE_NAME"]."` ENGINE=INNODB;\n";
 }
-$output .="SET FOREIGN_KEY_CHECKS=1; \n";
+$output .="SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS; \n";
 $fp=fopen($filename, "w");
 fwrite($fp, $output);
 fclose($fp);

--- a/tools/Engine_Change_MyISAM_to_INNODB_schemaTables.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB_schemaTables.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Script exporting Update statements to remove 0000-00-00 values
+ * and replace them by NULL
+ *
+ * PHP Version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Various <example@example.com>
+ * @license  Loris license
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+set_include_path(get_include_path().":".__DIR__."/../project/libraries:".":".__DIR__."/../php/libraries:");
+require_once __DIR__ . "/../vendor/autoload.php";
+
+// Base variables
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize(__DIR__."/../project/config.xml");
+$config = NDB_Config::singleton();
+$db =& Database::singleton();
+$base = $config->getSetting('base');
+
+
+echo "\n#################################################################\n\n".
+    "This script will create ALTER TABLE statements to change any table in the ".
+    "Loris SCHEMA with a MyISAM engine to use INNODB. \nThe output file is ".
+    "tables_sql/change_MyISQM_to_INNODB.sql and includes foreign key ".
+    "checks disabling and re-enabling.\n".
+    "\n#################################################################\n\n";
+
+
+// SETUP INPUT from schema files in SQL loris directory
+$schemaFiles=array(
+    "0000-00-00-schema.sql",
+    "0000-00-01-Permission.sql",
+    "0000-00-02-Menus.sql",
+    "0000-00-03-ConfigTables.sql",
+    "0000-00-04-Help.sql"
+);
+$schemaFileBase=$base."SQL/";
+$completeSchema="";
+foreach ($schemaFiles as $file) {
+    $completeSchema .= $fc =file_get_contents($schemaFileBase.$file, "r");
+}
+//print_r($completeSchema);
+$createdTables=array();
+preg_match_all('/CREATE TABLE \`([_a-zA-Z0-9]+)\`/', $completeSchema, $createdTables);
+//END INPUT
+
+// SETUP OUTPUT to file in project/tables_sql/change_MyISQM_to_INNODB_schemaTables.sql
+$filename = __DIR__ . "/../project/tables_sql/change_MyISQM_to_INNODB_schemaTables.sql";
+$output = "";
+$output .="SET FOREIGN_KEY_CHECKS=0; \n";
+
+foreach ($createdTables[1] as $key=>$table)
+{
+    $output .= "ALTER TABLE `".$table."` ENGINE=INNODB;\n";
+}
+$output .="SET FOREIGN_KEY_CHECKS=1; \n";
+$fp=fopen($filename, "w");
+fwrite($fp, $output);
+fclose($fp);
+?>

--- a/tools/Engine_Change_MyISAM_to_INNODB_schemaTables.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB_schemaTables.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Script exporting Update statements to remove 0000-00-00 values
- * and replace them by NULL
+ * Script changing all table engines from the schema to InnoDB
  *
  * PHP Version 5
  *

--- a/tools/Engine_Change_MyISAM_to_INNODB_schemaTables.php
+++ b/tools/Engine_Change_MyISAM_to_INNODB_schemaTables.php
@@ -49,16 +49,17 @@ $createdTables=array();
 preg_match_all('/CREATE TABLE \`([_a-zA-Z0-9]+)\`/', $completeSchema, $createdTables);
 //END INPUT
 
-// SETUP OUTPUT to file in project/tables_sql/change_MyISQM_to_INNODB_schemaTables.sql
-$filename = __DIR__ . "/../project/tables_sql/change_MyISQM_to_INNODB_schemaTables.sql";
+// SETUP OUTPUT to file in project/tables_sql/change_MyISAM_to_INNODB_schemaTables.sql
+$filename = __DIR__ . "/../project/tables_sql/change_MyISAM_to_INNODB_schemaTables.sql";
 $output = "";
+$output .="SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS; \n";
 $output .="SET FOREIGN_KEY_CHECKS=0; \n";
 
 foreach ($createdTables[1] as $key=>$table)
 {
     $output .= "ALTER TABLE `".$table."` ENGINE=INNODB;\n";
 }
-$output .="SET FOREIGN_KEY_CHECKS=1; \n";
+$output .="SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS; \n";
 $fp=fopen($filename, "w");
 fwrite($fp, $output);
 fclose($fp);


### PR DESCRIPTION
This will be necessary for all old databases. 

The new changes coming to 18.0 will require InnoDB engine for foreign key constraints.