### PR TITLE
[SQL] Adding missing patch

### DIFF
--- a/SQL/Archive/17.1/2017-02-28_SNP_table_structure_check.sql
+++ b/SQL/Archive/17.1/2017-02-28_SNP_table_structure_check.sql
@@ -1,0 +1,16 @@
+-- This is for LORIS instance that source the schema of LORIS v15.04.
+-- The ExonicFunction column got added in 15.10 but there was a missing patch.
+SET @s = (SELECT IF(
+    (SELECT COUNT(*)
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'SNP'
+        AND table_schema = DATABASE()
+        AND column_name = 'ExonicFunction'
+    ) > 0,
+    "SELECT 'conform' as 'SNP table structure check'",
+    "ALTER TABLE SNP ADD `ExonicFunction` enum('nonsynonymous','unknown') DEFAULT NULL AFTER `Damaging`"
+));
+
+PREPARE stmt FROM @s;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
This will only affect projects that started with LORISv15.04
The ExonicFunction column got added in the SNP table in LORISv15.10 but the sql patch was missing.

RM#11889