### PR TITLE
[Instrument List] Fixed questionable code so it stops spamming error logs

### DIFF
--- a/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
+++ b/modules/instrument_list/php/Instrument_List_ControlPanel.class.inc
@@ -209,7 +209,9 @@ Class Instrument_List_ControlPanel extends TimePoint
             return;
         }
         $condition1 = isset($_REQUEST['setSubmitted']);
-        $condition2 = $_REQUEST['setSubmitted'] == 'N';
+        $condition2 = $condition1 ?
+            $_REQUEST['setSubmitted'] == 'N' :
+            false;
         $condition3 = $this->_hasAccess_SendToDCC();
         $condition4 = !in_array(
             $currentStage,

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -70,12 +70,10 @@ class BVL_Feedback_Panel
         $candidateObject         = Candidate::singleton($candidateID);
         $this->tpl_data['pscid'] = $candidateObject->getPSCID();
 
-        $this->tpl_data['sessionID'] = isset($feedbackProfile["SessionID"]) ?
-            $feedbackProfile["SessionID"] : null;
+        $this->tpl_data['sessionID'] = $feedbackProfile["SessionID"] ?? null;
 
         $feedbackObject = $this->_feedbackThread->_feedbackObjectInfo;
-        $this->tpl_data['commentID'] = isset($feedbackObject["CommentID"]) ?
-            $feedbackObject["CommentID"] : null;
+        $this->tpl_data['commentID'] = $feedbackObject["CommentID"] ?? null;
 
         $this->tpl_data['thread_list']    = $this->_feedbackThread->getThreadList();
         $this->tpl_data['feedback_level'] = $this->_feedbackThread->_feedbackLevel;

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -62,16 +62,21 @@ class BVL_Feedback_Panel
      */
     function display()
     {
-        $this->tpl_data['candID']
-            = $this->_feedbackThread->_feedbackCandidateProfileInfo["CandID"];
-        $candidateID     = $this->_feedbackThread
-            ->_feedbackCandidateProfileInfo["CandID"];
-        $candidateObject = Candidate::singleton($candidateID);
-        $this->tpl_data['pscid']          = $candidateObject->getPSCID();
-        $this->tpl_data['sessionID']      = $this->_feedbackThread
-            ->_feedbackCandidateProfileInfo["SessionID"];
-        $this->tpl_data['commentID']      = $this->_feedbackThread
-            ->_feedbackObjectInfo["CommentID"];
+        $feedbackProfile = $this->_feedbackThread->_feedbackCandidateProfileInfo;
+        $candidateID     = $feedbackProfile["CandID"];
+
+        $this->tpl_data['candID'] = $candidateID;
+
+        $candidateObject         = Candidate::singleton($candidateID);
+        $this->tpl_data['pscid'] = $candidateObject->getPSCID();
+
+        $this->tpl_data['sessionID'] = isset($feedbackProfile["SessionID"]) ?
+            $feedbackProfile["SessionID"] : null;
+
+        $feedbackObject = $this->_feedbackThread->_feedbackObjectInfo;
+        $this->tpl_data['commentID'] = isset($feedbackObject["CommentID"]) ?
+            $feedbackObject["CommentID"] : null;
+
         $this->tpl_data['thread_list']    = $this->_feedbackThread->getThreadList();
         $this->tpl_data['feedback_level'] = $this->_feedbackThread->_feedbackLevel;
         $this->tpl_data['feedback_types']


### PR DESCRIPTION
Accessing `/instrument_list/?candID=XXXXXX&sessionID=XXXX` always generates three error log messages with warnings about undefined indices. This pull request stops them from appearing without modifying the behaviour of the code.

I plan to go through the code base and fix these little things where ever I see them.