### PR TITLE
[LorisForm] Multiselect required rule

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -658,6 +658,7 @@ class LorisForm
         $id            = '';
         $disabled      = '';
         $name          = $el['name'];
+        $hasSelection = false;
 
         foreach ($options as $optionKey => $optionVal) {
             $selected = '';
@@ -671,6 +672,7 @@ class LorisForm
                     && in_array($optionKey, $this->getValue($el['name']))
                 ) {
                     $selected = 'selected="selected"';
+                    $hasSelection = true;
                 }
             } else {
                 if ($optionKey === $this->getValue($el['name'])) {
@@ -683,8 +685,11 @@ class LorisForm
                 }
             }
 
+            // Don't add empty option to multiselect, it is done outside the loop
+            if (isset($el['multiple']) && !$optionKey) { continue; }
+
             $strOptions .= "<option value='$optionKey' $selected>"
-                .$optionVal
+                . $optionVal
                 . "</option>";
         }
 
@@ -703,6 +708,10 @@ class LorisForm
         if (isset($el['multiple'])) {
             $name     = $name . '[]';
             $multiple = "multiple=\"multiple\"";
+
+            // Add empty option and select it if nothing else was selected
+            $selected = $hasSelection ? '' : 'selected';
+            $strOptions = "<option value='' $selected></option>" . $strOptions;
         }
 
         $retVal = "<select name=\"$name\" $cls $id $changehandler $multiple "

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -658,7 +658,7 @@ class LorisForm
         $id            = '';
         $disabled      = '';
         $name          = $el['name'];
-        $hasSelection = false;
+        $hasSelection  = false;
 
         foreach ($options as $optionKey => $optionVal) {
             $selected = '';
@@ -671,7 +671,7 @@ class LorisForm
                 if (!empty($this->getValue($el['name']))
                     && in_array($optionKey, $this->getValue($el['name']))
                 ) {
-                    $selected = 'selected="selected"';
+                    $selected     = 'selected="selected"';
                     $hasSelection = true;
                 }
             } else {
@@ -686,7 +686,9 @@ class LorisForm
             }
 
             // Don't add empty option to multiselect, it is done outside the loop
-            if (isset($el['multiple']) && !$optionKey) { continue; }
+            if (isset($el['multiple']) && !$optionKey) {
+                continue;
+            }
 
             $strOptions .= "<option value='$optionKey' $selected>"
                 . $optionVal
@@ -710,7 +712,7 @@ class LorisForm
             $multiple = "multiple=\"multiple\"";
 
             // Add empty option and select it if nothing else was selected
-            $selected = $hasSelection ? '' : 'selected';
+            $selected   = $hasSelection ? '' : 'selected';
             $strOptions = "<option value='' $selected></option>" . $strOptions;
         }
 

--- a/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
@@ -121,6 +121,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends \PHPUnit_Framework_TestCase
                 "Description" => "Test Question",
                 "Options" => [
                     "Values" => [
+                        "_empty_" => "",
                         "value" => "Option"
                     ],
                     "RequireResponse" => false,
@@ -136,6 +137,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends \PHPUnit_Framework_TestCase
                 "Description" => "Test Question",
                 "Options" => [
                     "Values" => [
+                        "_empty_" => "",
                         "value" => "Option"
                     ],
                     "RequireResponse" => true,


### PR DESCRIPTION
Currently, the multi-select is not required by default, unless user explicitly selects the 'empty' option. See screenshots.

**Not preselected:**
![image](https://cloud.githubusercontent.com/assets/6627543/21369989/9fa8c5ca-c6d7-11e6-8b2a-e601f7471ff6.png)

**Preselected:**
![image](https://cloud.githubusercontent.com/assets/6627543/21370009/b2ea59fa-c6d7-11e6-8350-3cad47572ec4.png)

----

This PR addresses issue (Redmine 9049) and makes the empty option selected by default. (unless there is already an existing selection) 

