### PR TITLE
Fixes broken links in templates when using LORIS in a url subdir

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -19,7 +19,7 @@
  RewriteRule ^([0-9]{6,6})/([0-9]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/$ main.php?test_name=$3&candID=$1&sessionID=$2&subtest=$4 [QSA]
 
  # Preferences is a special case for url rewriting
- RewriteRule ^preferences/$ /main.php?test_name=user_accounts&subtest=my_preferences
+ RewriteRule ^preferences/$ main.php?test_name=user_accounts&subtest=my_preferences
  # Rewrite /foo/ to appropriate module
  # Includes /foo/css/cssfile.css
  #          /foo/js/javascriptfile.js

--- a/smarty/templates/login.tpl
+++ b/smarty/templates/login.tpl
@@ -8,7 +8,7 @@
         <div class="panel-body">
           {if $study_logo}
             <section class="study-logo">
-              <img src="/{$study_logo}" alt="{$study_title}"/>
+              <img src="{$baseurl}/{$study_logo}" alt="{$study_title}"/>
             </section>
           {/if}
           <form method="POST" action="{$action}">
@@ -28,8 +28,8 @@
             </div>
           </form>
           <div class="help-links">
-            <a href="/password-reset">Forgot your password?</a><br/>
-            <a href="/request-account">Request Account</a>
+            <a href="{$baseurl}/password-reset">Forgot your password?</a><br/>
+            <a href="{$baseurl}/request-account">Request Account</a>
           </div>
           <div class="help-text">
             A WebGL-compatible browser is required for full functionality (Mozilla Firefox, Google Chrome)

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -9,17 +9,17 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{$page_title}</title>
-  <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/css/public_layout.css">
-  <link type="image/x-icon" rel="icon" href="/images/favicon.ico">
+  <link rel="stylesheet" href="{$baseurl}/bootstrap/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{$baseurl}/css/public_layout.css">
+  <link type="image/x-icon" rel="icon" href="{$baseurl}/images/favicon.ico">
 </head>
 <body>
   <header class="header">
     <div class="container">
       <div class="flex-wrapper">
         <div class="loris-logo">
-          <a href="/">
-            <img src="/images/LORIS_logo_white.svg" class="loris-logo" alt="Loris Logo"/>
+          <a href="{$baseurl}">
+            <img src="{$baseurl}/images/LORIS_logo_white.svg" class="loris-logo" alt="Loris Logo"/>
           </a>
         </div>
         <div class="study-title hidden-xs">
@@ -27,7 +27,7 @@
         </div>
         <div class="github-logo">
           <a href="https://github.com/aces/Loris" target="_blank">
-            <img src="/images/GitHub-Mark-Light-64px.png" alt="Github"/>
+            <img src="{$baseurl}/images/GitHub-Mark-Light-64px.png" alt="Github"/>
           </a>
         </div>
       </div>
@@ -56,7 +56,7 @@
     </a>
     by <a href="http://mcin-cnim.ca" target="_blank">MCIN</a>
   </footer>
-  <script src="/js/modernizr/modernizr.min.js"/>
+  <script src="{$baseurl}/js/modernizr/modernizr.min.js"/>
   <script>
     if (!Modernizr.webgl) {
       alert("Please download the latest version of Google Chrome of Mozilla Firefox in order to use Loris!");


### PR DESCRIPTION
This pull request fixes templates with broken links when using LORIS in a url subdirectory. I'm working in a project that don't follow the base url suggested and I saw that only few templates were with problems.

- Added {$baseurl} to some urls on these templates.
- Adjusted RewriteRule for preferences page in .htaccess (also not working when using the configuration)


I tested using the project that I'm working.