### PR TITLE
[Candidate_list] Check for possible override of candidate parameters

### DIFF
--- a/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
+++ b/modules/candidate_list/php/NDB_Menu_Filter_candidate_list.class.inc
@@ -208,14 +208,19 @@ class NDB_Menu_Filter_Candidate_List extends NDB_Menu_Filter
      */
     function _setFilterForm()
     {
-        include_once __DIR__
-            . "/../../candidate_parameters/php/"
-            . "NDB_Form_candidate_parameters.class.inc";
-            //+  NDB_Form_candidate_parameters::getParticipantStatusOptions();
-        // create user object
         $user   =& User::singleton();
         $config =& NDB_Config::singleton();
+        $base   = $config->getSetting('base');
 
+        $moduleToCP = '/modules/candidate_parameters/'.
+        'php/NDB_Form_candidate_parameters.class.inc';
+        $overrideCP = $base."/project".$moduleToCP;
+        $originalCP = $base.$moduleToCP;
+        if (stream_resolve_include_path($overrideCP) !== false) {
+            include_once $overrideCP;
+        } else {
+            include_once $originalCP;
+        }
         // PSC
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object


### PR DESCRIPTION
The candidate_list includes the candidate_parameter code in a naive way. This change makes it look first for an override before reverting to the base module

to test, simply make sure that the correct candidate parameter class is being loaded when you add or remove an override