### PR TITLE
[Tools] lorisform_parser.php, better error checking

### DIFF
--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -59,7 +59,7 @@ foreach ($files AS $file) {
 
     //Some instruments ought not be parsed with the quickform_parser
     if ((in_array($obj->testName, $instrumentsToSkip))) {
-        echo "quickform_parser will	skip file {$file}\n";
+        echo "quickform_parser will    skip file {$file}\n";
         continue;
     }
 
@@ -68,6 +68,11 @@ foreach ($files AS $file) {
         $obj->page =$subtest['Name'];
         echo "Building instrument page '$subtest[Name]'...\n";
         $obj->_setupForm();
+    }
+    
+    if (is_array($obj->getFullName())) {
+        echo "Could not find row for $matches[1] in table test_names, please populate test_names, instrument_subtests\n";
+        continue;
     }
 
     if (!empty($output)) {
@@ -86,9 +91,13 @@ foreach ($files AS $file) {
     $output      .=parseElements($formElements["elements"]);
     echo "Parsing complete\n---------------------------------------------------\n\n";
 }
-$fp =fopen("ip_output.txt", "w");
-fwrite($fp, $output);
-fclose($fp);
+if (empty($output)) {
+    echo "Nothing to output, 'ip_output.txt' not created\n";
+} else {
+    $fp =fopen("ip_output.txt", "w");
+    fwrite($fp, $output);
+    fclose($fp);
+}
 
 /**
  * Create a linst formated string for an LorisForm element.


### PR DESCRIPTION
lorisform_parser.php currently requires that the instrument already exist in `test_names` table, where it looks up the full name of the instrument.   
This change will return a user-friendly warning and fail gracefully if the instrument does not exist in `test_names`, instead of just (at present) returning a PHP warning about array-string conversion and a botched output file.  

The steps to add an instrumentation are:
1. Add the necessary rows into the DB
2. Use `lorisform_parser.php` and `generate_tables_sql.php`
3. Source the output file

Checking for missing rows in `test_names` ensures that step 2 will fail if you skip step 1.

Without the check, step 2 will pass but will output the title `Array` with a warning about an `array to string conversion`.

Checking for empty output just prevents the `ip_output.txt` file from being generated if there's nothing to output.