### PR TITLE
Imaging Browser: remove php warnings from the error log: Redmine 13086

### DIFF
--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -232,8 +232,8 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         $this->headers = array_merge(
             $this->headers,
             $as,
-            'sessionID'
-        );
+            array('sessionID')
+      );
 
         // Insert project column after DCCID, if useProject config is enabled
         if ($config->getSetting('useProjects') === "true") {
@@ -317,7 +317,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
         }
 
         $DB    = Database::singleton();
-        $allAr = array('' => All);
+        $allAr = array('' => 'All');
 
         $this->addBasicText(
             'pscid',

--- a/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
+++ b/modules/imaging_browser/php/NDB_Menu_Filter_imaging_browser.class.inc
@@ -207,11 +207,9 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
                          );
         $this->columns = array_merge(
             $this->columns,
-            array(
-             "GROUP_CONCAT(DISTINCT OutputType) as Links",
-             's.ID as sessionID',
-            ),
-            $modalities_subquery_as
+            array("GROUP_CONCAT(DISTINCT OutputType) as Links"),
+            $modalities_subquery_as,
+            array('s.ID as sessionID')
         );
 
         $this->order_by = 'c.PSCID, s.Visit_label';
@@ -233,7 +231,7 @@ class NDB_Menu_Filter_Imaging_Browser extends NDB_Menu_Filter
             $this->headers,
             $as,
             array('sessionID')
-      );
+        );
 
         // Insert project column after DCCID, if useProject config is enabled
         if ($config->getSetting('useProjects') === "true") {


### PR DESCRIPTION
These warnings/notices in the error log are causing some setups to fail loading imaging browser, so this pull requests fixes them.