### PR TITLE
Moved hasAccess from subclasses to base class

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_instrument_preview.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_instrument_preview.class.inc
@@ -25,17 +25,6 @@
 class NDB_BVL_Instrument_Instrument_Preview
     extends \Loris\Behavioural\NDB_BVL_Instrument_LINST
 {
-
-    /**
-     * Everyone has access to preview since it does nothing
-     *
-     * @return true
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
     /**
      * Loads a LINST file and rules from the data posted to it in order
      * to preview how Loris would render that file.

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -114,28 +114,6 @@ class NDB_Form extends NDB_Page
         $this->form->applyFilter('__ALL__', 'trim');
     }
 
-    /**
-     * Returns false if user does not have access to page.
-     *
-     * Usage: the hasAccess() function in a child class should contain
-     * something like:
-     *
-     *     // create user object
-     *     $user =& User::singleton();
-     *
-     *     return $user->hasPermission('superuser');
-     *
-     * You do not need to overload hasAccess() if there are no access restrictions
-     *
-     * @note   overloaded function
-     * @return bool
-     * @access private
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
 
     /**
      * Saves the form

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -96,30 +96,6 @@ class NDB_Menu extends NDB_Page
         return $obj;
     }
 
-
-    /**
-     * Returns false if user does not have access to page
-     *
-     * Usage: the hasAccess() function in a child class should contain
-     *    something like:
-     *
-     *     // create user object
-     *     $user =& User::singleton();
-     *
-     *     return $user->hasPermission('superuser');
-     *
-     * You do not need to overload hasAccess() if there are no access restrictions
-     *
-     * @note   overloaded function
-     * @return bool
-     * @access private
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
-
     /**
      * Calls other member functions to do all the work necessary to create the menu
      *

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -628,5 +628,27 @@ class NDB_Page
     function setup()
     {
     }
+
+    /**
+     * Returns false if user does not have access to page.
+     *
+     * Usage: the hasAccess() function in a child class should contain
+     * something like:
+     *
+     *     // create user object
+     *     $user =& User::singleton();
+     *
+     *     return $user->hasPermission('superuser');
+     *
+     * You do not need to overload hasAccess() if there are no access restrictions
+     *
+     * @note   overloaded function
+     * @return bool
+     * @access private
+     */
+    function _hasAccess()
+    {
+        return true;
+    }
 }
 ?>


### PR DESCRIPTION
Every type of page overrode _hasAccess to provide the same behaviour. This moves it up to the NDB_Page class to simplify things.