### PR TITLE
API: Update candidate and visit creation message for multisite users (re-open of PR2838)

### DIFF
--- a/htdocs/api/v0.0.2/Candidates.php
+++ b/htdocs/api/v0.0.2/Candidates.php
@@ -110,24 +110,45 @@ class Candidates extends APIBase
                 $this->safeExit(0);
             }
 
-            $this->verifyField($data, 'Gender', ['Male', 'Female']);
-            $this->verifyField($data, 'EDC', 'YYYY-MM-DD');
-            $this->verifyField($data, 'DoB', 'YYYY-MM-DD');
-            //Candidate::createNew
-            try {
-                $candid = $this->createNew(
-                    $data['Candidate']['DoB'],
-                    $data['Candidate']['EDC'],
-                    $data['Candidate']['Gender'],
-                    $data['Candidate']['PSCID']
-                );
-                $this->header("HTTP/1.1 201 Created");
-                $this->JSON = [
-                               'Meta' => ["CandID" => $candid],
-                              ];
-            } catch(\LorisException $e) {
-                $this->header("HTTP/1.1 400 Bad Request");
+            // This version of the API does not handle candidate creation
+            // when users are at multiple sites
+            $user      = \User::singleton();
+            $centerIDs = $user->getCenterIDs();
+            $num_sites = count($centerIDs);
+            if ($num_sites == 0) {
+                $this->header("HTTP/1.1 401 Unauthorized");
+                $this->error("You are not affiliated with any site");
                 $this->safeExit(0);
+            } else if ($num_sites > 1) {
+                $this->header("HTTP/1.1 501 Not Implemented");
+                $this->error(
+                    "This API version does not support candidate creation " .
+                    "by users with multiple site affiliations. This will be ".
+                    "implemented in a future release."
+                );
+                $this->safeExit(0);
+            } else {
+                $centerID = $centerIDs[0];
+                $this->verifyField($data, 'Gender', ['Male', 'Female']);
+                $this->verifyField($data, 'EDC', 'YYYY-MM-DD');
+                $this->verifyField($data, 'DoB', 'YYYY-MM-DD');
+                //Candidate::createNew
+                try {
+                    $candid = $this->createNew(
+                        $centerID,
+                        $data['Candidate']['DoB'],
+                        $data['Candidate']['EDC'],
+                        $data['Candidate']['Gender'],
+                        $data['Candidate']['PSCID']
+                    );
+                    $this->header("HTTP/1.1 201 Created");
+                    $this->JSON = [
+                                   'Meta' => ["CandID" => $candid],
+                                  ];
+                } catch(\LorisException $e) {
+                    $this->header("HTTP/1.1 400 Bad Request");
+                    $this->safeExit(0);
+                }
             }
         } else {
             $this->header("HTTP/1.1 400 Bad Request");
@@ -174,11 +195,11 @@ class Candidates extends APIBase
      *
      * @return none
      */
-    public function createNew($DoB, $edc, $gender, $PSCID)
+    public function createNew($centerID, $DoB, $edc, $gender, $PSCID)
     {
         $user = \User::singleton();
         return \Candidate::createNew(
-            $user->getCenterID(),
+            $centerID,
             $DoB,
             $edc,
             $gender,

--- a/htdocs/api/v0.0.2/Candidates.php
+++ b/htdocs/api/v0.0.2/Candidates.php
@@ -188,10 +188,11 @@ class Candidates extends APIBase
     /**
      * Testable wrapper for Candidate::createNew
      *
-     * @param string $DoB    Date of birth of the candidate
-     * @param string $edc    EDC of the candidate
-     * @param string $gender Gender of the candidate to be created
-     * @param string $PSCID  PSCID of the candidate to be created
+     * @param string $centerID The center id of the candidate
+     * @param string $DoB      Date of birth of the candidate
+     * @param string $edc      EDC of the candidate
+     * @param string $gender   Gender of the candidate to be created
+     * @param string $PSCID    PSCID of the candidate to be created
      *
      * @return none
      */

--- a/htdocs/api/v0.0.2/candidates/Visit.php
+++ b/htdocs/api/v0.0.2/candidates/Visit.php
@@ -169,9 +169,36 @@ class Visit extends \Loris\API\Candidates\Candidate
             $this->safeExit(0);
 
         }
-        // need to extract subprojectID
-        $this->createNew($this->CandID, $subprojectID, $this->VisitLabel);
-        $this->header("HTTP/1.1 201 Created");
+        // This version of the API does not handle timepoint creation
+        // when users are at multiple sites
+        $user      = \User::singleton();
+        $centerIDs = $user->getCenterIDs();
+        $num_sites = count($centerIDs);
+        if ($num_sites == 0) {
+            $this->header("HTTP/1.1 401 Unauthorized");
+            $this->error("You are not affiliated with any site");
+            $this->safeExit(0);
+        } else if ($num_sites > 1) {
+            $this->header("HTTP/1.1 501 Not Implemented");
+            $this->error(
+                "This API version does not support timepoint creation " .
+                "by users with multiple site affiliations. This will be ".
+                "implemented in a future release."
+            );
+            $this->safeExit(0);
+        } else {
+            $centerID          = $centerIDs[0];
+            $candidateCenterID = \Candidate::singleton($this->CandID)
+                ->getCenterID();
+            if ($centerID != $candidateCenterID) {
+                $this->header("HTTP/1.1 401 Unauthorized");
+                $this->error("You are not affiliated with the candidate's site");
+                $this->safeExit(0);
+            }
+            // need to extract subprojectID
+            $this->createNew($this->CandID, $subprojectID, $this->VisitLabel);
+            $this->header("HTTP/1.1 201 Created");
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request informs the users that have a multi-site affiliation that they can not create candidates or visits with this version of the API, and that this will become possible in the next API release.

In Reference to Redmine 12020 (item 11 in the list)

This is partially based off of this pull request (which was closed):
https://github.com/aces/Loris/pull/2838

Update only v0.0.2, as v0.0.1 will eventually be removed (#2882)

