### PR TITLE
Declare User::isPasswordStrong to be a static function

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -397,8 +397,11 @@ class User extends UserPermissions
      * @access public
      * @static
      */
-    function isPasswordStrong($password, $values = array(), $operators = array())
-    {
+    static function isPasswordStrong(
+        $password,
+        $values = array(),
+        $operators = array()
+    ) {
         $CharTypes = 0;
         // less than 6 characters
         if (strlen($password) < 8) {


### PR DESCRIPTION
This fixes the error:

"Deprecated: Non-static method User::isPasswordStrong() should not be called statically in /var/www/loris/php/libraries/SinglePointLogin.class.inc on line 201" when resetting a password.

`git grep isPasswordStrong` shows that all calls to User::isPasswordStrong are already
made statically, so only the function signature needs to be updated.