### PR TITLE
[Install] Removing reference to removed file

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -248,9 +248,6 @@ class Installer
         if ($this->_sourceSchemaFile($DB, "04-Help.sql") == false) {
             return false;
         };
-        if ($this->_sourceSchemaFile($DB, "99-indexes.sql") == false) {
-            return false;
-        };
         return true;
     }
 


### PR DESCRIPTION
This pull request fixes an error that occur where installing LORIS.  It remove the code that tries to source the deleted 0000-00-99-indexes.sql file in the installation process.

This as been reported by @AnyhowStep 
