### PR TITLE
[Security] Correct occurrences of (needle,haystack) to (haystack,needle) in strpos file validation

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -59,7 +59,7 @@ if (empty($Module) || empty($File)) {
 // using a relative filename.
 // No need to check for '/' since all scripts are relative to $basePath
 // and there's no way to go up a level.
-if (strpos("..", $File) !== false) {
+if (strpos($File, "..") !== false) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(4);

--- a/htdocs/GetCSS.php
+++ b/htdocs/GetCSS.php
@@ -68,7 +68,7 @@ if (strpos($File, ".css") === false) {
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $basePath
-if (strpos("..", $File) !== false) {
+if (strpos($File, "..") !== false) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(4);

--- a/htdocs/GetJS.php
+++ b/htdocs/GetJS.php
@@ -88,7 +88,7 @@ if (strpos($File, ".js") === false) {
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $basePath
-if (strpos("..", $File) !== false) {
+if (strpos($File, "..") !== false) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(4);

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -117,7 +117,7 @@ unset($path_parts);
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $imagePath,
 // $DownloadPath or $mincPath
-if (strpos("..", $File) !== false) {
+if (strpos($File, "..") !== false) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(4);

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -24,7 +24,7 @@ $File   = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $basePath
-if (strpos("..", $File) !== false) {
+if (strpos($File, "..") !== false) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(4);

--- a/modules/training/ajax/getTrainingDoc.php
+++ b/modules/training/ajax/getTrainingDoc.php
@@ -56,7 +56,7 @@ if (!$user->hasPermission('training')) {
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $basePath
-if (strpos("..", $File) !== false) {
+if (strpos($File, "..") !== false) {
     error_log("ERROR: Invalid filename");
     header("HTTP/1.1 400 Bad Request");
     exit(3);


### PR DESCRIPTION
This pull request fixes several errors where code used to prevent path traversal was incorrectly using _needle-haystack_ syntax instead of _haystack-needle_ for the `strpos` function.

In order to prevent this occurring in the future, I strongly suggest that we merge #2918 and use the `resolvePath()` function for the prevention of path traversal. However, this PR addresses the immediate problem and should provide some hardening until the 2918 is merged and can be applied throughout the codebase.

The below changes were made based on executing `grep -nr "strpos(\".." .` in the LORIS root and modifying each of the results (excluding the `.vendor` results). 

Broken access control has been tested and confirmed on `GetStatic.php`, `GetJs.php` and `data_release`.

See also: 
* #2950 which addresses the same error in `GetStatic.php` and inspired this PR
* [strpos syntax](http://php.net/manual/en/function.strpos.php)
* #2918 for a more robust was of preventing path traversal

