### PR TITLE
[Radiological review module]  because sql_mode=only_full_group_by on mysql 5.7 (redmine 11703)

### DIFF
--- a/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
@@ -190,7 +190,8 @@ class NDB_Form_final_radiological_review extends NDB_Form
                 LEFT JOIN tarchive t ON (upper(t.PatientName) 
                 LIKE CONCAT(upper(c.PSCID), '_', upper(s.CandID), '_', upper(s.visit_label), '%')) 
                 WHERE r.CommentID=:CID 
-                GROUP by CandID, PSCID, Visit_label, SessionID, CommentID", 
+                GROUP by CandID, PSCID, Visit_label, SessionID, CommentID,
+                r.Scan_done, r.review_results, r.abnormal_atypical_exclusionary, r.Incidental_findings, e.full_name", 
                 array('CID' => $this->identifier)
             );
             if(empty($original_review)) {

--- a/modules/final_radiological_review/php/NDB_Menu_Filter_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Menu_Filter_final_radiological_review.class.inc
@@ -156,7 +156,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
                 SELECT fi.FileID
                 FROM files fi
                 WHERE fi.SessionID=s.ID AND fi.AcquisitionProtocolID=44
-                GROUP BY fi.SessionID),'')
+                GROUP BY fi.SessionID, fi.FileID),'')
             WHEN '' THEN 'No'
             ELSE 'Yes'
             END

--- a/modules/final_radiological_review/php/NDB_Menu_Filter_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Menu_Filter_final_radiological_review.class.inc
@@ -156,7 +156,7 @@ class NDB_Menu_Filter_final_radiological_review extends NDB_Menu_Filter
                 SELECT fi.FileID
                 FROM files fi
                 WHERE fi.SessionID=s.ID AND fi.AcquisitionProtocolID=44
-                GROUP BY fi.SessionID, fi.FileID),'')
+                GROUP BY fi.SessionID, fi.FileID LIMIT 1),'')
             WHEN '' THEN 'No'
             ELSE 'Yes'
             END


### PR DESCRIPTION
This fixes this error:

Error Code: 1055. Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'fi.FileID' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by