### PR TITLE
Allow "0" to be saved in required fields

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1198,8 +1198,9 @@ class LorisForm
             if ($el['type'] === 'group') {
                 if (isset($el['required'])) {
                     foreach ($el['required'] as $elementIndex) {
-                        $childEl = $el['elements'][$elementIndex];
-                        if (empty(($this->getValue($childEl['name'])))) {
+                        $childEl  = $el['elements'][$elementIndex];
+                        $childVal = $this->getValue($childEl['name']);
+                        if ($childVal === null || $childVal === '') {
                             $this->setElementError(
                                 $el['name'],
                                 "$childEl[requireMsg]"


### PR DESCRIPTION
LorisForm was determining if a value is supplied by using the empty()
function, which means that 0 was not considered a submitted value.

This changes it to be more specific about what values it checks and only
denies null or the empty string.