### PR TITLE
[Statistics]Fixing issues in behavioural statistics

### DIFF
--- a/modules/statistics/php/NDB_Menu_statistics_site.class.inc
+++ b/modules/statistics/php/NDB_Menu_statistics_site.class.inc
@@ -38,7 +38,8 @@ class NDB_Menu_Statistics_Site extends NDB_Menu
      */
     function _hasAccess($centerID)
     {
-        $user =& User::singleton();
+        $user     =& User::singleton();
+        $centerID =$user->getData('CenterID');
         return $user->hasCenterPermission('data_entry', $centerID);
     }
 

--- a/modules/statistics/php/NDB_Menu_statistics_site.class.inc
+++ b/modules/statistics/php/NDB_Menu_statistics_site.class.inc
@@ -32,14 +32,12 @@ class NDB_Menu_Statistics_Site extends NDB_Menu
     /**
      * Checking user's permission
      *
-     * @param string $centerID the value of centerID
-     *
      * @return bool
      */
-    function _hasAccess($centerID)
+    function _hasAccess()
     {
         $user     =& User::singleton();
-        $centerID =$user->getData('CenterID');
+        $centerID = htmlspecialchars($_REQUEST['CenterID']);
         return $user->hasCenterPermission('data_entry', $centerID);
     }
 


### PR DESCRIPTION
Ref: Redmine 12900

 In Behavioural statistics tab, the 'Please Click Here' and 'Click here for breakdown per participant '  don't work except for the 'superuser'.

- The hasAccess overridden method declaration was not compatible with the parent class was the cause of this issue.

This PR fixes the above-mentioned issue.