### PR TITLE
[configuration] Use PHP`s error_log() to show SQL Queries when Show Database Queries is set to Yes

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -69,6 +69,8 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, Or
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'css', 'CSS file used for rendering (default main.css)', 1, 0, 'text', ID, 'CSS file', 1 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'rowsPerPage', 'Number of table rows to display per page', 1, 0, 'text', ID, 'Table rows per page', 2 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'StudyDescription', 'Description of the Study', 1, 0, 'textarea', ID , 'Study Description', 2 FROM ConfigSettings WHERE Name="gui";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'usePHPErrorLogForSQLQueries', 'Use PHP`s error_log() to show SQL Queries when Show Database Queries is set to Yes', 1, 0, 'boolean', ID, 'Use error_log for SQL', 4 FROM ConfigSettings WHERE Name="gui";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showDatabaseQueries', 'Show Database Queries', 1, 0, 'boolean', ID, 'Show Database Queries', 5 FROM ConfigSettings WHERE Name="gui";
 
 -- www
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('www', 'Web address settings', 1, 0, 'WWW', 4);
@@ -152,6 +154,8 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSett
 -- default gui settings
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 25 FROM ConfigSettings WHERE Name="rowsPerPage";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="usePHPErrorLogForSQLQueries";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="showDatabaseQueries";
 
 -- default www settings
 INSERT INTO Config (ConfigID, Value) SELECT ID, "localhost" FROM ConfigSettings WHERE Name="host";

--- a/SQL/Archive/17.1/2017-02-06-WriteSQLQueriesToPHPErrorLog.sql
+++ b/SQL/Archive/17.1/2017-02-06-WriteSQLQueriesToPHPErrorLog.sql
@@ -1,0 +1,4 @@
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'usePHPErrorLogForSQLQueries', 'Use PHP`s error_log() to show SQL Queries when Show Database Queries is set to Yes', 1, 0, 'boolean', ID, 'Use error_log for SQL', 4 FROM ConfigSettings WHERE Name="gui";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showDatabaseQueries', 'Show Database Queries', 1, 0, 'boolean', ID, 'Show Database Queries', 5 FROM ConfigSettings WHERE Name="gui";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="usePHPErrorLogForSQLQueries";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="showDatabaseQueries";

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -60,7 +60,7 @@ class Database
     var $lastInsertID;
 
     var $_showQueries = false;
-    var $_usePHPErrorLog = false;
+    var $_usePHPELog  = false;
 
     var $_trackChanges = true;
 
@@ -159,8 +159,8 @@ class Database
         $historytable = "history";
 
         if (class_exists('NDB_Config')) {
-            $config =& NDB_Config::singleton();
-            $this->_usePHPErrorLog = $config->getSetting('usePHPErrorLogForSQLQueries');
+            $config            =& NDB_Config::singleton();
+            $this->_usePHPELog = $config->getSetting('usePHPErrorLogForSQLQueries');
             $this->_showQueries = $config->getSetting('showDatabaseQueries');
 
             // get history database from config
@@ -976,10 +976,10 @@ class Database
         if ($params) {
             $query = str_replace(array_keys($params), array_values($params), $query);
         }
-        if ($this->_usePHPErrorLog) {
-          error_log("$this->_databaseName:" . $query);
+        if ($this->_usePHPELog) {
+            error_log("$this->_databaseName:" . $query);
         } else {
-          print "$this->_databaseName:"
+            print "$this->_databaseName:"
             . date("j-M-Y G:i:s", time())
             .": $query<br>\n";
         }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -60,6 +60,7 @@ class Database
     var $lastInsertID;
 
     var $_showQueries = false;
+    var $_usePHPErrorLog = false;
 
     var $_trackChanges = true;
 
@@ -147,11 +148,19 @@ class Database
         $this->_trackChanges = $trackChanges;
         $this->_databaseName = $database;
 
+        $this->_PDO = new PDO(
+            "mysql:host=$host;dbname=$database;charset=UTF8",
+            $username,
+            $password
+        );
+        $this->_PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+
         $historydb    = null;
         $historytable = "history";
 
         if (class_exists('NDB_Config')) {
             $config =& NDB_Config::singleton();
+            $this->_usePHPErrorLog = $config->getSetting('usePHPErrorLogForSQLQueries');
             $this->_showQueries = $config->getSetting('showDatabaseQueries');
 
             // get history database from config
@@ -164,13 +173,6 @@ class Database
             }
 
         }
-
-        $this->_PDO = new PDO(
-            "mysql:host=$host;dbname=$database;charset=UTF8",
-            $username,
-            $password
-        );
-        $this->_PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 
         $this->_preparedStoreHistory = $this->_PDO->prepare(
             "INSERT INTO history (tbl, col, new, old,"
@@ -974,9 +976,13 @@ class Database
         if ($params) {
             $query = str_replace(array_keys($params), array_values($params), $query);
         }
-        print "$this->_databaseName:"
+        if ($this->_usePHPErrorLog) {
+          error_log("$this->_databaseName:" . $query);
+        } else {
+          print "$this->_databaseName:"
             . date("j-M-Y G:i:s", time())
             .": $query<br>\n";
+        }
     }
 
     /**


### PR DESCRIPTION
This adds one new config option to use PHP`s error_log() to show SQL Queries instead of in the browser which is not compatible with ajax
.
It also brings the config.xml option of showDatabaseQueries to the config module.

Both options are set to false as to not alter the default behavior.


