### PR TITLE
[Statistics]Fixing demographics/MRI tab non responsive issue

### DIFF
--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -819,7 +819,6 @@ class NDB_Form_Statistics extends NDB_Form
         $this->tpl_data['MRI_Done_Table'] = $this->renderStatsTable(
             "Breakdown By Scan Type",
             $MRIHeader,
-            "",
             $MRISubcategories,
             $M_Visits,
             "mri_type",
@@ -828,6 +827,7 @@ class NDB_Form_Statistics extends NDB_Form
             $centers,
             $result,
             "mri",
+            "",
             $currentProject
         );
         //END BIGTABLE

--- a/modules/statistics/php/NDB_Form_statistics.class.inc
+++ b/modules/statistics/php/NDB_Form_statistics.class.inc
@@ -439,7 +439,6 @@ class NDB_Form_Statistics extends NDB_Form
                 "Breakdown of Registered Candidates",
                 "Data Entry Completion Status for ".
                       $instrument_list[$_REQUEST['DemographicInstrument']],
-                '',
                 $Subcategories,
                 $Visits,
                 "DemographicInstrument",
@@ -448,6 +447,7 @@ class NDB_Form_Statistics extends NDB_Form
                 $centers,
                 $result,
                 "demographics",
+                '',
                 $currentProject
             );
         } else {
@@ -473,7 +473,6 @@ class NDB_Form_Statistics extends NDB_Form
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
                 "Breakdown of Registered Candidates",
                 "Breakdown by Sex",
-                '',
                 $Subcategories,
                 $Visits,
                 "DemographicInstrument",
@@ -482,6 +481,7 @@ class NDB_Form_Statistics extends NDB_Form
                 $centers,
                 $result,
                 "demographics",
+                '',
                 $currentProject
             );
         }


### PR DESCRIPTION
[Redmine 12896](https://redmine.cbrain.mcgill.ca/issues/12896)
         &
[Redmine 12897](https://redmine.cbrain.mcgill.ca/issues/12897)

The summary of the above issue is that the demographics tab in statistics is not properly working
1)Statistics Tab Breakdown Table drop down completely missing
 2) Sorting of results not working etc

The issue was that the parameters in renderStatsTable function were not properly given on the function calls.