### PR TITLE
[Imaging Browser] $DB->escape() on column names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
 npm-debug.log*
+.phan/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
 npm-debug.log*
-.phan/*

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -136,8 +136,8 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             JOIN files_qcstatus USING (FileID) 
             WHERE files.AcquisitionProtocolID=" . $DB->quote($key) . " 
             AND files_qcstatus.QCStatus IN (1, 2) 
-            GROUP BY files.SessionID) `" . $pass[$key] . "` 
-            ON (`" . $pass[$key] . "`.SessionID=f.SessionID) ";
+            GROUP BY files.SessionID) " . $DB->escape($pass[$key]) . "
+            ON (" . $DB->escape($pass[$key]) . ".SessionID=f.SessionID) ";
         }
 
         $where = "

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -131,7 +131,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         foreach ($case_desc as $key => $value) {
             $left_joins .= "
             LEFT JOIN (SELECT files.SessionID, 
-            MIN(files_qcstatus.QCStatus+0) as " . $DB->quote($qc[$key]) . " 
+            MIN(files_qcstatus.QCStatus+0) as " . $DB->escape($qc[$key]) . " 
             FROM files 
             JOIN files_qcstatus USING (FileID) 
             WHERE files.AcquisitionProtocolID=" . $DB->quote($key) . " 


### PR DESCRIPTION
Simple change, `$DB->escape()` is now called on whatever is being used as a column name. Prevents potentially nasty things from happening, too.