### PR TITLE
Illustrate abject failure of democracy

### DIFF
--- a/docs/LorisCS.xml
+++ b/docs/LorisCS.xml
@@ -10,6 +10,10 @@
     <!-- Make sure there's no weird spacing for array brackets -->
     <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
 
+     <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+        <type>warning</type>
+     </rule>
+
     <!-- Pick up any calls to deprecated functions. -->
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
 

--- a/htdocs/api/v0.0.1/APIBase.php
+++ b/htdocs/api/v0.0.1/APIBase.php
@@ -30,7 +30,7 @@ abstract class APIBase
     var $DB;
     var $client;
     var $JSON;
-    var $AllowedMethods = [];
+    var $AllowedMethods = array();
     var $AutoHandleRequestDelegation = true;
     var $HTTPMethod;
 
@@ -45,7 +45,7 @@ abstract class APIBase
     function __construct($method)
     {
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
         // Verify that method is allowed for this type of request.
         if (!in_array($method, $this->AllowedMethods)) {
@@ -223,7 +223,7 @@ abstract class APIBase
      */
     function error($msg)
     {
-        print json_encode(["error" => $msg]);
+        print json_encode(array("error" => $msg));
     }
 
     /**

--- a/htdocs/api/v0.0.1/Candidates.php
+++ b/htdocs/api/v0.0.1/Candidates.php
@@ -35,10 +35,10 @@ class Candidates extends APIBase
      */
     public function __construct($method, $data=null)
     {
-        $this->AllowedMethods = [
+        $this->AllowedMethods = array(
                                  'GET',
                                  'POST',
-                                ];
+                                );
         $this->RequestData    = $data;
 
         parent::__construct($method);
@@ -77,7 +77,7 @@ class Candidates extends APIBase
                 FROM candidate c JOIN psc s on (s.CenterID=c.CenterID)
              WHERE Active='Y'
                 ",
-            []
+            array()
         );
 
         $projects   = \Utility::getProjectList();
@@ -92,7 +92,7 @@ class Candidates extends APIBase
             $candidates
         );
 
-        $this->JSON = ["Candidates" => $candValues];
+        $this->JSON = array("Candidates" => $candValues);
     }
 
     /**
@@ -110,7 +110,7 @@ class Candidates extends APIBase
                 $this->safeExit(0);
             }
 
-            $this->verifyField($data, 'Gender', ['Male', 'Female']);
+            $this->verifyField($data, 'Gender', array('Male', 'Female'));
             $this->verifyField($data, 'EDC', 'YYYY-MM-DD');
             $this->verifyField($data, 'DoB', 'YYYY-MM-DD');
             //Candidate::createNew
@@ -122,9 +122,9 @@ class Candidates extends APIBase
                     $data['Candidate']['PSCID']
                 );
                 $this->header("HTTP/1.1 201 Created");
-                $this->JSON = [
-                               'Meta' => ["CandID" => "123456"],
-                              ];
+                $this->JSON = array(
+                               'Meta' => array("CandID" => "123456"),
+                              );
             } catch(\LorisException $e) {
                 $this->header("HTTP/1.1 400 Bad Request");
                 $this->safeExit(0);

--- a/htdocs/api/v0.0.1/Projects.php
+++ b/htdocs/api/v0.0.1/Projects.php
@@ -60,25 +60,25 @@ class Projects extends APIBase
 
         $type = $PSCID['generation'] == 'sequential' ? 'auto' : 'prompt';
 
-        $settings = [
+        $settings = array(
                      "useEDC" => $useEDC,
-                     "PSCID"  => [
+                     "PSCID"  => array(
                                   "Type"  => $type,
                                   "Regex" => $PSCIDFormat,
-                                 ],
-                    ];
+                                 ),
+                    );
 
         if ($useProjects && $useProjects !== "false" && $useProjects !== "0") {
             $projects  = \Utility::getProjectList();
-            $projArray = [];
+            $projArray = array();
             foreach ($projects as $project) {
                 $projArray[$project] = $settings;
             }
-            $this->JSON = ["Projects" => $projArray];
+            $this->JSON = array("Projects" => $projArray);
         } else {
-            $this->JSON = [
+            $this->JSON = array(
                            "Projects" => array("loris" => $settings),
-                          ];
+                          );
         }
     }
 

--- a/htdocs/api/v0.0.1/candidates/Candidate.php
+++ b/htdocs/api/v0.0.1/candidates/Candidate.php
@@ -77,8 +77,8 @@ class Candidate extends \Loris\API\APIBase
         $Site   = $this->Candidate->getCandidateSite();
         $Gender = $this->Candidate->getCandidateGender();
 
-        $this->JSON = [
-                       "Meta"   => [
+        $this->JSON = array(
+                       "Meta"   => array(
                                     "CandID"  => $this->CandID,
                                     'Project' => $this->Candidate->getProjectTitle(),
                                     'PSCID'   => $this->Candidate->getPSCID(),
@@ -86,11 +86,11 @@ class Candidate extends \Loris\API\APIBase
                                     'EDC'     => $this->Candidate->getCandidateEDC(),
                                     'DoB'     => $this->Candidate->getCandidateDoB(),
                                     'Gender'  => $Gender,
-                                   ],
+                                   ),
                        "Visits" => array_values(
                            $this->Candidate->getListOfVisitLabels()
                        ),
-                      ];
+                      );
     }
 
     /**

--- a/htdocs/api/v0.0.1/candidates/InstrumentData.php
+++ b/htdocs/api/v0.0.1/candidates/InstrumentData.php
@@ -49,12 +49,12 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
         $bFlags
     ) {
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
                                      'PATCH',
                                      'OPTIONS',
-                                    ];
+                                    );
         }
         $this->AutoHandleRequestDelegation = false;
         $this->bDDE   = $bDDE;
@@ -115,14 +115,14 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
      */
     function handleGET()
     {
-        $this->JSON = [
-                       "Meta" => [
+        $this->JSON = array(
+                       "Meta" => array(
                                   "Instrument" => $this->Instrument->testName,
                                   "Visit"      => $this->VisitLabel,
                                   "Candidate"  => $this->CandID,
                                   "DDE"        => $this->bDDE,
-                                 ],
-                      ];
+                                 ),
+                      );
 
         if (!$this->bFlags) {
             $Values = \NDB_BVL_Instrument::loadInstanceData($this->Instrument);
@@ -137,7 +137,7 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
             $flags = $this->DB->pselectRow(
                 "SELECT Data_entry, Administration, Validity
                  FROM flag WHERE CommentID=:CID",
-                ['CID' => $this->Instrument->getCommentID()]
+                array('CID' => $this->Instrument->getCommentID())
             );
 
             if (!$this->Instrument->ValidityEnabled) {

--- a/htdocs/api/v0.0.1/candidates/Instruments.php
+++ b/htdocs/api/v0.0.1/candidates/Instruments.php
@@ -40,7 +40,7 @@ class Instruments extends Visit
     public function __construct($method, $CandID, $Visit)
     {
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
         $requestDelegationCascade = $this->AutoHandleRequestDelegation;
         // Parent will validate CandID and Visit Label and abort if necessary
@@ -79,13 +79,13 @@ class Instruments extends Visit
             $Insts
         );
 
-        $this->JSON = [
-                       "Meta"        => [
+        $this->JSON = array(
+                       "Meta"        => array(
                                          "CandID" => $this->CandID,
                                          'Visit'  => $this->VisitLabel,
-                                        ],
+                                        ),
                        'Instruments' => $Instruments,
-                      ];
+                      );
     }
 }
 

--- a/htdocs/api/v0.0.1/candidates/Visit.php
+++ b/htdocs/api/v0.0.1/candidates/Visit.php
@@ -48,10 +48,10 @@ class Visit extends \Loris\API\Candidates\Candidate
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
-                                    ];
+                                    );
         }
         $this->CandID     = $CandID;
         $this->VisitLabel = $VisitLabel;
@@ -93,41 +93,41 @@ class Visit extends \Loris\API\Candidates\Candidate
     {
         $SubProjTitle = $this->Timepoint->getData("SubprojectTitle");
 
-        $this->JSON = [
-                       "Meta" => [
+        $this->JSON = array(
+                       "Meta" => array(
                                   "CandID"  => $this->CandID,
                                   'Visit'   => $this->VisitLabel,
                                   'Battery' => $SubProjTitle,
-                                 ],
-                      ];
+                                 ),
+                      );
         if ($this->Timepoint) {
-            $stages = [];
+            $stages = array();
             if ($this->Timepoint->getDateOfScreening() !== null) {
                 $Date   = $this->Timepoint->getDateOfScreening();
                 $Status = $this->Timepoint->getScreeningStatus();
 
-                $stages['Screening'] = [
+                $stages['Screening'] = array(
                                         'Date'   => $Date,
                                         'Status' => $Status,
-                                       ];
+                                       );
             }
             if ($this->Timepoint->getDateOfVisit() !== null) {
                 $Date   = $this->Timepoint->getDateOfVisit();
                 $Status = $this->Timepoint->getVisitStatus();
 
-                $stages['Visit'] = [
+                $stages['Visit'] = array(
                                     'Date'   => $Date,
                                     'Status' => $Status,
-                                   ];
+                                   );
             }
             if ($this->Timepoint->getDateOfApproval() !== null) {
                 $Date   = $this->Timepoint->getDateOfApproval();
                 $Status = $this->Timepoint->getApprovalStatus();
 
-                $stages['Approval'] = [
+                $stages['Approval'] = array(
                                        'Date'   => $Date,
                                        'Status' => $Status,
-                                      ];
+                                      );
             }
             $this->JSON['Stages'] = $stages;
         }

--- a/htdocs/api/v0.0.1/projects/Project.php
+++ b/htdocs/api/v0.0.1/projects/Project.php
@@ -103,7 +103,7 @@ class Project extends \Loris\API\APIBase
 
         if (!is_numeric($this->ProjectID)) {
             $this->header("HTTP/1.1 404 Not Found");
-            $this->error(['error' => 'Invalid project']);
+            $this->error(array('error' => 'Invalid project'));
             $this->safeExit(0);
         }
 
@@ -122,11 +122,11 @@ class Project extends \Loris\API\APIBase
             return $this->JSON;
         }
 
-        $JSONArray = [
-                      "Meta" => [
+        $JSONArray = array(
+                      "Meta" => array(
                                  "Project" => $this->ProjectName,
-                                ],
-                     ];
+                                ),
+                     );
 
         if ($this->bCandidates) {
             if ($this->ProjectID === 0) {
@@ -140,7 +140,7 @@ class Project extends \Loris\API\APIBase
                     array("projID" => $this->ProjectID)
                 );
             }
-            $CandIDs = [];
+            $CandIDs = array();
 
             foreach ($rows as $row) {
                 $CandIDs[] = $row['CandID'];
@@ -153,7 +153,7 @@ class Project extends \Loris\API\APIBase
             $Instruments = \Utility::getAllInstruments();
 
             if ($this->bInstrumentDetails) {
-                $dets   = [];
+                $dets   = array();
                 $config = $this->Factory->config();
                 $DB     = $this->Factory->database();
 
@@ -170,11 +170,11 @@ class Project extends \Loris\API\APIBase
 
                     $DDEEn = in_array($instrument, $DDE);
 
-                    $dets[$instrument] = [
+                    $dets[$instrument] = array(
                                           'FullName'               => $FullName,
                                           'Subgroup'               => $subgroup,
                                           'DoubleDataEntryEnabled' => $DDEEn,
-                                         ];
+                                         );
                 }
                 $JSONArray['Instruments'] = $dets;
             } else {

--- a/htdocs/api/v0.0.2/APIBase.php
+++ b/htdocs/api/v0.0.2/APIBase.php
@@ -30,7 +30,7 @@ abstract class APIBase
     var $DB;
     var $client;
     var $JSON;
-    var $AllowedMethods = [];
+    var $AllowedMethods = array();
     var $AutoHandleRequestDelegation = true;
     var $HTTPMethod;
 
@@ -45,7 +45,7 @@ abstract class APIBase
     function __construct($method)
     {
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
         // Verify that method is allowed for this type of request.
         if (!in_array($method, $this->AllowedMethods)) {
@@ -223,7 +223,7 @@ abstract class APIBase
      */
     function error($msg)
     {
-        print json_encode(["error" => $msg]);
+        print json_encode(array("error" => $msg));
     }
 
     /**

--- a/htdocs/api/v0.0.2/Candidates.php
+++ b/htdocs/api/v0.0.2/Candidates.php
@@ -35,10 +35,10 @@ class Candidates extends APIBase
      */
     public function __construct($method, $data=null)
     {
-        $this->AllowedMethods = [
+        $this->AllowedMethods = array(
                                  'GET',
                                  'POST',
-                                ];
+                                );
         $this->RequestData    = $data;
 
         parent::__construct($method);
@@ -77,7 +77,7 @@ class Candidates extends APIBase
                 FROM candidate c JOIN psc s on (s.CenterID=c.CenterID)
              WHERE Active='Y'
                 ",
-            []
+            array()
         );
 
         $projects   = \Utility::getProjectList();
@@ -92,7 +92,7 @@ class Candidates extends APIBase
             $candidates
         );
 
-        $this->JSON = ["Candidates" => $candValues];
+        $this->JSON = array("Candidates" => $candValues);
     }
 
     /**
@@ -110,7 +110,7 @@ class Candidates extends APIBase
                 $this->safeExit(0);
             }
 
-            $this->verifyField($data, 'Gender', ['Male', 'Female']);
+            $this->verifyField($data, 'Gender', array('Male', 'Female'));
             $this->verifyField($data, 'EDC', 'YYYY-MM-DD');
             $this->verifyField($data, 'DoB', 'YYYY-MM-DD');
             //Candidate::createNew
@@ -122,9 +122,9 @@ class Candidates extends APIBase
                     $data['Candidate']['PSCID']
                 );
                 $this->header("HTTP/1.1 201 Created");
-                $this->JSON = [
-                               'Meta' => ["CandID" => $candid],
-                              ];
+                $this->JSON = array(
+                               'Meta' => array("CandID" => $candid),
+                              );
             } catch(\LorisException $e) {
                 $this->header("HTTP/1.1 400 Bad Request");
                 $this->safeExit(0);

--- a/htdocs/api/v0.0.2/Projects.php
+++ b/htdocs/api/v0.0.2/Projects.php
@@ -60,25 +60,25 @@ class Projects extends APIBase
 
         $type = $PSCID['generation'] == 'sequential' ? 'auto' : 'prompt';
 
-        $settings = [
+        $settings = array(
                      "useEDC" => $useEDC,
-                     "PSCID"  => [
+                     "PSCID"  => array(
                                   "Type"  => $type,
                                   "Regex" => $PSCIDFormat,
-                                 ],
-                    ];
+                                 ),
+                    );
 
         if ($useProjects && $useProjects !== "false" && $useProjects !== "0") {
             $projects  = \Utility::getProjectList();
-            $projArray = [];
+            $projArray = array();
             foreach ($projects as $project) {
                 $projArray[$project] = $settings;
             }
-            $this->JSON = ["Projects" => $projArray];
+            $this->JSON = array("Projects" => $projArray);
         } else {
-            $this->JSON = [
+            $this->JSON = array(
                            "Projects" => array("loris" => $settings),
-                          ];
+                          );
         }
     }
 

--- a/htdocs/api/v0.0.2/candidates/Candidate.php
+++ b/htdocs/api/v0.0.2/candidates/Candidate.php
@@ -77,8 +77,8 @@ class Candidate extends \Loris\API\APIBase
         $Site   = $this->Candidate->getCandidateSite();
         $Gender = $this->Candidate->getCandidateGender();
 
-        $this->JSON = [
-                       "Meta"   => [
+        $this->JSON = array(
+                       "Meta"   => array(
                                     "CandID"  => $this->CandID,
                                     'Project' => $this->Candidate->getProjectTitle(),
                                     'PSCID'   => $this->Candidate->getPSCID(),
@@ -86,11 +86,11 @@ class Candidate extends \Loris\API\APIBase
                                     'EDC'     => $this->Candidate->getCandidateEDC(),
                                     'DoB'     => $this->Candidate->getCandidateDoB(),
                                     'Gender'  => $Gender,
-                                   ],
+                                   ),
                        "Visits" => array_values(
                            $this->Candidate->getListOfVisitLabels()
                        ),
-                      ];
+                      );
     }
 
     /**

--- a/htdocs/api/v0.0.2/candidates/InstrumentData.php
+++ b/htdocs/api/v0.0.2/candidates/InstrumentData.php
@@ -49,12 +49,12 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
         $bFlags
     ) {
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
                                      'PATCH',
                                      'OPTIONS',
-                                    ];
+                                    );
         }
         $this->AutoHandleRequestDelegation = false;
         $this->bDDE   = $bDDE;
@@ -115,14 +115,14 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
      */
     function handleGET()
     {
-        $this->JSON = [
-                       "Meta" => [
+        $this->JSON = array(
+                       "Meta" => array(
                                   "Instrument" => $this->Instrument->testName,
                                   "Visit"      => $this->VisitLabel,
                                   "Candidate"  => $this->CandID,
                                   "DDE"        => $this->bDDE,
-                                 ],
-                      ];
+                                 ),
+                      );
 
         if (!$this->bFlags) {
             $Values = \NDB_BVL_Instrument::loadInstanceData($this->Instrument);
@@ -137,7 +137,7 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
             $flags = $this->DB->pselectRow(
                 "SELECT Data_entry, Administration, Validity
                  FROM flag WHERE CommentID=:CID",
-                ['CID' => $this->Instrument->getCommentID()]
+                array('CID' => $this->Instrument->getCommentID())
             );
 
             if (!$this->Instrument->ValidityEnabled) {

--- a/htdocs/api/v0.0.2/candidates/Instruments.php
+++ b/htdocs/api/v0.0.2/candidates/Instruments.php
@@ -40,7 +40,7 @@ class Instruments extends Visit
     public function __construct($method, $CandID, $Visit)
     {
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
         $requestDelegationCascade = $this->AutoHandleRequestDelegation;
         // Parent will validate CandID and Visit Label and abort if necessary
@@ -79,13 +79,13 @@ class Instruments extends Visit
             $Insts
         );
 
-        $this->JSON = [
-                       "Meta"        => [
+        $this->JSON = array(
+                       "Meta"        => array(
                                          "CandID" => $this->CandID,
                                          'Visit'  => $this->VisitLabel,
-                                        ],
+                                        ),
                        'Instruments' => $Instruments,
-                      ];
+                      );
     }
 }
 

--- a/htdocs/api/v0.0.2/candidates/Visit.php
+++ b/htdocs/api/v0.0.2/candidates/Visit.php
@@ -48,10 +48,10 @@ class Visit extends \Loris\API\Candidates\Candidate
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
-                                    ];
+                                    );
         }
         $this->CandID     = $CandID;
         $this->VisitLabel = $VisitLabel;
