### PR TITLE
[config] Config support for including other config file

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -143,7 +143,7 @@ class NDB_Config
             // Absolute path given
             $file = $pathToFile;
         } else {
-            throw new LorisException(
+            throw new ConfigurationException(
                 "Config file $pathToFile does not exist in the defined locations."
             );
         }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -78,9 +78,7 @@ class NDB_Config
 
             // Load all includes found in the config
             foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
-                if (file_exists($path)) {
-                    $config->load($path);
-                }
+                $config->load($config->configFilePath($path));
             }
         }
 
@@ -117,6 +115,8 @@ class NDB_Config
      * @param string $pathToFile relative file path or file name
      *
      * @return string  absolute path of config file
+     *
+     * @throws LorisException when any config file is missing
      */
     function configFilePath($pathToFile = "config.xml")
     {
@@ -136,6 +136,13 @@ class NDB_Config
         } else if (file_exists("/usr/local/etc/loris/$pathToFile")) {
             // Standard Unix filesystem layout, option 2
             $file = "/usr/local/etc/loris/$pathToFile";
+        } else if (file_exists($pathToFile)) {
+            // Absolute path given
+            $file = $pathToFile;
+        } else {
+            throw new LorisException(
+                "Config file $pathToFile does not exist in the defined locations."
+            );
         }
 
         return $file;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -64,32 +64,24 @@ class NDB_Config
     {
         static $config = null;
         if (is_null($config)) {
-            // If calling singleton without any parameter, first check
-            // for a project/config.xml, then check for the config
-            // file in a standard unix filesystem location.
-            // /etc/loris/config.xml
+
+            $config = new NDB_Config();
+
             if ($configFile === null) {
                 // Can't directly check !empty because of a bug
                 // in PHP < 5.5, need to assign to a variable first
-                $env = getenv('LORIS_DB_CONFIG');
-                if (!empty($env)) {
-                    $configFile = $env;
-                } else if (file_exists(__DIR__ . "/../../project/config.xml")) {
-                    // "Classic" Loris location of project directory
-                    // parallel to php directory
-                    $configFile = __DIR__ . "/../../project/config.xml";
-                } else if (file_exists("/etc/loris/config.xml")) {
-                    // Standard Unix filesystem layout
-                    $configFile = "/etc/loris/config.xml";
-                } else if (file_exists("/usr/local/etc/loris/config.xml")) {
-                    // Standard Unix filesystem layout, option 2
-                    $configFile = "/usr/local/etc/loris/config.xml";
-                }
+                $configFile = $config->configFilePath();
             }
 
             // Load the file
-            $config  = new NDB_Config();
-            $success = $config->load($configFile);
+            $config->load($configFile);
+
+            // Load all includes found in the config
+            foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
+                if (file_exists($path)) {
+                    $config->load($path);
+                }
+            }
         }
 
         return $config;
@@ -100,7 +92,9 @@ class NDB_Config
      *
      * @param string $configFile the neurodb config.xml config file
      *
-     * @return none, but as side-effect loads $this->_settings
+     * @return void, but as side-effect loads $this->_settings
+     *
+     * @throws Exception
      */
     function load($configFile = "../project/config.xml")
     {
@@ -113,8 +107,40 @@ class NDB_Config
             );
         }
 
-        $this->_settings = NDB_Config::convertToArray($newroot);
+        $this->_settings += NDB_Config::convertToArray($newroot);
     }
+
+    /**
+     * Takes a path and checks if file exists under all locations where config file
+     * can exist.
+     *
+     * @param string $pathToFile relative file path or file name
+     *
+     * @return string  absolute path of config file
+     */
+    function configFilePath($pathToFile = "config.xml")
+    {
+        // first check for a project/config.xml, then check for the config
+        // file in a standard unix filesystem location ->  /etc/loris/config.xml
+
+        $env = getenv('LORIS_DB_CONFIG');
+        if (!empty($env)) {
+            $file = $env;
+        } else if (file_exists(__DIR__ . "/../../project/$pathToFile")) {
+            // "Classic" Loris location of project directory
+            // parallel to php directory
+            $file = __DIR__ . "/../../project/$pathToFile";
+        } else if (file_exists("/etc/loris/$pathToFile")) {
+            // Standard Unix filesystem layout
+            $file = "/etc/loris/$pathToFile";
+        } else if (file_exists("/usr/local/etc/loris/$pathToFile")) {
+            // Standard Unix filesystem layout, option 2
+            $file = "/usr/local/etc/loris/$pathToFile";
+        }
+
+        return $file;
+    }
+
 
     /**
      * Converts a SimpleXMLElement to an array.

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -77,9 +77,9 @@ class NDB_Config
             $config->load($configFile);
 
             // Load all includes found in the config
-            foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
-                $config->load($config->configFilePath($path));
-            }
+//            foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
+//                $config->load($config->configFilePath($path));
+//            }
         }
 
         return $config;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -75,10 +75,11 @@ class NDB_Config
 
             // Load the file
             $config->load($configFile);
-            
+
             if (!empty($config->_settings['include'])) {
                 // Load all includes found in the config
-                foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
+                $includes = Utility::asArray($config->_settings['include']);
+                foreach ($includes as $k=>$path) {
                     $config->load($config->configFilePath($path));
                 }
             }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -75,10 +75,12 @@ class NDB_Config
 
             // Load the file
             $config->load($configFile);
-
-            // Load all includes found in the config
-            foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
-                $config->load($config->configFilePath($path));
+            
+            if (!empty($config->_settings['include'])) {
+                // Load all includes found in the config
+                foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
+                    $config->load($config->configFilePath($path));
+                }
             }
         }
 

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -77,9 +77,11 @@ class NDB_Config
             $config->load($configFile);
 
             // Load all includes found in the config
-//            foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
-//                $config->load($config->configFilePath($path));
-//            }
+            foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
+                if (!empty($path)) {
+                    $config->load($config->configFilePath($path));
+                }
+            }
         }
 
         return $config;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -78,9 +78,7 @@ class NDB_Config
 
             // Load all includes found in the config
             foreach (Utility::asArray($config->_settings['include']) as $k=>$path) {
-                if (!empty($path)) {
-                    $config->load($config->configFilePath($path));
-                }
+                $config->load($config->configFilePath($path));
             }
         }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -558,7 +558,7 @@ class Utility
      */
     static function asArray($var)
     {
-        if (!is_array($var)) {
+        if (!is_array($var) && !empty($var)) {
             return array($var);
         }
         return $var;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -558,7 +558,7 @@ class Utility
      */
     static function asArray($var)
     {
-        if (!is_array($var) && !empty($var)) {
+        if (!is_array($var)) {
             return array($var);
         }
         return $var;


### PR DESCRIPTION
projects can use the `<include>` tag to import secondary config xml files and append them to the main config array.

This can be used to separate the database and couchdb settings from the main config