### PR TITLE
[Core] Save instrument data in JSON as well as in tables

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -555,6 +555,7 @@ CREATE TABLE `flag` (
   `Flag_status` enum('P','Y','N','F') default NULL,
   `UserID` varchar(255) default NULL,
   `Testdate` timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
+  `Data` TEXT default NULL,
   PRIMARY KEY  (`CommentID`),
   KEY `Status` (`Flag_status`),
   KEY `flag_ID` (`ID`),

--- a/SQL/Archive/17.1/2017-01-19-AddInstrumentJSON.sql
+++ b/SQL/Archive/17.1/2017-01-19-AddInstrumentJSON.sql
@@ -1,0 +1,1 @@
+ALTER TABLE flag ADD `Data` TEXT;

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -77,7 +77,7 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
      * @return array Options array suitable for use in QuickForm select
      *               element
      */
-    function getParticipantStatusOptions()
+    static function getParticipantStatusOptions()
     {
         $DB           =& Database::singleton();
         $options      = $DB->pselect(

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -705,6 +705,32 @@ class NDB_BVL_Instrument extends NDB_Page
             $values,
             array('CommentID' => $this->getCommentID())
         );
+
+        // Extract the old data and merge it with what was submitted so that we
+        // don't overwrite data from other pages.
+        $oldData = $db->pselectOne(
+            "SELECT Data FROM flag WHERE CommentID=:cid",
+            array('cid' => $this->getCommentID())
+        );
+
+        // (The PDO driver seems to return null as "null" for JSON column types)
+        if (!empty($oldData) && $oldData !== "null") {
+            $oldData = json_decode($oldData, true);
+        } else {
+            $oldData = array();
+        }
+        $newData = array_merge($oldData, $values);
+
+        // Save the JSON to the flag.Data column.
+        //
+        // json_encode ensures that this is safe. If we use the safe wrapper,
+        // HTML encoding the quotation marks will make it invalid JSON.
+        $result = $db->unsafeUpdate(
+            "flag",
+            array("Data" => json_encode($newData)),
+            array('CommentID' => $this->getCommentID())
+        );
+
     }
 
 


### PR DESCRIPTION
This adds experimental support for LORIS to save instrument data 
into a JSON formatted column in the flag table, instead of requiring
a table for each instrument.

For now, it only adds the ability to save data and doesn't use it,
but it adds the possibility of cleaning up our schema and requiring
less MySQL permissions to use in the future.