### PR TITLE
[LorisForm] allow files to validate

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1171,17 +1171,17 @@ class LorisForm
                         }
                     }
                 }
-            } else if ($el['type'] === 'file') {
-                $value = $_FILES[$el['name']]['name'];
-                // $el['required'] not present in the file $el array
-                // the file required will get cought by "custom fail"
             } else {
-                $value = $this->getValue($el['name']);
+                if ($el['type'] === 'file') {
+                  $value = $_FILES[$el['name']]['name'];
+                } else {
+                  $value = $this->getValue($el['name']);
+                }
+
                 if (isset($el['required'])
                     && $el['required'] === true
                     && empty($value)
                 ) {
-                    //$this->setElementError($el['name'], "$el[name] required.");
                     $errors[$el['name']] = "required fail";
                 }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1171,6 +1171,14 @@ class LorisForm
                         }
                     }
                 }
+            } else if ($el['type'] === 'file') {
+                $value = $el['name'];
+                if (isset($el['required'])
+                    && $el['required'] === true
+                    && empty($value)
+                ) {
+                    $errors[$el['name']] = "required file fail";
+                }
             } else {
                 $value = $this->getValue($el['name']);
                 if (isset($el['required'])

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1173,9 +1173,9 @@ class LorisForm
                 }
             } else {
                 if ($el['type'] === 'file') {
-                  $value = $_FILES[$el['name']]['name'];
+                    $value = $_FILES[$el['name']]['name'];
                 } else {
-                  $value = $this->getValue($el['name']);
+                    $value = $this->getValue($el['name']);
                 }
 
                 if (isset($el['required'])

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1172,13 +1172,9 @@ class LorisForm
                     }
                 }
             } else if ($el['type'] === 'file') {
-                $value = $el['name'];
-                if (isset($el['required'])
-                    && $el['required'] === true
-                    && empty($value)
-                ) {
-                    $errors[$el['name']] = "required file fail";
-                }
+                $value = $_FILES[$el['name']]['name'];
+                // $el['required'] not present in the file $el array
+                // the file required will get cought by "custom fail"
             } else {
                 $value = $this->getValue($el['name']);
                 if (isset($el['required'])


### PR DESCRIPTION
Fixes the problem where in the else section of validate the 
`$value = $this->getValue($el['name']);`
would use the LorisForm::getValue rather than LorisFormFileElement::getValue

When using XINRules, file are always required by default, add this rule if your file element is not required:
`$this->XINRegisterRule("vineland_file", array("vineland_file{@}==={@}NEVER_REQUIRED"));`
NOTE: the triple equal in the rule!!

I tested this with:

- When file is required
  - Will fail when file not provided.
  - Will pass when file is provided.
- When file is not required
  - Will pass when file not provided.
  - Will pass when file is provided.