### PR TITLE
[tools] Strips html tags from labels and more comments for instruction

### DIFF
--- a/tools/data_dictionary_builder.php
+++ b/tools/data_dictionary_builder.php
@@ -11,9 +11,12 @@
  *
  * Input:
  * data_dictionary_builder.php takes as input the ip_output.txt file (generated
- * by quickform_parser.php) and inserts records for each field of each
+ * by lorisform_parser.php) and inserts records for each field of each
  * discovered NDB_BVL_Instrument. To be complete, this tool must be run on an
  * ip_output.txt file that was constructed from all instruments.
+ * You will also need to concatenate the linst instruments (which are the same 
+ * format as ip_output.txt internally) to the end of the file 
+ * before running the script.
  *
  * *
  * * WARNING THIS FILE ACTIVELY AFFECTS THE DATABASE INDICATED BY CONFIG.XML.

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -118,6 +118,7 @@ function parseElements($elements, $groupLabel="")
         } else {
             $label = trim(preg_replace('/\s+/', ' ', $groupLabel));
         }
+        $label = strip_tags($label);
 
         switch ($element['type']) {
         case "select":
@@ -237,7 +238,10 @@ function getExcludedInstruments()
     // Get the abbreviated instruments
     $config =& NDB_Config::singleton();
     $excluded_instruments = $config->getSetting('excluded_instruments');
-
+    if (strlen(trim($excluded_instruments)) == 0) {
+        $excluded_instruments = array();
+    }
+    
     $ex_instruments =array();
     foreach ($excluded_instruments as $instruments) {
         foreach (Utility::asArray($instruments) as $instrument) {


### PR DESCRIPTION
Strips html tags from labels and more comments for instruction.
Also if no excluded instrument is returned, return an empty array.