### PR TITLE
Incorrect initializers in class NDB_BVL_Feedback

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -39,10 +39,10 @@
 class NDB_BVL_Feedback
 {
     // contains info necessary to structure the object
-    var $_feedbackObjectInfo ='';
+    var $_feedbackObjectInfo = [];
 
     // contains full candidate profile/timepoint/instrument info
-    var $_feedbackCandidateProfileInfo ='';
+    var $_feedbackCandidateProfileInfo = [];
 
     // set of status options
     var $_feedbackStatusOptions = array(


### PR DESCRIPTION
Two member variables were incorrectly initialized to empty strings rather than empty arrays.
Subsequent attempts to access them as arrays fail in PHP7.  Fixes #2576 