### PR TITLE
[Doc Repo] Ensure file exists in DB before serving (Redmine #12220)

### DIFF
--- a/modules/document_repository/ajax/GetFile.php
+++ b/modules/document_repository/ajax/GetFile.php
@@ -34,32 +34,33 @@ $client->initialize("../project/config.xml");
 // Checks that config settings are set
 $config =& NDB_Config::singleton();
 
-$File = $_GET['File'];
+$file = $_GET['File'];
 
 // Ensure file exists in the document_repository table before serving
 $db     =& Database::singleton();
 $record = $db->pselectOne(
     "SELECT record_id FROM document_repository WHERE "
     . "Data_dir=:dd",
-    array('dd' => $File)
+    array('dd' => $file)
 );
 
 if (empty($record)) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(4);
-} else {
-    $FullPath = __DIR__ . "/../user_uploads/$File";
-    echo "$FullPath";
+} 
 
-    if (!file_exists($FullPath)) {
-        error_log("ERROR: File $FullPath does not exist");
-        header("HTTP/1.1 404 Not Found");
-        exit(5);
-    }
+$path = __DIR__ . "/../user_uploads/$file";
 
-    $fp = fopen($FullPath, 'r');
-    fpassthru($fp);
-    fclose($fp);
+if (!file_exists($path)) {
+    error_log("ERROR: File $path does not exist");
+    header("HTTP/1.1 404 Not Found");
+    exit(5);
 }
-?>
+
+// Output file in downloadable format
+header('Content-Description: File Transfer');
+header('Content-Type: application/force-download');
+header("Content-Transfer-Encoding: Binary");
+header("Content-disposition: attachment; filename=\"" . basename($path) . "\"");
+readfile($path);


### PR DESCRIPTION
This pull request ensures that a requested file exists in the `document_repository` database before serving it.

- [x] Check that a file (in the format of `$username/$filename`) exists before serving

-  _This format is consistent w.r.t. the DB variable `Data_dir`. See [here](https://github.com/aces/Loris/blob/01f2467f9e150e617b1c6c9a0b7401edfdc59b1f/modules/document_repository/ajax/documentEditUpload.php#L63)._

- [x] Give a status code `400 Bad Request` otherwise
- [x] Fix a security issue regarding file access



See also: Redmine `#12220`
