### PR TITLE
MRI Violated scans: use getStudySites() from the User class for cleanup

### DIFF
--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -409,7 +409,6 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $sites = array();
             $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_mri_violations.class.inc
@@ -409,14 +409,8 @@ class NDB_Menu_Filter_Form_Mri_Violations extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $sites    = array();
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
-                }
-            }
+            $sites = array();
+            $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }
         $this->addSelect('Site', 'Site', $sites);

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -393,14 +393,8 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $sites    = array();
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
-                }
-            }
+            $sites = array();
+            $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }
         $this->addSelect('Site', 'Site', $sites);

--- a/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
+++ b/modules/mri_violations/php/NDB_Menu_Filter_Form_resolved_violations.class.inc
@@ -393,7 +393,6 @@ class NDB_Menu_Filter_Form_Resolved_Violations extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $sites = array();
             $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }


### PR DESCRIPTION
Cleanup the code to use the getStudySites() in the User class that was introduced in #2996 for data team helper.
This is one of many similar pull requests to come.

In reference to Redmine 12946;