### PR TITLE
Added PHP 7.1 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 php:
     - "5.6"
     - "7"
+    - "7.1"
 
 sudo: false
 


### PR DESCRIPTION
@jstirling91 pointed out that PHP 7.1 is released.

This adds it to Travis to make sure we catch any problems proactively..