### PR TITLE
[LorisForm] Ensure array is an array before using in foreach loop

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -677,45 +677,52 @@ class LorisForm
     protected function selectHTML($el)
     {
         $strOptions    = '';
-        $options       = $el['options'];
+        $options       = $el['options'] ?? '';
         $cls           = '';
         $changehandler = '';
         $multiple      = '';
         $id            = '';
         $disabled      = '';
-        $name          = $el['name'];
+        $name          = $el['name'] ?? '';
 
-        foreach ($options as $optionKey => $optionVal) {
-            $selected = '';
+        if (is_array($options) || $options instanceof Traversable) {
+            foreach ($options as $optionKey => $optionVal) {
+                $selected = '';
 
-            if (!is_null($optionKey)) {
-                $optionKey = (string) $optionKey;
-            }
+                if (!is_null($optionKey)) {
+                    $optionKey = (string) $optionKey;
+                }
 
-            $defaultValue = $this->getValue($el['name']);
+                $defaultValue = $this->getValue($el['name']);
 
-            if (isset($el['multiple'])) {
-                if (!empty($defaultValue)) {
-                    if (in_array($optionKey, $defaultValue)
-                        || $optionKey === $defaultValue
+                if (isset($el['multiple'])) {
+                    if (!empty($defaultValue)) {
+                        if (in_array($optionKey, $defaultValue)
+                            || $optionKey === $defaultValue
+                        ) {
+                            $selected = 'selected="selected"';
+                        }
+                    }
+                } else {
+                    if ($optionKey === $defaultValue) {
+                        $selected = 'selected="selected"';
+                    } elseif (isset($el['selected'])
+                        && $optionKey === $el['selected']
+                        && $defaultValue === null
                     ) {
                         $selected = 'selected="selected"';
                     }
                 }
-            } else {
-                if ($optionKey === $defaultValue) {
-                    $selected = 'selected="selected"';
-                } elseif (isset($el['selected'])
-                    && $optionKey === $el['selected']
-                    && $defaultValue === null
-                ) {
-                    $selected = 'selected="selected"';
-                }
-            }
 
-            $strOptions .= "<option value='$optionKey' $selected>"
-                .$optionVal
-                . "</option>";
+                $strOptions .= "<option value='$optionKey' $selected>"
+                    .$optionVal
+                    . "</option>";
+            }
+        } else  {
+            // $options is not Traversable and will throw an error
+            // if used in a foreach loop.
+            error_log("Options for element '$name' are not an array or are not traversable."
+                . ' Please validate the LorisForm syntax in the calling code.');
         }
 
         if (isset($el['class'])) {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -718,11 +718,14 @@ class LorisForm
                     .$optionVal
                     . "</option>";
             }
-        } else  {
+        } else {
             // $options is not Traversable and will throw an error
             // if used in a foreach loop.
-            error_log("Options for element '$name' are not an array or are not traversable."
-                . ' Please validate the LorisForm syntax in the calling code.');
+            error_log(
+                "Options for element '$name' are not an array or are not"
+                . ' traversable. Please validate the LorisForm syntax in '
+                .' the calling code.'
+            );
         }
 
         if (isset($el['class'])) {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -685,7 +685,7 @@ class LorisForm
         $disabled      = '';
         $name          = $el['name'] ?? '';
 
-        if (!is_array($options) || !$options instanceof Traversable) {
+        if (!is_array($options) || !($options instanceof Traversable)) {
             // $options is not Traversable and will throw an error
             // if used in a foreach loop.
             error_log(

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -685,7 +685,7 @@ class LorisForm
         $disabled      = '';
         $name          = $el['name'] ?? '';
 
-        if (!is_array($options) || !($options instanceof Traversable)) {
+        if (!(is_array($options) || $options instanceof Traversable)) {
             // $options is not Traversable and will throw an error
             // if used in a foreach loop.
             error_log(

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -677,7 +677,7 @@ class LorisForm
     protected function selectHTML($el)
     {
         $strOptions    = '';
-        $options       = $el['options'] ?? '';
+        $options       = $el['options'] ?? array();
         $cls           = '';
         $changehandler = '';
         $multiple      = '';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -685,40 +685,7 @@ class LorisForm
         $disabled      = '';
         $name          = $el['name'] ?? '';
 
-        if (is_array($options) || $options instanceof Traversable) {
-            foreach ($options as $optionKey => $optionVal) {
-                $selected = '';
-
-                if (!is_null($optionKey)) {
-                    $optionKey = (string) $optionKey;
-                }
-
-                $defaultValue = $this->getValue($el['name']);
-
-                if (isset($el['multiple'])) {
-                    if (!empty($defaultValue)) {
-                        if (in_array($optionKey, $defaultValue)
-                            || $optionKey === $defaultValue
-                        ) {
-                            $selected = 'selected="selected"';
-                        }
-                    }
-                } else {
-                    if ($optionKey === $defaultValue) {
-                        $selected = 'selected="selected"';
-                    } elseif (isset($el['selected'])
-                        && $optionKey === $el['selected']
-                        && $defaultValue === null
-                    ) {
-                        $selected = 'selected="selected"';
-                    }
-                }
-
-                $strOptions .= "<option value='$optionKey' $selected>"
-                    .$optionVal
-                    . "</option>";
-            }
-        } else {
+        if (!is_array($options) || !$options instanceof Traversable) {
             // $options is not Traversable and will throw an error
             // if used in a foreach loop.
             error_log(
@@ -726,6 +693,41 @@ class LorisForm
                 . ' traversable. Please validate the LorisForm syntax in '
                 .' the calling code.'
             );
+            throw new InvalidArgumentException(
+                "Options for LorisForm HTML element $name not an array"
+            );
+        }
+        foreach ($options as $optionKey => $optionVal) {
+            $selected = '';
+
+            if (!is_null($optionKey)) {
+                $optionKey = (string) $optionKey;
+            }
+
+            $defaultValue = $this->getValue($el['name']);
+
+            if (isset($el['multiple'])) {
+                if (!empty($defaultValue)) {
+                    if (in_array($optionKey, $defaultValue)
+                        || $optionKey === $defaultValue
+                    ) {
+                        $selected = 'selected="selected"';
+                    }
+                }
+            } else {
+                if ($optionKey === $defaultValue) {
+                    $selected = 'selected="selected"';
+                } elseif (isset($el['selected'])
+                    && $optionKey === $el['selected']
+                    && $defaultValue === null
+                ) {
+                    $selected = 'selected="selected"';
+                }
+            }
+
+            $strOptions .= "<option value='$optionKey' $selected>"
+                .$optionVal
+                . "</option>";
         }
 
         if (isset($el['class'])) {


### PR DESCRIPTION
This pull request adds a check to ensure the `$options` param is an array and traversable before passing it to a `foreach` loop.

Previously, this code would pass the parameter to the `foreach` loop and generate a warning and strange results. Now the error message is explicit and aids the developer in debugging the problem.