### PR TITLE
[Core] "Location" header instead of JS to redirect

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -451,9 +451,8 @@ class NDB_Caller
             );
 
             $this->instrument = $instrument;
-            return "<script language='javascript'>"
-                . "window.location='$redirectToOnSuccess'"
-                . "</script>";
+            header("Location: $redirectToOnSuccess");
+            die();
         }
         $user =& User::singleton();
 
@@ -484,9 +483,8 @@ class NDB_Caller
         $success = $instrument->save();
 
         if ($redirectToOnSuccess !== null && $success !== false) {
-            return "<script language='javascript'>"
-                .   "window.location='$redirectToOnSuccess'"
-                . "</script>";
+            header("Location: $redirectToOnSuccess");
+            die();
         }
         // create an instrument status object
         $status  = new NDB_BVL_InstrumentStatus;

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -452,7 +452,7 @@ class NDB_Caller
 
             $this->instrument = $instrument;
             header("Location: $redirectToOnSuccess");
-            die();
+            return "";
         }
         $user =& User::singleton();
 
@@ -484,7 +484,7 @@ class NDB_Caller
 
         if ($redirectToOnSuccess !== null && $success !== false) {
             header("Location: $redirectToOnSuccess");
-            die();
+            return "";
         }
         // create an instrument status object
         $status  = new NDB_BVL_InstrumentStatus;


### PR DESCRIPTION
In reference to Redmine ticket 6851,

>Our forms should return with an HTTP redirect instead of a 200 OK when posting data (ie instrument forms, menu filters, etc) so that the back button doesn't break and return a blank page.

I ran `grep -nr --include \*.inc 'window\.location' ./`

Made the changes to:

```
header("Location: $redirectToOnSuccess");
die();
```

...
Looks exploitable...

However, I ran `grep -nr --include \*.php \>load\( ./` and `grep -nr --include \*.inc \>load\( ./` and could not find anything that was using the `$redirectToOnSuccess`. Can someone else double check this? If it isn't being used, I should just remove it.