### PR TITLE
[Dataquery] remove the functionality of upper casing visits when loading longitud…

### DIFF
--- a/modules/dataquery/js/react.app.js
+++ b/modules/dataquery/js/react.app.js
@@ -760,7 +760,7 @@ DataQueryApp = React.createClass({
                 if (!Visits[visit]) {
                     Visits[visit] = true;
                 }
-                identifier = temp[0].toUpperCase();
+                identifier = temp[0];
                 if (Identifiers.indexOf(identifier) === -1) {
                     Identifiers.push(identifier);
                 }

--- a/modules/dataquery/js/react.app.js
+++ b/modules/dataquery/js/react.app.js
@@ -755,10 +755,8 @@ DataQueryApp = React.createClass({
 
             // Loop trough session data building the row identifiers and desired visits
             for (var session in sessiondata) {
-                sessiondata[session.toUpperCase()] = sessiondata[session];
-                delete session[session];
                 temp = session.split(',');
-                visit = temp[1].toUpperCase();
+                visit = temp[1];
                 if (!Visits[visit]) {
                     Visits[visit] = true;
                 }
@@ -928,7 +926,7 @@ DataQueryApp = React.createClass({
                     React.createElement(
                         "span",
                         { "aria-hidden": "true" },
-                        "×"
+                        "\xD7"
                     )
                 ),
                 React.createElement(
@@ -951,7 +949,7 @@ DataQueryApp = React.createClass({
                     React.createElement(
                         "span",
                         { "aria-hidden": "true" },
-                        "×"
+                        "\xD7"
                     )
                 ),
                 React.createElement(

--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -720,7 +720,7 @@ DataQueryApp = React.createClass({
                 if (!Visits[visit]) {
                     Visits[visit] = true;
                 }
-                identifier = temp[0].toUpperCase();
+                identifier = temp[0];
                 if (Identifiers.indexOf(identifier) === -1) {
                     Identifiers.push(identifier);
                 }

--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -715,10 +715,8 @@ DataQueryApp = React.createClass({
 
             // Loop trough session data building the row identifiers and desired visits
             for(var session in sessiondata){
-                sessiondata[session.toUpperCase()] = sessiondata[session];
-                delete session[session];
-                temp = session.split(',')
-                visit = temp[1].toUpperCase();
+                temp = session.split(',');
+                visit = temp[1];
                 if (!Visits[visit]) {
                     Visits[visit] = true;
                 }


### PR DESCRIPTION
This pull request fixes an issue when displaying data longitudinally. When using visits such as ```Screening``` the data would not show up because the logic would uppercase the visit, this would cause for the required data to not show up because there was no data associated to the uppercase visit. 