### PR TITLE
[Issues] Removed usage of CouchDB in User class when updating password

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -26,7 +26,6 @@
     </database>
 
     <CouchDB>
-        <SyncAccounts>false</SyncAccounts>
     </CouchDB>
 
     <!-- study variables -->

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -399,62 +399,6 @@ class User extends UserPermissions
         );
 
         $this->update($updateArray);
-
-        $config       =& NDB_Config::singleton();
-        $couch_config = $config->getSetting("CouchDB");
-        if ($couch_config['SyncAccounts'] === "true") {
-            $this->updateCouchUser($password);
-        }
-    }
-    /**
-     * Updates the CouchDB user for this user to synchronize
-     * the password with Loris.
-     *
-     * @param string $password Plaintext password to synchronize
-     *
-     * @return none
-     */
-    function updateCouchUser($password)
-    {
-        $factory = NDB_Factory::singleton();
-        $cdb     = $factory->CouchDB();
-        $config  = $factory->Config();
-
-        $c_config = $config->getSetting('CouchDB');
-        if ($c_config['SyncAccounts'] !== 'true') {
-            return false;
-        }
-        $username = $this->getUsername();
-        $authkey  = base64_encode(
-            $c_config['admin']
-            . ':'
-            . $c_config['adminpass']
-        );
-
-        $auth     = array('Authorization' => 'Basic ' . $authkey);
-        $userjson = $cdb->_getURL(
-            "/_users/org.couchdb.user:" . $username,
-            'GET',
-            $auth
-        );
-        $userobj  = json_decode($userjson, true);
-        if (isset($userobj['error']) && $userobj['error'] == 'not_found') {
-            $userobj = array(
-                        '_id'   => 'org.couchdb.user:' . $username,
-                        'type'  => 'user',
-                        'name'  => $username,
-                        'roles' => array(
-                                    'dqg',
-                                    $c_config['database'],
-                                   ),
-                       );
-        }
-        $userobj['password'] = $password;
-
-        $response = $cdb->_postURL(
-            "PUT /_users/org.couchdb.user:" . $username,
-            json_encode($userobj)
-        );
     }
 }
 ?>

--- a/test/config.xml
+++ b/test/config.xml
@@ -27,7 +27,6 @@
     </database>
 
     <CouchDB>
-        <SyncAccounts>false</SyncAccounts>
     </CouchDB>
 
     <!-- study variables -->

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -13,7 +13,6 @@
 #       Some changes to verify in this test/config.xml file:
 #       *  Database connection credentials: specify credentials to the test DB which you create in step 1
 #       *  Set sandbox mode to 1: <sandbox>1</sandbox>
-#       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
 
 host="127.0.0.1"
 database="LorisTest"

--- a/test/unittests.sh
+++ b/test/unittests.sh
@@ -13,7 +13,6 @@
 #       Changes to make in this config.xml file:
 #       *  Database connection credentials: specify credentials to LorisTest DB which you create in step 1
 #       *  Set sandbox mode to 1: <sandbox>1</sandbox>
-#       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
 
 # set environment variable LORIS_DB_CONFIG to test config.xml file
 host="127.0.0.1"


### PR DESCRIPTION
In reference to a bug as reported:

> If CouchDB is not running, trying to use the socket still causes the request to time out.
>
> I thought this was fixed a while ago.
>
> Very low priority though.

I found code in the `User` class that would attempt to connect to CouchDB when updating a user's password if `SyncAccounts` is set to `true` in the `config.xml`.

That bit of code has been removed because it should not be used. Also, the following lines have been found in the code base,

```
./test/config.xml:        <SyncAccounts>false</SyncAccounts>
./test/unittests.sh:#       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
./test/integration.sh:#       *  Set SyncAccounts to false: <SyncAccounts>false</SyncAccounts>
./docs/config/config.xml:        <SyncAccounts>false</SyncAccounts>
./project/config.xml:        <SyncAccounts>false</SyncAccounts>
```

Should I remove them all?

They appear to be wrapped in a `<CouchDB>` tag,

```
    <CouchDB>
        <SyncAccounts>false</SyncAccounts>
    </CouchDB>
```

Do I remove the `<CouchDB>` tags, too?