### PR TITLE
[Core] Print SQL Queries to screen without breaking Loris

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -289,13 +289,13 @@ $tpl_data['jsonParams']  = json_encode(
 $tpl_data['css'] = $config->getSetting('css');
 
 // Prints SQL Queries if a file with output exists
-if (isset($_REQUEST['file_sql_queries'])) {
-    $tempFile = $_REQUEST['file_sql_queries'];
+if (isset($GLOBALS['file_sql_queries'])) {
+    $tempFile = "/tmp/" . basename($GLOBALS['file_sql_queries']);
     $handle   = fopen($tempFile, "r");
     echo fread($handle, filesize($tempFile));
     fclose($handle);
     unlink($tempFile);
-    unset($_REQUEST['file_sql_queries']);
+    unset($GLOBALS['file_sql_queries']);
 }
 //--------------------------------------------------
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -289,13 +289,13 @@ $tpl_data['jsonParams']  = json_encode(
 $tpl_data['css'] = $config->getSetting('css');
 
 // Prints SQL Queries if a file with output exists
-if (isset($_SESSION['file_sql_queries'])) {
-    $tempFile = $_SESSION['file_sql_queries'];
+if (isset($_GLOBALS['file_sql_queries'])) {
+    $tempFile = $_GLOBALS['file_sql_queries'];
     $handle   = fopen($tempFile, "r");
     echo fread($handle, filesize($tempFile));
     fclose($handle);
     unlink($tempFile);
-    unset($_SESSION['file_sql_queries']);
+    unset($_GLOBALS['file_sql_queries']);
 }
 //--------------------------------------------------
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -289,13 +289,13 @@ $tpl_data['jsonParams']  = json_encode(
 $tpl_data['css'] = $config->getSetting('css');
 
 // Prints SQL Queries if a file with output exists
-if (isset($_GLOBALS['file_sql_queries'])) {
-    $tempFile = $_GLOBALS['file_sql_queries'];
+if (isset($_REQUEST['file_sql_queries'])) {
+    $tempFile = $_REQUEST['file_sql_queries'];
     $handle   = fopen($tempFile, "r");
     echo fread($handle, filesize($tempFile));
     fclose($handle);
     unlink($tempFile);
-    unset($_GLOBALS['file_sql_queries']);
+    unset($_REQUEST['file_sql_queries']);
 }
 //--------------------------------------------------
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -288,6 +288,15 @@ $tpl_data['jsonParams']  = json_encode(
 
 $tpl_data['css'] = $config->getSetting('css');
 
+// Prints SQL Queries if a file with output exists
+if (isset($_SESSION['file_sql_queries'])) {
+    $tempFile = $_SESSION['file_sql_queries'];
+    $handle   = fopen($tempFile, "r");
+    echo fread($handle, filesize($tempFile));
+    fclose($handle);
+    unlink($tempFile);
+    unset($_SESSION['file_sql_queries']);
+}
 //--------------------------------------------------
 
 //Output template using Smarty

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -992,11 +992,11 @@ class Database
 
         // Print queries to screen
         if ($this->_showQueries === "1" || $this->_showQueries === "3") {
-            if (isset($_REQUEST['file_sql_queries'])) {
-                $tempFile = $_REQUEST['file_sql_queries'];
+            if (isset($GLOBALS['file_sql_queries'])) {
+                $tempFile = $GLOBALS['file_sql_queries'];
             } else {
                 $tempFile = tempnam("/tmp", "SQL");
-                $_REQUEST['file_sql_queries'] = $tempFile;
+                $GLOBALS['file_sql_queries'] = $tempFile;
             }
 
             $handle = fopen($tempFile, "a");

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -956,17 +956,21 @@ class Database
     }
 
     /**
-     * Print a query if showDatabaseQueries defined in config file
+     * Writes all database queries for HTTP request to a single temporary file,
+     * if showDatabaseQueries defined in config file.
+     *
+     * Note: Saves reference to the file to SESSION. SESSION is used in
+     * main.php which reads file contents and prints them to the Loris page.
+     * Then closes and deletes the file.
      *
      * @param string $query  The query to replace
      * @param array  $params The prepared statement parameters used for this query
      *                       They will be replaced in the print statement so that the
      *                       user knows what parameters were used.
      *
-     * @return null As a side-effect, prints to the screen if config option is
-     *              enabled
+     * @return null
      */
-    function _printQuery($query, $params=null)
+    function _printQuery($query, $params = null)
     {
         if (!$this->_showQueries) {
             return;
@@ -974,9 +978,24 @@ class Database
         if ($params) {
             $query = str_replace(array_keys($params), array_values($params), $query);
         }
-        print "$this->_databaseName:"
-            . date("j-M-Y G:i:s", time())
-            .": $query<br>\n";
+        // Remove multispaces, line breaks to show query inline
+        $query = str_replace(["\r", "\n", "\t"], " ", $query);
+        while (strpos($query, "  ") !== false) {
+            $query = str_replace("  ", " ", $query);
+        }
+        $dateTime = date("j-M-Y G:i:s", time());
+        $output   = "[$dateTime] [$this->_databaseName]: $query\n";
+
+        if (isset($_SESSION['file_sql_queries'])) {
+            $tempFile = $_SESSION['file_sql_queries'];
+        } else {
+            $tempFile = tempnam("/tmp", "SQL");
+            $_SESSION['file_sql_queries'] = $tempFile;
+        }
+
+        $handle = fopen($tempFile, "a");
+        fwrite($handle, $output);
+        fclose($handle);
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -956,12 +956,14 @@ class Database
     }
 
     /**
-     * Writes all database queries for HTTP request to a single temporary file,
-     * if showDatabaseQueries defined in config file.
+     * Print database queries to screen (1), error log (2) or both (3).
      *
-     * Note: Saves reference to the file in $_REQUEST. $_REQUEST is used in
-     * main.php which reads file contents and prints them to the Loris page.
-     * Then closes and deletes the file.
+     * Note: In order to print to screen the function writes all database queries
+     * for HTTP request to a single temporary file and saves a reference to it
+     * in $_REQUEST. $_REQUEST is used in main.php which reads file contents and
+     * prints them to the Loris page. Then closes and deletes the file.
+     * This is done to prevent sending response headers before the page is
+     * actually rendered.
      *
      * @param string $query  The query to replace
      * @param array  $params The prepared statement parameters used for this query
@@ -972,13 +974,15 @@ class Database
      */
     function _printQuery($query, $params = null)
     {
+        // Don't print queries
         if (!$this->_showQueries) {
             return;
         }
+
+        // Remove multispaces, line breaks to show query inline
         if ($params) {
             $query = str_replace(array_keys($params), array_values($params), $query);
         }
-        // Remove multispaces, line breaks to show query inline
         $query = str_replace(["\r", "\n", "\t"], " ", trim($query));
         while (strpos($query, "  ") !== false) {
             $query = str_replace("  ", " ", $query);
@@ -986,16 +990,24 @@ class Database
         $dateTime = date("j-M-Y G:i:s", time());
         $output   = "[$dateTime] [$this->_databaseName]: $query\n";
 
-        if (isset($_REQUEST['file_sql_queries'])) {
-            $tempFile = $_REQUEST['file_sql_queries'];
-        } else {
-            $tempFile = tempnam("/tmp", "SQL");
-            $_REQUEST['file_sql_queries'] = $tempFile;
+        // Print queries to screen
+        if ($this->_showQueries === "1" || $this->_showQueries === "3") {
+            if (isset($_REQUEST['file_sql_queries'])) {
+                $tempFile = $_REQUEST['file_sql_queries'];
+            } else {
+                $tempFile = tempnam("/tmp", "SQL");
+                $_REQUEST['file_sql_queries'] = $tempFile;
+            }
+
+            $handle = fopen($tempFile, "a");
+            fwrite($handle, $output);
+            fclose($handle);
         }
 
-        $handle = fopen($tempFile, "a");
-        fwrite($handle, $output);
-        fclose($handle);
+        // Print queries to error log
+        if ($this->_showQueries === "2" || $this->_showQueries === "3") {
+            error_log($output);
+        }
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -986,11 +986,11 @@ class Database
         $dateTime = date("j-M-Y G:i:s", time());
         $output   = "[$dateTime] [$this->_databaseName]: $query\n";
 
-        if (isset($_SESSION['file_sql_queries'])) {
-            $tempFile = $_SESSION['file_sql_queries'];
+        if (isset($_GLOBALS['file_sql_queries'])) {
+            $tempFile = $_GLOBALS['file_sql_queries'];
         } else {
             $tempFile = tempnam("/tmp", "SQL");
-            $_SESSION['file_sql_queries'] = $tempFile;
+            $_GLOBALS['file_sql_queries'] = $tempFile;
         }
 
         $handle = fopen($tempFile, "a");

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -959,7 +959,7 @@ class Database
      * Writes all database queries for HTTP request to a single temporary file,
      * if showDatabaseQueries defined in config file.
      *
-     * Note: Saves reference to the file to SESSION. SESSION is used in
+     * Note: Saves reference to the file in $_GLOBALS. $_GLOBALS is used in
      * main.php which reads file contents and prints them to the Loris page.
      * Then closes and deletes the file.
      *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -959,7 +959,7 @@ class Database
      * Writes all database queries for HTTP request to a single temporary file,
      * if showDatabaseQueries defined in config file.
      *
-     * Note: Saves reference to the file in $_GLOBALS. $_GLOBALS is used in
+     * Note: Saves reference to the file in $_REQUEST. $_REQUEST is used in
      * main.php which reads file contents and prints them to the Loris page.
      * Then closes and deletes the file.
      *
@@ -979,18 +979,18 @@ class Database
             $query = str_replace(array_keys($params), array_values($params), $query);
         }
         // Remove multispaces, line breaks to show query inline
-        $query = str_replace(["\r", "\n", "\t"], " ", $query);
+        $query = str_replace(["\r", "\n", "\t"], " ", trim($query));
         while (strpos($query, "  ") !== false) {
             $query = str_replace("  ", " ", $query);
         }
         $dateTime = date("j-M-Y G:i:s", time());
         $output   = "[$dateTime] [$this->_databaseName]: $query\n";
 
-        if (isset($_GLOBALS['file_sql_queries'])) {
-            $tempFile = $_GLOBALS['file_sql_queries'];
+        if (isset($_REQUEST['file_sql_queries'])) {
+            $tempFile = $_REQUEST['file_sql_queries'];
         } else {
             $tempFile = tempnam("/tmp", "SQL");
-            $_GLOBALS['file_sql_queries'] = $tempFile;
+            $_REQUEST['file_sql_queries'] = $tempFile;
         }
 
         $handle = fopen($tempFile, "a");

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -960,8 +960,8 @@ class Database
      *
      * Note: In order to print to screen the function writes all database queries
      * for HTTP request to a single temporary file and saves a reference to it
-     * in $_REQUEST. $_REQUEST is used in main.php which reads file contents and
-     * prints them to the Loris page. Then closes and deletes the file.
+     * in $GLOBALS. $GLOBALS is used in main.php which reads file contents and
+     * prints them to the Loris page, then closes and deletes the file.
      * This is done to prevent sending response headers before the page is
      * actually rendered.
      *

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -775,6 +775,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function toJSON()
     {
+        ob_clean();
         return json_encode($this->toArray());
     }
     /**


### PR DESCRIPTION
>Note: This was inspired to @gluneau https://github.com/aces/Loris/pull/2572 about SQL queries. ~If necessary I could rebase on his PR to get the best of both worlds.~

- [x] Loris pages work when `showDatabaseQueries` is enabled
- [x] Restyled output for better legibility
![image](https://cloud.githubusercontent.com/assets/6627543/23819541/b334e8f2-05d5-11e7-870f-9cb9654f0261.png)
- [x] **Bonus:** clean output buffer before sending a JSON response, to avoid invalid json, hence breaking react tables, hence breaking modules
- [x] **Bonus 2**: added option to print to both screen and error log as in #2572

----

### For the curious

Currently Loris pages break when `showDatabaseQueries` is set to true. This is because the queries are output to the page before the rest of the response body (aka the main Loris page). 

As a workaround, instead of sending output to the screen, I send output to a temporary file and then save reference to the file in `$_REQUEST`. Once `main.php` gets to load the page, it reads the file from session, opens it and output all the queries. Then closes the file, deletes and unsets the session.
