### PR TITLE
[Issues] Schema fix `issues` table creation

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1306,7 +1306,7 @@ CREATE TABLE `issues` (
   CONSTRAINT `fk_issues_2` FOREIGN KEY (`assignee`) REFERENCES `users` (`UserID`),
   CONSTRAINT `fk_issues_3` FOREIGN KEY (`candID`) REFERENCES `candidate` (`CandID`),
   CONSTRAINT `fk_issues_4` FOREIGN KEY (`sessionID`) REFERENCES `session` (`ID`),
-  CONSTRAINT `fk_issues_5` FOREIGN KEY (`CenterID`) REFERENCES `psc` (`CenterID`),
+  CONSTRAINT `fk_issues_5` FOREIGN KEY (`centerID`) REFERENCES `psc` (`CenterID`),
   CONSTRAINT `fk_issues_6` FOREIGN KEY (`lastUpdatedBy`) REFERENCES `users` (`UserID`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
 

--- a/SQL/Archive/17.1/2017-03-27-SchemaFixIssuesTableCreation.sql
+++ b/SQL/Archive/17.1/2017-03-27-SchemaFixIssuesTableCreation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE issues DROP FOREIGN KEY `fk_issues_5`;
+ALTER TABLE issues ADD CONSTRAINT `fk_issues_5` FOREIGN KEY (`centerID`) REFERENCES `psc` (`CenterID`);

--- a/SQL/Release_patches/17.0_To_17.1_upgrade.sql
+++ b/SQL/Release_patches/17.0_To_17.1_upgrade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE issues DROP FOREIGN KEY `fk_issues_5`; 
+ALTER TABLE issues ADD CONSTRAINT `fk_issues_5` FOREIGN KEY (`centerID`) REFERENCES `psc` (`CenterID`);

--- a/SQL/Release_patches/17.0_To_17.1_upgrade.sql
+++ b/SQL/Release_patches/17.0_To_17.1_upgrade.sql
@@ -1,2 +1,0 @@
-ALTER TABLE issues DROP FOREIGN KEY `fk_issues_5`; 
-ALTER TABLE issues ADD CONSTRAINT `fk_issues_5` FOREIGN KEY (`centerID`) REFERENCES `psc` (`CenterID`);


### PR DESCRIPTION
`CenterID` gets converted to lowercase `centerID` anyway but just in case certain databases/database settings differentiate the case-sensitivity of certain fields, this would help.