### PR TITLE
	[Core] Change getCenterID() and getSiteName() to getCenterIDs() and getSiteNames() in the User class

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -137,7 +137,7 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
 
         if (!$user->hasPermission('access_all_profiles')) {
 
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -249,7 +249,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         $user = User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -88,7 +88,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -36,7 +36,7 @@ class NDB_Form_Dashboard extends NDB_Form
         $DB     = Database::singleton();
         $user   = User::singleton();
         $config = NDB_Config::singleton();
-        $site   = explode(';', $user->getSiteName());
+        $site   = explode(';', $user->getSiteNames());
 
         $userID     = $user->getUsername();
         $last_login = $DB->pselectOne(
@@ -49,7 +49,7 @@ class NDB_Form_Dashboard extends NDB_Form
             array('UserID' => $userID)
         );
 
-        $siteID = $user->getCenterID();
+        $siteID = $user->getCenterIDs();
         $this->tpl_data['user_site'] = $siteID;
 
         // Welcome panel
@@ -142,12 +142,13 @@ class NDB_Form_Dashboard extends NDB_Form
                     "SELECT COUNT(*) FROM conflicts_unresolved cu 
                      LEFT JOIN flag ON (cu.CommentId1=flag.CommentID) 
                      LEFT JOIN session s ON (flag.SessionID=s.ID)
-		             LEFT JOIN candidate c ON (c.CandID=s.CandID)
+                     LEFT JOIN candidate c ON (s.CandID=c.CandID)
                      LEFT JOIN psc ON (psc.CenterID=s.CenterID) 
-                     WHERE FIND_IN_SET(psc.CenterID, :siteID) 
+                     WHERE FIND_IN_SET(psc.CenterID, :siteID)
 			            AND s.Active='Y' AND c.Active='Y'",
                     array('siteID' => implode(',', $siteID))
                 );
+
                 $this->tpl_data['conflicts_site'] = 'Sites: All User Sites';
             }
         }
@@ -206,7 +207,7 @@ class NDB_Form_Dashboard extends NDB_Form
             );
             $this->tpl_data['pending_users_site'] = 'Sites: all';
         } elseif ($user->hasPermission('user_accounts')) {
-            $site_arr = $user->getCenterID();
+            $site_arr = $user->getCenterIDs();
             $this->tpl_data['pending_users'] = $DB->pselectOne(
                 "SELECT COUNT(*) FROM users 
                 LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
@@ -266,7 +267,7 @@ class NDB_Form_Dashboard extends NDB_Form
                 $this->tpl_data['issues_assigned_site'] = 'Sites: all';
             } else {
                 $this->tpl_data['issues_assigned_site'] = 'Sites: '.
-                    $user->getSiteName();
+                    $user->getSiteNames();
             }
         }
 

--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -142,13 +142,12 @@ class NDB_Form_Dashboard extends NDB_Form
                     "SELECT COUNT(*) FROM conflicts_unresolved cu 
                      LEFT JOIN flag ON (cu.CommentId1=flag.CommentID) 
                      LEFT JOIN session s ON (flag.SessionID=s.ID)
-                     LEFT JOIN candidate c ON (s.CandID=c.CandID)
+		             LEFT JOIN candidate c ON (c.CandID=s.CandID)
                      LEFT JOIN psc ON (psc.CenterID=s.CenterID) 
-                     WHERE FIND_IN_SET(psc.CenterID, :siteID)
+                     WHERE FIND_IN_SET(psc.CenterID, :siteID) 
 			            AND s.Active='Y' AND c.Active='Y'",
                     array('siteID' => implode(',', $siteID))
                 );
-
                 $this->tpl_data['conflicts_site'] = 'Sites: All User Sites';
             }
         }

--- a/modules/examiner/php/NDB_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Form_examiner.class.inc
@@ -44,7 +44,7 @@ class NDB_Form_Examiner extends NDB_Form
 
         $user         = User::singleton();
         $userFullName = $user->getFullname();
