### PR TITLE
Set default charset of instrument tables to UTF-8 (3-byte)

### DIFF
--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -106,7 +106,7 @@ foreach($instruments AS $instrument){
 
     }
     $output.="PRIMARY KEY  (`CommentID`)\n
-              );\n";
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8;\n";
     $fp=fopen($filename, "w");
     fwrite($fp, $output);
     fclose($fp);

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -85,7 +85,7 @@ foreach($instruments AS $instrument){
         }
 
     }
-    $output.="PRIMARY KEY  (`CommentID`)\n);\n";
+    $output.="PRIMARY KEY  (`CommentID`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8;\n";
     print "Filename: $filename\n";
     $fp=fopen($filename, "w");
     fwrite($fp, $output);


### PR DESCRIPTION
This pull request sets the charset of instrument SQL tables to UTF-8 which uses 3-bytes per character which is necessary for mysql 5.7 and maria-db which use UTF8-mb4 by default.

See also: https://github.com/aces/Loris/issues/2627
