### PR TITLE
Remove support for ancient module format, deprecate old one

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -145,9 +145,11 @@ class NDB_Caller
             // this code. If we do it right now, absolutely every page will
             // include an error.. at the very least, this should be uncommented
             // in 18.0 so that we can delete the old code for 19.0.
-            error_log("Module $test_name is missing Module class descriptor. "
-                 . "Modules missing a Module file will stop working in a future"
-                 . "version of LORIS.");
+            error_log(
+                "Module $test_name is missing Module class descriptor. "
+                . "Modules missing a Module file will stop working in a future"
+                . "version of LORIS."
+            );
             $ModuleDir = is_dir($base . "project/modules/$test_name")
                 ? $base . "project/modules/$test_name"
                 : $base . "modules/$test_name";
@@ -203,8 +205,8 @@ class NDB_Caller
             error_log("Could not load Loris module $test_name.");
             exit(-1);
         } else {
-            // Reliability and instruments aren't "real" modules. They probably should be
-            // at some point in the future.
+            // Reliability and instruments aren't "real" modules. They probably
+            // should be at some point in the future.
             $proj_reliable = $base . "project/reliability/"
                                    . "NDB_Reliability_$test_name.class.inc";
             if ($this->existsAndRequire($proj_reliable)

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -145,9 +145,9 @@ class NDB_Caller
             // this code. If we do it right now, absolutely every page will
             // include an error.. at the very least, this should be uncommented
             // in 18.0 so that we can delete the old code for 19.0.
-            //error_log("Module $mname is missing Module class descriptor. " .
-            //     . "Modules missing a Module file will stop working in a future"
-            //     . "version of LORIS.");
+            error_log("Module $test_name is missing Module class descriptor. "
+                 . "Modules missing a Module file will stop working in a future"
+                 . "version of LORIS.");
             $ModuleDir = is_dir($base . "project/modules/$test_name")
                 ? $base . "project/modules/$test_name"
                 : $base . "modules/$test_name";
@@ -203,61 +203,8 @@ class NDB_Caller
             error_log("Could not load Loris module $test_name.");
             exit(-1);
         } else {
-            // Old precedence style for "modules"
-            // This (except for instruments and reliability) should be removed
-            // in LORIS 18.0 now that all modules are updated, but we forgot
-            // to include a warning in the 16.x line so that we could have
-            // removed it in 17.0.
-            error_log(
-                "php/libraries 'modules' are deprecated and will be "
-                . " removed in a future release. Please update your code in "
-                . "$test_name to use proper LORIS style modules. See the loris-dev"
-                . "  mailing list for help if required."
-            );
-            // it is a menu
-            $proj_menu = $base . "project/libraries/NDB_Menu_$test_name.class.inc";
-            $php_menu  = $base . "php/libraries/NDB_Menu_$test_name.class.inc";
-
-            $proj_menu_filter = $base . "project/libraries/"
-                                      . "NDB_Menu_Filter_$test_name.class.inc";
-            $php_menu_filter  = $base . "php/libraries/"
-                                      . "NDB_Menu_Filter_$test_name.class.inc";
-
-            $proj_menu_filter_form = $base . "project/libraries/"
-                . "NDB_Menu_Filter_Form_$test_name.class.inc";
-            $php_menu_filter_form  = $base . "php/libraries/"
-                . "NDB_Menu_Filter_Form_$test_name.class.inc";
-
-            if (empty($subtest) && ($this->existsAndRequire($proj_menu)
-                || $this->existsAndRequire($php_menu)
-                || $this->existsAndRequire($proj_menu_filter)
-                || $this->existsAndRequire($php_menu_filter)
-                || $this->existsAndRequire($proj_menu_filter_form)
-                || $this->existsAndRequire($php_menu_filter_form))
-            ) {
-
-                $mode = $_REQUEST['mode'] ?? '';
-                $html = $this->loadMenu($test_name, $mode);
-
-                $this->type = 'menu';
-                return $html;
-            }
-
-            // it is a form
-            $proj_form = $base."project/libraries/NDB_Form_$test_name.class.inc";
-            $php_form  = $base."php/libraries/NDB_Form_$test_name.class.inc";
-            if ($this->existsAndRequire($proj_form)
-                || $this->existsAndRequire($php_form)
-            ) {
-
-                $identifier = $_REQUEST['identifier'] ?? '';
-                $html       = $this->loadForm($test_name, $subtest, $identifier);
-
-                $this->type = 'form';
-                return $html;
-            }
-
-            // it is a reliability form
+            // Reliability and instruments aren't "real" modules. They probably should be
+            // at some point in the future.
             $proj_reliable = $base . "project/reliability/"
                                    . "NDB_Reliability_$test_name.class.inc";
             if ($this->existsAndRequire($proj_reliable)


### PR DESCRIPTION
Remove support for modules of the format php/libraries/NDB_Menu_Filter_$modulename
where all the modules were jumbled together in php/libraries.

Deprecate support for modules/$modulename modules that are missing a Module
class.