### PR TITLE
Fixing html tags showing up in help section

### DIFF
--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -48,7 +48,7 @@ if (!empty($_REQUEST['testName'])) {
 $help_file = HelpFile::factory($helpID);
 $data = $help_file->toArray();
 $data['content'] = trim($data['content']);
-$data['content']=html_entity_decode($data['content']);
+$data['content'] = html_entity_decode($data['content']);
 
 if (empty($data['updated'])) {
     $data['updated'] = "-";

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -48,6 +48,7 @@ if (!empty($_REQUEST['testName'])) {
 $help_file = HelpFile::factory($helpID);
 $data = $help_file->toArray();
 $data['content'] = trim($data['content']);
+$data['content']=html_entity_decode($data['content']);
 
 if (empty($data['updated'])) {
     $data['updated'] = "-";

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -47,8 +47,7 @@ if (!empty($_REQUEST['testName'])) {
 
 $help_file = HelpFile::factory($helpID);
 $data = $help_file->toArray();
-$data['content'] = trim($data['content']);
-$data['content'] = html_entity_decode($data['content']);
+$data['content'] = html_entity_decode(trim($data['content']));
 
 if (empty($data['updated'])) {
     $data['updated'] = "-";


### PR DESCRIPTION
As an impact of this pull request; #1454
Ref: Redmine issue-10109

As per the issue, html tags are visible or edied content is not properly formatted in help section after editing/styling the contents. 

It is because html entities are inserted into the database for the corresponding html characters(as part of security concern). We want to use html_entity_decode function to get it properly formatted and display it properly.


