### PR TITLE
[Core] Use alias for disabledDueToInactivity

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -564,7 +564,7 @@ class SinglePointLogin
     function disabledDueToInactivity($username, $maximumDaysInactive)
     {
         $DB    =& Database::singleton();
-        $query = "SELECT MAX(Login_timestamp) 
+        $query = "SELECT MAX(Login_timestamp) as Login_timestamp
                   FROM user_login_history 
                   WHERE UserID = :username";
 


### PR DESCRIPTION
This add an alias so the 'Login_timestamp' key exists in the `$row` at line 572 of the same file.
This will also fix the update where a user would get inactive on next login attempt if not login after 1 year.