### PR TITLE
[Conflict Resolver] Stopped it from accessing undefined indices

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -130,11 +130,16 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                     );
 
                     $TableName = $row['TableName'];
-                    $date      = explode('-', $setArray['Date_taken']);
+                    $date      = explode(
+                        '-',
+                        isset($setArray['Date_taken']) ?
+                            $setArray['Date_taken'] :
+                            null
+                    );
                     $dateArray = array(
                                   'Y' => $date[0],
-                                  'M' => $date[1],
-                                  'd' => $date[2],
+                                  'M' => isset($date[1]) ? $date[1] : null,
+                                  'd' => isset($date[2]) ? $date[2] : null,
                                  );
 
                     $Instrument = NDB_BVL_Instrument::factory(


### PR DESCRIPTION
*A lot* of the warnings, when clicking "Save", come from `LorisForm`, fixed by #2810 
This module is a very good example of why 2810 really needs to be merged, so it stops clogging up the error log file.

This particular pull request fixes those relevant to the `conflict_resolver` module.