### PR TITLE
[Core] Referencing 'master' branch in README instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,3 @@
-branches:
-  only:
-    - master
-    - major
-    - minor
-    - bugfix
-
 language: php
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+branches:
+  only:
+    - master
+    - major
+    - minor
+    - bugfix
+
 language: php
 
 cache:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LORIS Neuroimaging Platform [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
+# LORIS Neuroimaging Platform
 
 LORIS (Longitudinal Online Research and Imaging System) is a web-based data and project management software for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
@@ -9,6 +9,8 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/master)
 <hr>
+
+'master' branch status: [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
 
 This Readme covers installation of the <b>18.0</b> LORIS release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LORIS Neuroimaging Platform [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=17.1-dev)](https://travis-ci.org/aces/Loris)
+# LORIS Neuroimaging Platform [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
 
 LORIS (Longitudinal Online Research and Imaging System) is a web-based data and project management software for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
@@ -7,7 +7,7 @@ NEW <b>⇾  Try LORIS on Heroku</b> before installing it on your system<br>
 Test out the project management and clinical data management side of LORIS (complete Imaging features not yet available)<br>
 Deploy and log in with username <i>admin</i> and the password that's set up during deployment via ClearDB.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/17.1-dev)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/master)
 <hr>
 
 This Readme covers installation of the <b>18.0</b> LORIS release on <b>Ubuntu</b>.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 | --------------------- | -------- |
 | master         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
 
-This Readme covers installation of the <b>18.0</b> LORIS release on <b>Ubuntu</b>.
+This Readme covers installation of the LORIS <b>v18.0.0</b> release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).
 
 Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information not included in this Readme. The [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) may also provide installation guidance not covered in the Wiki. 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/master)
 <hr>
 
-| Branch      | Status |
-| --------------------- | -------- |
-| master         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
-| minor         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=minor)](https://travis-ci.org/aces/Loris)
+| Branch | Status |
+| ------ | ------ |
+| master | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
+| major  | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=major)](https://travis-ci.org/aces/Loris)
+| minor  | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=minor)](https://travis-ci.org/aces/Loris)
+| bugfix | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=bugfix)](https://travis-ci.org/aces/Loris)
 
 This Readme covers installation of the LORIS <b>v18.0.0</b> release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/aces/Loris/tree/master)
 <hr>
 
-'master' branch status: [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
+| Branch      | Status |
+| --------------------- | -------- |
+| master         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=17.0-dev)](https://travis-ci.org/aces/Loris)
 
 This Readme covers installation of the <b>18.0</b> LORIS release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 | Branch      | Status |
 | --------------------- | -------- |
 | master         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
+| minor         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=minor)](https://travis-ci.org/aces/Loris)
 
 This Readme covers installation of the LORIS <b>v18.0.0</b> release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 
 | Branch      | Status |
 | --------------------- | -------- |
-| master         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=17.0-dev)](https://travis-ci.org/aces/Loris)
+| master         |  [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
 
 This Readme covers installation of the <b>18.0</b> LORIS release on <b>Ubuntu</b>.
 ([CentOS Readme also available](https://github.com/aces/Loris/blob/master/README.CentOS6.md)).


### PR DESCRIPTION
Updating README now that 'master' is supposed to be up-to-date & 'stable'