### PR TITLE
Adding caveat set date to candidate table

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE `candidate` (
   `flagged_reason` int(6) DEFAULT NULL,
   `flagged_other` varchar(255) DEFAULT NULL,
   `flagged_other_status` enum('not_answered') DEFAULT NULL,
+  `flagged_date` date DEFAULT NULL,
   `Testdate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `Entity_type` enum('Human','Scanner') NOT NULL DEFAULT 'Human',
   `ProbandGender` enum('Male','Female') DEFAULT NULL,

--- a/SQL/Archive/17.1/2017-03-13-CaveatSetDate.sql
+++ b/SQL/Archive/17.1/2017-03-13-CaveatSetDate.sql
@@ -1,0 +1,2 @@
+--Adding caveat flag set date
+ALTER TABLE `candidate` ADD COLUMN `flagged_date` DATE DEFAULT NULL;


### PR DESCRIPTION
Caveat flag set date is needed to populate(as per Leigh) in the candidate info section.

So adding the flagged_date to the candidate table.  