### PR TITLE
[Conflict Resolver] Convert module to LORIS module

### DIFF
--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -318,6 +318,12 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     /**
      * Sets up the smarty menu filter items for the conflict resolver
      *
+     * @param string $name       The test name being accessed
+     * @param string $page       The subtest being accessed (may be null)
+     * @param string $identifier The identifier for the data to load on this page
+     * @param string $commentID  The CommentID to load the data for
+     * @param string $formname   The name to give this form
+     *
      * @return none
      */
     function _setupPage($name, $page, $identifier, $commentID, $formname)

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -11,7 +11,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
-
+namespace LORIS\conflict_resolver;
 /**
  * Menu_Filter_Form_Conflicts_Resolver Class
  *
@@ -24,7 +24,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
-class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
+class Conflict_Resolver extends \NDB_Menu_Filter_Form
 {
 
     /**
@@ -36,7 +36,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
     function _hasAccess()
     {
         // create user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
         return ($user->hasPermission('conflict_resolver'));
     }
 
@@ -54,9 +54,9 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
             return true;
         }
 
-        $DB =& Database::singleton();
+        $DB =& \Database::singleton();
 
-        $user =& User::singleton();
+        $user =& \User::singleton();
 
         foreach ($values AS $key => $val) {
             // The only valid values are 1, 2 or none.  Therefore we are only
@@ -130,7 +130,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
 
                     $TableName = $row['TableName'];
 
-                    $Instrument = NDB_BVL_Instrument::factory(
+                    $Instrument = \NDB_BVL_Instrument::factory(
                         $TableName,
                         $row['CommentId1'],
                         '',
@@ -152,7 +152,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
                         // not the instrument
                     }
 
-                    $Instrument = NDB_BVL_Instrument::factory(
+                    $Instrument = \NDB_BVL_Instrument::factory(
                         $TableName,
                         $row['CommentId2'],
                         '',
@@ -183,8 +183,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
      */
     function _setupVariables()
     {
-
-        $config =& NDB_Config::singleton();
+        $config =& \NDB_Config::singleton();
 
         // set the class variables
         $useProjects = $config->getSetting("useProjects");
@@ -239,7 +238,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
             LEFT JOIN Project ON (candidate.ProjectID=Project.ProjectID )
             WHERE 1=1";
 
-        $user = User::singleton();
+        $user = \User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -321,25 +320,26 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
      *
      * @return none
      */
-    function _setFilterForm()
+    function _setupPage($name, $page, $identifier, $commentID, $formname)
     {
+        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
         // Create user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
 
-        $config =& NDB_Config::singleton();
+        $config =& \NDB_Config::singleton();
 
         // Get instruments
-        $instruments = Utility::getAllInstruments();
+        $instruments = \Utility::getAllInstruments();
         $instruments = array_merge(array('' => 'All Instruments'), $instruments);
 
         // Get visits
-        $visits = Utility::getVisitList();
+        $visits = \Utility::getVisitList();
         $visits = array_merge(array('' => 'All'), $visits);
 
         // Get sites
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
-            $sites = Utility::getSiteList();
+            $sites = \Utility::getSiteList();
             if (is_array($sites)) {
                 $sites = array('' => 'All') + $sites;
             }
@@ -374,7 +374,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         // Project list, if applicable
         if ($config->getSetting("useProjects")==="true") {
             $list_of_projects = array(null => 'All');
-            $projectList      = Utility::getProjectList();
+            $projectList      = \Utility::getProjectList();
             foreach ($projectList as $key => $value) {
                 $list_of_projects[$key] = $value;
             }
@@ -394,7 +394,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
     function _getFullList()
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB =& \Database::singleton();
 
         $qparams = array();
         // add the base query
@@ -447,7 +447,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
      */
     function getJSDependencies()
     {
-        $factory = NDB_Factory::singleton();
+        $factory = \NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
         $deps    = parent::getJSDependencies();
         return array_merge(
@@ -456,5 +456,3 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
         );
     }
 }
-
-?>

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This serves as a hint to LORIS that this module is a real module.
+ * It does nothing but implement the module class in the module's namespace.
+ *
+ * PHP Version 5
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Conflict_Resolver
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris-Trunk/
+ */
+namespace LORIS\conflict_resolver;
+
+/**
+ * Class module implements the basic LORIS module functionality
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Conflict_Resolver
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris-Trunk/
+ */
+class Module extends \Module
+{
+}

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -11,6 +11,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris-Trunk
  */
+namespace LORIS\conflict_resolver;
 
 /**
  * Menu_Filter_Form_resolved_conflicts Class
@@ -25,7 +26,7 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
+class Resolved_Conflicts extends \NDB_Menu_Filter
 {
 
     /**
@@ -36,7 +37,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& User::singleton();
+        $user =& \User::singleton();
         return ($user->hasPermission('conflict_resolver'));
     }
 
@@ -49,7 +50,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $config =& NDB_Config::singleton();
+        $config =& \NDB_Config::singleton();
 
         $useProjects = $config->getSetting("useProjects");
         if ($useProjects === "false") {
@@ -85,7 +86,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             LEFT JOIN Project ON (candidate.ProjectID=Project.ProjectID )
             WHERE 1=1";
 
-        $user = User::singleton();
+        $user = \User::singleton();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -177,24 +178,25 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
      *
      * @return none
      */
-    function _setFilterForm()
+    function _setupPage($name, $page, $identifier, $commentID, $formname)
     {
+        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
         // Create user object
-        $user   =& User::singleton();
-        $config =& NDB_Config::singleton();
+        $user   =& \User::singleton();
+        $config =& \NDB_Config::singleton();
 
         // Get instruments
-        $instruments = Utility::getAllInstruments();
+        $instruments = \Utility::getAllInstruments();
         $instruments = array_merge(array('' => 'All Instruments'), $instruments);
 
         // Get visits
-        $visits = Utility::getVisitList();
+        $visits = \Utility::getVisitList();
         $visits = array_merge(array('' => 'All'), $visits);
 
         // Get sites
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
-            $sites = Utility::getSiteList();
+            $sites = \Utility::getSiteList();
             if (is_array($sites)) {
                 $sites = array('' => 'All') + $sites;
             }
@@ -230,7 +232,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         // Project list, if applicable
         if ($config->getSetting("useProjects")==="true") {
             $list_of_projects = array(null => 'All');
-            $projectList      = Utility::getProjectList();
+            $projectList      = \Utility::getProjectList();
             foreach ($projectList as $key => $value) {
                 $list_of_projects[$key] = $value;
             }
@@ -251,7 +253,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
     function _getFullList()
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB =& \Database::singleton();
 
         $qparams = array();
         // add the base query
@@ -297,7 +299,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
      */
     function getJSDependencies()
     {
-        $factory = NDB_Factory::singleton();
+        $factory = \NDB_Factory::singleton();
         $baseURL = $factory->settings()->getBaseURL();
         $deps    = parent::getJSDependencies();
         $urls    = "/conflict_resolver/js/resolved_conflicts_columnFormatter.js";
@@ -307,5 +309,3 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
         );
     }
 }
-
-?>

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -176,6 +176,12 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     /**
      * Adds the form elements required for the filter
      *
+     * @param string $name       The test name being accessed
+     * @param string $page       The subtest being accessed (may be null)
+     * @param string $identifier The identifier for the data to load on this page
+     * @param string $commentID  The CommentID to load the data for
+     * @param string $formname   The name to give this form
+     *
      * @return none
      */
     function _setupPage($name, $page, $identifier, $commentID, $formname)

--- a/modules/conflict_resolver/templates/menu_conflict_resolver.tpl
+++ b/modules/conflict_resolver/templates/menu_conflict_resolver.tpl
@@ -73,7 +73,7 @@
 <div id="tabs" style="background: white">
     <ul class="nav nav-tabs ">
         <li class="active"><a id="onLoad">Unresolved Conflicts</a></li>
-        <li><a href="{$baseurl}/conflict_resolver/?submenu=resolved_conflicts">Resolved Conflicts</a></li>
+        <li><a href="{$baseurl}/conflict_resolver/resolved_conflicts">Resolved Conflicts</a></li>
     </ul>
     <div class="tab-content">
         <div class="tab-pane active">

--- a/modules/conflict_resolver/templates/menu_resolved_conflicts.tpl
+++ b/modules/conflict_resolver/templates/menu_resolved_conflicts.tpl
@@ -1,7 +1,7 @@
 <script src="{$baseurl}/js/filterControl.js" type="text/javascript"></script>
 <div class="col-sm-12">
     <div class="col-md-8 col-sm-8">
-        <form method="post" action="{$baseurl}/conflict_resolver/?submenu=resolved_conflicts">
+        <form method="post" action="{$baseurl}/conflict_resolver/resolved_conflicts">
             <div class="panel panel-primary">
                 <div class="panel-heading" onclick="hideFilter();">
                     Selection Filter
@@ -55,7 +55,7 @@
                             <div class="visible-xs col-xs-12"> </div>
                             <div class="visible-xs col-xs-12"> </div>
                             <div class="col-sm-5 col-xs-12">
-                                <input type="button" name="reset" value="Clear Form" id="testClearForm1" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/conflict_resolver/?submenu=resolved_conflicts&reset=true'">
+                                <input type="button" name="reset" value="Clear Form" id="testClearForm1" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/conflict_resolver/resolved_conflicts?reset=true'">
                             </div>
                         </div>
                     </div>
@@ -64,7 +64,7 @@
                             <input type="submit" name="filter" value="Show Data" class="btn btn-sm btn-primary col-xs-12"/>
                         </div>
                         <div class="col-sm-6 col-xs-12">
-                            <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/conflict_resolver/?submenu=resolved_conflicts&reset=true'">
+                            <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/conflict_resolver/resolved_conflicts?reset=true'">
                         </div>
                     </div>
                     <input type="hidden" name="test_name" value="conflict_resolver" />
@@ -89,7 +89,7 @@
 <script>
 loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
 var table = RDynamicDataTable({
-     "DataURL" : "{$baseurl}/conflict_resolver/?submenu=resolved_conflicts&format=json",
+     "DataURL" : "{$baseurl}/conflict_resolver/resolved_conflicts?format=json",
      "getFormattedCell" : formatColumn,
      "freezeColumn" : "Instrument"
   });


### PR DESCRIPTION
Add namespace and module class descriptor to conflict resolver.

(This also removes the need for the submenu hack that was in place
to allow 2 menu filters in the same module for the conflict resolver,
and, in fact, doesn't work with the namespaced module structure.)