### PR TITLE
XIN Rules Fix

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_XIN_Rule_Test.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_XIN_Rule_Test.class.inc
@@ -1,0 +1,149 @@
+<?php
+class NDB_BVL_Instrument_XIN_Rule_Test extends NDB_BVL_Instrument
+{
+    /**
+     * Sample SQL statement for test_names table and instrument subtests table
+     *
+     * INSERT INTO test_names(Test_name, Full_name,Sub_group,isDirectEntry) VALUES ('<TEST_NAME>','<INSTRUMENT_TITLE>',1, false);
+     * INSERT INTO instrument_subtests(Test_name, Subtest_name, Description, Order_number) VALUES('<TEST_NAME>', '<TEST_NAME>_page1', 'Page1', 1);
+     */
+
+    /**
+     * sets up basic data, such as the HTML_Quickform object, and so on.
+     *
+     * @param string $commentID  the CommentID identifying the data to load
+     * @param string $page       if a multipage form, the page to show
+     * @return void
+     * @access public
+     */
+    function setup($commentID, $page){
+        $this->formType="XIN";
+        $this->form = new LorisForm('test_form');
+        $this->page = $page;            // page label (number or
+        // string - used by
+        // user-defined child classes)
+
+        // set the object properties
+        $this->testName = "XIN_Rule_Test";           // test_names.Test_name
+        $this->table = 'XIN_Rule_Test';              // name of database table corresponding to instrument
+        // data keyed by commentID
+        $this->commentID = $commentID;
+
+        //The array of dates/timestamps to convert to database dates/timestamps
+        //Any HTML_Quickform date elements must be listed here
+        $this->dateTimeFields=array("Date_taken");
+
+        //The array of selects with multiple answers allowed
+        //Any HTML_Quickform multiple selects must be listed here
+        $this->_selectMultipleElements = array();
+
+        // required fields for data entry completion status
+        //$this->_requiredElements = array('Examiner', '<FIRST QUESTION OF EACH PAGE>');
+
+        // setup the form
+        $this->_setupForm();
+
+    }
+
+    //If the instrument is not paged, remove the switch from the _setupForm method and add all the form Elements in this function.
+
+    /**
+     * method to build the HTML_Quickform object into a paged form
+     *
+     * @return void
+     * @access private
+     */
+    function _setupForm(){
+        if(preg_match("/<XIN_Rule_Test>(_page[0-9]+)/",$this->page,$matches)){
+            call_user_func(array($this, $matches[1]));
+        } else {
+            $this->_main();
+        }
+        //Defines the call back function for HTML Quickform to use when validating the form.
+        $this->form->addFormRule(array(&$this,'XINValidate'));
+    }
+
+    /**
+     * generates the main page of the form.
+     *
+     * @return void
+     * @access private
+     *
+     */
+    function _main(){
+        // display test name
+        $this->addHeader("XIN Rule Test");
+
+        $q1Opts = array(
+            null => "",
+            "A" => "A",
+            "B" => "B",
+            "C" => "C",
+            "D" => "D"
+        );
+
+        $this->addSelect(
+            "q1",
+            "Q1) Required by default",
+            $q1Opts
+        );
+
+        $this->addSelect(
+            "q2",
+            "Q2) Never required",
+            $q1Opts
+        );
+
+        $this->XINRegisterRule(
+            "q2",
+            array("q2{@}=={@}NEVER_REQUIRED"),
+            "Not required."
+        );
+
+        $this->addBasicText(
+            "q3",
+            "Q3) Required if Q1 equals A"
+        );
+
+        $this->XINRegisterRule(
+            "q3",
+            array("q1{@}=={@}A"),
+            "Required."
+        );
+
+        $this->addBasicText(
+            'q4',
+            "Q4) Required if Q1 equals A, B, or C"
+        );
+
+        $this->XINRegisterRule(
+            'q4',
+            array('q1{@}=={@}A|B|C'),
+            'Required.'
+        );
+
+        $this->addBasicText(
+            'q5',
+            'Q5) Required if Q1 equals A and Q2 equals D'
+        );
+
+        $this->XINRegisterRule(
+            'q5',
+            array('q1{@}=={@}A', 'q2{@}=={@}D'),
+            'Required.'
+        );
+
+        $this->addBasicText(
+            'q6',
+            'Q6) Required if Q1 equals A or Q2 equals D'
+        );
+
+        $this->XINRegisterRule(
+            'q6',
+            array('q1{@}=={@}A|q2{@}=={@}D'),
+            'Required'
+        );
+    }
+
+}
+?>

