### PR TITLE
[PHPCS] Increase characer limit line length

### DIFF
--- a/docs/LorisCS.xml
+++ b/docs/LorisCS.xml
@@ -62,4 +62,12 @@
              <property name="eolChar" value="\n"/>
          </properties>
      </rule>
+
+    <!-- Increase PHPCS/PEAR limit of 85 chars per line to 120 -->
+     <rule ref="Generic.Files.LineLength">
+         <properties>
+             <property name="lineLimit" value="120"/>
+             <property name="absoluteLineLimit" value="0"/>
+         </properties>
+     </rule>
 </ruleset>


### PR DESCRIPTION
# 85 characters per line is just too few 💢 

This PR:

- [x] Increases the PHPCS character limit from 85 to 120.

I really like phpcs and standardizing code in general, but 85 characters is much too few. This is the most annoying part about PHPCS and in fact makes code uglier in my opinion. 

120 characters is a modest increase and I don't think it should cause any problems for anyone's monitors.

**Note that this is also backward-compatible because it only increases the limit, so all the code passing our previous standards will also pass the new standards.**

### **Please weigh in if you have an opinion about this!**

_[Solution from here.](https://github.com/squizlabs/PHP_CodeSniffer/issues/378)_