### PR TITLE
 Fix-Survey cannot be created/emailed in survey accounts

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1065,7 +1065,7 @@ CREATE TABLE `participant_accounts` (
   `Test_name` varchar(255) DEFAULT NULL,
   `Email` varchar(255) DEFAULT NULL,
   `Status` enum('Created','Sent','In Progress','Complete') DEFAULT NULL,
-  `OneTimePassword` varchar(8) DEFAULT NULL,
+  `OneTimePassword` varchar(16) DEFAULT NULL,
   `CommentID` varchar(255) DEFAULT NULL,
   `UserEaseRating` varchar(1) DEFAULT NULL,
   `UserComments` text,

--- a/SQL/Archive/17.1/2017-07-28_survey_accounts_password_storge.sql
+++ b/SQL/Archive/17.1/2017-07-28_survey_accounts_password_storge.sql
@@ -1,0 +1,3 @@
+-- The OneTimePassword storage capacity should be extended according to new key generation logic
+
+ALTER TABLE participant_accounts MODIFY COLUMN OneTimePassword VARCHAR(16) ;


### PR DESCRIPTION
Redmine 12894

When trying to create a survey in survey accounts, we get an error like 'Data too long for column OneTimePassword'...

Currently, 'OneTimePassword' has limited character storage- varchar(8), but the key generation logic is changed as per #2593 and it should be capable of storing more.

This pull request modifies the varchar capacity  'OneTimePassword' column to VARCHAR(255) and fix the issue.