### PR TITLE
Fixing the loris form '0' emptying issue

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1180,7 +1180,7 @@ class LorisForm
 
                 if (isset($el['required'])
                     && $el['required'] === true
-                    && empty($value)
+                    && (is_null($value) || (empty($value) && $value !=0))
                 ) {
                     $errors[$el['name']] = "required fail";
                 }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1180,7 +1180,7 @@ class LorisForm
 
                 if (isset($el['required'])
                     && $el['required'] === true
-                    && (is_null($value) || (empty($value) && $value !=0))
+                    && $value === ""
                 ) {
                     $errors[$el['name']] = "required fail";
                 }


### PR DESCRIPTION
Loris form $this->form->addRule("value", "Required", 'required');  sets the 'required fail' for the value '0' which is sometimes a valid value/option for some instruments.

empty($value) is true for 0 which cause the issue.

So going for a better option to overcome that issue.
