### PR TITLE
[LorisForm] Add readonly capabilities to text elements

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -880,6 +880,7 @@ class LorisForm
     {
         $cls      = '';
         $disabled = '';
+        $readonly = '';
         if (isset($el['class'])) {
             $cls = "class=\"$el[class]\"";
         }
@@ -913,6 +914,7 @@ class LorisForm
                 : ''
               )
             . $disabled
+            . ' '
             . $readonly
             .">";
     }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -93,6 +93,9 @@ class LorisForm
         if (isset($attribs['disabled'])) {
             $el['disabled'] = true;
         }
+        if (isset($attribs['readonly'])) {
+            $el['readonly'] = true;
+        }
         if (isset($attribs['required']) && $attribs['required'] === true) {
             $el['required'] = true;
         }
@@ -883,6 +886,9 @@ class LorisForm
         if (isset($el['disabled']) || $this->frozen) {
             $disabled = 'disabled';
         }
+        if (isset($el['readonly'])) {
+            $readonly = 'readonly';
+        }
         $value = $this->getValue($el['name']);
         return "<input name=\"$el[name]\" type=\"$type\" $cls"
             . (
@@ -907,6 +913,7 @@ class LorisForm
                 : ''
               )
             . $disabled
+            . $readonly
             .">";
     }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -399,8 +399,9 @@ class NDB_Page
     function createText(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attribs=array()
     ) {
+        $attr=array_merge($attribs,array('class' => 'form-control input-sm'));
         return $this->form->createElement("text", $field, $label, $attr);
     }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -390,9 +390,9 @@ class NDB_Page
     /**
      * Creates a QuickForm text element but does not add it to the form
      *
-     * @param string $field The field name for this text element
-     * @param string $label The label to attach to the element
-     * @param array  $attr  Extra HTML attributes to add to the element
+     * @param string $field   The field name for this text element
+     * @param string $label   The label to attach to the element
+     * @param array  $attribs Extra HTML attributes to add to the element
      *
      * @return HTML_QuickForm Text element
      */
@@ -401,7 +401,7 @@ class NDB_Page
         $label=null,
         $attribs=array()
     ) {
-        $attr=array_merge($attribs,array('class' => 'form-control input-sm'));
+        $attr =array_merge($attribs, array('class' => 'form-control input-sm'));
         return $this->form->createElement("text", $field, $label, $attr);
     }
 


### PR DESCRIPTION
This pull request adds the ability to make text fields readonly. readonly text fields get submitted with the form. disabled does not.
