### PR TITLE
[Core] Fix bug where $val=0 would pass as blank!

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1080,7 +1080,7 @@ class NDB_BVL_Instrument extends NDB_Page
             $flag = true;
             if (is_array($elvalue)) {
                 foreach ($elvalue AS $val) {
-                    if ($val == "") {
+                    if ($val === "") {
                         $flag = false;
                     }
                 }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1088,7 +1088,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
             //If the answer is empty (or its a group and one of answers in the
             //group is empty) then run the rules
-            if ($elvalue=="" || $flag==false) {
+            if ($elvalue==="" || $flag==false) {
                 if ($this->XINDebug) {
                     //debugging code
                     echo "<p><b>$elname</b><br> ";


### PR DESCRIPTION
This bug affected the upload capability of LorisForm for addFile()

cause:
```{r_tidy=false}
    [recording_file] => Array
        (
            [name] => Screenshot from 2016-08-09 18:54:44.png
            [type] => image/png
            [tmp_name] => /tmp/phpNvwMAZ
            [error] => 0
            [size] => 261121
        )
```