### PR TITLE
[Core] Making clearConflictsForInstance function static in Conflict Detector class

### DIFF
--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -124,7 +124,7 @@ class ConflictDetector
      *
      * @return null As a side-effect deletes from database
      */
-    function clearConflictsForInstance($commentId)
+    static function clearConflictsForInstance($commentId)
     {
         $deleteWhere = array('CommentId1' => $commentId);
 


### PR DESCRIPTION
Possibly throwing a lot of warnings/notices when running recreate_conflicts depending on your settings.