### PR TITLE
[Examiner] fix mysql 5.7 error -- add e.examinerID into group by  

### DIFF
--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -87,7 +87,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
                                'e.radiologist as Radiologist',
                                'GROUP_CONCAT(tn.full_name) as Certification',
                               );
-        $this->group_by     = "e.full_name,psc.Name";
+        $this->group_by     = "e.full_name,psc.Name,e.examinerID";
         $this->query        = $query;
         $this->order_by     = 'e.full_name';
         $this->headers      = array(


### PR DESCRIPTION
This pull request adding e.examinerID into "group by" clause.  
Fix the error in Mysql 5.7.
[Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'loris_test.e.examinerID' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by]
https://redmine.cbrain.mcgill.ca/issues/12513