### PR TITLE
add dicom archive format js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ var config = {
     './modules/dataquery/js/react.sidebar.js': './modules/dataquery/jsx/react.sidebar.js',
     './modules/dataquery/js/react.tabs.js': './modules/dataquery/jsx/react.tabs.js',
     './modules/dicom_archive/js/dicom_archive.js': './modules/dicom_archive/jsx/dicom_archive.js',
+    './modules/dicom_archive/js/columnFormatter.js': './modules/dicom_archive/jsx/columnFormatter.js',
     './modules/genomic_browser/js/FileUploadModal.js': './modules/genomic_browser/jsx/FileUploadModal.js',
     './modules/imaging_browser/js/ImagePanel.js': './modules/imaging_browser/jsx/ImagePanel.js',
     './modules/imaging_browser/js/columnFormatter.js': './modules/imaging_browser/jsx/columnFormatter.js',


### PR DESCRIPTION
Fix can't load columnFormat.js.
Add 
'./modules/dicom_archive/js/columnFormatter.js': './modules/dicom_archive/jsx/columnFormatter.js',
into webpackage.config.js
