### PR TITLE
[Core] Site Affiliations Tooltip

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -96,7 +96,7 @@ try {
     $tpl_data['userNumSites']         = count($site_arr);
     $tpl_data['user']['SitesTooltip'] = str_replace(
         ";",
-        "\n",
+        "<br/>",
         $user->getData('Sites')
     );
 } catch(Exception $e) {

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -73,6 +73,11 @@
               monthInputs.on('keydown paste', function(e) { e.preventDefault(); });
             }
 
+            // Initialize bootstrap tooltip for site affiliations
+            $('#site-affiliations').tooltip({
+              html: true,
+              container: 'body'
+            });
           });
         </script>
         <link type="text/css" href="{$baseurl}/css/jqueryslidemenu.css" rel="Stylesheet" />
@@ -170,8 +175,12 @@
                             </a>
                         </li>
                         <li class="nav">
-                            <a href="#" data-toggle="tooltip" title="{$user.SitesTooltip}">
-                                Site Affiliations: {$userNumSites} 
+                            <a href="#"
+                               id="site-affiliations"
+                               data-toggle="tooltip"
+                               data-placement="bottom"
+                               title="{$user.SitesTooltip}">
+                                Site Affiliations: {$userNumSites}
                             </a>
                         </li>
 


### PR DESCRIPTION
I realized that @MounaSafiHarab's site affiliations PR did not actually initialize bootstrap tooltip (which is why a generic browser tooltip was showing instead). 

- [x] Init bootstrap tooltip and show sites 1 per line

| Before | After |
| :----: | :---: |
|   ![image](https://cloud.githubusercontent.com/assets/6627543/25243600/93fc9ff0-25cb-11e7-8994-942f2b9cffd6.png) |  ![image](https://cloud.githubusercontent.com/assets/6627543/25243533/564fbe6c-25cb-11e7-8573-e9ac68b449c5.png)   |



