### PR TITLE
Stop PHPUnit on first test failures

### DIFF
--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -2,7 +2,9 @@
 <phpunit
         bootstrap="bootstrap.php"
         verbose="true"
-        colors="true">
+        colors="true"
+        stopOnFailure="true"
+        >
     <testsuites>
         <testsuite name='LorisUnitTests'>
             <directory>./unittests/</directory>


### PR DESCRIPTION
This adds the flag to the Loris PHPunit configuration to cause it
to stop on the first error, rather than waiting until the whole
(long) integration test suite has failed before indicating a
problem on Travis.