### PR TITLE
Imaging Browser: Set the filter for Site to session.CenterID instead of candidate.CenterID

### DIFF
--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -148,7 +148,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             's.Visit_label',
             'c.CandID',
             'c.ProjectID',
-            'c.CenterID',
+            's.CenterID',
             's.MRIQCStatus',
             'pending',
             'f.AcquisitionProtocolID'
@@ -159,7 +159,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             'VL'    => 's.Visit_label',
             'DCCID'=> 'c.CandID',
             'ProjectID' => 'c.ProjectID',
-            'SiteID' => 'c.CenterID',
+            'SiteID' => 's.CenterID',
             'VisitQCStatus' => 's.MRIQCStatus',
             'Pending' => 'pending',
             'Scan_type'=>'f.AcquisitionProtocolID'


### PR DESCRIPTION
I think the filter should be based on session not candidate CenterID. Filtering for a specific site can already be done through the PSCID field.


