### PR TITLE
[ImgBrowser] Add DICOM Download 

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -90,6 +90,11 @@ if (strpos("..", $File) !== false) {
     exit(4);
 }
 
+// If $File contains "tarchive", identify it as $FileExt: "DICOMTAR"
+if (strpos($File, "tarchive") ) { 
+    $FileExt = "DICOMTAR";
+}
+
 switch($FileExt) {
 case 'mnc':
     $FullPath         = $mincPath . '/' . $File;
@@ -129,6 +134,12 @@ case 'xml':
 case 'nrrd':
     $FullPath         = $imagePath . '/' . $File;
     $MimeType         = 'image/vnd.nrrd';
+    $DownloadFilename = basename($File);
+    break;
+case 'DICOMTAR':   
+    // ADD case for DICOMTAR
+    $FullPath         = $File;
+    $MimeType         = "application/x-nifti-gz";
     $DownloadFilename = basename($File);
     break;
 default:

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -136,10 +136,10 @@ case 'nrrd':
     $MimeType         = 'image/vnd.nrrd';
     $DownloadFilename = basename($File);
     break;
-case 'DICOMTAR':   
+case 'tar':   
     // ADD case for DICOMTAR
-    $FullPath         = $File;
-    $MimeType         = "application/x-nifti-gz";
+    $FullPath         = $imagePath . '/' . $File;
+    $MimeType         = 'application/x-tar';
     $DownloadFilename = basename($File);
     break;
 default:

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -90,8 +90,9 @@ if (strpos("..", $File) !== false) {
     exit(4);
 }
 
-// If $File contains "tarchive", identify it as $FileExt: "DICOMTAR"
-if (strpos($File, "tarchive") ) { 
+// If $File contains "DCM_", prefix automatically inserted by the
+// LORIS-MRI pipeline, identify it as $FileExt: "DICOMTAR"
+if (strpos($File, "DCM_") ) {
     $FileExt = "DICOMTAR";
 }
 
@@ -136,7 +137,7 @@ case 'nrrd':
     $MimeType         = 'image/vnd.nrrd';
     $DownloadFilename = basename($File);
     break;
-case 'tar':   
+case 'DICOMTAR':
     // ADD case for DICOMTAR
     $FullPath         = $imagePath . '/' . $File;
     $MimeType         = 'application/x-tar';

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -97,22 +97,16 @@ class Imaging_Session_ControlPanel
             $params['PVL']     = $timePoint->getVisitLabel();
         }
 
-        $tarchiveIDs = $DB->pselectRow(
-            "SELECT TarchiveID 
-            FROM tarchive 
-            WHERE PatientName LIKE $ID",
-            $params
-        );
-        $subjectData['tarchiveids'] = $tarchiveIDs;
-
         // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
-        $qresult = $DB->pselect(
+        $qresult = $DB->pselectRow(
             "SELECT TarchiveID, ArchiveLocation
             FROM tarchive
             WHERE PatientName LIKE $ID",
             $params
         );
-        $subjectData['tarchiveidLoc'] =  (empty($qresult['ArchiveLocation'])) ? "" : $qresult['ArchiveLocation'];
+        $subjectData['tarchiveids']   = $qresult['TarchiveID'];
+        $subjectData['tarchiveidLoc'] =  (empty($qresult['ArchiveLocation'])) ? ""
+                                         : $qresult['ArchiveLocation'];
 
         $config =& NDB_Config::singleton();
 

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -96,7 +96,8 @@ class Imaging_Session_ControlPanel
             $params['PCandID'] = $timePoint->getCandID();
             $params['PVL']     = $timePoint->getVisitLabel();
         }
-        $tarchiveIDs = $DB->pselect(
+
+        $tarchiveIDs = $DB->pselectRow(
             "SELECT TarchiveID 
             FROM tarchive 
             WHERE PatientName LIKE $ID",
@@ -105,13 +106,13 @@ class Imaging_Session_ControlPanel
         $subjectData['tarchiveids'] = $tarchiveIDs;
 
         // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
-        $qresult = $DB->pselectRow(
+        $qresult = $DB->pselect(
             "SELECT TarchiveID, ArchiveLocation
             FROM tarchive
-            WHERE PatientName LIKE :patient_name",
-            array('patient_name' => $params)
+            WHERE PatientName LIKE $ID",
+            $params
         );
-        $subjectData['tarchiveidLoc'] =  (empty($qresult)) ? "" : $qresult;
+        $subjectData['tarchiveidLoc'] =  (empty($qresult['ArchiveLocation'])) ? "" : $qresult['ArchiveLocation'];
 
         $config =& NDB_Config::singleton();
 

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -104,6 +104,15 @@ class Imaging_Session_ControlPanel
         );
         $subjectData['tarchiveids'] = $tarchiveIDs;
 
+        // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
+        $tarchiveIDLoc = $DB->pselect(
+            "SELECT TarchiveID, ArchiveLocation
+            FROM tarchive
+            WHERE PatientName LIKE $ID",
+            $params
+        );
+        $subjectData['tarchiveidLoc'] = $tarchiveIDLoc;
+
         $config =& NDB_Config::singleton();
 
         //if table is not in database return false to not display in the template

--- a/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
+++ b/modules/imaging_browser/php/Imaging_Session_ControlPanel.class.inc
@@ -105,13 +105,13 @@ class Imaging_Session_ControlPanel
         $subjectData['tarchiveids'] = $tarchiveIDs;
 
         // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
-        $tarchiveIDLoc = $DB->pselect(
+        $qresult = $DB->pselectRow(
             "SELECT TarchiveID, ArchiveLocation
             FROM tarchive
-            WHERE PatientName LIKE $ID",
-            $params
+            WHERE PatientName LIKE :patient_name",
+            array('patient_name' => $params)
         );
-        $subjectData['tarchiveidLoc'] = $tarchiveIDLoc;
+        $subjectData['tarchiveidLoc'] =  (empty($qresult)) ? "" : $qresult;
 
         $config =& NDB_Config::singleton();
 

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -38,11 +38,13 @@
         {if $rad_review_table_exists}
             <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/radiology_review/?commentID={$subject.RadiologyReviewCommentID}">Radiology Review</a></li>
         {/if}
+        {foreach from=$subject.tarchiveids item=tarchive}
+          <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|escape:"url"}">DICOM Archive(s) {$tarchive}</a></li>
+        {/foreach}
         {foreach from=$subject.tarchiveidLoc item=tarchiveLoc}
-          <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchiveLoc.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive(s) {$tarchiveLoc.TarchiveID}</a></li>
-              <li><a href="mri/jiv/get_file.php?file={$tarchiveLoc.ArchiveLocation}"><button class="button">
+              <li><a href="/mri/jiv/get_file.php?file=tarchive/{$tarchiveLoc}" class="btn btn-primary btn-small">
                   <span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM</span>
-              </button></a></li>
+              </a></li>
         {/foreach}
         {if $mantis}
             <li><a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a></li>

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -38,8 +38,12 @@
         {if $rad_review_table_exists}
             <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/radiology_review/?commentID={$subject.RadiologyReviewCommentID}">Radiology Review</a></li>
         {/if}
-        {foreach from=$subject.tarchiveids item=tarchive}
-        <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive.TarchiveID}</a></li>{/foreach}
+        {foreach from=$subject.tarchiveidLoc item=tarchiveLoc}
+          <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchiveLoc.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive(s) {$tarchiveLoc.TarchiveID}</a></li>
+              <li><a href="mri/jiv/get_file.php?file={$tarchiveLoc.ArchiveLocation}"><button class="button">
+                  <span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM</span>
+              </button></a></li>
+        {/foreach}
         {if $mantis}
             <li><a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a></li>
         {/if}


### PR DESCRIPTION
This pull request adds DICOM download to the Imaging Browser View Session page, via a button in the navigation panel.  
All files for the given session (specifically, tarchiveID) will be downloaded.
get_file.php is also modified to identify DICOM tarchives as type of file for download. 

Note that your Dicom tarchives (and above directories) must be Executable* (unix permission-wise) for the download (get_file.php) to work.
