### PR TITLE
[DDE] Added diff warning data, if DDE input does not match original input

### DIFF
--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -30,25 +30,32 @@ class ConflictDetector
      * @param string $instrumentName The instrument being checked
      * @param string $commentId1     The first data entry CommentID
      * @param string $commentId2     The second data entry CommentID
+     * @param string $forceDiff      If `true`, incomplete instruments
+     *                               are still diff'd
      *
      * @return array An array of differences between the 2 data entry
      *               points.
      */
-    function detectConflictsForCommentIds($instrumentName, $commentId1, $commentId2)
-    {
+    function detectConflictsForCommentIds(
+        $instrumentName,
+        $commentId1,
+        $commentId2,
+        $forceDiff=false
+    ) {
+
         $diffResult = array();
 
         // Get data entry status for $commentId1
         $status = new NDB_BVL_InstrumentStatus();
         $status->select($commentId1);
-        if ($status->getDataEntryStatus() != 'Complete') {
+        if (!$forceDiff && $status->getDataEntryStatus() != 'Complete') {
             return $diffResult;
         }
 
         // Get data entry status for $commentId2
         $status = new NDB_BVL_InstrumentStatus();
         $status->select($commentId2);
-        if ($status->getDataEntryStatus() != 'Complete') {
+        if (!$forceDiff && $status->getDataEntryStatus() != 'Complete') {
             return $diffResult;
         }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -35,6 +35,7 @@ class LorisForm
     var $defaultValues = array();
     var $formRules     = array();
     var $errors        = array();
+    var $warnings      = array();
     var $filters       = array();
     var $frozen        = false;
     var $enctype       = '';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1578,6 +1578,7 @@ class LorisForm
                     'elements' => array(),
                     'type'     => 'page',
                     'errors'   => $this->errors,
+                    'warnings' => $this->warnings,
                    );
         $retVal  = $curPage;
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -481,10 +481,12 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function save()
     {
-        //$scoreResult = '';
+        //Do not comment this out; used for score calculation
+        $scoreResult = '';
         if ($this->form->validate()) {
             $this->form->process(array(&$this, '_saveValues'), true);
-            //$scoreResult = $this->score();
+            //Do not comment this out; used for score calculation
+            $scoreResult = $this->score();
 
             $input = $this->form->getSubmitValues();
             if (preg_match("/^DDE_/", $input["commentID"])) {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -481,10 +481,28 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function save()
     {
-        $scoreResult = '';
+        //$scoreResult = '';
         if ($this->form->validate()) {
             $this->form->process(array(&$this, '_saveValues'), true);
-            $scoreResult = $this->score();
+            //$scoreResult = $this->score();
+
+            $input = $this->form->getSubmitValues();
+            if (preg_match("/^DDE_/", $input["commentID"])) {
+                //This is a double-data entry form
+                $otherCommentID = substr($input["commentID"], 4);
+
+                $diff = ConflictDetector::detectConflictsForCommentIds(
+                    $input["test_name"],
+                    $input["commentID"],
+                    $otherCommentID,
+                    true
+                );
+                if (count($diff) > 0) {
+                    foreach ($diff as $d) {
+                        $this->form->warnings[$d["FieldName"]] = $d;
+                    }
+                }
+            }
 
             // determine the data entry completion status, and store that in
             // the database

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -497,10 +497,8 @@ class NDB_BVL_Instrument extends NDB_Page
                     $otherCommentID,
                     true
                 );
-                if (count($diff) > 0) {
-                    foreach ($diff as $d) {
-                        $this->form->warnings[$d["FieldName"]] = $d;
-                    }
+                foreach ($diff as $d) {
+                    $this->form->warnings[$d["FieldName"]] = $d;
                 }
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -499,8 +499,16 @@ class NDB_BVL_Instrument extends NDB_Page
                     $otherCommentID,
                     true
                 );
+                $diff_warnings = array();
                 foreach ($diff as $d) {
-                    $this->form->warnings[$d["FieldName"]] = $d;
+                    $diff_warnings[$d["FieldName"]] = $d;
+                }
+                $this->form->warnings["diff_warnings"] = $diff_warnings;
+                
+                $otherStatus = new NDB_BVL_InstrumentStatus();
+                $otherStatus->select($otherCommentID);
+                if ($otherStatus->getDataEntryStatus() != "Complete") {
+                    $this->form->warnings["other_incomplete"] = $otherCommentID;
                 }
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -493,7 +493,7 @@ class NDB_BVL_Instrument extends NDB_Page
                 //This is a double-data entry form
                 $otherCommentID = substr($input["commentID"], 4);
 
-                $diff = ConflictDetector::detectConflictsForCommentIds(
+                $diff          = ConflictDetector::detectConflictsForCommentIds(
                     $input["test_name"],
                     $input["commentID"],
                     $otherCommentID,
@@ -504,7 +504,7 @@ class NDB_BVL_Instrument extends NDB_Page
                     $diff_warnings[$d["FieldName"]] = $d;
                 }
                 $this->form->warnings["diff_warnings"] = $diff_warnings;
-                
+
                 $otherStatus = new NDB_BVL_InstrumentStatus();
                 $otherStatus->select($otherCommentID);
                 if ($otherStatus->getDataEntryStatus() != "Complete") {

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -11,6 +11,11 @@
 <div class="row">
 	{$form.hidden}
 	{$form.errors.mainError}
+    {if $form.warnings.other_incomplete}
+        <div class="alert alert-warning" role="alert">
+            <em>Warning</em>: The original entries are incomplete <small>({$form.warnings.other_incomplete})</small>
+        </div>
+    {/if}
 	{assign var="inTable" value="FALSE"}
 	{foreach from=$form.elements item=element}
 		{if $element.name neq mainError}
@@ -41,7 +46,7 @@
 					{/if}
                     {assign var="has_warning" value=false}
                     {foreach key=gkey item=gitem from=$element.elements}
-                        {if array_key_exists($gitem.name, $form.warnings)}
+                        {if array_key_exists($gitem.name, $form.warnings.diff_warnings)}
                             {assign var="has_warning" value=true}
                         {/if}
                     {/foreach}
@@ -70,7 +75,7 @@
 				                </div>
 							{/if}
                             {foreach key=gkey item=gitem from=$element.elements}
-                                {if array_key_exists($gitem.name, $form.warnings)}
+                                {if array_key_exists($gitem.name, $form.warnings.diff_warnings)}
                                     <div class="col-xs-12">
                                         <font class="warning">{$gitem.name} does not match the original input</font>
                                     </div>
@@ -120,7 +125,7 @@
 					{assign var="inTable" value="FALSE"}
 					</table>
 				{/if}
-                {assign var="has_warning" value=array_key_exists($element.name, $form.warnings)}
+                {assign var="has_warning" value=array_key_exists($element.name, $form.warnings.diff_warnings)}
 				{if $element.error}
 		    	<div class="row form-group form-inline form-inline has-error">
                 {elseif $has_warning}
@@ -143,7 +148,7 @@
 			                    <font class="form-error">{$element.error}</font>
 			                </div>
 						{/if}
-                        {if array_key_exists($element.name, $form.warnings)}
+                        {if array_key_exists($element.name, $form.warnings.diff_warnings)}
                             <div class="col-xs-12">
                                 <font class="warning">{$element.name} does not match the original input</font>
                             </div>
@@ -240,7 +245,7 @@
 						{assign var="inTable" value="FALSE"}
 						</table>
 					{/if}
-                    {assign var="has_warning" value=array_key_exists($element.name, $form.warnings)}
+                    {assign var="has_warning" value=array_key_exists($element.name, $form.warnings.diff_warnings)}
 					{if $element.error}
 			    	<div class="row form-group form-inline has-error">
                     {elseif $has_warning}
@@ -263,7 +268,7 @@
 				                    <font class="form-error">{$element.error}</font>
 				                </div>
 							{/if}
-                            {if array_key_exists($element.name, $form.warnings)}
+                            {if array_key_exists($element.name, $form.warnings.diff_warnings)}
                                 <div class="col-xs-12">
                                     <font class="warning">{$element.name} does not match the original input</font>
                                 </div>

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -9,7 +9,6 @@
 </style>
 <form method="post" name="test_form" id="test_form" {$form.enctype} {$form.action}>
 <div class="row">
-    <pre>{var_dump($form.warnings)}</pre>
 	{$form.hidden}
 	{$form.errors.mainError}
 	{assign var="inTable" value="FALSE"}
@@ -40,8 +39,16 @@
 						{assign var="inTable" value="FALSE"}
 						</table>
 					{/if}
+                    {assign var="has_warning" value=false}
+                    {foreach key=gkey item=gitem from=$element.elements}
+                        {if array_key_exists($gitem.name, $form.warnings)}
+                            {assign var="has_warning" value=true}
+                        {/if}
+                    {/foreach}
 					{if $element.error}
 			    	<div class="row form-group form-inline form-inline has-error">
+                    {elseif $has_warning}
+			    	<div class="row form-group form-inline form-inline has-warning">
 			        {else}
 			        <div class="row form-group form-inline form-inline">
 			        {/if}
@@ -65,7 +72,7 @@
                             {foreach key=gkey item=gitem from=$element.elements}
                                 {if array_key_exists($gitem.name, $form.warnings)}
                                     <div class="col-xs-12">
-                                        <font class="form-warning">{$gitem.name} does not match the original input</font>
+                                        <font class="warning">{$gitem.name} does not match the original input</font>
                                     </div>
                                 {/if}
                             {/foreach}
@@ -113,8 +120,11 @@
 					{assign var="inTable" value="FALSE"}
 					</table>
 				{/if}
+                {assign var="has_warning" value=array_key_exists($element.name, $form.warnings)}
 				{if $element.error}
 		    	<div class="row form-group form-inline form-inline has-error">
+                {elseif $has_warning}
+		    	<div class="row form-group form-inline form-inline has-warning">
 		        {else}
 		        <div class="row form-group form-inline form-inline">
 		        {/if}
@@ -135,7 +145,7 @@
 						{/if}
                         {if array_key_exists($element.name, $form.warnings)}
                             <div class="col-xs-12">
-                                <font class="form-warning">{$element.name} does not match the original input</font>
+                                <font class="warning">{$element.name} does not match the original input</font>
                             </div>
                         {/if}
 					</div>
@@ -163,6 +173,7 @@
 							{assign var="inTable" value="FALSE"}
 							</table>
 						{/if}
+                        
 						{if $element.error}
 				    	<div class="row form-group form-inline form-inline has-error">
 				        {else}
@@ -229,8 +240,11 @@
 						{assign var="inTable" value="FALSE"}
 						</table>
 					{/if}
+                    {assign var="has_warning" value=array_key_exists($element.name, $form.warnings)}
 					{if $element.error}
 			    	<div class="row form-group form-inline has-error">
+                    {elseif $has_warning}
+			    	<div class="row form-group form-inline has-warning">
 			        {else}
 			        <div class="row form-group form-inline">
 			        {/if}
@@ -251,7 +265,7 @@
 							{/if}
                             {if array_key_exists($element.name, $form.warnings)}
                                 <div class="col-xs-12">
-                                    <font class="form-warning">{$element.name} does not match the original input</font>
+                                    <font class="warning">{$element.name} does not match the original input</font>
                                 </div>
                             {/if}
 						</div>

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -9,6 +9,7 @@
 </style>
 <form method="post" name="test_form" id="test_form" {$form.enctype} {$form.action}>
 <div class="row">
+    <pre>{var_dump($form.warnings)}</pre>
 	{$form.hidden}
 	{$form.errors.mainError}
 	{assign var="inTable" value="FALSE"}
@@ -61,6 +62,13 @@
 				                    <font class="form-error">{$element.error}</font>
 				                </div>
 							{/if}
+                            {foreach key=gkey item=gitem from=$element.elements}
+                                {if array_key_exists($gitem.name, $form.warnings)}
+                                    <div class="col-xs-12">
+                                        <font class="form-warning">{$gitem.name} does not match the original input</font>
+                                    </div>
+                                {/if}
+                            {/foreach}
 						</div>
 					</div>
 				{else}
@@ -125,6 +133,11 @@
 			                    <font class="form-error">{$element.error}</font>
 			                </div>
 						{/if}
+                        {if array_key_exists($element.name, $form.warnings)}
+                            <div class="col-xs-12">
+                                <font class="form-warning">{$element.name} does not match the original input</font>
+                            </div>
+                        {/if}
 					</div>
 				</div>
 			{/if}
@@ -236,6 +249,11 @@
 				                    <font class="form-error">{$element.error}</font>
 				                </div>
 							{/if}
+                            {if array_key_exists($element.name, $form.warnings)}
+                                <div class="col-xs-12">
+                                    <font class="form-warning">{$element.name} does not match the original input</font>
+                                </div>
+                            {/if}
 						</div>
 					</div>
 				{/if}


### PR DESCRIPTION
If the original input is:

A = 1

And the DDE input is:

A = 9001

Then, when the DDE input is submitted, LorisForm->warnings will be populated with:
```
[
    "A"=>[
        //The data returned by ConflictDetector::detectConflictsForCommentIds()
    ]
]
```

No user feedback is provided yet. To be done in the future ;D