### PR TITLE
Issue tracker: use getStudySites() from the User class for cleanup

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -563,13 +563,7 @@ function getIssueFields()
         $sites = Utility::getAssociativeSiteList();
     } else {
         // allow only to view own site data
-        $site_arr = $user->getData('CenterIDs');
-        foreach ($site_arr as $key=>$val) {
-            $site_arr[$key] = Site::singleton($val);
-            if ($site_arr[$key]->isStudySite()) {
-                $sites[$val] = $site_arr[$key]->getCenterName();
-            }
-        }
+        $sites = $user->getStudySites();
     }
 
     //not yet ideal permissions

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_issue_tracker.class.inc
@@ -165,13 +165,7 @@ class NDB_Menu_Filter_Form_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$val] = $site[$key]->getCenterName();
-                }
-            }
+            $list_of_sites = $user->getStudySites();
             $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_my_issue_tracker.class.inc
@@ -164,13 +164,7 @@ class NDB_Menu_Filter_Form_My_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key=>$val) {
-                $site[$key] = Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$key] = $site[$key]->getCenterName();
-                }
-            }
+            $list_of_sites = $user->getStudySites();
             $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 

--- a/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/NDB_Menu_Filter_Form_resolved_issue_tracker.class.inc
@@ -163,14 +163,8 @@ class NDB_Menu_Filter_Form_Resolved_Issue_Tracker extends NDB_Menu_Filter_Form
                 $list_of_sites = array('' => 'All') + $list_of_sites;
             }
         } else {// allow only to view own site data
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
-                }
-            }
-            $list_of_sites = array('' => 'All User Sites') + $sites;
+            $list_of_sites = $user->getStudySites();
+            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 
         //reporters


### PR DESCRIPTION
this pull request is similar to #3197 but for Issue Tracker.

Cleanup the code to use the getStudySites() in the User class that was introduced in #2996 for data team helper.
This is one of many similar pull requests to come.

In reference to Redmine 12946;
