### PR TITLE
[Core] Added safe(r) NDB_Page wrapper around $tpl_data

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -46,12 +46,6 @@ class NDB_Form extends NDB_Page
     var $_GUIDelimiter = "&nbsp;\n";
 
     /**
-    * Additional template data
-    */
-    var $tpl_data = array();
-
-
-    /**
      * Generates a new form instance and runs the appropriate method
      *
      * @param string $name       Identifies the form
@@ -93,11 +87,9 @@ class NDB_Form extends NDB_Page
             throw new Exception("Form does not exist: $name $page", 404);
         }
 
-        //set the baseurl of the tpl_data
         $factory  = NDB_Factory::singleton();
         $settings = $factory->settings();
-
-        $obj->tpl_data['baseurl'] = $settings->getBaseURL();
+        $obj->setTemplateVar('baseurl', $settings->getBaseURL());
 
         return $obj;
     }

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -40,15 +40,6 @@ class NDB_Menu extends NDB_Page
     var $mode;
 
     /**
-     * The template data for Smarty
-     *
-     * @var    array
-     * @access private
-     */
-    var $tpl_data;
-
-
-    /**
      * Generates a new menu instance
      *
      * @param string $menu The name of the menu to use
@@ -87,11 +78,9 @@ class NDB_Menu extends NDB_Page
             throw new Exception("You do not have access to this page.", 403);
         }
 
-        //set the baseurl of the tpl_data
         $factory  = NDB_Factory::singleton();
         $settings = $factory->settings();
-
-        $obj->tpl_data['baseurl'] = $settings->getBaseURL();
+        $obj->setTemplateVar('baseurl', $settings->getBaseURL());
 
         return $obj;
     }
@@ -148,7 +137,7 @@ class NDB_Menu extends NDB_Page
         // dump the html for the menu
         $smarty = new Smarty_neurodb($this->Module);
         $smarty->assign('mode', $this->mode);
-        $smarty->assign($this->tpl_data);
+        $smarty->assign($this->getTemplateData());
         $html = $smarty->fetch("menu_$this->menu.tpl");
         return $html;
     }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -615,21 +615,24 @@ class NDB_Menu_Filter extends NDB_Menu
 
         $pageID = isset($_GET['pageID']) ? $_GET['pageID'] : 1;
 
-        $this->tpl_data['rowsPerPage'] = $rowsPerPage;
-        $this->tpl_data['pageID']      = $pageID;
+        $this->setTemplateVar('rowsPerPage', $rowsPerPage);
+        $this->setTemplateVar('pageID', $pageID);
 
-        $this->tpl_data['filterfield'] = isset($_GET['filter']['order']['field'])
-              ? $_GET['filter']['order']['field']
-              : '';
+        $this->setTemplateVar(
+            'filterfield',
+            $_GET['filter']['order']['field'] ?? ''
+        );
+        $this->setTemplateVar(
+            'filterfieldOrder',
+            $_GET['filter']['order']['fieldOrder'] ?? ''
+        );
+        $this->setTemplateVar('TotalItems', $this->TotalItems);
 
-        $this->tpl_data['filterfieldOrder']
-            = isset($_GET['filter']['order']['fieldOrder'])
-              ? $_GET['filter']['order']['fieldOrder']
-              : '';
-
-        $this->tpl_data['TotalItems'] = $this->TotalItems;
         // print out column headings
         $i = 0;
+
+        // FIXME: Someone needs to investigate if this can use setTemplateVar, or if
+        // that would break anything.
         foreach ($this->headers as $header) {
             $this->tpl_data['headers'][$i]['name'] = $header;
             // format header
@@ -668,6 +671,7 @@ class NDB_Menu_Filter extends NDB_Menu
         $x = 0;
         foreach ($this->list as $item) {
             //count column
+            // FIXME: Someone should investigate if this can use setTemplateVar
             $this->tpl_data['items'][$x][0]['value'] = $x + $count;
 
             //print out data rows
@@ -704,20 +708,19 @@ class NDB_Menu_Filter extends NDB_Menu
         // Set the csvFile links
         $uri    = ltrim($_SERVER['REQUEST_URI'], "/");
         $suffix = strpos($uri, '?') ? '&format=csv' : '?&format=csv';
-        $this->tpl_data['csvUrl']  = $uri . $suffix;
-        $this->tpl_data['csvFile'] = $_REQUEST['test_name'];
-        if (isset($_REQUEST['subtest'])) {
-            $this->tpl_data['csvFile'] .= '-' . $_REQUEST['subtest'];
-        } elseif (isset($_REQUEST['submenu'])) {
-            $this->tpl_data['csvFile'] .= '-' . $_REQUEST['submenu'];
-        }
-        $this->tpl_data['csvFile'] .= date('-Y_m_d');
+        $this->setTemplateVar('csvURL', $uri . $suffix);
+        $this->setTemplateVar(
+            'csvFile',
+            $_REQUEST['test_name']
+            . ($_REQUEST['subtest'] ?? $_REQUEST['submenu'] ?? '')
+            . date('-Y_m_d')
+        );
 
         // dump the html for the menu
         $smarty = new Smarty_neurodb($this->Module);
         $smarty->assign('mode', $this->mode);
         $smarty->assign('form', $this->form->toArray());
-        $smarty->assign($this->tpl_data);
+        $smarty->assign($this->getTemplateData());
         $html = $smarty->fetch("menu_$this->menu.tpl");
         return $html;
     }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -62,6 +62,39 @@ class NDB_Page
     var $skipTemplate = false;
 
     /**
+     * Template data to be passed to Smarty.
+     *
+     * FIXME: This should be private to ensure users go through the getter and setter
+     * methods to safely update the template data, but all references that directly
+     * use tpl_data must be updated first.
+     */
+    protected $tpl_data = array();
+
+    /**
+     * Safely sets a smarty template variable.
+     *
+     * @param string $name  The name of the template variable to set
+     * @param string $value The (unescaped, unsafe) value to set the template
+     *                      variable to
+     *
+     * @return void
+     */
+    function setTemplateVar($name, $value)
+    {
+        $this->tpl_data[$name] = htmlspecialchars($value);
+    }
+
+    /**
+     * Return the template data for this page.
+     *
+     * @return array Mapping of variable names to template value.
+     */
+    function getTemplateData()
+    {
+        return $this->tpl_data;
+    }
+
+    /**
      * Does the setup required for this page. By default, sets up elements
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.


### PR DESCRIPTION
Add a getter and setter for tpl_data functions, in order to have a place to
sanitize variables for XSS (or other) attacks.

This would ideally be a private to enforce using the getter and setter, but
there are too many modules that directly access it, so such a change would
need to be for 18.0. For now, the infrastructure is put in place to let
people use the getter and setter methods without any defense against directly
mutating the array.

This change only updates the page type base classes in php/libraries to use the
setter and getter, not the modules.