### PR TITLE
Modularize instrument_list page

### DIFF
--- a/modules/instrument_list/help/instrument_list.md
+++ b/modules/instrument_list/help/instrument_list.md
@@ -1,0 +1,18 @@
+# Timepoint Instrument List
+
+Once inside a time-point, users will see some general information about the candidate across the top of the screen, such as date of birth, gender, visit label, and subproject(cohort).
+
+The blue sidebar panel contains key actions and flags to mark timepoint validity and completion status.  On mobile devices or in narrow browser windows, this sidebar panel is hidden but can be accessed by clicking the list icon in the top left-hand corner.
+
+The sidebar shows the status of the visit can be viewed under "Stage:Visit"; here status can be updated to "Pass", "Failure", "Withdrawal", or "In Progress". After all instruments have completed data entry, a timepoint can be marked as Valid and "Complete".
+
+Each timepoint is associated with a specific battery of tests or measures, also known as instruments. For any newly created timepoint, click "Start Next Stage" at the top of the sidebar to begin populating the behavioural battery for the candidate-timepoint.  No instruments will be visible within a timepoint until this step has been completed.
+
+Once a timepoint is populated with instruments, the data table will list instrument name, status including Administration and Data Entry status, as well as whether any feedback notes exist for a particular instrument. Click on any instrument name to open the instrument form, to enter or view data.
+
+If a study uses Double Data Entry forms to protect against user input errors and typos, the Double Data Entry (DDE) status will be displayed in the instrument list table. Double data entry can be performed by clicking on the "Double Data Entry" link for a given instrument.
+
+To finalize data entry for a timepoint: in the sidebar under "Send Time Point" users must select "Send to DCC". After clicking "Send to DCC", no data entry changes can be made in the timepoint (including instruments) for this candidate. Users with the authorization to "Reverse Send to DCC" can make this timepoint editable after it has been finalized in this manner.
+
+The "BVL QC Type" flag in the sidebar panel is used to record whether Behavioural Quality Control (QC) was done via visual inspection or based on detailed comparison with a paper hard copy.  The "BVL QC Status" flag records whether Quality Control has been reviewed and completed.
+I am a test

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -15,7 +15,8 @@
  *
  * @package behavioural
  */
-require_once __DIR__ ."/Instrument_List_ControlPanel.class.inc";
+namespace LORIS\instrument_list;
+
 /**
  * Instrument_List
  *
@@ -27,7 +28,7 @@ require_once __DIR__ ."/Instrument_List_ControlPanel.class.inc";
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
-class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
+class Instrument_List extends \NDB_Menu_Filter
 {
     /**
     * Checking permissions
@@ -37,12 +38,12 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
 
-        $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
+        $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
         $candID    = $timePoint->getCandID();
 
-        $candidate =& Candidate::singleton($candID);
+        $candidate =& \Candidate::singleton($candID);
 
         // check user permissions
         return ($user->hasPermission('access_all_profiles')
@@ -59,6 +60,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
         );
 
     }
+
     /**
     * GetControlPanel function
     *
@@ -76,10 +78,11 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
         $html = $controlPanel->display();
         // I don't know why this is here, but it
         // was in main.php, so moved it to be safe.
-        $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
+        $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
         $timePoint->select($_REQUEST['sessionID']);
         return $html;
     }
+
     /**
     * Setup function
     *
@@ -93,13 +96,13 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
 
         $this->_setupPage(null, null, null, null, 'filter');
         // get behavioral battery for this visit (time point)
-        $battery = new NDB_BVL_Battery;
+        $battery = new \NDB_BVL_Battery;
         $success = $battery->selectBattery($_REQUEST['sessionID']);
 
-        $this->tpl_data['stage']        = Utility::getStageUsingCandID(
+        $this->tpl_data['stage']        = \Utility::getStageUsingCandID(
             $this->tpl_data['candID']
         );
-        $this->tpl_data['subprojectID'] = Utility::getSubprojectIDUsingCandID(
+        $this->tpl_data['subprojectID'] = \Utility::getSubprojectIDUsingCandID(
             $this->tpl_data['candID']
         );
 
@@ -111,7 +114,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
 
         // display list of instruments
         if (!empty($listOfInstruments)) {
-            $user     =& User::singleton();
+            $user     =& \User::singleton();
             $username = $user->getData('UserID');
 
             $feedback_select_inactive = null;
@@ -132,10 +135,10 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
                 $prevSubgroup = $instrument['Sub_group'];
 
                 // make an instrument status object
-                $status  = new NDB_BVL_InstrumentStatus;
+                $status  = new \NDB_BVL_InstrumentStatus;
                 $success = $status->select($instrument['CommentID']);
 
-                $ddeStatus = new NDB_BVL_InstrumentStatus;
+                $ddeStatus = new \NDB_BVL_InstrumentStatus;
                 $success   = $ddeStatus->select($instrument['DDECommentID']);
 
                 $Ins = "instruments";
@@ -156,7 +159,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
                 $ins = $instrument['CommentID'];
                 $this->tpl_data[$Ins][$x][$i]['commentID'] = $ins;
 
-                $ins = NDB_BVL_Battery::isDoubleDataEntryEnabledForInstrument(
+                $ins = \NDB_BVL_Battery::isDoubleDataEntryEnabledForInstrument(
                     $instrument['Test_name']
                 );
                 $this->tpl_data[$Ins][$x][$i]['isDdeEnabled'] = $ins;
@@ -174,7 +177,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
                 $this->tpl_data[$Ins][$x][$i]['instrumentOrder'] = $ins;
 
                 // create feedback object for the time point
-                $feedback = NDB_BVL_Feedback::singleton(
+                $feedback = \NDB_BVL_Feedback::singleton(
                     $username,
                     null,
                     null,
@@ -205,10 +208,10 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
             }
         }
 
-        $timePoint =& TimePoint::singleton($_REQUEST['sessionID']);
+        $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
         $candID    = $timePoint->getCandID();
 
-        $candidate =& Candidate::singleton($candID);
+        $candidate =& \Candidate::singleton($candID);
 
         $this->tpl_data['display']
             = array_merge($candidate->getData(), $timePoint->getData());
@@ -224,7 +227,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
      */
     function getFeedbackPanel($candID, $sessionID)
     {
-        $feedbackPanel = new BVL_Feedback_Panel($candID, $sessionID);
+        $feedbackPanel = new \BVL_Feedback_Panel($candID, $sessionID);
         $html          =  $feedbackPanel->display();
         return $html;
     }
