### PR TITLE
[Instruments] Match addElement argument count for PHP 7.1 compatibility

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1922,8 +1922,13 @@ class LorisForm
      *
      * @return array of the form supported by $this->form
      */
-    function createElement($type, $elname, $label='', $options=array(), $attribs=array())
-    {
+    function createElement(
+        $type,
+        $elname,
+        $label='',
+        $options=array(),
+        $attribs=array()
+    ) {
         switch($type) {
         case 'text':
             return $this->createText($elname, $label, $options, $attribs);

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -407,7 +407,7 @@ class LorisForm
     public function addElement(
         $type,
         $name,
-        $label,
+        $label='',
         $options=array(),
         $attribs=array()
     ) {
@@ -1922,7 +1922,7 @@ class LorisForm
      *
      * @return array of the form supported by $this->form
      */
-    function createElement($type, $elname, $label, $options, $attribs=array())
+    function createElement($type, $elname, $label='', $options=array(), $attribs=array())
     {
         switch($type) {
         case 'text':

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -500,7 +500,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
                 // the form WAS submitted but validate() failed...
                 // main error message
-                $this->form->addElement('static', 'mainError');
+                $this->form->addElement('static', 'mainError', '');
                 $this->form->setElementError(
                     'mainError',
                     "<p>

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -500,7 +500,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
                 // the form WAS submitted but validate() failed...
                 // main error message
-                $this->form->addElement('static', 'mainError', '');
+                $this->form->addElement('static', 'mainError');
                 $this->form->setElementError(
                     'mainError',
                     "<p>


### PR DESCRIPTION
PHP 7.1 produces HTTP 500 for whenever an instrument w/ errors is saved because addElement needs at least 3 arguments