### PR TITLE
[WIP] Switch instrument data loading from MySQL table to JSON column in flag table.

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -341,6 +341,15 @@ class NDB_BVL_Instrument extends NDB_Page
         }
     }
 
+    protected function getSavedValues() {
+
+        $db = Database::singleton();
+        $jsonstring = $db->pselectOne(
+                "SELECT Data FROM flag WHERE CommentID=:CID",
+                array('CID' => $this->getCommentID())
+        );
+        return json_decode($jsonstring, true);
+    }
 
 
     /**
@@ -388,16 +397,9 @@ class NDB_BVL_Instrument extends NDB_Page
             $this->addGroup($buttons, null, null, "&nbsp;");
         }
 
-        // get saved data to pre-populate form
-        $db = Database::singleton();
-
-        $defaults = $db->pselect(
-            "SELECT * FROM $this->table WHERE CommentID=:CID",
-            array('CID' => $this->getCommentID())
-        );
         // set the defaults (call private method _setDefaultsArray
         // which could be overridden if necessary)
-        $defaults = $this->_setDefaultsArray($defaults[0]);
+        $defaults = $this->_setDefaultsArray($this->getSavedValues());
 
         // merge in the localDefaults property so that simple
         // additions to the defaults array no longer requires
@@ -728,12 +730,6 @@ class NDB_BVL_Instrument extends NDB_Page
             $values = Utility::nullifyEmpty($values, $key);
         }
         $db     =& Database::singleton();
-        $result = $db->update(
-            $this->table,
-            $values,
-            array('CommentID' => $this->getCommentID())
-        );
-
         // Extract the old data and merge it with what was submitted so that we
         // don't overwrite data from other pages.
         $oldData = $db->pselectOne(
@@ -1351,10 +1347,14 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function getFieldValue($field)
     {
+
         $DB =& Database::singleton();
 
-        $query      = "SELECT $field FROM $this->table WHERE CommentID = :CID";
-        $fieldValue = $DB->pselectOne($query, array('CID' => $this->getCommentID()));
+        $query      = "SELECT Data FROM flag WHERE CommentID = :CID";
+        $json = $DB->pselectOne($query, array('CID' => $this->getCommentID()));
+        $allfields = json_decode($json, true);
+        $fieldValue = $allfields[$field];
+
 
         if (!empty($fieldValue)) {
             return $fieldValue;
@@ -1396,14 +1396,8 @@ class NDB_BVL_Instrument extends NDB_Page
 
         $db =& Database::singleton();
 
-        $query = "SELECT " . join(',', $this->_requiredElements)
-            . " FROM $this->table WHERE CommentID=:CID";
-
-        $dataFields = $db->pselectRow(
-            $query,
-            array('CID' => $this->getCommentID())
-        );
-        foreach ($dataFields as $field) {
+        $dataFields = $this->getSavedValues();
+        foreach ($this->_requiredElements as $field) {
             // this shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
             if (is_null($field) || $field === "") {
@@ -1421,11 +1415,7 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function getDataEntryCompletionStatus()
     {
-        $db =& Database::singleton();
-
-        $query = "SELECT Data_entry_completion_status
-            FROM $this->table WHERE CommentID=:CID";
-        return $db->pselectOne($query, array('CID' => $this->getCommentID()));
+        return $this->getFieldValue("Data_entry_completion_status");
     }
 
 
@@ -1447,13 +1437,10 @@ class NDB_BVL_Instrument extends NDB_Page
             );
         }
 
-        $db =& Database::singleton();
-
-        $success = $db->update(
-            $this->table,
-            array('Data_entry_completion_status' => $status),
-            array('CommentID' => $this->getCommentID())
-        );
+        $fields = $this->getSavedValues();
+        // FIXME: This should probably be moved to the flag table.
+        $fields['Data_entry_completion_status'] = $status;
+        $this->_saveValues($fields);
     }
 
     /**
@@ -1914,13 +1901,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
         }
 
-        // update the scores
-        $success = $db->update(
-            $this->table,
-            $scores,
-            array('CommentID' => $this->getCommentID())
-        );
-
+        $this->_saveValues($scores);
         return;
     }
 

--- a/tools/assign_missing_json.php
+++ b/tools/assign_missing_json.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once __DIR__ . "/../vendor/autoload.php";
+
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize();
+
+$config = NDB_Config::singleton();
+$db = Database::singleton();
+
+$rows = $db->pselect("SELECT Test_name, CommentID FROM flag WHERE Data IS NULL ORDER BY Test_name", array());
+
+foreach ($rows as $row) {
+    $inst = NDB_BVL_Instrument::factory($row['Test_name'], $row['CommentID'], "");
+    $data = NDB_BVL_Instrument::loadInstanceData($inst);
+    // Unset things that are on the flag table
+    unset($data['CommentID'], $data['UserID'], $data['Testdate']);
+    // FIXME: Figure out what to do with this. Is should be moved to the flag table?
+    //unset($data['Data_entry_completion_status']);
+    // FIXME: It would also make sense to move Examiner to the flag table, since every instrument
+    //        has it and that way it could include a foreign key (or be null for instruments that don't have it).
+    print $row['Test_name'] . " " . $row['CommentID'] . "\n";
+    $db->unsafeUpdate(
+        "flag",
+        array("Data" => json_encode($data)),
+        array('CommentID' => $row['CommentID'])
+    );
+}
+


### PR DESCRIPTION
This updates the LORIS code to use the `Data` column of JSON data from the `flag` for instrument data. The Data column was added in 18.0 with experimental support to save to it, and this updates the code to use the data column, as well as a script to back-populate existing data from the existing instrument MySQL tables.

This should lower the administrative overhead of instruments and remove most of the need for MySQL administrator access for normal LORIS usage (after the initial install.) 
 
TODO:
- [ ] Add feature flag to enable it on an experimental basis for at least one release before switching cold turkey
- [ ] Update DQT import script
- [ ] Move examiner to the flag table (with a foreign key).
- [ ] Move Data_entry_completion_status to the flag table (and rename to something less confusing at the same time?)
- [ ] Change column type from TEXT to JSON?
- [ ] Test more thoroughly on a variety of instruments