### PR TITLE
Added the ability for pages to bypass the smarty module.

### DIFF
--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -48,6 +48,8 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
+        $this->skipTemplate = true;
+
         $this->_setDicomArchiveSettings();
 
         $this->query = " FROM tarchive t

--- a/modules/dicom_archive/templates/menu_dicom_archive.tpl
+++ b/modules/dicom_archive/templates/menu_dicom_archive.tpl
@@ -1,4 +1,0 @@
-{*
-  Everything is rendered in dicom_archvie.js now!
-  I'm here because currently Loris breaks without me :(
-*}

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -142,6 +142,9 @@ class NDB_Menu extends NDB_Page
      */
     function display()
     {
+        if ($this->skipTemplate) {
+            return "";
+        }
         // dump the html for the menu
         $smarty = new Smarty_neurodb($this->Module);
         $smarty->assign('mode', $this->mode);

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -699,6 +699,9 @@ class NDB_Menu_Filter extends NDB_Menu
                 return $this->toJSON();
             }
         }
+        if ($this->skipTemplate) {
+            return "";
+        }
         // Set the csvFile links
         $uri    = ltrim($_SERVER['REQUEST_URI'], "/");
         $suffix = strpos($uri, '?') ? '&format=csv' : '?&format=csv';

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -55,6 +55,13 @@ class NDB_Page
     var $defaults = array();
 
     /**
+     * If true, the default display function will not try to load any template.
+     * This is intended to be used with, for instance, pages that completely
+     * construct the DOM from javascript.
+     */
+    var $skipTemplate = false;
+
+    /**
      * Does the setup required for this page. By default, sets up elements
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
@@ -492,11 +499,13 @@ class NDB_Page
     /**
      * Displays the form
      *
-     * @return void
-     * @access public
+     * @return a string of the content to be inserted into the template
      */
     function display()
     {
+        if ($this->skipTemplate) {
+            return "";
+        }
         if (!$this->form->isFrozen()) {
             // hidden values
               $this->addHidden('test_name', $this->name);


### PR DESCRIPTION
This adds a "skiptemplate" flag on a page level, which hints at the renderer
that it should not try and load any smarty templates.

This is mostly intended for pages that do their rendering from javascript,
and avoids the need for an empty smarty template just to avoid an exception
because smarty can't open the template file.