### PR TITLE
Imaging Processing Scripts: parameter_file table not populated on MySQL 5.7: Redmine 12733

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1518,7 +1518,7 @@ CREATE TABLE `parameter_file` (
   `ParameterFileID` int(10) unsigned NOT NULL auto_increment,
   `FileID` int(10) unsigned NOT NULL default '0',
   `ParameterTypeID` int(10) unsigned NOT NULL default '0',
-  `Value` text,
+  `Value` longtext,
   `InsertTime` int(10) unsigned NOT NULL default '0',
   PRIMARY KEY  (`ParameterFileID`),
   UNIQUE KEY `file_type_uniq` (`FileID`,`ParameterTypeID`),

--- a/SQL/Archive/17.1/2017-06-22_parameter_file_LONGTEXT.sql
+++ b/SQL/Archive/17.1/2017-06-22_parameter_file_LONGTEXT.sql
@@ -1,0 +1,2 @@
+ALTER table parameter_file MODIFY Value LONGTEXT;
+


### PR DESCRIPTION
Parameter_file table was not being populated on MySQL 5.7;
error is as follows:
`DBD::mysql::db do failed: Data too long for column 'Value' at row 334 at /data/braincode/bin/mri/uploadNeuroDB/NeuroDB/MRI.pm line 753.`

This pull request changes the type of the Value column to LONGTEXT.
