### PR TITLE
[Imaging Uploader] If TarchiveID is NULL or 0 (zero), no link will be shown

### DIFF
--- a/modules/imaging_uploader/js/columnFormatter.js
+++ b/modules/imaging_uploader/js/columnFormatter.js
@@ -63,6 +63,13 @@ function formatColumn(column, cell, rowData, rowHeaders) {
   }
 
   if (column === 'Tarchive Info') {
+    if (cell === null || cell === "0") {
+      return React.createElement(
+        'td',
+        { style: cellStyle },
+        'No Metadata'
+      );
+    }
     var url = loris.BaseURL + '/dicom_archive/viewDetails/?tarchiveID=' + cell;
     return React.createElement(
       'td',

--- a/modules/imaging_uploader/jsx/columnFormatter.js
+++ b/modules/imaging_uploader/jsx/columnFormatter.js
@@ -56,6 +56,11 @@ function formatColumn(column, cell, rowData, rowHeaders) {
   }
 
   if (column === 'Tarchive Info') {
+    if (cell === null || cell === "0") {
+      return (
+        <td style={cellStyle}>No Metadata</td>
+      );
+    }
     let url = loris.BaseURL + '/dicom_archive/viewDetails/?tarchiveID=' + cell;
     return (
       <td style={cellStyle}>


### PR DESCRIPTION
Currently, if `TarchiveID` is `NULL` or `0`, it will still present the "View Details" link. Clicking on the link will display invalid data. This change makes it so it just says "No Metadata" without a link.