### PR TITLE
[Data Release] Force file downloading instead of rendering arbitrary HTML/JS

### DIFF
--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -61,7 +61,6 @@ if (empty($permission)) {
 
 // Output file in downloadable format
 header('Content-Description: File Transfer');
-header('Content-Type: application/force-download');
 header("Content-Transfer-Encoding: Binary");
 header("Content-disposition: attachment; filename=\"" . basename($FullPath) . "\"");
 readfile($FullPath);

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -3,7 +3,7 @@
 /**
  * Controls access to data release files.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  *  @category Loris
  *  @package  Data_Release
@@ -58,8 +58,12 @@ if (empty($permission)) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }
-$fp = fopen($FullPath, 'r');
-fpassthru($fp);
-fclose($fp);
+
+// Output file in downloadable format
+header('Content-Description: File Transfer');
+header('Content-Type: application/force-download');
+header("Content-Transfer-Encoding: Binary");
+header("Content-disposition: attachment; filename=\"" . basename($FullPath) . "\"");
+readfile($FullPath);
 
 ?>


### PR DESCRIPTION
This pull request addresses an issue with file downloading and is consistent with similar fixes in #2745 and #2742.

Without forcing the download, user-uploaded HTML files containing arbitrary Javascript can be made to render and execute which poses a security problem.

I've marked this for 17.1 as it pertains to security.