@@ -93,41 +93,41 @@ class Visit extends \Loris\API\Candidates\Candidate
     {
         $SubProjTitle = $this->Timepoint->getData("SubprojectTitle");
 
-        $this->JSON = [
-                       "Meta" => [
+        $this->JSON = array(
+                       "Meta" => array(
                                   "CandID"  => $this->CandID,
                                   'Visit'   => $this->VisitLabel,
                                   'Battery' => $SubProjTitle,
-                                 ],
-                      ];
+                                 ),
+                      );
         if ($this->Timepoint) {
-            $stages = [];
+            $stages = array();
             if ($this->Timepoint->getDateOfScreening() !== null) {
                 $Date   = $this->Timepoint->getDateOfScreening();
                 $Status = $this->Timepoint->getScreeningStatus();
 
-                $stages['Screening'] = [
+                $stages['Screening'] = array(
                                         'Date'   => $Date,
                                         'Status' => $Status,
-                                       ];
+                                       );
             }
             if ($this->Timepoint->getDateOfVisit() !== null) {
                 $Date   = $this->Timepoint->getDateOfVisit();
                 $Status = $this->Timepoint->getVisitStatus();
 
-                $stages['Visit'] = [
+                $stages['Visit'] = array(
                                     'Date'   => $Date,
                                     'Status' => $Status,
-                                   ];
+                                   );
             }
             if ($this->Timepoint->getDateOfApproval() !== null) {
                 $Date   = $this->Timepoint->getDateOfApproval();
                 $Status = $this->Timepoint->getApprovalStatus();
 
-                $stages['Approval'] = [
+                $stages['Approval'] = array(
                                        'Date'   => $Date,
                                        'Status' => $Status,
-                                      ];
+                                      );
             }
             $this->JSON['Stages'] = $stages;
         }

--- a/htdocs/api/v0.0.2/candidates/visits/Images.php
+++ b/htdocs/api/v0.0.2/candidates/visits/Images.php
@@ -39,7 +39,7 @@ class Images extends \Loris\API\Candidates\Candidate\Visit
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
         $this->CandID     = $CandID;
         $this->VisitLabel = $VisitLabel;
@@ -62,12 +62,12 @@ class Images extends \Loris\API\Candidates\Candidate\Visit
      */
     public function handleGET()
     {
-        $this->JSON          = [
-                                'Meta' => [
+        $this->JSON          = array(
+                                'Meta' => array(
                                            'CandID' => $this->CandID,
                                            'Visit'  => $this->VisitLabel,
-                                          ],
-                               ];
+                                          ),
+                               );
         $this->JSON['Files'] = $this->GetVisitImages();
 
     }
@@ -91,10 +91,10 @@ class Images extends \Loris\API\Candidates\Candidate\Visit
                     JOIN candidate c ON (s.CandID=c.CandID)
                 WHERE s.Visit_label=:VL AND c.CandID=:CID 
                     AND c.Active='Y' AND s.Active='Y'",
-            [
+            array(
              'VL'  => $this->VisitLabel,
              'CID' => $this->CandID,
-            ]
+            )
         );
         return $rows;
     }

--- a/htdocs/api/v0.0.2/candidates/visits/images/Image.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/Image.php
@@ -41,10 +41,10 @@ class Image extends \Loris\API\Candidates\Candidate\Visit
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
-                                    ];
+                                    );
         }
         $this->CandID     = $CandID;
         $this->VisitLabel = $VisitLabel;

--- a/htdocs/api/v0.0.2/candidates/visits/images/format/BrainBrowser.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/format/BrainBrowser.php
@@ -40,11 +40,11 @@ class BrainBrowser extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
                                      'PATCH',
