### PR TITLE
Fix mangling of numeric column names in instruments

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2134,7 +2134,7 @@ class LorisForm
     function getSubmitValues()
     {
         $retVal     = array();
-        $submitKeys = array_merge($_POST, $_FILES);
+        $submitKeys = $_POST + $_FILES;
 
         $this->getGroupValues(array_keys($submitKeys), $retVal);
         return $retVal;


### PR DESCRIPTION
In LorisForm, the array key for any numeric field name was getting
mangled to "0" by the array_merge function, causing the saving and
validation to fail.

This replaces array_merge with "+" to ensure that the keys do not
get changed in the submit values.
