### PR TITLE
allow post data to be resent instead of discarded after redirect

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -36,7 +36,7 @@
 
  # Add trailing slash to all directories
  RewriteCond %{REQUEST_FILENAME} !-f
- RewriteRule ^(.*[^/])$ /$1/ [L,R=301]
+ RewriteRule ^(.*[^/])$ /$1/ [L,R=307]
 
 </IfModule>
 


### PR DESCRIPTION
This pull request should allow post data to be automatically resent after a redirect. It chnage the HTTP status code from 301 to 307.

See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
