### PR TITLE
[login] added slashes at the end of URL

### DIFF
--- a/smarty/templates/login.tpl
+++ b/smarty/templates/login.tpl
@@ -28,8 +28,8 @@
             </div>
           </form>
           <div class="help-links">
-            <a href="{$baseurl}/password-reset">Forgot your password?</a><br/>
-            <a href="{$baseurl}/request-account">Request Account</a>
+            <a href="{$baseurl}/password-reset/">Forgot your password?</a><br/>
+            <a href="{$baseurl}/request-account/">Request Account</a>
           </div>
           <div class="help-text">
             A WebGL-compatible browser is required for full functionality (Mozilla Firefox, Google Chrome)


### PR DESCRIPTION
This pull request adds slashes at the end of the password-reset and request-account urls because that is the expected behavior and in their absence nginx servers seem to throw a 301 error
