### PR TITLE
[Core, User Accounts] Change getPermissionIDs to return flat list

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -288,7 +288,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                     $result = $DB->pselectRow(
                         "
                           SELECT full_name, centerID
-                          FROM examiners 
+                          FROM examiners
                           WHERE full_name=:fn AND centerID=:cid",
                         array(
                          "fn"  => $values['Real_name'],
@@ -442,27 +442,27 @@ class NDB_Form_User_Accounts extends NDB_Form
 
             // Check for new permissions
             if (!empty($permIDs)) {
-                foreach ($permIDs as $key => $value) {
+                foreach ($permIDs as $permID) {
                     /* if the user didn't have the permission
                        and the permission is now assigned then insert
                        insert into the user_account_history as 'I'
                      */
-                    if (!(in_array($key, $current_permissionids))) {
-                        $user->insertIntoUserAccountHistory($key, 'I');
-                        $permissionsAdded[] = $this->getDescriptionUsingPermID($key);
+                    if (!(in_array($permID, $current_permissionids))) {
+                        $user->insertIntoUserAccountHistory($permID, 'I');
+                        $permissionsAdded[] = $this->getDescriptionUsingPermID($permID);
                     }
                 }
             }
 
             if (!empty($current_permissionids)) {
                 // Check for permissions that are to be deleted
-                foreach ($current_permissionids as $key) {
+                foreach ($current_permissionids as $currentPermID) {
                     //if the permission existed before and it's removed now///
                     ///Then insert into the user_account_history as 'D'
-                    if (!in_array($key, array_keys($permIDs))) {
-                        $user->insertIntoUserAccountHistory($key, 'D');
+                    if (!in_array($currentPermID, $permIDs)) {
+                        $user->insertIntoUserAccountHistory($currentPermID, 'D');
                         $permissionsRemoved[]
-                            = $this->getDescriptionUsingPermID($key);
+                            = $this->getDescriptionUsingPermID($currentPermID);
                     }
                 }
             }
@@ -490,7 +490,7 @@ class NDB_Form_User_Accounts extends NDB_Form
             }
 
             if (!empty($permIDs)) {
-                $user->addPermissions(array_keys($permIDs));
+                $user->addPermissions($permIDs);
             }
         }
 
@@ -814,12 +814,12 @@ class NDB_Form_User_Accounts extends NDB_Form
 
             // add hidden permissions if editor has less permissions than user
             // being edited
-            $perms = array_diff(
+            $permDiff = array_diff(
                 $user->getPermissionIDs(),
                 $editor->getPermissionIDs()
             );
-            foreach ($perms as $value) {
-                $this->addHidden("permID[$value]", 1);
+            foreach ($permDiff as $permID) {
+                $this->addHidden("permID[$permID]", 1);
             }
         }
 
@@ -1185,7 +1185,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         //--- Get current password stored in database
         $passwordQuery
             = "SELECT Password_hash
-               FROM users 
+               FROM users
                WHERE UserID = :UID";
 
         $passwords = $db->pselectRow(

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -2,7 +2,7 @@
 /**
 * The user account page
 *
-* PHP Version 7
+* PHP Version 5,7
 *
 * @category Main
 * @package  User_Account

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -2,7 +2,7 @@
 /**
 * The user account page
 *
-* PHP Version 5
+* PHP Version 7
 *
 * @category Main
 * @package  User_Account

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -449,7 +449,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                      */
                     if (!(in_array($permID, $current_permissionids))) {
                         $user->insertIntoUserAccountHistory($permID, 'I');
-                        $permissionsAdded[] = $this->getDescriptionUsingPermID($permID);
+                        $permissionsAdded[]
+                            = $this->getDescriptionUsingPermID($permID);
                     }
                 }
             }

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -201,7 +201,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         $permIDs = array();
         // store the permission IDs
         if (!empty($values['permID'])) {
-            $permIDs = $values['permID'];
+            $permIDs = array_keys($values['permID']);
         }
         unset($values['permID']);
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -2,7 +2,7 @@
 /**
  * The UserPermissions class manages checking of user permissions
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  Main

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -2,7 +2,7 @@
 /**
  * The UserPermissions class manages checking of user permissions
  *
- * PHP Version 7
+ * PHP Version 5,7
  *
  * @category Main
  * @package  Main

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -227,13 +227,13 @@ class UserPermissions
         $results = $DB->pselect($query, array('UID' => $this->userID));
 
         // isolate and return numeric permission values
-        $toRet = array();
+        $permIDs = array();
         foreach ($results as $row) {
             foreach ($row as $k=>$v) {
-                $toRet[] = $v;
+                $permIDs[] = $v;
             }
         }
-        return $toRet;
+        return $permIDs;
     }
 
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -226,7 +226,14 @@ class UserPermissions
 
         $results = $DB->pselect($query, array('UID' => $this->userID));
 
-        return $results;
+        // isolate and return numeric permission values
+        $toRet = array();
+        foreach ($results as $row) {
+            foreach ($row as $k=>$v) {
+                $toRet[] = $v;
+            }
+        }
+        return $toRet;
     }
 
 


### PR DESCRIPTION
- [x] Modify `getPermissionIDs` to return a flat list of IDs 

- This seems to be the expected behaviour based on the function comment and calling code

- [x] Modify (all) instances of calling code to expect this new return type

- Some were already, and the remainder were only using `array_keys` and `$key`, indicating that the desired behaviour was a flat list anyway

- [x] Prevent the generation of noisy PHP warnings related to Array/String conversion as a result of the unexpected function behaviour 