### PR TITLE
[Document Repository] Fixed errors, warnings and added missing filter

### DIFF
--- a/modules/document_repository/ajax/addCategory.php
+++ b/modules/document_repository/ajax/addCategory.php
@@ -39,12 +39,14 @@ $Notifier = new NDB_Notifier(
     "new_category"
 );
 
-if (empty($_POST['category_name']) && $_POST['category_name'] !== '0') {
+if (!isset($_POST['category_name'])
+    || (empty($_POST['category_name']) && $_POST['category_name'] !== '0')
+) {
     header("HTTP/1.1 400 Bad Request");
     exit;
-} else {
-    $category_name = $_POST['category_name'];
 }
+
+$category_name = $_POST['category_name'];
 if ($_POST['parent_id'] !== '') {
     if (isset($_POST['parent_id']) || is_numeric($_POST['parent_id'])) {
         $parent_id = $_POST['parent_id'];
@@ -53,6 +55,7 @@ if ($_POST['parent_id'] !== '') {
         die();
     }
 }
+$comments = null;
 if ($_POST['comments'] !== '') {
     $comments = $_POST['comments'];
 }

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -77,9 +77,11 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
                           'v.Date_uploaded',
                          );
 
-        $openAccordion = $_GET['openAccordion'];
+        $openAccordion = isset($_GET['openAccordion']) ?
+            $_GET['openAccordion'] : null;
         $this->tpl_data['openAccordion'] = $openAccordion;
-        $filtered = $_GET['filtered'];
+        $filtered = isset($_GET['filtered']) ?
+            $_GET['filtered'] : null;
         $this->tpl_data['filtered'] = $filtered;
         $this->query        = $query;
         $this->group_by     = '';
@@ -118,6 +120,61 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         return true;
     }
 
+    private static function _fetchAllFileCategoriesImpl ($prefix, $parent_id, &$results) {
+        $child_arr = Database::singleton()->pselect("
+            SELECT
+                id,
+                category_name
+            FROM
+                document_repository_categories
+            WHERE
+                parent_id = :parent_id
+        ", array(
+            "parent_id" => $parent_id
+        ));
+        foreach ($child_arr as $row) {
+            $name = $prefix . ">" . $row["category_name"];
+            $results[$row["id"]] = $name;
+            self::_fetchAllFileCategoriesImpl(
+                $name,
+                $row["id"],
+                $results
+            );
+        }
+    }
+    private static function _fetchAllFileCategories () {
+        $results = array();
+        
+        //Subquery necessary because `parent_id` IS NOT
+        //a foreign key. It could possibly be referring to
+        //a row that does not exist...
+        $root_arr = Database::singleton()->pselect("
+            SELECT
+                r.id,
+                r.category_name
+            FROM
+                document_repository_categories r
+            WHERE
+                NOT EXISTS (
+                    SELECT
+                        *
+                    FROM
+                        document_repository_categories p
+                    WHERE
+                        p.id = r.parent_id
+                )
+        ", array());
+        
+        foreach ($root_arr as $row) {
+            $results[$row["id"]] = $row["category_name"];
+            self::_fetchAllFileCategoriesImpl(
+                $row["category_name"],
+                $row["id"],
+                $results
+            );
+        }
+        return $results;
+    }
     /**
      * Set filter form function
      *
@@ -170,6 +227,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         }
         $fileTypes = array_merge(array(null => 'Any') + $fileTypes);
 
+        $fileCategories = array(null => "Any") + self::_fetchAllFileCategories();
         // Form Elements
         $this->addBasicText('File_name', 'File name:');
         $this->addBasicText('version', 'Version:');

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -83,7 +83,7 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
 
         $filtered = $_GET['filtered'] ?? null;
 
-        $this->tpl_data['filtered'] = $filtered;
+        $this->tpl_data['filtered'] = htmlspecialchars($filtered);
         $this->query        = $query;
         $this->group_by     = '';
         $this->order_by     = 'v.File_name';

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -120,18 +120,33 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         return true;
     }
 
-    private static function _fetchAllFileCategoriesImpl ($prefix, $parent_id, &$results) {
-        $child_arr = Database::singleton()->pselect("
-            SELECT
-                id,
-                category_name
-            FROM
-                document_repository_categories
-            WHERE
-                parent_id = :parent_id
-        ", array(
-            "parent_id" => $parent_id
-        ));
+    /**
+     * Fetches all file categories in a format suitable for
+     * addSelect()
+     *
+     * @param string     $prefix    The prefix
+     * @param string|int $parent_id The parent id
+     * @param &array      $results   The results
+     *
+     * @return void
+     */
+    private static function _fetchAllFileCategoriesImpl(
+        $prefix,
+        $parent_id,
+        &$results
+    ) {
+        $child_arr = Database::singleton()->pselect(
+            "
+                SELECT
+                    id,
+                    category_name
+                FROM
+                    document_repository_categories
+                WHERE
+                    parent_id = :parent_id
+            ",
+            array("parent_id" => $parent_id)
+        );
         foreach ($child_arr as $row) {
             $name = $prefix . ">" . $row["category_name"];
             $results[$row["id"]] = $name;
@@ -142,29 +157,40 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
             );
         }
     }
