### PR TITLE
Add the minimal config for phan which LORIS passes

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,75 @@
+<?php
+
+return [
+	"backward_compatibility_checks" => true,
+	// The docs on quick_mode at
+	// https://github.com/etsy/phan/wiki/Incrementally-Strengthening-Analysis
+	// don't seem reasonable. They claim that quick_mode=true add more errors.
+	// This is false on the assumption that that's a typo.
+	// It doesn't seem to have any effect on LORIS's codebase anyways.
+	"quick_mode" => false,
+	// FIXME: analyze signature compatibility should be true, but
+	// there's too many other things to fix first.
+	"analyze_signature_compatibility" => false,
+	// FIXME: allow_missing_properties should be false, but there's
+	// too many other things to fix first.
+	"allow_missing_properties" => true,
+	// FIXME: null_casts_as_any_type should be false.
+	// This only adds 2 errors, which should be fairly easy to fix.
+	"null_casts_as_any_type" => true,
+	"scalar_implicit_cast" => false,
+	"ignore_undeclared_variables_in_global_scope" => false,
+	"suppress_issue_types" => [
+		"PhanDeprecatedFunction",
+		"PhanRedefineClass",
+		"PhanUndeclaredMethod",
+		"PhanUndeclaredFunction",
+		"PhanUndeclaredVariable",
+		"PhanUndelcaredStaticMethod",
+		"PhanUndeclaredClassMethod",
+		"PhanUndeclaredTypeParameter",
+		"PhanUndeclaredConstant",
+		"PhanUndeclaredClass",
+		"PhanUndeclaredClassCatch",
+		"PhanUndeclaredStaticMethod",
+		"PhanUndeclaredExtendedClass",
+		"PhanTypeMismatchForeach",
+		"PhanTypeMismatchDefault",
+		"PhanTypeMismatchArgument",
+		"PhanTypeMismatchArgumentInternal",
+		"PhanTypeMismatchReturn",
+		"PhanTypeMismatchProperty",
+		"PhanTypeMissingReturn",
+		"PhanNonClassMethodCall",
+		"PhanTypeVoidAssignment",
+		"PhanParamTooFew",
+		"PhanParamTooMany",
+		"PhanStaticCallToNonStatic",
+		"PhanTypeComparisonToArray",
+		"PhanTypeArraySuspicious",
+		"PhanTypeInvalidRightOperand",
+		"PhanRedefineFunctionInternal",
+		"PhanRedefineFunction",
+		"PhanNoopVariable",
+		"PhanParamSpecial1",
+		"PhanParamSpecial2",
+	],
+	"analyzed_file_extensions" => ["php", "inc"],
+	"directory_list" => [
+		/* This doesn't include php/installer, because there's
+		   (intentionally) classes in the installer namespace
+                   which redeclare classes from php/libraries, in order
+		   to bootstrap the installer before the config/database
+		   is set up */
+		"php/libraries",
+		"php/exceptions",
+		"htdocs",
+		/* Modules should be included, but there's enough problems
+		identified by phan without the modules included.. */
+		// "modules",
+		"vendor",
+	],
+	"exclude_analysis_directory_list" => [
+		"vendor",
+	],
+];


### PR DESCRIPTION
Add the minimal config for LORIS which lets the LORIS
codebase pass with the phan static analysis tool, so that
type errors can be fixed one class of error at a time. See:
https://github.com/etsy/phan/wiki/Incrementally-Strengthening-Analysis

Unfortunately, this means that most classes of errors are
currently ignored, however phan does still do enough analysis to
have picked up on the references to undefined classes in PR#2802.

Ideally, phan would be run as part of the CI, but the requirements
for phan are PHP 7.1 with the AST extension installed, and adding
it to composer.json would mean that Travis wouldn't pass on either
7.0 or 5.6 because of unmet requirements (which aren't actually
requirements for LORIS), so until the minimum requirements for LORIS
are PHP 7.1 this will need to be run manually by developers on occasion.