### PR TITLE
[LorisForm] Multiselect required rule (Redmine #9049)

### DIFF
--- a/htdocs/js/instrument_form_control.js
+++ b/htdocs/js/instrument_form_control.js
@@ -74,14 +74,4 @@ $(document).ready(function() {
       addEmptyOption(form, $(this));
     });
   });
-
-  var msg = '';
-  var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-  if (isMac) {
-    msg = "Hold CMD ⌘ to select multiple options";
-  } else {
-    msg = "Hold CTRL to select multiple options";
-  }
-  multiselect.attr("title", msg);
-  multiselect.tooltip();
 });

--- a/htdocs/js/instrument_form_control.js
+++ b/htdocs/js/instrument_form_control.js
@@ -26,24 +26,62 @@ function notAnswered() {
         }
     }
 }
-$(document).ready(function () {
-    "use strict";
-    $(".element").children().addClass("form-control input-sm");
-    $(".button").removeClass("form-control");
-    var naList = document.getElementsByClassName('not-answered'), i, name, index;
-    for (i = 0; i < naList.length; i++) {
-        name = $(naList[i]).attr('name');
-        name = name.replace('_status', '');
-        index = naList[i].selectedIndex;
-        if (name.indexOf('_date') > -1) {
-            if (index !== 0) {
-                $('.' + name).prop('disabled', true);
-            }
-        } else {
-            if (index !== 0) {
-                $('[name=' + name + ']').prop('disabled', true);
-            }
-        }
-        naList[i].onchange = notAnswered;
+
+/**
+ * Appends a hidden empty value, if a multiselect dropdown has nothing selected
+ * Required to trigger validation on the backend
+ * @param {JQuery} form <form> element
+ * @param {JQuery} element <select> element
+ */
+function addEmptyOption(form, element) {
+  var selectedOptions = element.find(':selected');
+  var name = element[0].name;
+
+  if (selectedOptions.length === 0) {
+    form.append("<input type='hidden' name=" + name + " value='' />");
+  } else {
+    $("[type='hidden' name='" + name + "']").remove();
+  }
+}
+
+$(document).ready(function() {
+  "use strict";
+  $(".element").children().addClass("form-control input-sm");
+  $(".button").removeClass("form-control");
+  var naList = document.getElementsByClassName('not-answered');
+  var i;
+  var name;
+  var index;
+  for (i = 0; i < naList.length; i++) {
+    name = $(naList[i]).attr('name');
+    name = name.replace('_status', '');
+    index = naList[i].selectedIndex;
+    if (name.indexOf('_date') > -1) {
+      if (index !== 0) {
+        $('.' + name).prop('disabled', true);
+      }
+    } else if (index !== 0) {
+      $('[name=' + name + ']').prop('disabled', true);
     }
+    naList[i].onchange = notAnswered;
+  }
+
+  var form = $('form');
+  var multiselect = $('form select[multiple]');
+
+  form.on('submit', function() {
+    multiselect.each(function() {
+      addEmptyOption(form, $(this));
+    });
+  });
+
+  var msg = '';
+  var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  if (isMac) {
+    msg = "Hold CMD ⌘ to select multiple options";
+  } else {
+    msg = "Hold CTRL to select multiple options";
+  }
+  multiselect.attr("title", msg);
+  multiselect.tooltip();
 });

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -689,18 +689,22 @@ class LorisForm
                 $optionKey = (string) $optionKey;
             }
 
+            $defaultValue = $this->getValue($el['name']);
+
             if (isset($el['multiple'])) {
-                if (!empty($this->getValue($el['name']))
-                    && in_array($optionKey, $this->getValue($el['name']))
-                ) {
-                    $selected = 'selected="selected"';
+                if (!empty($defaultValue)) {
+                    if (in_array($optionKey, $defaultValue)
+                        || $optionKey === $defaultValue
+                    ) {
+                        $selected = 'selected="selected"';
+                    }
                 }
             } else {
-                if ($optionKey === $this->getValue($el['name'])) {
+                if ($optionKey === $defaultValue) {
                     $selected = 'selected="selected"';
                 } elseif (isset($el['selected'])
                     && $optionKey === $el['selected']
-                    && $this->getValue($el['name']) === null
+                    && $defaultValue === null
                 ) {
                     $selected = 'selected="selected"';
                 }


### PR DESCRIPTION
Currently, the multi-select is not required by default, unless user explicitly selects the 'empty' option. 

- [x] Append hidden empty field of the same whenever no multiselect options are selected (See JS file)
- [x] Fix a bug where multiselect would not get default values when there is only one item (See PHP file)

>Note: the hidden field is needed because when all multiselect options are unselected, it is simply not sent to the server for validation (i.e is ignored)