### PR TITLE
Bug fix in consent section

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -439,7 +439,7 @@ function getConsentStatusHistory($candID, $consents)
             . $db->escape($consent) . ", "
             . $db->escape($consent . '_date') . ", "
             . $db->escape($consent . '_withdrawal')
-            ." FROM consent_info_history WHERE CandID=:cid",
+            ." FROM consent_info_history WHERE $consent IS NOT NULL and CandID=:cid",
             array('cid' => $candID)
         );
 


### PR DESCRIPTION
There seem to be unwanted duplicate entries displaying in consent history section when a consent is updated.

This is a bug in looping the consent history table where all of the consent even if not updated is pushed.

Before the fix

![screenshot from 2017-05-12 15 12 10](https://cloud.githubusercontent.com/assets/23702452/26075368/041fcb48-3983-11e7-9c5e-153579f5bd24.png)


After the fix

![screenshot from 2017-05-12 15 15 24](https://cloud.githubusercontent.com/assets/23702452/26075385/134ea5d0-3983-11e7-8a75-f0d649728c5e.png)

