### PR TITLE
[CouchDB] Fixing getScanTypes query in CouchDB MRI Importer

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -336,9 +336,10 @@ class CouchDBMRIImporter
     {
 
         $ScanTypes = $this->SQLDB->pselect(
-            "SELECT DISTINCT msc.Scan_type as ScanType from mri_scan_type msc
-JOIN files f ON msc.ID= f.AcquisitionProtocolID
-JOIN files_qcstatus fqc ON f.FileID=fqc.FileID ORDER BY f.AcquisitionProtocolID",
+            "SELECT DISTINCT msc.Scan_type as ScanType, f.AcquisitionProtocolID from mri_scan_type msc
+            JOIN files f ON msc.ID= f.AcquisitionProtocolID
+            JOIN files_qcstatus fqc ON f.FileID=fqc.FileID
+            ORDER BY f.AcquisitionProtocolID",
             array()
         );
 


### PR DESCRIPTION
Script is currently broken for 5.7