### PR TITLE
HTML displayed on front end for candidate age

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -455,7 +455,7 @@ class NDB_BVL_Instrument extends NDB_Page
             && $defaults['Window_Difference'] != 0
         ) {
             $defaults['Candidate_Age']
-                = '<span class="error">' . $defaults['Candidate_Age'] . '</span>';
+                = $defaults['Candidate_Age'] . " (Age out of range)";
         }
         //Convert select multiple elements into a quickform array
         if (!empty($this->_selectMultipleElements)) {


### PR DESCRIPTION
This pull request replaces the error HTML code by a short message `(age out of range)` for candidate ages out of the permitted range in visit_windows table

Before:
![screenshot from 2017-08-06 20-38-14](https://user-images.githubusercontent.com/15268287/29242070-0b1fdc8c-7f54-11e7-9234-514542aeb2cc.png)

After:
![screenshot from 2017-08-12 11-46-25](https://user-images.githubusercontent.com/15268287/29242073-10653872-7f54-11e7-8cb2-18c3aa7e905c.png)

