### PR TITLE
[User Accounts] Fix bug where users could see data from sites they don't belong to

### DIFF
--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -48,13 +48,13 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
     {
         $user =& User::singleton();
         // the base query
-        $query = " FROM users 
+        $query = " FROM users
             LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
             WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
             $site_arr     = implode(",", $user->getCenterIDs());
-            $this->query .= " AND user_psc_rel.CenterID IN (" . $site_arr . ")";
+            $query .= " AND FIND_IN_SET(user_psc_rel.CenterID,'$site_arr')";
         }
 
         // set the class variables

--- a/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Menu_Filter_user_accounts.class.inc
@@ -53,8 +53,8 @@ class NDB_Menu_Filter_User_Accounts extends NDB_Menu_Filter
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
             WHERE 1=1";
         if (!$user->hasPermission('user_accounts_multisite')) {
-            $site_arr     = implode(",", $user->getCenterIDs());
-            $query .= " AND FIND_IN_SET(user_psc_rel.CenterID,'$site_arr')";
+            $site_arr = implode(",", $user->getCenterIDs());
+            $query   .= " AND FIND_IN_SET(user_psc_rel.CenterID,'$site_arr')";
         }
 
         // set the class variables


### PR DESCRIPTION
Previously a query preventing this access control was being overwritten by mistake. This caused the data from all sites to appear to a user whose access should be restricted to only their own site(s).

See: Redmine 12874