### PR TITLE
[CouchDB] Renamed CouchDB <database> tag to <dbName> to avoid conflicts

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -26,11 +26,11 @@
     </database>
 
     <CouchDB>
-        <dbName>loris</dbName>
-        <hostname>localhost</hostname>
-        <port>5984</port>
-        <admin>USER</admin>
-        <adminpass>PASS</adminpass>
+        <dbName>%COUCH_DATABASE%</dbName>
+        <hostname>%COUCH_HOSTNAME%</hostname>
+        <port>%COUCH_PORT%</port>
+        <admin>%COUCH_USERNAME%</admin>
+        <adminpass>%COUCH_PASSWORD%</adminpass>
     </CouchDB>
 
     <!-- study variables -->

--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -26,6 +26,11 @@
     </database>
 
     <CouchDB>
+        <dbName>loris</dbName>
+        <hostname>localhost</hostname>
+        <port>5984</port>
+        <admin>USER</admin>
+        <adminpass>PASS</adminpass>
     </CouchDB>
 
     <!-- study variables -->

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -194,9 +194,9 @@ class CouchDB
     function _constructURL($op, $doc)
     {
         $config = NDB_Config::singleton();
-        $db     = $config->getSetting("CouchDB");
+        $db     = $config->getSetting('CouchDB');
 
-        return "$op /$db[database]/$doc";
+        return "$op /$db[dbName]/$doc";
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -381,7 +381,7 @@ class User extends UserPermissions
      * @param string $expiry   The password expiry date. If not supplied, the
      *                         password expiry date will be set to now+6months.
      *
-     * @return none
+     * @return void
      */
     function updatePassword($password, $expiry = null)
     {


### PR DESCRIPTION
The <database> tag in config.xml is used for both MySQL database settings and CouchDB. This pull request renames the CouchDB <database> tag to use <dbName> insteal