### PR TITLE
Revise allowed special characters in generated passwords

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -311,8 +311,9 @@ class User extends UserPermissions
         $password = '';
 
         $numbers      = '0123456789';
-        $specialChars = '!@#$%^*()';
-        // & not part of $specialChars since it causes URL to break
+        $specialChars = '-._~';
+        // URL safe (no encoding necessary) special characters as defined by
+        // Section 2.3 of http://www.ietf.org/rfc/rfc3986.txt
 
         $possible = $numbers . $specialChars . 'abcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
I ran into this bug when adding a survey. The key (which is generated by `User:newPassword`) contained a `#`, which when passed via the URL acts as delimiter. 
e.g. `?key=abc#123` was being parsed by `survey.php` as just `abc`. Obviously it couldn't locate the record in the DB and failed.

There are other problem characters, such as `%`. I replaced the allowed special characters in `User:newPassword` with a list of unreserved characters from Section 2.3 of http://www.ietf.org/rfc/rfc3986.txt.

I can understand if this list is too restrictive for generated passwords. If that is the case, maybe we should have a separate function for generating survey keys. Either that, or we can percent-encode reserved characters.