### PR TITLE
[Utility/candidate_parameters] Add helper function to validate that parameters are well-formed

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -56,9 +56,9 @@ class Candidate
      */
     static function &singleton($candID)
     {
-        $param_name = 'candID';
+        $param_name  = 'candID';
         $param_value = $candID;
-        $valid = Utility::validParam($param_name, $param_value);
+        $valid       = Utility::validParam($param_name, $param_value);
         if (!$valid) {
             throw new LorisException(
                 "CandID parameter is invalid. Request refused."

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -12,6 +12,8 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
+require_once 'Utility.class.inc';
+
 /* Define constants used by the file */
 // error codes
 define('CANDIDATE_INVALID', 1);
@@ -54,6 +56,15 @@ class Candidate
      */
     static function &singleton($candID)
     {
+        $param_name = 'candID';
+        $param_value = $candID;
+        $valid = Utility::validParam($param_name, $param_value);
+        if (!$valid) {
+            throw new LorisException(
+                "CandID parameter is invalid. Request refused."
+            );
+            return;
+        }
         $candidateList =& $GLOBALS['__candidateObjects'];
         if (!isset($candidateList[$candID])) {
             $candidateList[$candID] = new Candidate();

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1277,7 +1277,7 @@ class Utility
      * @return True if pattern matches, false otherwise. false if $param
      * falls through the switch-case statement.
      */
-    static function validParam($param, $value)
+    static function _validParam($param, $value)
     {
         switch ($param) {
         case 'candID':

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1265,5 +1265,31 @@ class Utility
         }
         return checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
     }
+
+    static function validParam($param, $value) {
+        switch ($param) {
+        case 'candID':
+            $pattern = '/^[0-9]{6}$/';
+            break;
+        case 'sessonID':
+            $pattern = '/^[a-zA-Z0-9_]+$/';
+            break;
+        default:
+            return false;
+        }
+        return preg_match($pattern, $value);
+    }
+
+    static function validParams(array $param_names = array()) {
+        // Iterate over parameters and validate that they are well-formed
+        foreach ($params_names as $param_name) {
+            $param_value = isset($_REQUEST[$param_name]) ? $_REQUEST[$param_name] : '';
+            if ($param_value) {
+                if (!self::_validParam($param_name, $param_value)) { 
+                    return false;
+                }
+            }
+        }
+    }
 }
 ?>

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1271,13 +1271,14 @@ class Utility
      * to validate user input across trust boundaries to ensure
      * there is no malicious input being reflected to the user.
      *
-     * @param String $param, the name of a parameter
-     * @param String $value, the value of a parameter
+     * @param string $param The name of a parameter
+     * @param string $value The value of a parameter
      *
-     * @return true if pattern matches, false otherwise. false if $param
+     * @return True if pattern matches, false otherwise. false if $param
      * falls through the switch-case statement.
      */
-    static function validParam($param, $value) {
+    static function validParam($param, $value)
+    {
         switch ($param) {
         case 'candID':
             $pattern = '/^[0-9]{6}$/';
@@ -1299,13 +1300,14 @@ class Utility
      *
      * @return True if all parameters well-formed, false otherwise.
      */
-        
-    static function validParams(array $param_names = array()) {
+    static function validParams(array $param_names = array())
+    {
         // Iterate over parameters and validate that they are well-formed
         foreach ($param_names as $param_name) {
-            $param_value = isset($_REQUEST[$param_name]) ? $_REQUEST[$param_name] : '';
+            $param_value = isset($_REQUEST[$param_name]) ?
+                                 $_REQUEST[$param_name] : '';
             if ($param_value) {
-                if (!self::_validParam($param_name, $param_value)) { 
+                if (!self::_validParam($param_name, $param_value)) {
                     return false;
                 }
             }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1266,6 +1266,17 @@ class Utility
         return checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
     }
 
+    /**
+     * Given a parameter, check that it is well-formed. Used
+     * to validate user input across trust boundaries to ensure
+     * there is no malicious input being reflected to the user.
+     *
+     * @param String $param, the name of a parameter
+     * @param String $value, the value of a parameter
+     *
+     * @return true if pattern matches, false otherwise. false if $param
+     * falls through the switch-case statement.
+     */
     static function validParam($param, $value) {
         switch ($param) {
         case 'candID':
@@ -1280,9 +1291,18 @@ class Utility
         return preg_match($pattern, $value);
     }
 
+    /**
+     * Wrapper for validParam which allows for testing of multiple
+     * parameter values.
+     *
+     * @param Array $param_names of parameter names, e.g. ('candID', 'sessionID')
+     *
+     * @return True if all parameters well-formed, false otherwise.
+     */
+        
     static function validParams(array $param_names = array()) {
         // Iterate over parameters and validate that they are well-formed
-        foreach ($params_names as $param_name) {
+        foreach ($param_names as $param_name) {
             $param_value = isset($_REQUEST[$param_name]) ? $_REQUEST[$param_name] : '';
             if ($param_value) {
                 if (!self::_validParam($param_name, $param_value)) { 


### PR DESCRIPTION
## This pull request adds a helper function to check that parameters are well-formed. 

We need to do this in the LORIS codebase for reasons of security. This function is simple to use and will allow for easier refactoring in the core as well as in LORIS modules.

I included an example usage in the `Candidate` class which should indicate why we need to do this and how such issues can be fixed.

### Before - "bad LORIS"
User supplies malicious input into a URL parameter which then executes. ([More](https://www.hacksplaining.com/exercises/xss-reflected) [info](https://security.stackexchange.com/questions/65142/what-is-reflected-xss#65147)).

![badloris](https://cloud.githubusercontent.com/assets/4022790/25591397/5ce87f42-2e82-11e7-9a67-55b576a5af15.gif)


### After - "good LORIS"
Invalid user input is rejected.

![goodloris](https://cloud.githubusercontent.com/assets/4022790/25591407/61e02a68-2e82-11e7-8893-5076f3f0bdb9.gif)