### PR TITLE
[New Profile]/[Core] Cleaned Up new_profile, LorisForm, NDB_Caller related code to stop generating warnings

### DIFF
--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -61,6 +61,7 @@ class NDB_Form_New_Profile extends NDB_Form
         $config =& NDB_Config::singleton();
         $dob    = empty($values['dob1']) ? null : $values['dob1'];
 
+        $edc = null;
         if ($config->getSetting('useEDC') == "true") {
             $edc = empty($values['edc1']) ? null : $values['edc1'];
         }
@@ -76,7 +77,7 @@ class NDB_Form_New_Profile extends NDB_Form
                 $dob,
                 $edc,
                 $values['gender'],
-                $values['PSCID']
+                isset($values['PSCID']) ? $values['PSCID'] : null
             );
         } else {
             $centerIDs = $user->getData('CenterIDs');
@@ -86,7 +87,7 @@ class NDB_Form_New_Profile extends NDB_Form
                 $dob,
                 $edc,
                 $values['gender'],
-                $values['PSCID']
+                isset($values['PSCID']) ? $values['PSCID'] : null
             );
         }
 

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -77,7 +77,7 @@ class NDB_Form_New_Profile extends NDB_Form
                 $dob,
                 $edc,
                 $values['gender'],
-                isset($values['PSCID']) ? $values['PSCID'] : null
+                $values['PSCID'] ?? null
             );
         } else {
             $centerIDs = $user->getData('CenterIDs');
@@ -87,7 +87,7 @@ class NDB_Form_New_Profile extends NDB_Form
                 $dob,
                 $edc,
                 $values['gender'],
-                isset($values['PSCID']) ? $values['PSCID'] : null
+                $values['PSCID'] ?? null
             );
         }
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1949,9 +1949,7 @@ class LorisForm
     {
         foreach ($submitKeys as $key) {
             if (!isset($this->form[$key])) {
-                $tp = isset($this->groupMapping[$key]) ?
-                    $this->groupMapping[$key] :
-                    null;
+                $tp = $this->groupMapping[$key] ?? null;
                 $el = is_null($tp) ?
                     null :
                     $this->form[$tp['groupName']]['elements'][$tp['index']];

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1949,8 +1949,12 @@ class LorisForm
     {
         foreach ($submitKeys as $key) {
             if (!isset($this->form[$key])) {
-                $tp = $this->groupMapping[$key];
-                $el = $this->form[$tp['groupName']]['elements'][$tp['index']];
+                $tp = isset($this->groupMapping[$key]) ?
+                    $this->groupMapping[$key] :
+                    null;
+                $el = is_null($tp) ?
+                    null :
+                    $this->form[$tp['groupName']]['elements'][$tp['index']];
                 if (!$el) {
                     $arr[$key] = $_REQUEST[$key];
                     continue;

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -358,7 +358,9 @@ class NDB_Caller
         if (method_exists($menu, 'getFeedbackPanel')) {
             $this->feedbackPanel = $menu->getFeedbackPanel(
                 $_REQUEST['candID'],
-                $_REQUEST['sessionID']
+                isset($_REQUEST['sessionID']) ?
+                    $_REQUEST['sessionID'] :
+                    null
             );
         }
         if (method_exists($menu, 'save')) {

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -180,7 +180,7 @@ class NDB_Caller
             ) {
                 // No subtest, load the menu
 
-                $mode = isset($_REQUEST['mode']) ? $_REQUEST['mode'] : '';
+                $mode = $_REQUEST['mode'] ?? '';
                 if ($submenu !== null) {
                     $html = $this->loadMenu($submenu, $mode);
                 } else {
@@ -190,9 +190,7 @@ class NDB_Caller
                 $this->type = 'menu';
                 return $html;
             } else if ($this->existsAndRequire("NDB_Form_$test_name.class.inc")) {
-                $identifier = isset($_REQUEST['identifier'])
-                    ? $_REQUEST['identifier']
-                    : '';
+                $identifier = $_REQUEST['identifier'] ?? '';
                 $html       = $this->loadForm($test_name, $subtest, $identifier);
 
                 $this->type = 'form';
@@ -237,7 +235,7 @@ class NDB_Caller
                 || $this->existsAndRequire($php_menu_filter_form))
             ) {
 
-                $mode = isset($_REQUEST['mode']) ? $_REQUEST['mode'] : '';
+                $mode = $_REQUEST['mode'] ?? '';
                 $html = $this->loadMenu($test_name, $mode);
 
                 $this->type = 'menu';
@@ -251,9 +249,7 @@ class NDB_Caller
                 || $this->existsAndRequire($php_form)
             ) {
 
-                $identifier = isset($_REQUEST['identifier'])
-                    ? $_REQUEST['identifier']
-                    : '';
+                $identifier = $_REQUEST['identifier'] ?? '';
                 $html       = $this->loadForm($test_name, $subtest, $identifier);
 
                 $this->type = 'form';
@@ -358,9 +354,7 @@ class NDB_Caller
         if (method_exists($menu, 'getFeedbackPanel')) {
             $this->feedbackPanel = $menu->getFeedbackPanel(
                 $_REQUEST['candID'],
-                isset($_REQUEST['sessionID']) ?
-                    $_REQUEST['sessionID'] :
-                    null
+                $_REQUEST['sessionID'] ?? null
             );
         }
         if (method_exists($menu, 'save')) {


### PR DESCRIPTION
Creating a new candidate at `/new_profile/` or accessing a candidate at `/XXXXXX/` (Horrible route name, btw) will generate error log warnings.

This pull request removes them without modifying the behaviour.

You will still see warnings from L72 and 74 of `BVL_Feedback_Panel.class.inc` but that is fixed in #2809 