### PR TITLE
[Tools] Added shortcut for phpcbf

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "lint:javascript": "./test/run-js-linter.sh",
     "lint:php": "./test/run-php-linter.sh",
+    "fix:php": "phpcbf --standard=./docs/LorisCS.xml",
     "tests:unit": "./test/dockerized-unit-tests.sh",
     "tests:unit:debug": "DEBUG=true ./test/dockerized-unit-tests.sh",
     "tests:integration": "./test/dockerized-integration-tests.sh",


### PR DESCRIPTION
Before,

`./vendor/bin/phpcbf --standard=LorisCS.xml <file>`

Now,

`npm run fix:php <file>`

It's shorter and easier to type, imo. And follows the `lint:php` script.

----

One thing to note, if there is nothing to fix, `phpcbf` returns a status of `0`, and everything runs fine.

If `phpcbf` fixes something, it will return a status of `1`, and `npm` will think `phpcbf` did not run correctly.

The only way around it, that I know of, is, `npm run fix:php <file> -s` or `npm run fix:php <file> --silent`.

But the error doesn't annoy me too much and beats having to type `--standard=docs/LorisCS.xml` all the time.

-----

Example usage of `npm run fix:php ./php/libraries/NDB_Client.class.inc -s`

![image](https://user-images.githubusercontent.com/5655961/27446500-c8a8bd40-574b-11e7-983d-16e4f5f195a7.png)


-----

Example of usage: `npm run fix:php ./php/libraries/NDB_Client.class.inc`

![image](https://user-images.githubusercontent.com/5655961/27446271-f16aeb00-574a-11e7-9365-c8d29719380d.png)
