### PR TITLE
[Conflict Resolver] Display Examiner's full_name rather than examinerID

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -86,7 +86,6 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                         "SELECT UserID FROM flag WHERE CommentID=:CID",
                         array('CID' => $row['CommentId2'])
                     );
-
                     $resolutionLog = array(
                                       'UserID'         => $user->getUsername(),
                                       'User1'          => $user1,

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -86,6 +86,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                         "SELECT UserID FROM flag WHERE CommentID=:CID",
                         array('CID' => $row['CommentId2'])
                     );
+
                     $resolutionLog = array(
                                       'UserID'         => $user->getUsername(),
                                       'User1'          => $user1,
@@ -392,7 +393,75 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
 
         return true;
     }
+    /**
+     * Returns a list of candidates, users, etc.
+     * Need override for when Examiner field is conflicting,
+     * need Examiner's full name
+     *
+     * @return array
+     * @access private
+     */
+    function _getFullList()
+    {
+        // create DB object
+        $DB =& Database::singleton();
 
+        $qparams = array();
+        // add the base query
+        $query  = '';
+        $query .= $this->_getBaseQuery();
+
+        $filterdetails = $this->_getBaseFilter();
+        $query        .= $filterdetails['clause'];
+        $qparams       = $filterdetails['params'];
+        // apply ORDER BY filters
+        $query .= " ORDER BY ";
+        if (!empty($this->filter['order'])) {
+            $query .= $this->filter['order']['field']
+                ." ".$this->filter['order']['fieldOrder'].", ";
+        }
+        $query .= $this->order_by;
+        // get the list
+
+        $pageNum = 1;
+        if (isset($_REQUEST['pageID'])) {
+            $pageNum = $_REQUEST['pageID'];
+        }
+
+        $this->_getNumberPages($query);
+
+        $config         =& NDB_Config::singleton();
+        $resultsPerPage = $config->getSetting('rowsPerPage');
+        $limit          = " LIMIT $resultsPerPage"
+            ." OFFSET " . (($pageNum-1)*$resultsPerPage);
+        $result         = $DB->pselect($query . $limit, $qparams);
+
+        // OVERRIDE START
+        foreach ($result as $k => $r) {
+            if ($r['Question'] === 'Examiner') {
+                if (!empty($r['Value1'])) {
+                    $r['Value1'] = $DB->pselectOne(
+                        'SELECT full_name 
+                         FROM examiners 
+                         WHERE examinerID=:eid',
+                        array('eid' => $r['Value1'])
+                    );
+                }
+                if (!empty($r['Value2'])) {
+                    $r['Value2'] = $DB->pselectOne(
+                        'SELECT full_name 
+                         FROM examiners 
+                         WHERE examinerID=:eid',
+                        array('eid' => $r['Value2'])
+                    );
+                }
+                $result[$k] = $r;
+            }
+        }
+        //OVERRIDE END
+
+        return $result;
+    }
     /**
      * Gathers JS dependecies and merge them with the parent
      *

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -243,6 +243,68 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
     }
 
     /**
+     * Returns a list of candidates, users, etc.
+     * Need override for when Examiner field is conflicting,
+     * need Examiner's full name
+     *
+     * @return array
+     * @access private
+     */
+    function _getFullList()
+    {
+        // create DB object
+        $DB =& Database::singleton();
+
+        $qparams = array();
+        // add the base query
+        $query  = '';
+        $query .= $this->_getBaseQuery();
+
+        $filterdetails = $this->_getBaseFilter();
+        $query        .= $filterdetails['clause'];
+        $qparams       = $filterdetails['params'];
+        // apply ORDER BY filters
+        $query .= " ORDER BY ";
+        if (!empty($this->filter['order'])) {
+            $query .= $this->filter['order']['field']
+                ." ".$this->filter['order']['fieldOrder'].", ";
+        }
+        $query .= $this->order_by;
+        // get the list
+
+        $pageNum = 1;
+        if (isset($_REQUEST['pageID'])) {
+            $pageNum = $_REQUEST['pageID'];
+        }
+
+        $this->_getNumberPages($query);
+
+        $config         =& NDB_Config::singleton();
+        $resultsPerPage = $config->getSetting('rowsPerPage');
+        $limit          = " LIMIT $resultsPerPage"
+            ." OFFSET " . (($pageNum-1)*$resultsPerPage);
+        $result         = $DB->pselect($query . $limit, $qparams);
+        
+        // OVERRIDE START
+        foreach ($result as $k => $r) {
+            if ($r['Question'] === 'Examiner') {
+                if (!empty($r['CorrectAnswer'])) {
+                    $r['CorrectAnswer'] = $DB->pselectOne(
+                        'SELECT full_name 
+                         FROM examiners 
+                         WHERE examinerID=:eid',
+                        array('eid' => $r['CorrectAnswer'])
+                    );
+                }
+                $result[$k] = $r;
+            }
+        }
+        //OVERRIDE END
+
+        return $result;
+    }
+
+    /**
      * Gathers JS dependecies and merge them with the parent
      *
      * @return array of javascript to be inserted

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -284,7 +284,6 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         $limit          = " LIMIT $resultsPerPage"
             ." OFFSET " . (($pageNum-1)*$resultsPerPage);
         $result         = $DB->pselect($query . $limit, $qparams);
-        
         // OVERRIDE START
         foreach ($result as $k => $r) {
             if ($r['Question'] === 'Examiner') {


### PR DESCRIPTION
Conflict Resolver displays the examinerID for conflicts in the Examiner field making it difficult / impossible for anyone doing conflict resolution to resolve this field

To test: 
1. create a data entry conflict for the Examiner field if your DB does not have any already
2. resolve Examiner conflict  & make sure examiner names populate the select
3. check respective instrument table that ExaminerID is valid for the resolved conflict
4. comment "Good job, David! :beers:" and approve PR 