### PR TITLE
[Loris Form] Don't try to sanitize arrays

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -689,7 +689,9 @@ class LorisForm
             }
         }
         // Always sanitize user-controlled input
-        $newValue = htmlspecialchars($newValue);
+        if (!is_array) {
+            $newValue = htmlspecialchars($newValue);
+        }
 
         return $newValue;
     }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -689,7 +689,7 @@ class LorisForm
             }
         }
         // Always sanitize user-controlled input
-        if (!is_array) {
+        if (!is_array($newValue)) {
             $newValue = htmlspecialchars($newValue);
         }
 


### PR DESCRIPTION
This PR:
- [x] Only runs `htmlspecialchars` on strings, not arrays 

- [x] Eliminates PHP warnings caused by the above 