### PR TITLE
[Core] Fixing NDB_Client command line user instantiation

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -89,7 +89,7 @@ class NDB_Client
         if (!$this->_isWebClient) {
             // Set user as unix username.
             // Requires Loris to have user with this username
-            $user =& User::singleton(get_current_user());
+            $user =& User::singleton(getenv('USER'));
             return true;
         }
 


### PR DESCRIPTION
Correctly calling User singleton with the accurate username

This came up because when fix_timepoint_date_problems.php calls User::singleton, it passes the current unix user as an argument but it's pretty useless since the static instance is already being initialized at the beginning. Plus the code is incorrectly using the "owner of the file" as the argument. This also fixes the inaccurate error message produced by fix_timepoint_date_problems.php.

We can also merge https://github.com/aces/Loris/pull/3216 once this is merged.