### PR TITLE
[Core] New React Panel component

### DIFF
--- a/htdocs/js/components/Panel.js
+++ b/htdocs/js/components/Panel.js
@@ -85,7 +85,11 @@ var Panel = function (_React$Component) {
   return Panel;
 }(React.Component);
 
-Panel.propTypes = {};
+Panel.propTypes = {
+  id: React.PropTypes.string,
+  height: React.PropTypes.string,
+  title: React.PropTypes.string
+};
 Panel.defaultProps = {
   id: 'default-panel',
   height: '100%',

--- a/htdocs/js/components/Panel.js
+++ b/htdocs/js/components/Panel.js
@@ -1,0 +1,91 @@
+"use strict";
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/* exported Panel */
+
+/**
+ * This file contains React component for Panel
+ *
+ * @author Alex I.
+ * @version 1.0.0
+ *
+ */
+
+/**
+ * Panel component
+ * Wraps children in a collapsible bootstrap panel
+ */
+var Panel = function (_React$Component) {
+  _inherits(Panel, _React$Component);
+
+  function Panel(props) {
+    _classCallCheck(this, Panel);
+
+    var _this = _possibleConstructorReturn(this, (Panel.__proto__ || Object.getPrototypeOf(Panel)).call(this, props));
+
+    _this.state = {
+      collapsed: false
+    };
+
+    _this.toggleCollapsed = _this.toggleCollapsed.bind(_this);
+    return _this;
+  }
+
+  _createClass(Panel, [{
+    key: "toggleCollapsed",
+    value: function toggleCollapsed() {
+      this.setState({ collapsed: !this.state.collapsed });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      // Selection filter open by default
+      var glyphClass = "glyphicon pull-right glyphicon-chevron-up";
+      var panelClass = "panel-collapse collapse in";
+
+      // Change arrow direction when closed
+      if (this.state.collapsed) {
+        glyphClass = "glyphicon pull-right glyphicon-chevron-down";
+      }
+
+      return React.createElement(
+        "div",
+        { className: "panel panel-primary" },
+        React.createElement(
+          "div",
+          { className: "panel-heading",
+            onClick: this.toggleCollapsed,
+            "data-toggle": "collapse",
+            "data-target": '#' + this.props.id
+          },
+          this.props.title,
+          React.createElement("span", { className: glyphClass })
+        ),
+        React.createElement(
+          "div",
+          { id: this.props.id, className: panelClass, role: "tabpanel" },
+          React.createElement(
+            "div",
+            { className: "panel-body" },
+            this.props.children
+          )
+        )
+      );
+    }
+  }]);
+
+  return Panel;
+}(React.Component);
+
+Panel.propTypes = {};
+Panel.defaultProps = {
+  id: 'default-panel',
+  title: 'Selection Filter'
+};

--- a/htdocs/js/components/Panel.js
+++ b/htdocs/js/components/Panel.js
@@ -63,7 +63,8 @@ var Panel = function (_React$Component) {
           { className: "panel-heading",
             onClick: this.toggleCollapsed,
             "data-toggle": "collapse",
-            "data-target": '#' + this.props.id
+            "data-target": '#' + this.props.id,
+            style: { cursor: 'pointer' }
           },
           this.props.title,
           React.createElement("span", { className: glyphClass })
@@ -73,7 +74,7 @@ var Panel = function (_React$Component) {
           { id: this.props.id, className: panelClass, role: "tabpanel" },
           React.createElement(
             "div",
-            { className: "panel-body" },
+            { className: "panel-body", style: { height: this.props.height } },
             this.props.children
           )
         )
@@ -87,5 +88,6 @@ var Panel = function (_React$Component) {
 Panel.propTypes = {};
 Panel.defaultProps = {
   id: 'default-panel',
+  height: '100%',
   title: 'Selection Filter'
 };

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -59,7 +59,11 @@ class Panel extends React.Component {
   }
 }
 
-Panel.propTypes = {};
+Panel.propTypes = {
+  id: React.PropTypes.string,
+  height: React.PropTypes.string,
+  title: React.PropTypes.string
+};
 Panel.defaultProps = {
   id: 'default-panel',
   height: '100%',

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -44,12 +44,13 @@ class Panel extends React.Component {
              onClick={this.toggleCollapsed}
              data-toggle="collapse"
              data-target={'#' + this.props.id}
+             style={{cursor: 'pointer'}}
         >
           {this.props.title}
           <span className={glyphClass}></span>
         </div>
         <div id={this.props.id} className={panelClass} role="tabpanel">
-          <div className="panel-body">
+          <div className="panel-body" style={{height: this.props.height}}>
             {this.props.children}
           </div>
         </div>
@@ -61,5 +62,6 @@ class Panel extends React.Component {
 Panel.propTypes = {};
 Panel.defaultProps = {
   id: 'default-panel',
+  height: '100%',
   title: 'Selection Filter'
 };

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -1,0 +1,65 @@
+/* exported Panel */
+
+/**
+ * This file contains React component for Panel
+ *
+ * @author Alex I.
+ * @version 1.0.0
+ *
+ */
+
+/**
+ * Panel component
+ * Wraps children in a collapsible bootstrap panel
+ */
+class Panel extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      collapsed: false
+    };
+
+    this.toggleCollapsed = this.toggleCollapsed.bind(this);
+  }
+
+  toggleCollapsed() {
+    this.setState({collapsed: !this.state.collapsed});
+  }
+
+  render() {
+    // Selection filter open by default
+    let glyphClass = "glyphicon pull-right glyphicon-chevron-up";
+    let panelClass = "panel-collapse collapse in";
+
+    // Change arrow direction when closed
+    if (this.state.collapsed) {
+      glyphClass = "glyphicon pull-right glyphicon-chevron-down";
+    }
+
+    return (
+      <div className="panel panel-primary">
+        <div className="panel-heading"
+             onClick={this.toggleCollapsed}
+             data-toggle="collapse"
+             data-target={'#' + this.props.id}
+        >
+          {this.props.title}
+          <span className={glyphClass}></span>
+        </div>
+        <div id={this.props.id} className={panelClass} role="tabpanel">
+          <div className="panel-body">
+            {this.props.children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+Panel.propTypes = {};
+Panel.defaultProps = {
+  id: 'default-panel',
+  title: 'Selection Filter'
+};

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -589,6 +589,7 @@ class NDB_Page
                   $baseurl . '/bootstrap/js/bootstrap.min.js',
                   $baseurl . '/js/components/react.breadcrumb.js',
                   $baseurl . "/js/util/queryString.js",
+                  $baseurl . '/js/components/Panel.js',
                   $baseurl . '/js/components/Form.js',
                   $baseurl . '/js/components/Markdown.js',
                  );

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -589,7 +589,6 @@ class NDB_Page
                   $baseurl . '/bootstrap/js/bootstrap.min.js',
                   $baseurl . '/js/components/react.breadcrumb.js',
                   $baseurl . "/js/util/queryString.js",
-                  $baseurl . '/js/components/Panel.js',
                   $baseurl . '/js/components/Form.js',
                   $baseurl . '/js/components/Markdown.js',
                  );


### PR DESCRIPTION
A react component that renders a collapsible Bootstrap panel (i.e the one used everywhere in Loris)
![image](https://cloud.githubusercontent.com/assets/6627543/21555470/62b5777e-cde6-11e6-917c-a14086b4994e.png)

>Hopefully this will help to standardize these panels across Loris and get rid of `filterControl.js` and such

**Usage:**
```js
<Panel id="panel-id" title="Selection Filter">
 // Panel content goes here
</Panel>
```
