### PR TITLE
Fix convert array to string error in dashboard

### DIFF
--- a/modules/dashboard/php/NDB_Form_dashboard.class.inc
+++ b/modules/dashboard/php/NDB_Form_dashboard.class.inc
@@ -293,7 +293,7 @@ class NDB_Form_Dashboard extends NDB_Form
                         "SELECT Test_name from flag WHERE CommentID=:cid",
                         array('cid' => $bvl_feedback[$i]['CommentID'])
                     );
-                    if ($instrument !== null) {
+                    if (!empty($instrument)) {
                         $bvl_feedback[$i]['URL'] = '/' . $instrument . '/?candID='
                             . $bvl_feedback[$i]['CandID'] . '&sessionID='
                             . $bvl_feedback[$i]['SessionID'] . '&commentID='


### PR DESCRIPTION
I was getting an error about converting arrays to strings on the dashboard,
because a query which returns no results return an empty array.

This changes the check from !== null to !empty() to fix this error.