### PR TITLE
[Security] Improve file validation when downloading files

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -57,9 +57,11 @@ if ($imagePath === '/' || $DownloadPath === '/' || $mincPath === '/') {
     exit(2);
 }
 
-// Now get the file and do file validation
-$File = $_GET['file'];
+// Now get the file and do file validation.
+// Resolve the filename before doing anything.
+$File = realpath($_GET['file']);
 
+// Extra sanity checks, just in case something went wrong with realpath.
 // File validation
 if (strpos($File, ".") === false) {
     error_log("ERROR: Could not determine file type.");


### PR DESCRIPTION
Update get_file.php to use PHP's realpath to fully resolve file
paths before doing validation.

This resolves an issue identified by @johnsaigle.

See also: https://github.com/aces/Loris/pull/2860, https://github.com/aces/Loris/pull/2867