### PR TITLE
[STATS] Removing array_search calls and fixed bug 

### DIFF
--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -46,8 +46,8 @@ class NDB_Form_statistics extends NDB_Form
             $subcat  = $row['Subcat'];
             $center  = $row['CenterID'];
 
-            if(array_search($vl, $visits) !== false
-                && array_search($subcat, $subcats) !== false
+            if(in_array($vl, $visits) !== false
+                && in_array($subcat, $subcats) !== false
                 && $this->_inCenter($center, $centres) !== false
             ) {
                 $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
@@ -696,7 +696,7 @@ class NDB_Form_statistics extends NDB_Form
                           CASE($MRI_Type_Field)
                           WHEN 'Partial' THEN 'Partial Run'
                           WHEN 'No' THEN 'No Scan'
-                          ELSE $MRI_Type_Field
+                          ELSE 'Complete'
                           END";
 
         $result = $DB->pselect(

--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -46,9 +46,9 @@ class NDB_Form_statistics extends NDB_Form
             $subcat  = $row['Subcat'];
             $center  = $row['CenterID'];
 
-            if(in_array($vl, $visits) !== false
-                && in_array($subcat, $subcats) !== false
-                && $this->_inCenter($center, $centres) !== false
+            if(in_array($vl, $visits)
+                && in_array($subcat, $subcats)
+                && $this->_inCenter($center, $centres)
             ) {
                 $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
                 $tpl_data['data'][$subproj][$vl]['total'] += $row['val'];


### PR DESCRIPTION
[comment]: # (
Make sure you send your pull request to the right VERSIONNUMBER-dev branch.
It's still possible to change it afterwards and if you are not sure which branch to send to, please consult the CONTRIBUTING.md.
)
[comment]: # (
Please also make sure to indicate in the pull request title the general domain in which your pull request pertains to.
For example, "[Core] Adding CentOS support to Install Script" or "[Document Repository] Adding functionality to group files under Categories".
)
[comment]: # (
Also set appropriate Labels and Milestones as you see fit. Assignee is usually set to whoever may be the right person to test your pull request.
)

The current query returns as value 'no', 'partial' or $MRI_Type_Field it shpuld return 'complete' instead. this is legacy from the old non-functioning query

- array_search returns the key which can be 0 in some cases
- bug in the case statement returning field name instead of "Complete"

