### PR TITLE
[Survey] Replace key generation logic

### DIFF
--- a/modules/survey_accounts/php/NDB_Form_survey_accounts.class.inc
+++ b/modules/survey_accounts/php/NDB_Form_survey_accounts.class.inc
@@ -226,7 +226,7 @@ class NDB_Form_survey_accounts extends NDB_Form
      * @return string
      */
     function _generateSurveyKey() {
-        $bytes = random_bytes(12);
+        $bytes = openssl_random_pseudo_bytes(8);
         return bin2hex($bytes);
     }
 

--- a/modules/survey_accounts/php/NDB_Form_survey_accounts.class.inc
+++ b/modules/survey_accounts/php/NDB_Form_survey_accounts.class.inc
@@ -182,7 +182,7 @@ class NDB_Form_survey_accounts extends NDB_Form
 
         $commentID = $battery->addInstrument($values['Test_name']);
 
-        $key = User::newPassword();
+        $key = $this->_generateSurveyKey();
 
         $email = false;
         if (isset($_REQUEST['send_email'])) {
@@ -218,6 +218,16 @@ class NDB_Form_survey_accounts extends NDB_Form
             );
             Email::send($values['Email'], 'new_survey.tpl', $msg_data);
         }
+    }
+
+    /**
+     * Generates a URL safe key
+     *
+     * @return string
+     */
+    function _generateSurveyKey() {
+        $bytes = random_bytes(12);
+        return bin2hex($bytes);
     }
 
     /**


### PR DESCRIPTION
Replaces #2579 

I ran into this bug when adding a survey. The key (which is generated by User:newPassword) contained a #, which when passed via the URL acts as delimiter.
e.g. ?key=abc#123 was being parsed by survey.php as just abc. Obviously it couldn't locate the record in the DB and failed.

I replaced the use of `User:newPassword` with a method on `NDB_Form_survey_accounts`.

Note: `random_bytes` is a PHP7 only function.