### PR TITLE
[tools] CouchDB_MRI_Importer - removed innocuous lines

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -323,9 +323,6 @@ class CouchDBMRIImporter
             );
             print $docid . ": " . $success . "\n";
 
-            $config = NDB_Config::singleton();
-            $paths  = $config->getSetting('paths');
-
         }
         return;
     }


### PR DESCRIPTION
I was tasked with removing superfluous/innocuous lines from tools/CouchDB_MRI_Importer. php. I went through the whole file, and it appears that only two lines are unnecessary. I don't have CouchDB or any imaging data, so I can't test whether my deletions may break anything. 