### PR TITLE
[API] Login response content-type header

### DIFF
--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -155,6 +155,7 @@ if (isset($_REQUEST['PrintLogin'])) {
     } else {
         $obj = new Login($_SERVER['REQUEST_METHOD']);
     }
+    header('Content-type: application/json');
     print $obj->toJSONString();
 }
 ?>


### PR DESCRIPTION
Specify content-type as JSON instead of default to text/html