### PR TITLE
[core] removed symbol & since it breaks URLs

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -276,7 +276,8 @@ class User extends UserPermissions
         $password = '';
 
         $numbers      = '0123456789';
-        $specialChars = '!@#$%^&*()';
+        $specialChars = '!@#$%^*()';
+        // & not part of $specialChars since it causes URL to break
 
         $possible = $numbers . $specialChars . 'abcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
This bug affects the survey_accounts module. 

Since the newPassword() function is used to create unique key for URL use, it needs to be URL safe.

ie: no & or ? symbols.

