### PR TITLE
[libraries/User] Add checks and error logging to prevent notices and warnings

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -66,26 +66,40 @@ class User extends UserPermissions
         $row = $DB->pselectRow($query, array('UID' => $username));
 
         // get user sites
-        $user_centerID_query =  $DB->pselect(
-            "SELECT CenterID FROM user_psc_rel upr 
-                        WHERE upr.UserID= :UID",
-            array('UID' => $row['ID'])
-        );
+        if (!isset($row['ID']) {
+            error_log(
+                "Could not get user center ID(s) because'
+                . ' user DB query value 'ID' is not set."
+            );
+        } else {
+            $user_centerID_query =  $DB->pselect(
+                "SELECT CenterID FROM user_psc_rel upr
+                WHERE upr.UserID= :UID",
+                array('UID' => $row['ID'])
+            );
 
-        foreach ($user_centerID_query as $key=>$val) {
-            $user_cid[$key] =$val['CenterID'];
+            foreach ($user_centerID_query as $key=>$val) {
+                $user_cid[$key] =$val['CenterID'];
+            }
         }
 
         // Get examiner information
-        $examiner_check = $DB->pselect(
-            "SELECT full_name, centerID, radiologist, active, pending_approval 
-                  FROM examiners 
-                  WHERE full_name=:fn 
-                    AND (active='Y' OR (active='N' AND pending_approval='Y'))",
-            array(
-             "fn" => $row['Real_name'],
-            )
-        );
+        if (!isset($row['Real_name']) {
+            error_log(
+                "Could not get user examiner info because'
+                . ' user DB query value 'Real_name' is not set."
+            );
+        } else {
+            $examiner_check = $DB->pselect(
+                "SELECT full_name, centerID, radiologist, active, pending_approval
+                FROM examiners
+                WHERE full_name=:fn
+                AND (active='Y' OR (active='N' AND pending_approval='Y'))",
+                array(
+                 "fn" => $row['Real_name'],
+                )
+            );
+        }
 
         $examiner_info =array();
         if (!empty($examiner_check) && !is_null($examiner_check)) {
@@ -100,8 +114,8 @@ class User extends UserPermissions
             }
         }
         // store user data in object property
-        $row['examiner']  =$examiner_info;
-        $row['CenterIDs'] =$user_cid;
+        $row['examiner']  =$examiner_info ?? '';
+        $row['CenterIDs'] =$user_cid ?? '';
         $obj->userInfo    =$row;
         return $obj;
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -67,7 +67,7 @@ class User extends UserPermissions
 
         // get user sites
         $user_cid = array();
-        if (!isset($row['ID']) {
+        if (!isset($row['ID'])) {
             error_log(
                 "Could not get user center ID(s) because'
                 . ' user DB query value 'ID' is not set."
@@ -85,7 +85,7 @@ class User extends UserPermissions
         }
 
         // Get examiner information
-        if (!isset($row['Real_name']) {
+        if (!isset($row['Real_name'])) {
             error_log(
                 "Could not get user examiner info because'
                 . ' user DB query value 'Real_name' is not set."

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -66,6 +66,7 @@ class User extends UserPermissions
         $row = $DB->pselectRow($query, array('UID' => $username));
 
         // get user sites
+        $user_cid = array();
         if (!isset($row['ID']) {
             error_log(
                 "Could not get user center ID(s) because'
@@ -113,9 +114,11 @@ class User extends UserPermissions
                                                   );
             }
         }
-        // store user data in object property
-        $row['examiner']  =$examiner_info ?? '';
-        $row['CenterIDs'] =$user_cid ?? '';
+        // store user data in object property.
+        // if Examiner or CenterID info isn't possible to retrieve,
+        // the two values below will be set to empty arrays
+        $row['examiner']  =$examiner_info;
+        $row['CenterIDs'] =$user_cid;
         $obj->userInfo    =$row;
         return $obj;
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -2,7 +2,7 @@
 /**
  * This file contains the Loris user class
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  Main

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -43,6 +43,10 @@ class User extends UserPermissions
      */
     static function &factory($username)
     {
+        if (is_null($username)) {
+            throw new LorisException('User factory called with null username');
+            return null;
+        }
         $obj = new User;
 
         // right off, set the username


### PR DESCRIPTION
- [x] Ensure array values exist before passing them into SQL queries

- [x] Provide more verbose error logging to assist developers in debugging 

- [x] Prevent generation of vague PHP Notices when these values did not exist but were used 

**Note**: These issues largely came up while using `request_account` so it's possible that some of the execution flow in that code is responsible (e.g. looking for examiner associations before the user is actually created?). As such, the underlying issue may exist somewhere other than this class.

Still, these checks should exist and if the issues lie in other places in the code base, this will aid us in discovering and fixing them.