### PR TITLE
[STATS] DDE behavioural display site names

### DIFF
--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -67,7 +67,7 @@
             <td class="spacer"> </td>
             {foreach from=$Centers item=center key=centername}
                 <th id='{$center.ID}DD' class="centers tip" colspan="2" onclick="hideStats(this)">
-                    {$center.ID}
+                  {$center.LongName}
                 </th>
             {/foreach}
             <!--  <th colspan="3" id='total'>Total</th>


### PR DESCRIPTION
before:
![screenshot from 2017-01-11 12-44-59](https://cloud.githubusercontent.com/assets/15268287/21859727/cc792056-d7fb-11e6-832d-e51fde8ff17c.png)

after:
![screenshot from 2017-01-11 12-44-37](https://cloud.githubusercontent.com/assets/15268287/21859749/e298e1f0-d7fb-11e6-934a-90815fb77ae8.png)
