### PR TITLE
[Install/Vagrant] Add zip + unzip to vagrant install so that composer works 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
     sudo add-apt-repository ppa:ondrej/php
     sudo apt-get -q update
 
-    apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php php-mysql php-gd php-json php-xml
+    apt-get install -yq libapache2-mod-php libmysqlclient-dev mysql-client mysql-server php php-mysql php-gd php-json php-xml zip unzip
 
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');
     \\\$hash = trim(file_get_contents('https://composer.github.io/installer.sig'));


### PR DESCRIPTION
Composer fails to download packages after running the command `vagrant up` with many errors similar to the following:

"`Failed to download firebase/php-jwt from dist: The zip extension and unzip command are both missing, skipping.`"

This PR adds `zip` and `unzip` to the install process and composer should work properly as a result.