### PR TITLE
[Core] Fix LorisMenu empty tab bug

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -574,7 +574,6 @@ class NDB_Config
             if (!empty($nextLevel)) {
                 $thisRow['subtabs'] = $nextLevel;
             }
-            print_r($thisRow);
         }
 
         return $thisLevel;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -526,8 +526,8 @@ class NDB_Config
      *                        be passed. It's used to build the tree recursively
      *                        from the LorisMenu table.
      *
-     * @return An array of Label, Visible, Link, and ID to build the menu
-     *         for the currently logged in user
+     * @return array          Label, Visible, Link, and ID to build the menu
+     *                        for the currently logged in user
      */
     static function getMenuTabs($parent = null)
     {
@@ -570,8 +570,11 @@ class NDB_Config
             $nextLevel = NDB_Config::getMenuTabs($thisRow['ID']);
 
             if (!empty($nextLevel)) {
-                if (NDB_Config::checkMenuPermission($nextLevel[0]['ID'])) {
-                    $thisRow['subtabs'] = $nextLevel;
+                foreach ($nextLevel as $k=>$info) {
+                    if ($info['Visible']) {
+                        $thisRow['subtabs'] = $nextLevel;
+                        break;
+                    }
                 }
             }
         }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -539,7 +539,8 @@ class NDB_Config
                        Link,
                        ID
                   FROM LorisMenu
-                  WHERE Parent IS NULL ORDER BY OrderNumber",
+                  WHERE Parent IS NULL AND (Visible = 'true' OR Visible IS NULL)
+                  ORDER BY OrderNumber",
                 array()
             );
         } else {
@@ -549,7 +550,8 @@ class NDB_Config
                         Link,
                         ID
                   FROM LorisMenu
-                  WHERE Parent=:ParentID ORDER BY OrderNumber",
+                  WHERE Parent=:ParentID AND (Visible = 'true' OR Visible IS NULL)
+                  ORDER BY OrderNumber",
                 array('ParentID' => $parent)
             );
 
@@ -570,13 +572,9 @@ class NDB_Config
             $nextLevel = NDB_Config::getMenuTabs($thisRow['ID']);
 
             if (!empty($nextLevel)) {
-                foreach ($nextLevel as $k=>$info) {
-                    if ($info['Visible']) {
-                        $thisRow['subtabs'] = $nextLevel;
-                        break;
-                    }
-                }
+                $thisRow['subtabs'] = $nextLevel;
             }
+            print_r($thisRow);
         }
 
         return $thisLevel;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -543,6 +543,16 @@ class NDB_Config
                   ORDER BY OrderNumber",
                 array()
             );
+
+            foreach ($thisLevel as &$thisRow) {
+                $nextLevel = NDB_Config::getMenuTabs($thisRow['ID']);
+
+                if (!empty($nextLevel)) {
+                    $thisRow['subtabs'] = $nextLevel;
+                }
+            }
+
+            return $thisLevel;
         } else {
             $thisLevel = $DB->pselect(
                 "SELECT Label,
@@ -567,16 +577,6 @@ class NDB_Config
             }
             return;
         }
-
-        foreach ($thisLevel as &$thisRow) {
-            $nextLevel = NDB_Config::getMenuTabs($thisRow['ID']);
-
-            if (!empty($nextLevel)) {
-                $thisRow['subtabs'] = $nextLevel;
-            }
-        }
-
-        return $thisLevel;
     }
 
     /**


### PR DESCRIPTION
This pull request fixes issue where a loris menu tab still shows when all elements under are set to visible=false, the tab opens to an empty list of subtabs.

To test:
 - choose tab ie reports
 - set all entries in the LorisMenu table that have as parent `reports` to visible = false.
 - tab should disappear
