### PR TITLE
Conflict resolver: use getStudySites() from the User class for cleanup

### DIFF
--- a/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_Form_conflict_resolver.class.inc
@@ -345,14 +345,7 @@ class NDB_Menu_Filter_Form_Conflict_Resolver extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $sites    = array();
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
-                }
-            }
+            $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }
 

--- a/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/NDB_Menu_Filter_resolved_conflicts.class.inc
@@ -200,14 +200,7 @@ class NDB_Menu_Filter_Resolved_Conflicts extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $sites    = array();
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
-                }
-            }
+            $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }
 


### PR DESCRIPTION
this pull request is similar to #3197 but for Conflict resolver

Cleanup the code to use the getStudySites() in the User class that was introduced in #2996 for data team helper.
This is one of many similar pull requests to come.

In reference to Redmine 12946;