--- a/docs/instruments/NDB_BVL_Instrument_XIN_Rule_Test.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_XIN_Rule_Test.class.inc
@@ -100,7 +100,7 @@ class NDB_BVL_Instrument_XIN_Rule_Test extends NDB_BVL_Instrument
             "Not required."
         );
 
-        $this->addBasicText(
+        $this->addTextElement(
             "q3",
             "Q3) Required if Q1 equals A"
         );
@@ -108,10 +108,11 @@ class NDB_BVL_Instrument_XIN_Rule_Test extends NDB_BVL_Instrument
         $this->XINRegisterRule(
             "q3",
             array("q1{@}=={@}A"),
-            "Required."
+            "Required.",
+            "q3_group"
         );
 
-        $this->addBasicText(
+        $this->addTextElement(
             'q4',
             "Q4) Required if Q1 equals A, B, or C"
         );
@@ -119,10 +120,11 @@ class NDB_BVL_Instrument_XIN_Rule_Test extends NDB_BVL_Instrument
         $this->XINRegisterRule(
             'q4',
             array('q1{@}=={@}A|B|C'),
-            'Required.'
+            'Required.',
+            "q4_group"
         );
 
-        $this->addBasicText(
+        $this->addTextElement(
             'q5',
             'Q5) Required if Q1 equals A and Q2 equals D'
         );
@@ -130,18 +132,20 @@ class NDB_BVL_Instrument_XIN_Rule_Test extends NDB_BVL_Instrument
         $this->XINRegisterRule(
             'q5',
             array('q1{@}=={@}A', 'q2{@}=={@}D'),
-            'Required.'
+            'Required.',
+            "q5_group"
         );
 
-        $this->addBasicText(
+        $this->addTextElement(
             'q6',
-            'Q6) Required if Q1 equals A or Q2 equals D'
+            'Q6) Required if Q1 equals B or Q2 equals C'
         );
 
         $this->XINRegisterRule(
             'q6',
-            array('q1{@}=={@}A|q2{@}=={@}D'),
-            'Required'
+            array('q1{@}=={@}B|q2{@}=={@}C'),
+            'Required',
+            "q6_group"
         );
     }
 

--- a/docs/instruments/XIN_Rule_Test_Setup.sql
+++ b/docs/instruments/XIN_Rule_Test_Setup.sql
@@ -1,0 +1,22 @@
+INSERT INTO test_names(Test_name, Full_name,Sub_group,isDirectEntry) VALUES ('XIN_Rule_Test','XIN RULE TEST',1, false);
+INSERT INTO test_battery (Test_name, AgeMinDays, AgeMaxDays, Stage, SubprojectID, Visit_label) VALUES ('XIN_Rule_Test', 0, 0, 'Visit', 1, 'Initial_Assessment_Screening');
+
+CREATE TABLE `XIN_Rule_Test` (
+`CommentID` varchar(255) NOT NULL default '',
+
+                            `UserID` varchar(255) default NULL,
+
+                            `Examiner` varchar(255) default NULL,
+
+                            `Testdate` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+                            `Data_entry_completion_status` enum('Incomplete','Complete') NOT NULL default 'Incomplete',
+`q1` enum('A','B','C','D') default NULL,
+`q2` enum('A','B','C','D') default NULL,
+`q3` varchar(255) default NULL,
+`q4` varchar(255) default NULL,
+`q5` varchar(255) default NULL,
+`q6` varchar(255) default NULL,
+PRIMARY KEY  (`CommentID`)
+
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/instruments/XIN_Rule_Test_Setup.sql
+++ b/docs/instruments/XIN_Rule_Test_Setup.sql
@@ -1,5 +1,5 @@
 INSERT INTO test_names(Test_name, Full_name,Sub_group,isDirectEntry) VALUES ('XIN_Rule_Test','XIN RULE TEST',1, false);
-INSERT INTO test_battery (Test_name, AgeMinDays, AgeMaxDays, Stage, SubprojectID, Visit_label) VALUES ('XIN_Rule_Test', 0, 0, 'Visit', 1, 'Initial_Assessment_Screening');
+INSERT INTO test_battery (Test_name, AgeMinDays, AgeMaxDays, Stage, SubprojectID, Visit_label) VALUES ('XIN_Rule_Test', 0, 0, 'Visit', 1, YOUR_VL_HERE);
 
 CREATE TABLE `XIN_Rule_Test` (
 `CommentID` varchar(255) NOT NULL default '',
@@ -14,9 +14,13 @@ CREATE TABLE `XIN_Rule_Test` (
 `q1` enum('A','B','C','D') default NULL,
 `q2` enum('A','B','C','D') default NULL,
 `q3` varchar(255) default NULL,
+`q3_status` enum('not_answered') default NULL,
 `q4` varchar(255) default NULL,
+`q4_status` enum('not_answered') default NULL,
 `q5` varchar(255) default NULL,
+`q5_status` enum('not_answered') default NULL,
 `q6` varchar(255) default NULL,
+`q6_status` enum('not_answered') default NULL,
 PRIMARY KEY  (`CommentID`)
 
               ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1227,16 +1227,18 @@ class NDB_BVL_Instrument extends NDB_Page
     function XINRunElementRules($elname, $elements, $rules)
     {
         $errors = array();
+        //Conditions for the rule to be true, thus the element to be required.
+        $rule_outcomes = array();
 
         foreach ($rules['rules'] AS $rule) {
-            //Conditions for the rule to be true, thus the element to be required.
-            $rule_outcomes = array();
             //Loop through the assigned rules (which is the array of formatted
             //statements passed in XINRegisterRule)
             //If this is an OR rule using two different controllers explode it
             //at the pipe.  ex: q_1{@}=={@}yes|q_2{@}=={@}yes
-            if (stristr(substr($rule, strpos($rule, "|")), "{@}")) {
+            $isInterfieldOr = false;
+            if (substr_count($rule, '{@}') > 2 && strstr($rule, '|')) {
                 $rules_array = explode("|", $rule);
+                $isInterfieldOr = true;
             } else {  //Otherwise its a regular rule.  ex: q_1{@}=={@}yes
                 $rules_array[] = $rule;
             }
@@ -1247,6 +1249,7 @@ class NDB_BVL_Instrument extends NDB_Page
                 //Some rules compare against multiple values, handle this here.
                 if (stristr($rule[2], "|")) {  //ex: q_1{@}=={@}yes|no
                     $values = explode("|", $rule[2]);
+                    //print_r($values);
                 } else {  //ex: q_1{@}=={@}yes
                     $values = array($rule[2]);
                 }
@@ -1273,6 +1276,8 @@ class NDB_BVL_Instrument extends NDB_Page
 
                     if ($ElementResult) {
                         $or_conditions = true; //If any of the OR rules is true
+                    } else if (!$isInterfieldOr) {
+                        $or_conditions = false;
                     }
                 }
             }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1237,7 +1237,7 @@ class NDB_BVL_Instrument extends NDB_Page
             //at the pipe.  ex: q_1{@}=={@}yes|q_2{@}=={@}yes
             $isInterfieldOr = false;
             if (substr_count($rule, '{@}') > 2 && strstr($rule, '|')) {
-                $rules_array = explode("|", $rule);
+                $rules_array    = explode("|", $rule);
                 $isInterfieldOr = true;
             } else {  //Otherwise its a regular rule.  ex: q_1{@}=={@}yes
                 $rules_array[] = $rule;
@@ -1249,7 +1249,6 @@ class NDB_BVL_Instrument extends NDB_Page
                 //Some rules compare against multiple values, handle this here.
                 if (stristr($rule[2], "|")) {  //ex: q_1{@}=={@}yes|no
                     $values = explode("|", $rule[2]);
-                    //print_r($values);
                 } else {  //ex: q_1{@}=={@}yes
                     $values = array($rule[2]);
                 }


### PR DESCRIPTION
https://redmine.cbrain.mcgill.ca/issues/12902
XIN Rules are currently broken on 17.1 for intrafield OR (e.g., `q1{@}=={@}A|B`) as well as AND conditions when either of these rules are being applied to fields with status options

If you do not or cannot think of any instruments which you think would be sufficient to test this PR, i've created a sample instrument in the `docs/instruments` directory which uses each of the basic XIN rule functionalities as described in: https://redmine.cbrain.mcgill.ca/projects/loris/wiki/Xin-Rules/

To setup sample instrument: 
1. alter the included SQL script `XIN_Rule_Test_Setup.sql` so that YOUR_VL_HERE is a valid visit label for your current DB setup

2. Run the aforementioned script on your DB

3. Copy the example instrument into your project's instruments directory

4. run `php assign_missing_instruments.php confirm` from within the `loris/tools` directory

5. Go to a visit for the provided visit label which is registered under SubprojectID=1 and make sure each of the conditions specified in the sample instrument work as expected

if this gets approved i will remove the sample instrument files before merging