### PR TITLE
[SQL] Fix 0000-00-00-schema.sql can't install new Loris database in Ubuntu 

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -164,8 +164,8 @@ INSERT INTO subproject (title, useEDC, WindowDifference) VALUES
   ('Experimental', false, 'optimal');
 
 CREATE TABLE `project_rel` (
-  `ProjectID` int(2) DEFAULT NULL,
-  `SubprojectID` int(2) DEFAULT NULL,
+  `ProjectID` int(2) NOT NULL,
+  `SubprojectID` int(2) NOT NULL,
   PRIMARY KEY (ProjectID, SubprojectID)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/SQL/Archive/17.1/2017-08-22_project_rel_primary_key.sql
+++ b/SQL/Archive/17.1/2017-08-22_project_rel_primary_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project_rel MODIFY COLUMN ProjectID int(2) NOT NULL;
+ALTER TABLE project_rel MODIFY COLUMN SubprojectID int(2) NOT NULL;


### PR DESCRIPTION
This pull request fix 0000-00-00-schema.sql.
It can't run in MySQL 5.7.
In MySQL 5.7, the primary key should not be null.