@@ -243,7 +246,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
      */
     function getBatteryInstrumentList($stage=null, $SubprojectID=null)
     {
-        $DB = Database::singleton();
+        $DB = \Database::singleton();
 
         // assert that a battery has already been selected
         if (is_null($_REQUEST['sessionID'])) {
@@ -278,7 +281,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
         $query .= " WHERE f.SessionID=:SID
             AND LEFT(f.CommentID, 3) != 'DDE'";
 
-        if (Utility::columnsHasNull('test_subgroups', 'group_order')) {
+        if (\Utility::columnsHasNull('test_subgroups', 'group_order')) {
             $query .= " ORDER BY Subgroup_name";
         } else {
             $query .= " ORDER BY Subgroup_order";
@@ -304,7 +307,7 @@ class NDB_Menu_Filter_Instrument_List extends NDB_Menu_Filter
      */
     function getJSDependencies()
     {
-        $factory = NDB_Factory::singleton();
+        $factory = \NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
         $deps    = parent::getJSDependencies();
         return array_merge(

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -13,6 +13,8 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
+namespace LORIS\instrument_list;
+
 /**
  * Time Point status control panel class
  *
@@ -27,7 +29,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
-Class Instrument_List_ControlPanel extends TimePoint
+class Instrument_List_ControlPanel extends \TimePoint
 {
     /**
      * Construct funcion
@@ -50,7 +52,7 @@ Class Instrument_List_ControlPanel extends TimePoint
      */
     function display()
     {
-        $factory = NDB_Factory::singleton();
+        $factory = \NDB_Factory::singleton();
         $this->tpl_data['baseurl'] = $factory->settings()->getBaseURL();
 
         $this->tpl_data['candID']    = $this->getData('CandID');
@@ -69,7 +71,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         }
 
         // BVLQC - get permission and set the tpl element
-        $user =& User::singleton();
+        $user =& \User::singleton();
         $this->tpl_data['access']['bvl_qc']
             = $user->hasPermission('bvl_feedback');
 
@@ -78,7 +80,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         // BVLQCStatus
         $success = $this->_displayBVLQCStatus();
 
-        $smarty = new Smarty_neurodb("instrument_list");
+        $smarty = new \Smarty_neurodb("instrument_list");
         $smarty->assign($this->tpl_data);
         $html = $smarty->fetch("instrument_list_controlpanel.tpl");
         return $html;
@@ -97,7 +99,7 @@ Class Instrument_List_ControlPanel extends TimePoint
 
         // update the status of the current stage
         if (!empty($_REQUEST['setStageUpdate'])
-            && $this->_hasAccess_Status()
+            && $this->_hasAccessStatus()
             && in_array($_REQUEST['setStageUpdate'], $this->_statusOptions)
             && in_array($currentStage, $this->_dynamicStageOptions)
         ) {
@@ -107,13 +109,13 @@ Class Instrument_List_ControlPanel extends TimePoint
 
         // submit to dcc (a.k.a., finalize)
         if (isset($_REQUEST['setSubmitted']) && $_REQUEST['setSubmitted'] == 'Y'
-            && $this->_hasAccess_SendToDCC()
+            && $this->_hasAccessSendToDCC()
             && in_array($currentStage, array('Visit', 'Screening'))
             && $currentStatus != 'In Progress'
         ) {
 
             // trigger timepoint flags
-            $config    =& NDB_Config::singleton();
+            $config    =& \NDB_Config::singleton();
             $study     = $config->getSetting('study');
             $sessionID = $this->getData('SessionID');
             $condition = $study['timepointFlagCheck_send2dcc'];
@@ -121,7 +123,7 @@ Class Instrument_List_ControlPanel extends TimePoint
                 include_once __DIR__ .
                     "../../modules/timepoint_flag/php/TimePoint_Flag.class.inc";
                 // object instance
-                $timepointFlagObject =& TimePoint_Flag::singleton($sessionID);
+                $timepointFlagObject =& \TimePoint_Flag::singleton($sessionID);
                 // flag types
                 $flagTypeIDs = $timepointFlagObject->getFlagTypeIDs();
                 // evaluate the flags for the timepoint
@@ -176,7 +178,7 @@ Class Instrument_List_ControlPanel extends TimePoint
 
             if ($nextStage = 'Recycling Bin') {
 
-                $battery = new NDB_BVL_Battery();
+                $battery = new \NDB_BVL_Battery();
 
                 // set the SessionID for the battery
                 $success = $battery->selectBattery(
@@ -187,7 +189,7 @@ Class Instrument_List_ControlPanel extends TimePoint
                 $batteryList = $battery->getBatteryVerbose();
 
                 // Get the list of DDE instruments
-                $config         =& NDB_Config::singleton();
+                $config         =& \NDB_Config::singleton();
                 $ddeInstruments = $config->getSetting(
                     'DoubleDataEntryInstruments'
                 );
@@ -198,7 +200,7 @@ Class Instrument_List_ControlPanel extends TimePoint
                     // If the instrument requires double data entry, check that
                     // DDE is also done
                     if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                        ConflictDetector::clearConflictsForInstance(
+                        \ConflictDetector::clearConflictsForInstance(
                             $instrument['CommentID']
                         );
                     }
@@ -212,7 +214,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         $condition2 = $condition1 ?
             $_REQUEST['setSubmitted'] == 'N' :
             false;
-        $condition3 = $this->_hasAccess_SendToDCC();
+        $condition3 = $this->_hasAccessSendToDCC();
         $condition4 = !in_array(
             $currentStage,
             array(
@@ -239,7 +241,7 @@ Class Instrument_List_ControlPanel extends TimePoint
                 $previousStage = $this->_determinePreviousStage();
                 $this->startStage($previousStage);
 
-                $battery = new NDB_BVL_Battery();
+                $battery = new \NDB_BVL_Battery();
                 // set the SessionID for the battery
                 $success = $battery->selectBattery(
                     $this->getData('SessionID')
@@ -247,7 +249,7 @@ Class Instrument_List_ControlPanel extends TimePoint
                 // get the list of instruments
                 $batteryList = $battery->getBatteryVerbose();
                 // Get the list of DDE instruments
-                $config         =& NDB_Config::singleton();
+                $config         =& \NDB_Config::singleton();
                 $ddeInstruments = $config->getSetting(
                     'DoubleDataEntryInstruments'
                 );
@@ -260,15 +262,15 @@ Class Instrument_List_ControlPanel extends TimePoint
                     if (in_array($instrument['Test_name'], $ddeInstruments)) {
                         // ConflictDetector::
                         //clearConflictsForInstance($instrument['CommentID']);
-                        ConflictDetector::clearConflictsForInstance(
+                        \ConflictDetector::clearConflictsForInstance(
                             $instrument['CommentID']
                         );
-                        $diff =ConflictDetector::detectConflictsForCommentIds(
+                        $diff =\ConflictDetector::detectConflictsForCommentIds(
                             $instrument['Test_name'],
                             $instrument['CommentID'],
                             $instrument['DDECommentID']
                         );
-                        ConflictDetector::recordUnresolvedConflicts($diff);
+                        \ConflictDetector::recordUnresolvedConflicts($diff);
 
                     }
                 }
@@ -277,11 +279,11 @@ Class Instrument_List_ControlPanel extends TimePoint
         }
 
         // set the BVLQC flag
-        $user =& User::singleton();
+        $user =& \User::singleton();
         if (isset($_REQUEST['setBVLQCStatus'])
             && $user->hasPermission('bvl_feedback')
         ) {
-            $status = Utility::nullifyEmpty(
+            $status = \Utility::nullifyEmpty(
                 $_REQUEST['setBVLQCStatus'],
                 'BVLQCStatus'
             );
@@ -291,7 +293,7 @@ Class Instrument_List_ControlPanel extends TimePoint
         if (isset($_REQUEST['setBVLQCType']) && !empty($_REQUEST['setBVLQCType'])
             && $user->hasPermission('bvl_feedback')
         ) {
-            $QCtype = Utility::nullifyEmpty(
+            $QCtype = \Utility::nullifyEmpty(
                 $_REQUEST['setBVLQCType'],
                 'BVLQCType'
             );
@@ -345,15 +347,15 @@ Class Instrument_List_ControlPanel extends TimePoint
         }
 
         // new DB Object
-        $db =& Database::singleton();
+        $db =& \Database::singleton();
 
         // create user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
 
-        $hasAccess = $this->_hasAccess_Status();
+        $hasAccess = $this->_hasAccessStatus();
 
         // check that all the instruments' Data Entry is market Complete
-        $battery = new NDB_BVL_Battery;
+        $battery = new \NDB_BVL_Battery;
 
         // set the SessionID for the battery
         $success = $battery->selectBattery($_REQUEST['sessionID']);
@@ -362,13 +364,13 @@ Class Instrument_List_ControlPanel extends TimePoint
         $batteryList = $battery->getBatteryVerbose();
 
         // Get the list of DDE instruments
-        $config         =& NDB_Config::singleton();
+        $config         =& \NDB_Config::singleton();
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 
         // loop the list and check the Data Entry status
         $ddeConflictDetected =false;
         foreach ($batteryList as $instrument) {
-            $status = new NDB_BVL_InstrumentStatus();
+            $status = new \NDB_BVL_InstrumentStatus();
             $status->select($instrument['CommentID']);
             $dataEntry = $status->getDataEntryStatus();
             if ($dataEntry != 'Complete') {
@@ -378,7 +380,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             // If the instrument requires double data entry,
             //check that DDE is also done
             if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                $status = new NDB_BVL_InstrumentStatus();
+                $status = new \NDB_BVL_InstrumentStatus();
                 $status->select($instrument['DDECommentID']);
                 $dataEntry = $status->getDataEntryStatus();
                 if ($dataEntry != 'Complete') {
@@ -450,10 +452,10 @@ Class Instrument_List_ControlPanel extends TimePoint
      *
      * @return bool
      */
-    function _hasAccess_Status()// @codingStandardsIgnoreLine
+    function _hasAccessStatus()
     {
         // get user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
 
         // disable the button for all these users
         $currentStage = $this->getCurrentStage();
@@ -536,10 +538,10 @@ Class Instrument_List_ControlPanel extends TimePoint
      */
     function _displaySendToDCC()
     {
-        $config =& NDB_Config::singleton();
+        $config =& \NDB_Config::singleton();
         $study  = $config->getSetting('study');
 
-        $hasAccess = $this->_hasAccess_SendToDCC();
+        $hasAccess = $this->_hasAccessSendToDCC();
 
         // This is a toggle button.
         if ($this->getData('Submitted')=='Y') {
@@ -558,7 +560,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             $this->tpl_data['send_to_dcc']['reverse'] = 'Reverse Send To DCC';
         }
 
-        $battery = new NDB_BVL_Battery();
+        $battery = new \NDB_BVL_Battery();
 
         // set the SessionID for the battery
         $success = $battery->selectBattery($this->getData('SessionID'));
@@ -567,14 +569,14 @@ Class Instrument_List_ControlPanel extends TimePoint
         $batteryList = $battery->getBatteryVerbose();
 
         // Get the list of DDE instruments
-        $config         =& NDB_Config::singleton();
+        $config         =& \NDB_Config::singleton();
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 
         // clear the unresolved conflicts for all the instruments
         $allDataEntryComplete =true;
         foreach ($batteryList as $instrument) {
 
-            $status = new NDB_BVL_InstrumentStatus();
+            $status = new \NDB_BVL_InstrumentStatus();
             $status->select($instrument['CommentID']);
             $dataEntry = $status->getDataEntryStatus();
             if ($dataEntry != 'Complete') {
@@ -585,7 +587,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             // If the instrument requires double data entry,
             // check that DDE is also done
             if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                $status = new NDB_BVL_InstrumentStatus();
+                $status = new \NDB_BVL_InstrumentStatus();
                 $status->select($instrument['DDECommentID']);
                 $dataEntry = $status->getDataEntryStatus();
                 if ($dataEntry != 'Complete') {
@@ -609,8 +611,8 @@ Class Instrument_List_ControlPanel extends TimePoint
     function _getSendToDCCStatusMessage()
     {
         // create user object
-        $user   =& User::singleton();
-        $config =& NDB_Config::singleton();
+        $user   =& \User::singleton();
+        $config =& \NDB_Config::singleton();
 
         // get the value of the session.Scan_done field
         $scanDone = $this->getData('Scan_done');
@@ -663,7 +665,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             return "The Scan done field must be entered for the Visit stage";
         }
 
-        $battery = new NDB_BVL_Battery();
+        $battery = new \NDB_BVL_Battery();
 
         // set the SessionID for the battery
         $success = $battery->selectBattery($this->getData('SessionID'));
@@ -672,14 +674,14 @@ Class Instrument_List_ControlPanel extends TimePoint
         $batteryList = $battery->getBatteryVerbose();
 
         // Get the list of DDE instruments
-        $config         =& NDB_Config::singleton();
+        $config         =& \NDB_Config::singleton();
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 
         // clear the unresolved conflicts for all the instruments
         $allDataEntryComplete =true;
         foreach ($batteryList as $instrument) {
 
-            $status = new NDB_BVL_InstrumentStatus();
+            $status = new \NDB_BVL_InstrumentStatus();
             $status->select($instrument['CommentID']);
             $dataEntry = $status->getDataEntryStatus();
             if ($dataEntry != 'Complete') {
@@ -690,7 +692,7 @@ Class Instrument_List_ControlPanel extends TimePoint
             // If the instrument requires double data entry,
             // check that DDE is also done
             if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                $status = new NDB_BVL_InstrumentStatus();
+                $status = new \NDB_BVL_InstrumentStatus();
                 $status->select($instrument['DDECommentID']);
                 $dataEntry = $status->getDataEntryStatus();
                 if ($dataEntry != 'Complete') {
@@ -704,15 +706,15 @@ Class Instrument_List_ControlPanel extends TimePoint
         }
     }
     /**
-     * HasAccess_SendToDCC function
+     * HasAccessSendToDCC function
      *
      * @return bool
      */
-    function _hasAccess_SendToDCC()// @codingStandardsIgnoreLine
+    function _hasAccessSendToDCC()
     {
         // create user object
-        $user   =& User::singleton();
-        $config =& NDB_Config::singleton();
+        $user   =& \User::singleton();
+        $config =& \NDB_Config::singleton();
 
         // get the value of the session.Scan_done field
         $scanDone = $this->getData('Scan_done');
@@ -762,10 +764,14 @@ Class Instrument_List_ControlPanel extends TimePoint
         $this->tpl_data['next_stage'] = $this->getNextStage();
 
         // create user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
 
         // check user permissions
-        if (!$user->hasPermission('data_entry') || !in_array($this->getData('CenterID'), $user->getData('CenterIDs'))) {// @codingStandardsIgnoreLine
+        if (!$user->hasPermission('data_entry') || !in_array(
+            $this->getData('CenterID'),
+            $user->getData('CenterIDs')
+        )
+        ) {
             return false;
         }
         return $this->isStartable();

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -388,7 +388,7 @@ class Instrument_List_ControlPanel extends \TimePoint
                 }
 
                 // Pretend data entry is not complete if there are conflicts
-                if (ConflictDetector::isInstrumentInstanceInConflictState(
+                if (\ConflictDetector::isInstrumentInstanceInConflictState(
                     $instrument['CommentID']
                 )
                 ) {

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This serves as a hint to LORIS that this module is a real module.
+ * It does nothing but implement the module class in the module's namespace.
+ *
+ * PHP Version 5
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris-Trunk/
+ */
+namespace LORIS\instrument_list;
+
+/**
+ * Class module implements the basic LORIS module functionality
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris-Trunk/
+ */
+class Module extends \Module
+{
+}


### PR DESCRIPTION
This converts the instrument_list page into a real LORIS module with
a module class to handle metadata, and converts the help to be written
in markdown.

Note that the help text is based on #3097 with some typos (such as using MS-Word style quotes) that were missed in the (for all practical purposes, un-reviewable) SQL patch version fixed.