### PR TITLE
[Libraries] Move resolvePath function to the Utility class

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -36,8 +36,6 @@ $client = new NDB_Client();
 if ($client->initialize("../../../project/config.xml") == false) {
     return false;
 }
-// needed to resolve paths
-require_once "Utility.class.inc";
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -19,36 +19,6 @@
  *  @link     https://github.com/aces/Loris-Trunk
  */
 
-/**
- * Effectively resolve '..' characters in a file path
- *
- * @param string $path A potentially-relative filepath to be resolved
- *
- * @return string $resolvedPath a path containing no .. sequences
- */
-function resolvePath($path)
-{
-    $resolvedPath = array();
-    // do some normalization
-    $path        = str_replace('//', '/', $path);
-    $path_pieces = explode('/', $path);
-    foreach ($path_pieces as $piece) {
-        if ($piece == '.') {
-            continue;
-        }
-        if ($piece == '..') {
-            if (!is_array($resolvedPath)) {
-                error_log("ERROR: Resolved path not an array");
-                return "";
-            }
-            array_pop($resolvedPath);
-            continue;
-        }
-        array_push($resolvedPath, $piece);
-    }
-    $resolvedPath = implode('/', $resolvedPath);
-    return $resolvedPath;
-}
 
 
 // Load config file and ensure paths are correct
@@ -60,13 +30,14 @@ require_once __DIR__ . "/../../../vendor/autoload.php";
 // inline. They'll still show up in the Apache logs.
 ini_set("display_errors", "Off");
 
-require_once __DIR__ . "/../../../vendor/autoload.php";
 // Ensures the user is logged in, and parses the config file.
 require_once "NDB_Client.class.inc";
 $client = new NDB_Client();
 if ($client->initialize("../../../project/config.xml") == false) {
     return false;
 }
+// needed to resolve paths
+require_once "Utility.class.inc";
 
 // Checks that config settings are set
 $config =& NDB_Config::singleton();
@@ -90,7 +61,7 @@ if ($imagePath === '/' || $DownloadPath === '/' || $mincPath === '/') {
 
 // Now get the file and do file validation.
 // Resolve the filename before doing anything.
-$File = resolvePath($_GET['file']);
+$File = Utility::resolvePath($_GET['file']);
 
 // Extra sanity checks, just in case something went wrong with path resolution.
 // File validation

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1265,5 +1265,36 @@ class Utility
         }
         return checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
     }
+
+    /**
+     * Effectively resolve '..' characters in a file path
+     *
+     * @param string $path A potentially-relative filepath to be resolved
+     *
+     * @return string $resolvedPath a path containing no .. sequences
+     */
+    static function resolvePath($path)
+    {
+        $resolvedPath = array();
+        // do some normalization
+        $path        = str_replace('//', '/', $path);
+        $path_pieces = explode('/', $path);
+        foreach ($path_pieces as $piece) {
+            if ($piece == '.') {
+                continue;
+            }
+            if ($piece == '..') {
+                if (!is_array($resolvedPath)) {
+                    error_log("ERROR: Resolved path not an array");
+                    return "";
+                }
+                array_pop($resolvedPath);
+                continue;
+            }
+            array_push($resolvedPath, $piece);
+        }
+        $resolvedPath = implode('/', $resolvedPath);
+        return $resolvedPath;
+    }
 }
 ?>


### PR DESCRIPTION
### This pull request moves the _resolvePath()_ function introduced in #2876 to the _Utility_ class so that it can be used in other code.

----

There are several places where files are retrieved and they could make use of this function instead of `realpath()` -- this function doesn't often work for us as it requires that the web-user have write access in each directory in the hierarchy.

This also removes a duplicated `require` call in `get_file.php`.