### PR TITLE
[Instruments] Prevent failed update attempt after login on instrument URL

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -91,6 +91,7 @@ class NDB_Caller
             $url .= Utility::removeCommonAffix($url, $_SERVER['REQUEST_URI']);
             // sending user to the url that was requested
             header("Location: $url");
+            return;
         }
         if (empty($CommentID) && isset($_REQUEST['commentID'])) {
             $CommentID = $_REQUEST['commentID'];
@@ -476,9 +477,7 @@ class NDB_Caller
         }
 
         // save instrument form data
-        if (empty($_POST['login'])) {
-            $success = $instrument->save();
-        }
+        $success = $instrument->save();
 
         if ($redirectToOnSuccess !== null && $success !== false) {
             header("Location: $redirectToOnSuccess");

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -476,7 +476,9 @@ class NDB_Caller
         }
 
         // save instrument form data
-        $success = $instrument->save();
+        if (empty($_POST['login'])) {
+            $success = $instrument->save();
+        }
 
         if ($redirectToOnSuccess !== null && $success !== false) {
             header("Location: $redirectToOnSuccess");


### PR DESCRIPTION
![screenshot from 2017-08-17 16-52-41](https://user-images.githubusercontent.com/6571449/29435291-729977be-8374-11e7-8390-337409576f29.png)
I think this is important to get in for this release because we are planning on emailing links to instruments to users using the new notification system. it is more than likely that these users will not have a session in loris open so it would be ideal if they were not shown an error message immediately upon logging in especially when that error message includes their password in plain text