-    private static function _fetchAllFileCategories () {
+
+    /**
+     * Fetches all file categories in a format suitable for
+     * addSelect()
+     *
+     * @return array
+     */
+    private static function _fetchAllFileCategories()
+    {
         $results = array();
-        
+
         //Subquery necessary because `parent_id` IS NOT
         //a foreign key. It could possibly be referring to
         //a row that does not exist...
-        $root_arr = Database::singleton()->pselect("
-            SELECT
-                r.id,
-                r.category_name
-            FROM
-                document_repository_categories r
-            WHERE
-                NOT EXISTS (
-                    SELECT
-                        *
-                    FROM
-                        document_repository_categories p
-                    WHERE
-                        p.id = r.parent_id
-                )
-        ", array());
-        
+        $root_arr = Database::singleton()->pselect(
+            "
+                SELECT
+                    r.id,
+                    r.category_name
+                FROM
+                    document_repository_categories r
+                WHERE
+                    NOT EXISTS (
+                        SELECT
+                            *
+                        FROM
+                            document_repository_categories p
+                        WHERE
+                            p.id = r.parent_id
+                    )
+            ",
+            array()
+        );
+
         foreach ($root_arr as $row) {
             $results[$row["id"]] = $row["category_name"];
             self::_fetchAllFileCategoriesImpl(

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -80,8 +80,9 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
         $openAccordion = $_GET['openAccordion'] ?? null;
 
         $this->tpl_data['openAccordion'] = $openAccordion;
-        $filtered = isset($_GET['filtered']) ?
-            $_GET['filtered'] : null;
+
+        $filtered = $_GET['filtered'] ?? null;
+
         $this->tpl_data['filtered'] = $filtered;
         $this->query        = $query;
         $this->group_by     = '';

--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -77,8 +77,8 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
                           'v.Date_uploaded',
                          );
 
-        $openAccordion = isset($_GET['openAccordion']) ?
-            $_GET['openAccordion'] : null;
+        $openAccordion = $_GET['openAccordion'] ?? null;
+
         $this->tpl_data['openAccordion'] = $openAccordion;
         $filtered = isset($_GET['filtered']) ?
             $_GET['filtered'] : null;

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -100,6 +100,8 @@
                             <div class="col-sm-12 col-md-3">{$form.File_type.html}</div>
                             <label class="col-sm-12 col-md-1">{$form.For_site.label}</label>
                             <div class="col-sm-12 col-md-3">{$form.For_site.html}</div>
+                            <label class="col-sm-12 col-md-1">{$form.File_category.label}</label>
+                            <div class="col-sm-12 col-md-3">{$form.File_category.html}</div>
                         </div>
                     </div>
                     <div class="row">

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -119,7 +119,9 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        session_start();
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
 
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {


### PR DESCRIPTION
Category filter was not implemented. Implemented it, taking into account the tree structure categories have.

Adding a category was not working because an earlier merged pull request broke `NDB_Notifier_Abstract`. Changed `getCenterID()` to `getCenterIDs()`, to fix it.

Warnings were generated when adding a category, regarding uninitialized variables and calling `NDB_Client::initialize()` when `session_start()` has already been called, elsewhere (`session_start() already called, ignoring`).

Fixed warnings on `GET` of `/document_repository/`.