### PR TITLE
[Media] Sites Filter for users without access all profile

### DIFF
--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -85,8 +85,8 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $val) {
+            $siteIDs = $user->getData('CenterIDs');
+            foreach ($siteIDs as $val) {
                 $site = &Site::singleton($val);
                 if ($site->isStudySite()) {
                     $siteList[$site->getCenterName()] = $site->getCenterName();

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -91,13 +91,12 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             // allow only to view own site data
             $siteList =array();
             $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $siteList[$val] = $site[$key]->getCenterName();
+            foreach ($site_arr as $val) {
+                $site = &Site::singleton($val);
+                if ($site->isStudySite()) {
+                    $siteList[$site->getCenterName()] = $site->getCenterName();
                 }
             }
-            $siteList = array('' => 'All User Sites') + $siteList;
         }
 
         $instrumentList   = [];

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -72,13 +72,12 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $user =& User::singleton();
         $db   = Database::singleton();
 
-        $siteList = array();
+        $siteList  = array();
         $visitList = Utility::getVisitList();
-
 
         // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles')) {
-            $siteList  = Utility::getSiteList(false);
+            $siteList = Utility::getSiteList(false);
             // Index sites using their names (used to filter react tables)
             foreach ($siteList as $key => $site) {
                 unset($siteList[$key]);

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -72,24 +72,20 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $user =& User::singleton();
         $db   = Database::singleton();
 
-        $siteList  = Utility::getSiteList(false);
+        $siteList = array();
         $visitList = Utility::getVisitList();
 
-        // Index sites using their names (used to filter react tables)
-        foreach ($siteList as $key => $site) {
-            unset($siteList[$key]);
-            $siteList[$site] = $site;
-        }
 
         // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles')) {
-            // get the list of study sites - to be replaced by the Site object
-            if (is_array($siteList)) {
-                $siteList = $siteList;
+            $siteList  = Utility::getSiteList(false);
+            // Index sites using their names (used to filter react tables)
+            foreach ($siteList as $key => $site) {
+                unset($siteList[$key]);
+                $siteList[$site] = $site;
             }
         } else {
             // allow only to view own site data
-            $siteList =array();
             $site_arr = $user->getData('CenterIDs');
             foreach ($site_arr as $val) {
                 $site = &Site::singleton($val);


### PR DESCRIPTION
This pull request indexes the sites by their names (used to filter react tables) when the user does not have access_all_profiles permission.
In addition, the 'All User Sites' option is removed as the 'empty' option does the same thing (like it was done for the 'All' option when user has access_all_profiles permission).

This is in reference to: #2592.