### PR TITLE
[Global] Remove LORIS version info

### DIFF
--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -33,7 +33,6 @@ $tpl_data['css'] =$config->getSetting('css');
 $tpl_data['study_title'] = $config->getSetting('title');
 $tpl_data['page']        = 'password-reset';
 $tpl_data['currentyear'] = date('Y');
-$tpl_data['version']     = file_get_contents(__DIR__ . "/../VERSION");
 $tpl_data['page_title']  = 'Reset Password';
 try {
     $tpl_data['study_logo'] = $config->getSetting('studylogo');
@@ -68,7 +67,7 @@ if (isset($_POST['username'])) {
             $msg_data['password'] = $password;
             Email::send($email, 'lost_password.tpl', $msg_data);
 
-            $tpl_data['success'] = 'You should receive an email with instructions 
+            $tpl_data['success'] = 'You should receive an email with instructions
                                     within a few minutes!';
         } else {
             $tpl_data['error_message'] = 'Please provide a valid username!';

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -484,7 +484,7 @@
                     </ul>
                 </center>
                 <div align="center" colspan="1">
-                    Powered by LORIS {$currentyear}. All rights reserved.
+                    Powered by LORIS &copy; {$currentyear}. All rights reserved.
                 </div>
       		<div align="center" colspan="1">
                     Created by <a href="http://mcin-cnim.ca/" target="_blank">

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -484,7 +484,7 @@
                     </ul>
                 </center>
                 <div align="center" colspan="1">
-                    Powered by LORIS. {$currentyear}. All rights reserved.
+                    Powered by LORIS {$currentyear}. All rights reserved.
                 </div>
       		<div align="center" colspan="1">
                     Created by <a href="http://mcin-cnim.ca/" target="_blank">

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -484,7 +484,7 @@
                     </ul>
                 </center>
                 <div align="center" colspan="1">
-                    Powered by LORIS version {$version} &copy; {$currentyear}. All rights reserved.
+                    Powered by LORIS. {$currentyear}. All rights reserved.
                 </div>
       		<div align="center" colspan="1">
                     Created by <a href="http://mcin-cnim.ca/" target="_blank">

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -49,7 +49,7 @@
 
   <footer class="footer">
     Powered by <a href="http://www.loris.ca/" target="_blank">LORIS</a>
-    {$version} | GPL-3.0 &copy; {$currentyear} <br/>
+    | GPL-3.0 &copy; {$currentyear} <br/>
     Developed at
     <a href="http://www.mni.mcgill.ca" target="_blank">
       Montreal Neurological Institute and Hospital


### PR DESCRIPTION
From a security perspective, it's considered against "best-practices" to globally disclose the software version running on a server. Also I'd argue that we remove this info now (as we release 18.0) rather than later

When attacking a website, the first things you do are:

1. Find information about the software version a site is using
2. Search for known vulnerabilities affecting that software version
3. Exploit those vulnerabilties.

Typically these vulnerabilities are well-documented and even point to specific lines of code...!

So, for example, if we are between releases and have issued security fixes, it becomes trivial for somebody to check which instances of LORIS are vulnerable and how to exploit them.

Obviously this doesn't actually make the software more secure but this fix makes an attacker's life harder.

See also:
* https://security.stackexchange.com/questions/4940/is-displaying-what-server-i-am-running-on-the-error-pages-a-security-risk
* https://www.acunetix.com/blog/articles/configure-web-server-disclose-identity/


