### PR TITLE
Fix syntax errors in API

### DIFF
--- a/htdocs/api/v0.0.1/candidates/InstrumentData.php
+++ b/htdocs/api/v0.0.1/candidates/InstrumentData.php
@@ -98,7 +98,7 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
                 null,
                 true
             );
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             $this->header("HTTP/1.1 404 Not Found");
             $this->error("Invalid instrument");
             $this->safeExit(0);

--- a/htdocs/api/v0.0.2/candidates/InstrumentData.php
+++ b/htdocs/api/v0.0.2/candidates/InstrumentData.php
@@ -98,7 +98,7 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
                 null,
                 true
             );
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             $this->header("HTTP/1.1 404 Not Found");
             $this->error("Invalid instrument");
             $this->safeExit(0);

--- a/htdocs/api/v0.0.2/candidates/visits/images/format/BrainBrowser.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/format/BrainBrowser.php
@@ -86,7 +86,7 @@ class BrainBrowser extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                        "zspace" => $this->_getDimension("zspace"),
                       ];
         if (count($orderArray) === 4) {
-            $this->JSON['time'] = $this->_getDimension("time")
+            $this->JSON['time'] = $this->_getDimension("time");
         }
         $this->JSON['order'] = $orderArray;
     }


### PR DESCRIPTION
This fixes two errors in the API code. BrainBrowser was missing
a semicolon for a statement, and instrument data was trying to
catch "Exception" so that it can return an error if anything
goes wrong, but since the code lives in a namespace it needs
to catch Exception from the root namespace, not it's own
(undefined) Exception type.