### PR TITLE
[Core: Candidate, Timepoint, main.php] Sanitize error messages 

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -100,7 +100,7 @@ try {
         $user->getData('Sites')
     );
 } catch(Exception $e) {
-    $tpl_data['error_message'][] = "Error: " . $e->getMessage();
+    $tpl_data['error_message'][] = "Error: " . htmlspecialchars($e->getMessage());
 }
 
 // the the list of tabs, their links and perms
@@ -159,7 +159,7 @@ if (!empty($_REQUEST['candID'])) {
         $candidate =& Candidate::singleton($_REQUEST['candID']);
         $tpl_data['candidate'] = $candidate->getData();
     } catch(Exception $e) {
-        $tpl_data['error_message'][] = $e->getMessage();
+        $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
     }
 }
 
@@ -191,14 +191,14 @@ try {
     $tpl_data['workspace'] = $workspace;
 } catch(ConfigurationException $e) {
     header("HTTP/1.1 500 Internal Server Error");
-    $tpl_data['error_message'][] = $e->getMessage();
+    $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
 } catch(DatabaseException $e) {
     header("HTTP/1.1 500 Internal Server Error");
-    $tpl_data['error_message'][] = $e->getMessage();
-    $tpl_data['error_message'][] = "Query: <pre>" . $e->query . "</pre>";
+    $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
+    $tpl_data['error_message'][] = "Query: <pre>" . htmlspecialchars($e->query) . "</pre>";
     $tpl_data['error_message'][] = "Bind parameters: " . print_r($e->params, true);
     $tpl_data['error_message'][] = "Stack Trace: <pre>"
-        . $e->getTraceAsString()
+        . htmlspecialchars($e->getTraceAsString())
         . "</pre>";
 } catch(Exception $e) {
     switch($e->getCode()) {
@@ -207,7 +207,7 @@ try {
     case 403: header("HTTP/1.1 403 Forbidden");
         break;
     }
-    $tpl_data['error_message'][] = $e->getMessage();
+    $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
 } finally {
     // Set dependencies if they are not set
     if (!isset($tpl_data['jsfiles']) || !isset($tpl_data['cssfiles'])) {
@@ -225,7 +225,7 @@ try {
 
     $tpl_data['crumbs'] = $crumbs;
 } catch(Exception $e) {
-    $tpl_data['error_message'][] = $e->getMessage();
+    $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
 }
 
 //--------------------------------------------------

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -126,7 +126,8 @@ if (!empty($_REQUEST['sessionID'])) {
         $tpl_data['timePoint'] = $timePoint->getData();
     } catch (Exception $e) {
         $tpl_data['error_message'][]
-            = "TimePoint Error (".htmlspecialchars($_REQUEST['sessionID'])."): ".$e->getMessage();
+            = "TimePoint Error (".htmlspecialchars($_REQUEST['sessionID'])."): "
+                                                             . $e->getMessage();
     }
 }
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -195,7 +195,8 @@ try {
 } catch(DatabaseException $e) {
     header("HTTP/1.1 500 Internal Server Error");
     $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
-    $tpl_data['error_message'][] = "Query: <pre>" . htmlspecialchars($e->query) . "</pre>";
+    $tpl_data['error_message'][] = "Query: <pre>" .
+                               htmlspecialchars($e->query) . "</pre>";
     $tpl_data['error_message'][] = "Bind parameters: " . print_r($e->params, true);
     $tpl_data['error_message'][] = "Stack Trace: <pre>"
         . htmlspecialchars($e->getTraceAsString())

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -113,16 +113,20 @@ $tpl_data['tabs'] = NDB_Config::GetMenuTabs();
 // accept candidate data
 $argstring = '';
 if (!empty($_REQUEST['candID'])) {
-    $argstring .= "filter%5BcandID%5D=".$_REQUEST['candID']."&";
+    $argstring .= "filter%5BcandID%5D=".htmlspecialchars($_REQUEST['candID'])."&";
 }
 
 if (!empty($_REQUEST['sessionID'])) {
     try {
         $timePoint  =& TimePoint::singleton($_REQUEST['sessionID']);
         $argstring .= "filter%5Bm.VisitNo%5D=".$timePoint->getVisitNo()."&";
+        if ($config->getSetting("SupplementalSessionStatus")) {
+            $tpl_data['SupplementalSessionStatuses'] = true;
+        }
+        $tpl_data['timePoint'] = $timePoint->getData();
     } catch (Exception $e) {
         $tpl_data['error_message'][]
-            = "TimePoint Error (".$_REQUEST['sessionID']."): ".$e->getMessage();
+            = "TimePoint Error (".htmlspecialchars($_REQUEST['sessionID'])."): ".$e->getMessage();
     }
 }
 
@@ -156,21 +160,6 @@ if (!empty($_REQUEST['candID'])) {
     } catch(Exception $e) {
         $tpl_data['error_message'][] = $e->getMessage();
     }
-}
-
-// get time point data
-if (!empty($_REQUEST['sessionID'])) {
-    try {
-        $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
-        if ($config->getSetting("SupplementalSessionStatus")) {
-            $tpl_data['SupplementalSessionStatuses'] = true;
-        }
-        $tpl_data['timePoint'] = $timePoint->getData();
-    } catch(Exception $e) {
-        $tpl_data['error_message'][]
-            = "TimePoint Error (".$_REQUEST['sessionID']."): ".$e->getMessage();
-    }
-
 }
 
 //--------------------------------------------------

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -98,7 +98,7 @@ class Candidate
 
         if (!is_array($row) || sizeof($row) == 0) {
             throw new LorisException(
-                "Could not select Candidate data from the database (DCCID: ($candID)",
+                "Could not select Candidate data from the database (DCCID: $candID)",
                 CANDIDATE_INVALID
             );
         }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -98,7 +98,7 @@ class Candidate
 
         if (!is_array($row) || sizeof($row) == 0) {
             throw new LorisException(
-                "Could not select Candidate data from the database (DCCID: $candID)",
+                'Could not select Candidate data from the database (DCCID: ' . htmlspecialchars($candID),
                 CANDIDATE_INVALID
             );
         }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -98,8 +98,7 @@ class Candidate
 
         if (!is_array($row) || sizeof($row) == 0) {
             throw new LorisException(
-                'Could not select Candidate data from the database (DCCID: '
-                                                . htmlspecialchars($candID),
+                "Could not select Candidate data from the database (DCCID: ($candID)",
                 CANDIDATE_INVALID
             );
         }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -98,7 +98,8 @@ class Candidate
 
         if (!is_array($row) || sizeof($row) == 0) {
             throw new LorisException(
-                'Could not select Candidate data from the database (DCCID: ' . htmlspecialchars($candID),
+                'Could not select Candidate data from the database (DCCID: '
+                                                . htmlspecialchars($candID),
                 CANDIDATE_INVALID
             );
         }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -140,7 +140,7 @@ class TimePoint
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new Exception(
-                "Failed to retrieve data for timepoint ($sessionID)"
+                'Failed to retrieve data for timepoint '. htmlspecialchars($sessionID)
             );
         }
         // New feature, older databases might not have the table created,

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -140,7 +140,8 @@ class TimePoint
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new Exception(
-                'Failed to retrieve data for timepoint '. htmlspecialchars($sessionID)
+                'Failed to retrieve data for timepoint '
+                . htmlspecialchars($sessionID)
             );
         }
         // New feature, older databases might not have the table created,


### PR DESCRIPTION
This pull request implements simple output sanitizing on user-controllable data that were previously printed in exception messages.

Prior to this, these error messages were a potential vector for Javascript injection.

Some light refactoring was also performed in `htdocs/main.php`.