-        $userCenter   = $user->getCenterID();
+        $userCenter   = $user->getCenterIDs();
 
         $certification = $config->getSetting('Certification');
         if (isset($certification['EnableCertification'])) {

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cnv_browser.class.inc
@@ -145,7 +145,7 @@ class NDB_Menu_Filter_CNV_Browser extends NDB_Menu_Filter
         $DB   = Database::singleton();
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_cpg_browser.class.inc
@@ -166,7 +166,7 @@ class NDB_Menu_Filter_CpG_Browser extends NDB_Menu_Filter
         $user = User::singleton();
 
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_genomic_browser.class.inc
@@ -125,7 +125,7 @@ class NDB_Menu_Filter_Genomic_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             // allow only to view own site data
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
+++ b/modules/genomic_browser/php/NDB_Menu_Filter_snp_browser.class.inc
@@ -156,7 +156,7 @@ class NDB_Menu_Filter_SNP_Browser extends NDB_Menu_Filter
         $user = User::singleton();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             // restrict data to own site
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -123,7 +123,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $user   =& User::singleton();
         $DB     = Database::singleton();
         if (!$user->hasPermission('imaging_browser_view_allsites')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -217,7 +217,7 @@ function validateInput($values)
 
         $user =& User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
-            $params['CenterID'] = implode(',', $user->getCenterID());
+            $params['CenterID'] = implode(',', $user->getCenterIDs());
             $query .= " AND FIND_IN_SET(CenterID,:CenterID)";
         }
 
@@ -531,7 +531,7 @@ function getIssueFields()
             array()
         );
     } else {
-        $CenterID = implode(',', $user->getCenterID());
+        $CenterID = implode(',', $user->getCenterIDs());
         $DCCID    = $db->pselectOne(
             "SELECT CenterID from psc where Name='DCC'",
             array()

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -51,7 +51,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status != 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -51,7 +51,7 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
             "WHERE i.status = 'closed'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND i.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -91,13 +91,13 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             // allow only to view own site data
             $siteList =array();
             $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $siteList[$val] = $site[$key]->getCenterName();
+
+            foreach ($site_arr as $val) {
+                $site = &Site::singleton($val);
+                if ($site->isStudySite()) {
+                    $siteList[$site->getCenterName()] = $site->getCenterName();
                 }
             }
-            $siteList = array('' => 'All User Sites') + $siteList;
         }
 
         $instrumentList   = [];
@@ -164,7 +164,7 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
         $this->query = $query;
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND c.CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/media/php/NDB_Menu_Filter_media.class.inc
+++ b/modules/media/php/NDB_Menu_Filter_media.class.inc
@@ -91,13 +91,13 @@ class NDB_Menu_Filter_Media extends NDB_Menu_Filter
             // allow only to view own site data
             $siteList =array();
             $site_arr = $user->getData('CenterIDs');
-
-            foreach ($site_arr as $val) {
-                $site = &Site::singleton($val);
-                if ($site->isStudySite()) {
-                    $siteList[$site->getCenterName()] = $site->getCenterName();
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $siteList[$val] = $site[$key]->getCenterName();
                 }
             }
+            $siteList = array('' => 'All User Sites') + $siteList;
         }
 
         $instrumentList   = [];

--- a/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
+++ b/modules/reliability/php/NDB_Menu_Filter_reliability.class.inc
@@ -104,7 +104,7 @@ class NDB_Menu_Filter_Reliability extends NDB_Menu_Filter
 
         // only view their own profiles, unless they have permission to see all
         if (!($user->hasPermission('reliability_edit_all') || $user->hasPermission('access_all_profiles'))) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
         }
 
@@ -600,13 +600,13 @@ class NDB_Menu_Filter_Reliability extends NDB_Menu_Filter
                     'error' => "Candidates are not from the same site.".
                           " Cannot swap candidates across sites.",
                    );
