### PR TITLE
[User accounts] Reject users

### DIFF
--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -9,7 +9,7 @@
  * @category Loris
  * @package  User_Accounts
  * @author   Leo T. <lthomas.mcin@gmail.com>
- * @license  Loris license    "PSCID has an invalid structure",
+ * @license  Loris license
  * @link     https://github.com/aces/Loris
  */
 

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -30,8 +30,7 @@ if (!isset($_POST['identifier'])) {
 * Checks that logged in user has user_accounts permissions, which is
 * also included in admin permissions
 *
-* @return boolean true is user has admin permission or user accounts
-                false otherwise
+* @return boolean true if user has admin permission or user accounts false otherwise
 */
 function _hasPerm()
 {

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -7,10 +7,9 @@
  * PHP Version 5
  *
  * @category Loris
- * @package  user_accounts
+ * @package  User_Accounts
  * @author   Leo T. <lthomas.mcin@gmail.com>
  * @license  Loris license    "PSCID has an invalid structure",
-                    PSCID_INVALID_STRUCTURE
  * @link     https://github.com/aces/Loris
  */
 
@@ -20,24 +19,31 @@
     define('ACCOUNT_ACTIVE', 4);
 
 
-    if (!isset($_POST['identifier'])){
-        throw new LorisException("No identifier supplied", NO_IDENTIFIER_SUPPLIED);
-        exit(1);
-    }else{
-        $identifier = $_POST["identifier"];
-        reject_user($identifier);
-    }
-    
-    function _hasPerm(){
-        $user =& User::singleton();
-        if (isset($user)){
-            if (!$user->hasPermission('user_accounts')) {
-                return false;
-            }
-            return true;
+if (!isset($_POST['identifier'])) {
+    throw new LorisException("No identifier supplied", NO_IDENTIFIER_SUPPLIED);
+    exit(1);
+} else {
+    $identifier = $_POST["identifier"];
+    reject_user($identifier);
+}
+/**
+* Checks that logged in user has user_accounts permissions, which is
+* also included in admin permissions
+*
+* @return boolean true is user has admin permission or user accounts
+                false otherwise
+*/
+function _hasPerm()
+{
+    $user =& User::singleton();
+    if (isset($user)) {
+        if (!$user->hasPermission('user_accounts')) {
+            return false;
         }
-        return false;
+        return true;
     }
+    return false;
+}
 
     /**
     * Query database on UserID to check that password has doesn't
@@ -45,40 +51,41 @@
     * users with account activity can't be rejected by setting
     * their status to pending.
     *
-    * @param string $id identifier of account to verify
+    * @param string $identifier of account to verify
     *
-    * @return boolean true is Password_hash is null and
+    * @return boolean true if Password_hash is null and
     * Pending_approval is Yes, false otherwsie
+    *
+    * @throws Loris exception if the userID isn't found in the database.
     */
-    function _canRejectAccount($identifier)
-    {
-        $DB     = Database::singleton();
-        try{
-            $fields =  $DB->pselect(
-                "SELECT Password_hash, Pending_approval
+function _canRejectAccount($identifier)
+{
+    $DB = Database::singleton();
+    try{
+        $fields =  $DB->pselect(
+            "SELECT Password_hash, Pending_approval
                        FROM users
                        WHERE UserID=:id",
-                array("id" => $identifier)
-            );
-            if (is_null($fields[0]['Password_hash'])
-                && $fields[0]['Pending_approval']=="Y"
-            ) {
-                return true;
-            }
-            return false;
-        } catch (DatabaseException $e) {
-            throw new LorisException("User not found in database", USER_NOT_FOUND);
-            exit(1);
+            array("id" => $identifier)
+        );
+        if (is_null($fields[0]['Password_hash'])
+            && $fields[0]['Pending_approval']=="Y"
+        ) {
+            return true;
         }
-    }   
+        return false;
+    } catch (DatabaseException $e) {
+        throw new LorisException("User not found in database", USER_NOT_FOUND);
+        exit(1);
+    }
+}
 
 
     /**
-    * Send DB query to remove user based on userID through a GET
-    * request, after checking that the user is logged in as
-    * admin / user accounts, and the user to be removed is 
-    * pending approval and has no password hash. 
-    * The URL is redirected to user_account after the operation.
+    * Send DB query to remove user based on userID, checking that the
+    * user sending the request has admin permissions and the account
+    * can be removed (no password hash => has never had an activity on
+    * Loris, and is pending).
     *
     * @return void
     */
@@ -86,24 +93,31 @@
     function reject_user($identifier)
     {
     // @codingStandardsIgnoreEnd
-        $DB     = Database::singleton();
-        $config = NDB_Config::singleton();
-        $baseURL  = $config->getSetting('url');
+        $DB      = Database::singleton();
+        $config  = NDB_Config::singleton();
+        $baseURL = $config->getSetting('url');
 
         $redirect = $baseURL . "/user_accounts/";
-        
-        if (!_hasPerm()){
-            throw new LorisException("You do not have the correct permissions for this operation (need admin or user accounts)", INCORRECT_PERMISSION);
+
+    if (!_hasPerm()) {
+        throw new LorisException(
+            "You do not have the correct permissions for this 
+            operation (need admin or user accounts)",
+            INCORRECT_PERMISSION
+        );
+        exit(1);
+    } else {
+        if (!_canRejectAccount($identifier)) {
+            throw new LorisException(
+                "This account is active and connot be rejected",
+                ACCOUNT_ACTIVE
+            );
             exit(1);
-        }else{
-            if (!_canRejectAccount($identifier)){
-                throw new LorisException("This account is active and connot be rejected", ACCOUNT_ACTIVE);
-                exit(1);
-            }else{
-                $DB->delete('users', array("UserID" => $identifier));
-                exit;
-            }   
+        } else {
+            $DB->delete('users', array("UserID" => $identifier));
+            exit;
         }
+    }
     }
 
 ?>

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Media uploader.
+ *
+ * Handles media upload and update actions received from a front-end ajax call
+ *
+ * PHP Version 5
+ *
+ * @category Loris
+ * @package  user_accounts
+ * @author   Leo T. <lthomas.mcin@gmail.com>
+ * @license  Loris license
+ * @link     https://github.com/aces/Loris
+ */
+	
+	if (isset($_GET['identifier'])) {
+    	$identifier = $_GET['identifier'];
+    	reject_user($identifier);
+	}
+    
+    function _hasPerm(){
+    	$db   =& Database::singleton();
+   	 	$user =& User::singleton();
+   	 	if (isset($user)){
+    		if (!$user->hasPermission('user_accounts')) {
+        		return False;
+    		}
+    		return True;
+    	}
+    	return False;
+    }
+
+    /**
+    * Query database on UserID to check that password has doesn't
+    * exist and account is still pending approval, to ensure the
+    * users with account activity can't be rejected by setting
+    * their status to pending.
+    *
+    * @param string $id identifier of account to verify
+    *
+    * @return boolean true is Password_hash is null and
+    * Pending_approval is Yes, false otherwsie
+    */
+    function _canRejectAccount($identifier)
+    {
+        $DB     = Database::singleton();
+        $fields =  $DB->pselect(
+            "SELECT Password_hash, Pending_approval
+                   FROM users
+                   WHERE UserID=:id",
+            array("id" => $identifier)
+        );
+        if (is_null($fields[0]['Password_hash'])
+            && $fields[0]['Pending_approval']=="Y"
+        ) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+    * Send DB query to remove user based on userID through a GET
+    * request.
+    * The reject user button populates on edit_users page, therefore
+    * any user that has access to the button has user_accounts
+    * privileges.
+    * The URL is redirected to user_account after the operation
+    *
+    * @return void
+    */
+    // @codingStandardsIgnoreStart
+    function reject_user($identifier)
+    {
+    // @codingStandardsIgnoreEnd
+        $DB     = Database::singleton();
+
+        $redirect = $baseURL . "/user_accounts/";
+
+        // The $editor variable is set by the edit_user script.
+        // Checking that this is set ensures that the user is
+        // accessing this function through the authorized button
+        // and not by pointing their URL directly to this script.
+     	if (_hasPerm()){ 
+        	if (_canRejectAccount($identifier)){
+        		$DB->delete('users', array("UserID" => $identifier));
+        		header('Location: '.$redirect);
+        	}else{
+	        	header("HTTP/1.1 403 Forbidden");
+
+        	}
+    	}else{
+        	header("HTTP/1.1 403 Forbidden");
+
+    	}
+
+    }

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -25,7 +25,7 @@ class NDB_Form_User_Accounts extends NDB_Form
     /**
      * Determines whether this form is in edit or create mode.
      *
-     * @return boolean true if in crete mode, false otherwise.
+     * @return boolean true if in create mode, false otherwise.
      */
     function isCreatingNewUser()
     {
@@ -111,7 +111,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             $defaults['Zip_code']    = htmlspecialchars($defaults['Zip_code']);
             $defaults['Country']     = htmlspecialchars($defaults['Country']);
             $defaults['Fax']         = htmlspecialchars($defaults['Fax']);
-
+            
             foreach ($defaults['examiner'] as $cid=>$vals) {
                 //sets pending approval info
                 if ($cid=='pending') {
@@ -171,6 +171,7 @@ class NDB_Form_User_Accounts extends NDB_Form
      */
     function _process($values)
     {
+
         $config = NDB_Config::singleton();
         $DB     = Database::singleton();
 
@@ -736,15 +737,20 @@ class NDB_Form_User_Accounts extends NDB_Form
         );
 
         //------------------------------------------------------------
+        
+        // checking if the account can be rejected (no password hash
+        // pending approval)
+        $this->tpl_data['can_reject']=$this->_canRejectAccount($this->identifier);
 
         // get the editor's permissions
+
         $perms    = $editor->getPermissionsVerbose();
         $lastRole = '';
         foreach ($perms as $row) {
             if ($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
                 $group[]  = $this->form->createElement(
-                    'static',
+                  'static',
                     null,
                     null,
                     '</div>'
@@ -826,6 +832,72 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         // unique key and password rules
         $this->form->addFormRule(array(&$this, '_validateEditUser'));
+    }
+        
+    /**
+    * Query database on UserID to check that password has doesn't
+    * exist and account is still pending approval, to ensure the 
+    * users with account activity can't be rejected by setting 
+    * their status to pending. 
+    * 
+    * return @boolean true is Password_hash is null and 
+    * Pending_approval is Yes, false otherwsie
+    */
+
+    function _canRejectAccount($id)
+    {
+        $DB = Database::singleton();
+        $fields =  $DB->pselect(
+                  "SELECT Password_hash, Pending_approval
+                   FROM users
+                   WHERE UserID=:id",
+                   array("id" => $id,)
+        );
+        var_dump($id);
+        var_dump($fields);
+        if((is_null($fields[0]['Password_hash'])) && 
+            $fields[0]['Pending_approval']=="Y"){
+            return true;
+        }
+        return false;
+    }
+
+    /**
+    * 
+    * Send DB query to remove user based on userID through a GET 
+    * request.
+    * The reject user button populates on edit_users page, therefore
+    * any user that has access to the button has user_accounts 
+    * privileges.
+    * The URL is redirected to user_account after the operation
+    *
+    * @return void
+    */
+    // @codingStandardsIgnoreStart
+    function reject_user()
+    {
+    // @codingStandardsIgnoreEnd
+        $DB = Database::singleton();
+        $editor = User::singleton();
+
+        $redirect = $baseURL . "/user_accounts";
+        
+        // The $editor variable is set by the edit_user script. 
+        // Checking that this is set ensures that the user is 
+        // accessing this function through the authorized button 
+        // and not by pointing their URL directly to this script.
+        if(isset($editor)){
+            if($this->identifier!=''){
+                $DB->delete('users',array("UserID"=> $this->identifier));
+                }
+        }
+        // if the user tried to access this function through the URL
+        // nothing will execute and they will be brought back to
+        // the to the user_accounts menu where an error message will
+        // be displayed if the user doesn't have the correct 
+        // permissions
+        header('Location: '.$redirect);
+       
     }
 
     /**
@@ -1248,6 +1320,7 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         return $errors;
     }
+    
 
     /**
      * Validates that en email address entered for a given user

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -862,43 +862,6 @@ class NDB_Form_User_Accounts extends NDB_Form
     }
 
     /**
-    * Send DB query to remove user based on userID through a GET
-    * request.
-    * The reject user button populates on edit_users page, therefore
-    * any user that has access to the button has user_accounts
-    * privileges.
-    * The URL is redirected to user_account after the operation
-    *
-    * @return void
-    */
-    // @codingStandardsIgnoreStart
-    function reject_user()
-    {
-    // @codingStandardsIgnoreEnd
-        $DB     = Database::singleton();
-        $editor = User::singleton();
-
-        $redirect = $baseURL . "/user_accounts/";
-
-        // The $editor variable is set by the edit_user script.
-        // Checking that this is set ensures that the user is
-        // accessing this function through the authorized button
-        // and not by pointing their URL directly to this script.
-        if (isset($editor)) {
-            if ($this->identifier!='') {
-                $DB->delete('users', array("UserID" => $this->identifier));
-            }
-        }
-        // If the user tried to access this function through the URL
-        // nothing will execute and they will be brought back to
-        // the to the user_accounts menu where an error message will
-        // be displayed if the user doesn't have the correct
-        // permissions
-        header('Location: '.$redirect);
-
-    }
-
-    /**
      * Controls the output/behaviour of the form is used to edit
      * the user's preferences.
      *

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -111,7 +111,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             $defaults['Zip_code']    = htmlspecialchars($defaults['Zip_code']);
             $defaults['Country']     = htmlspecialchars($defaults['Country']);
             $defaults['Fax']         = htmlspecialchars($defaults['Fax']);
-            
+
             foreach ($defaults['examiner'] as $cid=>$vals) {
                 //sets pending approval info
                 if ($cid=='pending') {
@@ -737,10 +737,10 @@ class NDB_Form_User_Accounts extends NDB_Form
         );
 
         //------------------------------------------------------------
-        
+
         // checking if the account can be rejected (no password hash
         // pending approval)
-        $this->tpl_data['can_reject']=$this->_canRejectAccount($this->identifier);
+        $this->tpl_data['can_reject'] =$this->_canRejectAccount($this->identifier);
 
         // get the editor's permissions
 
@@ -750,7 +750,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             if ($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
                 $group[]  = $this->form->createElement(
-                  'static',
+                    'static',
                     null,
                     null,
                     '</div>'
@@ -833,39 +833,40 @@ class NDB_Form_User_Accounts extends NDB_Form
         // unique key and password rules
         $this->form->addFormRule(array(&$this, '_validateEditUser'));
     }
-        
+
     /**
     * Query database on UserID to check that password has doesn't
-    * exist and account is still pending approval, to ensure the 
-    * users with account activity can't be rejected by setting 
-    * their status to pending. 
-    * 
-    * return @boolean true is Password_hash is null and 
+    * exist and account is still pending approval, to ensure the
+    * users with account activity can't be rejected by setting
+    * their status to pending.
+    *
+    * @param string $id identifier of account to verify
+    *
+    * @return boolean true is Password_hash is null and
     * Pending_approval is Yes, false otherwsie
     */
-
     function _canRejectAccount($id)
     {
-        $DB = Database::singleton();
+        $DB     = Database::singleton();
         $fields =  $DB->pselect(
-                  "SELECT Password_hash, Pending_approval
+            "SELECT Password_hash, Pending_approval
                    FROM users
                    WHERE UserID=:id",
-                   array("id" => $id,)
+            array("id" => $id)
         );
-        if((is_null($fields[0]['Password_hash'])) && 
-            $fields[0]['Pending_approval']=="Y"){
+        if (is_null($fields[0]['Password_hash'])
+            && $fields[0]['Pending_approval']=="Y"
+        ) {
             return true;
         }
         return false;
     }
 
     /**
-    * 
-    * Send DB query to remove user based on userID through a GET 
+    * Send DB query to remove user based on userID through a GET
     * request.
     * The reject user button populates on edit_users page, therefore
-    * any user that has access to the button has user_accounts 
+    * any user that has access to the button has user_accounts
     * privileges.
     * The URL is redirected to user_account after the operation
     *
@@ -875,27 +876,27 @@ class NDB_Form_User_Accounts extends NDB_Form
     function reject_user()
     {
     // @codingStandardsIgnoreEnd
-        $DB = Database::singleton();
+        $DB     = Database::singleton();
         $editor = User::singleton();
 
         $redirect = $baseURL . "/user_accounts";
-        
-        // The $editor variable is set by the edit_user script. 
-        // Checking that this is set ensures that the user is 
-        // accessing this function through the authorized button 
+
+        // The $editor variable is set by the edit_user script.
+        // Checking that this is set ensures that the user is
+        // accessing this function through the authorized button
         // and not by pointing their URL directly to this script.
-        if(isset($editor)){
-            if($this->identifier!=''){
-                $DB->delete('users',array("UserID"=> $this->identifier));
-                }
+        if (isset($editor)) {
+            if ($this->identifier!='') {
+                $DB->delete('users', array("UserID" => $this->identifier));
+            }
         }
-        // if the user tried to access this function through the URL
+        // If the user tried to access this function through the URL
         // nothing will execute and they will be brought back to
         // the to the user_accounts menu where an error message will
-        // be displayed if the user doesn't have the correct 
+        // be displayed if the user doesn't have the correct
         // permissions
         header('Location: '.$redirect);
-       
+
     }
 
     /**
@@ -1318,7 +1319,7 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         return $errors;
     }
-    
+
 
     /**
      * Validates that en email address entered for a given user

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -853,8 +853,6 @@ class NDB_Form_User_Accounts extends NDB_Form
                    WHERE UserID=:id",
                    array("id" => $id,)
         );
-        var_dump($id);
-        var_dump($fields);
         if((is_null($fields[0]['Password_hash'])) && 
             $fields[0]['Pending_approval']=="Y"){
             return true;

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -171,7 +171,6 @@ class NDB_Form_User_Accounts extends NDB_Form
      */
     function _process($values)
     {
-
         $config = NDB_Config::singleton();
         $DB     = Database::singleton();
 
@@ -879,7 +878,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         $DB     = Database::singleton();
         $editor = User::singleton();
 
-        $redirect = $baseURL . "/user_accounts";
+        $redirect = $baseURL . "/user_accounts/";
 
         // The $editor variable is set by the edit_user script.
         // Checking that this is set ensures that the user is

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -3,9 +3,9 @@
 {literal}
 <script>
 
-$(document).ready(function() {
-    function toggleGroup(group) {
-        if(group) {
+    $(document).ready(function() {
+        function toggleGroup(group) {
+            if(group) {
             // id is the header that was clicked
             id = group.target.id;
 
@@ -30,77 +30,77 @@ $(document).ready(function() {
 {/literal}
 <form method="post" name="edit_user">
     {if $form.errors}
-        <div class="alert alert-danger" role="alert">
-            The form you submitted contains data entry errors
-        </div>
-    {/if}
-   <div class="panel panel-default">
-      <div class="panel-body">
-	    <h3>Password Rules</h3>
-	    <ul>
-		    <li>The password must be at least 8 characters long</li>
-            <li>The password must contain at least 1 letter, 1 number and 1 character from   !@#$%^&amp;*()</li>
-            <li>The password and the user name must not be the same</li>
-            <li>The password and the email address must not be the same</li>
-        </ul>
-        <h3>Notes</h3>
-        <ul>
-            <li>It is recommended to use an email address as the username, for clarity and uniqueness.</li>
-            <li>When generating a new password, please notify the user by checking 'Send email to user' box below!</li>
-        </ul>
-       </div>
+    <div class="alert alert-danger" role="alert">
+        The form you submitted contains data entry errors
     </div>
-	<h3>Add/Edit User</h3>
+    {/if}
+    <div class="panel panel-default">
+      <div class="panel-body">
+       <h3>Password Rules</h3>
+       <ul>
+          <li>The password must be at least 8 characters long</li>
+          <li>The password must contain at least 1 letter, 1 number and 1 character from   !@#$%^&amp;*()</li>
+          <li>The password and the user name must not be the same</li>
+          <li>The password and the email address must not be the same</li>
+      </ul>
+      <h3>Notes</h3>
+      <ul>
+        <li>It is recommended to use an email address as the username, for clarity and uniqueness.</li>
+        <li>When generating a new password, please notify the user by checking 'Send email to user' box below!</li>
+    </ul>
+</div>
+</div>
+<h3>Add/Edit User</h3>
 	<!-- {foreach from=$form.errors item=error key=k}
 	    <ul>
 	        <li class="error">{$k}: k{$error}</li>
 	    </ul>
-    {/foreach} -->
-    <!-- <div class="row"> -->
+        {/foreach} -->
+        <!-- <div class="row"> -->
         {if $form.errors.UserID_Group}
-    	<div class="row form-group form-inline form-inline has-error">
+        <div class="row form-group form-inline form-inline has-error">
+            {else}
+            <div class="row form-group form-inline form-inline">
+                {/if}
+                {if $form.UserID_Group != null}
+                <label class="col-sm-12 col-sm-2 form-label">
+                 {$form.UserID_Group.label}
+             </label>
+             <div class="col-sm-10">
+                 {$form.UserID_Group.html}
+             </div>
+             {if $form.errors.UserID_Group}
+             <div class="col-sm-offset-2 col-xs-12">
+                <font class="form-error">{$form.errors.UserID_Group}</font>
+            </div>
+            {/if}
+            {else}
+            <label class="col-sm-12 col-sm-2 form-label">
+             {$form.UserID.label}
+         </label>
+         <div class="col-sm-10">
+             {$form.UserID.html}
+         </div>
+
+         {/if}
+     </div>
+     <!-- </div> -->
+     <br>
+     {if $form.errors.Password_Group}
+     <div class="row form-group form-inline form-inline has-error">
         {else}
         <div class="row form-group form-inline form-inline">
-        {/if}
-        {if $form.UserID_Group != null}
-	    	<label class="col-sm-12 col-sm-2 form-label">
-                   {$form.UserID_Group.label}
-            </label>
-	    	<div class="col-sm-10">
-	    		{$form.UserID_Group.html}
-	    	</div>
-            {if $form.errors.UserID_Group}
-                <div class="col-sm-offset-2 col-xs-12">
-                    <font class="form-error">{$form.errors.UserID_Group}</font>
-                </div>
             {/if}
-        {else}
-	    	<label class="col-sm-12 col-sm-2 form-label">
-                   {$form.UserID.label}
-            </label>
-	    	<div class="col-sm-10">
-	    		{$form.UserID.html}
-	    	</div>
-        
-        {/if}
-	     </div>
-    <!-- </div> -->
-    <br>
-    {if $form.errors.Password_Group}
-    <div class="row form-group form-inline form-inline has-error">
-    {else}
-    <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2">
-    		{$form.Password_Group.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.Password_Group.html}
-    	</div>
-        {if $form.errors.Password_Group}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.Password_Group}</font>
-            </div>
+            <label class="col-sm-2">
+              {$form.Password_Group.label}
+          </label>
+          <div class="col-sm-10">
+              {$form.Password_Group.html}
+          </div>
+          {if $form.errors.Password_Group}
+          <div class="col-sm-offset-2 col-xs-12">
+            <font class="form-error">{$form.errors.Password_Group}</font>
+        </div>
         {/if}
     </div>
     <div class="row form-group form-inline">
@@ -121,36 +121,36 @@ $(document).ready(function() {
     </div> -->
     {if $form.errors.First_name}
     <div class="row form-group form-inline form-inline has-error">
-    {else}
-    <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2 form-label">
-    		{$form.First_name.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.First_name.html}
-    	</div>
-        {if $form.errors.First_name}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.First_name}</font>
-            </div>
+        {else}
+        <div class="row form-group form-inline form-inline">
+            {/if}
+            <label class="col-sm-2 form-label">
+              {$form.First_name.label}
+          </label>
+          <div class="col-sm-10">
+              {$form.First_name.html}
+          </div>
+          {if $form.errors.First_name}
+          <div class="col-sm-offset-2 col-xs-12">
+            <font class="form-error">{$form.errors.First_name}</font>
+        </div>
         {/if}
     </div>
     {if $form.errors.Last_name}
     <div class="row form-group form-inline form-inline has-error">
-    {else}
-    <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2 form-label">
-    		{$form.Last_name.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.Last_name.html}
-    	</div>
-        {if $form.errors.Last_name}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.Last_name}</font>
-            </div>
+        {else}
+        <div class="row form-group form-inline form-inline">
+            {/if}
+            <label class="col-sm-2 form-label">
+              {$form.Last_name.label}
+          </label>
+          <div class="col-sm-10">
+              {$form.Last_name.html}
+          </div>
+          {if $form.errors.Last_name}
+          <div class="col-sm-offset-2 col-xs-12">
+            <font class="form-error">{$form.errors.Last_name}</font>
+        </div>
         {/if}
     </div>
     {if $form.Degree}
@@ -255,37 +255,37 @@ $(document).ready(function() {
     {/if}
     {if $form.errors.Email_Group}
     <div class="row form-group form-inline form-inline has-error">
-    {else}
-    <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2 form-label">
-    		{$form.Email_Group.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.Email_Group.html}
-    	</div>
-        {if $form.errors.Email_Group}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.Email_Group}</font>
-            </div>
+        {else}
+        <div class="row form-group form-inline form-inline">
+            {/if}
+            <label class="col-sm-2 form-label">
+              {$form.Email_Group.label}
+          </label>
+          <div class="col-sm-10">
+              {$form.Email_Group.html}
+          </div>
+          {if $form.errors.Email_Group}
+          <div class="col-sm-offset-2 col-xs-12">
+            <font class="form-error">{$form.errors.Email_Group}</font>
+        </div>
         {/if}
     </div>
     {if $form.__ConfirmEmail}
     {if $form.errors.__ConfirmEmail}
     <div class="row form-group form-inline form-inline has-error">
-    {else}
-    <div class="row form-group form-inline form-inline">
-    {/if}
-    	<label class="col-sm-2">
-    		{$form.__ConfirmEmail.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.__ConfirmEmail.html}
-    	</div>
-        {if $form.errors.__ConfirmEmail}
-            <div class="col-sm-offset-2 col-xs-12">
-                <font class="form-error">{$form.errors.__ConfirmEmail}</font>
-            </div>
+        {else}
+        <div class="row form-group form-inline form-inline">
+            {/if}
+            <label class="col-sm-2">
+              {$form.__ConfirmEmail.label}
+          </label>
+          <div class="col-sm-10">
+              {$form.__ConfirmEmail.html}
+          </div>
+          {if $form.errors.__ConfirmEmail}
+          <div class="col-sm-offset-2 col-xs-12">
+            <font class="form-error">{$form.errors.__ConfirmEmail}</font>
+        </div>
         {/if}
     </div>
     {/if}
@@ -297,92 +297,123 @@ $(document).ready(function() {
     		{$form.CenterIDs.html}
     	</div>
     </div>
-        {if $form.errors.examiner_sites}
-        <div class="row form-group form-inline form-inline has-error">
-            {else}
-            <div class="row form-group form-inline form-inline">
-                {/if}
-                <label class="col-sm-2">
-                    {$form.examiner_sites.label}
-                </label>
-                <div class="col-sm-10">
-                    {$form.examiner_sites.html}
-                </div>
-                {if $form.errors.examiner_sites}
-                    <div class="col-sm-offset-2 col-xs-12">
-                        <font class="form-error">{$form.errors.examiner_sites}</font>
-                    </div>
-                {/if}
+    {if $form.errors.examiner_sites}
+    <div class="row form-group form-inline form-inline has-error">
+        {else}
+        <div class="row form-group form-inline form-inline">
+            {/if}
+            <label class="col-sm-2">
+                {$form.examiner_sites.label}
+            </label>
+            <div class="col-sm-10">
+                {$form.examiner_sites.html}
             </div>
+            {if $form.errors.examiner_sites}
+            <div class="col-sm-offset-2 col-xs-12">
+                <font class="form-error">{$form.errors.examiner_sites}</font>
+            </div>
+            {/if}
         </div>
-        {if $form.errors.examiner_group}
-        <div class="row form-group form-inline form-inline has-error">
-            {else}
-            <div class="row form-group form-inline form-inline">
-                {/if}
-                <label class="col-sm-2">
-                    {$form.examiner_group.label}
-                </label>
-                <div class="col-sm-10">
-                    <b>{$form.examiner_group.html}<b>
+    </div>
+    {if $form.errors.examiner_group}
+    <div class="row form-group form-inline form-inline has-error">
+        {else}
+        <div class="row form-group form-inline form-inline">
+            {/if}
+            <label class="col-sm-2">
+                {$form.examiner_group.label}
+            </label>
+            <div class="col-sm-10">
+                <b>{$form.examiner_group.html}<b>
                 </div>
                 {if $form.errors.examiner_group}
-                    <div class="col-sm-offset-2 col-xs-12">
-                        <font class="form-error">{$form.errors.examiner_group}</font>
-                    </div>
+                <div class="col-sm-offset-2 col-xs-12">
+                    <font class="form-error">{$form.errors.examiner_group}</font>
+                </div>
                 {/if}
             </div>
         </div>
-    <div class="row form-group form-inline">
-    	<label class="col-sm-2">
-    		{$form.Active.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.Active.html}
-    	</div>
-    </div>
-    <div class="row form-group form-inline">
-    	<label class="col-sm-2">
-    		{$form.Pending_approval.label}
-    	</label>
-    	<div class="col-sm-10">
-    		{$form.Pending_approval.html}
-    	</div>
-    </div>
-    <div class="row form-group form-inline">
-    	<label class="col-sm-2">
-    		{$form.PermID_Group.label}
-    	</label>
-    	<div class="col-sm-10 col-xs-12">
-    		<div>
-    		{$form.PermID_Group.html}
-    		</div>
-    	</div>
-    </div>
-    <div class="row form-group form-inline">
-        <label class="col-sm-2">
-          {$form.Supervisors_Group.label}
-        </label>
-        <div class="col-sm-10 col-xs-12">
-          <div>
-            {$form.Supervisors_Group.html}
+        <div class="row form-group form-inline">
+           <label class="col-sm-2">
+              {$form.Active.label}
+          </label>
+          <div class="col-sm-10">
+              {$form.Active.html}
           </div>
-        </div>
-     </div>
-    <div class="row form-group form-inline">
-    	<div class="col-sm-2">
-    		<input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit" />
-    	</div>
-        <div class="col-sm-2">
-            <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset"/>
-        </div>
-    	<div class="col-sm-2">
-    		<input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/'" value="Back" type="button" />
-    	</div>
-        {if $can_reject}
+      </div>
+      <div class="row form-group form-inline">
+       <label class="col-sm-2">
+          {$form.Pending_approval.label}
+      </label>
+      <div class="col-sm-10">
+          {$form.Pending_approval.html}
+      </div>
+  </div>
+  <div class="row form-group form-inline">
+   <label class="col-sm-2">
+      {$form.PermID_Group.label}
+  </label>
+  <div class="col-sm-10 col-xs-12">
+      <div>
+          {$form.PermID_Group.html}
+      </div>
+  </div>
+</div>
+<div class="row form-group form-inline">
+    <label class="col-sm-2">
+      {$form.Supervisors_Group.label}
+  </label>
+  <div class="col-sm-10 col-xs-12">
+      <div>
+        {$form.Supervisors_Group.html}
+    </div>
+</div>
+</div>
+<div class="row form-group form-inline">
+   <div class="col-sm-2">
+      <input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit" />
+  </div>
+  <div class="col-sm-2">
+    <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset"/>
+</div>
+<div class="col-sm-2">
+  <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/'" value="Back" type="button" />
+</div>
+{if $can_reject}
+
+<div class="col-sm-2">
+    <input type=hidden id ="UserID" value="{$form.UserID.html}">
+    <input type=hidden id = "baseurl" value="{$baseurl}">
+    <input class="btn btn-sm btn-primary col-xs-12" value="Reject User" type="button" id="btn_reject"/>
+    {literal}
+    <script type="text/javascript">
+        $(document).ready(
+            function(){
+                $("#btn_reject").click(
+                    function(){
+                        var userID = document.getElementById("UserID").value;
+                        var baseurl = document.getElementById("baseurl").value;
+                        $.ajax(baseurl+'/user_accounts/ajax/rejectUser.php', {
+                            type:'POST',
+                            data: {identifier: userID},
+                            success: function(data, textStatus){
+                                alert("success");
+                                //location.href=baseurl+'/user_accounts/';
+                            },
+                            error: function(jqXHR, textStatus, errorThrown){
+                                alert(textStatus, errorThrown);
+                           }
+                       });       
+                    });
+            });
+        </script>
+        {/literal}
+    </div>
+        <!-- 
         <div class="col-sm-2">
             <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/ajax/rejectUser.php?identifier={$form.UserID.html}'" value="Reject User" type="button"/>
         </div>
-        {/if}
-    </div>
+    -->
+    {/if}
+</div>
 </form>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -397,8 +397,7 @@
                             type:'POST',
                             data: {identifier: userID},
                             success: function(data, textStatus){
-                                alert("success");
-                                //location.href=baseurl+'/user_accounts/';
+                                location.href=baseurl+'/user_accounts/';
                             },
                             error: function(jqXHR, textStatus, errorThrown){
                                 alert(textStatus, errorThrown);

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -408,11 +408,6 @@
         </script>
         {/literal}
     </div>
-        <!-- 
-        <div class="col-sm-2">
-            <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/ajax/rejectUser.php?identifier={$form.UserID.html}'" value="Reject User" type="button"/>
-        </div>
-    -->
     {/if}
 </div>
 </form>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -381,7 +381,7 @@ $(document).ready(function() {
     	</div>
         {if $can_reject}
         <div class="col-sm-2">
-            <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/reject_user/?identifier={$form.UserID.html}'" value="Reject User" type="button"/>
+            <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/ajax/rejectUser.php?identifier={$form.UserID.html}'" value="Reject User" type="button"/>
         </div>
         {/if}
     </div>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -381,7 +381,7 @@ $(document).ready(function() {
     	</div>
         {if $can_reject}
         <div class="col-sm-2">
-            <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/reject_user/?identifier={$form.UserID.html}/" value="Reject User" type="button"/>
+            <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/reject_user/?identifier={$form.UserID.html}'" value="Reject User" type="button"/>
         </div>
         {/if}
     </div>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -369,17 +369,20 @@ $(document).ready(function() {
           </div>
         </div>
      </div>
-
     <div class="row form-group form-inline">
     	<div class="col-sm-2">
     		<input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit" />
     	</div>
-    	<div class="col-sm-2">
-    		<input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" />
-    	</div>
+        <div class="col-sm-2">
+            <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset"/>
+        </div>
     	<div class="col-sm-2">
     		<input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/'" value="Back" type="button" />
     	</div>
+        {if $can_reject}
+        <div class="col-sm-2">
+            <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/reject_user/?identifier={$form.UserID.html}/" value="Reject User" type="button"/>
+        </div>
+        {/if}
     </div>
-<!-- </form> -->
 </form>


### PR DESCRIPTION
Functionality to reject pending user accounts (delete from users table) from front end. Reject_user button is only presented if the user is pending approval and has no password hash (to avoid rejecting active users by setting their approval status to pending) on the edit_user menu. Only people with user_account (admin) permissions have access to this function since the button is populated on edit_users page.