### PR TITLE
[user accounts] all fields that are empty are saved as null

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -280,7 +280,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                  "fn" => $values['Real_name'],
                 )
             );
-
+            // set empty string to null
+            
             // If examiner not in table add him,
             // otherwise update the radiologist field
             if (empty($examinerID)) {
@@ -449,7 +450,11 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         // make the set
         foreach ($values as $key => $value) {
-            $set[$key] = $value;
+          if (!empty($value)) {
+              $set[$key] = $value; 
+           } else {
+            $set[$key] = null;
+           }
         }
 
         // update the user

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -120,7 +120,7 @@ class NDB_Form_User_Accounts extends NDB_Form
                     $defaults[$fieldName] = htmlspecialchars($defaults[$fieldName]);
                 }
                 else {
-                  $defaults[$fieldName] = "";
+                  $defaults[$fieldName] = null;
                 }
             }
 

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -119,9 +119,6 @@ class NDB_Form_User_Accounts extends NDB_Form
                 if (!empty($defaults[$fieldName])) {
                     $defaults[$fieldName] = htmlspecialchars($defaults[$fieldName]);
                 }
-                else {
-                  $defaults[$fieldName] = null;
-                }
             }
 
             foreach ($defaults['examiner'] as $cid=>$vals) {

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -280,8 +280,6 @@ class NDB_Form_User_Accounts extends NDB_Form
                  "fn" => $values['Real_name'],
                 )
             );
-            // set empty string to null
-            
             // If examiner not in table add him,
             // otherwise update the radiologist field
             if (empty($examinerID)) {

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -119,6 +119,9 @@ class NDB_Form_User_Accounts extends NDB_Form
                 if (!empty($defaults[$fieldName])) {
                     $defaults[$fieldName] = htmlspecialchars($defaults[$fieldName]);
                 }
+                else {
+                  $defaults[$fieldName] = "";
+                }
             }
 
             foreach ($defaults['examiner'] as $cid=>$vals) {

--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -445,11 +445,11 @@ class NDB_Form_User_Accounts extends NDB_Form
 
         // make the set
         foreach ($values as $key => $value) {
-          if (!empty($value)) {
-              $set[$key] = $value; 
-           } else {
-            $set[$key] = null;
-           }
+            if (!empty($value)) {
+                $set[$key] = $value;
+            } else {
+                $set[$key] = null;
+            }
         }
 
         // update the user


### PR DESCRIPTION
When data is saved in user accounts, all fields that are empty are saved as empty strings in the database instead of remaining NULL.
https://redmine.cbrain.mcgill.ca/issues/12959
