### PR TITLE
[Utility] Remove return value from nullifyEmpty cause it works by reference

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -659,7 +659,7 @@ class Utility
      * @param string $field The field for which '' should be converted
      *                      to null.
      *
-     * @return array The same array passed in, after modifications.
+     * @return void
      */
     public static function nullifyEmpty(&$arr, $field)
     {

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -666,7 +666,6 @@ class Utility
         if ($arr[$field] === '') {
             $arr[$field] = null;
         }
-        return $arr;
     }
 
     /**


### PR DESCRIPTION
This pull request removes a confusing return statement from a function that seems to want to work by reference instead.

No code currently uses the return value but it was caused [some confusion](https://github.com/aces/Loris/pull/2952).