### PR TITLE
[Lost Password] Don't display to users which accounts exist/don't exist

### DIFF
--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -50,7 +50,7 @@ if (isset($_POST['username'])) {
     // check that the email is valid
     if (!$user->isEmailValid()) {
         error_log(
-            'Could not send password reset email to user' . $user::getUsername()
+            'Could not send password reset email to user' . $user->getUsername()
             . " with email $email. Email is invalid"
         );
     } else {

--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -50,7 +50,7 @@ if (isset($_POST['username'])) {
     // check that the email is valid
     if (!$user->isEmailValid()) {
         error_log(
-            "Could not send password reset email to user $user->getUsername()"
+            'Could not send password reset email to user' . $user::getUsername()
             . " with email $email. Email is invalid"
         );
     } else {

--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -49,8 +49,10 @@ if (isset($_POST['username'])) {
 
     // check that the email is valid
     if (!$user->isEmailValid()) {
-        error_log("Could not send password reset email to user $user->getUsername()"
-            . " with email $email. Email is invalid");
+        error_log(
+            "Could not send password reset email to user $user->getUsername()"
+            . " with email $email. Email is invalid"
+        );
     } else {
         // generate a new password
         $password = User::newPassword();

--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -44,7 +44,7 @@ try {
 if (isset($_POST['username'])) {
 
     // create the user object
-    $user =& User::singleton($_POST['username']);
+    $user  =& User::singleton($_POST['username']);
     $email = $user->getData('Email');
 
     // check that the email is valid

--- a/htdocs/lost_password.php
+++ b/htdocs/lost_password.php
@@ -45,37 +45,30 @@ if (isset($_POST['username'])) {
 
     // create the user object
     $user =& User::singleton($_POST['username']);
-
     $email = $user->getData('Email');
 
-    // check that it is a valid user
-    if (!empty($email)) {
-
-        // check that the email is valid
-        if ($user->isEmailValid()) {
-
-            // generate a new password
-            $password = User::newPassword();
-
-            // reset the password in the database
-            // expire password so user must change it upon login
-            $success = $user->updatePassword($password, '1990-04-01');
-
-            // send the user an email
-            $msg_data['study']    = $config->getSetting('title');
-            $msg_data['url']      = $config->getSetting('url');
-            $msg_data['realname'] = $user->getData('Real_name');
-            $msg_data['password'] = $password;
-            Email::send($email, 'lost_password.tpl', $msg_data);
-
-            $tpl_data['success'] = 'You should receive an email with instructions 
-                                    within a few minutes!';
-        } else {
-            $tpl_data['error_message'] = 'Please provide a valid username!';
-        }
+    // check that the email is valid
+    if (!$user->isEmailValid()) {
+        error_log("Could not send password reset email to user $user->getUsername()"
+            . " with email $email. Email is invalid");
     } else {
-        $tpl_data['error_message'] = "Couldn't find a user with this username!";
+        // generate a new password
+        $password = User::newPassword();
+
+        // reset the password in the database
+        // expire password so user must change it upon login
+        $success = $user->updatePassword($password, '1990-04-01');
+
+        // send the user an email
+        $msg_data['study']    = $config->getSetting('title');
+        $msg_data['url']      = $config->getSetting('url');
+        $msg_data['realname'] = $user->getData('Real_name');
+        $msg_data['password'] = $password;
+        Email::send($email, 'lost_password.tpl', $msg_data);
+
     }
+    $tpl_data['success'] = 'You should receive an email with instructions
+        within a few minutes!';
 }
 
 //Output template using Smarty


### PR DESCRIPTION
It's considered security best practice not to display to the user which accounts do and don't exist in the DB. Currently when a user types in an invalid username, there is an error message shown. This is nice from a UI perspective, but in this way an attacker can determine the names of valid user accounts and proceed to launch other attacks from there.

The best practice is to show the email as being sent even if the user doesn't exist in the DB.