### PR TITLE
[Misc] Updated to ignore npm-debug.log and npm-debug.log.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,4 @@ htdocs/js/components/.module-cache/
 node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
-npm-debug.log
-npm-debug.log.*
+npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ htdocs/js/components/.module-cache/
 node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
+npm-debug.log
+npm-debug.log.*


### PR DESCRIPTION
I'm getting kind of lazy to delete the `npm-debug.log` and `npm-debug.log.XXXX` files every time before I use `git add *`.

Is anyone else getting this, too? Can we add these files to the `.gitignore` file?