### PR TITLE
[MRI Violations] Get year/age related settings without warnings

### DIFF
--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -371,9 +371,8 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
         $user        =& User::singleton();
         $config      =& NDB_Config::singleton();
         $db          =& Database::singleton();
-        $study       = $config->getSetting('study');
-        $minYear     = $study['startYear'] - $study['ageMax'];
-        $maxYear     = $study['endYear'] - $study['ageMin'];
+        $minYear     = $config->getSetting('startYear') - $config->getSetting('ageMax');
+        $maxYear     = $config->getSetting('endYear') - $config->getSetting('ageMin');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -371,8 +371,10 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
         $user        =& User::singleton();
         $config      =& NDB_Config::singleton();
         $db          =& Database::singleton();
-        $minYear     = $config->getSetting('startYear') - $config->getSetting('ageMax');
-        $maxYear     = $config->getSetting('endYear') - $config->getSetting('ageMin');
+        $minYear     = $config->getSetting('startYear')
+            - $config->getSetting('ageMax');
+        $maxYear     = $config->getSetting('endYear')
+            - $config->getSetting('ageMin');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',


### PR DESCRIPTION
It was previously getting the settings in a way which would generate warnings with some set ups. This pull request makes it work without warnings on all (?) set ups.

When the warnings get generated, the min and max date on the UI do not get set. Minor bug, nothing too serious.