### PR TITLE
[candidate_parameters ] PHPCS

### DIFF
--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -56,8 +56,7 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
      *
      * @return void
      */
-//@codingStandardsIgnoreStart
-    function candidate_parameters()
+    function candidate_parameters()//@codingStandardsIgnoreLine
     {
         $config    =& NDB_Config::singleton();
         $candidate =& Candidate::singleton($this->identifier);
@@ -70,7 +69,6 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
 
         $this->tpl_data['useConsent'] = $consent['useConsent'];
     }
-//@codingStandardsIgnoreEnd
     /**
      * Gets the participant_status options from participant_status_options
      * getParticipantStatusOptions()

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -56,6 +56,7 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
      *
      * @return void
      */
+//@codingStandardsIgnoreStart
     function candidate_parameters()
     {
         $config    =& NDB_Config::singleton();
@@ -69,7 +70,7 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
 
         $this->tpl_data['useConsent'] = $consent['useConsent'];
     }
-
+//@codingStandardsIgnoreEnd
     /**
      * Gets the participant_status options from participant_status_options
      * getParticipantStatusOptions()

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -21,7 +21,7 @@ vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php module
 vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/brainbrowser 
 vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/bvl_feedback
 vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/candidate_list
-# vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/candidate_parameters
+vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/candidate_parameters
 vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/configuration
 vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/conflict_resolver
 vendor/bin/phpcs --standard=docs/LorisCS.xml --extensions=php/php,inc/php modules/create_timepoint


### PR DESCRIPTION
It runs PHPCS in [candidate_parameters] module. It fixed the format.
