### PR TITLE
[Documentation] React readme

### DIFF
--- a/LORIS_react.README.md
+++ b/LORIS_react.README.md
@@ -56,7 +56,7 @@ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
 sudo apt-get install -y build-essential
 ```
-(optional) For Ubuntu 14.04:
+>**Note**: Older LTS version (14.04<=)
 ```
 curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 sudo apt-get install -y nodejs
@@ -95,7 +95,7 @@ Follow these steps in your terminal:
   npm install --only=dev
 ```
 
-(Optional)
+>**Note**: Permissions might be adjusted using
 ```bash
 sudo chown -R $USER:$(id -gn $USER) ./node_modules
 ```

--- a/LORIS_react.README.md
+++ b/LORIS_react.README.md
@@ -56,6 +56,13 @@ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
 sudo apt-get install -y build-essential
 ```
+(optional) For Ubuntu 14.04:
+```
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo apt-get install -y build-essential
+```
+
 
 **CentOS**
 
@@ -86,6 +93,11 @@ Follow these steps in your terminal:
 ```bash
   cd $loris$ # your LORIS home directory
   npm install --only=dev
+```
+
+(Optional)
+```bash
+sudo chown -R $USER:$(id -gn $USER) ./node_modules
 ```
 
 >**Note**: to see a list of all dependencies refer to `package.json` under LORIS home directory


### PR DESCRIPTION
This pull request add instructions for npm package installation on Ubuntu 14.04. 

I was getting thies error message:
```
$ sudo apt-get install npm
```
```
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 npm : Depends: nodejs but it is not going to be installed
       Depends: node-abbrev (>= 1.0.4) but it is not going to be installed
       Depends: node-ansi but it is not going to be installed
[...]
```
And
```
$ npm install --only=dev
```
```
npm ERR! Linux 3.13.0-119-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "--only=dev"
npm ERR! node v4.8.3
npm ERR! npm  v2.15.11
npm ERR! path [...]node_modules/.bin/babel
npm ERR! code EACCES
npm ERR! errno -13
npm ERR! syscall unlink

npm ERR! Error: EACCES: permission denied, unlink [...]
```