### PR TITLE
[Data Release] Remove superfluous session checks generating PHP Notices

### DIFF
--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -14,7 +14,7 @@
 
 $user =& User::singleton();
 
-$File   = $_GET['File'];
+$File = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.
 // No need to check for '/' since all downloads are relative to $basePath

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -14,12 +14,6 @@
 
 $user =& User::singleton();
 
-// Ensures the user is logged in, and parses the config file.
-require_once "NDB_Client.class.inc";
-$client = new NDB_Client();
-$client->initialize("../project/config.xml");
-// Checks that config settings are set
-$config =& NDB_Config::singleton();
 $File   = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by
 // using a relative filename.


### PR DESCRIPTION
This pull request removes redundant code checking config files and client initialization.

It is redundant because these lines of codes don't affect functionality. Attempts to download files, whether logged in or not, function in the same way whether these lines of code are present or not. Successful download if logged in, 401 status code otherwise.

However, the presence of `$client->initialize("../project/config.xml");` causes a PHP Notice when a session already exists everytime a file is downloaded.

This code is copy-pasted widely across LORIS and it is likely worth reviewing to see if it adds any functionality.