### PR TITLE
Updated Loris Forum to enable "required" attribute 

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -141,7 +141,8 @@ class LorisForm
         $el            =& $this->addBase($name, $label, $attribs);
         $el['type']    = 'select';
         $el['options'] = $options;
-        if (isset($attribs['multiple']) || in_array('multiple', $attribs)) {
+
+        if (isset($attribs['multiple']) || in_array('multiple', $attribs,true)) {
             $el['multiple'] = 'multiple';
         }
         return $el;


### PR DESCRIPTION
Adding the parameter "true" to the in_array function allows the attribute "required" to be set to html tag without triggering the attribute "multiple" as well. This seems to be a PHP bug and this is the work-around.