### PR TITLE
[Tools] installdb.php additional options

### DIFF
--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -158,8 +158,8 @@ case 'createmysqlaccount':
 
     if ($installer->ConfigWritable()) {
         if ($installer->WriteConfig($_POST) === false) {
-            $tpl_data["error"] = $installer->GetLastError();
-            $tpl_data["Page"]  = "MySQLUserPrompt";
+            $tpl_data['error'] = $installer->GetLastError();
+            $tpl_data['Page']  = "MySQLUserPrompt";
             break;
         }
         $tpl_data['configfile'] = $installer->GetBaseDir() . "/project/config.xml";

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -91,82 +91,87 @@ $tpl_data = array();
 // Page 4: 1. Check if user exists -- if so, error, if not create
 //	 2. Update config.xml if write access, otherwise download copy
 switch(isset($_POST["formname"]) ? $_POST["formname"] : "") {
-    case "validaterootaccount":
-        // This will connect to MySQL, check the permissions of the
-        // account provided, check that the database doesn't already
-        // exist, and create the database.
-        if (!isset($_POST["do_not_install"])) {
-            if (!isset($_POST["use_existing_database"])) {
-                if ($installer->CreateMySQLDB($_POST) === false) {
-                    $tpl_data["error"] = $installer->GetLastError();
-                    $tpl_data["Page"]  = "";
-                    break;
-                }
-            }
-            if ($installer->SourceSchema($_POST) === false) {
+case "validaterootaccount":
+    // This will connect to MySQL, check the permissions of the
+    // account provided, check that the database doesn't already
+    // exist, and create the database.
+    if (!isset($_POST["do_not_install"])) {
+        if (!isset($_POST["use_existing_database"])) {
+            if ($installer->CreateMySQLDB($_POST) === false) {
                 $tpl_data["error"] = $installer->GetLastError();
                 $tpl_data["Page"]  = "";
                 break;
             }
         }
-        if (!isset($_POST["do_not_update_config"])) {
-            if ($installer->UpdateBaseConfig($_POST) === false) {
-                $tpl_data["error"] = $installer->GetLastError();
-                $tpl_data["Page"]  = "";
-                break;
-            }
-        }
-        if (!Database::CanLogIn(
-            $_POST['dbhost'], $_POST['dbname'],
-            $_POST['dbadminuser'], $_POST['dbadminpassword']
-        )) {
-            $tpl_data["error"] = "The specified user does not exist or is using an incorrect password or the database does not exist";
+        if ($installer->SourceSchema($_POST) === false) {
+            $tpl_data["error"] = $installer->GetLastError();
             $tpl_data["Page"]  = "";
             break;
         }
-        $tpl_data["Page"] = "MySQLUserPrompt";
-        break;
-    case "createmysqlaccount":
-        if (isset($_POST["lorismysql_already_created"])) {
-            //Verify that it is, indeed, the case.
-            if (!Database::CanLogIn(
-                $_POST["dbhost"], $_POST["dbname"],
-                $_POST["lorismysqluser"], $_POST["lorismysqlpassword"]
-            )) {
-                
-                $tpl_data["error"] = "The specified user does not exist or is using an incorrect password or the database does not exist";
-                $tpl_data["Page"]  = "MySQLUserPrompt";
-                break;
-            }
-        } else {
-            if ($installer->CreateMySQLAccount($_POST) === false) {
-                $tpl_data["error"] = $installer->GetLastError();
-                $tpl_data["Page"]  = "MySQLUserPrompt";
-                break;
-            }
+    }
+    if (!isset($_POST["do_not_update_config"])) {
+        if ($installer->UpdateBaseConfig($_POST) === false) {
+            $tpl_data["error"] = $installer->GetLastError();
+            $tpl_data["Page"]  = "";
+            break;
         }
-        if ($installer->ResetFrontEndAdmin($_POST) === false) {
+    }
+    if (!Database::canLogIn(
+        $_POST['dbhost'],
+        $_POST['dbname'],
+        $_POST['dbadminuser'],
+        $_POST['dbadminpassword']
+    )) {
+        $tpl_data["error"] = "The specified user does not exist or ".
+            "is using an incorrect password or the database does not exist";
+        $tpl_data["Page"]  = "";
+        break;
+    }
+    $tpl_data["Page"] = "MySQLUserPrompt";
+    break;
+case "createmysqlaccount":
+    if (isset($_POST["lorismysql_already_created"])) {
+        //Verify that it is, indeed, the case.
+        if (!Database::canLogIn(
+            $_POST["dbhost"],
+            $_POST["dbname"],
+            $_POST["lorismysqluser"],
+            $_POST["lorismysqlpassword"]
+        )) {
+            $tpl_data["error"] = "The specified user does not exist or ".
+                "is using an incorrect password or the database does not exist";
+            $tpl_data["Page"]  = "MySQLUserPrompt";
+            break;
+        }
+    } else {
+        if ($installer->CreateMySQLAccount($_POST) === false) {
             $tpl_data["error"] = $installer->GetLastError();
             $tpl_data["Page"]  = "MySQLUserPrompt";
             break;
         }
-
-        if ($installer->ConfigWritable()) {
-            if ($installer->WriteConfig($_POST) === false) {
-                $tpl_data["error"] = $installer->GetLastError();
-                $tpl_data["Page"]  = "MySQLUserPrompt";
-                break;
-            }
-            $tpl_data["configfile"] = $installer->GetBaseDir() . "/project/config.xml";
-        } else {
-            $tpl_data["configlocation"] = $installer->GetBaseDir()
-                     . "/project/config.xml";
-            $tpl_data["configcontent"]  = htmlspecialchars(
-                $installer->GetConfigContent($_POST)
-            );
-        }
-        $tpl_data["Page"] = "Done";
+    }
+    if ($installer->ResetFrontEndAdmin($_POST) === false) {
+        $tpl_data["error"] = $installer->GetLastError();
+        $tpl_data["Page"]  = "MySQLUserPrompt";
         break;
+    }
+
+    if ($installer->ConfigWritable()) {
+        if ($installer->WriteConfig($_POST) === false) {
+            $tpl_data["error"] = $installer->GetLastError();
+            $tpl_data["Page"]  = "MySQLUserPrompt";
+            break;
+        }
+        $tpl_data["configfile"] = $installer->GetBaseDir() . "/project/config.xml";
+    } else {
+        $tpl_data["configlocation"] = $installer->GetBaseDir()
+                 . "/project/config.xml";
+        $tpl_data["configcontent"]  = htmlspecialchars(
+            $installer->GetConfigContent($_POST)
+        );
+    }
+    $tpl_data["Page"] = "Done";
+    break;
 }
 $tpl_data["console"] = htmlspecialchars(ob_get_contents());
 

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -90,7 +90,7 @@ $tpl_data = array();
 // Page 3: Help, prompt for new username/password (include defaults)
 // Page 4: 1. Check if user exists -- if so, error, if not create
 //	 2. Update config.xml if write access, otherwise download copy
-switch(isset($_POST["formname"]) ? $_POST["formname"] : "") {
+switch(isset($_POST['formname']) ? $_POST['formname'] : '') {
 case 'validaterootaccount':
     // This will connect to MySQL, check the permissions of the
     // account provided, check that the database doesn't already
@@ -127,7 +127,7 @@ case 'validaterootaccount':
         $tpl_data["Page"]  = "";
         break;
     }
-    $tpl_data["Page"] = "MySQLUserPrompt";
+    $tpl_data['Page'] = 'MySQLUserPrompt';
     break;
 case 'createmysqlaccount':
     if (isset($_POST["lorismysql_already_created"])) {

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -4,7 +4,7 @@
  *
  * It should only be accessed the first time LORIS is installed.
  *
- * Since it"s written in PHP, obviously Apache and PHP are required to be
+ * Since it's written in PHP, obviously Apache and PHP are required to be
  * set up before accessing this page. Nonetheless, it will verify all
  * of the dependencies on the server being installed, create required
  * accounts, and source the schema. Users can either use the NeuroDebian,
@@ -14,19 +14,19 @@
  * this page, because the vendor/autoload.php file is required to load smarty.
  *
  * It does the following:
- *    1. Check if LORIS is already installed (there"s a config.xml
- *       setup), and if so bail to ensure it doesn"t affect an
+ *    1. Check if LORIS is already installed (there's a config.xml
+ *       setup), and if so bail to ensure it doesn't affect an
  *       existing system.
  *    2. Check that the external dependencies are installed (PHP version,
  *       MySQL, etc) and check their versions (if possible.)
  *    3. Prompt for the admin MySQL account to use for setup
- *    4. Check that the LORIS database doesn"t already exist
+ *    4. Check that the LORIS database doesn't already exist
  *    5. Prompt for (and create) the non-root MySQL user
  *    5a. Prompt for and update the LORIS frontend admin account username
  *       and password at the same time.
  *    6. Create the database, MySQL user, source the schema, and
  *       reset the admin username and password in the users table
- *    7. Write the config.xml if possible. If the directory isn"t
+ *    7. Write the config.xml if possible. If the directory isn't
  *       writable, print the content that should go there and ask
  *       the user to manually create the file.
  *
@@ -39,15 +39,15 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-// the installer directory doesn"t get autoloaded by composer, so we
+// the installer directory doesn't get autoloaded by composer, so we
 // need to manually require this.
 require_once __DIR__ . "/../php/installer/Installer.class.inc";
 
-// Since LORIS isn"t configured yet, these classes from the php/
-// directory won"t work. We need stubs for the installer to use, and
-// they need to have the same name so that composer doesn"t try and
-// autoload the ones that we can"t use which try to access config.xml.
-// We don"t need to implement all the functionality, just enough for
+// Since LORIS isn't configured yet, these classes from the php/
+// directory won't work. We need stubs for the installer to use, and
+// they need to have the same name so that composer doesn't try and
+// autoload the ones that we can't use which try to access config.xml.
+// We don't need to implement all the functionality, just enough for
 // smarty to use when it gets autoloaded.
 require_once __DIR__ . "/../php/installer/Database.class.inc";
 require_once __DIR__ . "/../php/installer/NDB_Config.class.inc";
@@ -93,7 +93,7 @@ $tpl_data = array();
 switch(isset($_POST["formname"]) ? $_POST["formname"] : "") {
     case "validaterootaccount":
         // This will connect to MySQL, check the permissions of the
-        // account provided, check that the database doesn"t already
+        // account provided, check that the database doesn't already
         // exist, and create the database.
         if (!isset($_POST["do_not_install"])) {
             if (!isset($_POST["use_existing_database"])) {

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -151,7 +151,7 @@ case 'createmysqlaccount':
         }
     }
     if ($installer->ResetFrontEndAdmin($_POST) === false) {
-        $tpl_data['error"' = $installer->GetLastError();
+        $tpl_data['error'] = $installer->GetLastError();
         $tpl_data['Page']  = "MySQLUserPrompt";
         break;
     }

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -4,7 +4,7 @@
  *
  * It should only be accessed the first time LORIS is installed.
  *
- * Since it's written in PHP, obviously Apache and PHP are required to be
+ * Since it"s written in PHP, obviously Apache and PHP are required to be
  * set up before accessing this page. Nonetheless, it will verify all
  * of the dependencies on the server being installed, create required
  * accounts, and source the schema. Users can either use the NeuroDebian,
@@ -14,19 +14,19 @@
  * this page, because the vendor/autoload.php file is required to load smarty.
  *
  * It does the following:
- *    1. Check if LORIS is already installed (there's a config.xml
- *       setup), and if so bail to ensure it doesn't affect an
+ *    1. Check if LORIS is already installed (there"s a config.xml
+ *       setup), and if so bail to ensure it doesn"t affect an
  *       existing system.
  *    2. Check that the external dependencies are installed (PHP version,
  *       MySQL, etc) and check their versions (if possible.)
  *    3. Prompt for the admin MySQL account to use for setup
- *    4. Check that the LORIS database doesn't already exist
+ *    4. Check that the LORIS database doesn"t already exist
  *    5. Prompt for (and create) the non-root MySQL user
  *    5a. Prompt for and update the LORIS frontend admin account username
  *       and password at the same time.
  *    6. Create the database, MySQL user, source the schema, and
  *       reset the admin username and password in the users table
- *    7. Write the config.xml if possible. If the directory isn't
+ *    7. Write the config.xml if possible. If the directory isn"t
  *       writable, print the content that should go there and ask
  *       the user to manually create the file.
  *
@@ -39,15 +39,15 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-// the installer directory doesn't get autoloaded by composer, so we
+// the installer directory doesn"t get autoloaded by composer, so we
 // need to manually require this.
 require_once __DIR__ . "/../php/installer/Installer.class.inc";
 
-// Since LORIS isn't configured yet, these classes from the php/
-// directory won't work. We need stubs for the installer to use, and
-// they need to have the same name so that composer doesn't try and
-// autoload the ones that we can't use which try to access config.xml.
-// We don't need to implement all the functionality, just enough for
+// Since LORIS isn"t configured yet, these classes from the php/
+// directory won"t work. We need stubs for the installer to use, and
+// they need to have the same name so that composer doesn"t try and
+// autoload the ones that we can"t use which try to access config.xml.
+// We don"t need to implement all the functionality, just enough for
 // smarty to use when it gets autoloaded.
 require_once __DIR__ . "/../php/installer/Database.class.inc";
 require_once __DIR__ . "/../php/installer/NDB_Config.class.inc";
@@ -76,10 +76,10 @@ if ($installer->CheckSystemDependenciesValid() == false) {
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
-ini_set('default_charset', 'utf-8');
+ini_set("default_charset", "utf-8");
 // Create an output buffer to capture console output, separately from the
 // gzip handler.
-//ob_start('ob_gzhandler');
+//ob_start("ob_gzhandler");
 ob_start();
 $tpl_data = array();
 
@@ -90,68 +90,95 @@ $tpl_data = array();
 // Page 3: Help, prompt for new username/password (include defaults)
 // Page 4: 1. Check if user exists -- if so, error, if not create
 //	 2. Update config.xml if write access, otherwise download copy
-switch(isset($_POST['formname']) ? $_POST['formname'] : '') {
-case 'validaterootaccount':
-    // This will connect to MySQL, check the permissions of the
-    // account provided, check that the database doesn't already
-    // exist, and create the database.
-    if ($installer->CreateMySQLDB($_POST) === false) {
-        $tpl_data['error'] = $installer->GetLastError();
-        $tpl_data['Page']  = "";
-        break;
-    }
-    if ($installer->SourceSchema($_POST) === false) {
-        $tpl_data['error'] = $installer->GetLastError();
-        $tpl_data['Page']  = "";
-        break;
-    }
-    if ($installer->UpdateBaseConfig($_POST) === false) {
-        $tpl_data['error'] = $installer->GetLastError();
-        $tpl_data['Page']  = "";
-        break;
-    }
-
-    $tpl_data['Page'] = "MySQLUserPrompt";
-    break;
-case 'createmysqlaccount':
-    if ($installer->CreateMySQLAccount($_POST) === false) {
-        $tpl_data['error'] = $installer->GetLastError();
-        $tpl_data['Page']  = "MySQLUserPrompt";
-        break;
-    }
-
-    if ($installer->ResetFrontEndAdmin($_POST) === false) {
-        $tpl_data['error'] = $installer->GetLastError();
-        $tpl_data['Page']  = "MySQLUserPrompt";
-        break;
-    }
-
-    if ($installer->ConfigWritable()) {
-        if ($installer->WriteConfig($_POST) === false) {
-            $tpl_data['error'] = $installer->GetLastError();
-            $tpl_data['Page']  = "MySQLUserPrompt";
+switch(isset($_POST["formname"]) ? $_POST["formname"] : "") {
+    case "validaterootaccount":
+        // This will connect to MySQL, check the permissions of the
+        // account provided, check that the database doesn"t already
+        // exist, and create the database.
+        if (!isset($_POST["do_not_install"])) {
+            if (!isset($_POST["use_existing_database"])) {
+                if ($installer->CreateMySQLDB($_POST) === false) {
+                    $tpl_data["error"] = $installer->GetLastError();
+                    $tpl_data["Page"]  = "";
+                    break;
+                }
+            }
+            if ($installer->SourceSchema($_POST) === false) {
+                $tpl_data["error"] = $installer->GetLastError();
+                $tpl_data["Page"]  = "";
+                break;
+            }
+        }
+        if (!isset($_POST["do_not_update_config"])) {
+            if ($installer->UpdateBaseConfig($_POST) === false) {
+                $tpl_data["error"] = $installer->GetLastError();
+                $tpl_data["Page"]  = "";
+                break;
+            }
+        }
+        if (!Database::CanLogIn(
+            $_POST['dbhost'], $_POST['dbname'],
+            $_POST['dbadminuser'], $_POST['dbadminpassword']
+        )) {
+            $tpl_data["error"] = "The specified user does not exist or is using an incorrect password or the database does not exist";
+            $tpl_data["Page"]  = "";
             break;
         }
-        $tpl_data['configfile'] = $installer->GetBaseDir() . "/project/config.xml";
-    } else {
-        $tpl_data['configlocation'] = $installer->GetBaseDir()
-                 . "/project/config.xml";
-        $tpl_data['configcontent']  = htmlspecialchars(
-            $installer->GetConfigContent($_POST)
-        );
-    }
-    $tpl_data['Page'] = "Done";
-    break;
+        $tpl_data["Page"] = "MySQLUserPrompt";
+        break;
+    case "createmysqlaccount":
+        if (isset($_POST["lorismysql_already_created"])) {
+            //Verify that it is, indeed, the case.
+            if (!Database::CanLogIn(
+                $_POST["dbhost"], $_POST["dbname"],
+                $_POST["lorismysqluser"], $_POST["lorismysqlpassword"]
+            )) {
+                
+                $tpl_data["error"] = "The specified user does not exist or is using an incorrect password or the database does not exist";
+                $tpl_data["Page"]  = "MySQLUserPrompt";
+                break;
+            }
+        } else {
+            if ($installer->CreateMySQLAccount($_POST) === false) {
+                $tpl_data["error"] = $installer->GetLastError();
+                $tpl_data["Page"]  = "MySQLUserPrompt";
+                break;
+            }
+        }
+        if ($installer->ResetFrontEndAdmin($_POST) === false) {
+            $tpl_data["error"] = $installer->GetLastError();
+            $tpl_data["Page"]  = "MySQLUserPrompt";
+            break;
+        }
+
+        if ($installer->ConfigWritable()) {
+            if ($installer->WriteConfig($_POST) === false) {
+                $tpl_data["error"] = $installer->GetLastError();
+                $tpl_data["Page"]  = "MySQLUserPrompt";
+                break;
+            }
+            $tpl_data["configfile"] = $installer->GetBaseDir() . "/project/config.xml";
+        } else {
+            $tpl_data["configlocation"] = $installer->GetBaseDir()
+                     . "/project/config.xml";
+            $tpl_data["configcontent"]  = htmlspecialchars(
+                $installer->GetConfigContent($_POST)
+            );
+        }
+        $tpl_data["Page"] = "Done";
+        break;
 }
-$tpl_data['console'] = htmlspecialchars(ob_get_contents());
+$tpl_data["console"] = htmlspecialchars(ob_get_contents());
 
 // Set up some special smarty variables that are required on different
 // pages
-if ($tpl_data['Page'] == 'MySQLUserPrompt') {
-    $tpl_data['SamplePassword']  = User::newPassword(16);
-    $tpl_data['SamplePassword2'] = User::newPassword(16);
-} else if ($tpl_data['Page'] == "Done") {
-    $tpl_data['lorisurl'] = $installer->getBaseURL();
+if (isset($tpl_data["Page"])) {
+    if ($tpl_data["Page"] == "MySQLUserPrompt") {
+        $tpl_data["SamplePassword"]  = User::newPassword(16);
+        $tpl_data["SamplePassword2"] = User::newPassword(16);
+    } else if ($tpl_data["Page"] == "Done") {
+        $tpl_data["lorisurl"] = $installer->getBaseURL();
+    }
 }
 // end ob_start that captures console output. The Smarty hook
 // needs to be able to write to the client.
@@ -171,7 +198,7 @@ function tplvar($name)
     if (isset($_REQUEST[$name])) {
         $tpl_data[$name] = $_REQUEST[$name];
     } else {
-        $tpl_data[$name] = '';
+        $tpl_data[$name] = "";
     }
 }
 tplvar("dbhost");
@@ -182,9 +209,13 @@ tplvar("lorismysqluser");
 tplvar("lorismysqlpassword");
 tplvar("frontenduser");
 tplvar("frontendpassword");
+tplvar("use_existing_database");
+tplvar("do_not_install");
+tplvar("do_not_update_config");
+tplvar("lorismysql_already_created");
 $smarty = new Smarty_NeuroDB;
 $smarty->assign($tpl_data);
-$smarty->display('install.tpl');
+$smarty->display("install.tpl");
 
 //ob_end_flush();
 ?>

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -76,10 +76,10 @@ if ($installer->CheckSystemDependenciesValid() == false) {
 
 require_once __DIR__ . "/../vendor/autoload.php";
 
-ini_set("default_charset", "utf-8");
+ini_set('default_charset', 'utf-8');
 // Create an output buffer to capture console output, separately from the
 // gzip handler.
-//ob_start("ob_gzhandler");
+//ob_start('ob_gzhandler');
 ob_start();
 $tpl_data = array();
 
@@ -91,7 +91,7 @@ $tpl_data = array();
 // Page 4: 1. Check if user exists -- if so, error, if not create
 //	 2. Update config.xml if write access, otherwise download copy
 switch(isset($_POST["formname"]) ? $_POST["formname"] : "") {
-case "validaterootaccount":
+case 'validaterootaccount':
     // This will connect to MySQL, check the permissions of the
     // account provided, check that the database doesn't already
     // exist, and create the database.
@@ -129,7 +129,7 @@ case "validaterootaccount":
     }
     $tpl_data["Page"] = "MySQLUserPrompt";
     break;
-case "createmysqlaccount":
+case 'createmysqlaccount':
     if (isset($_POST["lorismysql_already_created"])) {
         //Verify that it is, indeed, the case.
         if (!Database::canLogIn(

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -127,7 +127,7 @@ case 'validaterootaccount':
         $tpl_data["Page"]  = "";
         break;
     }
-    $tpl_data['Page'] = 'MySQLUserPrompt';
+    $tpl_data['Page'] = "MySQLUserPrompt";
     break;
 case 'createmysqlaccount':
     if (isset($_POST["lorismysql_already_created"])) {
@@ -151,8 +151,8 @@ case 'createmysqlaccount':
         }
     }
     if ($installer->ResetFrontEndAdmin($_POST) === false) {
-        $tpl_data["error"] = $installer->GetLastError();
-        $tpl_data["Page"]  = "MySQLUserPrompt";
+        $tpl_data['error"' = $installer->GetLastError();
+        $tpl_data['Page']  = "MySQLUserPrompt";
         break;
     }
 
@@ -162,18 +162,18 @@ case 'createmysqlaccount':
             $tpl_data["Page"]  = "MySQLUserPrompt";
             break;
         }
-        $tpl_data["configfile"] = $installer->GetBaseDir() . "/project/config.xml";
+        $tpl_data['configfile'] = $installer->GetBaseDir() . "/project/config.xml";
     } else {
-        $tpl_data["configlocation"] = $installer->GetBaseDir()
+        $tpl_data['configlocation'] = $installer->GetBaseDir()
                  . "/project/config.xml";
-        $tpl_data["configcontent"]  = htmlspecialchars(
+        $tpl_data['configcontent']  = htmlspecialchars(
             $installer->GetConfigContent($_POST)
         );
     }
-    $tpl_data["Page"] = "Done";
+    $tpl_data['Page'] = "Done";
     break;
 }
-$tpl_data["console"] = htmlspecialchars(ob_get_contents());
+$tpl_data['console'] = htmlspecialchars(ob_get_contents());
 
 // Set up some special smarty variables that are required on different
 // pages
@@ -203,7 +203,7 @@ function tplvar($name)
     if (isset($_REQUEST[$name])) {
         $tpl_data[$name] = $_REQUEST[$name];
     } else {
-        $tpl_data[$name] = "";
+        $tpl_data[$name] = '';
     }
 }
 tplvar("dbhost");
@@ -220,7 +220,7 @@ tplvar("do_not_update_config");
 tplvar("lorismysql_already_created");
 $smarty = new Smarty_NeuroDB;
 $smarty->assign($tpl_data);
-$smarty->display("install.tpl");
+$smarty->display('install.tpl');
 
 //ob_end_flush();
 ?>

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -43,79 +43,102 @@ class Database
         }
         return $DB;
     }
-    
-    /*
-     * @see https://dev.mysql.com/doc/refman/5.7/en/show-grants.html
+
+    /**
+     * On executing `SHOW GRANT;`, rows with a single column are returned.
+     * Each row's value is a string that lists the MySQL user's privileges for
+     * a given table.
+     *
      * @param string $raw The string of each row returned by `SHOW GRANT;`
-     * @return object The parsed privilege for a given string returned by `SHOW GRANT;`
+     *
+     * @see https://dev.mysql.com/doc/refman/5.7/en/show-grants.html
+     *
+     * @return object The parsed privilege for a string returned by `SHOW GRANT;`
      */
-    private function parsePrivilege ($raw) {
+    private function _parsePrivilege($raw)
+    {
         $token_arr = explode(" ON ", $raw);
         if (count($token_arr) != 2) {
             //Avoid letting the user see the "privileges", output to error_log()
-            error_log("Database::parsePrivilege(): Received {$raw}, could not split in half");
+            error_log(
+                "Database::_parsePrivilege():Received {$raw}, could not split in two"
+            );
             throw new Exception("Could not parse privilege");
         }
         $database_table_end = strpos($token_arr[1], " ");
-        $database_table = substr($token_arr[1], 0, $database_table_end);
-        
+        $database_table     = substr($token_arr[1], 0, $database_table_end);
+
         $privilege_arr_raw = substr($token_arr[0], strlen("GRANT "));
-        $privilege_arr = explode(", ", $privilege_arr_raw);
-        
+        $privilege_arr     = explode(", ", $privilege_arr_raw);
+
         return (object)array(
-            "database_table"=>$database_table,
-            "privilege_arr" =>$privilege_arr,
-        );
+                        "database_table" => $database_table,
+                        "privilege_arr"  => $privilege_arr,
+                       );
     }
-    private $privileges = null;
+    private $_privileges = null;
     /**
-     * @see https://dev.mysql.com/doc/refman/5.7/en/show-grants.html
-     * @return array An associative array mapping "`<database>`.`<table>`" strings to an array of privileges
+     * Fetches and caches all the current MySQL user's privileges.
+     * Subsequent calls return a cached copy.
+     *
+     * @see    https://dev.mysql.com/doc/refman/5.7/en/show-grants.html
+     * @return array An associative array mapping "`<database>`.`<table>`" strings
+     *               to an array of privileges
      */
-    public function getOrFetchAllPrivileges () {
-        if (is_null($this->privileges)) {
+    public function getOrFetchAllPrivileges()
+    {
+        if (is_null($this->_privileges)) {
             $stmt = $this->PDO->query("SHOW GRANTS");
             $arr  = $stmt->fetchAll(PDO::FETCH_COLUMN);
             $stmt->closeCursor();
-            
-            $this->privileges = array();
+
+            $this->_privileges = array();
             foreach ($arr as $raw) {
-                $obj = $this->parsePrivilege($raw);
-                $this->privileges[$obj->database_table] = $obj->privilege_arr;
+                $obj = $this->_parsePrivilege($raw);
+                $this->_privileges[$obj->database_table] = $obj->privilege_arr;
             }
         }
-        return $this->privileges;
+        return $this->_privileges;
     }
     /**
-     * @see https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html ; Table 6.2 Permissible Privileges for GRANT and REVOKE; "Privilege" column
-     * @param  string $database
-     * @param  string $table
-     * @param  string $privilege A string representing the privilege
-     * @return bool Returns true if the current MySQL user has the specified privilege
+     * Checks if the current MySQL user has the specified privilege.
+     *
+     * @param string $database  The database to check
+     * @param string $table     The table to check
+     * @param string $privilege A string representing the privilege
+     *
+     * @see https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html
+     *      Table 6.2 Permissible Privileges for GRANT and REVOKE; "Privilege" column
+     *
+     * @return bool Returns true if current MySQL user has the specified privilege
      */
-    public function hasPrivilege ($database, $table, $privilege) {
+    public function hasPrivilege($database, $table, $privilege)
+    {
         $arr = $this->getOrFetchAllPrivileges();
         if (!isset($arr[$database_table])) {
             return false;
         }
-        
+
         $database_escaped = ($database == "*") ?
             "*" : "`{$database}`";
-        $table_escaped = ($table == "*") ?
+        $table_escaped    = ($table == "*") ?
             "*" : "`{$table}`";
-        $database_table = "{$database_escaped}.{$table_escaped}";
+        $database_table   = "{$database_escaped}.{$table_escaped}";
         if (isset($arr[$database_table])) {
             $privilege_arr = $arr[$database_table];
-            //@see https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html#priv_all
-            if (
-                in_array("ALL", $privilege_arr) ||
-                in_array("ALL PRIVILEGES", $privilege_arr) ||
-                in_array($privilege, $privilege_arr)
+            /*
+            This passes phpcs. Putting the URL on a single-line comment
+            will make it fail. Thank you, phpcs.
+            https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html#priv_all
+            */
+            if (in_array("ALL", $privilege_arr)
+                || in_array("ALL PRIVILEGES", $privilege_arr)
+                || in_array($privilege, $privilege_arr)
             ) {
                 return true;
             }
         }
-        
+
         //Privilege was not found at this level, try to look higher
         //@see https://dev.mysql.com/doc/refman/5.7/en/grant.html
         if ($table == "*") {
@@ -135,8 +158,16 @@ class Database
             return $this->hasPrivilege($database, "*", $privilege);
         }
     }
-    
-    public function databaseExists ($database) {
+
+    /**
+     * Checks if the database exists
+     *
+     * @param bool $database The database name
+     *
+     * @return bool Returns true if the database exists
+     */
+    public function databaseExists($database)
+    {
         $exists = $this->PDO->query("SHOW DATABASES LIKE '$database'")
             ->fetch(PDO::FETCH_ASSOC);
         // this needs to be !empty, because otherwise if there's
@@ -147,7 +178,18 @@ class Database
         return !empty($exists);
     }
 
-    public static function CanLogIn ($host, $database, $username, $password) {
+    /**
+     * Checks if we can access the database with the given info
+     *
+     * @param string $host     The host
+     * @param string $database The database
+     * @param string $username The username
+     * @param string $password The password
+     *
+     * @return bool Returns true of the user can log in with the given info
+     */
+    public static function canLogIn($host, $database, $username, $password)
+    {
         try {
             $test = new PDO(
                 "mysql:host={$host};dbname={$database};charset=UTF8",
@@ -170,11 +212,11 @@ class Database
      * script are satisfied while we're connecting. This will only happen
      * once.
      *
-     * @param string $database     The database to be created
-     * @param string $username     The username to connect as
-     * @param string $password     The password to connect with
-     * @param string $host         The hostname that the SQL server is running
-     *                             on.
+     * @param string $database The database to be created
+     * @param string $username The username to connect as
+     * @param string $password The password to connect with
+     * @param string $host     The hostname that the SQL server is running
+     *                         on.
      *
      * @return bool true on success, false on failure.
      */
@@ -194,10 +236,9 @@ class Database
 
             if (!$this->hasPrivilege("*", "*", "CREATE")) {
                 if ($this->databaseExists($database)) {
-                     $this->lastErr ="
-                        User does not have create database privileges but the database `{$database}` already exists.
-                        Consider checking the 'use existing database checkbox'.
-                    ";
+                     $this->lastErr = "User does not have create database ".
+                        "privileges but the database `{$database}` already exists.".
+                        "Consider checking the 'use existing database checkbox'.";
                 } else {
                      $this->lastErr = "User does not have create database "
                     . "privileges; cannot create `{$database}`";
@@ -236,25 +277,27 @@ class Database
     ) {
         if ($this->isConnected() === true) {
             if (!$this->databaseExists($database)) {
-                $this->lastErr = "Database `{$database}` does not exist; consider creating it first";
+                $this->lastErr = "Database `{$database}` does not ".
+                    "exist; consider creating it first";
                 return false;
-             }
-             $this->PDO->exec("USE $database");
+            }
+            $this->PDO->exec("USE $database");
             return true;
         }
         try {
-             $this->PDO = new PDO(
-                 "mysql:host=$host;charset=UTF8",
-                 $username,
-                 $password
-             );
-             $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
-             if (!$this->databaseExists($database)) {
-                $this->lastErr = "Database `{$database}` does not exist; consider creating it first";
+            $this->PDO = new PDO(
+                "mysql:host=$host;charset=UTF8",
+                $username,
+                $password
+            );
+            $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+            if (!$this->databaseExists($database)) {
+                $this->lastErr = "Database `{$database}` does not exist; ".
+                    "consider creating it first";
                 return false;
-             }
-             $this->PDO->exec("USE $database");
-             return true;
+            }
+            $this->PDO->exec("USE $database");
+            return true;
         } catch(Exception $e) {
             $this->lastErr = "Exceptional error connecting to the database "
             . $database . ".";

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -31,6 +31,11 @@ class Database
     public $PDO;
 
     /**
+     * Not meant to be used outside of getOrFetchAllPrivileges()
+     */
+    private $_privileges = null;
+
+    /**
      * Returns one and only one Database object.
      *
      * @return Database
@@ -76,7 +81,7 @@ class Database
                         "privilege_arr"  => $privilege_arr,
                        );
     }
-    private $_privileges = null;
+
     /**
      * Fetches and caches all the current MySQL user's privileges.
      * Subsequent calls return a cached copy.
@@ -100,6 +105,7 @@ class Database
         }
         return $this->_privileges;
     }
+
     /**
      * Checks if the current MySQL user has the specified privilege.
      *
@@ -127,8 +133,6 @@ class Database
         if (isset($arr[$database_table])) {
             $privilege_arr = $arr[$database_table];
             /*
-            This passes phpcs. Putting the URL on a single-line comment
-            will make it fail. Thank you, phpcs.
             https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html#priv_all
             */
             if (in_array("ALL", $privilege_arr)
@@ -201,6 +205,7 @@ class Database
             return false;
         }
     }
+
     /**
      * This wrapper connects differently than the normal database wrapper.
      * Instead of connecting to a database, it will connect to the server,

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -43,7 +43,122 @@ class Database
         }
         return $DB;
     }
+    
+    /*
+     * @see https://dev.mysql.com/doc/refman/5.7/en/show-grants.html
+     * @param string $raw The string of each row returned by `SHOW GRANT;`
+     * @return object The parsed privilege for a given string returned by `SHOW GRANT;`
+     */
+    private function parsePrivilege ($raw) {
+        $token_arr = explode(" ON ", $raw);
+        if (count($token_arr) != 2) {
+            //Avoid letting the user see the "privileges", output to error_log()
+            error_log("Database::parsePrivilege(): Received {$raw}, could not split in half");
+            throw new Exception("Could not parse privilege");
+        }
+        $database_table_end = strpos($token_arr[1], " ");
+        $database_table = substr($token_arr[1], 0, $database_table_end);
+        
+        $privilege_arr_raw = substr($token_arr[0], strlen("GRANT "));
+        $privilege_arr = explode(", ", $privilege_arr_raw);
+        
+        return (object)array(
+            "database_table"=>$database_table,
+            "privilege_arr" =>$privilege_arr,
+        );
+    }
+    private $privileges = null;
+    /**
+     * @see https://dev.mysql.com/doc/refman/5.7/en/show-grants.html
+     * @return array An associative array mapping "`<database>`.`<table>`" strings to an array of privileges
+     */
+    public function getOrFetchAllPrivileges () {
+        if (is_null($this->privileges)) {
+            $stmt = $this->PDO->query("SHOW GRANTS");
+            $arr  = $stmt->fetchAll(PDO::FETCH_COLUMN);
+            $stmt->closeCursor();
+            
+            $this->privileges = array();
+            foreach ($arr as $raw) {
+                $obj = $this->parsePrivilege($raw);
+                $this->privileges[$obj->database_table] = $obj->privilege_arr;
+            }
+        }
+        return $this->privileges;
+    }
+    /**
+     * @see https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html ; Table 6.2 Permissible Privileges for GRANT and REVOKE; "Privilege" column
+     * @param  string $database
+     * @param  string $table
+     * @param  string $privilege A string representing the privilege
+     * @return bool Returns true if the current MySQL user has the specified privilege
+     */
+    public function hasPrivilege ($database, $table, $privilege) {
+        $arr = $this->getOrFetchAllPrivileges();
+        if (!isset($arr[$database_table])) {
+            return false;
+        }
+        
+        $database_escaped = ($database == "*") ?
+            "*" : "`{$database}`";
+        $table_escaped = ($table == "*") ?
+            "*" : "`{$table}`";
+        $database_table = "{$database_escaped}.{$table_escaped}";
+        if (isset($arr[$database_table])) {
+            $privilege_arr = $arr[$database_table];
+            //@see https://dev.mysql.com/doc/refman/5.5/en/privileges-provided.html#priv_all
+            if (
+                in_array("ALL", $privilege_arr) ||
+                in_array("ALL PRIVILEGES", $privilege_arr) ||
+                in_array($privilege, $privilege_arr)
+            ) {
+                return true;
+            }
+        }
+        
+        //Privilege was not found at this level, try to look higher
+        //@see https://dev.mysql.com/doc/refman/5.7/en/grant.html
+        if ($table == "*") {
+            if ($database == "*") {
+                //*.*
+                //Already checked the highest level and privilege was not found
+                return false;
+            } else {
+                //`<database>`.*
+                return $this->hasPrivilege("*", "*", $privilege);
+            }
+        } else if ($database == "*") {
+            //*.`<table>` makes no sense.
+            throw new Exception("Invalid database-table combination");
+        } else {
+            //`<database>`.`<table>`
+            return $this->hasPrivilege($database, "*", $privilege);
+        }
+    }
+    
+    public function databaseExists ($database) {
+        $exists = $this->PDO->query("SHOW DATABASES LIKE '$database'")
+            ->fetch(PDO::FETCH_ASSOC);
+        // this needs to be !empty, because otherwise if there's
+        // no results returned count($dbexists) == 1 when no
+        // results are returned, because the result isn't an array
+        // Something to do with how the Countable interface is
+        // implemented in PHP..
+        return !empty($exists);
+    }
 
+    public static function CanLogIn ($host, $database, $username, $password) {
+        try {
+            $test = new PDO(
+                "mysql:host={$host};dbname={$database};charset=UTF8",
+                $username,
+                $password
+            );
+            return true;
+        } catch (Exception $ex) {
+            return false;
+        }
+    }
     /**
      * This wrapper connects differently than the normal database wrapper.
      * Instead of connecting to a database, it will connect to the server,
@@ -60,8 +175,6 @@ class Database
      * @param string $password     The password to connect with
      * @param string $host         The hostname that the SQL server is running
      *                             on.
-     * @param bool   $trackChanges Unused. For signature compatibility with the
-     *                             "real" Database class.
      *
      * @return bool true on success, false on failure.
      */
@@ -69,8 +182,7 @@ class Database
         $database,
         $username,
         $password,
-        $host,
-        $trackChanges = true
+        $host
     ) {
         try {
             $this->PDO = new PDO(
@@ -80,42 +192,16 @@ class Database
             );
             $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
 
-            $userperms = $this->PDO->query(
-                "SELECT
-                   Create_user_priv, Create_priv
-                 FROM `mysql`.`user`
-                 WHERE CONCAT(user, '@', host)=CURRENT_USER"
-            );
-
-            $userperms = $userperms->fetchall(PDO::FETCH_ASSOC);
-
-            if (count($userperms) != 1) {
-                $this->lastErr = "Error retrieving user permissions for $username.";
-                return false;
-            }
-
-            $userperms = $userperms[0];
-            if ($userperms['Create_priv'] != 'Y') {
-                $this->lastErr = "User does not have create "
-                . "privileges.";
-                return false;
-            }
-            if ($userperms['Create_user_priv'] != 'Y') {
-                $this->lastErr = "Specified user can not create new "
-                ." user for LORIS to connect as.";
-                return false;
-            }
-
-            $dbexists = $this->PDO->query("SHOW DATABASES LIKE '$database'")
-                ->fetch(PDO::FETCH_ASSOC);
-            // this needs to be !empty, because otherwise if there's
-            // no results returned count($dbexists) == 1 when no
-            // results are returned, because the result isn't an array
-            // Something to do with how the Countable interface is
-            // implemented in PHP..
-            if (!empty($dbexists)) {
-                $this->lastErr = "Database $database already exists."
-                . " Can only install new databases.";
+            if (!$this->hasPrivilege("*", "*", "CREATE")) {
+                if ($this->databaseExists($database)) {
+                     $this->lastErr ="
+                        User does not have create database privileges but the database `{$database}` already exists.
+                        Consider checking the 'use existing database checkbox'.
+                    ";
+                } else {
+                     $this->lastErr = "User does not have create database "
+                    . "privileges; cannot create `{$database}`";
+                }
                 return false;
             }
 
@@ -125,9 +211,6 @@ class Database
         } catch(Exception $e) {
             return false;
         }
-        // should be inaccessible, but include it just in case we
-        // somehow get here.
-        return false;
     }
 
     /**
@@ -152,15 +235,25 @@ class Database
         $trackChanges = true
     ) {
         if ($this->isConnected() === true) {
+            if (!$this->databaseExists($database)) {
+                $this->lastErr = "Database `{$database}` does not exist; consider creating it first";
+                return false;
+             }
+             $this->PDO->exec("USE $database");
             return true;
         }
         try {
              $this->PDO = new PDO(
-                 "mysql:host=$host;dbname=$database;charset=UTF8",
+                 "mysql:host=$host;charset=UTF8",
                  $username,
                  $password
              );
              $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+             if (!$this->databaseExists($database)) {
+                $this->lastErr = "Database `{$database}` does not exist; consider creating it first";
+                return false;
+             }
+             $this->PDO->exec("USE $database");
              return true;
         } catch(Exception $e) {
             $this->lastErr = "Exceptional error connecting to the database "

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -387,13 +387,12 @@ class Installer
     function createMySQLAccount($values)
     {
         $DB = Database::singleton();
-        if (
-            $DB->connect(
-                $values['dbname'],
-                $values['dbadminuser'],
-                $values['dbadminpassword'],
-                $values['dbhost']
-            ) == false
+        if ($DB->connect(
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) == false
         ) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
@@ -449,9 +448,11 @@ class Installer
             // (the MySQL Password() function has been deprecated,
             // so we can't rely on it to select a hash from the mysql.user
             // table and compare.)
-            if (Database::CanLogIn(
-                $values["dbhost"], $values["dbname"],
-                $values["lorismysqluser"], $values["lorismysqlpassword"]
+            if (Database::canLogIn(
+                $values["dbhost"],
+                $values["dbname"],
+                $values["lorismysqluser"],
+                $values["lorismysqlpassword"]
             )) {
                 // the user already exists and the password is valid.
                 // we don't need to go any further than this.
@@ -465,7 +466,7 @@ class Installer
                 return false;
             }
         }
-        
+
         if (!$DB->hasPrivilege("*", "*", "CREATE USER")) {
             $this->_lastErr = "User does not have privilege to create "
                 . "a mysql user.";

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -187,7 +187,6 @@ class Installer
             return false;
         }
         $DB = Database::singleton();
-        error_log("createMySQLDB-A");
         if ($DB->connectAndCreate(
             $values['dbname'],
             $values['dbadminuser'],
@@ -195,20 +194,15 @@ class Installer
             $values['dbhost']
         ) == false
         ) {
-            error_log("createMySQLDB-B");
             if (!empty($DB->lastErr)) {
-                error_log("createMySQLDB-C");
                 $this->_lastErr = $DB->lastErr;
             } else {
-                error_log("createMySQLDB-D");
                 $this->_lastErr = "Could not connect to MySQL server "
                 . "and create database with credentials provided.";
             }
-            error_log("createMySQLDB-E");
             return false;
 
         }
-        error_log("createMySQLDB-F");
         return true;
     }
 

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -187,6 +187,7 @@ class Installer
             return false;
         }
         $DB = Database::singleton();
+        error_log("createMySQLDB-A");
         if ($DB->connectAndCreate(
             $values['dbname'],
             $values['dbadminuser'],
@@ -194,15 +195,20 @@ class Installer
             $values['dbhost']
         ) == false
         ) {
+            error_log("createMySQLDB-B");
             if (!empty($DB->lastErr)) {
+                error_log("createMySQLDB-C");
                 $this->_lastErr = $DB->lastErr;
             } else {
+                error_log("createMySQLDB-D");
                 $this->_lastErr = "Could not connect to MySQL server "
                 . "and create database with credentials provided.";
             }
+            error_log("createMySQLDB-E");
             return false;
 
         }
+        error_log("createMySQLDB-F");
         return true;
     }
 
@@ -387,12 +393,13 @@ class Installer
     function createMySQLAccount($values)
     {
         $DB = Database::singleton();
-        if ($DB->connect(
-            $values['dbname'],
-            $values['dbadminuser'],
-            $values['dbadminpassword'],
-            $values['dbhost']
-        ) == false
+        if (
+            $DB->connect(
+                $values['dbname'],
+                $values['dbadminuser'],
+                $values['dbadminpassword'],
+                $values['dbhost']
+            ) == false
         ) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
@@ -403,6 +410,11 @@ class Installer
             return false;
         }
 
+        if (!$DB->hasPrivilege("mysql", "user", "SELECT")) {
+            $this->_lastErr = "User does not have privilege to check if "
+                . "a mysql user exists.";
+            return false;
+        }
         // This script is being run by the web server, so get the host
         // that the current user is connect from to be the host of the
         // new user, since the new user is also going to be used from
@@ -443,17 +455,14 @@ class Installer
             // (the MySQL Password() function has been deprecated,
             // so we can't rely on it to select a hash from the mysql.user
             // table and compare.)
-            try {
-                $test = new PDO(
-                    "mysql:host=$values[dbhost];dbname=$values[dbname];charset=UTF8",
-                    $values['lorismysqluser'],
-                    $values['lorismysqlpassword']
-                );
-
+            if (Database::CanLogIn(
+                $values["dbhost"], $values["dbname"],
+                $values["lorismysqluser"], $values["lorismysqlpassword"]
+            )) {
                 // the user already exists and the password is valid.
                 // we don't need to go any further than this.
                 return true;
-            } catch(Exception $e) {
+            } else {
                 // the user already exists but we couldn't connect as it.
                 $this->_lastErr = "MySQL user $quotedUser already exists and "
                 . " password does not match or it does not"
@@ -462,7 +471,12 @@ class Installer
                 return false;
             }
         }
-
+        
+        if (!$DB->hasPrivilege("*", "*", "CREATE USER")) {
+            $this->_lastErr = "User does not have privilege to create "
+                . "a mysql user.";
+            return false;
+        }
         // The user does not exist and needs to be created
         $DB->PDO->exec(
             "CREATE USER $quotedUser IDENTIFIED BY " .

--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -43,19 +43,30 @@
 			<fieldset>
 				<legend>LORIS MySQL User</legend>
 			<div>
-				<label for="lorisuser">Username: <input type="text" name="lorismysqluser" placeholder="ie. lorisuser" value="{$lorismysqluser}">
+				<label for="lorismysqluser">Username: <input type="text" name="lorismysqluser" placeholder="ie. lorisuser" value="{$lorismysqluser}">
 			</div>
 			<div>
-				<label for="lorispassword">Password: <input type="password" value="{$lorismysqlpassword}" name="lorismysqlpassword" placeholder="ie. LORISISTHEBEST!!!1">
+				<label for="lorismysqlpassword">Password: <input type="password" value="{$lorismysqlpassword}" name="lorismysqlpassword" placeholder="ie. LORISISTHEBEST!!!1">
+			</div>
+			<div>
+				<label for="lorismysql_already_created">Already Created:
+                <input type="checkbox" name="lorismysql_already_created" value="on" {($lorismysql_already_created == 'on') ? 'checked' : ''}/>
 			</div>
 			</fieldset>
+            <hr/>
+            <div>
+                Check "<strong>Already Created</strong>" only if the appropriate mysql user has already been created!<br/>
+                If you or the web admin wish to give the appropriate privileges to an existing MySQL user, <br/>
+                the privileges are <code>UPDATE, INSERT, SELECT, DELETE, CREATE TEMPORARY TABLES</code><br/>
+                for the following: <code>`{$dbname}`.*</code>
+            </div>
 			<fieldset>
 				<legend>LORIS Front End Admin</legend>
 			<div>
-				<label for="lorisuser">Username: <input type="text" name="frontenduser" placeholder="ie. myname" value="{$frontenduser}">
+				<label for="frontenduser">Username: <input type="text" name="frontenduser" placeholder="ie. myname" value="{$frontenduser}">
 			</div>
 			<div>
-				<label for="lorisuser">Password: <input type="password" name="frontendpassword" placeholder="ie. LORISISSTILLTHEBEST!!1" value="{$frontendpassword}">
+				<label for="frontendpassword">Password: <input type="password" name="frontendpassword" placeholder="ie. LORISISSTILLTHEBEST!!1" value="{$frontendpassword}">
 			</div>
 			</fieldset>
 			<input type="hidden" name="formname"        value="createmysqlaccount" />
@@ -149,6 +160,40 @@
 				</div>
 				<div class="col-md-10">
 					<input id="dbname" value="{if $dbname}{$dbname}{else}LORIS{/if}" type="text" name="dbname">
+				</div>
+			</div>
+			<div>
+				<div class="col-md-2">
+					<label for="use_existing_database">Use Existing Database:</label>
+				</div>
+				<div class="col-md-9">
+					<input type="checkbox" id="use_existing_database" name="use_existing_database" value="on" {($use_existing_database == 'on') ? 'checked' : ''}/>
+                    Check this if the database already exists but does not have Loris installed yet
+                    <!--The following is a hack to get the UI to align correctly *shrug*-->
+                    <div style="height:10px;">&nbsp;</div>
+				</div>
+			</div>
+			<div>
+				<div class="col-md-2">
+					<label for="do_not_install">Do Not Install:</label>
+				</div>
+				<div class="col-md-10">
+					<input type="checkbox" id="do_not_install" name="do_not_install" value="on" {($do_not_install == 'on') ? 'checked' : ''}/>
+                    Check this if you already installed Loris at the specified database
+                    <!--The following is a hack to get the UI to align correctly *shrug*-->
+                    <div style="height:10px;">&nbsp;</div>
+				</div>
+			</div>
+			<div>
+				<div class="col-md-2">
+					<label for="do_not_update_config">Do Not Update Configuration:</label>
+				</div>
+				<div class="col-md-10">
+					<input type="checkbox" id="do_not_update_config" name="do_not_update_config" value="on" {($do_not_update_config == 'on') ? 'checked' : ''}/>
+                    Check this if you don't want to update the configuration.
+                    <em>(You really should update the configuration if possible, though)</em>
+                    <!--The following is a hack to get the UI to align correctly *shrug*-->
+                    <div style="height:10px;">&nbsp;</div>
 				</div>
 			</div>
 			</fieldset>

--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -57,7 +57,7 @@
             <div>
                 Check "<strong>Already Created</strong>" only if the appropriate mysql user has already been created!<br/>
                 If you or the web admin wish to give the appropriate privileges to an existing MySQL user, <br/>
-                the privileges are <code>UPDATE, INSERT, SELECT, DELETE, CREATE TEMPORARY TABLES</code><br/>
+                the privileges are <code>SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, CREATE TEMPORARY TABLES, LOCK TABLES</code><br/>
                 for the following: <code>`{$dbname}`.*</code>
             </div>
 			<fieldset>
@@ -145,6 +145,9 @@
 				<div class="col-md-10">
 					<input id="serveruser" value="{$dbadminuser}" name="dbadminuser" type="text" placeholder="ie. root">
 				</div>
+                <div>
+                    The admin should have <strong>ALL</strong> privileges granted for the database specified.
+                </div>
 			</div>
 			<div>
 				<div class="col-md-2">
@@ -162,6 +165,7 @@
 					<input id="dbname" value="{if $dbname}{$dbname}{else}LORIS{/if}" type="text" name="dbname">
 				</div>
 			</div>
+            <hr/>
 			<div>
 				<div class="col-md-2">
 					<label for="use_existing_database">Use Existing Database:</label>


### PR DESCRIPTION
`installdb.php` now allows you to:

+ Specify a database and mark it as already created (so the script doesn't try to create something that already exists)
+ Specify that the database was already created
+ Specify that the config is already good
+ Specify that the MySQL user was already created

Also fixed a small part where it tried to access `mysql.users` to check if you can `CREATE DATABASE`. Not necessary. It's entirely possible that you can `CREATE DATABASE` but cannot `SELECT ... FROM mysql.users`.

This is needed for us, especially, and for the summer interns coming in. They'll be installing Loris with this script and they will not be able to `CREATE DATABASE` or `CREATE USER` because an empty database and users will already be provided by `[insert whoever is responsible for that]`.