### PR TITLE
fix bug with generating PSCIDs

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -729,13 +729,12 @@ class Candidate
                 $pscid = Candidate::generateRandomStringFromArrays($pscidArrays);
             }
 
-            if($pscid == '') {
+            if ($pscid == '') {
                 throw new LorisException(
                     "Well this is embarissing, our automated PSCID generator "
                     . "is about to enter an infinite loop."
                 );
             }
-
 
             // check if the pscid is used
         } while (

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -731,7 +731,7 @@ class Candidate
 
             if ($pscid == '') {
                 throw new LorisException(
-                    "Well this is embarissing, our automated PSCID generator "
+                    "Well this is embarrassing, our automated PSCID generator "
                     . "is about to enter an infinite loop."
                 );
             }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -729,6 +729,14 @@ class Candidate
                 $pscid = Candidate::generateRandomStringFromArrays($pscidArrays);
             }
 
+            if($pscid == '') {
+                throw new LorisException(
+                    "Well this is embarissing, our automated PSCID generator "
+                    . "is about to enter an infinite loop."
+                );
+            }
+
+
             // check if the pscid is used
         } while (
             $db->pselectOne(
@@ -865,6 +873,14 @@ class Candidate
     static function generateArrays($idStructure, $siteAbbrev=null)
     {
         $idStructure = $idStructure['structure']['seq'];
+
+        if (!$idStructure[0]) {
+            // There's only one seq tag so the param format
+            // needs to be fixed
+            $temp        = array();
+            $temp[]      = $idStructure;
+            $idStructure = $temp;
+        }
 
         $arrays = array();
         foreach ($idStructure AS $seq) {


### PR DESCRIPTION
When using the automated PSCID generator, if only one seq tag was set, the returned format from the config file was wrong. This pull requests checks to see if the formate is right, if not it corrects it.