### PR TITLE
Fix empty result in getMaxThreadStatus for NDB_BVL_Feedback

### DIFF
--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -390,7 +390,7 @@ class NDB_BVL_Feedback
         $query .= " ORDER BY Status ASC";
         $result = $db->pselectOne($query, $qparams);
 
-        if (isset($result)) {
+        if (!empty($result)) {
             return $result;
         }
         return null;


### PR DESCRIPTION
The NDB_BVL_Feedback class incorrectly had a isset check instead of an !empty
check to determine if an SQL query returned any results. isset would never
be false, because the variable is set directly above the check.

This updates it to be !empty, so that "null" is properly returned when
there is no feedback.