### PR TITLE
[MRI Violations] Show / Hide table bugfix on MRI Protocol Violations submenu

### DIFF
--- a/modules/mri_violations/js/mri_protocol_violations.js
+++ b/modules/mri_violations/js/mri_protocol_violations.js
@@ -5,14 +5,14 @@ function change() {
     $('#show').hide();
     $('#mri-protocol').show();
     $('#show').bind('click', function () {
-        $('#mri-protocol').show('slow', function () {});
+        $('#mri-protocol').parents('.dynamicContentWrapper').show('slow', function () {});
         $('#hide').show();
         $('#show').hide();
     });
 
     //To hide : table hides...and the show shows...
     $('#hide').bind('click', function () {
-        $('#mri-protocol').hide('slow', function () {});
+        $('#mri-protocol').parents('.dynamicContentWrapper').hide('slow', function () {});
         $('#show').show();
         $('#hide').hide();
     });

--- a/modules/mri_violations/templates/menu_mri_protocol_violations.tpl
+++ b/modules/mri_violations/templates/menu_mri_protocol_violations.tpl
@@ -85,7 +85,7 @@
                 <span class="glyphicon glyphicon-plus"></span> Show mri-protocol Table
             </div>
 
-            <table class="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
+            <table id="mri-protocol" class="dynamictable table table-hover table-primary table-bordered" border="0" width="100%">
                 <thead>
                 <tr class="info">
                     {assign var=count value=0}


### PR DESCRIPTION
Show / Hide mri-protocol table functionality was not doing anything. Need to re-add the mri-protocol id to the table and call show / hide functions on parent element to get rid of dynamic table artifacts
https://redmine.cbrain.mcgill.ca/issues/8830