### PR TITLE
Ensure that UserID matches database when logging in

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -400,6 +400,7 @@ class SinglePointLogin
 
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
+                        UserID,
                         Password_expiry,
                         Active,
                         Pending_approval,
@@ -450,7 +451,7 @@ class SinglePointLogin
                 }
 
                 // user is valid
-                $this->_username = $username;
+                $this->_username = $row['UserID'];
 
                 $result =  $DB->insert('user_login_history', $setArray);
                 return true;


### PR DESCRIPTION
The MySQL string comparison in SinglePointLogin was
authenticating in a case-insensitive manner, resulting
in various places in the code failing if they tried to
compare $_SESSION['State']->getUsername() (which has
the value from when the user logged in) with User::singleton()->getUsername()
(which has the value from the database) in PHP (which,
unlike MySQL, *is* case sensitive.)

This updates the SinglePointLogin class so that it uses
the username from the database, rather than the HTTP request
for the username in $_SESSION['State'].