### PR TITLE
Remove unnecessary code from main.php

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -122,19 +122,7 @@ $link_args['MRIBrowser'] = $argstring;
 $paths = $config->getSetting('paths');
 
 if (!empty($TestName)) {
-    // Get CSS for a module
     $base = $paths['base'];
-    if (file_exists($base . "modules/$TestName/css/$TestName.css")
-        || file_exists($base . "project/modules/$TestName/css/$TestName.css")
-    ) {
-        if (strpos($_SERVER['REQUEST_URI'], "main.php") === false
-            && strcmp($_SERVER['REQUEST_URI'], '/') != 0
-        ) {
-              $tpl_data['test_name_css'] = "/$TestName/css/$TestName.css";
-        } else {
-              $tpl_data['test_name_css'] = "GetCSS.php?Module=$TestName";
-        }
-    }
 
     // Used for CSS for a specific instrument.
     if (file_exists($paths['base'] . "project/instruments/$TestName.css")) {


### PR DESCRIPTION
There is no longer any need for the GetCSS hack for modules,
because pages directly implement getCSSDependencies() as needed.

(It remains in place for instruments for now, because they aren't part of any module.)