### PR TITLE
[SQL] Added primary key to project_rel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
 npm-debug.log*
+.phan/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ node_modules/
 modules/*/js/*.map
 htdocs/js/components/*.map
 npm-debug.log*
-.phan/*

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -164,7 +164,8 @@ INSERT INTO subproject (title, useEDC, WindowDifference) VALUES
 
 CREATE TABLE `project_rel` (
   `ProjectID` int(2) DEFAULT NULL,
-  `SubprojectID` int(2) DEFAULT NULL
+  `SubprojectID` int(2) DEFAULT NULL,
+  PRIMARY KEY (ProjectID, SubprojectID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `psc` (

--- a/SQL/Archive/17.1/2017-06-15-Project_rel-should-have-a-primary-key.sql
+++ b/SQL/Archive/17.1/2017-06-15-Project_rel-should-have-a-primary-key.sql
@@ -1,0 +1,18 @@
+CREATE TEMPORARY TABLE
+    project_rel_tmp
+AS
+    SELECT DISTINCT
+        ProjectID, SubprojectID
+    FROM
+        project_rel;
+
+DELETE FROM project_rel;
+
+INSERT INTO
+    project_rel (ProjectID, SubprojectID)
+SELECT
+    ProjectID, SubprojectID
+FROM
+    project_rel_tmp;
+
+ALTER TABLE `project_rel` ADD PRIMARY KEY( `ProjectID`, `SubprojectID`);


### PR DESCRIPTION
The table is missing primary keys. This causes problems if `Database::trackChanges()` is called on the `project_rel` table. I didn't add the needed foreign keys because that is not part of the fix for this particular problem.

This pull request adds the primary key, fixing the problem.