### PR TITLE
[Notifications] Update user#getCenterIDs method call

### DIFF
--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -236,7 +236,7 @@ abstract class NDB_Notifier_Abstract
         $user =& User::singleton();
 
         //array of sites concerned
-        $sites_concerned =  $user->getCenterID();
+        $sites_concerned =  $user->getCenterIDs();
         $sql_sites       =implode(",", $sites_concerned);
 
         // query needs to take into account the notified user permissions.


### PR DESCRIPTION
`user#getCenterID` no longer exists. This PR just updates a call to it.

There are two more instances of this:
https://github.com/aces/Loris/blob/17.1-dev/htdocs/api/v0.0.1/Candidates.php#L182
https://github.com/aces/Loris/blob/17.1-dev/htdocs/api/v0.0.2/Candidates.php#L181

I think those are a bit broader in scope though. We'll probably need to modify `Candidate::createNew` to accept an array of centerIDs. I suggest we tackle that in a separate ticket.