### PR TITLE
[Issue Tracker] Fix issue creation

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -303,7 +303,7 @@ function getChangedValues($issueValues, $issueID)
     $changedValues = [];
     foreach ($issueValues as $key => $value) {
         // Only include fields that have changed
-        if ($issueValues[$key] != $issueData[$key] && !empty($value)) {
+        if ($issueValues[$key] != ($issueData[$key] ?? '') && !empty($value)) {
             $changedValues[$key] = $value;
         }
     }


### PR DESCRIPTION
Issue creation does not currently work (or rather, it works but
then displays an error message saying it didn't work) in PHP7 or
higher (effectively, this means that the issue tracker doesn't work
since the minimum supported version of PHP is PHP7..), because of
a PHP warning thats generated and printed in the AJAX response
before printing the JSON which is the expected return value.

This uses the null coalesce operator to suppress the warning and
make the module work again.