-                                    ];
+                                    );
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);
@@ -64,11 +64,11 @@ class BrainBrowser extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
      */
     private function _getDimension($dim)
     {
-        return [
+        return array(
                 'start'        => $this->getHeader("$dim:start"),
                 'space_length' => $this->getHeader("$dim:length"),
                 'step'         => $this->getHeader("$dim:step"),
-               ];
+               );
     }
 
     /**
@@ -80,11 +80,11 @@ class BrainBrowser extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
     {
         $order      = $this->getHeader("image:dimorder");
         $orderArray = explode(",", $order);
-        $this->JSON = [
+        $this->JSON = array(
                        'xspace' => $this->_getDimension("xspace"),
                        'yspace' => $this->_getDimension("yspace"),
                        "zspace" => $this->_getDimension("zspace"),
-                      ];
+                      );
         if (count($orderArray) === 4) {
             $this->JSON['time'] = $this->_getDimension("time")
         }

--- a/htdocs/api/v0.0.2/candidates/visits/images/format/Raw.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/format/Raw.php
@@ -40,7 +40,7 @@ class Raw extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);

--- a/htdocs/api/v0.0.2/candidates/visits/images/format/Thumbnail.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/format/Thumbnail.php
@@ -40,7 +40,7 @@ class Thumbnail extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);

--- a/htdocs/api/v0.0.2/candidates/visits/images/headers/Full.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/headers/Full.php
@@ -40,11 +40,11 @@ class Full extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
                                      'PATCH',
-                                    ];
+                                    );
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);
@@ -64,18 +64,18 @@ class Full extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
     {
         $headersDB = $this->getHeaders();
 
-        $headers = [];
+        $headers = array();
         foreach ($headersDB as $row) {
             $headers[$row['Header']] = $row['Value'];
         }
-        $this->JSON = [
-                       'Meta'    => [
+        $this->JSON = array(
+                       'Meta'    => array(
                                      'CandID'   => $this->CandID,
                                      'Visit'    => $this->VisitLabel,
                                      'Filename' => $this->Filename,
-                                    ],
+                                    ),
                        "Headers" => $headers,
-                      ];
+                      );
     }
 
     /**

--- a/htdocs/api/v0.0.2/candidates/visits/images/headers/Headers.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/headers/Headers.php
@@ -40,11 +40,11 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
                                      'PATCH',
-                                    ];
+                                    );
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);
@@ -70,46 +70,46 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $SeriesName        =  $this->getHeader("acquisition:protocol");
         $SeriesDescription = $this->getHeader("acquisition:series_description");
 
-        $XSpace     = [
+        $XSpace     = array(
                        "Length"   => $this->getHeader("xspace:length"),
                        "StepSize" => $this->getHeader("xspace:step"),
-                      ];
-        $YSpace     = [
+                      );
+        $YSpace     = array(
                        "Length"   => $this->getHeader("yspace:length"),
                        "StepSize" => $this->getHeader("yspace:step"),
-                      ];
-        $ZSpace     = [
+                      );
+        $ZSpace     = array(
                        "Length"   => $this->getHeader("zspace:length"),
                        "StepSize" => $this->getHeader("zspace:step"),
-                      ];
-        $TimeD      = [
+                      );
+        $TimeD      = array(
                        "Length"   => $this->getHeader("time:length"),
                        "StepSize" => $this->getHeader("time:step"),
-                      ];
-        $this->JSON = [
-                       'Meta'        => [
+                      );
+        $this->JSON = array(
+                       'Meta'        => array(
                                          'CandID'   => $this->CandID,
                                          'Visit'    => $this->VisitLabel,
                                          'Filename' => $this->Filename,
-                                        ],
-                       'Physical'    => [
+                                        ),
+                       'Physical'    => array(
                                          "TE"             => $TE,
                                          "TR"             => $TR,
                                          "TI"             => $TI,
                                          "SliceThickness" => $ST,
-                                        ],
-                       'Description' => [
+                                        ),
+                       'Description' => array(
                                          "SeriesName"        => $SeriesName,
                                          "SeriesDescription" => $SeriesDescription,
-                                        ],
-                       'Dimensions'  => [
+                                        ),
+                       'Dimensions'  => array(
                                          "XSpace"        => $XSpace,
                                          "YSpace"        => $YSpace,
                                          "ZSpace"        => $ZSpace,
                                          "TimeDimension" => $TimeD,
-                                        ],
+                                        ),
 
-                      ];
+                      );
     }
 
     /**

--- a/htdocs/api/v0.0.2/candidates/visits/images/headers/Specific.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/headers/Specific.php
@@ -41,7 +41,7 @@ class SpecificHeader extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = ['GET'];
+            $this->AllowedMethods = array('GET');
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);
@@ -65,15 +65,15 @@ class SpecificHeader extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         foreach ($headersDB as $row) {
             $headers[$row['Header']] = $row['Value'];
         }
-        $this->JSON = [
-                       'Meta'  => [
+        $this->JSON = array(
+                       'Meta'  => array(
                                    'CandID'   => $this->CandID,
                                    'Visit'    => $this->VisitLabel,
                                    'Filename' => $this->Filename,
                                    "Header"   => $this->Header,
-                                  ],
+                                  ),
                        "Value" => $this->getHeader($this->Header),
-                      ];
+                      );
     }
 
     /**

--- a/htdocs/api/v0.0.2/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/qc/QC.php
@@ -40,10 +40,10 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
-                                    ];
+                                    );
         }
 
         parent::__construct($method, $CandID, $VisitLabel, $Filename);
@@ -73,15 +73,15 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                 WHERE f.File LIKE CONCAT('%', :FName)",
             array('FName' => $this->Filename)
         );
-        $this->JSON = [
-                       'Meta'     => [
+        $this->JSON = array(
+                       'Meta'     => array(
                                       'CandID' => $this->CandID,
                                       'Visit'  => $this->VisitLabel,
                                       'File'   => $this->Filename,
-                                     ],
+                                     ),
                        'QC'       => $QCStatus['QCStatus'],
                        'Selected' => $QCStatus['Selected'],
-                      ];
+                      );
     }
 
     /**
@@ -177,7 +177,7 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         }
         $this->_saveFileQC($data['QCStatus'], $selval);
 
-        $this->JSON = ['success' => 'Updated file QC information'];
+        $this->JSON = array('success' => 'Updated file QC information');
 
     }
 
@@ -206,20 +206,20 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         if ($AlreadySavedQC > 0) {
             $DB->update(
                 "files_qcstatus",
-                [
+                array(
                  'QCStatus' => $qcval,
                  'Selected' => $selval,
-                ],
-                ['FileID' => $FileID]
+                ),
+                array('FileID' => $FileID)
             );
         } else {
             $DB->insert(
                 "files_qcstatus",
-                [
+                array(
                  'QCStatus' => $qcval,
                  'Selected' => $selval,
                  'FileID'   => $FileID,
-                ]
+                )
             );
         }
     }

--- a/htdocs/api/v0.0.2/candidates/visits/qc/Imaging.php
+++ b/htdocs/api/v0.0.2/candidates/visits/qc/Imaging.php
@@ -39,10 +39,10 @@ class Imaging extends \Loris\API\Candidates\Candidate\Visit
         $this->AutoHandleRequestDelegation = false;
 
         if (empty($this->AllowedMethods)) {
-            $this->AllowedMethods = [
+            $this->AllowedMethods = array(
                                      'GET',
                                      'PUT',
-                                    ];
+                                    );
         }
         $this->CandID     = $CandID;
         $this->VisitLabel = $VisitLabel;
@@ -77,12 +77,12 @@ class Imaging extends \Loris\API\Candidates\Candidate\Visit
              )
          );
 
-         $this->JSON = [
-                        'Meta' => [
+         $this->JSON = array(
+                        'Meta' => array(
                                    'CandID' => $this->CandID,
                                    'Visit'  => $this->VisitLabel,
-                                  ],
-                       ];
+                                  ),
+                       );
 
          $this->JSON['SessionQC'] = $qcstatus['MRIQCStatus'];
          $this->JSON['Pending']   = $qcstatus['MRIQCPending'] === 'N' ? false : true;
@@ -198,13 +198,13 @@ class Imaging extends \Loris\API\Candidates\Candidate\Visit
          );
          $qcstatus   = $DB->update(
              'session',
-             [
+             array(
               'MRIQCStatus'  => $data['SessionQC'],
               'MRIQCPending' => $savePending,
-             ],
-             ['ID' => $sessionID]
+             ),
+             array('ID' => $sessionID)
          );
-         $this->JSON = ["success" => "Updated QC"];
+         $this->JSON = array("success" => "Updated QC");
     }
 }
 

--- a/htdocs/api/v0.0.2/projects/Project.php
+++ b/htdocs/api/v0.0.2/projects/Project.php
@@ -75,7 +75,7 @@ class Project extends \Loris\API\APIBase
         } catch (\LorisException $e) {
             // This projectName does not exists
             $this->header("HTTP/1.1 404 Not Found");
-            $this->error(['error' => 'Invalid project']);
+            $this->error(array('error' => 'Invalid project'));
             $this->safeExit(0);
         }
 
@@ -92,11 +92,11 @@ class Project extends \Loris\API\APIBase
         if (!empty($this->JSON)) {
             return $this->JSON;
         }
-        $JSONArray = [
-                      "Meta" => [
+        $JSONArray = array(
+                      "Meta" => array(
                                  "Project" => $this->project->getName(),
-                                ],
-                     ];
+                                ),
+                     );
 
         if ($this->bCandidates) {
             $JSONArray['Candidates'] = $this->project->getCandidateIds();
@@ -106,7 +106,7 @@ class Project extends \Loris\API\APIBase
             $Instruments = \Utility::getAllInstruments();
 
             if ($this->bInstrumentDetails) {
-                $dets   = [];
+                $dets   = array();
                 $config = $this->Factory->config();
                 $DB     = $this->Factory->database();
 
@@ -123,11 +123,11 @@ class Project extends \Loris\API\APIBase
 
                     $DDEEn = in_array($instrument, $DDE);
 
-                    $dets[$instrument] = [
+                    $dets[$instrument] = array(
                                           'FullName'               => $FullName,
                                           'Subgroup'               => $subgroup,
                                           'DoubleDataEntryEnabled' => $DDEEn,
-                                         ];
+                                         );
                 }
                 $JSONArray['Instruments'] = $dets;
             } else {

--- a/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
+++ b/modules/brainbrowser/php/NDB_Form_brainbrowser.class.inc
@@ -84,11 +84,11 @@ class NDB_Form_Brainbrowser extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [
+            array(
              $baseURL . "/css/loris-jquery/jquery-ui-1.10.4.custom.min.css",
              $baseURL . "/brainbrowser/css/volume-viewer-demo.css",
              $baseURL . "/brainbrowser/css/brainbrowser.css",
-            ]
+            )
         );
     }
 }

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -64,7 +64,7 @@ function editCandInfoFields($db, $user)
         $_POST['flaggedReason'] : null;
     $other        = null;
 
-    $options = $db->pselect("SELECT ID, Description FROM caveat_options", []);
+    $options = $db->pselect("SELECT ID, Description FROM caveat_options", array());
     foreach ($options as $row) {
         if ($row['Description'] === "Other" && $row['ID'] === $reason) {
             if (isset($_POST['flaggedOther'])) {
@@ -73,34 +73,34 @@ function editCandInfoFields($db, $user)
         };
     }
 
-    $updateValues = [
+    $updateValues = array(
                      'flagged_caveatemptor' => $caveatEmptor,
                      'flagged_reason'       => $reason,
                      'flagged_other'        => $other,
-                    ];
+                    );
 
-    $db->update('candidate', $updateValues, ['CandID' => $candID]);
+    $db->update('candidate', $updateValues, array('CandID' => $candID));
 
     foreach (array_keys($_POST) as $field) {
         if (!empty($_POST[$field])) {
             if (substr($field, 0, 4) === 'PTID') {
                 $ptid = substr($field, 4);
 
-                $updateValues = [
+                $updateValues = array(
                                  'ParameterTypeID' => $ptid,
                                  'CandID'          => $candID,
                                  'Value'           => $_POST[$field],
                                  'InsertTime'      => time(),
-                                ];
+                                );
 
                 $result = $db->pselectOne(
                     'SELECT * from parameter_candidate 
                     WHERE CandID=:cid 
                     AND ParameterTypeID=:ptid',
-                    [
+                    array(
                      'cid'  => $candID,
                      'ptid' => $ptid,
-                    ]
+                    )
                 );
 
                 if (empty($result)) {
@@ -109,10 +109,10 @@ function editCandInfoFields($db, $user)
                     $db->update(
                         'parameter_candidate',
                         $updateValues,
-                        [
+                        array(
                          'CandID'          => $candID,
                          'ParameterTypeID' => $ptid,
-                        ]
+                        )
                     );
                 }
             }
@@ -143,12 +143,12 @@ function editProbandInfoFields($db, $user)
     $gender = isset($_POST['ProbandGender']) ? $_POST['ProbandGender'] : null;
     $dob    = isset($_POST['ProbandDoB']) ? $_POST['ProbandDoB'] : null;
 
-    $updateValues = [
+    $updateValues = array(
                      'ProbandGender' => $gender,
                      'ProbandDoB'    => $dob,
-                    ];
+                    );
 
-    $db->update('candidate', $updateValues, ['CandID' => $candID]);
+    $db->update('candidate', $updateValues, array('CandID' => $candID));
 }
 
 /**
@@ -178,37 +178,37 @@ function editFamilyInfoFields($db, $user)
 
     $familyID = $db->pselectOne(
         "SELECT FamilyID from family WHERE CandID=:candid",
-        ['candid' => $candID]
+        array('candid' => $candID)
     );
 
     // Add new candidate
     if ($siblingCandID != null) {
 
-        $updateValues = [
+        $updateValues = array(
                          'CandID'            => $siblingCandID,
                          'Relationship_type' => $relationship,
                          'FamilyID'          => $familyID,
-                        ];
+                        );
 
         if ($familyID != null) {
 
             $siblingID = $db->pselectOne(
                 "SELECT ID from family WHERE CandID=:candid and FamilyID=:familyid",
-                [
+                array(
                  'candid'   => $siblingCandID,
                  'familyid' => $familyID,
-                ]
+                )
             );
 
             if ($siblingID == null) {
                 $db->insert('family', $updateValues);
             } else {
-                $db->update('family', $updateValues, ['ID' => $siblingID]);
+                $db->update('family', $updateValues, array('ID' => $siblingID));
             }
         } else {
             $familyID    = $db->pselectOne(
                 "SELECT max(FamilyID) from family",
-                []
+                array()
             );
             $newFamilyID = $familyID + 1;
 
@@ -233,19 +233,19 @@ function editFamilyInfoFields($db, $user)
 
         $siblingID = $db->pselectOne(
             "SELECT ID from family WHERE CandID=:candid and FamilyID=:familyid",
-            [
+            array(
              'candid'   => $siblingCandID,
              'familyid' => $familyID,
-            ]
+            )
         );
 
-        $updateValues = [
+        $updateValues = array(
                          'CandID'            => $siblingCandID,
                          'Relationship_type' => $relationship,
                          'FamilyID'          => $familyID,
-                        ];
+                        );
 
-        $db->update('family', $updateValues, ['ID' => $siblingID]);
+        $db->update('family', $updateValues, array('ID' => $siblingID));
 
         $i++;
     }
@@ -275,13 +275,13 @@ function deleteFamilyMember($db, $user)
         'SELECT FamilyID 
         FROM family 
         WHERE CandID=:cid',
-        ['cid' => $candID]
+        array('cid' => $candID)
     );
 
-    $where = [
+    $where = array(
               'FamilyID' => $familyID,
               'CandID'   => $familyMemberID,
-             ];
+             );
 
     $db->delete('family', $where);
 
@@ -320,17 +320,17 @@ function editParticipantStatusFields($db, $user)
         $id          = $currentUser->getData("UserID");
     }
 
-    $updateValues = [
+    $updateValues = array(
                      'participant_status'     => $status,
                      'participant_suboptions' => $suboption,
                      'reason_specify'         => $reason,
                      'CandID'                 => $candID,
                      'entry_staff'            => $id,
-                    ];
+                    );
 
     $exists = $db->pselectOne(
         "SELECT * from participant_status WHERE CandID=:candid",
-        ['candid' => $candID]
+        array('candid' => $candID)
     );
 
     if ($exists === null || empty($exists)) {
@@ -339,7 +339,7 @@ function editParticipantStatusFields($db, $user)
         $db->update(
             'participant_status',
             $updateValues,
-            ['CandID' => $candID]
+            array('CandID' => $candID)
         );
     }
 
@@ -398,20 +398,20 @@ function editConsentStatusFields($db, $user)
         $withdrawal = (isset($consentWithdrawal) && $consentWithdrawal !== "null") ?
             $consentWithdrawal : null;
 
-        $updateValues = [
+        $updateValues = array(
                          'CandID'                               => $candID,
                          'entry_staff'                          => $id,
                          $consentType['name']                   => $consent,
                          ($consentType['name'] . '_date')       => $date,
                          ($consentType['name'] . '_withdrawal') => $withdrawal,
-                        ];
+                        );
 
         $newRecord = true;
 
         if ($candID) {
             $exists = $db->pselectOne(
                 "SELECT * from participant_status WHERE CandID=:candid",
-                ['candid' => $candID]
+                array('candid' => $candID)
             );
             if ($exists && count($exists) > 0) {
                 $newRecord = false;
@@ -423,7 +423,7 @@ function editConsentStatusFields($db, $user)
                 $db->update(
                     'participant_status',
                     $updateValues,
-                    ['CandID' => $candID]
+                    array('CandID' => $candID)
                 );
             }
 

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -44,7 +44,7 @@ function getCandInfoFields()
     $db =& Database::singleton();
 
     // get caveat options
-    $caveat_options = [];
+    $caveat_options = array();
     $options        = $db->pselect(
         "SELECT ID, Description FROM caveat_options",
         array()
@@ -89,12 +89,12 @@ function getCandInfoFields()
         array('cid' => $candID)
     );
 
-    $parameter_values = [];
+    $parameter_values = array();
     foreach ($fields as $row) {
         $parameter_values[$row['ParameterTypeID']] = $row['Value'];
     }
 
-    $result = [
+    $result = array(
                'pscid'                => $pscid,
                'candID'               => $candID,
                'caveatReasonOptions'  => $caveat_options,
@@ -103,7 +103,7 @@ function getCandInfoFields()
                'flagged_other'        => $other,
                'extra_parameters'     => $extra_parameters,
                'parameter_values'     => $parameter_values,
-              ];
+              );
 
     return $result;
 }
@@ -153,13 +153,13 @@ function getProbandInfoFields()
         }
     }
 
-    $result = [
+    $result = array(
                'pscid'         => $pscid,
                'candID'        => $candID,
                'ProbandGender' => $gender,
                'ProbandDoB'    => $dob,
                'ageDifference' => $ageDifference,
-              ];
+              );
 
     return $result;
 }
@@ -225,12 +225,12 @@ function getFamilyInfoFields()
         )
     );
 
-    $result = [
+    $result = array(
                'pscid'                 => $pscid,
                'candID'                => $candID,
                'candidates'            => $candidates,
                'existingFamilyMembers' => $familyMembers,
-              ];
+              );
 
     return $result;
 }
@@ -307,7 +307,7 @@ function getParticipantStatusFields()
 
     $history = getParticipantStatusHistory($candID);
 
-    $result = [
+    $result = array(
                'pscid'                 => $pscid,
                'candID'                => $candID,
                'statusOptions'         => $statusOptions,
@@ -318,7 +318,7 @@ function getParticipantStatusFields()
                'participantSuboptions' => $suboption,
                'reasonSpecify'         => $reason,
                'history'               => $history,
-              ];
+              );
 
     return $result;
 }
@@ -372,10 +372,10 @@ function getConsentStatusFields()
 
     $config        =& NDB_Config::singleton();
     $consent       = $config->getSetting('ConsentModule');
-    $consents      = [];
-    $consentStatus = [];
-    $date          = [];
-    $withdrawal    = [];
+    $consents      = array();
+    $consentStatus = array();
+    $date          = array();
+    $withdrawal    = array();
 
     $consent_details =Utility::asArray($consent['Consent']);
     if (!$consent_details[0]) {
@@ -407,7 +407,7 @@ function getConsentStatusFields()
 
     $history = getConsentStatusHistory($candID, $consents);
 
-    $result = [
+    $result = array(
                'pscid'           => $pscid,
                'candID'          => $candID,
                'consentStatuses' => $consentStatus,
@@ -415,7 +415,7 @@ function getConsentStatusFields()
                'withdrawals'     => $withdrawal,
                'consents'        => $consents,
                'history'         => $history,
-              ];
+              );
 
     return $result;
 }

--- a/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/NDB_Form_candidate_parameters.class.inc
@@ -131,7 +131,7 @@ class NDB_Form_Candidate_Parameters extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/candidate_parameters/css/candidate_parameters.css"]
+            array($baseURL . "/candidate_parameters/css/candidate_parameters.css")
         );
     }
 

--- a/modules/configuration/php/NDB_Form_configuration.class.inc
+++ b/modules/configuration/php/NDB_Form_configuration.class.inc
@@ -231,7 +231,7 @@ class NDB_Form_Configuration extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/configuration/css/configuration.css"]
+            array($baseURL . "/configuration/css/configuration.css")
         );
     }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -297,7 +297,13 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
              'Hash',
             )
         );
-        $this->tpl_data['hiddenHeaders'] = json_encode(['Value1', 'Value2', 'Hash']);
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array(
+             'Value1',
+             'Value2',
+             'Hash',
+            )
+        );
         $this->formToFilter = array(
                                'Instrument' => 'conflicts_unresolved.TableName',
                                'site'       => 'session.CenterID',

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -139,11 +139,11 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             )
         );
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'New Value',
              'OldValue2',
              'CenterID',
-            ]
+            )
         );
         $con = "conflicts_resolved";
 

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -454,7 +454,7 @@ class NDB_Form_Dashboard extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/dashboard/css/dashboard.css"]
+            array($baseURL . "/dashboard/css/dashboard.css")
         );
     }
 

--- a/modules/data_integrity_flag/php/NDB_Form_data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/NDB_Form_data_integrity_flag.class.inc
@@ -18,25 +18,25 @@ class NDB_Form_data_integrity_flag extends NDB_Form
     function _getDefaults()
     {
         $defaults = array();
-        $DB =& Database::singleton();
+        $DB       =& Database::singleton();
 
         /////////////////////////////////////////////////////
         ///////////////Constructs the where clause...
         ////////////////////////////////////////////////////////
-        $extra_where = "";
+        $extra_where  = "";
         $extra_where .= $this->AddWhere("dataflag_visitlabel", 'visit_label');
         $extra_where .= $this->AddWhere("dataflag_instrument", 'instrument');
         $extra_where .= $this->AddWhere("dataflag_userid", 'users');
 
         //construct the query
-        if (($extra_where) !=null){
+        if (($extra_where) !=null) {
             $query = "SELECT * FROM data_integrity_flag
                 WHERE 1=1 $extra_where ORDER BY dataflag_date";
-            $info = $DB->pselect($query, array());
+            $info  = $DB->pselect($query, array());
 
-            $defaults["instrument"] = $_REQUEST['instrument'];
+            $defaults["instrument"]  = $_REQUEST['instrument'];
             $defaults["visit_label"] = $_REQUEST['visit_label'];
-            $defaults["users"] = $_REQUEST['users'];
+            $defaults["users"]       = $_REQUEST['users'];
         }
         return $defaults;
     }
@@ -45,24 +45,23 @@ class NDB_Form_data_integrity_flag extends NDB_Form
     {
 
         // get the userID
-        $user =& User::singleton();
+        $user      =& User::singleton();
         $user_name = $user->getUsername();
 
         $instrument = $this->getTestNameusingMappedName($_REQUEST['instrument']); //get actual test_name
 
         $visit_label = $_REQUEST['visit_label'];
         //save the date, flag status and comment in the data_integrity_flag table
-        $DB =& Database::singleton();
+        $DB      =& Database::singleton();
         $comment = $values['comment'];
-
 
         $date = empty($values['date']) ? null : $values['date'];
 
         $flag = $values['flag_status'];
 
         //$instrument=
-        $sucess =  $DB->update('data_integrity_flag',array('latest_entry'=>0),array('dataflag_instrument' => $instrument, 'dataflag_visitlabel'=>$visit_label));
-        $success = $DB->insert("data_integrity_flag", array('dataflag_instrument'=>$instrument,'dataflag_visitlabel'=>$visit_label,'dataflag_comment'=>$comment,'dataflag_date'=>$date,'dataflag_status'=>$flag,'latest_entry'=>1,'dataflag_userid'=>$user_name));
+        $sucess  =  $DB->update('data_integrity_flag', array('latest_entry' => 0), array('dataflag_instrument' => $instrument, 'dataflag_visitlabel' => $visit_label));
+        $success = $DB->insert("data_integrity_flag", array('dataflag_instrument' => $instrument, 'dataflag_visitlabel' => $visit_label, 'dataflag_comment' => $comment, 'dataflag_date' => $date, 'dataflag_status' => $flag, 'latest_entry' => 1, 'dataflag_userid' => $user_name));
 
         $this->tpl_data['success'] = true;
     }
@@ -72,20 +71,20 @@ class NDB_Form_data_integrity_flag extends NDB_Form
     {
 
         //initializations
-        $DB =& Database::singleton();
+        $DB          =& Database::singleton();
         $extra_where = '';
-        $conflicts = array();
-        $smarty = new Smarty_neurodb();
-        $config =& NDB_Config::singleton();
-        $startYear = $config->getSetting('startYear');
-        $endYear = $config->getSetting('endYear');
-        $instrument = '';
+        $conflicts   = array();
+        $smarty      = new Smarty_neurodb();
+        $config      =& NDB_Config::singleton();
+        $startYear   = $config->getSetting('startYear');
+        $endYear     = $config->getSetting('endYear');
+        $instrument  = '';
         if (!empty($_REQUEST['instrument'])) {
             $instrument = $this->getTestNameusingMappedName($_REQUEST['instrument']); //converts the full_name into the test_name
         }
-        $visit_array=Utility::getExistingVisitLabels();
-        $visit_array = array_combine($visit_array,$visit_array);
-        $visit_array = array_merge(array('all_visits'=>"All Visits"),$visit_array);
+        $visit_array =Utility::getExistingVisitLabels();
+        $visit_array = array_combine($visit_array, $visit_array);
+        $visit_array = array_merge(array('all_visits' => "All Visits"), $visit_array);
 
         //Menu Filters
         $this->tpl_data['visitLabels'] = $visit_array;
@@ -94,17 +93,14 @@ class NDB_Form_data_integrity_flag extends NDB_Form
             $this->tpl_data['visit_label'] = $_REQUEST['visit_label'];
         }
         $this->tpl_data['test_name'] = $instrument;
-        $this->addSelect('users','Users',array_merge(array(''=>'All Users'),$this->getDIUsers()),array('id'=>'users'));
+        $this->addSelect('users', 'Users', array_merge(array('' => 'All Users'), $this->getDIUsers()), array('id' => 'users'));
 
-
-
-
-        $this->form->addFormRule(array(&$this,'_validate'));
+        $this->form->addFormRule(array(&$this, '_validate'));
 
         /////////////////////////////////////////////////////
         ///////////////Constructs the where clause...
         ////////////////////////////////////////////////////////
-        $extra_where = null;
+        $extra_where  = null;
         $extra_where .= $this->AddWhere("dataflag_visitlabel", 'visit_label');
         $extra_where .= $this->AddWhere("dataflag_instrument", 'instrument');
         $extra_where .= $this->AddWhere("dataflag_userid", 'users');
@@ -113,32 +109,30 @@ class NDB_Form_data_integrity_flag extends NDB_Form
         //if (($extra_where) !=null){
         $query = "SELECT * FROM data_integrity_flag
             WHERE 1=1 $extra_where ORDER BY dataflag_date desc";
-        $info = $DB->pselect($query, array());
+        $info  = $DB->pselect($query, array());
         //}
-
-
 
         ////////////////////////////////////////////////////////
         /////////create the quickform elements/////////////////
         ////////////////////////////////////////////////////////
         $dateOptions = array(
-                'language'        => 'en',
-                'format'          => 'YMd',
-                'addEmptyOption'  => true,
-                'minYear'         => $startYear,
-                'maxYear'         => $endYear
-                );
+                        'language'       => 'en',
+                        'format'         => 'YMd',
+                        'addEmptyOption' => true,
+                        'minYear'        => $startYear,
+                        'maxYear'        => $endYear,
+                       );
 
         $this->addBasicDate('date', "Date:", $dateOptions); //date drop down
         $flag_status_list = array(
-            '' => null,
-            "1" => '1- Ready For Review',
-            "2" => '2- Review Completed',
-            "3" => '3- Feedbacks Closed',
-            "4" => '4- Finalization'
-        );
+                             ''  => null,
+                             "1" => '1- Ready For Review',
+                             "2" => '2- Review Completed',
+                             "3" => '3- Feedbacks Closed',
+                             "4" => '4- Finalization',
+                            );
         $this->addSelect('flag_status', 'Flag Status:', $flag_status_list); //flag status
-        $this->addBasicTextArea('comment','Comment:',array('rows' => 2, 'cols' => 20));//comment box
+        $this->addBasicTextArea('comment', 'Comment:', array('rows' => 2, 'cols' => 20));//comment box
 
         //static or hiddent elements
         $this->form->addElement("static", "instrument", "Instrument: ");//comment box
@@ -150,7 +144,7 @@ class NDB_Form_data_integrity_flag extends NDB_Form
 
         //Show the number of generated results...
         //If there are no data print a message to that effect
-        if(empty($info)){
+        if(empty($info)) {
             $this->form->addElement('static', "status", "No matching criteria found.");
             return;
         } else {
@@ -158,18 +152,18 @@ class NDB_Form_data_integrity_flag extends NDB_Form
         }
         //Loop through the conflicts and add a row per
         foreach($info AS $data) {
-            $this->tpl_data['elements_list_names'] [] = $data['dataflag_id'];
-            $full_name = $DB->pselectOne("SELECT Full_name from test_names where Test_name = :tname",array('tname'=>$data['dataflag_instrument']));
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['date']= $data['dataflag_date'];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['flag'] = $flag_status_list[$data['dataflag_status']];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['comment']= $data['dataflag_comment'];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['instrument']= $data['dataflag_instrument'];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['full_name']= $full_name;
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['visit_label']= $data['dataflag_visitlabel'];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['userid']= $data['dataflag_userid'];
-            
+            $this->tpl_data['elements_list_names'][] = $data['dataflag_id'];
+            $full_name = $DB->pselectOne("SELECT Full_name from test_names where Test_name = :tname", array('tname' => $data['dataflag_instrument']));
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['date']        = $data['dataflag_date'];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['flag']        = $flag_status_list[$data['dataflag_status']];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['comment']     = $data['dataflag_comment'];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['instrument']  = $data['dataflag_instrument'];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['full_name']   = $full_name;
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['visit_label'] = $data['dataflag_visitlabel'];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['userid']      = $data['dataflag_userid'];
+
             //$this->tpl_data['elements_array'][$data['dataflag_id']]['dc_open_feedback']= $data['dataflag_dc_open_feedback'];
-            $this->tpl_data['elements_array'][$data['dataflag_id']]['dc_open_feedback']= $data['dataflag_fbcreated'] - $data['dataflag_fbclosed']-$data['dataflag_fbcomment'];
+            $this->tpl_data['elements_array'][$data['dataflag_id']]['dc_open_feedback'] = $data['dataflag_fbcreated'] - $data['dataflag_fbclosed']-$data['dataflag_fbcomment'];
         }
     }
 
@@ -177,24 +171,24 @@ class NDB_Form_data_integrity_flag extends NDB_Form
      * AddWhere
      * Constructs the query....
      *
-     * @param unknown_type $Column
-     * @param unknown_type $Filter
+     * @param  unknown_type $Column
+     * @param  unknown_type $Filter
      * @return unknown
      */
 
