### PR TITLE
[couchdb] Show selected scantype only, ordering by pass first

### DIFF
--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -165,7 +165,7 @@ class FeedbackMRI
                       FROM feedback_mri_comments
                   WHERE ".$this->_buildWhere();
 
-        $result = $DB->pselect($query, array());
+        $result   = $DB->pselect($query, array());
         $comments = array();
 
         // build the output array

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -166,6 +166,7 @@ class FeedbackMRI
                   WHERE ".$this->_buildWhere();
 
         $result = $DB->pselect($query, array());
+        $comments = array();
 
         // build the output array
         if (is_array($result)) {
@@ -473,10 +474,10 @@ class FeedbackMRI
         // build the where depending on object and subject type
         if ($this->objectType == 'volume') {
             // per-volume
-            $where .= "FileID='$this->fileID'";
+            $where = "FileID='$this->fileID'";
         } else {
             // per-visit
-            $where .= "SessionID='$this->sessionID'";
+            $where = "SessionID='$this->sessionID'";
         }
         return $where;
     }

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -88,17 +88,19 @@ class CouchDBMRIImporter
 
         foreach($s as $scan){
             $scantype=$scan['ScanType'];
-            $Query .= ", (SELECT f.File FROM files f
+            $Query  .= ", (SELECT f.File FROM files f
                     LEFT JOIN files_qcstatus fqc USING(FileID)
                     LEFT JOIN mri_scan_type msc ON (msc.ID= f.AcquisitionProtocolID)
               WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype'
-              AND fqc.Selected='true' LIMIT 1)
+              AND fqc.Selected='true' ORDER BY
+              FIND_IN_SET(fqc.QCStatus, 'Fail,Pass') DESC LIMIT 1)
                     as Selected_$scantype,
               (SELECT fqc.QCStatus FROM files f
                     LEFT JOIN files_qcstatus fqc USING(FileID)
                     LEFT JOIN mri_scan_type msc ON(msc.ID= f.AcquisitionProtocolID)
               WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype'
-              AND fqc.Selected='true' LIMIT 1)
+              AND fqc.Selected='true' ORDER BY
+              FIND_IN_SET(fqc.QCStatus, 'Fail,Pass') DESC LIMIT 1)
                      as $scantype"."_QCStatus";
         }
         $Query .= " FROM session s JOIN candidate c USING (CandID)

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -88,14 +88,17 @@ class CouchDBMRIImporter
 
         foreach($s as $scan){
             $scantype=$scan['ScanType'];
-            $Query .= ", (SELECT f.File FROM files f LEFT JOIN mri_scan_type msc
-              ON (msc.ID= f.AcquisitionProtocolID)
-              WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype' LIMIT 1)
-                    as Selected_$scantype, (SELECT fqc.QCStatus
-                    FROM files f 
+            $Query .= ", (SELECT f.File FROM files f
+                    LEFT JOIN files_qcstatus fqc USING(FileID)
+                    LEFT JOIN mri_scan_type msc ON (msc.ID= f.AcquisitionProtocolID)
+              WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype'
+              AND fqc.Selected='true' LIMIT 1)
+                    as Selected_$scantype,
+              (SELECT fqc.QCStatus FROM files f
                     LEFT JOIN files_qcstatus fqc USING(FileID)
                     LEFT JOIN mri_scan_type msc ON(msc.ID= f.AcquisitionProtocolID)
-              WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype' LIMIT 1)
+              WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype'
+              AND fqc.Selected='true' LIMIT 1)
                      as $scantype"."_QCStatus";
         }
         $Query .= " FROM session s JOIN candidate c USING (CandID)
@@ -125,6 +128,10 @@ class CouchDBMRIImporter
         $tot_rej   = 'processing:total_rejected';
         $inter_rej = 'IntergradientRejected_'.$type;
         $pipeline  = 'processing:pipeline';
+        $sliceRej  = '';
+        $laceRej   = '';
+        $interRej  = '';
+        $acqDate   = '';
 
         $header['ScannerID_'.$type]           = $this->_getScannerID((int)$FileObj->getParameter('FileID'));
         $header['Pipeline_'.$type]            = $FileObj->getParameter('Pipeline');


### PR DESCRIPTION
**Situation:**
Redmine ticket number 12636, when multiple scans of a scan type are available per session, the old query would not care to return the selected scan or if one of them was passed or failed.  Any scan of any status found would be returned so results were not consistent.

**Solution:**
Since LORIS allows multiple scans of a scan type to be selected, the DQT needs to be able to handle that as well.

- show selected scan type only since the column name is supposed to relate to selected scans.
- ordering by pass first, fail second and no status third, then limit that to one result.
- reduce error log noise

**Resolution**
IBIS has put this solution on production as an override until LORIS code is updated.