### PR TITLE
[user_accounts] fixing multiple faults in logic

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -1,15 +1,15 @@
 <?php
 /**
-* The user account page
-*
-* PHP Version 5,7
-*
-* @category Main
-* @package  User_Account
-* @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
-* @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
-* @link     https://www.github.com/aces/Loris/
-*/
+ * The user account page
+ *
+ * PHP Version 5,7
+ *
+ * @category Main
+ * @package  User_Account
+ * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
 
 /**
  * Implements the user account page
@@ -129,11 +129,13 @@ class NDB_Form_User_Accounts extends NDB_Form
                 }
                 //gets radiologist Y/N from any of the active sites
                 if ($vals[0]=='Y') {
-                    $defaults['examiner_radiologist'] =$vals[1];
+                    if ($vals[1]==='1') {
+                        $defaults['examiner_radiologist'] = 'Y';
+                    } else {
+                        $defaults['examiner_radiologist'] = 'N';
+                    }
                 }
-                if ($vals[0]=='Y'
-                    || ($vals[0]=='N' && $defaults['examiner_pending']=='Y')
-                ) {
+                if ($vals[0]=='Y') {
                     $defaults['ex_'.$cid] ='on';
                 }
             }
@@ -168,7 +170,7 @@ class NDB_Form_User_Accounts extends NDB_Form
     {
         $editor = User::singleton();
         return !$this->isCreatingNewUser()
-            && ($editor->getUsername() == $this->identifier);
+        && ($editor->getUsername() == $this->identifier);
     }
 
     /**
@@ -269,10 +271,36 @@ class NDB_Form_User_Accounts extends NDB_Form
             // END multi-site UPDATE
 
             // EXAMINER UPDATE
+            // get all fields that are related to examiners
+            $ex_curr_sites  = array();
+            $ex_prev_sites  = array();
+            $ex_radiologist = 'N';
+            $ex_pending     = 'Y';
+
+            foreach ($values as $k => $v) {
+                //examiner fields
+                if (preg_match("/^ex_[0-9]+$/", $k)) {
+                    //get centerID
+                    $parse_key = explode('_', $k);
+                    $cid       = $parse_key[1];
+                    $ex_curr_sites[$k] = $cid;
+                }
+                if ($k === 'examiner_radiologist') {
+                    $ex_radiologist = $v;
+                }
+                if ($k === 'examiner_pending') {
+                    $ex_pending = $v;
+                }
+            }
+
             // first check if an update is needed then actually do it
-            if (!empty($values['examiner_radiologist'])
-                && !empty($values['examiner_pending'])
+            if (!empty($ex_radiologist)
+                && !empty($ex_pending)
+                && !empty($ex_curr_sites)
             ) {
+                //modify examiner radiologist to be in the binary format 0-1
+                $ex_radiologist = $ex_radiologist === 'Y' ? 1:0;
+
                 $examinerID = $DB->pselect(
                     "SELECT e.examinerID
                      FROM examiners e
@@ -281,15 +309,17 @@ class NDB_Form_User_Accounts extends NDB_Form
                      "fn" => $values['Real_name'],
                     )
                 );
+
                 // If examiner not in table add him,
-                // otherwise update the radiologist field
+                // otherwise update the radiologist field and get the current sites
                 $values = Utility::nullifyEmpty($values, 'examiner_radiologist');
                 if (empty($examinerID)) {
+
                     $DB->insert(
                         'examiners',
                         array(
                          'full_name'   => $values['Real_name'],
-                         'radiologist' => $values['examiner_radiologist'] ?? 0,
+                         'radiologist' => $ex_radiologist,
                          'userID'      => $uid,
                         )
                     );
@@ -300,10 +330,11 @@ class NDB_Form_User_Accounts extends NDB_Form
                         array('fullName' => $values['Real_name'])
                     );
                 } else {
+
                     $DB->update(
                         'examiners',
                         array(
-                         'radiologist' => $values['examiner_radiologist'] ?? 0,
+                         'radiologist' => $ex_radiologist,
                          'userID'      => $uid,
                         ),
                         array(
@@ -311,69 +342,59 @@ class NDB_Form_User_Accounts extends NDB_Form
                         )
                     );
                     $examinerID = $examinerID[0]['examinerID'];
-                }
 
-                // Update CenterIDs
-                $ex_curr_sites = array();
-                $ex_prev_sites = array();
-
-                $prev_sites = $DB->pselect(
-                    "SELECT centerID
+                    //get existing sites for examiner
+                    $prev_sites = $DB->pselect(
+                        "SELECT centerID
                      FROM examiners_psc_rel epr
                      WHERE examinerID=:eid",
-                    array("eid" => $examinerID)
-                );
+                        array("eid" => $examinerID)
+                    );
 
-                //get sites where user is already an examiner at for compare
-                foreach ($prev_sites as $row => $center) {
-                    array_push($ex_prev_sites, $center['centerID']);
+                    //get sites where user is already an examiner at for compare
+                    foreach ($prev_sites as $row => $center) {
+                        array_push($ex_prev_sites, $center['centerID']);
+                    }
                 }
 
-                foreach ($values as $k => $v) {
-                    //examiner fields
-                    if (preg_match("/^ex_[0-9]+$/", $k)) {
-                        //get centerID
-                        $parse_key = explode('_', $k);
-                        $cid       = $parse_key[1];
-                        array_push($ex_curr_sites, $cid);
+                foreach ($ex_curr_sites as $k => $v) {
 
-                        //Check if examiner already in db for site
-                        $result = $DB->pselectRow(
-                            "SELECT epr.centerID
+                    //Check if examiner already in db for site
+                    $result = $DB->pselectRow(
+                        "SELECT epr.centerID
                              FROM examiners_psc_rel epr 
                              WHERE epr.examinerID=:eid AND epr.centerID=:cid",
+                        array(
+                         "eid" => $examinerID,
+                         "cid" => $v,
+                        )
+                    );
+
+                    // examiner was not previously added, add and set to active
+                    if (empty($result)) {
+                        $DB->insert(
+                            'examiners_psc_rel',
                             array(
-                             "eid" => $examinerID,
-                             "cid" => $cid,
+                             'examinerID'       => $examinerID,
+                             'centerID'         => $v,
+                             'active'           => 'Y',
+                             'pending_approval' => $ex_pending,
                             )
                         );
-
-                        // examiner was not previously added, add and set to active
-                        if (empty($result)) {
-                            $DB->insert(
-                                'examiners_psc_rel',
-                                array(
-                                 'examinerID'       => $examinerID,
-                                 'centerID'         => $cid,
-                                 'active'           => 'Y',
-                                 'pending_approval' => $values['examiner_pending'],
-                                )
-                            );
-                        } else {
-                            $DB->update(
-                                'examiners_psc_rel',
-                                array(
-                                 'active'           => 'Y',
-                                 'pending_approval' => $values['examiner_pending'],
-                                ),
-                                array(
-                                 'examinerID' => $examinerID,
-                                 'centerID'   => $cid,
-                                )
-                            );
-                        }
-                        unset($values[$k]);
+                    } else {
+                        $DB->update(
+                            'examiners_psc_rel',
+                            array(
+                             'active'           => 'Y',
+                             'pending_approval' => $ex_pending,
+                            ),
+                            array(
+                             'examinerID' => $examinerID,
+                             'centerID'   => $v,
+                            )
+                        );
                     }
+                    unset($values[$k]);
                 }
 
                 //de-activate examiner if sites where no longer checked
@@ -390,8 +411,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                     );
                 }
             }
-            unset($values['examiner_pending']);
             unset($values['examiner_radiologist']);
+            unset($values['examiner_pending']);
             //END EXAMINER UPDATE
         }
 
@@ -747,8 +768,8 @@ class NDB_Form_User_Accounts extends NDB_Form
                 "Radiologist: ",
                 array(
                  null => "",
-                 '1'  => 'Yes',
-                 '0'  => 'No',
+                 'Y'  => 'Yes',
+                 'N'  => 'No',
                 )
             );
             $groupB[] = $this->createLabel(
@@ -891,16 +912,16 @@ class NDB_Form_User_Accounts extends NDB_Form
     }
 
     /**
-    * Query database on UserID to check that password has doesn't
-    * exist and account is still pending approval, to ensure the
-    * users with account activity can't be rejected by setting
-    * their status to pending.
-    *
-    * @param string $id identifier of account to verify
-    *
-    * @return boolean true is Password_hash is null and
-    * Pending_approval is Yes, false otherwsie
-    */
+     * Query database on UserID to check that password has doesn't
+     * exist and account is still pending approval, to ensure the
+     * users with account activity can't be rejected by setting
+     * their status to pending.
+     *
+     * @param string $id identifier of account to verify
+     *
+     * @return boolean true is Password_hash is null and
+     * Pending_approval is Yes, false otherwsie
+     */
     function _canRejectAccount($id)
     {
         $DB     = Database::singleton();
@@ -1248,20 +1269,28 @@ class NDB_Form_User_Accounts extends NDB_Form
         //======================================
         //        Validate Examiner Status
         //======================================
-
+        $matched =false;
         foreach ($values as $k=>$v) {
-            if (preg_match("/^ex_[1-9]+$/", $k)
-                && $values['examiner_radiologist'] == ''
-            ) {
-                $errors['examiner_group'] = "Please specify if examiner is a ".
-                    "radiologist";
+            if (preg_match("/^ex_[1-9]+$/", $k)) {
+                $matched =true;
+                if ($values['examiner_radiologist'] == '') {
+                    $errors['examiner_group'] = "Please specify if examiner is a " .
+                        "radiologist";
+
+                }
+                if ($values['examiner_radiologist'] !== ''
+                    && $values['examiner_pending'] == ''
+                ) {
+                    $errors['examiner_group'] = "Please set pending approval Yes ".
+                        "or No";
+                }
             }
-            if (preg_match("/^ex_[1-9]+$/", $k)
-                && $values['examiner_radiologist'] !== ''
-                && $values['examiner_pending'] == ''
-            ) {
-                $errors['examiner_group'] = "Please set pending approval Yes or No";
-            }
+        }
+        if (!$matched
+            && ($values['examiner_radiologist'] !== ''
+            || $values['examiner_pending'] !== '')
+        ) {
+            $errors['examiner_sites'] = "Please select at least one examiner site.";
         }
         return $errors;
     }


### PR DESCRIPTION
This pull request fixes multiple processing logic fails:
 - PHP interprets the integer `0` as empty, thus causing incorrect processing steps. now using `Y` and `N` instead. 
 - assigning variable names for clearer code
 - getDefaults was showing checkmarks for values with `active=N, pending=Y` when these should not be checked.
- some forloops and if statements re-organized to avoid multiple iterations of the same sequence

sequel to: https://github.com/aces/Loris/pull/3133
