### PR TITLE
[Security] Fix Reflected XSS vulnerability on all NDB_Pages

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -662,6 +662,8 @@ class LorisForm
                 }
             }
         }
+        // Always sanitize user-controlled input
+        $newValue = htmlspecialchars($newValue);
 
         return $newValue;
     }


### PR DESCRIPTION
## This PR sanitizes user-input in LorisForm, thus taking much of the security burden off of developers

Previously, it was trivial to inject Javascript into nearly every page as malicious data could be injected via GET requests and served without being sanitized. This makes users vulnerable to CSRF, XSS, and phishing attacks among others.

By sanitizing values in LorisForm, we prevent many of these vulnerabilities. 

I suggest that this fix in combination with #2919 and #2826 warrant another release on 17.0.