### PR TITLE
[Configuration] nullify empty recruitmentTarget value

### DIFF
--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -1,16 +1,16 @@
 <?php
 /**
-* This file is used by the Configuration module to update
-* or insert values into the Project table.
-*
-* PHP version 5
-*
-* @category Main
-* @package  Loris
-* @author   Bruno Da Rosa Miranda <bruno.darosamiranda@mail.mcgill.ca>
-* @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
-* @link     https://github.com/aces/Loris
-*/
+ * This file is used by the Configuration module to update
+ * or insert values into the Project table.
+ *
+ * PHP version 5
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Bruno Da Rosa Miranda <bruno.darosamiranda@mail.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
 
 $user =& User::singleton();
 if (!$user->hasPermission('config')) {
@@ -30,11 +30,12 @@ $ProjectList = Utility::getProjectList();
 // Otherwise, update the existing project.
 if ($_POST['ProjectID'] === 'new') {
     if (!in_array($_POST['Name'], $ProjectList) && !empty($_POST['Name'])) {
+        $recTarget = empty($_POST['recruitmentTarget']) ? null : $_POST['recruitmentTarget'];
         $db->insert(
             "Project",
             array(
-             "Name"              => $_POST['Name'],
-             "recruitmentTarget" => $_POST['recruitmentTarget'],
+                "Name"              => $_POST['Name'],
+                "recruitmentTarget" => $recTarget,
             )
         );
     } else {
@@ -43,11 +44,12 @@ if ($_POST['ProjectID'] === 'new') {
         exit();
     }
 } else {
+    $recTarget = empty($_POST['recruitmentTarget']) ? null : $_POST['recruitmentTarget'];
     $db->update(
         "Project",
         array(
-         "Name"              => $_POST['Name'],
-         "recruitmentTarget" => $_POST['recruitmentTarget'],
+            "Name"              => $_POST['Name'],
+            "recruitmentTarget" => $recTarget,
         ),
         array("ProjectID" => $_POST['ProjectID'])
     );

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -26,16 +26,18 @@ $factory     = NDB_Factory::singleton();
 $db          = $factory->database();
 $ProjectList = Utility::getProjectList();
 
-// if a new project is created add the new project.
+// if a new project is created add the new project.php
 // Otherwise, update the existing project.
 if ($_POST['ProjectID'] === 'new') {
     if (!in_array($_POST['Name'], $ProjectList) && !empty($_POST['Name'])) {
-        $recTarget = empty($_POST['recruitmentTarget']) ? null : $_POST['recruitmentTarget'];
+        $recTarget
+            = empty($_POST['recruitmentTarget'])
+            ? null : $_POST['recruitmentTarget'];
         $db->insert(
             "Project",
             array(
-                "Name"              => $_POST['Name'],
-                "recruitmentTarget" => $recTarget,
+             "Name"              => $_POST['Name'],
+             "recruitmentTarget" => $recTarget,
             )
         );
     } else {
@@ -44,12 +46,14 @@ if ($_POST['ProjectID'] === 'new') {
         exit();
     }
 } else {
-    $recTarget = empty($_POST['recruitmentTarget']) ? null : $_POST['recruitmentTarget'];
+    $recTarget
+        = empty($_POST['recruitmentTarget'])
+        ? null : $_POST['recruitmentTarget'];
     $db->update(
         "Project",
         array(
-            "Name"              => $_POST['Name'],
-            "recruitmentTarget" => $recTarget,
+         "Name"              => $_POST['Name'],
+         "recruitmentTarget" => $recTarget,
         ),
         array("ProjectID" => $_POST['ProjectID'])
     );

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -25,14 +25,12 @@ $client->initialize();
 $factory     = NDB_Factory::singleton();
 $db          = $factory->database();
 $ProjectList = Utility::getProjectList();
-
+$recTarget   = empty($_POST['recruitmentTarget'])
+    ? null : $_POST['recruitmentTarget'];
 // if a new project is created add the new project.php
 // Otherwise, update the existing project.
 if ($_POST['ProjectID'] === 'new') {
     if (!in_array($_POST['Name'], $ProjectList) && !empty($_POST['Name'])) {
-        $recTarget
-            = empty($_POST['recruitmentTarget'])
-            ? null : $_POST['recruitmentTarget'];
         $db->insert(
             "Project",
             array(
@@ -46,9 +44,6 @@ if ($_POST['ProjectID'] === 'new') {
         exit();
     }
 } else {
-    $recTarget
-        = empty($_POST['recruitmentTarget'])
-        ? null : $_POST['recruitmentTarget'];
     $db->update(
         "Project",
         array(

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -26,6 +26,8 @@ $client->initialize();
 $factory = NDB_Factory::singleton();
 $db      = $factory->database();
 $SubprojectList = Utility::getSubprojectList();
+$recTarget   = empty($_POST['RecruitmentTarget'])
+    ? null : $_POST['RecruitmentTarget'];
 
 if ($_POST['subprojectID'] === 'new') {
     if (!in_array($_POST['title'], $SubprojectList) && !empty($_POST['title'])) {
@@ -35,7 +37,7 @@ if ($_POST['subprojectID'] === 'new') {
              "title"             => $_POST['title'],
              "useEDC"            => $_POST['useEDC'],
              "WindowDifference"  => $_POST['WindowDifference'],
-             "RecruitmentTarget" => $_POST['RecruitmentTarget'],
+             "RecruitmentTarget" => $recTarget,
             )
         );
     } else {
@@ -50,7 +52,7 @@ if ($_POST['subprojectID'] === 'new') {
          "title"             => $_POST['title'],
          "useEDC"            => $_POST['useEDC'],
          "WindowDifference"  => $_POST['WindowDifference'],
-         "RecruitmentTarget" => $_POST['RecruitmentTarget'],
+         "RecruitmentTarget" => $recTarget
         ),
         array("SubprojectID" => $_POST['subprojectID'])
     );

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -26,7 +26,7 @@ $client->initialize();
 $factory = NDB_Factory::singleton();
 $db      = $factory->database();
 $SubprojectList = Utility::getSubprojectList();
-$recTarget   = empty($_POST['RecruitmentTarget'])
+$recTarget      = empty($_POST['RecruitmentTarget'])
     ? null : $_POST['RecruitmentTarget'];
 
 if ($_POST['subprojectID'] === 'new') {
@@ -52,7 +52,7 @@ if ($_POST['subprojectID'] === 'new') {
          "title"             => $_POST['title'],
          "useEDC"            => $_POST['useEDC'],
          "WindowDifference"  => $_POST['WindowDifference'],
-         "RecruitmentTarget" => $recTarget
+         "RecruitmentTarget" => $recTarget,
         ),
         array("SubprojectID" => $_POST['subprojectID'])
     );


### PR DESCRIPTION
This PR fixes #3071 and addresses Redmine ticket 13057. If a new project name is submitted with an empty Recruitment Target value, the submission will successfully be saved with a null value for Recruitment Target instead of returning the error message "Failed to save, same name already exists". 