### PR TITLE
[Utility] Deprecated Utility::getStageUsingCandId()

### DIFF
--- a/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
+++ b/modules/instrument_list/php/NDB_Menu_Filter_instrument_list.class.inc
@@ -96,16 +96,12 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
         $battery = new NDB_BVL_Battery;
         $success = $battery->selectBattery($_REQUEST['sessionID']);
 
-        $this->tpl_data['stage']        = Utility::getStageUsingCandID(
-            $this->tpl_data['candID']
-        );
         $this->tpl_data['subprojectID'] = Utility::getSubprojectIDUsingCandID(
             $this->tpl_data['candID']
         );
 
         // get the list of instruments
         $listOfInstruments = $this->getBatteryInstrumentList(
-            $this->tpl_data['stage'],
             $this->tpl_data['subprojectID']
         );
 
@@ -233,15 +229,12 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
      * Gets an associative array of instruments which are members of the current
      * battery for instrument list module
      *
-     * @param string  $stage        Either 'visit' or 'screening' - determines
-     *                              whether to register only screening instruments
-     *                              or visit instruments
      * @param integer $SubprojectID The SubprojectID of that we want the battery for.
      *
      * @return array an associative array containing Test_name,
      *         Full_name, Sub_group, CommentID
      */
-    function getBatteryInstrumentList($stage=null, $SubprojectID=null)
+    function getBatteryInstrumentList($SubprojectID=null)
     {
         $DB = Database::singleton();
 
@@ -251,30 +244,26 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
         }
 
         // craft the select query
-        $query = "SELECT DISTINCT f.Test_name,
+        $query   = "SELECT DISTINCT f.Test_name,
                     t.Full_name,
                     f.CommentID,
                     CONCAT('DDE_', f.CommentID) AS DDECommentID,
                     ts.Subgroup_name as Sub_group,
                     ts.group_order as Subgroup_order,
                     t.isDirectEntry";
-        if (!is_null($stage)) {
-            $query .= ", b.instr_order as instrument_order";
-        }
+        $query  .= ", b.instr_order as instrument_order";
         $query  .= " FROM flag f
             	JOIN test_names t ON (f.Test_name=t.Test_name)
             	JOIN test_subgroups ts ON (ts.ID = t.Sub_group)
             	LEFT JOIN session s ON (s.ID=f.SessionID) ";
         $qparams = array('SID' => $_REQUEST['sessionID']);
 
-        if (!is_null($stage)) {
-            $query .= "
-            	LEFT JOIN test_battery b 
-       	        ON ((t.Test_name=b.Test_name OR b.Test_name IS NULL) 
-      	        AND (s.SubprojectID=b.SubprojectID OR b.SubprojectID IS NULL) 
-       	        AND (s.Visit_label=b.Visit_label OR b.Visit_label IS NULL) 
-       	        AND (s.CenterID=b.CenterID OR b.CenterID IS NULL)) ";
-        }
+        $query .= "
+        	LEFT JOIN test_battery b
+   	        ON ((t.Test_name=b.Test_name OR b.Test_name IS NULL)
+  	        AND (s.SubprojectID=b.SubprojectID OR b.SubprojectID IS NULL)
+   	        AND (s.Visit_label=b.Visit_label OR b.Visit_label IS NULL)
+   	        AND (s.CenterID=b.CenterID OR b.CenterID IS NULL)) ";
         $query .= " WHERE f.SessionID=:SID
             AND LEFT(f.CommentID, 3) != 'DDE'";
 
@@ -283,11 +272,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
         } else {
             $query .= " ORDER BY Subgroup_order";
         }
-        if (!is_null($stage)) {
-            $query .= ", instrument_order";
-        } else {
-            $query .= ", Full_name";
-        }
+        $query .= ", instrument_order";
         //print_r($query);
         // get the list of instruments
         $rows = $DB->pselect($query, $qparams);

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -928,16 +928,16 @@ class Utility
      *
      * @param string $Cand_id candidate ID
      *
-     * @return array
-     * @throws DatabaseException
+     * @return     array
+     * @throws     DatabaseException
+     * @deprecated
      */
     static function getStageUsingCandID($Cand_id)
     {
-        $db    =& Database::singleton();
-        $query = "select DISTINCT Current_stage from session where ".
-            "CandID = :Cand_id";
-        $stage = $db->pselect($query, array('Cand_id' => $Cand_id));
-        return $stage[0]['Current_stage'];
+        throw new LorisException(
+            "Utility::getStageUsingCandID() is deprecated. "
+            . "Use TimePoint::getCurrentStage() instead."
+        );
     }
 
     /**


### PR DESCRIPTION
`Utility::getStageUsingCandId()` doesn't work correctly at all. `TimePoint::getCurrentStage()` is the correct way, for now.

`NDB_Menu_Filter_Instrument_List` is the only place using it in core Loris. If any other projects are using it, they really should not or they risk getting the wrong stage. It makes no sense, anyway. A candidate can have multiple "stages" if they have multiple sessions/timepoints.

I consulted @MounaSafiHarab and was told that you cannot look at the instrument list of a candidate if they do not have a timepoint. Which is why the current code was "simplified" to what it is now. Since `is_null($stage)` will always be `false`.

Also, `$this->tpl_data["stage"]` is not being used by the `.tpl` file associated with the instrument list. Therefore, not needed.