### PR TITLE
[Reliability.class] Implode the User CenterIDs

### DIFF
--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -407,7 +407,7 @@ class NDB_Reliability extends NDB_Form
                 FROM examiners
             WHERE centerID IN (:CentID, 6)
                 ORDER BY full_name",
-            array('CentID' => $centerID)
+            array('CentID' => implode(',', $centerID))
         );
 
         $examiners = array('' => '');


### PR DESCRIPTION
With the users at multiple sites, the `$user->getCenterID()` now returns an array which needs to be imploded in the prepared query.
 
