### PR TITLE
[Conflict Resolver] remove date to array conversion

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -76,7 +76,6 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                     array('hash' => $hash)
                 );
                 if (!empty($row)) {
-
                     // insert into conflicts_resolved
                     $user1         = $DB->pselectOne(
                         "SELECT UserID FROM flag WHERE CommentID=:CID",
@@ -130,12 +129,6 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                     );
 
                     $TableName = $row['TableName'];
-                    $date      = explode('-', $setArray['Date_taken']);
-                    $dateArray = array(
-                                  'Y' => $date[0],
-                                  'M' => $date[1],
-                                  'd' => $date[2],
-                                 );
 
                     $Instrument = NDB_BVL_Instrument::factory(
                         $TableName,
@@ -147,7 +140,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                         //calculate candidate age if Date_taken was changed
                         if ($row['FieldName'] == 'Date_taken') {
                             $Instrument->_saveValues(
-                                array('Date_taken' => $dateArray)
+                                array('Date_taken' => $setArray['Date_taken'])
                             );
                         }
 
@@ -169,7 +162,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                         //calculate candidate age if Date_taken was changed
                         if ($row['FieldName'] == 'Date_taken') {
                             $Instrument->_saveValues(
-                                array('Date_taken' => $dateArray)
+                                array('Date_taken' => $setArray['Date_taken'])
                             );
                         }
 


### PR DESCRIPTION
converting date string to array causes Utility::calculateAge to throw the following error
![screenshot from 2017-06-15 12-55-14](https://user-images.githubusercontent.com/6571449/27192744-6a1f8d66-51ca-11e7-8202-e3585ff63fea.png)
when attempting to resolve conflicts for the Date_taken field

https://redmine.cbrain.mcgill.ca/issues/12659