### PR TITLE
[utility] Fix the toArray() function checking for value[0]

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -539,7 +539,7 @@ class Utility
      */
     static function toArray($var)
     {
-        if (!array_key_exists(0, $var)) {
+        if (is_array($var) && !array_key_exists(0, $var)) {
             $var = array($var);
         }
         return $var;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -539,7 +539,7 @@ class Utility
      */
     static function toArray($var)
     {
-        if (!isset($var[0])) {
+        if (!array_key_exists(0,$var)) {
             $var = array($var);
         }
         return $var;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -539,7 +539,7 @@ class Utility
      */
     static function toArray($var)
     {
-        if (!array_key_exists(0,$var)) {
+        if (!array_key_exists(0, $var)) {
             $var = array($var);
         }
         return $var;


### PR DESCRIPTION
The toArray function was using is_set val[0] which fails when a string is passed since the val[0] is the first value of the string.

replace call to is_set by array_key_exists.