### PR TITLE
Updating Contributing.md with new 18+ dev branch practices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,10 @@ before contributing is probably sign up for the [LORIS developers' mailing list]
 
 ## Development branches
 
-Pull requests should be based on and sent to the VERSIONNUMBER-dev branch of the version that you are targeting. The master branch is reserved for stable releases.
-
+The master branch is reserved for stable releases.
 Your current version number can be found in the VERSION file under the LORIS root.
+
+Pull requests should be based on and sent to a specific development branch according to the [Loris Wiki: Contributing to the Code](https://github.com/aces/Loris/wiki/Contributing-to-the-Code) guidelines  
 
 ## Code Contributions
 
@@ -22,18 +23,24 @@ If you'd like to contribute code, here are some things to keep in mind.
   If you have questions, feel free to mail the mailing list.
 * Add your new tests to get auto-run by Travis in the .travis.yml to make sure that
   other people don't accidentally break your module.
-* Check out our Coding Standards in the [docs/ directory](https://github.com/aces/Loris/tree/master/docs) and also our [Code Review Checklist](https://github.com/aces/Loris/wiki/Code-Review-Checklist) in the [GitHub Wiki](https://github.com/aces/Loris/wiki) and the Pull Request guidelines Readme in this directory. 
+
 * Try and make sure you run PHP codesniffer using the standards file in
   docs/LorisCS.xml before sending any pull request, otherwise the Loris tests may
   fail and we won't be able to merge your pull request.
-* Keep in mind that people are currently using Loris so try and make any changes
+  
+
+  * Check out our Coding Standards in the [docs/ directory](https://github.com/aces/Loris/tree/master/docs) and also our [Code Review Checklist](https://github.com/aces/Loris/wiki/Code-Review-Checklist) in the [GitHub Wiki](https://github.com/aces/Loris/wiki) and the Pull Request guidelines Readme in this directory. 
+  
+* Keep in mind that many projects using Loris so try to make any changes
   backwards-compatible with existing installations. If you must change something
   in a non-backwards-compatible way, document it in your pull request description and
   tag it with "Caveat For Existing Projects" so that we know that the change needs
-  to be mentioned in release notes. Non-backwards-compatible changes should be sent
-  to the next major release (e.g. 17.X -> 18.0) while backwards-compatible changes should
-  be sent to the next minor release (e.g. 17.1.0 -> 17.2.0) and backwards-compatible bug
-  fixes should be sent to the next minor release update (e.g. 17.1.0 -> 17.1.1)
+  to be mentioned in release notes. 
+* Choosing a branch: see [Contributing to the Code](https://github.com/aces/Loris/wiki/Contributing-to-the-Code) for full guidelines. 
+  Non-backwards-compatible changes should be sent
+  to the `major` branch (e.g. 18.* -> 19.0), while backwards-compatible changes should
+  be sent to the `minor` branch (e.g. 18.0.* -> 18.1), and backwards-compatible bug
+  fixes should be sent to `bugfix` branch (e.g. 18.1.0 -> 18.1.1)
 
 ## Ways To Get Started
 


### PR DESCRIPTION
This PR updates the `Contributing.md` file within post 18.0-release practice changes.
* points more to Rida's [Loris Wiki: Contributing to the Code](https://github.com/aces/Loris/wiki/Contributing-to-the-Code) page. 
* moves us away from the practice of committing to a `versionnum-dev` branch


