### PR TITLE
[Tools] Installer.class.inc, Removed attempt to use obsolete ~99-indexes.sql

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -248,9 +248,6 @@ class Installer
         if ($this->_sourceSchemaFile($DB, "04-Help.sql") == false) {
             return false;
         };
-        if ($this->_sourceSchemaFile($DB, "99-indexes.sql") == false) {
-            return false;
-        };
         return true;
     }
 


### PR DESCRIPTION
`Installer.class.inc` will try to use `0000-00-99-indexes.sql` as part of the install process. However, the file does not exist anymore because indexes are now created with table definitions.

This will cause `installdb.php` to return an error and not create the necessary `~/project/config.xml` file... Even if the database was actually created, in entirety, successfully.

`99-indexes.sql` does not exist anymore and is not needed because index creation has been moved to their respective table definition statements.

I just deleted the 3 lines that attempted to use the `~99-indexes.sql` file.

[EDIT]
This is a recent development from pull #2638.

Also, I only just realized we were doing the same thing, #2673