### PR TITLE
Modification in CouchDB MRI Import Script

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -81,22 +81,26 @@ class CouchDBMRIImporter
      */
     function _generateCandidatesQuery($ScanTypes)
     {
+
+       $s = $ScanTypes;
         $Query = "SELECT c.PSCID, s.Visit_label, s.ID as SessionID, fmric.Comment
-                  as QCComment";
-        foreach ($ScanTypes as $Scan) {
-            $Query .= ", (SELECT f.File FROM files f LEFT JOIN files_qcstatus fqc
-                      USING(FileID)
-                      WHERE f.SessionID=s.ID AND fqc.Selected='$Scan[ScanType]' LIMIT 1)
-                            as `Selected_$Scan[ScanType]`, (SELECT fqc.QCStatus
-                      FROM files f LEFT JOIN files_qcstatus fqc USING(FileID)
-                      WHERE f.SessionID=s.ID AND fqc.Selected='$Scan[ScanType]' LIMIT 1)
-                             as `$Scan[ScanType]_QCStatus`";
+          as QCComment";
+
+        foreach($s as $scan){
+            $scantype=$scan['ScanType'];
+            $Query .= ", (SELECT f.File FROM files f LEFT JOIN mri_scan_type msc
+              ON (msc.ID= f.AcquisitionProtocolID)
+              WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype' LIMIT 1)
+                    as Selected_$scantype, (SELECT msc.Scan_type
+              FROM files f LEFT JOIN mri_scan_type msc ON (msc.ID= f.AcquisitionProtocolID)
+              WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype' LIMIT 1)
+                     as $scantype"."_QCStatus";
         }
         $Query .= " FROM session s JOIN candidate c USING (CandID)
-                    LEFT JOIN feedback_mri_comments fmric
-                    ON (fmric.CommentTypeID=7 AND fmric.SessionID=s.ID)
-                    WHERE c.Entity_type != 'Scanner' AND c.PSCID NOT LIKE '%9999'
-                          AND c.Active='Y' AND s.Active='Y' AND c.CenterID <> 1";
+            LEFT JOIN feedback_mri_comments fmric
+            ON (fmric.CommentTypeID=7 AND fmric.SessionID=s.ID)
+            WHERE c.Entity_type != 'Scanner' AND c.PSCID NOT LIKE '%9999'
+                  AND c.Active='Y' AND s.Active='Y' AND c.CenterID <> 1";
         return $Query;
     }
 
@@ -383,12 +387,14 @@ class CouchDBMRIImporter
      */
     public function getScanTypes()
     {
+
         $ScanTypes = $this->SQLDB->pselect(
-            "SELECT DISTINCT fqc.Selected as ScanType
-                     FROM files_qcstatus fqc
-                     WHERE COALESCE(fqc.Selected, '') <> ''",
+            "SELECT DISTINCT msc.Scan_type as ScanType from mri_scan_type msc
+JOIN files f ON msc.ID= f.AcquisitionProtocolID 
+JOIN files_qcstatus fqc ON f.FileID=fqc.FileID",
             array()
         );
+        
         return $ScanTypes;
     }
 


### PR DESCRIPTION
In DQT, the mri_data fields are not populating correctly. It happened as an impact of a previous pull request #2136 
 In which there a database field was changed to enum type.




Now it is populating as: 


![screenshot from 2017-02-23 11 44 37](https://cloud.githubusercontent.com/assets/23702452/23269166/a872df10-f9bd-11e6-9662-50f62868a863.png)
#