### PR TITLE
Make Travis immediately exit if it fails linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,10 +91,6 @@ before_script:
  # - "LORIS_DB_CONFIG=test/config.xml"
 
 script:
-    - npm run lint:php
-    - npm run lint:javascript
-
-    # Run unit tests to make sure functions still do what they should.
-    - vendor/bin/phpunit --configuration test/phpunit.xml
+    - npm run lint:php && npm run lint:javascript && vendor/bin/phpunit --configuration test/phpunit.xml
 
 dist: precise


### PR DESCRIPTION
This makes Travis immediately fail if it fails a linting test, rather than waiting for the fully integration test suite to run before indicating failure.

This should speed up our CI process, since currently Travis is waiting for a backlog of builds (which mostly fail PHPCS) to finish before starting new builds.