### PR TITLE
Set smarty's autoescape template variable option

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -408,6 +408,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
         if ($this->DataEntryType == 'DirectEntry') {
             $smarty = new Smarty_neurodb;
+            $this->setEscapeHTML(false);
 
             $formArray = $this->form->toElementArray();
             if (isset($this->testName)) {
@@ -425,6 +426,7 @@ class NDB_BVL_Instrument extends NDB_Page
             return $this->toJSON();
         } else {
             $smarty    = new Smarty_neurodb;
+            $this->setEscapeHTML(false);
             $formArray = $this->form->toElementArray();
 
             $smarty->assign('form', $formArray);

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -92,6 +92,8 @@ class Smarty_NeuroDB extends Smarty
             $currentDir = array('base' => $this->loristemplate_dir);
         }
 
+        $this->escape_html = true;
+
         $newdir = array_merge(
             $currentDir,
             array(
@@ -106,6 +108,23 @@ class Smarty_NeuroDB extends Smarty
         //$this->addConfigDir($this->template_dir);
         //$this->addConfigDir($this->project_template_dir);
     }
-}
 
+    /**
+     * Sets whether the Smarty template engine should automatically escape
+     * HTML in templates.
+     *
+     * @param bool $val true if template variables should be automatically HTML escaped
+     *
+     * @return none
+     */
+    public function setEscapeHTML($val) {
+        switch ($val) {
+        case true: // fallthrough
+        case false:
+            $this->escape_html = $val;
+        default:
+            throw new LorisException("Invalid value for attempting to set template HTML escaping");
+        }
+    }
+}
 ?>


### PR DESCRIPTION
This sets the smarty escape_html option to true by default in the
Smarty_hook class, as well as adding a helper to change the value.

Instruments currently disable autoescaping, because a number of instruments
use hacks for layout which would break if this was changed without notice.

The override for instruments should likely be changed in LORIS 18.0, but
otherwise this should help minimize the risk of XSS attacks in LORIS modules.