### PR TITLE
[API] Add check for cryptographic strength of JWT keys

### DIFF
--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -134,7 +134,10 @@ class Login extends APIBase
 
         $key = $config->getSetting("JWTKey");
         if ($key === "S3cret") {
-            error_log("ERROR: Default JWT key detected. This should be changed immediately.");
+            error_log(
+                '"ERROR: Default JWT key detected. '
+                .'This should be changed immediately.'
+            );
             return "";
         }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -79,7 +79,7 @@ class Login extends APIBase
             if ($token) {
                 $this->JSON = array("token" => $token);
             } else {
-                $this->header("HTTP/1.1 403 Forbidden");
+                $this->header("HTTP/1.1 500 Internal Server Error");
                 $this->JSON = array("error" => "Unacceptable JWT key.");
             }
         } else {

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -75,9 +75,13 @@ class Login extends APIBase
         $login = $this->getLoginAuthenticator();
 
         if ($login->passwordAuthenticate($user, $password, false)) {
-            $this->JSON = array(
-                           "token" => $this->getEncodedToken($user),
-                          );
+            $token = $this->getEncodedToken($user);
+            if ($token) {
+                $this->JSON = array("token" => $token);
+            } else {
+                $this->header("HTTP/1.1 403 Forbidden");
+                $this->JSON = array("error" => "Unacceptable JWT key.");
+            }
         } else {
             $this->header("HTTP/1.1 401 Unauthorized");
             if (!empty($login->_lastError)) {
@@ -129,6 +133,10 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
+        if ($key === "S3cret") {
+            error_log("ERROR: Default JWT key detected. This should be changed immediately.");
+            return "";
+        }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");
     }
 

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -133,7 +133,7 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
-        if (!$isKeyStrong) {
+        if (!isKeyStrong($key)) {
             error_log(
                 'ERROR: JWTKey config variable is weak. '
                 .'Please change the key to a more cryptographically-secure value.'

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -138,7 +138,6 @@ class Login extends APIBase
                 'ERROR: JWTKey config variable is weak. '
                 .'Please change the key to a more cryptographically-secure value.'
             );
-            $this->header("HTTP/1.1 500 Internal Server Error");
             return "";
         }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -133,11 +133,12 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
-        if (!isKeyStrong($key)) {
+        if (!self::isKeyStrong($key)) {
             error_log(
                 'ERROR: JWTKey config variable is weak. '
                 .'Please change the key to a more cryptographically-secure value.'
             );
+            $this->header("HTTP/1.1 500 Internal Server Error");
             return "";
         }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");
@@ -163,7 +164,7 @@ class Login extends APIBase
     *
     * @return boolean Key passes strength test
     */
-    function isKeyStrong($key)
+    static function isKeyStrong($key)
     {
         // Note: this code adapted from User::isPasswordStrong
         $CharTypes = 0;

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -165,7 +165,7 @@ class Login extends APIBase
     */
     function isKeyStrong($key)
     {
-        // Note: this code adapted from User::isPasswordString
+        // Note: this code adapted from User::isPasswordStrong
         $CharTypes = 0;
         // less than 20 characters
         if (strlen($key) < 20) {

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -79,7 +79,7 @@ class Login extends APIBase
             if ($token) {
                 $this->JSON = array("token" => $token);
             } else {
-                $this->header("HTTP/1.1 403 Forbidden");
+                $this->header("HTTP/1.1 500 Internal Server Error");
                 $this->JSON = array("error" => "Unacceptable JWT key.");
             }
         } else {

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -75,9 +75,13 @@ class Login extends APIBase
         $login = $this->getLoginAuthenticator();
 
         if ($login->passwordAuthenticate($user, $password, false)) {
-            $this->JSON = array(
-                           "token" => $this->getEncodedToken($user),
-                          );
+            $token = $this->getEncodedToken($user);
+            if ($token) {
+                $this->JSON = array("token" => $token);
+            } else {
+                $this->header("HTTP/1.1 403 Forbidden");
+                $this->JSON = array("error" => "Unacceptable JWT key.");
+            }
         } else {
             $this->header("HTTP/1.1 401 Unauthorized");
             if (!empty($login->_lastError)) {
@@ -129,6 +133,10 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
+        if ($key === "S3cret") {
+            error_log("ERROR: Default JWT key detected. This should be changed immediately.");
+            return "";
+        }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");
     }
 

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -133,7 +133,7 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
-        if (!$isKeyStrong) {
+        if (!isKeyStrong($key)) {
             error_log(
                 'ERROR: JWTKey config variable is weak. '
                 .'Please change the key to a more cryptographically-secure value.'

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -138,7 +138,6 @@ class Login extends APIBase
                 'ERROR: JWTKey config variable is weak. '
                 .'Please change the key to a more cryptographically-secure value.'
             );
-            $this->header("HTTP/1.1 500 Internal Server Error");
             return "";
         }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -76,7 +76,7 @@ class Login extends APIBase
 
         if ($login->passwordAuthenticate($user, $password, false)) {
             $token = $this->getEncodedToken($user);
-            if ($token) {
+            if (!empty($token)) {
                 $this->JSON = array("token" => $token);
             } else {
                 $this->header("HTTP/1.1 500 Internal Server Error");
@@ -133,10 +133,10 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
-        if ($key === "S3cret") {
+        if (!$isKeyStrong) {
             error_log(
-                'ERROR: Default JWT key detected.' .
-                'This should be changed immediately.'
+                'ERROR: JWTKey config variable is weak. '
+                .'Please change the key to a more cryptographically-secure value.'
             );
             return "";
         }
@@ -154,6 +154,40 @@ class Login extends APIBase
     function calculateETag()
     {
         return;
+    }
+
+    /**
+    * Verify key meets cryptographic strength requirements
+    *
+    * @param string $key The JWT key to verify
+    *
+    * @return boolean Key passes strength test
+    */
+    function isKeyStrong($key)
+    {
+        // Note: this code adapted from User::isPasswordString
+        $CharTypes = 0;
+        // less than 20 characters
+        if (strlen($key) < 20) {
+            return false;
+        }
+        // nothing but letters
+        if (!preg_match('/[^A-Za-z]/', $key)) {
+            return false;
+        }
+        // nothing but numbers
+        if (!preg_match('/[^0-9]/', $key)) {
+            return false;
+        }
+        // preg_match returns 1 on match, 0 on non-match
+        $CharTypes += preg_match('/[0-9]+/', $key);
+        $CharTypes += preg_match('/[A-Za-z]+/', $key);
+        $CharTypes += preg_match('/[!\\\$\^@#%&\*\(\)]+/', $key);
+        if ($CharTypes < 3) {
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -133,11 +133,12 @@ class Login extends APIBase
                  );
 
         $key = $config->getSetting("JWTKey");
-        if (!isKeyStrong($key)) {
+        if (!self::isKeyStrong($key)) {
             error_log(
                 'ERROR: JWTKey config variable is weak. '
                 .'Please change the key to a more cryptographically-secure value.'
             );
+            $this->header("HTTP/1.1 500 Internal Server Error");
             return "";
         }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");
@@ -163,7 +164,7 @@ class Login extends APIBase
     *
     * @return boolean Key passes strength test
     */
-    function isKeyStrong($key)
+    static function isKeyStrong($key)
     {
         // Note: this code adapted from User::isPasswordStrong
         $CharTypes = 0;

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -134,7 +134,10 @@ class Login extends APIBase
 
         $key = $config->getSetting("JWTKey");
         if ($key === "S3cret") {
-            error_log("ERROR: Default JWT key detected. This should be changed immediately.");
+            error_log(
+                'ERROR: Default JWT key detected.' .
+                'This should be changed immediately.'
+            );
             return "";
         }
         return \Firebase\JWT\JWT::encode($token, $key, "HS256");

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -165,7 +165,7 @@ class Login extends APIBase
     */
     function isKeyStrong($key)
     {
-        // Note: this code adapted from User::isPasswordString
+        // Note: this code adapted from User::isPasswordStrong
         $CharTypes = 0;
         // less than 20 characters
         if (strlen($key) < 20) {


### PR DESCRIPTION
## Overview

- [x] ~~Create simple patch to overwrite default JWT key with random value~~ Patch was bad. Projects will do this manually.

- [x] ~~Blacklist default key in both versions of the API~~ Accept only secure JWT tokens

## Discussion points

* ~~Should this be rebased to 17.0 instead?~~ This has now been rebased.

* ~~Do we want to patch the default key [everywhere else](https://github.com/aces/Loris/search?utf8=%E2%9C%93&q=S3cret&type=)?~~ Dave says no.

* Neither SQL nor the API are my strong points so I don't feel confident testing this. Would really appreciate assistance