### PR TITLE
[libraries/Utility] Add startsWith, endsWith string functions to Utility (with example)

### DIFF
--- a/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
@@ -118,7 +118,7 @@ class NDB_Menu_Filter_Help_Editor extends NDB_Menu_Filter
             $this->tpl_data['items'][$x][0]['value'] = $x + $count;
             $i = 1;
             foreach ($item as $key => $val) {
-                if (substr($key, "Topic") == 0) {
+                if (Utility::startsWith($key, "Topic")) {
                     $this->tpl_data['items'][$x][$i]['helpID']   = array_search(
                         $val,
                         $help_section

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1226,12 +1226,12 @@ class Utility
     }
 
     /**
-    * Coverts array into CSV string
-    *
-    * @param array $array the array to be converted
-    *
-    * @return string CSV string of data
-    */
+     * Coverts array into CSV string
+     *
+     * @param array $array the array to be converted
+     *
+     * @return string CSV string of data
+     */
     static function arrayToCSV($array)
     {
         $fp = fopen("php://temp", 'w+');
@@ -1277,5 +1277,32 @@ class Utility
         }
         return checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
     }
+
+    /**
+     * Determine if a string starts with another string
+     *
+     * @param string $haystack string to search
+     * @param string $needle   substring to find
+     *
+     * @return boolean if $haystack begins with $needle
+     */
+    static function startsWith($haystack, $needle)
+    {
+        return substr($haystack, 0, strlen($needle)) === $needle;
+    }
+
+    /**
+     * Determine if a string ends with another string
+     *
+     * @param string $haystack string to search
+     * @param string $needle   substring to find
+     *
+     * @return boolean if $haystack ends with $needle
+     */
+    static function endsWith($haystack, $needle)
+    {
+        return substr($haystack, -strlen($needle)) === $needle;
+    }
 }
+
 ?>


### PR DESCRIPTION
- [x] Create syntax sugar for `substr` to prevent developer errors with string comparison

- Add startsWith string comparison function to Utility

- Add endsWith string comparison function to Utility

- see #2966 for an example of this error

 


