### PR TITLE
[Candidate_parameters] Fix warning about non-static function

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -77,7 +77,7 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
      * @return array Options array suitable for use in QuickForm select
      *               element
      */
-    function getParticipantStatusOptions()
+    static function getParticipantStatusOptions()
     {
         $DB           =& Database::singleton();
         $options      = $DB->pselect(


### PR DESCRIPTION
If your log level was set high enough, the candidate_list page was
printing a warning about non-static function getParticipantStatusOptions
being called statically.

