### PR TITLE
 [Statistics]Removing reliability statistics

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1296,7 +1296,6 @@ INSERT INTO StatisticsTabs (ModuleName, SubModuleName, Description, OrderNo) VAL
   ('statistics', 'stats_general', 'General Description', 1),
   ('statistics', 'stats_demographic', 'Demographic Statistics', 2),
   ('statistics', 'stats_behavioural', 'Behavioural Statistics', 3),
-  ('statistics', 'stats_reliability', 'Reliability Statistics', 4),
   ('statistics', 'stats_MRI', 'Imaging Statistics', 5);
 
 -- ********************************

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1296,7 +1296,7 @@ INSERT INTO StatisticsTabs (ModuleName, SubModuleName, Description, OrderNo) VAL
   ('statistics', 'stats_general', 'General Description', 1),
   ('statistics', 'stats_demographic', 'Demographic Statistics', 2),
   ('statistics', 'stats_behavioural', 'Behavioural Statistics', 3),
-  ('statistics', 'stats_MRI', 'Imaging Statistics', 5);
+  ('statistics', 'stats_MRI', 'Imaging Statistics', 4);
 
 -- ********************************
 -- server_processes tables

--- a/SQL/Archive/17.1/2017-08-01_remove_reliability_stats.sql
+++ b/SQL/Archive/17.1/2017-08-01_remove_reliability_stats.sql
@@ -1,0 +1,2 @@
+-- Removing reliability statistics as it is more project specific
+DELETE FROM `StatisticsTabs`  WHERE `ID`='4';

--- a/SQL/Archive/17.1/2017-08-01_remove_reliability_stats.sql
+++ b/SQL/Archive/17.1/2017-08-01_remove_reliability_stats.sql
@@ -1,2 +1,2 @@
 -- Removing reliability statistics as it is more project specific
-DELETE FROM `StatisticsTabs`  WHERE `ID`='4';
+DELETE FROM `StatisticsTabs`  WHERE `SubModuleName`='stats_reliability';


### PR DESCRIPTION
Redmine 12898
Reliability tab not working for LORIS. 
Dave suggested removing this tab from the default install as it is a more project specific thing.