### PR TITLE
[media] mediaPath not getting populated when uploading

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -77,7 +77,7 @@ function uploadFile()
     }
 
     // Validate media path and destination folder
-    $mediaPath = $config->getSetting('paths')['mediaPath'];
+    $mediaPath = $config->getSetting('mediaPath');
 
     if (!isset($mediaPath)) {
         showError("Error! Media path is not set in Loris Settings!");


### PR DESCRIPTION
The FileDownload.php script uses this format as well:

`$path     = $config->getSetting('mediaPath');`