### PR TITLE
New profile: for DCC it should be site alias not CenterName

### DIFF
--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -37,7 +37,7 @@ class NDB_Form_New_Profile extends NDB_Form
         foreach ($site_arr as $key=>$val) {
             $site[$key]        = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();
-            $isDCCSite[$key]   = $site[$key]->getCenterName();
+            $isDCCSite[$key]   = $site[$key]->getSiteAlias();
         }
         $oneIsStudySite = in_array("1", $isStudySite);
         $oneIsDCCSite   = in_array("DCC", $isDCCSite);


### PR DESCRIPTION
When comparing to "DCC", this should be based on Alias not Name (as per the default schema which has the name set at Data Coordinating Center and Alias at DCC).
In any case, DCC should not be hard coded in the codebase.