### PR TITLE
Removed isMultiSiteEnabled flag

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -129,8 +129,6 @@
                 <!--test value=InstrumentName>InstrumentName</test-->
             </CertificationInstruments>
         </Certification>
-        <!--This permission allows users from sites to have access to other sites bvl feedback info -->
-        <multiSiteEnabledCenters></multiSiteEnabledCenters>
 
         <!-- Consent module allows addition of consent information in the candidate information page-->
          <ConsentModule>

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -467,7 +467,7 @@ class NDB_BVL_Feedback
             $query .= " LEFT JOIN flag as f ON (ft.CommentID = f.CommentID)";
         }
         $query .= " WHERE ft.Active ='Y'";
-        if (!$user->isMultiSiteEnabled() && !$hasReadPermission===true) {
+        if (!$hasReadPermission===true) {
             $query            .= " AND c.CenterID=:CentID";
             $qparams['CentID'] = $user->getCenterID();
         }
@@ -574,7 +574,7 @@ class NDB_BVL_Feedback
 
         // DCC users should be able to see THEIR OWN inactive threads,
         // other users should see only active threads
-        if ($user->isMultiSiteEnabled() || $hasReadPermission===true) {
+        if ($hasReadPermission===true) {
             $query .= " AND (ft.Active='Y' OR
                 (ft.Active='N' AND ft.UserID=:Username)
             )";

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -922,14 +922,6 @@ class NDB_BVL_Feedback
             throw new Exception("Error: No threads selected to activate");
         }
 
-        // DCC users are able to activate THEIR OWN inactive threads
-        if (!$user->isMultiSiteEnabled()) {
-            $whereArray = array_merge(
-                $whereArray,
-                array('UserID' => $this->_username)
-            );
-        }
-
         $success = $db->update('feedback_bvl_thread', $setArray, $whereArray);
     }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -229,25 +229,6 @@ class User extends UserPermissions
 
 
     /**
-     * Unknown what this does. Maybe it should be removed?
-     * - Dave
-     *
-     * @return boolean
-     */
-    function isMultiSiteEnabled()
-    {
-        // if $userID is not passed,then look-up current user
-        // if CenterID = 0 then admin staff
-        // like dcc ccc nih or similar
-        // change 2002-10-23 Dario
-        $config =& NDB_Config::singleton();
-        return in_array(
-            $this->userInfo['CenterID'],
-            $config->getSetting('multiSiteEnabledCenters')
-        );
-    }
-
-    /**
      * Returns all sites where Examiner is active
      *
      * @return array

--- a/test/config.xml
+++ b/test/config.xml
@@ -130,8 +130,6 @@
                 <!--test value=InstrumentName>InstrumentName</test-->
             </CertificationInstruments>
         </Certification>
-        <!--This permission allows users from sites to have access to other sites bvl feedback info -->
-        <multiSiteEnabledCenters></multiSiteEnabledCenters>
 
         <!-- Consent module allows addition of consent information in the candidate information page-->
          <ConsentModule>


### PR DESCRIPTION
It's always been a mystery what this flag does, so now it's gone.

(It seems to have been intended to allow the DCC to view other site's feedback threads, but now that users can be part of multiple sites, it's no longer required.)
