### PR TITLE
[Imaging Uploader] Quick fix for sticky filters

### DIFF
--- a/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/NDB_Menu_Filter_imaging_uploader.class.inc
@@ -73,7 +73,7 @@ class NDB_Menu_Filter_Imaging_Uploader extends NDB_Menu_Filter_Form
      */
     function _setupVariables()
     {
-
+        $this->_resetFilters();
         $progressSelectPart = "IF(ISNULL(Inserting), 'Not Started',"
             . "IF(Inserting=1, 'In Progress...', "
             . "IF(InsertionComplete=0, 'Failure', 'Success'))) as Progress";


### PR DESCRIPTION
Same fix for issue that occurred for dicom_archive in #2943 
Quickly checked other modules for this issue and imaging uploader appears to be the only one