### PR TITLE
[Reset Password] UI should say username, not email

### DIFF
--- a/smarty/templates/password_reset.tpl
+++ b/smarty/templates/password_reset.tpl
@@ -15,11 +15,11 @@
       {else}
         <form method="POST">
           <p class="text-center">
-            Please enter your email below, and a new password will be sent to you.
+            Please enter your username below, and a new password will be sent to you.
           </p>
           <div class="form-group">
             <input type="text" name="username" size="40" class="form-control"
-                   placeholder="Email" value="{$username}"
+                   placeholder="Username" value="{$username}"
                    aria-describedby="helpBlock"/>
             {if $error_message}
               <span id="helpBlock" class="help-block">


### PR DESCRIPTION
Password resets use the username to send the password reset email, but the front-end prompts for an email.