### PR TITLE
[MRI Violations] Fix Time Run date filtering

### DIFF
--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -349,7 +349,7 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
         $user    =& User::singleton();
         $config  =& NDB_Config::singleton();
         $db      =& Database::singleton();
-        $minYear = $config->getSetting('startYear');
+        $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
         $maxYear = $config->getSetting('endYear');
 
         $dateOptions = array(

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -349,10 +349,9 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
         $user        =& User::singleton();
         $config      =& NDB_Config::singleton();
         $db          =& Database::singleton();
-        $minYear     = $config->getSetting('startYear')
-            - $config->getSetting('ageMax');
-        $maxYear     = $config->getSetting('endYear')
-            - $config->getSetting('ageMin');
+        $minYear     = $config->getSetting('startYear');
+        $maxYear     = $config->getSetting('endYear');
+
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -346,11 +346,11 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
     function _setFilterForm()
     {
         // create user object
-        $user        =& User::singleton();
-        $config      =& NDB_Config::singleton();
-        $db          =& Database::singleton();
-        $minYear     = $config->getSetting('startYear');
-        $maxYear     = $config->getSetting('endYear');
+        $user    =& User::singleton();
+        $config  =& NDB_Config::singleton();
+        $db      =& Database::singleton();
+        $minYear = $config->getSetting('startYear');
+        $maxYear = $config->getSetting('endYear');
 
         $dateOptions = array(
                         'language'       => 'en',

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -328,9 +328,8 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
         // create user object
         $user        =&        User::singleton();
         $config      =&        NDB_Config::singleton();
-        $study       = $config->getSetting('Study');
-        $minYear     = $study['startYear'] - $study['ageMax'];
-        $maxYear     = $study['endYear'];
+        $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
+        $maxYear = $config->getSetting('endYear');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -329,8 +329,8 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
         $user        =&        User::singleton();
         $config      =&        NDB_Config::singleton();
         $study       = $config->getSetting('study');
-        $minYear     = $study['startYear'] - $study['ageMax'];
-        $maxYear     = $study['endYear'] - $study['ageMin'];
+        $minYear     = $study['startYear'];
+        $maxYear     = $study['endYear'];
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -328,7 +328,7 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
         // create user object
         $user        =&        User::singleton();
         $config      =&        NDB_Config::singleton();
-        $study       = $config->getSetting('study');
+        $study       = $config->getSetting('Study');
         $minYear     = $study['startYear'] - $study['ageMax'];
         $maxYear     = $study['endYear'];
         $dateOptions = array(

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -328,8 +328,9 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
         // create user object
         $user        =&        User::singleton();
         $config      =&        NDB_Config::singleton();
-        $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
-        $maxYear = $config->getSetting('endYear');
+        $minYear     = $config->getSetting('startYear')
+            - $config->getSetting('ageMax');
+        $maxYear     = $config->getSetting('endYear');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -329,7 +329,7 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
         $user        =&        User::singleton();
         $config      =&        NDB_Config::singleton();
         $study       = $config->getSetting('study');
-        $minYear     = $study['startYear'];
+        $minYear     = $study['startYear'] - $study['ageMax'];
         $maxYear     = $study['endYear'];
         $dateOptions = array(
                         'language'       => 'en',

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
@@ -131,7 +131,7 @@ class NDB_Menu_Mri_Protocol_Violations extends NDB_Menu_Filter
     function _setFilterForm()
     {
         $config      =& NDB_Config::singleton();
-        $study       = $config->getSetting('study');
+        $study       = $config->getSetting('Study');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
@@ -136,8 +136,8 @@ class NDB_Menu_Mri_Protocol_Violations extends NDB_Menu_Filter
                         'language'       => 'en',
                         'format'         => 'YMd',
                         'addEmptyOption' => true,
-                        'minYear'        => $study['startYear'] - $study['ageMax'],
-                        'maxYear'        => $study['endYear'] - $study['ageMin'],
+                        'minYear'        => $study['startYear'],
+                        'maxYear'        => $study['endYear'],
                        );
 
         $this->addBasicText('CandID', 'DCC-ID:');

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
@@ -131,13 +131,14 @@ class NDB_Menu_Mri_Protocol_Violations extends NDB_Menu_Filter
     function _setFilterForm()
     {
         $config      =& NDB_Config::singleton();
-        $study       = $config->getSetting('Study');
+        $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
+        $maxYear = $config->getSetting('endYear');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',
                         'addEmptyOption' => true,
-                        'minYear'        => $study['startYear'] - $study['ageMax'],
-                        'maxYear'        => $study['endYear'],
+                        'minYear'        => $minYear,
+                        'maxYear'        => $maxYear,
                        );
 
         $this->addBasicText('CandID', 'DCC-ID:');

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
@@ -131,8 +131,9 @@ class NDB_Menu_Mri_Protocol_Violations extends NDB_Menu_Filter
     function _setFilterForm()
     {
         $config      =& NDB_Config::singleton();
-        $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
-        $maxYear = $config->getSetting('endYear');
+        $minYear     = $config->getSetting('startYear')
+            - $config->getSetting('ageMax');
+        $maxYear     = $config->getSetting('endYear');
         $dateOptions = array(
                         'language'       => 'en',
                         'format'         => 'YMd',

--- a/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_mri_protocol_violations.class.inc
@@ -136,7 +136,7 @@ class NDB_Menu_Mri_Protocol_Violations extends NDB_Menu_Filter
                         'language'       => 'en',
                         'format'         => 'YMd',
                         'addEmptyOption' => true,
-                        'minYear'        => $study['startYear'],
+                        'minYear'        => $study['startYear'] - $study['ageMax'],
                         'maxYear'        => $study['endYear'],
                        );
 


### PR DESCRIPTION
https://redmine.cbrain.mcgill.ca/issues/13022
MRI Violations was restricting date search within the range of [`startYear - ageMax`, `endYear - ageMin`] which for CCNA would be [1916, 1970]
Would be ideal to be able to search for scans that occured after the invention of  MRI technology