### PR TITLE
[Configuration] correct error message when no recruitment target is specified for a n…

### DIFF
--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -1,16 +1,16 @@
 <?php
 /**
-* This file is used by the Configuration module to update
-* or insert values into the Project table.
-*
-* PHP version 5
-*
-* @category Main
-* @package  Loris
-* @author   Bruno Da Rosa Miranda <bruno.darosamiranda@mail.mcgill.ca>
-* @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
-* @link     https://github.com/aces/Loris
-*/
+ * This file is used by the Configuration module to update
+ * or insert values into the Project table.
+ *
+ * PHP version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Bruno Da Rosa Miranda <bruno.darosamiranda@mail.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
 
 $user =& User::singleton();
 if (!$user->hasPermission('config')) {
@@ -26,28 +26,34 @@ $factory     = NDB_Factory::singleton();
 $db          = $factory->database();
 $ProjectList = Utility::getProjectList();
 
+
 // if a new project is created add the new project.
 // Otherwise, update the existing project.
 if ($_POST['ProjectID'] === 'new') {
-    if (!in_array($_POST['Name'], $ProjectList) && !empty($_POST['Name'])) {
-        $db->insert(
-            "Project",
-            array(
-             "Name"              => $_POST['Name'],
-             "recruitmentTarget" => $_POST['recruitmentTarget'],
-            )
-        );
+    if (!in_array($_POST['Name'], $ProjectList) && !empty($_POST['Name']) && !empty($_POST['recruitmentTarget'])) {
+            $db->insert(
+                "Project",
+                array(
+                    "Name" => $_POST['Name'],
+                    "recruitmentTarget" => $_POST['recruitmentTarget'],
+                )
+            );
     } else {
         header("HTTP/1.1 409 Conflict");
-        print '{ "error" : "Conflict" }';
+        if (in_array($_POST['Name'], $ProjectList)){
+            print '{ "error" : "Conflict" }';
+        }
+        if (empty($_POST['recruitmentTarget'])) {
+            print '{ "error" : "recruitmentTarget" }';
+        }
         exit();
     }
 } else {
     $db->update(
         "Project",
         array(
-         "Name"              => $_POST['Name'],
-         "recruitmentTarget" => $_POST['recruitmentTarget'],
+            "Name"              => $_POST['Name'],
+            "recruitmentTarget" => $_POST['recruitmentTarget'],
         ),
         array("ProjectID" => $_POST['ProjectID'])
     );

--- a/modules/configuration/js/project.js
+++ b/modules/configuration/js/project.js
@@ -17,10 +17,18 @@ $(document).ready(function() {
         }
         
         var errorClosure = function(i, form) {
+            console.log(form);
+            return function() {
+                $(form.find(".saveStatus")).text("Failed to save, same name already exists!").css({ 'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+            }
+        }
+
+        var errorNullClosure = function(i, form) {
             return function() {
                 $(form.find(".saveStatus")).text("Recruitment target is required.").css({ 'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
         }
+
 
         jQuery.ajax(
                 {
@@ -32,7 +40,8 @@ $(document).ready(function() {
                         "recruitmentTarget" : recruitmentTarget,
                     },
                     "success" : successClosure(ProjectID, form),
-                    "error" : errorClosure(ProjectID, form)   
+                    "error" : errorClosure(ProjectID, form)
+                    "error_null" : errorNullClosure(ProjectID, form)
                 }
 
           );

--- a/modules/configuration/js/project.js
+++ b/modules/configuration/js/project.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
         
         var errorClosure = function(i, form) {
             return function() {
-                $(form.find(".saveStatus")).text("Failed to save, same name already exist!").css({ 'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+                $(form.find(".saveStatus")).text("Recruitment target is required.").css({ 'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
         }
 


### PR DESCRIPTION
This PR addresses Redmine ticket #13057. Instead of indicating that a 'Recruitment Target' must be specified when creating a new project in the configuration module, the error message would be "Failed to save, same name already exists".  

Previously: 

![image](https://user-images.githubusercontent.com/17363738/29622181-c0e169b0-87f0-11e7-9b03-5d1355a118f3.png)


Now: 

![image](https://user-images.githubusercontent.com/17363738/29622020-44a9bbea-87f0-11e7-863c-d8b8db5c270a.png)


