### PR TITLE
[media] re-added accidentally removed declaration

### DIFF
--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -27,6 +27,12 @@ $config   =& NDB_Config::singleton();
 $path     = $config->getSetting('mediaPath');
 $filePath = $path . $file;
 
+$downloadNotifier = new NDB_Notifier(
+    "media",
+    "download",
+    array("file" => $file)
+);
+
 if (!file_exists($filePath)) {
     error_log("ERROR: File $filePath does not exist");
     header("HTTP/1.1 404 Not Found");


### PR DESCRIPTION
This pull request re-inserts into the code the instantiation of the FileDownload notification object. see link below to PR that removed it
