### PR TITLE
[user_accounts] Examiner validation missing 0 bug

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -1271,7 +1271,7 @@ class NDB_Form_User_Accounts extends NDB_Form
         //======================================
         $matched =false;
         foreach ($values as $k=>$v) {
-            if (preg_match("/^ex_[1-9]+$/", $k)) {
+            if (preg_match("/^ex_[0-9]+$/", $k)) {
                 $matched =true;
                 if ($values['examiner_radiologist'] == '') {
                     $errors['examiner_group'] = "Please specify if examiner is a " .


### PR DESCRIPTION
This modifies a regex to match with zeros where it should have already been the case. Without this PR, on the edit_user page, when a checkbox for `examiner at:` is associated with a site with a `0` in its ID, the validation will not match it and thus throw an error. 
