### PR TITLE
[Login] Change placeholder value from 'Email' to 'Username'

### DIFF
--- a/smarty/templates/login.tpl
+++ b/smarty/templates/login.tpl
@@ -13,7 +13,7 @@
           {/if}
           <form method="POST" action="{$action}">
             <div class="form-group">
-              <input type="text" name="username" class="form-control" placeholder="Email" value="{$username}"/>
+              <input type="text" name="username" class="form-control" placeholder="Username" value="{$username}"/>
             </div>
             <div class="form-group">
               <input type="password" name="password" class="form-control" placeholder="Password" aria-describedby="helpBlock" />


### PR DESCRIPTION
This is more accurate. Entering an email will only work if the user's account has been set up to use their email as a username.

This is also more consistent with the variable names themselves.