### PR TITLE
Instrument list: Removal of the require_once of battery.Class.inc

### DIFF
--- a/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
+++ b/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
@@ -5,7 +5,6 @@
  * @package behavioural
  */
 require_once __DIR__ ."/Instrument_List_ControlPanel.class.inc";
-require_once __DIR__ . "/../../../php/libraries/NDB_BVL_Battery.class.inc";
 class NDB_Menu_Filter_instrument_list extends NDB_Menu_Filter
 {
     function _hasAccess()


### PR DESCRIPTION
instrument_list project override was failing.
main.php autoloads the php/libraries classes.



