### PR TITLE
[Install] Made install.sh not auto-install composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
 npm-debug.log*
+.phan/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
 npm-debug.log*
-.phan/*

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -83,6 +83,7 @@ elif [[ -x ../composer ]]; then
 else
     echo ""
     echo "PHP Composer does not appear to be installed. Please install it before running this script."
+    echo ""
     echo "(e.g. curl -sS https://getcomposer.org/installer | php)"
     exit 2;
 fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -81,33 +81,24 @@ elif [[ -x ../composer ]]; then
     echo "PHP Composer appears to be installed."
     composer_scr="./composer install --no-dev"
 else
-    echo "PHP Composer does not appear to be installed. Attempting to install now..."
-    curl -sS https://getcomposer.org/installer | php
-    mv composer.phar ../composer
-    if [[ -x ../composer ]]; then
-        echo ""
-        echo "PHP Composer successfully installed."
-        composer_scr="./composer install --no-dev"
-    else
-        echo ""
-        echo "PHP Composer failed to install. Aborting."
-        exit 2;
-    fi
+    echo ""
+    echo "PHP Composer does not appear to be installed. Please install it before running this script."
+    exit 2;
 fi
 
 echo ""
 
 cat <<QUESTIONS
-This install script will ask you to provide inputs for different steps. 
-Please ensure you have the following information ready (if applicable):  
+This install script will ask you to provide inputs for different steps.
+Please ensure you have the following information ready (if applicable):
 
-  1) Your project directory name.   
+  1) Your project directory name.
      (Will be used to modify the paths for Imaging data in the generated
      config.xml file for LORIS, and may also be used to automatically
      create/install apache config files.) If unsure, a default like "LORIS"
      should be acceptable.
 
-Please also consult the Loris WIKI on GitHub for more information on these 
+Please also consult the Loris WIKI on GitHub for more information on these
 Install Script input parameters.
 QUESTIONS
 
@@ -249,7 +240,7 @@ while true; do
                 -e "s#%PROJECTNAME%#$projectname#g" \
                 -e "s#%LOGDIRECTORY%#$logdirectory#g" \
                 < ../docs/config/apache2-site | sudo tee /etc/httpd/conf.d/$projectname.conf > /dev/null
-            
+
             sudo service httpd restart
             echo "You may need to manually uncomment the load rewrite module line of your conf."
             break;;

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -83,6 +83,7 @@ elif [[ -x ../composer ]]; then
 else
     echo ""
     echo "PHP Composer does not appear to be installed. Please install it before running this script."
+    echo "(e.g. curl -sS https://getcomposer.org/installer | php)"
     exit 2;
 fi
 


### PR DESCRIPTION
The current `install.sh` file attempts to automatically install composer to the Loris root directory, if it finds that it is not present. This really shouldn't be done as users might want a global install or some other kind of set up. Also, presently, our `.gitignore` file does not ignore `composer`. Auto-installing it for a dev means they'll have to be careful not to commit it.

We've also had an issue where @leothomas or @ZainVirani (or both) couldn't check out any other branch because `git` could not remove the `composer` file automatically (would have probably required `sudo git <command>` but we deleted the local `composer` file before thinking of that).