### PR TITLE
[Request Account] Removed polytheism ability from non-admins

### DIFF
--- a/htdocs/request_account/process_new_account.php
+++ b/htdocs/request_account/process_new_account.php
@@ -198,23 +198,22 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         if ($result == 0) {
             // insert into DB only if email address doesn't exist
             $success = $DB->insert('users', $vals);
+            // Get the ID of the new user and insert into user_psc_rel
+            $user_id = $DB->pselectOne(
+                "SELECT ID FROM users WHERE Email = :VEmail",
+                array('VEmail' => $from)
+            );
+
+            $DB->insert(
+                'user_psc_rel',
+                array(
+                 'UserID'   => $user_id,
+                 'CenterID' => $site,
+                )
+            );
         }
         // Show success message even if email already exists for security reasons
         $tpl_data['success'] = true;
-
-        // Get the ID of the new user and insert into user_psc_rel
-        $user_id = $DB->pselectOne(
-            "SELECT ID FROM users WHERE Email = :VEmail",
-            array('VEmail' => $from)
-        );
-
-        $DB->insert(
-            'user_psc_rel',
-            array(
-             'UserID'   => $user_id,
-             'CenterID' => $site,
-            )
-        );
 
         unset($_SESSION['tntcon']);
     }


### PR DESCRIPTION
In reference to redmine, 12375,

New players should only be allowed one religion on character creation. Subsequent beliefs may be conferred upon the player by the game master, should his/her faith be strong enough to appease multiple gods.