### PR TITLE
[ImgUploader] Fixing Readme typos and markdown

### DIFF
--- a/modules/imaging_uploader/README.md
+++ b/modules/imaging_uploader/README.md
@@ -1,12 +1,14 @@
-For the imaging uploader can handle large files, please update the apache configuration file
-with the following values
+To enable the Imaging Uploader to handle large files, please update the apache configuration file
+with the following values.
 
-File to update : /etc/php5/apache2/php.ini
+File to update : `/etc/php5/apache2/php.ini`
 
 Sample values: 
 
+```
 session.gc_maxlifetime = 10800
 max_input_time = 10800
 max_execution_time = 10800
 upload_max_filesize = 1024M
 post_max_size = 1024M
+```


### PR DESCRIPTION
Fixing typos and markdown in the Readme for the Imaging Uploader, since it contains apache configuration instructions that are critical for successfully uploading scans
