### PR TITLE
[Help Editor] Fix incorrect substr syntax

### DIFF
--- a/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Menu_Filter_help_editor.class.inc
@@ -118,7 +118,9 @@ class NDB_Menu_Filter_Help_Editor extends NDB_Menu_Filter
             $this->tpl_data['items'][$x][0]['value'] = $x + $count;
             $i = 1;
             foreach ($item as $key => $val) {
-                if (substr($key, "Topic") == 0) {
+                // Check if key starts with $needle ("Topic")
+                $needle = "Topic";
+                if (substr($key, 0, strlen($needle)) === $needle) {
                     $this->tpl_data['items'][$x][$i]['helpID']   = array_search(
                         $val,
                         $help_section


### PR DESCRIPTION
This pull request fixes a syntax error in `help_editor` which caused several PHP Warnings: `substr() expects parameter 2 to be integer, string given`

This is the minimal change required to fix the bug. See also #2965 for a Utility method that will allow us to reuse this fix elsewhere (if needed).
