### PR TITLE
[Instrument] conform to NDB_BVL_Instrument->setup signature

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -44,7 +44,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      *
      * @return none
      */
-    function setup($commentID, $page)
+    function setup($commentID = null, $page = null)
     {
         $this->commentID = $commentID;
         $this->page      = $page;


### PR DESCRIPTION
This pull request add default value to parameter of the setup function in NDB_BVL_Instrument_LINST to match NDB_BVL_Instrument->setup signature. 

It should remove the 2 php Notices from travis log
