### PR TITLE
[Core] Added module override support to webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 var webpack = require('webpack');
 var path = require('path');
+var fs = require('fs');
 
-var config = {
+var config = [{
   entry: {
     './htdocs/js/components/DynamicDataTable.js': './jsx/DynamicDataTable.js',
     './htdocs/js/components/PaginationLinks.js': './jsx/PaginationLinks.js',
@@ -84,8 +85,17 @@ var config = {
   externals: {
     react: 'React'
   },
+  node: {
+    fs: "empty"
+  },
   devtool: 'source-map',
   plugins: [new webpack.optimize.UglifyJsPlugin({mangle: false})]
-};
+}];
+
+// Support project overrides
+if (fs.existsSync('./project/webpack-project.config.js')) {
+  var projConfig = require('./project/webpack-project.config.js');
+  config.push(projConfig);
+}
 
 module.exports = config;


### PR DESCRIPTION
This pull request does what the title says it does.

To test:
- create the project config file (see below for example)
- add specific jsx to compile in the same manner they are added in the loris webpack config
- run `npm run compile` make sure both the loris and project files are compiled properly  