-    function AddWhere($Column, $Filter) {
+    function AddWhere($Column, $Filter)
+    {
         // create Database object
         $DB = Database::singleton();
 
         if(!empty($_REQUEST[$Filter]) && $_REQUEST[$Filter] !=='All Instruments' && $_REQUEST[$Filter] !=='No instruments for this visit' &&  $_REQUEST[$Filter] !=='All Visits') {
 
-            if ($Filter =='instrument'){
+            if ($Filter =='instrument') {
                 $test_name = $this->getTestNameusingMappedName($_REQUEST[$Filter]); //get actual test_name
                 return " AND $Column LIKE " . $DB->quote($test_name);
             }
             return " AND $Column LIKE " . $DB->quote($_REQUEST[$Filter]);
         }
-
 
         return '';
     }
@@ -202,17 +196,18 @@ class NDB_Form_data_integrity_flag extends NDB_Form
     /**
      * _validate
      *
-     * @param unknown_type $fields
+     * @param  unknown_type $fields
      * @return unknown
      */
-    function _validate($fields){
-        $errors=array();
-        $inst = empty($_REQUEST['instrument']) ? '' : $_REQUEST['instrument'];
-        $vl   = empty($_REQUEST['visit_label']) ? '' : $_REQUEST['visit_label'];
+    function _validate($fields)
+    {
+        $errors     =array();
+        $inst       = empty($_REQUEST['instrument']) ? '' : $_REQUEST['instrument'];
+        $vl         = empty($_REQUEST['visit_label']) ? '' : $_REQUEST['visit_label'];
         $instFilter = $this->getTestNameusingMappedName($_REQUEST['instrument']);
-        
-        if ((preg_match('/All/',$inst,$matches)) || (preg_match('/All/',$vl,$matches)) || ($instFilter == null)){
-            $errors['comment']= 'An Instrument/Vist must be selected';
+
+        if ((preg_match('/All/', $inst, $matches)) || (preg_match('/All/', $vl, $matches)) || ($instFilter == null)) {
+            $errors['comment'] = 'An Instrument/Vist must be selected';
         }
 
         // create Database object
@@ -222,15 +217,15 @@ class NDB_Form_data_integrity_flag extends NDB_Form
 
         foreach ($fields as $field=>$value){
 
-            if (preg_match('/date/',$field,$matches)){
-                $bits = explode('-',$value);
+            if (preg_match('/date/', $field, $matches)) {
+                $bits = explode('-', $value);
 
                 if (count($bits) === 3) {
-                    $date_array = array_combine(array('Y','M','d'), $bits);
+                    $date_array = array_combine(array('Y', 'M', 'd'), $bits);
                 }
-                
-                if( empty($date_array)
-                    || empty($date_array['Y']) 
+
+                if(empty($date_array)
+                    || empty($date_array['Y'])
                     || empty($date_array['M'])
                     || empty($date_array['d'])
                     || !checkdate(
@@ -238,14 +233,14 @@ class NDB_Form_data_integrity_flag extends NDB_Form
                         $date_array['d'],
                         $date_array['Y']
                     )) {
-                    $errors[$field]= 'A valid date must be provided';
+                    $errors[$field] = 'A valid date must be provided';
                 }
             }
 
-            if (preg_match('/flag_status/',$field,$matches)){
+            if (preg_match('/flag_status/', $field, $matches)) {
 
-                if (($value == '') || ($value==null)){
-                    $errors[$field]= 'The validation flag is not set';
+                if (($value == '') || ($value==null)) {
+                    $errors[$field] = 'The validation flag is not set';
                 }
 
             }
@@ -255,77 +250,85 @@ class NDB_Form_data_integrity_flag extends NDB_Form
 
     // }}}
     // {{{ _getQuickformDate()
-/**
+    /**
  * Convert a database date or timestamp into a QuickForm acceptable date or time
  *
- * @param string  $databaseValue        the date or timestamp from the database
+ * @param  string $databaseValue the date or timestamp from the database
  * @return array   $formDateValue       the quickform date/timestamp array
  * @access private
  */
 
-function _getQuickformDate($databaseValue/*,$date_reference*/){
-    if(!empty($databaseValue)){
-        if(strstr($databaseValue,":")){
-            $formDateValue=explode(":",$databaseValue);
-            $formDateValue=array("H"=>$formDateValue[0],"i"=>$formDateValue[1]);  //handle time
-        } else {
-            // split mysql Date_taken field into array
-            $formDateValue = explode('-', $databaseValue);
-            $formDateValue = array('Y'=>$formDateValue[0], 'M'=>$formDateValue[1], 'd'=>$formDateValue[2]);  //handle date
+    function _getQuickformDate($databaseValue/*,$date_reference*/)
+    {
+        if(!empty($databaseValue)) {
+            if(strstr($databaseValue, ":")) {
+                $formDateValue =explode(":", $databaseValue);
+                $formDateValue =array(
+                                 "H" => $formDateValue[0],
+                                 "i" => $formDateValue[1],
+                                );  //handle time
+            } else {
+                // split mysql Date_taken field into array
+                $formDateValue = explode('-', $databaseValue);
+                $formDateValue = array(
+                                  'Y' => $formDateValue[0],
+                                  'M' => $formDateValue[1],
+                                  'd' => $formDateValue[2],
+                                 );  //handle date
+            }
         }
+        return $formDateValue;
     }
-    return $formDateValue;
-}
 
-/**
+    /**
  * getTestNameusingMappedName
  * returns the Test_name and its corresponding visit_label.. using the full_name  and/or subprojectID ..
  */
 
-function getTestNameusingMappedName ($full_name, $subprojectID = null)
-{
-    $DB =& Database::singleton();
-    $values = array();
-    if ((!(is_null($full_name)))) {
-        $test_name = Utility::getTestNameUsingFullName($full_name);
+    function getTestNameusingMappedName($full_name, $subprojectID = null)
+    {
+        $DB     =& Database::singleton();
+        $values = array();
+        if ((!(is_null($full_name)))) {
+            $test_name = Utility::getTestNameUsingFullName($full_name);
+        }
+        return     $test_name;
     }
-    return 	$test_name;
-}
 
 
-/**
+    /**
  * Returns the list of users changed the Data-integrity flags
  */
 
-function getDIUsers()
-{
-    $DB =& Database::singleton();
-    $users = $DB->pselect("SELECT DISTINCT dataflag_userid FROM data_integrity_flag",array());
-    $user_ids = array();
-    foreach ($users as $user){
-        $user_ids[$user['dataflag_userid']] = $user['dataflag_userid'];
+    function getDIUsers()
+    {
+        $DB       =& Database::singleton();
+        $users    = $DB->pselect("SELECT DISTINCT dataflag_userid FROM data_integrity_flag", array());
+        $user_ids = array();
+        foreach ($users as $user){
+            $user_ids[$user['dataflag_userid']] = $user['dataflag_userid'];
+        }
+        return $user_ids;
     }
-    return $user_ids;
-}
 
-/**
+    /**
  * Include the column formatter required to display the feedback link colours
  * in the candidate_list menu
  *
  * @return array of javascript to be inserted
  */
-function getJSDependencies()
-{
-    $factory = NDB_Factory::singleton();
-    $baseURL = $factory->settings()->getBaseURL();
-    $deps    = parent::getJSDependencies();
-    return array_merge(
-        $deps,
-        array(
-         $baseURL . "/data_integrity_flag/js/data_integrity_flag_helper.js",
-        )
-    );
-}
+    function getJSDependencies()
+    {
+        $factory = NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            array(
+             $baseURL . "/data_integrity_flag/js/data_integrity_flag_helper.js",
+            )
+        );
+    }
 
 }
 ?>

--- a/modules/data_team_helper/php/NDB_Form_data_team_helper.class.inc
+++ b/modules/data_team_helper/php/NDB_Form_data_team_helper.class.inc
@@ -694,7 +694,7 @@ class NDB_Form_Data_Team_Helper extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/data_team_helper/css/data_team_helper.css"]
+            array($baseURL . "/data_team_helper/css/data_team_helper.css")
         );
     }
 }

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -82,7 +82,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
 
         $this->order_by = 't.DateAcquired';
 
-        $this->headers = [];
+        $this->headers = array();
 
         if ($this->dicomArchiveSettings['showTransferStatus'] == 'true') {
             array_push($this->headers, 'Transfer_Status');
@@ -90,7 +90,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
 
         $this->headers = array_merge(
             $this->headers,
-            [
+            array(
              'Patient_ID',
              'Patient_Name',
              'Gender',
@@ -103,17 +103,17 @@ class Dicom_Archive extends \NDB_Menu_Filter
              'Site',
              'TarchiveID',
              'SessionID',
-            ]
+            )
         );
 
         // Set header as hidden from the data table
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'Seriesuid',
              'Site',
              'TarchiveID',
              'SessionID',
-            ]
+            )
         );
 
         $this->validFilters = array(
@@ -184,12 +184,12 @@ class Dicom_Archive extends \NDB_Menu_Filter
     {
         $result          = $this->toArray();
         $result['Sites'] = \Utility::getSiteList();
-        $result['hiddenHeaders'] = [
+        $result['hiddenHeaders'] = array(
                                     'Seriesuid',
                                     'Site',
                                     'TarchiveID',
                                     'SessionID',
-                                   ];
+                                   );
 
         return json_encode($result);
     }

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -291,7 +291,7 @@ class ViewDetails extends \NDB_Form
         $baseURL = $factory->settings()->getBaseURL();
         return array_merge(
             $depends,
-            [$baseURL . "/dicom_archive/css/dicom_archive.css"]
+            array($baseURL . "/dicom_archive/css/dicom_archive.css")
         );
     }
 

--- a/modules/document_repository/ajax/GetFile.php
+++ b/modules/document_repository/ajax/GetFile.php
@@ -11,7 +11,6 @@
  *  @author   Dave MacFarlane <driusan@bic.mni.mcgill.ca>
  *  @license  Loris license
  *  @link     https://github.com/aces/Loris-Trunk
- *
  */
 
 $user =& User::singleton();

--- a/modules/document_repository/ajax/addCategory.php
+++ b/modules/document_repository/ajax/addCategory.php
@@ -24,7 +24,7 @@ require_once "Email.class.inc";
 
 $factory = NDB_Factory::singleton();
 $baseURL = $factory->settings()->getBaseURL();
-$client = new NDB_Client();
+$client  = new NDB_Client();
 $client->initialize("../../project/config.xml");
 
 $config = NDB_Config::singleton();
@@ -55,9 +55,11 @@ $user =& User::singleton();
 if ($user->hasPermission('document_repository_view') || $user->hasPermission('document_repository_delete')) {
     $DB->insert(
         "document_repository_categories",
-        array("category_name" => $category_name,
-              "parent_id"     => $parent_id,
-              "comments"      => $comments)
+        array(
+         "category_name" => $category_name,
+         "parent_id"     => $parent_id,
+         "comments"      => $comments,
+        )
     );
 
 
@@ -67,7 +69,7 @@ if ($user->hasPermission('document_repository_view') || $user->hasPermission('do
 
     $Doc_Repo_Notification_Emails = $DB->pselect(
         "SELECT Email from users where Active='Y' and Doc_Repo_Notifications='Y' and UserID<>:uid",
-        array("uid"=>$user->getUsername())
+        array("uid" => $user->getUsername())
     );
     foreach ($Doc_Repo_Notification_Emails as $email) {
         Email::send($email['Email'], 'document_repository.tpl', $msg_data);

--- a/modules/document_repository/ajax/categoryEdit.php
+++ b/modules/document_repository/ajax/categoryEdit.php
@@ -40,8 +40,8 @@ $user =& User::singleton();
 if ($user->hasPermission('document_repository_view') || $user->hasPermission('document_repository_delete')) {
     $DB->update(
         'document_repository_categories',
-        array('comments'=>$comments),
-        array('id'=>$_REQUEST['id'])
+        array('comments' => $comments),
+        array('id' => $_REQUEST['id'])
     );
 }
 

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -22,12 +22,18 @@ $DB =& Database::singleton();
 
 $rid = $_POST['id'];
 
-$fileName = $DB->pselectOne("Select File_name from document_repository where record_id =:identifier",
-                            array(':identifier' => $rid));
-$userName = $DB->pselectOne("Select uploaded_by from document_repository where record_id =:identifier",
-                            array(':identifier'=> $rid));
-$dataDir  = $DB->pselectOne("Select Data_dir from document_repository where record_id =:identifier",
-                            array(':identifier'=> $rid));
+$fileName = $DB->pselectOne(
+    "Select File_name from document_repository where record_id =:identifier",
+    array(':identifier' => $rid)
+);
+$userName = $DB->pselectOne(
+    "Select uploaded_by from document_repository where record_id =:identifier",
+    array(':identifier' => $rid)
+);
+$dataDir  = $DB->pselectOne(
+    "Select Data_dir from document_repository where record_id =:identifier",
+    array(':identifier' => $rid)
+);
 
 $user =& User::singleton();
 
@@ -35,10 +41,10 @@ $user =& User::singleton();
 if ($user->hasPermission('document_repository_delete')) {
     $DB->delete("document_repository", array("record_id" => $rid));
     $msg_data['deleteDocument'] = $baseURL. "/document_repository/";
-    $msg_data['document'] = $fileName;
-    $msg_data['study'] = $config->getSetting('title');
+    $msg_data['document']       = $fileName;
+    $msg_data['study']          = $config->getSetting('title');
     $query_Doc_Repo_Notification_Emails = "SELECT Email from users where Active='Y' and Doc_Repo_Notifications='Y' and UserID<>:uid";
-    $Doc_Repo_Notification_Emails = $DB->pselect($query_Doc_Repo_Notification_Emails, array("uid"=>$user->getUsername()));
+    $Doc_Repo_Notification_Emails       = $DB->pselect($query_Doc_Repo_Notification_Emails, array("uid" => $user->getUsername()));
     foreach ($Doc_Repo_Notification_Emails as $email) {
         Email::send($email['Email'], 'document_repository.tpl', $msg_data);
     }
@@ -46,7 +52,8 @@ if ($user->hasPermission('document_repository_delete')) {
 
 $path = __DIR__ . "/../user_uploads/$dataDir";
 
-if (file_exists($path))
+if (file_exists($path)) {
     unlink($path);
+}
 
 ?>

--- a/modules/document_repository/ajax/documentEditUpload.php
+++ b/modules/document_repository/ajax/documentEditUpload.php
@@ -25,14 +25,14 @@ $action = $_POST['action'];
 //if user has document repository permission
 if ($userSingleton->hasPermission('document_repository_view') || $userSingleton->hasPermission('document_repository_delete')) {
     if ($action == 'upload') {
-        $puser = $_POST['user'];
-        $category = $_POST['category'];
-        $site = $_POST['site'];
+        $puser      = $_POST['user'];
+        $category   = $_POST['category'];
+        $site       = $_POST['site'];
         $instrument = $_POST['instrument'];
-        $pscid = $_POST['pscid'];
-        $visit = $_POST['visit'];
-        $comments = $_POST['comments'];
-        $version = $_POST['version'];
+        $pscid      = $_POST['pscid'];
+        $visit      = $_POST['visit'];
+        $comments   = $_POST['comments'];
+        $version    = $_POST['version'];
 
         $fileSize = $_FILES["file"]["size"];
         $fileName = $_FILES["file"]["name"];
@@ -43,7 +43,7 @@ if ($userSingleton->hasPermission('document_repository_view') || $userSingleton-
         // document_repository module directory, and use a
         // user_uploads directory as a base for user uploads
         $base_path = __DIR__ . "/../user_uploads/";
-        $fileBase = $puser . "/" . $fileName;
+        $fileBase  = $puser . "/" . $fileName;
 
         if (!file_exists($base_path . $puser)) {
             mkdir($base_path . $puser, 0777);
@@ -53,49 +53,69 @@ if ($userSingleton->hasPermission('document_repository_view') || $userSingleton-
         $target_path = $base_path  . $fileBase;
 
         if (move_uploaded_file($_FILES["file"]["tmp_name"], $target_path)) {
-            $success = $DB->insert('document_repository',
-                            array('File_category'=>$category, 'For_site'=>$site,
-                                  'comments'=>$comments, 'version'=>$version, 'File_name'=>$fileName,
-                                  'File_size'=>$fileSize, 'Data_dir'=>$fileBase, 'uploaded_by'=>$puser,
-                                  'Instrument'=>$instrument, 'PSCID'=>$pscid, 'visitLabel'=>$visit,
-                                  'File_type'=>$fileType));
-            $msg_data['newDocument'] = $baseURL . "/document_repository/";
-            $msg_data['document'] = $fileName;
-            $msg_data['study'] = $config->getSetting('title');
-            $query_Doc_Repo_Notification_Emails = "SELECT Email from users where Active='Y' and Doc_Repo_Notifications='Y' and UserID<>:uid";
-            $Doc_Repo_Notification_Emails = $DB->pselect($query_Doc_Repo_Notification_Emails, array("uid"=>$userSingleton->getUsername()));
+            $success = $DB->insert(
+                'document_repository',
+                array(
+                 'File_category' => $category,
+                 'For_site'      => $site,
+                 'comments'      => $comments,
+                 'version'       => $version,
+                 'File_name'     => $fileName,
+                 'File_size'     => $fileSize,
+                 'Data_dir'      => $fileBase,
+                 'uploaded_by'   => $puser,
+                 'Instrument'    => $instrument,
+                 'PSCID'         => $pscid,
+                 'visitLabel'    => $visit,
+                 'File_type'     => $fileType,
+                )
+            );
+                            $msg_data['newDocument'] = $baseURL . "/document_repository/";
+                            $msg_data['document']    = $fileName;
+                            $msg_data['study']       = $config->getSetting('title');
+                            $query_Doc_Repo_Notification_Emails = "SELECT Email from users where Active='Y' and Doc_Repo_Notifications='Y' and UserID<>:uid";
+                            $Doc_Repo_Notification_Emails       = $DB->pselect($query_Doc_Repo_Notification_Emails, array("uid" => $userSingleton->getUsername()));
             foreach ($Doc_Repo_Notification_Emails as $email) {
                 Email::send($email['Email'], 'document_repository.tpl', $msg_data);
             }
-            header("Location: $baseURL/document_repository/?uploadSuccess=true");
+                            header("Location: $baseURL/document_repository/?uploadSuccess=true");
         } else {
             echo "There was an error uploading the file";
         }
     } elseif ($action == 'edit') {
-        $id = $_POST['idEdit'];
-        $category = $_POST['categoryEdit'];
+        $id         = $_POST['idEdit'];
+        $category   = $_POST['categoryEdit'];
         $instrument = $_POST['instrumentEdit'];
-        $site = $_POST['siteEdit'];
-        $pscid = $_POST['pscidEdit'];
-        $visit = $_POST['visitEdit'];
-        $comments = $_POST['commentsEdit'];
-        $version = $_POST['versionEdit'];
+        $site       = $_POST['siteEdit'];
+        $pscid      = $_POST['pscidEdit'];
+        $visit      = $_POST['visitEdit'];
+        $comments   = $_POST['commentsEdit'];
+        $version    = $_POST['versionEdit'];
 
-        if(empty($category) && $category !== '0'){
+        if(empty($category) && $category !== '0') {
             header("HTTP/1.1 400 Bad Request");
             exit;
         }
 
-        $values = array('File_category' => $category, 'Instrument' => $instrument, 'For_site' => $site,
-                        'PSCID' => $pscid, 'visitLabel' => $visit, 'comments' => $comments, 'version' => $version);
-        $DB->update('document_repository', $values, array('record_id'=>$id));
+        $values = array(
+                   'File_category' => $category,
+                   'Instrument'    => $instrument,
+                   'For_site'      => $site,
+                   'PSCID'         => $pscid,
+                   'visitLabel'    => $visit,
+                   'comments'      => $comments,
+                   'version'       => $version,
+                  );
+        $DB->update('document_repository', $values, array('record_id' => $id));
 
-        $fileName = $DB->pselectOne("select File_name from document_repository where record_id=:record_id",
-                                     array('record_id'=>$id));
+        $fileName = $DB->pselectOne(
+            "select File_name from document_repository where record_id=:record_id",
+            array('record_id' => $id)
+        );
         $msg_data['updatedDocument'] = $baseURL . "/document_repository/";
-        $msg_data['document'] = $fileName;
+        $msg_data['document']        = $fileName;
         $query_Doc_Repo_Notification_Emails = "SELECT Email from users where Active='Y' and Doc_Repo_Notifications='Y' and UserID<>:uid";
-        $Doc_Repo_Notification_Emails = $DB->pselect($query_Doc_Repo_Notification_Emails, array("uid"=>$userSingleton->getUsername()));
+        $Doc_Repo_Notification_Emails       = $DB->pselect($query_Doc_Repo_Notification_Emails, array("uid" => $userSingleton->getUsername()));
         foreach ($Doc_Repo_Notification_Emails as $email) {
             Email::send($email['Email'], 'document_repository.tpl', $msg_data);
         }

--- a/modules/document_repository/ajax/getFileData.php
+++ b/modules/document_repository/ajax/getFileData.php
@@ -14,7 +14,7 @@ $client->initialize("../../project/config.xml");
 // create Database object
 $DB =& Database::singleton();
 
-$result = $DB->pselectRow("SELECT * FROM document_repository where record_id =:identifier", array(':identifier'=> $_GET['id']));
+$result = $DB->pselectRow("SELECT * FROM document_repository where record_id =:identifier", array(':identifier' => $_GET['id']));
 
 echo json_encode($result);
 

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -44,40 +44,69 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         $user =& User::singleton();
 
         // create the centerID map
-        $db =& Database::singleton();
+        $db      =& Database::singleton();
         $pscRows = $db->pselect("SELECT CenterID, Name FROM psc", array());
         foreach ($pscRows AS $row) {
             $this->centerIDMap[$row['CenterID']] = $row['Name'];
         }
 
-        $query = " FROM document_repository v";
+        $query  = " FROM document_repository v";
         $query .= " WHERE COALESCE(v.hide_video, false)=false";
 
         // set the class variables
-        $this->columns = array('v.record_id', 'v.File_name', 'v.version', 'v.File_size', 'v.File_category',
-                               'v.File_type', 'v.Instrument', 'v.uploaded_by', 'v.For_site', 'v.comments',
-                               'v.Data_dir', 'v.Date_uploaded');
+        $this->columns = array(
+                          'v.record_id',
+                          'v.File_name',
+                          'v.version',
+                          'v.File_size',
+                          'v.File_category',
+                          'v.File_type',
+                          'v.Instrument',
+                          'v.uploaded_by',
+                          'v.For_site',
+                          'v.comments',
+                          'v.Data_dir',
+                          'v.Date_uploaded',
+                         );
 
         $openAccordion = $_GET['openAccordion'];
         $this->tpl_data['openAccordion'] = $openAccordion;
         $filtered = $_GET['filtered'];
         $this->tpl_data['filtered'] = $filtered;
-        $this->query = $query;
-        $this->group_by = '';
-        $this->order_by = 'v.File_name';
-        $this->headers = array('File_name', 'version', 'File_type', 'Instrument', 'uploaded_by', 'For_site', 'comments', 'Date_uploaded', 'Edit', 'Delete');
-        $this->validFilters = array('v.For_site', 'v.File_name', 'v.File_category', 'v.File_type', 'v.version', 'v.uploaded_by');
+        $this->query        = $query;
+        $this->group_by     = '';
+        $this->order_by     = 'v.File_name';
+        $this->headers      = array(
+                               'File_name',
+                               'version',
+                               'File_type',
+                               'Instrument',
+                               'uploaded_by',
+                               'For_site',
+                               'comments',
+                               'Date_uploaded',
+                               'Edit',
+                               'Delete',
+                              );
+        $this->validFilters = array(
+                               'v.For_site',
+                               'v.File_name',
+                               'v.File_category',
+                               'v.File_type',
+                               'v.version',
+                               'v.uploaded_by',
+                              );
 
         $this->formToFilter = array(
-                                    'File_name' => 'v.File_name',
-                                    'File_type' => 'v.File_type',
-                                    'File_category' => 'v.File_category',
-                                    'version' => 'v.version',
-                                    'Data_dir'  => 'v.Data_dir',
-                                    'For_site' => 'v.For_site',
-                                    'uploaded_by' => 'v.uploaded_by',
-                                    'Date_uploaded' => 'v.Date_uploaded'
-                                    );
+                               'File_name'     => 'v.File_name',
+                               'File_type'     => 'v.File_type',
+                               'File_category' => 'v.File_category',
+                               'version'       => 'v.version',
+                               'Data_dir'      => 'v.Data_dir',
+                               'For_site'      => 'v.For_site',
+                               'uploaded_by'   => 'v.uploaded_by',
+                               'Date_uploaded' => 'v.Date_uploaded',
+                              );
         return true;
     }
 
@@ -91,11 +120,12 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
            // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
-            if (is_array($list_of_sites)) $list_of_sites = array(null => 'Any') + $list_of_sites;
+            if (is_array($list_of_sites)) { $list_of_sites = array(null => 'Any') + $list_of_sites;
+            }
         } else {
             // allow only to view own site data
             $list_of_sites = array();
-            $site_arr = $user->getData('CenterIDs');
+            $site_arr      = $user->getData('CenterIDs');
             foreach ($site_arr as $key => $val) {
                 $site[$key] = &Site::singleton($val);
                 if ($site[$key]->isStudySite()) {
@@ -107,20 +137,20 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
         $list_of_instruments = Utility::getAllInstruments();
 
-        $list_of_visit_labels = array_merge(array(null=>"Any") + Utility::getVisitList());
-        $subproject_options = Utility::getSubprojectList();
-        $subproject_options = array(null=>'Any') + $subproject_options;
+        $list_of_visit_labels = array_merge(array(null => "Any") + Utility::getVisitList());
+        $subproject_options   = Utility::getSubprojectList();
+        $subproject_options   = array(null => 'Any') + $subproject_options;
 
         $DB = Database::singleton();
 
         //There's no dropdown filter for file names?
         //$fileNames = $DB->pselect("Select File_name from document_repository", array());
         $fileTypes = array();
-        $fileT = $DB->pselect("SELECT DISTINCT File_type FROM document_repository ORDER BY File_type", array());
+        $fileT     = $DB->pselect("SELECT DISTINCT File_type FROM document_repository ORDER BY File_type", array());
         foreach ($fileT as $fileType) {
             $fileTypes[$fileType['File_type']] = $fileType['File_type'];
         }
-        $fileTypes = array_merge(array(null=>'Any') + $fileTypes);
+        $fileTypes = array_merge(array(null => 'Any') + $fileTypes);
 
         // Form Elements
         $this->addBasicText('File_name', 'File name:');
@@ -128,9 +158,9 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
         $this->addSelect('File_type', 'File type:', $fileTypes);
         $this->addSelect('File_category', 'File category:', $fileCategories);
-        $this->tpl_data['Sites'] = $list_of_sites;
+        $this->tpl_data['Sites']       = $list_of_sites;
         $this->tpl_data['Instruments'] = $list_of_instruments;
-        $user =& User::singleton();
+        $user   =& User::singleton();
         $userID = $user->getData('UserID');
         $this->tpl_data['User'] = $userID;
         $this->addSelect('For_site', 'For Site:', $list_of_sites);
@@ -148,14 +178,14 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
     function walkTree($item,$key)
     {
         if ($key == 'id') {
-            $this->treeToArray[]= $item;
+            $this->treeToArray[] = $item;
         }
     }
 
     function parseTree($treeToParse)
     {
         foreach ($treeToParse as $theTree) {
-            array_walk_recursive($theTree, array($this,'walkTree'));
+            array_walk_recursive($theTree, array($this, 'walkTree'));
         }
         return $this->treeToArray;
     }
@@ -163,13 +193,13 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
     function parseCategory($value)
     {
         $depth = 0;
-        $DB = Database::singleton();
+        $DB    = Database::singleton();
             $categoryName = $value['category_name'];
         do {
             if ($value['parent_id'] != 0) {
-                $depth += 1;
-                $parent_id = $value['parent_id'];
-                $value = $DB->pselectRow("SELECT * FROM document_repository_categories where id=$parent_id", array());
+                $depth       += 1;
+                $parent_id    = $value['parent_id'];
+                $value        = $DB->pselectRow("SELECT * FROM document_repository_categories where id=$parent_id", array());
                 $categoryName = $value['category_name'] . ">" . $categoryName;
             }
         } while ($value['parent_id'] != 0);
@@ -186,12 +216,12 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
         $qparams = array();
         // add the base query
-        $query = '';
+        $query  = '';
         $query .= $this->_getBaseQuery();
 
         $filterdetails = $this->_getBaseFilter();
-        $query .= $filterdetails['clause'];
-        $qparams = $filterdetails['params'];
+        $query        .= $filterdetails['clause'];
+        $qparams       = $filterdetails['params'];
         // apply ORDER BY filters
         $query .= " ORDER BY ";
         if (!empty($this->filter['order'])) {
@@ -200,13 +230,17 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         }
         $query .= $this->order_by;
 
-        return array('query' => $query, 'params' => $qparams);
+        return array(
+                'query'  => $query,
+                'params' => $qparams,
+               );
     }
     /**
      * Overwritten because the document repository isn't really a menu filter table, it doesn't
      * use pagination
      */
-    function _getList() {
+    function _getList()
+    {
         return;
     }
 
@@ -218,12 +252,12 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
      */
     function _setDataTable()
     {
-        $DB = Database::singleton();
-        $results = array();
-        $dbresult= $DB->pselect("SELECT * FROM document_repository_categories ORDER BY parent_id ASC", array());
+        $DB       = Database::singleton();
+        $results  = array();
+        $dbresult = $DB->pselect("SELECT * FROM document_repository_categories ORDER BY parent_id ASC", array());
         foreach ($dbresult as $row) {
-            $results[]=$row;
-            $tree = null;
+            $results[] =$row;
+            $tree      = null;
             foreach ($results as $result) {
                 $thisref = &$refs->{$result['id']};
                 if(empty($thisref)) {
@@ -242,11 +276,11 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
             $tree; // contains the newly sorted tree.
         }
 
-        $IDCategories = $DB->pselect("SELECT id,category_name,parent_id,comments FROM document_repository_categories ORDER BY parent_id", array());
+        $IDCategories    = $DB->pselect("SELECT id,category_name,parent_id,comments FROM document_repository_categories ORDER BY parent_id", array());
         $tmpIDCategories = $IDCategories;
 
         //$tree is an object with references, so here we are encoding it as json and then decoding it into a php associative array
-        $tmpIDCategories = json_decode(json_encode($tree), true);
+        $tmpIDCategories  = json_decode(json_encode($tree), true);
         $categoryOrdering = $this->parseTree($tmpIDCategories);
 
         foreach ($categoryOrdering as $order) {
@@ -254,11 +288,11 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
                 $CategoryID = $value['id'];
                 if ($CategoryID == $order) {
                     $fileCategories[$CategoryID] = array(
-                        'CategoryName' => $this->parseCategory($value),
-                        'Comment'      => $value['comments'],
-                        'Files'        => array(),
-                        'ParentID'     => $value['parent_id']
-                    );
+                                                    'CategoryName' => $this->parseCategory($value),
+                                                    'Comment'      => $value['comments'],
+                                                    'Files'        => array(),
+                                                    'ParentID'     => $value['parent_id'],
+                                                   );
                 }
             }
         }
@@ -270,7 +304,6 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
         // overriding pagination
         $DB = Database::singleton();
-
 
         // print out column headings
         $i = 0;
@@ -294,8 +327,8 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
     function _setDataTableRows($count)
     {
-        $DB = Database::singleton();
-        $query = $this->_getPreparedQuery();
+        $DB       = Database::singleton();
+        $query    = $this->_getPreparedQuery();
         $prepared = $DB->prepare($query['query']);
         $prepared->execute($query['params']);
 
@@ -304,7 +337,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         $x = 0;
         while ($item = $prepared->fetch(PDO::FETCH_ASSOC)) {
             $FileCategory =& $this->tpl_data['File_categories'][$item['File_category']];
-            $DisplayItem = $item;
+            $DisplayItem  = $item;
             $DisplayItem['File_name'] = utf8_encode($item['File_name']);
             $DisplayItem['File_size'] = $this->format_size($item['File_size']);
             $DisplayItem['For_site']  = $site_names[$item['For_site']];
@@ -356,10 +389,10 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [
-                $baseURL . "/css/loris-jquery/jquery-ui-1.10.4.custom.min.css",
-                $baseURL . "/document_repository/css/document_repository.css"
-            ]
+            array(
+             $baseURL . "/css/loris-jquery/jquery-ui-1.10.4.custom.min.css",
+             $baseURL . "/document_repository/css/document_repository.css",
+            )
         );
     }
 

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -27,7 +27,7 @@ class documentRepositoryTestIntegrationTest extends LorisIntegrationTest
     {
         parent::setUp();
         $window = new WebDriverWindow($this->webDriver);
-        $size   = new WebDriverDimension(1024,1768);
+        $size   = new WebDriverDimension(1024, 1768);
         $window->setSize($size);
         $this->DB->insert(
             "document_repository_categories",
@@ -125,7 +125,8 @@ class documentRepositoryTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/document_repository/");
         $this->safeFindElement(
             WebDriverBy::Name("addCategory"),
-            3000)->click();
+            3000
+        )->click();
         sleep(10);
         $this->safeFindElement(
             WebDriverBy::Name(
@@ -186,7 +187,8 @@ class documentRepositoryTestIntegrationTest extends LorisIntegrationTest
      * @return void
      */
     function testDocumentRepositoryUploadFileEditDeleteComment()
-    {    $this->markTestSkipped("This method isn't working properly on travis.");
+    {
+        $this->markTestSkipped("This method isn't working properly on travis.");
          $this->safeGet($this->url . "/document_repository/");
          $this->safeFindElement(
              WebDriverBy::Xpath("//*[@id='TESTTESTTESTTESTa']/td/span")

--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -113,11 +113,16 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
         // certification information
         if ($this->useCertification == '1') {
 
-            $this->tpl_data['hiddenHeaders'] = json_encode(['ID']);
+            $this->tpl_data['hiddenHeaders'] = json_encode(array('ID'));
 
         } else {
 
-            $this->tpl_data['hiddenHeaders'] = json_encode(['ID', 'Certification']);
+            $this->tpl_data['hiddenHeaders'] = json_encode(
+                array(
+                 'ID',
+                 'Certification',
+                )
+            );
 
         }
         return true;

--- a/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
+++ b/modules/final_radiological_review/php/NDB_Form_final_radiological_review.class.inc
@@ -39,7 +39,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
      *
      * @return boolean page access
      */
-    function _hasAccess() 
+    function _hasAccess()
     {
         $user =& User::singleton();
         return (
@@ -54,7 +54,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
      *
      * @param string $perm Name of the permission to check
      *
-     * @return boolean Whether the user has said permission
+     * @return  boolean Whether the user has said permission
      * @private
      */
     function _has_perm($perm)
@@ -70,21 +70,30 @@ class NDB_Form_final_radiological_review extends NDB_Form
      */
     function final_radiological_review()
     {
-        $yes_no = array('' => '', 'yes' => 'Yes', 'no' => 'No');
-        $exclusionary = array('' => '',
-                'exclusionary' => 'Exclusionary',
-                'non_exclusionary' => 'Non-Exclusionary'
-        );
-        $results = array('' => '',
-                         'normal' => 'Normal',
+        $yes_no       = array(
+                         ''    => '',
+                         'yes' => 'Yes',
+                         'no'  => 'No',
+                        );
+        $exclusionary = array(
+                         ''                 => '',
+                         'exclusionary'     => 'Exclusionary',
+                         'non_exclusionary' => 'Non-Exclusionary',
+                        );
+        $results      = array(
+                         ''         => '',
+                         'normal'   => 'Normal',
                          'abnormal' => 'Abnormal',
-                         'atypical' => 'Atypical');
-        $abnormality = array(null => '',
-                            '0' => 'None',
-                            '1' => 'Minimal',
-                            '2' => 'Mild',
-                            '3' => 'Moderate',
-                            '4' => 'Marked');
+                         'atypical' => 'Atypical',
+                        );
+        $abnormality  = array(
+                         null => '',
+                         '0'  => 'None',
+                         '1'  => 'Minimal',
+                         '2'  => 'Mild',
+                         '3'  => 'Moderate',
+                         '4'  => 'Marked',
+                        );
 
         $DB =& Database::singleton();
         $radiologists_q = $DB->pselect("SELECT * FROM examiners WHERE radiologist=True", array());
@@ -134,7 +143,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
 
     }
 
-    /** 
+    /**
      * Overrides the base class getDefaults to get the needed
      * information from the final_radiological_review table for
      * smarty
@@ -152,23 +161,23 @@ class NDB_Form_final_radiological_review extends NDB_Form
             );
             if(empty($final_review)) {
                 $final_review = array(
-                    'CommentID' => '',
-                    'Review_Done' => '',
-                    'Final_Review_Results' => '',
-                    'Final_Exclusionary' => '',
-                    'SAS' => '',
-                    'PVS' => '',
-                    'Final_Incidental_Findings' => '',
-                    'Final_Examiner' => '',
-                    'Final_Review_Results2' => '',
-                    'Final_Examiner2' => '',
-                    'Final_Exclusionary2' => '',
-                    'Review_Done2' => '',
-                    'SAS2' => '',
-                    'PVS2' => '',
-                    'Final_Incidental_Findings2' => '',
-                    'Finalized' => ''
-                );
+                                 'CommentID'                  => '',
+                                 'Review_Done'                => '',
+                                 'Final_Review_Results'       => '',
+                                 'Final_Exclusionary'         => '',
+                                 'SAS'                        => '',
+                                 'PVS'                        => '',
+                                 'Final_Incidental_Findings'  => '',
+                                 'Final_Examiner'             => '',
+                                 'Final_Review_Results2'      => '',
+                                 'Final_Examiner2'            => '',
+                                 'Final_Exclusionary2'        => '',
+                                 'Review_Done2'               => '',
+                                 'SAS2'                       => '',
+                                 'PVS2'                       => '',
+                                 'Final_Incidental_Findings2' => '',
+                                 'Finalized'                  => '',
+                                );
             }
 
             $original_review = $DB->pselectRow(
@@ -191,19 +200,18 @@ class NDB_Form_final_radiological_review extends NDB_Form
                 LIKE CONCAT(upper(c.PSCID), '_', upper(s.CandID), '_', upper(s.visit_label), '%')) 
                 WHERE r.CommentID=:CID 
                 GROUP by CandID, PSCID, Visit_label, SessionID, CommentID,
-                r.Scan_done, r.review_results, r.abnormal_atypical_exclusionary, r.Incidental_findings, e.full_name", 
+                r.Scan_done, r.review_results, r.abnormal_atypical_exclusionary, r.Incidental_findings, e.full_name",
                 array('CID' => $this->identifier)
             );
             if(empty($original_review)) {
                 $original_review = array(
-                    'Original_Scan_Done' => '',
-                    'Original_Review_Results' => '',
-                    'Original_Exclusionary' => '',
-                    'Original_Incidental_Findings' => '',
-                    'Original_Examiner' => ''
-                );
+                                    'Original_Scan_Done'           => '',
+                                    'Original_Review_Results'      => '',
+                                    'Original_Exclusionary'        => '',
+                                    'Original_Incidental_Findings' => '',
+                                    'Original_Examiner'            => '',
+                                   );
             }
-
 
             $history = $DB->pselect(
                 'SELECT userID, changeDate, col, old, new FROM final_radiological_review_history 
@@ -213,30 +221,28 @@ class NDB_Form_final_radiological_review extends NDB_Form
 
             $history_display = '';
             foreach ($history as &$history_item) {
-                $history_display .= '<tr><td>' . 
-                    $history_item['changeDate'] . '</td><td>' . 
-                    $history_item['userID'] . '</td><td>' . 
-                    $history_item['col'] . '</td><td>' . 
+                $history_display .= '<tr><td>' .
+                    $history_item['changeDate'] . '</td><td>' .
+                    $history_item['userID'] . '</td><td>' .
+                    $history_item['col'] . '</td><td>' .
                     _makePretty($history_item['col'], $history_item['old']) . '</td><td>'
                     . _makePretty($history_item['col'], $history_item['new'])
                     . '</td></tr>';
             }
             $defaults = array_merge(
-                $final_review, 
-                $original_review, 
+                $final_review,
+                $original_review,
                 array( 'history' => $history_display)
             );
 
-            if ($defaults['Final_Review_Results'] !=  $defaults['Final_Review_Results2'] 
-                || $defaults['Final_Exclusionary'] != $defaults['Final_Exclusionary2'] 
-                || $defaults['SAS'] != $defaults['SAS2'] 
-                || $defaults ['PVS'] != $defaults['PVS2']
+            if ($defaults['Final_Review_Results'] !=  $defaults['Final_Review_Results2']
+                || $defaults['Final_Exclusionary'] != $defaults['Final_Exclusionary2']
+                || $defaults['SAS'] != $defaults['SAS2']
+                || $defaults['PVS'] != $defaults['PVS2']
             ) {
                 $this->tpl_data['conflicts'][] = "Conflict between final and extra review";
             }
-            if ($defaults['Final_Review_Results'] != $defaults['Original_Review_Results']
-         
-            ) {
+            if ($defaults['Final_Review_Results'] != $defaults['Original_Review_Results']                ) {
                 $this->tpl_data['conflicts'][] = "Conflict between original and final review";
             }
 
@@ -252,7 +258,7 @@ class NDB_Form_final_radiological_review extends NDB_Form
      * @param array  &$arr  A reference to the array being cleaned
      * @param string $field The field being cleaned
      *
-     * @return array $arr Modified so that empty strings are instead
+     * @return  array $arr Modified so that empty strings are instead
      *                    null
      * @private
      */
@@ -273,8 +279,8 @@ class NDB_Form_final_radiological_review extends NDB_Form
      */
     function _process($values)
     {
-        if (!is_array($values) 
-            || count($values) == 0 
+        if (!is_array($values)
+            || count($values) == 0
             || $this->_has_perm('edit_final_radiological_review') == false
         ) {
             return true;
@@ -291,8 +297,8 @@ class NDB_Form_final_radiological_review extends NDB_Form
         $this->stripEmpty($values, 'Finalized');
 
         if (!(is_null($_SESSION['State']))) {
-            $currentUser           = User::singleton($_SESSION['State']->getUsername());
-            $userID                = $currentUser->getData("UserID");
+            $currentUser = User::singleton($_SESSION['State']->getUsername());
+            $userID      = $currentUser->getData("UserID");
         }
 
         $DB =& Database::singleton();
@@ -313,19 +319,22 @@ class NDB_Form_final_radiological_review extends NDB_Form
                  * if any field was updated */
                 foreach($values as $key=>$val) {
                     if ($exists[$key] != $val) {
-                        $update_vals = array('col'=>$key,
-                                'new'=>$val,
-                                'old'=>$exists[$key],
-                                'CommentID'=>$this->identifier,
-                                'userID'=>$userID );
+                        $update_vals = array(
+                                        'col'       => $key,
+                                        'new'       => $val,
+                                        'old'       => $exists[$key],
+                                        'CommentID' => $this->identifier,
+                                        'userID'    => $userID,
+                                       );
 
                         $DB->insert("final_radiological_review_history", $update_vals);
                     }
                 }
                 $DB->update(
-                        $this->__table, $values,
-                        array('CommentID' => $this->identifier)
-                        );
+                    $this->__table,
+                    $values,
+                    array('CommentID' => $this->identifier)
+                );
             }
 
         }

--- a/modules/final_radiological_review/test/final_radiological_reviewTest.php
+++ b/modules/final_radiological_review/test/final_radiological_reviewTest.php
@@ -18,6 +18,7 @@ class finalRadiologicalReviewTestIntegrationTest extends LorisIntegrationTest
      * Tests that the final Radiological Review loads if the user has the correct
      * permissions (edit_final_radiological_review or view_final_radiological_review)
      * It should only be able to see the menu item.
+     *
      * @return void
      */
     function testFinalRadiologicalReviewLoadsWithPermission()
@@ -25,7 +26,7 @@ class finalRadiologicalReviewTestIntegrationTest extends LorisIntegrationTest
         $this->setupPermissions(array("view_final_radiological_review"));
         $this->safeGet($this->url . "/final_radiological_review/");
 
-    // Test that the Imaging menu appears in the first row
+        // Test that the Imaging menu appears in the first row
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
@@ -35,4 +36,3 @@ class finalRadiologicalReviewTestIntegrationTest extends LorisIntegrationTest
     }
 }
 ?>
-

--- a/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
@@ -73,7 +73,7 @@ class NDB_Menu_Filter_Help_Editor extends NDB_Menu_Filter
                            'Content',
                           );
         $this->tpl_data['hiddenHeaders']
-            = json_encode(['HelpID', 'ParentID', 'ParentTopicID']);
+            = json_encode(array('HelpID', 'ParentID', 'ParentTopicID'));
         $this->validFilters = array('helpChild.topic');
 
         $this->formToFilter  = array('topic' => 'helpChild.topic');

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -108,7 +108,7 @@ class Imaging_Session_ControlPanel
 
         //if table is not in database return false to not display in the template
         $this->tpl_data['mri_param_form_table_exists'] = $DB->tableExists('mri_parameter_form');
-        $this->tpl_data['rad_review_table_exists'] = $DB->tableExists('radiology_review');
+        $this->tpl_data['rad_review_table_exists']     = $DB->tableExists('radiology_review');
         $this->tpl_data['mantis']       = $config->getSetting('mantis_url');
         $subjectData['mantis']          = $config->getSetting('mantis_url');
         $subjectData['has_permission']  = $this->_hasAccess();
@@ -121,8 +121,8 @@ class Imaging_Session_ControlPanel
                                            'Y' => 'Yes',
                                            'N' => 'No',
                                           );
-        $subjectData['caveat_options'] = array(
-                                           'true' => 'True',
+        $subjectData['caveat_options']  = array(
+                                           'true'  => 'True',
                                            'false' => 'False',
                                           );
 
@@ -133,8 +133,7 @@ class Imaging_Session_ControlPanel
 
         $subjectData['mriqcstatus']  = $qcstatus['MRIQCStatus'];
         $subjectData['mriqcpending'] = $qcstatus['MRIQCPending'];
-        $subjectData['mricaveat'] = $qcstatus['MRICaveat'];
-
+        $subjectData['mricaveat']    = $qcstatus['MRICaveat'];
 
         $factory = NDB_Factory::singleton();
         $subjectData['backURL'] = $factory->settings()->getBaseURL()

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -40,7 +40,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         // allow only to view own site data
         $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {
-            $site[$key] = & Site::singleton($val);
+            $site[$key]        = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
         }
         $oneIsStudySite = in_array("1", $isStudySite);
@@ -62,13 +62,13 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             WHEN '' THEN 'new'
             ELSE ''
             END";
-        $T1PassSubquery = "CASE 
+        $T1PassSubquery  = "CASE 
             COALESCE(t1pass.T1QC, '') 
             WHEN '' THEN ''
             WHEN 1 THEN 'Passed'
             WHEN 2 THEN 'Failed'
             END";
-        $T2PassSubquery = "CASE 
+        $T2PassSubquery  = "CASE 
             COALESCE(t2pass.T2QC, '') 
             WHEN '' THEN ''
             WHEN 1 THEN 'Passed'
@@ -101,77 +101,81 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             f.AcquisitionProtocolID not in (1, 2, 3, 52)";
 
         $config =& NDB_Config::singleton();
-        $user =& User::singleton();
-        $DB = Database::singleton();
+        $user   =& User::singleton();
+        $DB     = Database::singleton();
         if (!$user->hasPermission('imaging_browser_view_allsites')) {
-            $site_arr = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterID());
             $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 
         $this->columns = array(
-            'p.MRI_alias as Site',
-            'c.PSCID as PSCID',
-            'c.CandID as DCCID',
-            's.visit_label as Visit_Label',
-            "$PendingFailSubquery as QC_Status",
-            'MIN(md.AcquisitionDate) as First_Acq_Date',
-            'FROM_UNIXTIME(MIN(f.InsertTime)) as First_Insertion_Date',
-            'FROM_UNIXTIME(MAX(fqc.QCLastChangeTime)) as Last_QC',
-            "$NewDataSubquery as New_Data",
-            "$T1PassSubquery as T1_Passed",
-            "$T2PassSubquery as T2_Passed",
-            "GROUP_CONCAT(DISTINCT OutputType) as Links",
-            's.ID as sessionID'
-        );
+                          'p.MRI_alias as Site',
+                          'c.PSCID as PSCID',
+                          'c.CandID as DCCID',
+                          's.visit_label as Visit_Label',
+                          "$PendingFailSubquery as QC_Status",
+                          'MIN(md.AcquisitionDate) as First_Acq_Date',
+                          'FROM_UNIXTIME(MIN(f.InsertTime)) as First_Insertion_Date',
+                          'FROM_UNIXTIME(MAX(fqc.QCLastChangeTime)) as Last_QC',
+                          "$NewDataSubquery as New_Data",
+                          "$T1PassSubquery as T1_Passed",
+                          "$T2PassSubquery as T2_Passed",
+                          "GROUP_CONCAT(DISTINCT OutputType) as Links",
+                          's.ID as sessionID',
+                         );
 
         $this->order_by = 'c.PSCID, s.Visit_label';
         $this->group_by = 's.ID';
-        $this->headers = array(
-            'Site',
-            'PSCID',
-            'DCCID',
-            'Visit_Label',
-            'QC_Status',
-            'First_Acq_Date',
-            'First_Insertion_Date',
-            'Last_QC',
-            'New_Data',
-            'T1_Passed',
-            'T2_Passed',
-            'Links',
-            'sessionID'
-        );
+        $this->headers  = array(
+                           'Site',
+                           'PSCID',
+                           'DCCID',
+                           'Visit_Label',
+                           'QC_Status',
+                           'First_Acq_Date',
+                           'First_Insertion_Date',
+                           'Last_QC',
+                           'New_Data',
+                           'T1_Passed',
+                           'T2_Passed',
+                           'Links',
+                           'sessionID',
+                          );
 
         // Insert project column after DCCID, if useProject config is enabled
         if ($config->getSetting('useProjects') === "true") {
-            array_splice($this->columns, 3, 0,
-                '(SELECT Name FROM Project WHERE ProjectID=c.ProjectID) as project');
+            array_splice(
+                $this->columns,
+                3,
+                0,
+                '(SELECT Name FROM Project WHERE ProjectID=c.ProjectID) as project'
+            );
             array_splice($this->headers, 3, 0, 'Project');
         }
 
         $this->validFilters = array(
-            'c.PSCID',
-            's.Visit_label',
-            'c.CandID',
-            'c.ProjectID',
-            's.CenterID',
-            's.MRIQCStatus',
-            'pending',
-            'f.AcquisitionProtocolID'
-        );
+                               'c.PSCID',
+                               's.Visit_label',
+                               'c.CandID',
+                               'c.ProjectID',
+                               's.CenterID',
+                               's.MRIQCStatus',
+                               'pending',
+                               'f.AcquisitionProtocolID',
+                              );
 
-        $this->formToFilter = array(
-            'pscid' => 'c.PSCID',
-            'VL'    => 's.Visit_label',
-            'DCCID'=> 'c.CandID',
-            'ProjectID' => 'c.ProjectID',
-            'SiteID' => 's.CenterID',
-            'VisitQCStatus' => 's.MRIQCStatus',
-            'Pending' => 'pending',
-            'Scan_type'=>'f.AcquisitionProtocolID'
-        );
+        $this->formToFilter    = array(
+                                  'pscid'         => 'c.PSCID',
+                                  'VL'            => 's.Visit_label',
+                                  'DCCID'         => 'c.CandID',
+                                  'ProjectID'     => 'c.ProjectID',
+                                  'SiteID'        => 's.CenterID',
+                                  'VisitQCStatus' => 's.MRIQCStatus',
+                                  'Pending'       => 'pending',
+                                  'Scan_type'     => 'f.AcquisitionProtocolID',
+                                 );
         $this->EqualityFilters = array('f.AcquisitionProtocolID');
-        $this->searchKeyword    = array();
+        $this->searchKeyword   = array();
 
         $this->tpl_data['numTimepoints'] = 0;
 
@@ -201,7 +205,8 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         if ($user->hasPermission('imaging_browser_view_allsites')) {
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = Utility::getSiteList();
-            if(is_array($list_of_sites)) $list_of_sites = array('' => 'All') + $list_of_sites;
+            if(is_array($list_of_sites)) { $list_of_sites = array('' => 'All') + $list_of_sites;
+            }
         }
         else {
             // allow only to view own site data
@@ -215,20 +220,30 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             }
         }
 
-        $DB = Database::singleton();
+        $DB    = Database::singleton();
         $allAr = array('' => 'All');
-        $this->addBasicText('pscid', 'PSCID', array("size"=>10,"maxlength"=>25));
+        $this->addBasicText('pscid', 'PSCID', array("size" => 10, "maxlength" => 25));
         $this->addBasicText(
-            'VL', 'Visit Label', array('size' => "10", "maxlength"=>"25")
+            'VL',
+            'Visit Label',
+            array(
+             'size'      => "10",
+             "maxlength" => "25",
+            )
         );
         $this->addBasicText(
-            'DCCID', 'DCCID', array('size' => 10, "maxlength" => 25)
+            'DCCID',
+            'DCCID',
+            array(
+             'size'      => 10,
+             "maxlength" => 25,
+            )
         );
 
         $config =& NDB_Config::singleton();
         if ($config->getSetting('useProjects') === "true") {
             $list_of_projects = $allAr;
-            $projectList = Utility::getProjectList();
+            $projectList      = Utility::getProjectList();
             foreach ($projectList as $key => $value) {
                 $list_of_projects[$key] =$value;
             }
@@ -239,36 +254,47 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $this->addSelect(
             'VisitQCStatus',
             'QC Status',
-            array(''=>'All', 'Pass'=>'Pass', 'Fail'=>'Fail')
+            array(
+             ''     => 'All',
+             'Pass' => 'Pass',
+             'Fail' => 'Fail',
+            )
         );
 
         $this->addSelect(
             'Pending',
             'Pending and New',
-            array(''=>'All', 'P'=>'Pending', 'N'=>'New', 'PN'=>'Pending or New')
+            array(
+             ''   => 'All',
+             'P'  => 'Pending',
+             'N'  => 'New',
+             'PN' => 'Pending or New',
+            )
         );
 
         //query to get scan types that exist for the project
-        $types_q = $DB->pselect(
+        $types_q    = $DB->pselect(
             "SELECT ID, Scan_type FROM mri_scan_type mri
                  JOIN files f ON (f.AcquisitionProtocolID=mri.ID)",
             array()
         );
         $scan_types = $allAr;
         foreach ($types_q as $row) {
-            $type                   = $row['Scan_type'];
+            $type = $row['Scan_type'];
             $scan_types[$row['ID']] = $type;
         }
         $this->addSelect('Scan_type', 'Sequence Type', $scan_types);
 
         $outputTypes = $DB->pselect(
             "SELECT DISTINCT OutputType AS outputType 
-            FROM files WHERE FileType='mnc' AND OutputType!='native'", array()
+            FROM files WHERE FileType='mnc' AND OutputType!='native'",
+            array()
         );
 
         $this->tpl_data['outputTypes'] = array_merge(
             array(
-                array('outputType'=>'native'),array('outputType'=>'selected')
+             array('outputType' => 'native'),
+             array('outputType' => 'selected'),
             ),
             $outputTypes
         );
@@ -277,7 +303,10 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $this->addBasicText(
             'keyword',
             'Search keyword in Comments',
-            array("size"=>10,"maxlength"=>25)
+            array(
+             "size"      => 10,
+             "maxlength" => 25,
+            )
         );
 
         $this->tpl_data['backURL'] = $_SERVER['REQUEST_URI'];
@@ -304,7 +333,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
                     || strtolower(substr($field, -10)) == 'categoryid'
                     || strtolower(substr($field, -6)) == 'gender'
                     || (isset($this->EqualityFilters)
-                        && in_array($field, $this->EqualityFilters))
+                    && in_array($field, $this->EqualityFilters))
                 ) {
                     $query .= " AND $field = :v_$prepared_key";
                     // $qparams["v_$prepared_key"] = $val;
@@ -313,16 +342,16 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
                 }
             } else if ($field == 'pending') {
                 switch ($val) {
-                    case "P":
-                        $query .= " AND s.MRIQCPending='Y'";
-                        break;
-                    case "N":
-                        $query .= " AND fqc.QCFirstChangeTime IS NULL";
-                        break;
-                    case "PN":
-                        $query .= " AND (s.MRIQCPending='Y' 
+                case "P":
+                    $query .= " AND s.MRIQCPending='Y'";
+                    break;
+                case "N":
+                    $query .= " AND fqc.QCFirstChangeTime IS NULL";
+                    break;
+                case "PN":
+                    $query .= " AND (s.MRIQCPending='Y' 
                         OR fqc.QCFirstChangeTime IS NULL)";
-                        break;
+                    break;
                 }
             } else if ($field == 'AcquisitionProtocolID') {
                 $query .= " AND $field = :v_$prepared_key";
@@ -346,7 +375,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
      */
     function toArray()
     {
-        $data   = parent::toArray();
+        $data  = parent::toArray();
         $index = array_search('SessionID', $data['Headers']);
         if ($index !== false) {
             $_SESSION['State']->setProperty(
@@ -370,7 +399,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/imaging_browser/css/imaging_browser.css"]
+            array($baseURL . "/imaging_browser/css/imaging_browser.css")
         );
     }
 
@@ -380,14 +409,13 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
      *
      * @return array of javascript to be inserted
      */
-    function getJSDependencies() {
+    function getJSDependencies()
+    {
         $factory = NDB_Factory::singleton();
         $baseurl = $factory->settings()->getBaseURL();
         return array_merge(
             parent::getJSDependencies(),
-            array(
-                $baseurl . "/imaging_browser/js/columnFormatter.js"
-            )
+            array($baseurl . "/imaging_browser/js/columnFormatter.js")
         );
     }
 }

--- a/modules/imaging_uploader/ajax/read_log.php
+++ b/modules/imaging_uploader/ajax/read_log.php
@@ -68,7 +68,7 @@ if ($file) {
 
 
 /**
- * Get the last changed log file using in the 
+ * Get the last changed log file using in the
  * $paths['base'] . "/" . $paths['log']."/MRI_upload" directory
 
  * @return String latest log file

--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -626,7 +626,7 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/imaging_uploader/css/imaging_uploader.css"]
+            array($baseURL . "/imaging_uploader/css/imaging_uploader.css")
         );
     }
 }

--- a/modules/imaging_uploader/test/imaging_uploaderTest.php
+++ b/modules/imaging_uploader/test/imaging_uploaderTest.php
@@ -18,62 +18,62 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
      * Insert testing data
      *
      * @return void
-     */   
+     */
     function setUp()
     {
         parent::setUp();
          $this->DB->insert(
-            "psc",
-            array(
-             'CenterID' => '55',
-             'Name' => 'TESTinPSC',
-             'Alias' => 'tst',
-             'MRI_alias' => 'test'
-            )
-        );
+             "psc",
+             array(
+              'CenterID'  => '55',
+              'Name'      => 'TESTinPSC',
+              'Alias'     => 'tst',
+              'MRI_alias' => 'test',
+             )
+         );
           $this->DB->insert(
-            "candidate",
-            array(
-             'CandID'        => '999999',
-             'CenterID'      => '55',
-             'UserID'        => '1',
-             'PSCID'         => '8889',
-             'ProjectID'     => '7777'
-            )
-        );
-        $this->DB->insert(
-            "session",
-            array(
-             'ID'            => '111112',
-             'CandID'        => '999999',
-             'CenterID'      => '55',
-             'UserID'        => '1',
-             'MRIQCStatus'   => 'Pass',
-             'SubprojectID'  => '6666',
-             'Visit'         => 'In Progress',
-             'Visit_label'   => 'TestVisitLabel'
-            )
-        );
-        $this->DB->insert(
-            "mri_upload",
-            array(
-             'UploadID'                    => '9999999',
-             'UploadedBy'                  => 'test',
-             'UploadDate'                  => '2017-01-01',
-             'UploadLocation'              => '/data/incoming/test',
-             'DecompressedLocation'        => '/tmp/ImagingUpload-test',
-             'InsertionComplete'           => '0',
-             'Inserting'                   => '0',
-             'PatientName'                 => 'TestTestTest',
-             'number_of_mincInserted'      => '1',
-             'number_of_mincCreated'       => '1',
-             'TarchiveID'                  => '999999',
-             'SessionID'                   => '111112',
-             'IsCandidateInfoValidated'    => '1',
-             'IsTarchiveValidated'         => '0',
-             'IsPhantom'                   => 'N',
-            )
-        );
+              "candidate",
+              array(
+               'CandID'    => '999999',
+               'CenterID'  => '55',
+               'UserID'    => '1',
+               'PSCID'     => '8889',
+               'ProjectID' => '7777',
+              )
+          );
+          $this->DB->insert(
+              "session",
+              array(
+               'ID'           => '111112',
+               'CandID'       => '999999',
+               'CenterID'     => '55',
+               'UserID'       => '1',
+               'MRIQCStatus'  => 'Pass',
+               'SubprojectID' => '6666',
+               'Visit'        => 'In Progress',
+               'Visit_label'  => 'TestVisitLabel',
+              )
+          );
+          $this->DB->insert(
+              "mri_upload",
+              array(
+               'UploadID'                 => '9999999',
+               'UploadedBy'               => 'test',
+               'UploadDate'               => '2017-01-01',
+               'UploadLocation'           => '/data/incoming/test',
+               'DecompressedLocation'     => '/tmp/ImagingUpload-test',
+               'InsertionComplete'        => '0',
+               'Inserting'                => '0',
+               'PatientName'              => 'TestTestTest',
+               'number_of_mincInserted'   => '1',
+               'number_of_mincCreated'    => '1',
+               'TarchiveID'               => '999999',
+               'SessionID'                => '111112',
+               'IsCandidateInfoValidated' => '1',
+               'IsTarchiveValidated'      => '0',
+               'IsPhantom'                => 'N',
+              )
+          );
     }
     /**
      * Deleting the test data
@@ -84,7 +84,7 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
     {
         parent::tearDown();
         $this->DB->delete(
-            "mri_upload", 
+            "mri_upload",
             array('PatientName' => 'TestTestTest')
         );
         $this->DB->delete(
@@ -97,16 +97,16 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
         );
         $this->DB->delete(
             "psc",
-            array('CenterID'=>'55')
+            array('CenterID' => '55')
         );
-        
+
     }
     /**
      * Tests that, when loading the Imaging_uploader module, some
      * text appears in the body.
      *
      * @return void
-     */ 
+     */
     function testImagingUploaderDoespageLoad()
     {
         $this->safeGet($this->url . '/imaging_uploader/');
@@ -131,7 +131,7 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
      * "You do not have access to this page." not appears in the body.
      *
      * @return void
-     */    
+     */
     function testImagingUploaderLoadWithPermission()
     {
         $this->setupPermissions(array("imaging_uploader"));
@@ -142,7 +142,7 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
     }
     /**
      * Tests that, inputing some data into filter,then clicking the
-     * [clear form] button, make sure that all of filter form should be 
+     * [clear form] button, make sure that all of filter form should be
      * empty.
      *
      * @return void
@@ -152,16 +152,16 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/imaging_uploader/');
 
         $this->webDriver->findElement(
-             WebDriverBy::name("CandID")
-         )->sendKeys("test");
+            WebDriverBy::name("CandID")
+        )->sendKeys("test");
 
         $this->webDriver->findElement(
-             WebDriverBy::name("PSCID")
-         )->sendKeys("test");
+            WebDriverBy::name("PSCID")
+        )->sendKeys("test");
 
         $this->webDriver->findElement(
-             WebDriverBy::name("reset")
-         )->click();
+            WebDriverBy::name("reset")
+        )->click();
 
          $bodyText1 = $this->webDriver->findElement(
              WebDriverBy::name("CandID")
@@ -170,8 +170,8 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
              WebDriverBy::name("PSCID")
          )->getText();
 
-        $this->assertEquals('',$bodyText1);
-        $this->assertEquals('',$bodyText2);
+         $this->assertEquals('', $bodyText1);
+         $this->assertEquals('', $bodyText2);
     }
     /**
      * Tests that, when loading the Imaging_uploader module,
@@ -182,32 +182,30 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
     function testImagingUploaderFilter()
     {
         $this->safeGet($this->url . '/imaging_uploader/');
-        
+
         $this->webDriver->findElement(
-             WebDriverBy::name("CandID")
-         )->sendKeys("999999");
-        
+            WebDriverBy::name("CandID")
+        )->sendKeys("999999");
+
         $this->webDriver->findElement(
-             WebDriverBy::name("filter")
-         )->click();
+            WebDriverBy::name("filter")
+        )->click();
         $this->safeGet($this->url . '/imaging_uploader/?format=json');
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("TestVisitLabel", $bodyText);
-
 
         $this->safeGet($this->url . '/imaging_uploader/');
 
         $this->webDriver->findElement(
-             WebDriverBy::name("PSCID")
-         )->sendKeys("8889");
+            WebDriverBy::name("PSCID")
+        )->sendKeys("8889");
 
         $this->webDriver->findElement(
-             WebDriverBy::name("filter")
-         )->click();
+            WebDriverBy::name("filter")
+        )->click();
         $this->safeGet($this->url . '/imaging_uploader/?format=json');
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("TestVisitLabel", $bodyText);
-
 
         $this->safeGet($this->url . '/imaging_uploader/');
 
@@ -216,12 +214,11 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
         $Visit_label->selectByVisibleText("TestVisitLabel");
 
         $this->webDriver->findElement(
-             WebDriverBy::name("filter")
-         )->click();
+            WebDriverBy::name("filter")
+        )->click();
         $this->safeGet($this->url . '/imaging_uploader/?format=json');
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("TestVisitLabel", $bodyText);
-
 
         $this->safeGet($this->url . '/imaging_uploader/');
 
@@ -230,12 +227,11 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
         $Phantom->selectByVisibleText("No");
 
         $this->webDriver->findElement(
-             WebDriverBy::name("filter")
-         )->click();
+            WebDriverBy::name("filter")
+        )->click();
         $this->safeGet($this->url . '/imaging_uploader/?format=json');
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("TestVisitLabel", $bodyText);
-
 
     }
     /**
@@ -248,8 +244,8 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
     {
         $this->safeGet($this->url . '/imaging_uploader/');
         $this->webDriver->findElement(
-             WebDriverBy::ID("upload")
-         )->click();
+            WebDriverBy::ID("upload")
+        )->click();
         sleep(2);
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
         $this->assertContains("mri_file: Make sure 'Are these Phantom Scans' is filled out.", $bodyText);
@@ -264,28 +260,28 @@ class imaging_uploaderTestIntegrationTest extends LorisIntegrationTest
     {
         $this->safeGet($this->url . '/imaging_uploader/');
                 $this->webDriver->findElement(
-             WebDriverBy::Name("mri_file")
-         )->sendKeys("/TestVisitLabel.zip");
-        $this->webDriver->findElement(
-             WebDriverBy::name("CandID")
-         )->sendKeys("999999"); 
-        $this->webDriver->findElement(
-             WebDriverBy::name("PSCID")
-         )->sendKeys("8889");
+                    WebDriverBy::Name("mri_file")
+                )->sendKeys("/TestVisitLabel.zip");
+                $this->webDriver->findElement(
+                    WebDriverBy::name("CandID")
+                )->sendKeys("999999");
+                $this->webDriver->findElement(
+                    WebDriverBy::name("PSCID")
+                )->sendKeys("8889");
 
-        $Visit_labelElement =  $this->safeFindElement(WebDriverBy::Name("Visit_label"));
-        $Visit_label        = new WebDriverSelect($Visit_labelElement);
-        $Visit_label->selectByVisibleText("TestVisitLabel");
+                $Visit_labelElement =  $this->safeFindElement(WebDriverBy::Name("Visit_label"));
+                $Visit_label        = new WebDriverSelect($Visit_labelElement);
+                $Visit_label->selectByVisibleText("TestVisitLabel");
 
-        $PhantomElement =  $this->safeFindElement(WebDriverBy::Name("IsPhantom"));
-        $Phantom        = new WebDriverSelect($PhantomElement);
-        $Phantom->selectByVisibleText("No");
+                $PhantomElement =  $this->safeFindElement(WebDriverBy::Name("IsPhantom"));
+                $Phantom        = new WebDriverSelect($PhantomElement);
+                $Phantom->selectByVisibleText("No");
 
-        $this->webDriver->findElement(
-             WebDriverBy::ID("upload")
-         )->click();
-        $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
-        $this->assertContains("8889_999999_TestVisitLabel", $bodyText);
+                $this->webDriver->findElement(
+                    WebDriverBy::ID("upload")
+                )->click();
+                $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
+                $this->assertContains("8889_999999_TestVisitLabel", $bodyText);
     }
 }
 ?>

--- a/modules/instrument_builder/php/NDB_Form_instrument_builder.class.inc
+++ b/modules/instrument_builder/php/NDB_Form_instrument_builder.class.inc
@@ -74,7 +74,7 @@ class NDB_Form_Instrument_Builder extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/instrument_builder/css/instrument_builder.css"]
+            array($baseURL . "/instrument_builder/css/instrument_builder.css")
         );
     }
 

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -98,7 +98,7 @@ function editIssue()
     $historyValues = getChangedValues($issueValues, $issueID);
 
     if (!empty($issueID) || $issueID != 0) {
-        $db->update('issues', $issueValues, ['issueID' => $issueID]);
+        $db->update('issues', $issueValues, array('issueID' => $issueID));
     } else {
         $issueValues['reporter']    = $user->getData('UserID');
         $issueValues['dateCreated'] = date('Y-m-d H:i:s');
@@ -141,7 +141,7 @@ function editIssue()
         // Clear the list of current watchers
         $db->delete(
             'issues_watching',
-            ['issueID' => $issueID]
+            array('issueID' => $issueID)
         );
 
         // Add new watchers (if any)
@@ -150,10 +150,10 @@ function editIssue()
             if ($usersWatching) {
                 $db->insert(
                     'issues_watching',
-                    [
+                    array(
                      'userID'  => $usersWatching,
                      'issueID' => $issueID,
-                    ]
+                    )
                 );
             }
         }
@@ -162,7 +162,7 @@ function editIssue()
     //sending email
     emailUser($issueID, $issueValues['assignee']);
 
-    return ['issueID' => $issueID];
+    return array('issueID' => $issueID);
 }
 
 /**
@@ -179,12 +179,12 @@ function validateInput($values)
     $db         =& Database::singleton();
     $pscid      = (isset($values['PSCID']) ? $values['PSCID'] : null);
     $visitLabel = (isset($values['visitLabel']) ? $values['visitLabel'] : null);
-    $result     = [
+    $result     = array(
                    'PSCID'     => $pscid,
                    'visit'     => $visitLabel,
                    'candID'    => null,
                    'sessionID' => null,
-                  ];
+                  );
 
     // If both are set, return SessionID and CandID
     if (isset($result['PSCID']) && isset($result['visit'])) {
@@ -192,10 +192,10 @@ function validateInput($values)
             "SELECT s.ID as sessionID, c.candID as candID FROM candidate c 
             INNER JOIN session s on (c.CandID = s.CandID) 
             WHERE c.PSCID=:PSCID and s.Visit_label=:visitLabel",
-            [
+            array(
              'PSCID'      => $result['PSCID'],
              'visitLabel' => $result['visit'],
-            ]
+            )
         );
 
         if (isset($session[0]['sessionID'])) {
@@ -213,7 +213,7 @@ function validateInput($values)
     // If only PSCID is set, return CandID
     if (isset($result['PSCID'])) {
         $query  = "SELECT CandID FROM candidate WHERE PSCID=:PSCID";
-        $params = ['PSCID' => $result['PSCID']];
+        $params = array('PSCID' => $result['PSCID']);
 
         $user =& User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
@@ -252,7 +252,7 @@ function validateInput($values)
 function getChangedValues($issueValues, $issueID)
 {
     $issueData     = getIssueData($issueID);
-    $changedValues = [];
+    $changedValues = array();
     foreach ($issueValues as $key => $value) {
         // Only include fields that have changed
         if ($issueValues[$key] != $issueData[$key] && !empty($value)) {
@@ -279,12 +279,12 @@ function updateHistory($values, $issueID)
 
     foreach ($values as $key => $value) {
         if (!empty($value)) {
-            $changedValues = [
+            $changedValues = array(
                               'newValue'     => $value,
                               'fieldChanged' => $key,
                               'issueID'      => $issueID,
                               'addedBy'      => $user->getData('UserID'),
-                             ];
+                             );
             $db->insert('issues_history', $changedValues);
         }
     }
@@ -591,9 +591,9 @@ WHERE FIND_IN_SET(u.CenterID,:CenterID) OR FIND_IN_SET(u.CenterID,:DCC)",
 
     $unorgCategories = $db->pselect(
         "SELECT categoryName FROM issues_categories",
-        []
+        array()
     );
-    $categories      = [];
+    $categories      = array();
     foreach ($unorgCategories as $r_row) {
         $categoryName = $r_row['categoryName'];
         if ($categoryName) {
@@ -605,7 +605,7 @@ WHERE FIND_IN_SET(u.CenterID,:CenterID) OR FIND_IN_SET(u.CenterID,:DCC)",
     $modules_expanded = $db->pselect(
         "SELECT DISTINCT Label, ID FROM LorisMenu 
 WHERE Parent IS NOT NULL ORDER BY Label ",
-        []
+        array()
     );
     foreach ($modules_expanded as $m_row) {
         $modules[$m_row['ID']] = $m_row['Label'];
@@ -642,7 +642,7 @@ ORDER BY dateAdded",
         $isOwnIssue = false;
     }
 
-    $result = [
+    $result = array(
                'assignees'         => $assignees,
                'sites'             => $sites,
                'statuses'          => $statuses,
@@ -655,7 +655,7 @@ ORDER BY dateAdded",
                    'issue_tracker_developer'
                ),
                'isOwnIssue'        => $isOwnIssue,
-              ];
+              );
 
     return $result;
 }
@@ -680,11 +680,11 @@ function getIssueData($issueID)
             "LEFT JOIN candidate c ON (i.candID=c.CandID)" .
             "LEFT JOIN session s ON (i.sessionID=s.ID) " .
             "WHERE issueID=:issueID",
-            ['issueID' => $issueID]
+            array('issueID' => $issueID)
         );
     }
 
-    return [
+    return array(
             'reporter'      => $user->getData('UserID'),
             'dateCreated'   => date('Y-m-d H:i:s'),
             'centerID'      => $user->getData('CenterID'),
@@ -700,7 +700,7 @@ function getIssueData($issueID)
             'visitLabel'    => null,
             'category'      => null,
             'lastUpdatedBy' => null,
-           ];
+           );
 }
 
 /**
@@ -717,5 +717,5 @@ function showError($message)
     }
     header('HTTP/1.1 400 Bad Request');
     header('Content-Type: application/json; charset=UTF-8');
-    die(json_encode(['message' => $message]));
+    die(json_encode(array('message' => $message)));
 }

--- a/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Form_issue_tracker.class.inc
@@ -71,7 +71,7 @@ class NDB_Form_Issue_Tracker extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/issue_tracker/css/issue_tracker.css"]
+            array($baseURL . "/issue_tracker/css/issue_tracker.css")
         );
     }
 
@@ -100,7 +100,7 @@ class NDB_Form_Issue_Tracker extends NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/issue_tracker/js/issueIndex.js"]
+            array($baseURL . "/issue_tracker/js/issueIndex.js")
         );
     }
 
@@ -123,7 +123,7 @@ class NDB_Form_Issue_Tracker extends NDB_Form
 
         $issueData = $db->pselectRow(
             "SELECT centerID FROM issues WHERE issueID=:issueID",
-            ['issueID' => $issueID]
+            array('issueID' => $issueID)
         );
 
         if (in_array($issueData['centerID'], $user->getData('CenterIDs'))

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -94,10 +94,10 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
                           'CandID',
                          );
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'SessionID',
              'CandID',
-            ]
+            )
         );
 
         $this->validFilters = array(
@@ -200,7 +200,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
         $modules_expanded = $db->pselect(
             "SELECT DISTINCT Label, ID FROM LorisMenu 
 WHERE Parent IS NOT NULL ORDER BY Label",
-            []
+            array()
         );
         $modules          = $this->reorganizeQueryResults(
             $modules_expanded,
@@ -229,7 +229,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
         $unorgCategories = $db -> pselect(
             "SELECT categoryName
         FROM issues_categories",
-            []
+            array()
         );
         $categories      = array('' => "All");
         foreach ($unorgCategories as $r_row) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -95,10 +95,10 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                          );
 
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'SessionID',
              'CandID',
-            ]
+            )
         );
         $this->validFilters = array(
                                'i.issueID',
@@ -188,7 +188,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
         $modules_expanded = $db->pselect(
             "SELECT DISTINCT Label, ID FROM LorisMenu 
 WHERE Parent IS NOT NULL ORDER BY Label",
-            []
+            array()
         );
         $modules          = $this->reorganizeQueryResults(
             $modules_expanded,
@@ -217,7 +217,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
         $unorgCategories = $db -> pselect(
             "SELECT categoryName
         FROM issues_categories",
-            []
+            array()
         );
         $categories      = array('' => "All");
         foreach ($unorgCategories as $r_row) {

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -94,10 +94,10 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
                           'CandID',
                          );
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'SessionID',
              'CandID',
-            ]
+            )
         );
 
         $this->validFilters = array(
@@ -198,7 +198,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
         $modules_expanded = $db->pselect(
             "SELECT DISTINCT Label, ID FROM LorisMenu 
 WHERE Parent IS NOT NULL ORDER BY Label ",
-            []
+            array()
         );
         $modules          = $this->reorganizeQueryResults(
             $modules_expanded,
@@ -217,7 +217,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
         $unorgCategories = $db -> pselect(
             "SELECT categoryName
         FROM issues_categories",
-            []
+            array()
         );
         $categories      = array('' => "All");
         foreach ($unorgCategories as $r_row) {

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -49,14 +49,14 @@ function editFile()
         showError("Error! Invalid media file ID!");
     }
 
-    $updateValues = [
+    $updateValues = array(
                      'date_taken' => $req['dateTaken'],
                      'comments'   => $req['comments'],
                      'hide_file'  => $req['hideFile'] ? $req['hideFile'] : 0,
-                    ];
+                    );
 
     try {
-        $db->update('media', $updateValues, ['id' => $idMediaFile]);
+        $db->update('media', $updateValues, array('id' => $idMediaFile));
     } catch (DatabaseException $e) {
         showError("Could not update the file. Please try again!");
     }
@@ -122,11 +122,11 @@ function uploadFile()
         "SELECT s.ID as session_id FROM candidate c " .
         "LEFT JOIN session s USING(CandID) WHERE c.PSCID = :v_pscid AND " .
         "s.Visit_label = :v_visit_label AND s.CenterID = :v_center_id",
-        [
+        array(
          'v_pscid'       => $pscid,
          'v_visit_label' => $visit,
          'v_center_id'   => $site,
-        ]
+        )
     );
 
     if (!isset($sessionID) || count($sessionID) < 1) {
@@ -139,7 +139,7 @@ function uploadFile()
     }
 
     // Build insert query
-    $query = [
+    $query = array(
               'session_id'    => $sessionID,
               'instrument'    => $instrument,
               'date_taken'    => $dateTaken,
@@ -150,7 +150,7 @@ function uploadFile()
               'uploaded_by'   => $userID,
               'hide_file'     => 0,
               'date_uploaded' => date("Y-m-d H:i:s"),
-             ];
+             );
 
     if (move_uploaded_file($_FILES["file"]["tmp_name"], $mediaPath . $fileName)) {
         $existingFiles = getFilesList();
@@ -158,7 +158,7 @@ function uploadFile()
         try {
             // Override db record if file_name already exists
             if ($idMediaFile) {
-                $db->update('media', $query, ['id' => $idMediaFile]);
+                $db->update('media', $query, array('id' => $idMediaFile));
             } else {
                 $db->insert('media', $query);
             }
@@ -183,11 +183,11 @@ function getUploadFields()
 
     $instruments = $db->pselect(
         "SELECT Test_name FROM test_names ORDER BY Test_name",
-        []
+        array()
     );
     $candidates  = $db->pselect(
         "SELECT CandID, PSCID FROM candidate ORDER BY PSCID",
-        []
+        array()
     );
 
     $instrumentsList = toSelect($instruments, "Test_name", null);
@@ -197,21 +197,21 @@ function getUploadFields()
     $siteList        = Utility::getSiteList(false);
 
     // Build array of session data to be used in upload media dropdowns
-    $sessionData    = [];
+    $sessionData    = array();
     $sessionRecords = $db->pselect(
         "SELECT c.PSCID, s.Visit_label, s.CenterID, f.Test_name " .
         "FROM candidate c ".
         "LEFT JOIN session s USING(CandID) ".
         "LEFT JOIN flag f ON (s.ID=f.SessionID) ".
         "ORDER BY c.PSCID ASC",
-        []
+        array()
     );
 
     foreach ($sessionRecords as $record) {
 
         // Populate sites
         if (!isset($sessionData[$record["PSCID"]]['sites'])) {
-            $sessionData[$record["PSCID"]]['sites'] = [];
+            $sessionData[$record["PSCID"]]['sites'] = array();
         }
         if ($record["CenterID"] !== null && !in_array(
             $record["CenterID"],
@@ -225,7 +225,7 @@ function getUploadFields()
 
         // Populate visits
         if (!isset($sessionData[$record["PSCID"]]['visits'])) {
-            $sessionData[$record["PSCID"]]['visits'] = [];
+            $sessionData[$record["PSCID"]]['visits'] = array();
         }
         if ($record["Visit_label"] !== null && !in_array(
             $record["Visit_label"],
@@ -242,10 +242,10 @@ function getUploadFields()
         $pscid =$record["PSCID"];
 
         if (!isset($sessionData[$pscid]['instruments'][$visit])) {
-            $sessionData[$pscid]['instruments'][$visit] = [];
+            $sessionData[$pscid]['instruments'][$visit] = array();
         }
         if (!isset($sessionData[$pscid]['instruments']['all'])) {
-            $sessionData[$pscid]['instruments']['all'] = [];
+            $sessionData[$pscid]['instruments']['all'] = array();
         }
 
         if ($record["Test_name"] !== null && !in_array(
@@ -287,11 +287,11 @@ function getUploadFields()
             "hide_file as hideFile, " .
             "m.id FROM media m LEFT JOIN session s ON m.session_id = s.ID " .
             "WHERE m.id = $idMediaFile",
-            []
+            array()
         );
     }
 
-    $result = [
+    $result = array(
                'candidates'  => $candidatesList,
                'candIDs'     => $candIdList,
                'visits'      => $visitList,
@@ -300,7 +300,7 @@ function getUploadFields()
                'mediaData'   => $mediaData,
                'mediaFiles'  => array_values(getFilesList()),
                'sessionData' => $sessionData,
-              ];
+              );
 
     return $result;
 }
@@ -319,7 +319,7 @@ function showError($message)
     }
     header('HTTP/1.1 500 Internal Server Error');
     header('Content-Type: application/json; charset=UTF-8');
-    die(json_encode(['message' => $message]));
+    die(json_encode(array('message' => $message)));
 }
 
 /**
@@ -334,7 +334,7 @@ function showError($message)
  */
 function toSelect($options, $item, $item2)
 {
-    $selectOptions = [];
+    $selectOptions = array();
 
     $optionsValue = $item;
     if (isset($item2)) {
@@ -357,9 +357,9 @@ function toSelect($options, $item, $item2)
 function getFilesList()
 {
     $db       =& Database::singleton();
-    $fileList = $db->pselect("SELECT id, file_name FROM media", []);
+    $fileList = $db->pselect("SELECT id, file_name FROM media", array());
 
-    $mediaFiles = [];
+    $mediaFiles = array();
     foreach ($fileList as $row) {
         $mediaFiles[$row['id']] = $row['file_name'];
     }

--- a/modules/media/php/NDB_Form_media.class.inc
+++ b/modules/media/php/NDB_Form_media.class.inc
@@ -53,7 +53,7 @@ class NDB_Form_Media extends NDB_Form
         if (isset($idMediaFile)) {
             $result = $db->pselectRow(
                 "SELECT id FROM media WHERE id = $idMediaFile",
-                []
+                array()
             );
             if (count($result) < 1) {
                 header('Location: ' . $baseURL . '/media/');
@@ -76,7 +76,7 @@ class NDB_Form_Media extends NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/media/css/media.css"]
+            array($baseURL . "/media/css/media.css")
         );
     }
 
@@ -93,7 +93,7 @@ class NDB_Form_Media extends NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/media/js/editFormIndex.js"]
+            array($baseURL . "/media/js/editFormIndex.js")
         );
     }
 

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -100,23 +100,23 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             $siteList = array('' => 'All User Sites') + $siteList;
         }
 
-        $instrumentList   = [];
+        $instrumentList   = array();
         $instrumentsQuery = $db->pselect(
             "SELECT Test_name, Full_name FROM test_names ORDER BY Test_name",
-            []
+            array()
         );
         foreach ($instrumentsQuery as $instrument) {
             $instrumentList[$instrument['Full_name']] = $instrument['Full_name'];
         }
 
-        $fileTypeList  = [];
-        $fileTypeQuery = $db->pselect("SELECT file_type FROM media", []);
+        $fileTypeList  = array();
+        $fileTypeQuery = $db->pselect("SELECT file_type FROM media", array());
         foreach ($fileTypeQuery as $filetype) {
             $fileTypeList[$filetype['file_type']] = $filetype['file_type'];
         }
 
         // Form Elements
-        $this->addBasicText('pSCID', 'PSCID', ["size" => 9, "maxlength" => 7]);
+        $this->addBasicText('pSCID', 'PSCID', array("size" => 9, "maxlength" => 7));
         $this->addBasicText('fileName', 'File Name');
         $this->addSelect('fileType', 'File type', $fileTypeList);
         $this->addSelect('visitLabel', 'Visit Label', $visitList);
@@ -145,7 +145,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
 
         // set the class variables
         $this->columns
-            = [
+            = array(
                'm.file_name',
                '(SELECT PSCID from candidate WHERE CandID=s.CandID) as pscid',
                's.Visit_label as visit_label',
@@ -159,7 +159,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
                's.CandID as cand_id',
                's.ID as session_id',
                'm.id',
-              ];
+              );
 
         $this->query = $query;
 
@@ -170,7 +170,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
 
         $this->group_by = '';
         $this->order_by = 'm.instrument';
-        $this->headers  = [
+        $this->headers  = array(
                            'File Name',
                            'PSCID',
                            'Visit Label',
@@ -183,28 +183,33 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
                            'File Type',
                            'Cand ID',
                            'Session ID',
-                          ];
+                          );
 
         // Set header as hidden from the data table
-        $this->tpl_data['hiddenHeaders'] = json_encode(['Cand ID', 'Session ID']);
+        $this->tpl_data['hiddenHeaders'] = json_encode(
+            array(
+             'Cand ID',
+             'Session ID',
+            )
+        );
 
         // Add Edit field if user has permissions
         if ($this->hasWritePermission) {
             array_push($this->headers, 'Edit Metadata');
         }
 
-        $this->validFilters = [
+        $this->validFilters = array(
                                'c.PSCID',
                                'm.instrument',
                                's.Visit_label',
                                's.CenterID',
-                              ];
-        $this->formToFilter = [
+                              );
+        $this->formToFilter = array(
                                'pscid'       => 'c.PSCID',
                                'instrument'  => 'm.instrument',
                                'visit_label' => 's.Visit_label',
                                'for_site'    => 's.CenterID',
-                              ];
+                              );
 
         return true;
     }
@@ -236,7 +241,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            [$baseURL . "/media/css/media.css"]
+            array($baseURL . "/media/css/media.css")
         );
     }
 
@@ -252,11 +257,11 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            [
+            array(
              $baseURL . "/js/components/Tabs.js",
              $baseURL . "/js/components/ProgressBar.js",
              $baseURL . "/media/js/mediaIndex.js",
-            ]
+            )
         );
     }
 }

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -204,11 +204,11 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
             array_splice($this->headers, 2, 0, 'Subproject');
         }
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'SeriesUID',
              'Hash',
              'JoinID',
-            ]
+            )
         );
         // Recreating the path (MincFileViolated field) to the minc file
         // for the table mri_violations_log is more complicated

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -195,12 +195,12 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
         }
 
         $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
+            array(
              'SeriesUID',
              'Hash',
              'JoinID',
              'SiteID',
-            ]
+            )
         );
 
         $this->query    = " FROM (

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_check_violations.class.inc
@@ -76,7 +76,7 @@ class NDB_Menu_Filter_Mri_Protocol_Check_Violations extends NDB_Menu_Filter
                            'SeriesUID',
                            'TarchiveID',
                           );
-        $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
+        $this->tpl_data['hiddenHeaders'] = json_encode(array('TarchiveID'));
         $this->validFilters = array(
                                'l.TarchiveID',
                                'l.SeriesUID',
@@ -89,7 +89,7 @@ class NDB_Menu_Filter_Mri_Protocol_Check_Violations extends NDB_Menu_Filter
                                'PatientName' => 'l.PatientName',
                                'CandID'      => 'l.CandID',
                               );
-        $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
+        $this->tpl_data['hiddenHeaders'] = json_encode(array('TarchiveID'));
     }
 
     /**

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
@@ -104,7 +104,7 @@ class NDB_Menu_Mri_Protocol_Violations extends NDB_Menu_Filter
                                'SeriesUID',
                                'TarchiveID',
                               );
-        $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
+        $this->tpl_data['hiddenHeaders'] = json_encode(array('TarchiveID'));
         $this->query        = " FROM mri_protocol_violated_scans mpv
                  LEFT JOIN tarchive ON
                 (mpv.PatientName = tarchive.PatientName) WHERE 1=1";

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -126,7 +126,7 @@ class NDB_Form_New_Profile extends NDB_Form
                            'minYear'        => $startYear - $ageMax,
                            'maxYear'        => $endYear - $ageMin,
                           );
-        $dateAttributes = ['class' => 'form-control input-sm input-date'];
+        $dateAttributes = array('class' => 'form-control input-sm input-date');
 
         // add date of birth
         $this->addBasicDate(

--- a/modules/next_stage/php/NDB_Form_next_stage.class.inc
+++ b/modules/next_stage/php/NDB_Form_next_stage.class.inc
@@ -1,6 +1,7 @@
 <?php
 /**
  * The forms for the start next stage menu
+ *
  * @package main
  */
 class NDB_Form_next_stage extends NDB_Form
@@ -13,7 +14,7 @@ class NDB_Form_next_stage extends NDB_Form
         $timePoint =& TimePoint::singleton($this->identifier);
 
         // check user permissions
-    	if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('CenterIDs'))) {
+        if (!$user->hasPermission('data_entry') || !in_array($timePoint->getData('CenterID'), $user->getData('CenterIDs'))) {
             return false;
         }
         return $timePoint->isStartable();
@@ -44,12 +45,12 @@ class NDB_Form_next_stage extends NDB_Form
         }
 
         // create a new battery object && new battery
-        $battery = new NDB_BVL_Battery;
-        $candidate =& Candidate::singleton($timePoint->getCandID() );
+        $battery   = new NDB_BVL_Battery;
+        $candidate =& Candidate::singleton($timePoint->getCandID());
 
         $firstVisit = false;
-        $vLabel = $candidate->getFirstVisit();//get first visit for candidate
-        if($vLabel ==  $timePoint->getVisitLabel()){
+        $vLabel     = $candidate->getFirstVisit();//get first visit for candidate
+        if($vLabel ==  $timePoint->getVisitLabel()) {
             $firstVisit = true; //if current visit label is same as visit label returned must be first visit
         }
 
@@ -57,14 +58,19 @@ class NDB_Form_next_stage extends NDB_Form
         $battery->selectBattery($timePoint->getData('SessionID'));
 
         // add instruments to the time point (lower case stage)
-        $battery->createBattery($timePoint->getSubprojectID(), $newStage, $timePoint->getVisitLabel(),
-                                $timePoint->getCenterID(), $firstVisit);
+        $battery->createBattery(
+            $timePoint->getSubprojectID(),
+            $newStage,
+            $timePoint->getVisitLabel(),
+            $timePoint->getCenterID(),
+            $firstVisit
+        );
 
         //------------------------------------------------------------
 
-        $this->tpl_data['success'] = true;
+        $this->tpl_data['success']   = true;
         $this->tpl_data['sessionID'] = $this->identifier;
-        $this->tpl_data['candID'] = $timePoint->getCandID();
+        $this->tpl_data['candID']    = $timePoint->getCandID();
 
         // freeze it, just in case
         //$this->form->freeze();
@@ -73,16 +79,16 @@ class NDB_Form_next_stage extends NDB_Form
     function next_stage()
     {
         $timePoint =& TimePoint::singleton($this->identifier);
-        $config =& NDB_Config::singleton();
+        $config    =& NDB_Config::singleton();
 
-        $study = $config->getSetting('study');
+        $study       = $config->getSetting('study');
         $dateOptions = array(
-                             'language'        => 'en',
-                             'format'          => 'YMd',
-                             'addEmptyOption'  => true,
-                             'minYear'         => $study['startYear'],
-                             'maxYear'         => $study['endYear']
-                             );
+                        'language'       => 'en',
+                        'format'         => 'YMd',
+                        'addEmptyOption' => true,
+                        'minYear'        => $study['startYear'],
+                        'maxYear'        => $study['endYear'],
+                       );
 
         $this->addHidden('candID', $timePoint->getData('CandID'));
         $this->addHidden('sessionID', $timePoint->getData('SessionID'));
@@ -96,7 +102,7 @@ class NDB_Form_next_stage extends NDB_Form
             $this->addRule('scan_done', 'Scan done is required', 'required');
         }
 
-        $dateAttributes = ['class' => 'form-control input-sm input-date'];
+        $dateAttributes = array('class' => 'form-control input-sm input-date');
 
         // add dates
         $this->addBasicDate('date1', "Date of $stage", $dateOptions, $dateAttributes);
@@ -121,7 +127,7 @@ class NDB_Form_next_stage extends NDB_Form
         $config =& NDB_Config::singleton();
 
         $timePoint =& TimePoint::singleton($this->identifier);
-        $candID = $timePoint->getCandID();
+        $candID    = $timePoint->getCandID();
 
         $candidate =& Candidate::singleton($candID);
 
@@ -145,7 +151,7 @@ class NDB_Form_next_stage extends NDB_Form
         $stage = $timePoint->getNextStage();
         if ($stage == 'Visit') {
             // compare the dates date of MRI must be > DOB - ONLY WHEN starting Visit stage
-            $date = $values['date1']; 
+            $date = $values['date1'];
 
             if (empty($values['scan_done']) && $config->getSetting('useScanDone')!='false') {
                 $errors['scan_done'] = 'Scan done is required';
@@ -158,7 +164,8 @@ class NDB_Form_next_stage extends NDB_Form
             }
         }
 
-        if(empty($errors)) return true;
+        if(empty($errors)) { return true;
+        }
         return $errors;
     }
 }

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -350,7 +350,7 @@ class Installer
 				ConfigID=(SELECT ID FROM ConfigSettings 
 					WHERE Name=:q_sett)"
         );
-        $prepared->execute(['q_val' => $value, 'q_sett' => $setting]);
+        $prepared->execute(array('q_val' => $value, 'q_sett' => $setting));
     }
 
     /**
@@ -426,10 +426,10 @@ class Installer
 			WHERE user=:q_user AND host=:q_host"
         );
         $userExistsQ->execute(
-            [
+            array(
              'q_user' => $values['lorismysqluser'],
              'q_host' => $connectHost,
-            ]
+            )
         );
         $results    = $userExistsQ->fetchAll(PDO::FETCH_ASSOC);
         $userExists = false;
@@ -521,13 +521,13 @@ class Installer
             . " WHERE ID=1"
         );
         return $stmt->execute(
-            [
+            array(
              'q_userID'   => $values['frontenduser'],
              'q_password' => password_hash(
                  $values['frontendpassword'],
                  PASSWORD_DEFAULT
              ),
-            ]
+            )
         );
     }
 
@@ -556,18 +556,18 @@ class Installer
     {
         $contents = file_get_contents(__DIR__ . "/../../docs/config/config.xml");
         return str_replace(
-            [
+            array(
              '%HOSTNAME%',
              '%USERNAME%',
              '%PASSWORD%',
              '%DATABASE%',
-            ],
-            [
+            ),
+            array(
              $values['dbhost'],
              $values['lorismysqluser'],
              $values['lorismysqlpassword'],
              $values['dbname'],
-            ],
+            ),
             $contents
         );
     }

--- a/php/installer/NDB_Config.class.inc
+++ b/php/installer/NDB_Config.class.inc
@@ -59,9 +59,9 @@ class NDB_Config
         // the base path is used by smarty, so calculate it relative
         // to the current directory. Nothing else needs to be supported.
         if ($setting == "paths") {
-            return [
+            return array(
                     "base" => __DIR__ . "/../../",
-                   ];
+                   );
         }
         return null;
     }

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -39,10 +39,10 @@
 class NDB_BVL_Feedback
 {
     // contains info necessary to structure the object
-    var $_feedbackObjectInfo = [];
+    var $_feedbackObjectInfo = array();
 
     // contains full candidate profile/timepoint/instrument info
-    var $_feedbackCandidateProfileInfo = [];
+    var $_feedbackCandidateProfileInfo = array();
 
     // set of status options
     var $_feedbackStatusOptions = array(


### PR DESCRIPTION
This commit updates the code to disallow PHP 5.4+ short-array syntax, and
require the PHP3 style "array" keyword, after a vote in which it was
determined that a narrow majority of LORIS developers fear change.

Since being consistently wrong is better than being inconsistent, this
is still a slight improvement over the current state where different
people were doing different things.

See also: spaces for indentation.

Note: The code changes in this PR are just the result of updating the standards
XML file and running phpcbf until `test/run-php-linter.sh` stopped complaining.