### PR TITLE
[Libraries] Refactor File_Upload Class

### DIFF
--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -116,7 +116,7 @@ class File_Upload
                     if (!$this->getNewDirectory($newTargetDirectory)) {
                         continue;
                     }
-                    $this->_moveFile());
+                    $this->_moveFile();
                 }
 
                 //Import the file using the importFile method of the handler

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -1,9 +1,9 @@
 <?php
 /**
  * This file contains a wrapper for managing and verifying files that are
- * uploaded through PHP QuickForm and handles putting them in the correct place,
+ * uploaded through LorisForm and handles putting them in the correct place,
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  Behavioural
@@ -12,37 +12,30 @@
  * @link     https://github.com/aces/Loris
  */
 
-/**
- * Class for managing file uploads
- *
- * This class interoperates with HTML_QuickForm to allow easy verification and
- * manipulation of uploaded files.
- *
- * @category Main
- * @package  Behavioural
- * @author   Loris team <info-loris.mni@mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
- */
 class File_Upload
 {
+    private $errorLog;
+    private $destinationFilename;
+    private $destinationDirectory;
+    private $baseUploadDirectory;
+
     /**
      * Construct the File_Upload class. This sets the default parameters
      * for a file which can be overwritten by calling the set* methods
      */
-    function __construct()
+    public function __construct()
     {
-        //Set Defaults
-        $this->renameMode        = "incremental";
-        $this->overwriteMode     = "rename";
+        // TODO: fileMove should be removed after imaging uploader is refactored
+        // It is not a private variable because imaging_uploader currently
+        // changes its value manually.
+        // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L212
         $this->fileMove          = true;
-        $this->fileVerify        = true;
-        $this->fileImport        = true;
-        $this->filenamePrefix    = "";
-        $this->createDirectories = true;
         $this->errorLog          = array();
-        $this->moveOrCopy        = "move";
-        $this->isCLImport        = false;
+        $this->fieldName = '';
+        $this->fieldNames = '';
+        $this->destinationFilename = '';
+        $this->destinationDirectory = '';
+        $this->baseUploadDirectory = '';
     }
 
 
@@ -52,20 +45,20 @@ class File_Upload
      *
      * @return boolean True on success False on failure
      */
-    function processFiles()
+    public function processFiles()
     {
         //Loop through fields.
         if (empty($this->fieldNames) || !is_array($this->fieldNames)) {
             $this->setError(
                 "",
-                "No files to process!  Register handlers first."
+                "No files to process! Register handlers first."
             );
             return false;
         }
 
-        foreach ($this->fieldNames AS $field) {
+        foreach ($this->fieldNames as $field) {
             $this->fieldName =$field;
-            if (!$this->preProcessFile()) {
+            if (!$this->preprocessFile()) {
                 $this->setError(
                     $field,
                     "Could not upload file. Max file size is "
@@ -86,48 +79,36 @@ class File_Upload
 
             //Test the handler to ensure it exists and all methods are intact
             if ($this->isValidFileHandler($field)) {
-                //Verify the file
-                if ($this->fileVerify) {
-                    //Validate the file using the isValid method of the handler
-                    //class.
-                    $fileVerified =$this->callFileHandler($field, 'verify');
-                    if (is_array($fileVerified)) {
-                        $this->setError($field, $fileVerified);
-                        continue;
-                    }
+                //Validate using the isValid method of the handler class
+                $errors = $this->callFileHandler($field, 'verify');
+                // The above function call returns an array if something goes wrong,
+                // and returns true otherwise.
+                // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L265
+                if (is_array($errors)) {
+                    $this->setError($field, $errors);
+                    continue;
                 }
 
                 //If we are going to move the file, figure out what its new name
                 //will be before the import step, so we can save the new filename
                 //to the database.
+                // @TODO: Remove this check after imaging uploader is refactored
                 if ($this->fileMove) {
+                    // Note: The only implementation of the below gets the username
+                    // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L529
                     $newTargetDirectory =$this->callFileHandler($field, 'move');
                     if (!$this->getNewDirectory($newTargetDirectory)) {
                         continue;
                     }
-                    if (!$this->getNewFilename()) {
-                        continue;
-                    }
+                    $this->moveFile());
                 }
 
-                //Import the file
-                if ($this->fileImport) {
-                    //Import the file using the importFile method of the handler
-                    //class.
-                    $fileImported =$this->callFileHandler($field, 'import');
-                    if (is_array($fileImported)) {
-                        $this->setError($field, $fileImported);
-                        continue;
-                    }
-                }
-
-                //Move the file (comes before import so that import knows the
-                //name of the filename for storing int he database)
-                if ($this->fileMove) {
-                    $fileMoved =$this->moveFile();  //Move the file
-                    if (is_array($fileMoved)) {
-                        continue;
-                    }
+                //Import the file using the importFile method of the handler
+                //class.
+                $fileImported =$this->callFileHandler($field, 'import');
+                if (is_array($fileImported)) {
+                    $this->setError($field, $fileImported);
+                    continue;
                 }
             }
         }
@@ -145,24 +126,17 @@ class File_Upload
      *
      * @return bool    $success        if operation succeeded
      */
-    function preProcessFile()
+    private function preprocessFile()
     {
-        if (!$this->isCLImport) {
-            $this->file =& $this->form->getElement($this->fieldName);
-            if (!method_exists($this->file, "isUploadedFile")) {
-                return false;
-            }
-            if ($this->file->isUploadedFile()) {
-                $this->fileInfo = $this->file->getValue();
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            $this->file     =$this->CLFiles[$this->fieldName];
-            $this->fileInfo =$this->file['info'];
+        $this->file =& $this->form->getElement($this->fieldName);
+        if (!method_exists($this->file, "isUploadedFile")) {
+            return false;
+        }
+        if ($this->file->isUploadedFile()) {
+            $this->fileInfo = $this->file->getValue();
             return true;
         }
+        return false;
     }
 
 
@@ -174,9 +148,8 @@ class File_Upload
      * @param string $action The name of the method to call.
      *
      * @return boolean true if operation succeeded
-     * @access public
      */
-    function callFileHandler($field, $action)
+    public function callFileHandler($field, $action)
     {
         $class  =$this->fileHandlers[$field]['class'];
         $method =$this->fileHandlers[$field]['methods'][$action];
@@ -197,8 +170,7 @@ class File_Upload
                  $args,
                 );
 
-        $output =call_user_func_array($func, $args);
-
+        $output = call_user_func_array($func, $args);
         return $output;
     }
 
@@ -206,28 +178,24 @@ class File_Upload
     /**
      * Moves the file from the tmp directory to its final destination.
      *
-     * @return bool    $success        if operation succeeded
-     * @access public
+     * @return bool    status of operation
      */
-    function moveFile()
+    public function moveFile()
     {
-        if ($this->moveOrCopy=="move") {
-            if (!$this->file->moveUploadedFile(
-                $this->destinationDirectory,
-                $this->destinationFilename
-            )) {
-                $this->setError(
-                    $this->fieldName,
-                    "Could not move file to "
-                    . $this->destinationDirectory
-                    . $this->destinationFilename
-                );
-            }
-        } else if ($this->moveOrCopy=="copy") {
-            copy(
-                $this->fileInfo['tmp_name'],
-                $this->destinationDirectory.$this->destinationFilename
+        // Prepare the name before moving
+        $this->normalizeDestinationFilename();
+        // Move the file
+        if (!$this->file->moveUploadedFile(
+            $this->destinationDirectory,
+            $this->destinationFilename
+        )) {
+            $this->setError(
+                $this->fieldName,
+                "Could not move file to "
+                . $this->destinationDirectory
+                . $this->destinationFilename
             );
+            return false;
         }
         chmod("$this->destinationDirectory$this->destinationFilename", 0666);
         return true;
@@ -240,9 +208,8 @@ class File_Upload
      * @param string $destination_dir The name of the destination directory.
      *
      * @return bool    if operation succeeded
-     * @access public
      */
-    function getNewDirectory($destination_dir="")
+    public function getNewDirectory($destination_dir="")
     {
         $dest_dir =$this->baseUploadDirectory.$destination_dir;
 
@@ -259,14 +226,14 @@ class File_Upload
                 . "Could not create directory with same name."
             );
             return false;
-        } else if (!file_exists($dest_dir) && $this->createDirectories) {
+        } else if (!file_exists($dest_dir)) {
             $config = NDB_Config::singleton();
             mkdir($dest_dir, 0775);
             $grp = $config->getSetting('FileGroup');
             if (!empty($grp)) {
                 chgrp($dest_dir, $grp);
             }
-        } else if (!file_exists($dest_dir) && $this->createDirectories) {
+        } else if (!file_exists($dest_dir)) {
             $this->setError(
                 $this->fieldName,
                 "Destination directory '$dest_dir' does not exist"
@@ -287,42 +254,23 @@ class File_Upload
 
 
     /**
-     * Builds the final filename for the file.
+     * Remove unwanted characters from filename and add
+     * numeric suffix to prevent duplication.
      *
-     * @return bool    if operation succeeded
-     * @access public
+     * @return void
      */
-    function getNewFilename()
+    public function normalizeDestinationFilename()
     {
-        $dest_dir =$this->destinationDirectory;
-
         //Strip out any unwanted characters from the filename
-        $safe_name =$this->filenamePrefix.$this->nameToSafe($this->fileInfo['name']);
+        $safe_name = $this->nameToSafe($this->fileInfo['name']);
 
-        //If there is already a file with this name in the target directory either
-        //overwrite, rename, or reject.
-        if (file_exists($dest_dir.$safe_name)) {
-            switch($this->overwriteMode){
-            case "rename":
-                if ($this->renameMode=="incremental") {
-                    $safe_name =$this->nameToIncremental($dest_dir, $safe_name);
-                } elseif ($this->renameMode=="unique"
-                    || $this->renameMode=="unique-random"
-                ) {
-                    $safe_name =$this->nameToUniqueRandom($safe_name);
-                } elseif ($this->renameMode=="unique-timestamp") {
-                    $safe_name =$this->nameToUniqueTimestamp($safe_name);
-                }
-                break;
-            case "reject":
-                $this->setError($this->fieldName, "File Exists, rejecting");
-                return false;
-                break;
-            }
+        // If there is already a file with this name in the target directory
+        // add a numeric suffix to avoid overwriting
+        if (file_exists($this->destinationDirectory . $safe_name)) {
+            $safe_name = $this->nameToIncremental($dest_dir, $safe_name);
         }
 
-        $this->destinationFilename =$safe_name;
-        return true;
+        $this->destinationFilename = $safe_name;
     }
 
 
@@ -336,7 +284,7 @@ class File_Upload
      * @return boolean True if the class is valid.
      * @see    File_Upload::processFiles()
      */
-    function isValidFileHandler($field)
+    private function isValidFileHandler($field)
     {
         $class =&$this->fileHandlers[$field]['class'];
         if (is_object($class)) {
@@ -348,7 +296,7 @@ class File_Upload
             return false;
         }
         //Test each method
-        foreach ($this->fileHandlers[$field]['methods'] AS $method) {
+        foreach ($this->fileHandlers[$field]['methods'] as $method) {
             if (!method_exists($test, $method)) {
                 $this->setError(
                     $field,
@@ -370,11 +318,11 @@ class File_Upload
      *
      * @return true
      */
-    function registerForm(&$quickform)
+    public function registerForm(&$quickform)
     {
         $this->form =&$quickform;
         return true;
-        //@todo Should test to see if form is valid and if not return an error.
+        //@TODO Should test to see if form is valid and if not return an error.
     }
 
     /**
@@ -395,19 +343,18 @@ class File_Upload
     *
     * @return boolean true
     * @see    File_Upload::processFiles()
+    * @cleanup
     */
-    function setFileHandler($fieldName, $className, $methods="")
+    public function setFileHandler($fieldName, $className, $methods="")
     {
+        // TODO: There is no implementation of this function that uses
+        // custom methods. The function signature should be changed
         $default_methods =array(
                            "verify" => "isValid",
                            "import" => "importFile",
                            "move"   => "getTargetDirectory",
                           );
-        if (!empty($methods) && is_array($methods)) {
-            $methods =array_merge($default_methods, $methods);
-        } else {
-            $methods =$default_methods;
-        }
+        $methods =$default_methods;
         $this->fileHandlers[$fieldName]['class']   =$className;
         $this->fileHandlers[$fieldName]['methods'] =$methods;
         $this->fieldNames[] =$fieldName;
@@ -426,7 +373,7 @@ class File_Upload
      * @return boolean true
      * @see    File_Upload::processFiles()
      */
-    function setHandlerArgs($args)
+    public function setHandlerArgs($args)
     {
         if (!is_array($args)) {
             return false;
@@ -444,16 +391,12 @@ class File_Upload
      * @param string $name   The string file name
      * @param int    $maxlen Maximun permited string lenght
      *
-     * @return string Formatted file name
+     * @return string Valid file name
      * @see    File_Upload::moveFile()
      */
-    function nameToSafe($name, $maxlen=250)
+    private function nameToSafe($name, $maxlen=250)
     {
-        $noalpha = '???????????????????????????????????????????@';
-        $alpha   = 'aeiouaeiouaeiouAEIOUAEIOUAEIOUaeiouAEIOUncCa';
-        $name    = substr($name, 0, $maxlen);
-        $name    = strtr($name, $noalpha, $alpha);
-        // not permitted chars are replaced with "_"
+        // Non-permitted chars are replaced with "_"
         return preg_replace('/[^a-zA-Z0-9,._\+\()\-]/', '_', $name);
     }
 
@@ -464,10 +407,8 @@ class File_Upload
       *
       * @return string split file name
       * @see    File_Upload::nameToIncremental()
-      * @see    File_Upload::nameToUniqueRandom()
-      * @see    File_Upload::nameToUniqueTimestamp()
       */
-    function getSplitFilename($name)
+    private function getSplitFilename($name)
     {
         if (strstr($name, ".")) {
             $extpos       =strrpos($name, ".");
@@ -492,7 +433,7 @@ class File_Upload
      * @return string New filename
      * @see    File_Upload::moveFile()
      */
-    function nameToIncremental($dir, $name)
+    private function nameToIncremental($dir, $name)
     {
         $done =false;
         $i    =0;
@@ -508,144 +449,6 @@ class File_Upload
         return $new_name;
     }
 
-     /**
-      * Gets unique file names in the form:
-      *     9022210413b75410c28bef.html
-      *
-      * @param string $name The target directory for the file.
-      *
-      * @return string New filename
-      * @see    File_Upload::moveFile()
-      */
-    function nameToUniqueRandom($name)
-    {
-        $filename =$this->getSplitFilename($name);
-        if (! $this->_seeded) {
-            srand((double) microtime() * 1000000);
-            $this->_seeded = 1;
-        }
-        $name =$filename['name']."-".uniqid(rand()).$filename['ext'];
-        return $name;
-    }
-
-    /**
-    * Adds the timestamp to the filename in order to make it unique
-    *
-    * @param int $name The proposed name for the file.
-    *
-    * @return string $new_name   New filename
-    * @see    File_Upload::moveFile()
-    */
-    function nameToUniqueTimestamp($name)
-    {
-        $filename =$this->getSplitFilename($name);
-        $new_name =$filename['name']."-".time().$filename['ext'];
-        return $new_name;
-    }
-
-    /**
-     * Sets the action to take if moveFile finds discovers an
-     * existing file with the same name as the one it is trying to move.
-     *
-     * The options are:
-     * - overwrite:  This overwrites any existing file
-     * - rename   :  This renames the file.  Use File_Upload::setRenameMode() to
-     *               choose the renaming scheme.
-     * - reject   :  This raises an error and does not move the file in any form
-     *               to the new directory.
-     * Default: rename
-     *
-     * @param string $mode The desired mode.
-     *
-     * @return boolean true if overwriting, false on invalid argument
-     * @see    File_Upload::moveFile()
-     */
-    function setOverwriteMode($mode)
-    {
-        if ($mode=="overwrite"
-            || $mode=="reject"
-            || $mode=="rename"
-        ) {
-            $this->overwriteMode =$mode;
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-
-    /**
-     * Determines how to rename a file if an existing file of the original
-     * filename is discovered in the target directory.
-     *
-     * Used in conjuction with File::setOverwriteMode('rename').  The options are:
-     * - incremental        :  This adds a numeric extension to the file which is
-     *                         incremented until it does not match an existing file.
-     * - unique             :  This adds a unique random string to the end of the
-     *                         filename.
-     * - unique-random      :  Same as above.
-     * - unique-timestamp   :  This adds the current UNIX timestamp to the end of the
-     *                         filename.
-     * Default: incremental
-     *
-     * @param string $mode The desired mode.
-     *
-     * @return boolean true if renaming, false if invalid argument
-     * @see    File_Upload::moveFile()
-     */
-    function setRenameMode($mode)
-    {
-        if ($mode=="incremental"
-            || $mode=="unique"
-            || $mode=="unique-timestamp"
-            || $mode=="unique-random"
-        ) {
-            $this->renameMode =$mode;
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-    * Turns on/off verifying of files.
-    *
-    * @param boolean $mode The desired mode.
-    *
-    * @return boolean true
-    * @see    File_Upload::moveFile()
-    */
-    function setFileVerify($mode)
-    {
-        $this->fileVerify =$mode;
-    }
-
-    /**
-    * Turns on/off importing of files.
-    *
-    * @param boolean $mode The desired mode.
-    *
-    * @return void
-    * @see    File_Upload::moveFile()
-    */
-    function setFileImport($mode)
-    {
-        $this->fileImport =$mode;
-    }
-
-    /**
-     * Turns on/off moving of files.
-     *
-     * @param boolean $mode The desired mode.
-     *
-     * @return void
-     * @see    File_Upload::moveFile()
-     */
-    function setFileMove($mode)
-    {
-        $this->fileMove =$mode;
-    }
-
     /**
      * Sets the base directory to move validated files into.
      * This directory may be added to by individual class handlers.
@@ -655,27 +458,13 @@ class File_Upload
      * @return void
      * @see    File_Upload::moveFile()
      */
-    function setBaseUploadDirectory($dir)
+    public function setBaseUploadDirectory($dir)
     {
         if (substr($dir, -1, 1) != "/") {
             $dir .="/";
         }
-        $this->baseUploadDirectory =$dir;
+        $this->baseUploadDirectory = $dir;
     }
-
-    /**
-    * Sets prefix to be prepended to new filenames
-    *
-    * @param string $prefix The desired prefix.
-    *
-    * @return void
-    * @see    File_Upload::moveFile()
-    */
-    function setFilenamePrefix($prefix)
-    {
-        $this->filenamePrefix =$prefix;
-    }
-
 
     /**
     * Gets the final destination directory for the uploaded file
@@ -683,7 +472,7 @@ class File_Upload
     * @return string directory
     * @see    File_Upload::getNewFilename()
     */
-    function getDestinationDirectory()
+    public function getDestinationDirectory()
     {
         return $this->destinationDirectory;
     }
@@ -695,24 +484,10 @@ class File_Upload
     * @see    File_Upload::getNewFilename()
     * @return string filename
     */
-    function getDestinationFilename()
+    public function getDestinationFilename()
     {
         return $this->destinationFilename;
     }
-
-    /**
-    * Turns on/off creation of upload directories.
-    *
-    * @param boolean $mode The desired mode.
-    *
-    * @see    File_Upload::moveFile()
-    * @return null
-    */
-    function setCreateDirectories($mode)
-    {
-        $this->createDirectories =$mode;
-    }
-
 
     /**
     * Adds an error to the error log
@@ -722,7 +497,7 @@ class File_Upload
     *
     * @return void
     */
-    function setError($field, $msg)
+    private function setError($field, $msg)
     {
         if (!is_array($this->errorLog[$field])) {
             $this->errorLog[$field] = array();
@@ -744,25 +519,6 @@ class File_Upload
     function getErrors()
     {
         return $this->errorLog;
-    }
-
-
-    /**
-    * This function registers a file to be used instead of a quickform file.
-    *
-    * @param string $fileName the full filename including path of the file
-    * @param string $fileType the type of the file.  Used to determine which
-    *                         importers, etc to run on it.  Same as quickform
-    *                         fieldname.
-    *
-    * @see File_Upload::preProcessFile()
-    *
-    * @return null
-    */
-    function addCLFile($fileName, $fileType)
-    {
-        $this->CLFiles[$fileType]['info']['tmp_name'] =$fileName;
-        $this->CLFiles[$fileType]['info']['name']     =basename($fileName);
     }
 }
 

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -1,5 +1,6 @@
 <?php
 /**
+ * File_Upload File Doc Comment
  * This file contains a wrapper for managing and verifying files that are
  * uploaded through LorisForm and handles putting them in the correct place,
  *
@@ -12,12 +13,25 @@
  * @link     https://github.com/aces/Loris
  */
 
+/**
+ * Class for managing file uploads
+ *
+ * This class interoperates with HTML_QuickForm to allow easy verification and
+ * manipulation of uploaded files.
+ *
+ * @category Main
+ * @package  Behavioural
+ * @author   Loris team <info-loris.mni@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
 class File_Upload
 {
-    private $errorLog;
-    private $destinationFilename;
-    private $destinationDirectory;
-    private $baseUploadDirectory;
+    private $_errorLog;
+    private $_destinationFilename;
+    private $_destinationDirectory;
+    private $_baseUploadDirectory;
 
     /**
      * Construct the File_Upload class. This sets the default parameters
@@ -29,13 +43,13 @@ class File_Upload
         // It is not a private variable because imaging_uploader currently
         // changes its value manually.
         // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L212
-        $this->fileMove          = true;
-        $this->errorLog          = array();
-        $this->fieldName = '';
-        $this->fieldNames = '';
+        $this->fileMove            = true;
+        $this->errorLog            = array();
+        $this->fieldName           = '';
+        $this->fieldNames          = '';
         $this->destinationFilename = '';
         $this->destinationDirectory = '';
-        $this->baseUploadDirectory = '';
+        $this->baseUploadDirectory  = '';
     }
 
 
@@ -83,7 +97,8 @@ class File_Upload
                 $errors = $this->callFileHandler($field, 'verify');
                 // The above function call returns an array if something goes wrong,
                 // and returns true otherwise.
-                // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L265
+                // @see imaging_uploader/php/
+                //     NDB_Menu_Filter_imaging_uploader.class.inc#L265
                 if (is_array($errors)) {
                     $this->setError($field, $errors);
                     continue;
@@ -95,7 +110,8 @@ class File_Upload
                 // @TODO: Remove this check after imaging uploader is refactored
                 if ($this->fileMove) {
                     // Note: The only implementation of the below gets the username
-                    // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L529
+                    // @see imaging_uploader/php/
+                    //     NDB_Menu_Filter_imaging_uploader.class.inc#L529
                     $newTargetDirectory =$this->callFileHandler($field, 'move');
                     if (!$this->getNewDirectory($newTargetDirectory)) {
                         continue;
@@ -126,7 +142,7 @@ class File_Upload
      *
      * @return bool    $success        if operation succeeded
      */
-    private function preprocessFile()
+    private function _preprocessFile()
     {
         $this->file =& $this->form->getElement($this->fieldName);
         if (!method_exists($this->file, "isUploadedFile")) {
@@ -284,7 +300,7 @@ class File_Upload
      * @return boolean True if the class is valid.
      * @see    File_Upload::processFiles()
      */
-    private function isValidFileHandler($field)
+    private function _isValidFileHandler($field)
     {
         $class =&$this->fileHandlers[$field]['class'];
         if (is_object($class)) {
@@ -341,8 +357,8 @@ class File_Upload
     *                          import, or move.  If any (or all) of these
     *                          are empty the defaults will be used.
     *
-    * @return boolean true
-    * @see    File_Upload::processFiles()
+    * @return  boolean true
+    * @see     File_Upload::processFiles()
     * @cleanup
     */
     public function setFileHandler($fieldName, $className, $methods="")
@@ -354,7 +370,7 @@ class File_Upload
                            "import" => "importFile",
                            "move"   => "getTargetDirectory",
                           );
-        $methods =$default_methods;
+        $methods         =$default_methods;
         $this->fileHandlers[$fieldName]['class']   =$className;
         $this->fileHandlers[$fieldName]['methods'] =$methods;
         $this->fieldNames[] =$fieldName;
@@ -394,7 +410,7 @@ class File_Upload
      * @return string Valid file name
      * @see    File_Upload::moveFile()
      */
-    private function nameToSafe($name, $maxlen=250)
+    private function _nameToSafe($name, $maxlen=250)
     {
         // Non-permitted chars are replaced with "_"
         return preg_replace('/[^a-zA-Z0-9,._\+\()\-]/', '_', $name);
@@ -408,7 +424,7 @@ class File_Upload
       * @return string split file name
       * @see    File_Upload::nameToIncremental()
       */
-    private function getSplitFilename($name)
+    private function _getSplitFilename($name)
     {
         if (strstr($name, ".")) {
             $extpos       =strrpos($name, ".");
@@ -433,7 +449,7 @@ class File_Upload
      * @return string New filename
      * @see    File_Upload::moveFile()
      */
-    private function nameToIncremental($dir, $name)
+    private function _nameToIncremental($dir, $name)
     {
         $done =false;
         $i    =0;
@@ -497,7 +513,7 @@ class File_Upload
     *
     * @return void
     */
-    private function setError($field, $msg)
+    private function _setError($field, $msg)
     {
         if (!is_array($this->errorLog[$field])) {
             $this->errorLog[$field] = array();

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -28,10 +28,10 @@
 
 class File_Upload
 {
-    private $_errorLog;
-    private $_destinationFilename;
-    private $_destinationDirectory;
     private $_baseUploadDirectory;
+    private $_destinationDirectory;
+    private $_destinationFilename;
+    private $_errorLog;
 
     /**
      * Construct the File_Upload class. This sets the default parameters
@@ -39,17 +39,17 @@ class File_Upload
      */
     public function __construct()
     {
-        // TODO: fileMove should be removed after imaging uploader is refactored
+        // TODO: _fileMove should be removed after imaging uploader is refactored
         // It is not a private variable because imaging_uploader currently
         // changes its value manually.
         // @see imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc#L212
-        $this->fileMove            = true;
-        $this->errorLog            = array();
-        $this->fieldName           = '';
-        $this->fieldNames          = '';
-        $this->destinationFilename = '';
-        $this->destinationDirectory = '';
-        $this->baseUploadDirectory  = '';
+        $this->_baseUploadDirectory  = '';
+        $this->_destinationDirectory = '';
+        $this->_destinationFilename  = '';
+        $this->_errorLog  = array();
+        $this->fileMove   = true;
+        $this->fieldName  = '';
+        $this->fieldNames = '';
     }
 
 
@@ -63,7 +63,7 @@ class File_Upload
     {
         //Loop through fields.
         if (empty($this->fieldNames) || !is_array($this->fieldNames)) {
-            $this->setError(
+            $this->_setError(
                 "",
                 "No files to process! Register handlers first."
             );
@@ -72,8 +72,8 @@ class File_Upload
 
         foreach ($this->fieldNames as $field) {
             $this->fieldName =$field;
-            if (!$this->preprocessFile()) {
-                $this->setError(
+            if (!$this->_preprocessFile()) {
+                $this->_setError(
                     $field,
                     "Could not upload file. Max file size is "
                     . ini_get("upload_max_filesize") . "."
@@ -84,7 +84,7 @@ class File_Upload
             //Determine appropriate file handler class
             if (empty($this->fileHandlers[$field])) {
                 //If a field type is set use that.
-                $this->setError(
+                $this->_setError(
                     $field,
                     "No file handler registered for field '$field'"
                 );
@@ -92,7 +92,7 @@ class File_Upload
             }
 
             //Test the handler to ensure it exists and all methods are intact
-            if ($this->isValidFileHandler($field)) {
+            if ($this->_isValidFileHandler($field)) {
                 //Validate using the isValid method of the handler class
                 $errors = $this->callFileHandler($field, 'verify');
                 // The above function call returns an array if something goes wrong,
@@ -100,7 +100,7 @@ class File_Upload
                 // @see imaging_uploader/php/
                 //     NDB_Menu_Filter_imaging_uploader.class.inc#L265
                 if (is_array($errors)) {
-                    $this->setError($field, $errors);
+                    $this->_setError($field, $errors);
                     continue;
                 }
 
@@ -108,7 +108,7 @@ class File_Upload
                 //will be before the import step, so we can save the new filename
                 //to the database.
                 // @TODO: Remove this check after imaging uploader is refactored
-                if ($this->fileMove) {
+                if ($this->_fileMove) {
                     // Note: The only implementation of the below gets the username
                     // @see imaging_uploader/php/
                     //     NDB_Menu_Filter_imaging_uploader.class.inc#L529
@@ -116,14 +116,14 @@ class File_Upload
                     if (!$this->getNewDirectory($newTargetDirectory)) {
                         continue;
                     }
-                    $this->moveFile());
+                    $this->_moveFile());
                 }
 
                 //Import the file using the importFile method of the handler
                 //class.
                 $fileImported =$this->callFileHandler($field, 'import');
                 if (is_array($fileImported)) {
-                    $this->setError($field, $fileImported);
+                    $this->_setError($field, $fileImported);
                     continue;
                 }
             }
@@ -199,21 +199,21 @@ class File_Upload
     public function moveFile()
     {
         // Prepare the name before moving
-        $this->normalizeDestinationFilename();
+        $this->_normalizeDestinationFilename();
         // Move the file
         if (!$this->file->moveUploadedFile(
-            $this->destinationDirectory,
-            $this->destinationFilename
+            $this->_destinationDirectory,
+            $this->_destinationFilename
         )) {
-            $this->setError(
+            $this->_setError(
                 $this->fieldName,
                 "Could not move file to "
-                . $this->destinationDirectory
-                . $this->destinationFilename
+                . $this->_destinationDirectory
+                . $this->_destinationFilename
             );
             return false;
         }
-        chmod("$this->destinationDirectory$this->destinationFilename", 0666);
+        chmod("$this->_destinationDirectory$this->_destinationFilename", 0666);
         return true;
     }
 
@@ -227,7 +227,7 @@ class File_Upload
      */
     public function getNewDirectory($destination_dir="")
     {
-        $dest_dir =$this->baseUploadDirectory.$destination_dir;
+        $dest_dir =$this->_baseUploadDirectory.$destination_dir;
 
         //Make sure the dir ends with a trailing slash
         if (substr($dest_dir, -1, 1) != "/") {
@@ -236,7 +236,7 @@ class File_Upload
         //Make sure the dir exists, if necessary (and
         //$this->createDirectories==true) then create it.
         if (file_exists($dest_dir) && !is_dir($dest_dir)) {
-            $this->setError(
+            $this->_setError(
                 $this->fieldName,
                 "A file named '$dest_dir' exists in your chosen upload root. "
                 . "Could not create directory with same name."
@@ -250,21 +250,21 @@ class File_Upload
                 chgrp($dest_dir, $grp);
             }
         } else if (!file_exists($dest_dir)) {
-            $this->setError(
+            $this->_setError(
                 $this->fieldName,
                 "Destination directory '$dest_dir' does not exist"
             );
             return false;
         }
         if (!is_writable($dest_dir)) {
-            $this->setError(
+            $this->_setError(
                 $this->fieldName,
                 "Destination directory '$dest_dir' is not writeable"
             );
             return false;
         }
 
-        $this->destinationDirectory =$dest_dir;
+        $this->_destinationDirectory =$dest_dir;
         return true;
     }
 
@@ -275,18 +275,18 @@ class File_Upload
      *
      * @return void
      */
-    public function normalizeDestinationFilename()
+    private function _normalizeDestinationFilename()
     {
         //Strip out any unwanted characters from the filename
-        $safe_name = $this->nameToSafe($this->fileInfo['name']);
+        $safe_name = $this->_nameToSafe($this->fileInfo['name']);
 
         // If there is already a file with this name in the target directory
         // add a numeric suffix to avoid overwriting
-        if (file_exists($this->destinationDirectory . $safe_name)) {
-            $safe_name = $this->nameToIncremental($dest_dir, $safe_name);
+        if (file_exists($this->_destinationDirectory . $safe_name)) {
+            $safe_name = $this->_nameToIncremental($dest_dir, $safe_name);
         }
 
-        $this->destinationFilename = $safe_name;
+        $this->_destinationFilename = $safe_name;
     }
 
 
@@ -308,13 +308,13 @@ class File_Upload
         } else if (class_exists($class)) {
             $test =new $class;
         } else {
-            $this->setError($field, "$class does not exist.");
+            $this->_setError($field, "$class does not exist.");
             return false;
         }
         //Test each method
         foreach ($this->fileHandlers[$field]['methods'] as $method) {
             if (!method_exists($test, $method)) {
-                $this->setError(
+                $this->_setError(
                     $field,
                     "Method '$method' of object does not exist."
                 );
@@ -479,30 +479,28 @@ class File_Upload
         if (substr($dir, -1, 1) != "/") {
             $dir .="/";
         }
-        $this->baseUploadDirectory = $dir;
+        $this->_baseUploadDirectory = $dir;
     }
 
     /**
     * Gets the final destination directory for the uploaded file
     *
     * @return string directory
-    * @see    File_Upload::getNewFilename()
     */
     public function getDestinationDirectory()
     {
-        return $this->destinationDirectory;
+        return $this->_destinationDirectory;
     }
 
 
     /**
     * Gets the final filename for the uploaded file
     *
-    * @see    File_Upload::getNewFilename()
     * @return string filename
     */
     public function getDestinationFilename()
     {
-        return $this->destinationFilename;
+        return $this->_destinationFilename;
     }
 
     /**
@@ -515,13 +513,13 @@ class File_Upload
     */
     private function _setError($field, $msg)
     {
-        if (!is_array($this->errorLog[$field])) {
-            $this->errorLog[$field] = array();
+        if (!is_array($this->_errorLog[$field])) {
+            $this->_errorLog[$field] = array();
         }
         if (is_array($msg)) {
-            $this->errorLog[$field] =array_merge($this->errorLog[$field], $msg);
+            $this->_errorLog[$field] =array_merge($this->_errorLog[$field], $msg);
         } else {
-            $this->errorLog[$field][] =$msg;
+            $this->_errorLog[$field][] =$msg;
         }
     }
 
@@ -529,12 +527,12 @@ class File_Upload
     /**
     * Gets the array of errors
     *
-    * @see    File_Upload::setError()
+    * @see    File_Upload::_setError()
     * @return array   errors
     */
     function getErrors()
     {
-        return $this->errorLog;
+        return $this->_errorLog;
     }
 }
 


### PR DESCRIPTION
# Refactor of File Upload

## Purpose/Background

- It is important to have a centralized way of doing File Uploads, especially in PHP, as it is a major security concern. 

- Different modules have implemented ad-hoc file uploaders ranging from fairly secure to very vulnerable (`genomic_browser`, `imaging_uploader`, `document_repository`, `media`, others?)

- This class needs to be updated to allow for future refactoring of the above modules 

- This class is only used by `imaging_uploader` and as such as loosely coupled. This makes it suitable for tweaking and updating

----

## Things this PR (hopefully) does...

- [x] Removes unused flags and functions. See the differences in the `__construct` function for the deleted flags.

- [x] Changes some variable names to be more descriptive

- [x] Introduces minor refactoring to improve readability and reduce redundancy

- [x] Specifies the scope of functions to make code more clear and assist in further refactoring

- [x] Suggests further refactoring efforts with references to other code (mostly `imaging_uploader`)

- [x] Improves error messages, code comments, and adjusts programming conventions to be more consistent with more recent LORIS coding conventions

## Things this PR (hopefully) does not do....

- [x] Affect existing functionality in `imaging_uploader` -- it's not used anywhere else
