### PR TITLE
[Core] Remove last react error/warning from StaticDataTable

### DIFF
--- a/htdocs/js/components/StaticDataTable.js
+++ b/htdocs/js/components/StaticDataTable.js
@@ -345,8 +345,8 @@ var StaticDataTable = React.createClass({
           data = this.props.getFormattedCell(this.props.Headers[j], data, this.props.Data[index[_i2].RowIdx], this.props.Headers);
           if (data !== null) {
             // Note: Can't currently pass a key, need to update columnFormatter
-            // to not return a <td> node
-            curRow.push(data);
+            // to not return a <td> node. Using createFragment instead.
+            curRow.push(React.addons.createFragment({ data: data }));
           }
         } else {
           curRow.push(React.createElement(

--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -352,8 +352,8 @@ var StaticDataTable = React.createClass({
           );
           if (data !== null) {
             // Note: Can't currently pass a key, need to update columnFormatter
-            // to not return a <td> node
-            curRow.push(data);
+            // to not return a <td> node. Using createFragment instead.
+            curRow.push(React.addons.createFragment({data}));
           }
         } else {
           curRow.push(<td key={key}>{data}</td>);


### PR DESCRIPTION
>No more annoying console errors!

![image](https://cloud.githubusercontent.com/assets/6627543/21691448/93b36150-d346-11e6-91c5-c0c3e44546de.png)

Since children are returned from columnFormatter as a `<td>` element, there is no easy way to add a unique key to them. This fix seems to be the suggested approach for such situations.