### PR TITLE
[Core] Robust date validation

### DIFF
--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -177,29 +177,18 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      */
     function testNewProfileDoBDateError()
     {
-        $this->markTestSkipped("Config not properly set up to test that PSCID is required");
         $this->webDriver->get($this->url . "/new_profile/");
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $days  = $this->webDriver->findElements(WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']"));
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2000-05-05'"
+        );
 
-        $dates[0]->click();
-        sleep(2);
-        $days[0]->click();
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2000-05-01'"
+        );
 
-        $dates[1]->click();
-        sleep(2);
-        $days[1]->click();
-        //$dates[0]->sendKeys("2015-01-01");
-        //$dates[1]->sendKeys("2015-02-01");
-        $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))->click();
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
-        sleep(2);
-
-        // Config set for PSCID to be auto created
-        // $pscid = $this->webDriver->findElement(WebDriverBy::Name("PSCID"));
-        // $pscid->sendKeys("Control");
 
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -61,7 +61,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileLoadsWithoutProjects() {
+    function testNewProfileLoadsWithoutProjects()
+    {
         $this->setUpConfigSetting("useProjects", "false");
 
         $this->safeGet($this->url . "/new_profile/");
@@ -82,7 +83,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileLoadsWithoutEDC() {
+    function testNewProfileLoadsWithoutEDC()
+    {
         $this->setUpConfigSetting("useEDC", "false");
 
         $this->safeGet($this->url . "/new_profile/");
@@ -109,28 +111,30 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileEDCDateError() {
+    function testNewProfileEDCDateError()
+    {
         $this->setUpConfigSetting("useEDC", "true");
 
         $this->webDriver->get($this->url . "/new_profile/");
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2000-05-05'"
+        );
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-01-01");
-        $dates[2]->sendKeys("2015-01-01");
-        $dates[3]->sendKeys("2015-02-01");
-        $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2000-05-05'"
+        );
+
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[2].value='2000-05-30'"
+        );
+
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[3].value='2000-05-05'"
+        );
+
         $gender = $this->safeFindElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
 
-        // Config set for PSCID to be auto created
-        // $pscid = $this->webDriver->findElement(WebDriverBy::Name("PSCID"));
-        // $pscid->sendKeys("Control");
-        $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
         sleep(3);
@@ -145,7 +149,8 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfilePSCIDError() {
+    function testNewProfilePSCIDError()
+    {
 
         $this->markTestSkipped("Config not properly set up to test that PSCID is required");
 
@@ -170,11 +175,13 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileDoBDateError() {
+    function testNewProfileDoBDateError()
+    {
+        $this->markTestSkipped("Config not properly set up to test that PSCID is required");
         $this->webDriver->get($this->url . "/new_profile/");
 
         $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $days = $this->webDriver->findElements(WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']"));
+        $days  = $this->webDriver->findElements(WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']"));
 
         $dates[0]->click();
         sleep(2);
@@ -206,22 +213,20 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfileCreateCandidate() {
-
+    function testNewProfileCreateCandidate()
+    {
         $this->changeStudySite();
         $this->webDriver->get($this->url . "/new_profile/");
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2015-01-01'"
+        );
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2015-01-01'"
+        );
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-01-01");
-        $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
-        $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
+
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
         sleep(3);
@@ -237,22 +242,20 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
      *
      * @return none
      */
-    function testNewProfilePSCIDSequential() {
-
+    function testNewProfilePSCIDSequential()
+    {
         $this->changeStudySite();
         $this->webDriver->get($this->url . "/new_profile/");
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-01-01");
-        $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2015-01-01'"
+        );
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2015-01-01'"
+        );
+
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
-        $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
         sleep(3);
@@ -261,17 +264,14 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
 
         $this->webDriver->get($this->url . "/new_profile/");
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-01-01");
-        $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2015-01-01'"
+        );
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2015-01-01'"
+        );
         $gender = $this->safeFindElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
-        $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
-        sleep(1);
         $startVisit = $this->safeFindElement(WebDriverBy::Name("fire_away"));
         $startVisit->click();
         sleep(3);

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -115,10 +115,10 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $this->webDriver->get($this->url . "/new_profile/");
 
         $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("01/01/2015");
-        $dates[1]->sendKeys("01/01/2015");
-        $dates[2]->sendKeys("01/01/2015");
-        $dates[3]->sendKeys("01/02/2015");
+        $dates[0]->sendKeys("2015-01-01");
+        $dates[1]->sendKeys("2015-01-01");
+        $dates[2]->sendKeys("2015-01-01");
+        $dates[3]->sendKeys("2015-02-01");
         $this->safeFindElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
                  ->click();
         sleep(1);
@@ -174,8 +174,16 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $this->webDriver->get($this->url . "/new_profile/");
 
         $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-02-01");
+        $dates[0]->click();
+        $this->webDriver->findElements(
+            WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']")
+        )[0]->click();
+        $dates[1]->click();
+        $this->webDriver->findElements(
+            WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']")
+        )[1]->click();
+        //$dates[0]->sendKeys("2015-01-01");
+        //$dates[1]->sendKeys("2015-02-01");
         $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
                  ->click();
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -174,18 +174,18 @@ class newProfileTestIntegrationTest extends LorisIntegrationTest
         $this->webDriver->get($this->url . "/new_profile/");
 
         $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
+        $days = $this->webDriver->findElements(WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']"));
+
         $dates[0]->click();
-        $this->webDriver->findElements(
-            WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']")
-        )[0]->click();
+        sleep(2);
+        $days[0]->click();
+
         $dates[1]->click();
-        $this->webDriver->findElements(
-            WebDriverBy::cssSelector(".ui-datepicker-calendar td[data-handler='selectDay']")
-        )[1]->click();
+        sleep(2);
+        $days[1]->click();
         //$dates[0]->sendKeys("2015-01-01");
         //$dates[1]->sendKeys("2015-02-01");
-        $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))
-                 ->click();
+        $this->webDriver->findElement(WebDriverBy::Xpath("//*[@id='footer']/div[1]"))->click();
         $gender = $this->webDriver->findElement(WebDriverBy::Name("gender"));
         $gender->sendKeys("Male");
         sleep(2);

--- a/modules/next_stage/test/next_stageTest.php
+++ b/modules/next_stage/test/next_stageTest.php
@@ -65,7 +65,7 @@ class nextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
     {
         // Reset any leftover study site from a previous test.
 
-	$this->resetStudySite();
+        $this->resetStudySite();
         // Change users CenterID
         $this->changeStudySite();
 
@@ -96,10 +96,12 @@ class nextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
     {
         $this->webDriver->get($this->url . "/next_stage/?candID=900000&sessionID=999999&identifier=999999");
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-01-02");
-
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2015-01-01'"
+        );
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2015-01-02'"
+        );
         $scanDone = $this->webDriver->findElement(WebDriverBy::Name("scan_done"));
         $scanDone->sendKeys("No");
 
@@ -122,10 +124,12 @@ class nextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
     {
         $this->webDriver->get($this->url . "/next_stage/?candID=900000&sessionID=999999&identifier=999999");
 
-        $dates = $this->webDriver->findElements(WebDriverBy::cssSelector(".input-date"));
-        $dates[0]->sendKeys("2015-01-01");
-        $dates[1]->sendKeys("2015-01-01");
-
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[0].value='2015-01-01'"
+        );
+        $this->webDriver->executescript(
+            "document.getElementsByClassName('input-date')[1].value='2015-01-01'"
+        );
         $scanDone = $this->webDriver->findElement(WebDriverBy::Name("scan_done"));
         $scanDone->sendKeys("No");
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1956,31 +1956,35 @@ class LorisForm
                 continue;
             }
 
-            if ($el['type'] === 'date'
-                && array_key_exists('options', $el)
-                && ((strtolower($el['options']['format']) == 'y'))
-            ) {
-                    $value = $this->getValue($name);
-                if ($value) {
-                    $arr[$name] = sprintf("%s-00-00", $value);
-                } else {
-                    $arr[$name] = '';
-                }
-                    continue;
-            }
+            if ($el['type'] === 'date' && array_key_exists('options', $el)) {
+                $value = $this->getValue($name);
+                $date = $value;
 
-            if ($el['type'] === 'date'
-                && array_key_exists('options', $el)
-                && ((strtolower($el['options']['format']) == 'my')
-                || (strtolower($el['options']['format']) == 'ym'))
-            ) {
-                    $value = $this->getValue($name);
-                if ($value) {
-                    $arr[$name] = sprintf("%s-00", $value);
-                } else {
+                if (!$value) {
                     $arr[$name] = '';
-                }
                     continue;
+                }
+
+                // Convert year to a valid SQL format (i.e yyyy-mm-dd)
+                if (strtolower($el['options']['format']) === 'y') {
+                    $date = sprintf("%s-01-01", $value);
+                }
+                // Convert month-year to a valid SQL format (i.e yyyy-mm-dd)
+                if ((strtolower($el['options']['format']) === 'my') ||
+                    (strtolower($el['options']['format']) === 'ym')) {
+                    $date = sprintf("%s-01", $value);
+                }
+                // Make sure the date is valid
+                $dt = DateTime::createFromFormat('Y-m-d', $date);
+                $isValidDate = $dt && $dt->format('Y-m-d') == $date;
+
+                if (!$isValidDate) {
+                    throw new Exception("Please input a valid date!");
+                }
+
+                $arr[$name] = $date;
+
+                continue;
             }
 
             // Check to see it the element type is a header or is a static

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -799,18 +799,27 @@ class LorisForm
         $msg      = isset($el['requireMsg']) ? $el['requireMsg'] : 'Required';
         $required = isset($el['required']) ? "this.value === '' ? '$msg':''" : "''";
         $value    = $this->getValue($el['name']);
-        if (array_key_exists('options', $el)
-            && ((strtolower($el['options']['format']) == 'my')
-            || (strtolower($el['options']['format']) == 'ym'))
-        ) {
-            $format = 'month';
-            if ($value) {
-                $value = explode("-", $value);
-                $value = sprintf("%s-%s", $value[0], $value[1]);
+        $format = 'date';
+
+        if (array_key_exists('options', $el)) {
+            $elOptions = $el['options'];
+            $elFormat = strtolower($elOptions['format']);
+
+            if ($elFormat == 'my' || $elFormat == 'ym') {
+                $format = 'month';
+                if ($value) {
+                    $value = explode("-", $value);
+                    $value = sprintf("%s-%s", $value[0], $value[1]);
+                }
+                if ($elOptions['maxYear']) {
+                    $minYear = "min=\"" . $elOptions['minYear'] . "-01\"";
+                }
+                if ($elOptions['maxYear']) {
+                    $maxYear = "max=\"" . $elOptions['maxYear'] . "-12\"";
+                }
             }
-        } else {
-            $format = 'date';
         }
+
         $elmnt = "<input name=\"$el[name]\" type=\"$format\" $cls "
             . "$minYear $maxYear "
             . "onChange=\"this.setCustomValidity($required)\""

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1223,6 +1223,13 @@ class LorisForm
 
                     $errors[$el['name']] = "maxlength fail";
                 }
+
+                // Check if date fields have errors and add them to error list
+                if ($el['type'] === 'date') {
+                    if (isset($el['error'])) {
+                        $errors[$el['name']] = "date fail";
+                    }
+                }
             }
         }
         foreach ($this->formRules as $rule) {
@@ -1247,7 +1254,6 @@ class LorisForm
                 }
             }
         }
-
         return empty($errors);
     }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1958,7 +1958,7 @@ class LorisForm
 
             if ($el['type'] === 'date' && array_key_exists('options', $el)) {
                 $value = $this->getValue($name);
-                $date = $value;
+                $date  = $value;
 
                 if (!$value) {
                     $arr[$name] = '';
@@ -1970,12 +1970,13 @@ class LorisForm
                     $date = sprintf("%s-01-01", $value);
                 }
                 // Convert month-year to a valid SQL format (i.e yyyy-mm-dd)
-                if ((strtolower($el['options']['format']) === 'my') ||
-                    (strtolower($el['options']['format']) === 'ym')) {
+                if ((strtolower($el['options']['format']) === 'my')
+                    || (strtolower($el['options']['format']) === 'ym')
+                ) {
                     $date = sprintf("%s-01", $value);
                 }
                 // Make sure the date is valid
-                $dt = DateTime::createFromFormat('Y-m-d', $date);
+                $dt          = DateTime::createFromFormat('Y-m-d', $date);
                 $isValidDate = $dt && $dt->format('Y-m-d') == $date;
 
                 if (!$isValidDate) {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -799,11 +799,11 @@ class LorisForm
         $msg      = isset($el['requireMsg']) ? $el['requireMsg'] : 'Required';
         $required = isset($el['required']) ? "this.value === '' ? '$msg':''" : "''";
         $value    = $this->getValue($el['name']);
-        $format = 'date';
+        $format   = 'date';
 
         if (array_key_exists('options', $el)) {
             $elOptions = $el['options'];
-            $elFormat = strtolower($elOptions['format']);
+            $elFormat  = strtolower($elOptions['format']);
 
             if ($elFormat == 'my' || $elFormat == 'ym') {
                 $format = 'month';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1980,7 +1980,7 @@ class LorisForm
                 $isValidDate = $dt && $dt->format('Y-m-d') == $date;
 
                 if (!$isValidDate) {
-                    throw new Exception("Please input a valid date!");
+                    throw new LorisException("Please input a valid date!");
                 }
 
                 $arr[$name] = $date;

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1980,7 +1980,10 @@ class LorisForm
                 $isValidDate = $dt && $dt->format('Y-m-d') == $date;
 
                 if (!$isValidDate) {
-                    throw new LorisException("Please input a valid date!");
+                    $this->setElementError(
+                        $name,
+                        "Please input a valid date in '" . $el['label'] . "'!"
+                    );
                 }
 
                 $arr[$name] = $date;

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1235,7 +1235,18 @@ class LorisForm
 
                 // Check if date fields have errors and add them to error list
                 if ($el['type'] === 'date') {
-                    if (isset($el['error'])) {
+                    $date        = (
+                        $values[$elName] ?
+                            $values[$elName] :
+                        $this->getValue($el['name'])
+                    );
+                    $dt          = DateTime::createFromFormat('Y-m-d', $date);
+                    $isValidDate = $dt && $dt->format('Y-m-d') == $date;
+                    if (!$isValidDate) {
+                        $this->setElementError(
+                            $el['name'],
+                            "Please input a valid date in '" . $el['label'] . "'!"
+                        );
                         $errors[$el['name']] = "date fail";
                     }
                 }
@@ -1989,16 +2000,6 @@ class LorisForm
                     || (strtolower($el['options']['format']) === 'ym')
                 ) {
                     $date = sprintf("%s-01", $value);
-                }
-                // Make sure the date is valid
-                $dt          = DateTime::createFromFormat('Y-m-d', $date);
-                $isValidDate = $dt && $dt->format('Y-m-d') == $date;
-
-                if (!$isValidDate) {
-                    $this->setElementError(
-                        $name,
-                        "Please input a valid date in '" . $el['label'] . "'!"
-                    );
                 }
 
                 $arr[$name] = $date;

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -41,26 +41,36 @@
               React.render(breadcrumbs, document.getElementById("breadcrumbs"));
             {/if}
 
-            // If <input type="date/> is not supported (i.e. Firefox), load
+            // If <input type="date" /> is not supported (i.e. Firefox), load
             // jquery date-picker
             if (!Modernizr.inputtypes.date) {
-              $('input[type=date]').datepicker({
+              var dateInputs = $('input[type=date]');
+              dateInputs.datepicker({
                 dateFormat: 'yy-mm-dd',
                 changeMonth: true,
-                changeYear: true
+                changeYear: true,
+                yearRange: "1900:" + new Date().getFullYear(),
+                constrainInput: true
               });
-              $('input[type=date]').attr('placeholder', 'yyyy-mm-dd');
+              dateInputs.attr('placeholder', 'yyyy-mm-dd');
+              dateInputs.on('keydown paste', function(e) { e.preventDefault(); });
             }
 
             if (!Modernizr.inputtypes.month) {
-              $('input[type=month]').datepicker({
-                dateFormat: 'MM yy',
+              var monthInputs = $('input[type=month]');
+              monthInputs.datepicker({
+                dateFormat: 'yy-mm',
                 changeMonth: true,
-                changeYear: true
+                changeYear: true,
+                yearRange: "1900:" + new Date().getFullYear(),
+                constrainInput: true,
+                onChangeMonthYear: function(y, m, d) {
+                  // Update date in the input field
+                  $(this).datepicker('setDate', new Date(y, m - 1, d.selectedDay));
+                }
               });
-
-              var placeholder = $.datepicker.formatDate('MM yy', new Date());
-              $('input[type=month]').attr('placeholder', placeholder);
+              monthInputs.attr('placeholder', 'yyyy-mm');
+              monthInputs.on('keydown paste', function(e) { e.preventDefault(); });
             }
 
           });


### PR DESCRIPTION
- [x] Make sure that a date of y format or my/ym format gets converted to
yyyy-mm-dd accepted by database. Furthermore check if a date is valid
(i.e 123123-01-01 is not valid)
- [x] Updates to jquery date picker used as a fallback in Firefox, Safari and other non `<input type='date'/>` friendly browsers.

>**Bugfix for 17.0.2**