### PR TITLE
[Tools] Removed query statements causing installdb.php to fail

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1,6 +1,3 @@
-WARNINGS;
-SET SQL_NOTES=1;
-
 -- ********************************
 -- DROP TABLE (ORDER MATTERS)
 -- ********************************
@@ -137,7 +134,7 @@ DROP TABLE IF EXISTS `Project`;
 -- ********************************
 -- Core tables
 -- ********************************
-SELECT 'Core tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `Project` (
     `ProjectID` INT(2) NOT NULL AUTO_INCREMENT,
@@ -155,7 +152,7 @@ CREATE TABLE `subproject` (
     PRIMARY KEY (SubprojectID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Stores Subprojects used in Loris';
 
-SELECT 'Default value for subproject' as 'Important INSERT statement';
+
 INSERT INTO subproject (title, useEDC, WindowDifference) VALUES
   ('Control', false, 'optimal'),
   ('Experimental', false, 'optimal');
@@ -185,7 +182,7 @@ CREATE TABLE `psc` (
   UNIQUE KEY `Name` (`Name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Data Coordinating Center' as 'Important INSERT statement';
+
 INSERT INTO `psc` (Name, Alias, Study_site) VALUES ('Data Coordinating Center','DCC', 'Y');
 
 CREATE TABLE `users` (
@@ -219,7 +216,7 @@ CREATE TABLE `users` (
   UNIQUE KEY `UserID` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Admin user' as 'Important INSERT statement';
+
 
 INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expiry) 
 VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N','2016-03-30');
@@ -233,7 +230,7 @@ CREATE TABLE `user_psc_rel` (
   CONSTRAINT `FK_user_psc_rel_1` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Admin affiliation to all sites (psc)' as 'Important INSERT statement';
+
 INSERT INTO user_psc_rel (UserID, CenterID) SELECT 1, CenterID FROM psc;
 
 CREATE TABLE `caveat_options` (
@@ -336,7 +333,7 @@ CREATE TABLE `test_subgroups` (
   PRIMARY KEY  (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for instruments subgroups' as 'Important INSERT statement';
+
 INSERT INTO test_subgroups (Subgroup_name) VALUES ('Instruments');
 
 CREATE TABLE `test_names` (
@@ -436,13 +433,13 @@ CREATE TABLE `Visit_Windows` (
 -- ********************************
 -- Imaging tables
 -- ********************************
-SELECT 'Imaging tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `ImagingFileTypes` (
  `type` varchar(255) NOT NULL PRIMARY KEY
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for ImagingFileTypes' as 'Important INSERT statement';
+
 INSERT INTO `ImagingFileTypes` VALUES
       ('mnc'),
       ('obj'),
@@ -482,7 +479,7 @@ CREATE TABLE `mri_scanner` (
 SET @OLD_SQL_MODE=@@SQL_MODE;
 SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO';
 
-SELECT 'Default value for mri_scanner' as 'Important INSERT statement';
+
 INSERT INTO `mri_scanner` (ID) VALUES (0);
 
 SET SQL_MODE=@OLD_SQL_MODE;
@@ -610,7 +607,7 @@ CREATE TABLE `mri_protocol` (
   CONSTRAINT `FK_mri_protocol_1` FOREIGN KEY (`ScannerID`) REFERENCES `mri_scanner` (`ID`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for mri_protocol' as 'Important INSERT statement';
+
 INSERT INTO mri_protocol (Center_name,Scan_type,TR_range,TE_range,time_range) VALUES
   ('ZZZZ',48,'8000-14000','80-130','0-200'),
   ('ZZZZ',40,'1900-2700','10-30','0-500'),
@@ -713,7 +710,7 @@ CREATE TABLE `mri_protocol_violated_scans` (
 -- ********************************
 -- tarchive tables
 -- ********************************
-SELECT 'tarchive tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `tarchive` (
   `DicomArchiveID` varchar(255) NOT NULL default '',
@@ -796,7 +793,7 @@ CREATE TABLE `tarchive_find_new_uploads` (
 -- ********************************
 -- document_repository tables
 -- ********************************
-SELECT 'document_repository tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `document_repository_categories` (
   `id` int(3) unsigned NOT NULL AUTO_INCREMENT,
@@ -833,7 +830,7 @@ CREATE TABLE `document_repository` (
 -- ********************************
 -- Notification tables
 -- ********************************
-SELECT 'Notification tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `notification_types` (
   `NotificationTypeID` int(11) NOT NULL auto_increment,
@@ -843,7 +840,7 @@ CREATE TABLE `notification_types` (
   PRIMARY KEY  (`NotificationTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for notification_types' as 'Important INSERT statement';
+
 INSERT INTO `notification_types` (Type,private,Description) VALUES
     ('mri new study',0,'New studies processed by the MRI upload handler'),
     ('mri new series',0,'New series processed by the MRI upload handler'),
@@ -880,7 +877,7 @@ CREATE TABLE `notification_spool` (
 -- ********************************
 -- conflict_resolver tables
 -- ********************************
-SELECT 'conflict_resolver tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `conflicts_unresolved` (
   `ConflictID` int(10) NOT NULL AUTO_INCREMENT,
@@ -919,7 +916,7 @@ CREATE TABLE `conflicts_resolved` (
 -- ********************************
 -- candidate_parameter tables
 -- ********************************
-SELECT 'candidate_parameter tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `participant_status_options` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -930,7 +927,7 @@ CREATE TABLE `participant_status_options` (
   UNIQUE KEY `ID` (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for participant_status_options' as 'Important INSERT statement';
+
 INSERT INTO `participant_status_options` (Description, Required) VALUES
   ('Active',0),
   ('Refused/Not Enrolled',0),
@@ -939,13 +936,13 @@ INSERT INTO `participant_status_options` (Description, Required) VALUES
   ('Inactive',1),
   ('Incomplete',1),
   ('Complete',0);
-SELECT ID INTO @tmp_val FROM participant_status_options WHERE Description = 'Inactive' AND parentID IS NULL;
+
 INSERT INTO `participant_status_options` (Description, Required, parentID) VALUES
   ('Unsure',NULL,@tmp_val),
   ('Requiring Further Investigation',NULL,@tmp_val),
   ('Not Responding',NULL,@tmp_val);
 SET @tmp_val = NULL;
-SELECT ID INTO @tmp_val FROM participant_status_options WHERE Description = 'Incomplete' AND parentID IS NULL;
+
 INSERT INTO `participant_status_options` (Description, Required, parentID) VALUES
   ('Death',NULL,@tmp_val),
   ('Lost to Followup',NULL,@tmp_val);
@@ -1031,7 +1028,7 @@ CREATE TABLE `family` (
 -- ********************************
 -- Training tables
 -- ********************************
-SELECT 'Training tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `examiners` (
   `examinerID` int(10) unsigned NOT NULL auto_increment,
@@ -1108,7 +1105,7 @@ CREATE TABLE `certification_training_quiz_answers` (
 -- ********************************
 -- data_intergrity_flag tables
 -- ********************************
-SELECT 'data_intergrity_flag tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `data_integrity_flag` (
   `dataflag_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1129,7 +1126,7 @@ CREATE TABLE `data_integrity_flag` (
 -- ********************************
 -- final_radiological_review tables
 -- ********************************
-SELECT 'final_radiological_review tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `final_radiological_review` (
   `CommentID` varchar(255) NOT NULL,
@@ -1165,7 +1162,7 @@ CREATE TABLE `final_radiological_review_history` (
 -- ********************************
 -- user_account_history tables
 -- ********************************
-SELECT 'user_account_history tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `user_account_history` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1179,7 +1176,7 @@ CREATE TABLE `user_account_history` (
 -- ********************************
 -- user_login_history tables
 -- ********************************
-SELECT 'user_login_history tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `user_login_history` (
   `loginhistoryID` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1196,7 +1193,7 @@ CREATE TABLE `user_login_history` (
 -- ********************************
 -- StatisticsTabs tables
 -- ********************************
-SELECT 'StatisticsTabs tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `StatisticsTabs` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1207,7 +1204,7 @@ CREATE TABLE `StatisticsTabs` (
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Stores list of tabs for the statistics module';
 
-SELECT 'Default value for StatisticsTabs' as 'Important INSERT statement';
+
 INSERT INTO StatisticsTabs (ModuleName, SubModuleName, Description, OrderNo) VALUES
   ('statistics', 'stats_general', 'General Description', 1),
   ('statistics', 'stats_demographic', 'Demographic Statistics', 2),
@@ -1218,7 +1215,7 @@ INSERT INTO StatisticsTabs (ModuleName, SubModuleName, Description, OrderNo) VAL
 -- ********************************
 -- server_processes tables
 -- ********************************
-SELECT 'server_processes tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `server_processes` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1258,7 +1255,7 @@ CREATE TABLE `media` (
 -- ********************************
 -- issues tables
 -- ********************************
-SELECT 'issues tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `issues_categories` (
   `categoryID` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1267,7 +1264,7 @@ CREATE TABLE `issues_categories` (
   UNIQUE KEY `categoryName` (`categoryName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for issues_categories' as 'Important INSERT statement';
+
 INSERT INTO issues_categories (categoryName) VALUES
   ('Behavioural Battery'),
   ('Behavioural Instruments'),
@@ -1355,7 +1352,7 @@ CREATE TABLE `issues_watching` (
 -- ********************************
 -- parameter tables
 -- ********************************
-SELECT 'parameter tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `parameter_type` (
   `ParameterTypeID` int(10) unsigned NOT NULL auto_increment,
@@ -1374,7 +1371,7 @@ CREATE TABLE `parameter_type` (
   KEY `name` (`Name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='dictionary of all the variables in the project';
 
-SELECT 'Default value for parameter_type 1/2' as 'Important INSERT statement';
+
 INSERT INTO `parameter_type` VALUES
   (2,'Geometric_distortion','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
   (3,'Intensity_artifact','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
@@ -1385,7 +1382,7 @@ INSERT INTO `parameter_type` VALUES
   (8,'Color_Artifact','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0),
   (9,'Entropy','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,NULL,0,0);
 
-SELECT 'Default value for parameter_type 2/2' as 'Important INSERT statement';
+
 INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceField, SourceFrom, CurrentGUITable, Queryable, SourceCondition) VALUES
   ('candidate_label','text','Identifier_of_candidate',null,null,'PSCID','candidate',null,1,null),
   ('Visit_label','varchar(255)','Visit_label',null,null,'visit_label','session',null,1,null),
@@ -1398,7 +1395,7 @@ CREATE TABLE `parameter_type_category` (
   PRIMARY KEY  (`ParameterTypeCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for parameter_type_category' as 'Important INSERT statement';
+
 INSERT INTO `parameter_type_category` (Name, Type) VALUES 
   ('MRI Variables','Metavars'),
   ('Identifiers', 'Metavars');
@@ -1412,7 +1409,7 @@ CREATE TABLE `parameter_type_category_rel` (
   CONSTRAINT `FK_parameter_type_category_rel_1` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for parameter_type_category_rel' as 'Important INSERT statement';
+
 INSERT INTO parameter_type_category_rel (ParameterTypeID,ParameterTypeCategoryID)
   SELECT pt.ParameterTypeID,ptc.ParameterTypeCategoryID
   FROM parameter_type pt,parameter_type_category ptc
@@ -1466,7 +1463,7 @@ CREATE TABLE `parameter_type_override` (
 -- ********************************
 -- genomic_browser tables
 -- ********************************
-SELECT 'genomic_browser tables' AS 'CREATE TABLES';
+
 
 CREATE TABLE `genome_loc` (
   `GenomeLocID` bigint(20) NOT NULL AUTO_INCREMENT,
@@ -1583,7 +1580,7 @@ CREATE TABLE `genomic_analysis_modality_enum` (
   PRIMARY KEY (`analysis_modality`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Default value for genomic_analysis_modality_enum' as 'Important INSERT statement';
+
 INSERT IGNORE INTO `genomic_analysis_modality_enum` (analysis_modality) VALUES
 ('Methylation beta-values'),
 ('Other');
@@ -1677,7 +1674,7 @@ CREATE TABLE `genomic_cpg` (
 -- ********************************
 -- reliability
 -- ********************************
-SELECT 'reliability' as 'Tables for';
+
 
 CREATE TABLE `reliability` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
@@ -1694,7 +1691,7 @@ CREATE TABLE `reliability` (
 -- ********************************
 -- External links
 -- ********************************
-SELECT 'External links' as 'Tables for';
+
 
 CREATE TABLE `ExternalLinkTypes` (
   `LinkTypeID` int(11) NOT NULL AUTO_INCREMENT,
@@ -1702,7 +1699,7 @@ CREATE TABLE `ExternalLinkTypes` (
   PRIMARY KEY (`LinkTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'ExternalLinkTypes' as 'Important INSERT statement';
+
 INSERT INTO `ExternalLinkTypes` (LinkType) VALUES
   ('FooterLink'),
   ('StudyLinks'),
@@ -1718,7 +1715,7 @@ CREATE TABLE `ExternalLinks` (
   CONSTRAINT `ExternalLinks_ibfk_1` FOREIGN KEY (`LinkTypeID`) REFERENCES `ExternalLinkTypes` (`LinkTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'ExternalLinks' as 'Important INSERT statement';
+
 INSERT INTO `ExternalLinks` (LinkTypeID, LinkText, LinkURL) VALUES
   ((SELECT LinkTypeID from ExternalLinkTypes WHERE LinkType='FooterLink'), 'Loris Website', 'http://www.loris.ca'),
   ((SELECT LinkTypeID from ExternalLinkTypes WHERE LinkType='FooterLink'), 'GitHub', 'https://github.com/aces/Loris'),
@@ -1729,7 +1726,7 @@ INSERT INTO `ExternalLinks` (LinkTypeID, LinkText, LinkURL) VALUES
 -- ********************************
 -- empty_queries
 -- ********************************
-SELECT 'empty_queries' as 'Tables for';
+
 
 CREATE TABLE `empty_queries` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
@@ -1741,7 +1738,7 @@ CREATE TABLE `empty_queries` (
 -- ********************************
 -- data_release
 -- ********************************
-SELECT 'data_release' as 'Tables for';
+
 
 CREATE TABLE `data_release` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1764,7 +1761,7 @@ CREATE TABLE `data_release_permissions` (
 -- ********************************
 -- Acknowledgements
 -- ********************************
-SELECT 'acknowledgements' as 'Tables for';
+
 
 CREATE TABLE `acknowledgements` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -1784,7 +1781,7 @@ CREATE TABLE `acknowledgements` (
 -- ********************************
 -- Feedback
 -- ********************************
-SELECT 'Feedback' as 'Tables for';
+
 
 CREATE TABLE `feedback_bvl_type` (
   `Feedback_type` int(11) unsigned NOT NULL auto_increment,
@@ -1794,7 +1791,7 @@ CREATE TABLE `feedback_bvl_type` (
   UNIQUE KEY `Name` (`Name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'feedback_bvl_type' as 'Important INSERT statement';
+
 INSERT INTO `feedback_bvl_type` (Name, Description) VALUES
   ('Input','Input Errors'),
   ('Scoring','Scoring Errors');
@@ -1838,7 +1835,7 @@ CREATE TABLE `feedback_mri_comment_types` (
   PRIMARY KEY  (`CommentTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'feedback_mri_comment_types' as 'Important INSERT statement';
+
 INSERT INTO `feedback_mri_comment_types` (CommentName,CommentType,CommentStatusField) VALUES
   ('Geometric distortion','volume','a:2:{s:5:\"field\";s:20:\"Geometric_distortion\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"Good\";i:2;s:4:\"Fair\";i:3;s:4:\"Poor\";i:4;s:12:\"Unacceptable\";}}'),
   ('Intensity artifact','volume','a:2:{s:5:\"field\";s:18:\"Intensity_artifact\";s:6:\"values\";a:5:{i:0;s:0:\"\";i:1;s:4:\"Good\";i:2;s:4:\"Fair\";i:3;s:4:\"Poor\";i:4;s:12:\"Unacceptable\";}}'),
@@ -1859,7 +1856,7 @@ CREATE TABLE `feedback_mri_predefined_comments` (
   CONSTRAINT `FK_feedback_mri_predefined_comments_1` FOREIGN KEY (`CommentTypeID`) REFERENCES `feedback_mri_comment_types` (`CommentTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'feedback_mri_predefined_comments' as 'Important INSERT statement';
+
 INSERT INTO `feedback_mri_predefined_comments` (CommentTypeID, Comment) VALUES
   (2,'missing slices'),
   (2,'reduced dynamic range due to bright artifact/pixel'),
@@ -1922,4 +1919,4 @@ CREATE TABLE `feedback_mri_comments` (
   CONSTRAINT `FK_feedback_mri_comments_3` FOREIGN KEY (`FileID`) REFERENCES `files` (`FileID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Schema import completed' as 'Status';
+

--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -1,15 +1,12 @@
-WARNINGS;
-SET SQL_NOTES=1;
-
 SET FOREIGN_KEY_CHECKS=0;
 
-SELECT 'permissions' as 'DROP table';
+
 DROP TABLE IF EXISTS `permissions`;
 
-SELECT 'permissions_category' as 'DROP table';
+
 DROP TABLE IF EXISTS `permissions_category`;
 
-SELECT 'user_perm_rel' as 'DROP table';
+
 DROP TABLE IF EXISTS `user_perm_rel`;
 
 SET FOREIGN_KEY_CHECKS=1;
@@ -17,19 +14,19 @@ SET FOREIGN_KEY_CHECKS=1;
 -- Table structure for table `permissions_category`
 --
 
-SELECT 'permissions_category' as 'CREATE table';
+
 CREATE TABLE `permissions_category` (
   `ID` int(10) NOT NULL AUTO_INCREMENT,
   `Description` varchar(255) NOT NULL,
   PRIMARY KEY (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'permissions_category' as 'Inserting data';
+
 INSERT INTO `permissions_category` VALUES 
   (1,'Roles'),
   (2,'Permission');
 
-SELECT 'permissions' as 'CREATE table';
+
 CREATE TABLE `permissions` (
   `permID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `code` varchar(255) NOT NULL DEFAULT '',
@@ -45,7 +42,7 @@ CREATE TABLE `permissions` (
     ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'user_perm_rel' as 'CREATE table';
+
 CREATE TABLE `user_perm_rel` (
   `userID` int(10) unsigned NOT NULL default '0',
   `permID` int(10) unsigned NOT NULL default '0',
@@ -63,7 +60,7 @@ CREATE TABLE `user_perm_rel` (
     ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'permissions' as 'Inserting data';
+
 INSERT INTO `permissions` VALUES
     (1,'superuser','There can be only one Highlander','1'),
     (2,'user_accounts','User management','2'),
@@ -115,11 +112,11 @@ INSERT INTO `permissions` VALUES
     (48,'issue_tracker_developer', 'Can re-assign issues, mark issues as closed, comment on all, edit issues.', 2);
 
 
-SELECT 'user_perm_rel' as 'Inserting data';
+
 INSERT INTO `user_perm_rel` (userID, permID)
   SELECT u.ID, p.permID 
   FROM users u JOIN permissions p 
   WHERE u.userid = 'admin' 
   ORDER BY p.permID;
 
-SELECT 'Menu import completed' as 'Status';
+

--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -1,16 +1,13 @@
-WARNINGS;
-SET SQL_NOTES=1;
-
 --
 -- Table Definition
 --
-SELECT 'LorisMenuPermissions' as 'DROP table';
+
 DROP TABLE IF EXISTS `LorisMenuPermissions`;
 
-SELECT 'LorisMenu' as 'DROP table';
+
 DROP TABLE IF EXISTS `LorisMenu`;
 
-SELECT 'LorisMenu' as 'CREATE table';
+
 CREATE TABLE `LorisMenu` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `Parent` int(10) unsigned DEFAULT NULL,
@@ -24,7 +21,7 @@ CREATE TABLE `LorisMenu` (
   CONSTRAINT `fk_LorisMenu_1` FOREIGN KEY (`Parent`) REFERENCES `LorisMenu` (`ID`) ON DELETE RESTRICT ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'LorisMenuPermissions' as 'CREATE table';
+
 CREATE TABLE `LorisMenuPermissions` (
   `MenuID` int(10) unsigned NOT NULL,
   `PermID` int(10) unsigned NOT NULL,
@@ -38,7 +35,7 @@ CREATE TABLE `LorisMenuPermissions` (
 -- Data
 --
 
-SELECT 'Parent menu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, OrderNumber) VALUES
      ('Candidate', 1),
      ('Clinical', 2),
@@ -47,12 +44,12 @@ INSERT INTO LorisMenu (Label, OrderNumber) VALUES
      ('Tools', 5),
      ('Admin', 6);
 
-SELECT 'Candidate submenu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('New Profile', 'new_profile/', (SELECT ID FROM LorisMenu as L WHERE Label='Candidate'), 1),
     ('Access Profile', 'candidate_list/', (SELECT ID FROM LorisMenu as L WHERE Label='Candidate'), 2);
 
-SELECT 'Clinical submenu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Reliability', 'reliability/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 1),
     ('Conflict Resolver', 'conflict_resolver/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 2),
@@ -60,7 +57,7 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Training', 'training/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 4),
     ('Media', 'media/', (SELECT ID FROM LorisMenu as L WHERE Label='Clinical'), 5);
 
-SELECT 'Imaging submenu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Radiological Reviews', 'final_radiological_review/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 1),
     ('DICOM Archive', 'dicom_archive/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 2),
@@ -68,12 +65,12 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('MRI Violated Scans', 'mri_violations/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 4),
     ('Imaging Uploader', 'imaging_uploader/', (SELECT ID FROM LorisMenu as L WHERE Label='Imaging'), 5);
 
-SELECT 'Reports submenu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Statistics', 'statistics/', (SELECT ID FROM LorisMenu as L WHERE Label='Reports'), 1),
     ('Data Query Tool', 'dataquery/', (SELECT ID FROM LorisMenu as L WHERE Label='Reports'), 2);
 
-SELECT 'Tools submenu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Data Dictionary', 'datadict/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 1),
     ('Document Repository', 'document_repository/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 2),
@@ -85,7 +82,7 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Acknowledgements', 'acknowledgements/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 8),
     ('Issue Tracker', 'issue_tracker/', (SELECT ID FROM LorisMenu as L WHERE Label='Tools'), 9);
 
-SELECT 'Admin submenu items' as 'Inserting data';
+
 INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('User Accounts', 'user_accounts/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 1),
     ('Survey Module', 'survey_accounts/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 2),
@@ -95,19 +92,19 @@ INSERT INTO LorisMenu (Label, Link, Parent, OrderNumber) VALUES
     ('Server Processes Manager', 'server_processes_manager/', (SELECT ID FROM LorisMenu as L WHERE Label='Admin'), 6);
 
 
-SELECT 'New Profile' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='New Profile';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='New Profile';
 
-SELECT 'Access Profile' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Access Profile';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='Access Profile';
 
-SELECT 'Reliability' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='user_accounts' AND m.Label='Reliability';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
@@ -115,120 +112,120 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='access_all_profiles' AND m.Label='Reliability';
 
-SELECT 'Conflict Resolver' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='conflict_resolver' AND m.Label='Conflict Resolver';
 
-SELECT 'Examiner' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_site' AND m.Label='Examiner';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_multisite' AND m.Label='Examiner';
 
-SELECT 'Training' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='training' AND m.Label='Training';
 
-SELECT 'Radiological Reviews' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='edit_final_radiological_review' AND m.Label='Radiological Reviews';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='view_final_radiological_review' AND m.Label='Radiological Reviews';
 
-SELECT 'DICOM Archive' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='dicom_archive_view_allsites' AND m.Label='DICOM Archive';
 
-SELECT 'Imaging Browser' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='imaging_browser_view_site' AND m.Label='Imaging Browser';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='imaging_browser_view_allsites' AND m.Label='Imaging Browser';
 
-SELECT 'MRI Violated Scans' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='violated_scans_view_allsites' AND m.Label='MRI Violated Scans';
 
-SELECT 'MRI Upload' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='imaging_uploader' AND m.Label='Imaging Uploader';
 
-SELECT 'Statistics' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Statistics';
 
-SELECT 'Data Query Tool' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_dict_view' AND m.Label='Data Query Tool';
 
-SELECT 'Data Dictionary' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_dict_view' AND m.Label='Data Dictionary';
 
-SELECT 'Document Repository' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='document_repository_view' AND m.Label='Document Repository';
 
-SELECT 'Data Integrity Flag' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID) SELECT m.ID, p.PermID
     FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_integrity_flag' AND m.Label='Data Integrity Flag';
 
-SELECT 'Data Team Helper' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_team_helper' AND m.Label='Data Team Helper';
 
-SELECT 'Instrument Builder' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='instrument_builder' AND m.Label='Instrument Builder';
 
-SELECT 'Genomic Browser' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='genomic_browser_view_site' AND m.Label='Genomic Browser';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='genomic_browser_view_allsites' AND m.Label='Genomic Browser';
 
-SELECT 'User Accounts' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='user_accounts' AND m.Label='User Accounts';
 
-SELECT 'Survey Module' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='user_accounts' AND m.Label='Survey Module';
 
-SELECT 'Help Editor' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='context_help' AND m.Label='Help Editor';
 
-SELECT 'Instrument Manager' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='superuser' AND m.Label='Instrument Manager';
 
-SELECT 'Configuration' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='config' AND m.Label='Configuration';
 
-SELECT 'Server Processes Manager' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='server_processes_manager' AND m.Label='Server Processes Manager';
 
-SELECT 'Acknowledgement Generator' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='acknowledgements_view' AND m.Label='Acknowledgements';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='acknowledgements_edit' AND m.Label='Acknowledgements';
 
-SELECT 'Data Query Tool' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='dataquery_view' AND m.Label='Data Query Tool';
 
-SELECT 'Issue Tracker' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='issue_tracker_reporter' AND m.Label='Issue Tracker';
 
-SELECT 'Media' as 'Inserting LorisMenuPermissions';
+
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='media_read' AND m.Label='Media';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='media_write' AND m.Label='Media';
 
-SELECT 'Permission import completed' as 'Status';
+

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -1,19 +1,18 @@
 WARNINGS;
-SET SQL_NOTES=1;
 
 --
 -- DROP tables
 --
-SELECT 'Config' as 'DROP table';
+
 DROP TABLE IF EXISTS `Config`;
 
-SELECT 'ConfigSettings' as 'DROP table';
+
 DROP TABLE IF EXISTS `ConfigSettings`;
 
 --
 -- Table structure for table `ConfigSettings`
 --
-SELECT 'ConfigSettings' as 'CREATE table';
+
 CREATE TABLE `ConfigSettings` (
     `ID` int(11) NOT NULL AUTO_INCREMENT,
     `Name` varchar(255) NOT NULL,
@@ -28,7 +27,7 @@ CREATE TABLE `ConfigSettings` (
     UNIQUE KEY `Name` (`Name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-SELECT 'Config' as 'CREATE table';
+
 CREATE TABLE `Config` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
   `ConfigID` int(11) NOT NULL,
@@ -45,7 +44,7 @@ CREATE TABLE `Config` (
 --
 -- Filling ConfigSettings table
 --
-SELECT 'study' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('study', 'Settings related to details of the study', 1, 0, 'Study', 1);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'additional_user_info', 'Display additional user profile fields on the User accounts page (e.g. Institution, Position, Country, Address)', 1, 0, 'boolean', ID, 'Additional user information', 14 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'title', 'Full descriptive title of the study', 1, 0, 'text', ID, 'Study title', 1 FROM ConfigSettings WHERE Name="study";
@@ -71,7 +70,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'citation_policy', 'Citation Policy for Acknowledgements module', 1, 0, 'textarea', ID, 'Citation Policy', 22 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'CSPAdditionalHeaders', 'Extensions to the Content-security policy allow only for self-hosted content', 1, 0, 'text', ID, 'Content-Security Extensions', 23 FROM ConfigSettings WHERE Name="study";
 
-SELECT 'paths' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('paths', 'Specify directories where LORIS-related files are stored or created. Take care when editing these fields as changing them incorrectly can cause certain modules to lose functionality.', 1, 0, 'Paths', 2);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'imagePath', 'Path to images for display in Imaging Browser (e.g. /data/$project/data/) ', 1, 0, 'text', ID, 'Images', 9 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'base', 'The base filesystem path where LORIS is installed', 1, 0, 'text', ID, 'Base', 1 FROM ConfigSettings WHERE Name="paths";
@@ -86,24 +85,24 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'GenomicDataPath', 'Path to Genomic data files', 1, 0, 'text', ID, 'Genomic Data Path', 8 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'mediaPath', 'Path to uploaded media files', 1, 0, 'text', ID, 'Media', 9 FROM ConfigSettings WHERE Name="paths";
 
-SELECT 'gui' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'css', 'CSS file used for rendering (default main.css)', 1, 0, 'text', ID, 'CSS file', 1 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'rowsPerPage', 'Number of table rows to display per page', 1, 0, 'text', ID, 'Table rows per page', 2 FROM ConfigSettings WHERE Name="gui";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'StudyDescription', 'Description of the Study', 1, 0, 'textarea', ID , 'Study Description', 2 FROM ConfigSettings WHERE Name="gui";
 
-SELECT 'www' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('www', 'Web address settings', 1, 0, 'WWW', 4);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'host', 'Host', 1, 0, 'text', ID, 'Host', 1 FROM ConfigSettings WHERE Name="www";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'url', 'Main URL where LORIS can be accessed', 1, 0, 'text', ID, 'Main LORIS URL', 2 FROM ConfigSettings WHERE Name="www";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'mantis_url', 'Bug tracker URL', 1, 0, 'text', ID, 'Bug tracker URL', 3 FROM ConfigSettings WHERE Name="www";
 
-SELECT 'dashboard' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('dashboard', 'Settings that affect the appearance of the dashboard and its charts', 1, 0, 'Dashboard', 5);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'projectDescription', 'Description of the study displayed in main dashboard panel', 1, 0, 'textarea', ID, 'Project Description', 1 FROM ConfigSettings WHERE Name="dashboard";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'recruitmentTarget', 'Target number of participants for the study', 1, 0, 'text', ID, 'Target number of participants', 2 FROM ConfigSettings WHERE Name="dashboard";
 
-SELECT 'dicom_archive' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('dicom_archive', 'DICOM Archive settings', 1, 0, 'DICOM Archive', 6);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'patientIDRegex', 'Regex for masking the Patient ID header field', 1, 0, 'text', ID, 'Patient ID regex', 1 FROM ConfigSettings WHERE Name="dicom_archive";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'patientNameRegex', 'Regex for masking the Patient Name header field', 1, 0, 'text', ID, 'Patient name regex', 2 FROM ConfigSettings WHERE Name="dicom_archive";
@@ -111,22 +110,22 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'LivingPhantomRegex', 'Regex to be used on Living Phantom scan header', 1, 0, 'text', ID, 'Living phantom regex', 4 FROM ConfigSettings WHERE Name="dicom_archive";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showTransferStatus', 'Show transfer status in the DICOM Archive table', 1, 0, 'boolean', ID, 'Show transfer status', 5 FROM ConfigSettings WHERE Name="dicom_archive";
 
-SELECT 'statistics' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('statistics', 'Statistics module settings', 1, 0, 'Statistics', 7);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'excludedMeasures', 'Instruments to be excluded from Statistics calculations', 1, 1, 'instrument', ID, 'Excluded instruments', 1 FROM ConfigSettings WHERE Name="statistics";
 
-SELECT 'mail' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('mail', 'LORIS email settings for notifications sent to users', 1, 0, 'Email', 8);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'From', 'Sender email address header (e.g. admin@myproject.loris.ca)', 1, 0, 'email', ID, 'From', 1 FROM ConfigSettings WHERE Name="mail";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'Reply-to', 'Reply-to email address header (e.g. admin@myproject.loris.ca)', 1, 0, 'email', ID, 'Reply-to', 2 FROM ConfigSettings WHERE Name="mail";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'X-MimeOLE', 'X-MimeOLE', 1, 0, 'text', ID, 'X-MimeOLE', 3 FROM ConfigSettings WHERE Name="mail";
 
-SELECT 'upload' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('uploads', 'Settings related to file uploading', 1, 0, 'Uploads', '9');
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'FileGroup', 'Determines the group permission for new subdirectories created for uploaded files', 1, 0, 'text', ID, 'File Group for Uploads', 1 FROM ConfigSettings WHERE Name="uploads";
 
-SELECT 'API keys' as 'Inserting Config';
+
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('APIKeys', 'Specify any API keys required for LORIS', 1, 0, 'API Keys', 10);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'JWTKey', 'Secret key for signing JWT tokens on this server. This should be unique and never shared with anyone. ', 1, 0, 'text', ID, 'JWT Secret Key', 1 FROM ConfigSettings WHERE Name="APIKeys";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'reCAPTCHAPrivate', 'Private Key for Google reCAPTCHA', 1, 0, 'text', ID, 'reCAPTCHA Private Key', 2 FROM ConfigSettings WHERE Name="APIKeys";
@@ -135,7 +134,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 --
 -- Filling Config table with default values
 --
-SELECT 'Default study variables' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, 1 FROM ConfigSettings WHERE Name="additional_user_info";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "Example Study" FROM ConfigSettings WHERE Name="title";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "<h3>Example Study Description</h3>\r\n <p>This is a sample description for this study, because it is a new LORIS install that has not yet customized this text.</p>\r\n <p>A LORIS administrator can customize this text in the configuration module, under the configuration option labeled \"Study Description\"</p>\r\n <h3>Useful Links</h3>\r\n <ul>\r\n <li><a href=\"https://github.com/aces/Loris\" >LORIS GitHub Repository</a></li>\r\n <li><a href=\"https://github.com/aces/Loris/wiki/Setup\" >LORIS Setup Guide</a></li>\r\n <li><a href=\"https://www.youtube.com/watch?v=2Syd_BUbl5A\" >A video of a loris on YouTube</a></li>\r\n </ul>" FROM ConfigSettings WHERE Name="StudyDescription";
@@ -158,7 +157,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name
 INSERT INTO Config (ConfigID, Value) SELECT ID, "Modify this to your project's citation policy" FROM ConfigSettings WHERE Name="citation_policy";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "" FROM ConfigSettings WHERE Name="CSPAdditionalHeaders";
 
-SELECT 'Default path settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="imagePath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "%LORISROOT%" FROM ConfigSettings WHERE Name="base";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="data";
@@ -172,34 +171,34 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/incoming/" FROM ConfigSet
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/Genomic-Data/" FROM ConfigSettings WHERE Name="GenomicDataPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSettings WHERE Name="mediaPath";
 
-SELECT 'Default gui settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 25 FROM ConfigSettings WHERE Name="rowsPerPage";
 
-SELECT 'Default www settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "localhost" FROM ConfigSettings WHERE Name="host";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "http://localhost/" FROM ConfigSettings WHERE Name="url";
 
-SELECT 'Default dashboard settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun." FROM ConfigSettings WHERE Name="projectDescription";
 
-SELECT 'Default dicom_archive settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/./" FROM ConfigSettings WHERE Name="patientIDRegex";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/./i" FROM ConfigSettings WHERE Name="patientNameRegex";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/./i" FROM ConfigSettings WHERE Name="LegoPhantomRegex";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/./i" FROM ConfigSettings WHERE Name="LivingPhantomRegex";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="showTransferStatus";
 
-SELECT 'Default statistics settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "radiology_review" FROM ConfigSettings WHERE Name="excludedMeasures";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "mri_parameter_form" FROM ConfigSettings WHERE Name="excludedMeasures";
 
-SELECT 'Default mail settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "no-reply@example.com" FROM ConfigSettings WHERE Name="From";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "no-reply@example.com" FROM ConfigSettings WHERE Name="Reply-to";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "Produced by LorisDB" FROM ConfigSettings WHERE Name="X-MimeOLE";
 
-SELECT 'Default API keys settings' as 'Filling Config table with default values';
+
 INSERT INTO Config (ConfigID, Value) SELECT ID, "S3cret" FROM ConfigSettings WHERE Name="JWTKey";
 
-SELECT 'Config import completed' as 'Status';
+

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -1,5 +1,3 @@
-WARNINGS;
-
 --
 -- DROP tables
 --

--- a/SQL/0000-00-04-Help.sql
+++ b/SQL/0000-00-04-Help.sql
@@ -1,13 +1,10 @@
-WARNINGS;
-SET SQL_NOTES=1;
-
 --
 -- Table structure for table `help`
 --
-SELECT 'help' as 'DROP TABLE';
+
 DROP TABLE IF EXISTS `help`;
 
-SELECT 'help' as 'CREATE TABLE';
+
 CREATE TABLE `help` (
     `helpID` int(10) unsigned NOT NULL AUTO_INCREMENT, 
     `parentID` int(11) NOT NULL DEFAULT '-1',
@@ -24,7 +21,7 @@ CREATE TABLE `help` (
 --
 -- Dumping data for table `help`
 --
-SELECT 'help' as 'Inserting data';
+
 INSERT INTO `help` (helpID, parentID, hash, topic, content, created, updated) VALUES  (1,-1,md5('dashboard'),'LORIS HELP: Using the Database','Welcome to the LORIS database. \r\nThis Help section provides you with guidelines for adding and updating information in the database. On each page, click on the question mark icon in the Menu Bar across the top of the screen to access detailed information specific to the current page.\r\n\r\nUpon logging into the LORIS database, the user will come to the home page. Here, key user information can automatically be seen at the right-hand side of the Menu Bar at the top of the screen indicating the user’s name and the site to which the user belongs. To return to the home page at any time, the user can click on the \"LORIS\" button at the far left corner of the Menu Bar.\r\nThe menus spanning horizontally across the Menu Bar represent different categories of features within the database that allow data acquisition, storage, processing and dissemination using the web based interface. Please note that when accessing LORIS via tablet, mobile device, or in a narrow-width desktop browser window, these main menus will be hidden under the downward-pointing arrow icon in the Menu Bar. Clicking on this button will show or hide all main menus in a vertical list.\r\nThere are five main drop-down menus: Candidate, Clinical, Imaging, Reports and Admin. Hover over on each menu to display a list of features or modules, organized by category:\r\n- Candidate: New Profile, Access Profile\r\n- Clinical: Reliability Coding, Conflict Resolver, Certification, Document Repository\r\n- Imaging: Radiological Review, DICOM Archive, Imaging Browser, Imaging Uploader\r\n- Reports: Database Statistics, Data Dictionary, Data Querying Tool, Data Team Helper, Data Integrity Tool\r\n- Admin: User Accounts, Instrument Builder\r\n\r\nOn the right side of the Menu Bar there are two icons linking to the Feedback Module, a pencil on paper icon , and Help, a question mark icon. Each of these modules will open in a new pop-up window, or new tab on a mobile browser.\r\n\r\nAll five main menus, the two icons listed above, the user’s site and the user’s name are accessible from any page in LORIS, via the Menu Bar at the top of the screen. \r\n\r\nTo log out of the database, click on the username displayed at the right edge of the Menu Bar, and select the \"Log Out\" option from the drop-down menu. \r\n\r\nThe \"My Preferences\" feature, also listed in this menu, can be used to update certain user profile settings and change the user’s password. \r\n','2014-09-01 00:00:00',NULL),
 (2,-1,NULL,'HOW TO - Guide','Under Construction. Please visit us later',NULL,NULL),
 (3,-1,NULL,'Guidelines','Under Construction. Please visit us later',NULL,NULL),
@@ -76,4 +73,4 @@ INSERT INTO `help` (helpID, parentID, hash, topic, content, created, updated) VA
 (51,-1,md5('issue_tracker'), 'Issue Tracker', 'The Issue Tracker module allows users to report bugs and flag data concerns within a given LORIS. <br>Click the "Add Issue" button to register a new issue. Use the All Issues, Closed Issues, and My Issues tabs, in combination with the Selection filters, to build a custom view of issues of interest. Optionally, a PSCID can be associated to an issue, to link it to a specific subject record.  If PSCID is provided, a Visit label can also be specified for cases where an issue relates to a subject-timepoint.<br>Clicking on any issue will load a page displaying the Issue Details, enabling the user to edit or update the issue given appropriate user permissions.  This form can be used to re-assign an issue, change its status, and add further comments.  Email notifications are sent when a given issue is updated, to any user who is added to the list of those "watching" the issue. The history of all comments and updates to the issue is also visible at the end of the Issue page.', '2016-10-25 00:00:00', NULL),
 (52,-1,md5('data_release'), 'Data Release', 'The Data Release Module can be used to easily distribute packaged data releases of your study. Use the "Upload File" button to upload your file and tag it with a version based on your own version convention. Grant access to any of your users using the "Add Permission" button. These buttons will be visible only if you have the "superuser" permission.', '2016-11-04 00:00:00', NULL);
 
-SELECT 'Help import completed' as 'Status';
+


### PR DESCRIPTION
Running `installdb.php` when installing Loris fails. The fix is to remove the `SELECT`, `WARNINGS;` and `SET SQL_NOTES=1;` statements. Doing so allows `installdb.php` to function as desired.

Those statements cause `installdb.php` to fail because the script uses `PDO::exec()`, via `Installer.class.inc`, internally. `PDO::exec()` cannot return results and cannot clear results from its buffer, as far as I know. The subsequent call to `PDO::exec()` fails because the previous call returned results and are still stuck in the buffer. The error message returned is related to the buffer still having results.

Possible alternative fix would be to reset the database connection after each PDO::exec() call.