### PR TITLE
Imaging Uploader: Better error message when uploading a scan with candidate or visit label not registered: Redmine 11965

### DIFF
--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -351,11 +351,12 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
                      ':pid'    => $pscid,
                     )
                 )==0) {
-                        $errors[] = "Make sure you enter the CandID: $candid ,".
+                        $errors[] = "Make sure you enter the CandID: $candid,".
                                     " PSCID: $pscid and the corresponding".
-                                    " Visit-label: $visit_label which".
-                                    " already exist. <br>Please refresh this page".
-                                    " to return to the Imaging Uploader module";
+                                    " Visit-label: $visit_label. Candidate and".
+                                    " corresponding visit label must already be" .
+                                    " created in the database. <br>Please refresh this".
+                                    " page to return to the Imaging Uploader module";
                 }
             }
         }


### PR DESCRIPTION
![imaginguploadernewmessage](https://cloud.githubusercontent.com/assets/15198379/22942240/b5dbea7e-f2b6-11e6-93b4-14efefc8409b.png)
