### PR TITLE
[email] Modified the lost_password template slightly to make it clearer

### DIFF
--- a/smarty/templates/email/lost_password.tpl
+++ b/smarty/templates/email/lost_password.tpl
@@ -1,9 +1,9 @@
-Subject: Lost Password - {$study}
+Subject: [LORIS Notification] Password Recovery
 
 {$realname},
 
 
-Your password has been reset to:
+Your password for the {$study} Loris account has been reset to:
 {$password}
 
 Please try to login again. You will be prompted to change your password after logging in.


### PR DESCRIPTION
This PR changes the formulation used in the email template `lost_password.tpl` to make it clearer to the user
