### PR TITLE
Removing an invalid conflict checking from Final radiolical review module

### DIFF
--- a/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
@@ -206,7 +206,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
 
 
             $history = $DB->pselect(
-                'SELECT userID, changeDate, col, old, new FROM final_radiological_review_history
+                'SELECT userID, changeDate, col, old, new FROM final_radiological_review_history 
                 WHERE CommentID= :primKey ORDER BY changeDate DESC',
                 array('primKey' => $this->identifier)
             );
@@ -217,8 +217,8 @@ class NDB_Form_final_radiological_review extends NDB_Form
                     $history_item['changeDate'] . '</td><td>' . 
                     $history_item['userID'] . '</td><td>' . 
                     $history_item['col'] . '</td><td>' . 
-                    _makePretty($history_item['col'], $history_item['old']) . '</td><td>' 
-                    . _makePretty($history_item['col'], $history_item['new']) 
+                    _makePretty($history_item['col'], $history_item['old']) . '</td><td>'
+                    . _makePretty($history_item['col'], $history_item['new'])
                     . '</td></tr>';
             }
             $defaults = array_merge(
@@ -235,7 +235,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
                 $this->tpl_data['conflicts'][] = "Conflict between final and extra review";
             }
             if ($defaults['Final_Review_Results'] != $defaults['Original_Review_Results']
-                || $defaults['Original_Exclusionary'] != $defaults['Final_Exclusionary']
+                //|| $defaults['Final_Exclusionary'] != $defaults['Original_Exclusionary']
             ) {
                 $this->tpl_data['conflicts'][] = "Conflict between original and final review";
             }

--- a/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
@@ -235,7 +235,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
                 $this->tpl_data['conflicts'][] = "Conflict between final and extra review";
             }
             if ($defaults['Final_Review_Results'] != $defaults['Original_Review_Results']
-                //|| $defaults['Final_Exclusionary'] != $defaults['Original_Exclusionary']
+         
             ) {
                 $this->tpl_data['conflicts'][] = "Conflict between original and final review";
             }


### PR DESCRIPTION
Conflict messages are displayed even if there are no conflicts identified. The problem was that the original exclusionary status seems to be irrelevant/not used in original review is what causing the conflict. So removing that particular checking with Leigh's suggestion as well.





