### PR TITLE
[help_editor] Add support for links in the help section of each module

### DIFF
--- a/SQL/Archive/17.1/2017-08-24-help_links.sql
+++ b/SQL/Archive/17.1/2017-08-24-help_links.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `help_link` (
+  `helpID` int(10) unsigned NOT NULL,
+  `url` VARCHAR(255) NOT NULL,
+  `title` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (`helpID`,`url`),
+  CONSTRAINT `FK_help_link` FOREIGN KEY (`helpID`) REFERENCES `help` (`helpID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+

--- a/htdocs/js/helpHandler.js
+++ b/htdocs/js/helpHandler.js
@@ -44,6 +44,18 @@ $(document).ready(function() {
           wrap.innerHTML = "<h3></h3>";
         }
         wrap.innerHTML += content.content;
+
+        var links = content.links;
+        if (links != 0) {
+          wrap.innerHTML += "<br><br><h4>Helpful Links</h4>";
+          wrap.innerHTML += "<ul>";
+          for (var link in links) {
+            if (links.hasOwnProperty(link)) {
+              wrap.innerHTML += "<li><a href=\"" + link + "\" target=\"_blank\">" + links[link] + "</a></li>";
+            }
+          }
+          wrap.innerHTML += "</ul>";
+        }
         if (content.updated) {
           wrap.innerHTML = wrap.innerHTML + "<hr>Last updated: " + content.updated;
         }

--- a/modules/help_editor/php/HelpFile.class.inc
+++ b/modules/help_editor/php/HelpFile.class.inc
@@ -67,6 +67,16 @@ class HelpFile
              created, updated FROM help WHERE helpID = :HID",
             array('HID' => $helpID)
         );
+
+        $linksCol = $DB->pselect(
+            "SELECT url, title FROM help_link WHERE helpID=:HID",
+            array('HID' => $helpID)
+        );
+        $links    = array();
+        foreach ($linksCol as $k=>$row) {
+            $links[$row['url']] =$row['title'];
+        }
+        $result['links'] = $links;
         // set the help file
         $obj->data = $result;
 

--- a/modules/help_editor/php/NDB_Form_help_editor.class.inc
+++ b/modules/help_editor/php/NDB_Form_help_editor.class.inc
@@ -213,6 +213,10 @@ class NDB_Form_Help_Editor extends NDB_Form
       */
     function edit_help_content()// @codingStandardsIgnoreLine
     {
+        // Magical 5 value restricting number of links for each page
+        $maxLinks = 5;
+        $this->tpl_data['number_links'] = $maxLinks;
+
         $this->addBasicText('title', 'Title');
         $this->addBasicTextArea(
             'content',
@@ -223,6 +227,11 @@ class NDB_Form_Help_Editor extends NDB_Form
             )
         );
 
+        $this->form->addElement('static', 'links_header', 'Useful Links:');
+        for ($i=0; $i<$maxLinks; $i++) {
+            $this->addBasicText("link_$i",'');
+        }
+        print_r($this);
     }
 
     /**

--- a/modules/help_editor/templates/form_edit_help_content.tpl
+++ b/modules/help_editor/templates/form_edit_help_content.tpl
@@ -23,6 +23,14 @@
                 {$form.content.html}
             </div>
         </div>
+        <div class="row">
+            <label class="col-sm-2">{$form.links_header.label}</label>
+        </div>
+        <div class="row">
+            <div class="col-sm-8">
+                {$form.content.html}
+            </div>
+        </div>
         {foreach from=$elements_list item=element}
             <div class="row">
                 <label class="col-sm-4">{$form.$element.label}</label>


### PR DESCRIPTION
This pull request adds the necessary infrastructure to add and modify links which would be viewable and clickable from the help text of each module