### PR TITLE
BVL Feedback cursor pointer

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -441,3 +441,4 @@ a.btn.btn-primary {
   height: 57px;
   margin-bottom: 10px;
 }
+

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -441,7 +441,3 @@ a.btn.btn-primary {
   height: 57px;
   margin-bottom: 10px;
 }
-
-.navbar-bvl-fdbk-btn {
-    cursor: pointer;
-}

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -442,3 +442,6 @@ a.btn.btn-primary {
   margin-bottom: 10px;
 }
 
+.navbar-bvl-fdbk-btn {
+    cursor: pointer;
+}

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -148,7 +148,7 @@
                     <ul class="nav navbar-nav navbar-right" id="nav-right">
                         {if $bvl_feedback}
                         <li class="hidden-xs hidden-sm">
-                            <a class="navbar-toggle" data-toggle="offcanvas" data-target=".navmenu" data-canvas="body">
+                            <a class="navbar-toggle navbar-bvl-fdbk-btn" data-toggle="offcanvas" data-target=".navmenu" data-canvas="body">
                                 <span class="glyphicon glyphicon-edit"></span>
                             </a>
                         </li>

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -148,7 +148,7 @@
                     <ul class="nav navbar-nav navbar-right" id="nav-right">
                         {if $bvl_feedback}
                         <li class="hidden-xs hidden-sm">
-                            <a class="navbar-toggle navbar-bvl-fdbk-btn" data-toggle="offcanvas" data-target=".navmenu" data-canvas="body">
+                            <a href="#" class="navbar-toggle" data-toggle="offcanvas" data-target=".navmenu" data-canvas="body">
                                 <span class="glyphicon glyphicon-edit"></span>
                             </a>
                         </li>


### PR DESCRIPTION
The link to behavioral feedback does not turn the cursor into a pointer which confuses some users into thinking that the links is not clickable.

Currently:
![cursor_regular](https://cloud.githubusercontent.com/assets/6571449/22950756/b1dc3096-f2d4-11e6-9635-532978dd257f.png)

With this PR:
![cursorpointer](https://cloud.githubusercontent.com/assets/6571449/22950757/b1dcd53c-f2d4-11e6-9dab-3799b0e3b7f0.png)
