### PR TITLE
[BVL Feedback] Fix for visit level feedback

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -205,8 +205,7 @@ class NDB_BVL_Feedback
             || isset($this->_feedbackObjectInfo['SessionID'])
         ) {
             $this->_feedbackCandidateProfileInfo['SessionID']
-                = $result[0]['SessionID'] ? $result[0]['SessionID']
-                : $this->_feedbackObjectInfo['SessionID'];
+                = $result[0]['SessionID'] ?? $this->_feedbackObjectInfo['SessionID'];
         }
     }
 

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -194,7 +194,6 @@ class NDB_BVL_Feedback
         $query .= " LIMIT 1";
 
         $result = $db->pselect($query, $qparams);
-
         if (!is_array($result) || count($result) == 0) {
             throw new Exception(
                 "Error, unable to select data for the feedback object"
@@ -202,9 +201,12 @@ class NDB_BVL_Feedback
         }
 
         $this->_feedbackCandidateProfileInfo['CandID'] = $result[0]['CandID'];
-        if (isset($result[0]['SessionID'])) {
+        if (isset($result[0]['SessionID'])
+            || isset($this->_feedbackObjectInfo['SessionID'])
+        ) {
             $this->_feedbackCandidateProfileInfo['SessionID']
-                = $result[0]['SessionID'];
+                = $result[0]['SessionID'] ? $result[0]['SessionID']
+                : $this->_feedbackObjectInfo['SessionID'];
         }
     }
 

--- a/php/libraries/NDB_BVL_Fuck_You_Travis.class.inc
+++ b/php/libraries/NDB_BVL_Fuck_You_Travis.class.inc
@@ -1,0 +1,1 @@
+I hate Travis

--- a/php/libraries/NDB_BVL_Fuck_You_Travis.class.inc
+++ b/php/libraries/NDB_BVL_Fuck_You_Travis.class.inc
@@ -1,1 +1,0 @@
-I hate Travis


### PR DESCRIPTION
Currently trying to open a feedback thread at the visit level will result in a feedback thread at the profile level instead, since session ID does not successfully get passed along to the React component.
Added a small extra bit of logic to supply sessionID to the array which is being accessed for the tpl data, which then goes through to React / AJAX, etc.
https://redmine.cbrain.mcgill.ca/issues/12242
