### PR TITLE
[Media] Fix documentation about permissions

### DIFF
--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -25,19 +25,21 @@ By default, all files are uploaded under `/data/uploads/`.
 The upload path is configurable in `Paths` section of `Configuration` module.
 
 >**Important** 
- >
->The destination directory must have `775` permissions and `$GROUP$` group in order for upload to work. Note: group name is OS dependent. 
+>
+>The upload path must be readable and writable by your web server; either the web server `user` or `group` must have read and write permissions.
+>The default group for your web server process is listed below
 >```
 >Ubuntu: $GROUP$ = www-data
 >CentOS: $GROUP$ = apache
 >```
+>
+>To find the `user` of your web server, run `ps aux | grep 'apache' | egrep -v 'grep|Ss' | awk '{ print $1 }' | sort | uniq`
+>To find the `group` of your web server, run `ps aux | grep 'apache' | egrep -v 'grep|Ss' | awk '{ print $1 }' | sort | uniq | groups`
 
+>To see if your web server's user or group owns the upload path, run `ls -ld /data/uploads | awk '{ print "user:" $3 ", group:" $4 }'`
 
->Make sure to to run these commands where `/data/uploads/` is your upload directory:
->```
->chmod 775 /data/uploads/
->sudo chown lorisadmin:$GROUP$ /data/uploads/
->```
+>If neither owns the folder, you should run `sudo chown <unix-user>:<web-server-group> /data/uploads`
+>Then, run `chmod 775 /data/uploads`
 
 ### 💯 Features
 

--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -26,7 +26,7 @@ The upload path is configurable in `Paths` section of `Configuration` module.
 
 >**Important** 
  >
->The destination directory must have `755` permissions and `$GROUP$` group in order for upload to work. Note: group name is OS dependent. 
+>The destination directory must have `775` permissions and `$GROUP$` group in order for upload to work. Note: group name is OS dependent. 
 >```
 >Ubuntu: $GROUP$ = www-data
 >CentOS: $GROUP$ = apache
@@ -35,7 +35,7 @@ The upload path is configurable in `Paths` section of `Configuration` module.
 
 >Make sure to to run these commands where `/data/uploads/` is your upload directory:
 >```
->chmod 755 /data/uploads/
+>chmod 775 /data/uploads/
 >sudo chown lorisadmin:$GROUP$ /data/uploads/
 >```
 


### PR DESCRIPTION
A user had an issue, recently, about this module. The readme told the user to `chmod 755 /data/uploads`.

The problem here is that the `group` owning the directory is `www-data`.
And `5` for group means `read, execute` permissions... But *no* write permissions.

This causes users to be unable to upload files.
This pull request changes the documentation to make the permission `7` for group, including the write permission.