### PR TITLE
[user_accounts] Avoid erasing current sites from Database when saving my_preference page

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -223,7 +223,7 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         if ($this->page === 'edit_user') {
             // multi-site UPDATE
-            $uid = $user->getData('ID');
+            $uid           = $user->getData('ID');
             $us_curr_sites = $values['CenterIDs'];
             if (!$this->isCreatingNewUser()) {
                 $DB->delete('user_psc_rel', array("UserID" => $uid));
@@ -231,8 +231,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                     $DB->insert(
                         'user_psc_rel',
                         array(
-                            "UserID" => $uid,
-                            "CenterID" => $site,
+                         "UserID"   => $uid,
+                         "CenterID" => $site,
                         )
                     );
                 }

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -221,24 +221,25 @@ class NDB_Form_User_Accounts extends NDB_Form
             unset($values['Password_hash']);
         }
 
-        // multi-site UPDATE
-        $uid           = $user->getData('ID');
-        $us_curr_sites = $values['CenterIDs'];
-        if (!$this->isCreatingNewUser()) {
-            $DB->delete('user_psc_rel', array("UserID" => $uid));
-            foreach ($us_curr_sites as $site) {
-                $DB->insert(
-                    'user_psc_rel',
-                    array(
-                     "UserID"   => $uid,
-                     "CenterID" => $site,
-                    )
-                );
+        if ($this->page === 'edit_user') {
+            // multi-site UPDATE
+            $uid = $user->getData('ID');
+            $us_curr_sites = $values['CenterIDs'];
+            if (!$this->isCreatingNewUser()) {
+                $DB->delete('user_psc_rel', array("UserID" => $uid));
+                foreach ($us_curr_sites as $site) {
+                    $DB->insert(
+                        'user_psc_rel',
+                        array(
+                            "UserID" => $uid,
+                            "CenterID" => $site,
+                        )
+                    );
+                }
             }
+            unset($values['CenterIDs']);
+            // END multi-site UPDATE
         }
-        unset($values['CenterIDs']);
-        // END multi-site UPDATE
-
         // EXAMINER UPDATE
         $ex_curr_sites =array();
         $ex_prev_sites =array();


### PR DESCRIPTION
This pull request adds a validation on the user_accounts page being used to make sure sites are only processed when editing user
