### PR TITLE
[Password Expiry] Password cannot contain & character but frontend displays it as valid

### DIFF
--- a/smarty/templates/password_expiry.tpl
+++ b/smarty/templates/password_expiry.tpl
@@ -7,7 +7,7 @@
       <p><b>Password Strength Rules</b></p>
       <ul>
         <li>The password must be at least 8 characters long</li>
-        <li>The password must contain at least 1 letter, 1 number and 1 character from !@#$%^&amp;*()</li>
+        <li>The password must contain at least 1 letter, 1 number and 1 character from !@#$%^*()</li>
         <li>The password and the user name must not be the same</li>
         <li>The password and the email address must not be the same</li>
       </ul>


### PR DESCRIPTION
Since #2558, the character `&` is not allowed in passwords.