### PR TITLE
[create_timepoint,new_profile] Added site validation toform

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -230,8 +230,9 @@ class Create_Timepoint extends \NDB_Form
 
         // validate site entered
         $site = $val['psc'];
-
-        if (empty($site) || !$user->hasCenter($site)) {
+        $user_list_of_sites = $user->getData('CenterIDs');
+        $num_sites          = count($user_list_of_sites);
+        if ($num_sites > 1 && (empty($site) || !$user->hasCenter($site))) {
             $errors['psc'] = "Site must be selected from the available dropdown.";
         }
 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -189,23 +189,22 @@ class Create_Timepoint extends \NDB_Form
         // label rules
         if ($visitLabelAdded) {
             $this->addRule('visitLabel', 'Visit label is required', 'required');
-             // List of sites for the user
-             $user = \User::singleton();
-             $DB   = \Database::singleton();
-             $user_list_of_sites = $user->getData('CenterIDs');
-             $num_sites          = count($user_list_of_sites);
-
+            // List of sites for the user
+            $user = \User::singleton();
+            $DB   = \Database::singleton();
+            $user_list_of_sites = $user->getData('CenterIDs');
+            $num_sites          = count($user_list_of_sites);
             if ($num_sites >1) {
                 $pscLabelAdded =true;
                 $this->tpl_data['pscLabelAdded'] = true;
                 $psc_labelOptions = array(null => '');
                 foreach ($user_list_of_sites as $key => $siteID) {
-                        $center = $DB->pselectRow(
-                            "SELECT CenterID as ID, Name FROM psc 
+                    $center = $DB->pselectRow(
+                        "SELECT CenterID as ID, Name FROM psc 
                         WHERE CenterID =:cid",
-                            array('cid' => $siteID)
-                        );
-                        $psc_labelOptions[$siteID] = $center['Name'];
+                        array('cid' => $siteID)
+                    );
+                    $psc_labelOptions[$siteID] = $center['Name'];
                 }
             }
             $this->addSelect('psc', 'Site', $psc_labelOptions);
@@ -225,7 +224,16 @@ class Create_Timepoint extends \NDB_Form
      */
     function _validate(array $val)
     {
+        $user = \User::singleton();
+
         $errors = array();
+
+        // validate site entered
+        $site = $val['psc'];
+
+        if (empty($site) || !$user->hasCenter($site)) {
+            $errors['psc'] = "Site must be selected from the available dropdown.";
+        }
 
         $candid       = $this->identifier;
         $subprojectID = $val['subprojectID'];

--- a/modules/create_timepoint/test/TestPlan
+++ b/modules/create_timepoint/test/TestPlan
@@ -11,13 +11,14 @@ Create Timepoint Test Plan:
    candidate.[Manual Testing]
 5. Click create time point without choosing visit. Ensure there's an error.
    [Automation Testing]
-6. Choose visit label to be created and click "Create Time Point".
+6. Click create time point without choosing a site. Ensure there's an error
+7. Choose visit label to be created and click "Create Time Point".
    Ensure that you get a page saying creation was successful.
    Click on "Click here to continue" link and ensure that it brings you back
    to timepoint list page for that candidate (with new timepoint created)
    [Manual Testing]
-7. Repeat the steps above after creating a New Candidate.
+8. Repeat the steps above after creating a New Candidate.
    [Manual Testing]
-8. Check that page is inaccessible if either the user does not have data_entry
+9. Check that page is inaccessible if either the user does not have data_entry
    permission or the user and candidate are not the same site.
    [Manual Testing]

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -248,6 +248,7 @@ class NDB_Form_New_Profile extends NDB_Form
         $errors = array();
 
         $config =& NDB_Config::singleton();
+        $user   = \User::singleton();
 
         if ($values['dob1'] != $values['dob2']) {
             $errors['dob1'] = 'Date of Birth fields must match.';
@@ -297,6 +298,14 @@ class NDB_Form_New_Profile extends NDB_Form
                     $errors['PSCID'] = 'PSCID has already been registered';
             }
         }
+
+        // validate site entered
+        $site = $values['psc'];
+
+        if (empty($site) || !$user->hasCenter($site)) {
+            $errors['psc'] = "Site must be selected from the available dropdown.";
+        }
+
         $useProjects = $config->getSetting('useProjects');
         if ($useProjects === "true" && empty($values['ProjectID'])) {
             $errors['ProjectID'] = "Project is required";

--- a/modules/new_profile/php/NDB_Form_new_profile.class.inc
+++ b/modules/new_profile/php/NDB_Form_new_profile.class.inc
@@ -301,8 +301,9 @@ class NDB_Form_New_Profile extends NDB_Form
 
         // validate site entered
         $site = $values['psc'];
-
-        if (empty($site) || !$user->hasCenter($site)) {
+        $user_list_of_sites = $user->getData('CenterIDs');
+        $num_sites          = count($user_list_of_sites);
+        if ($num_sites > 1 && (empty($site) || !$user->hasCenter($site))) {
             $errors['psc'] = "Site must be selected from the available dropdown.";
         }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -491,7 +491,8 @@ class User extends UserPermissions
     {
         return in_array(
             $center_id,
-            $this->getCenterIDs()
+            $this->getCenterIDs(),
+            true
         );
     }
     /**


### PR DESCRIPTION
This adds validation to site value entered to avoid submitting the form with either no value selected or and incorrect value.

To test: 
- before going on this branch try creating a timepoint without a site (this is only possible in create_timepoint because new_profile has front end validation)
- after checking out the branch, try doing the same, an error should be thrown
- in new_profile and create_timepoint, try modifying the ID of the psc value selected using the inspector in the browser, try submitting, an error should be displayed