-        } elseif (!in_array($newCommentID['NewCenterID'], $user->getCenterID())) {
+        } elseif (!in_array($newCommentID['NewCenterID'], $user->getCenterIDs())) {
             $error_msg = $params_new['id_Replace']."/".
                          $params_new['id_replaceV'].
                          " is from a different site than you.".
                          " Can only swap candidates from the same site.";
             return array('error' => $error_msg);
-        } elseif (!in_array($CommentID['OldCenterID'], $user->getCenterID())) {
+        } elseif (!in_array($CommentID['OldCenterID'], $user->getCenterIDs())) {
             $error_msg = $params_new['id_Replace']."/".
                   $params_new['id_replaceV'].
                   " is from a different site than you.".

--- a/modules/training/ajax/markQuiz.php
+++ b/modules/training/ajax/markQuiz.php
@@ -36,7 +36,7 @@ if ($quizCorrect == false) {
     $user = User::singleton();
 
     $userFullName = $user->getFullname();
-    $userCenter   = implode(',', $user->getCenterID());
+    $userCenter   = implode(',', $user->getCenterIDs());
     $examinerID   = $DB->pselectOne(
         "SELECT examinerID 
          FROM examiners

--- a/modules/training/php/NDB_Form_training.class.inc
+++ b/modules/training/php/NDB_Form_training.class.inc
@@ -50,7 +50,7 @@ class NDB_Form_Training extends NDB_Form
 
         $user         = User::singleton();
         $userFullName = $user->getFullname();
-        $userSite     = $user->getCenterID();
+        $userSite     = $user->getCenterIDs();
 
         $isExaminer = $this->isExaminer($userFullName, $userSite);
 
@@ -148,7 +148,7 @@ class NDB_Form_Training extends NDB_Form
     {
         $user         = User::singleton();
         $userFullName = $user->getFullname();
-        $userCenter   = $user->getCenterID();
+        $userCenter   = $user->getCenterIDs();
 
         $DB = Database::singleton();
         $certificationStatus = $DB->pselectOne(

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -53,7 +53,7 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
             WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
-            $site_arr     = implode(",", $user->getCenterID());
+            $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND user_psc_rel.CenterID IN (" . $site_arr . ")";
         }
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -469,7 +469,7 @@ class NDB_BVL_Feedback
         $query .= " WHERE ft.Active ='Y'";
         if (!$hasReadPermission===true) {
             $query            .= " AND FIND_IN_SET (c.CenterID,:CentID)";
-            $qparams['CentID'] = implode(',', $user->getCenterID());
+            $qparams['CentID'] = implode(',', $user->getCenterIDs());
         }
 
         $query .= " AND Public = 'Y' AND Status <> 'closed'";
@@ -582,7 +582,7 @@ class NDB_BVL_Feedback
         } else {
             $query            .= " AND ft.Active ='Y' 
                                    AND FIND_IN_SET (c.CenterID,:CentID)";
-            $qparams['CentID'] = implode(',', $user->getCenterID());
+            $qparams['CentID'] = implode(',', $user->getCenterIDs());
         }
 
         $query .= " ORDER BY ft.CandID,

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -222,7 +222,7 @@ class NDB_Config
             $this->_siteSettings =& $this->_settings;
         } else {
             $user     =& User::singleton($username);
-            $siteName = Utility::getCleanString($user->getSiteName());
+            $siteName = Utility::getCleanString($user->getSiteNames());
             if (isset($this->_settings['sites'][$siteName])
                 && is_array($this->_settings['sites'][$siteName])
             ) {

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -397,7 +397,7 @@ class NDB_Reliability extends NDB_Form
     {
         $db       =& Database::singleton();
         $user     =& User::singleton();
-        $centerID = $user->getCenterID();
+        $centerID = $user->getCenterIDs();
 
         // UofA is a special case--they never enter their own data.
         // So the available examiners are either the ones at the logged

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -407,7 +407,7 @@ class NDB_Reliability extends NDB_Form
                 FROM examiners
             WHERE centerID IN (:CentID, 6)
                 ORDER BY full_name",
-            array('CentID' => implode(',', $centerID))
+            array('CentID' => $centerID)
         );
 
         $examiners = array('' => '');

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -208,21 +208,21 @@ class User extends UserPermissions
     }
 
     /**
-     * Get the user's site's name
+     * Get the user's sites' names
      *
      * @return string
      */
-    function getSiteName()
+    function getSiteNames()
     {
         return $this->userInfo['Sites'];
     }
 
     /**
-     * Get the user's site's ID number
+     * Get the user's sites' ID numbers
      *
      * @return array
      */
-    function getCenterID()
+    function getCenterIDs()
     {
         return $this->userInfo['CenterIDs'];
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -208,7 +208,8 @@ class User extends UserPermissions
     }
 
     /**
-     * Get the user's sites' names
+     * Get the user's sites' names, concatenated with
+     * a semi-colon if the User is at more than one site
      *
      * @return string
      */


### PR DESCRIPTION
This pull request changes the `getCenterID()` and `getSiteName()` in the `User.class.inc` to reflect users at multiple sites, by renaming them to  `getCenterIDs()` and `getSiteNames()` (and to make them in synch with `$this->userInfo['CenterIDs']`)

(one of the feedbacks from @driusan when the feature was presented at the Loris meeting; it is Item (10) of Redmine 12020).