### PR TITLE
Examiner: use getStudySites() from the User class for cleanup

### DIFF
--- a/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
+++ b/modules/examiner/php/NDB_Menu_Filter_Form_examiner.class.inc
@@ -142,14 +142,7 @@ class NDB_Menu_Filter_Form_Examiner extends NDB_Menu_Filter_Form
             }
         } else {
             // allow only to view own site data
-            $sites    = array();
-            $site_arr = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $sites[$val] = $site[$key]->getCenterName();
-                }
-            }
+            $sites = $user->getStudySites();
             $sites = array('' => 'All User Sites') + $sites;
         }
 


### PR DESCRIPTION
this pull request is similar to #3197 but for Examiners

Cleanup the code to use the getStudySites() in the User class that was introduced in #2996 for data team helper.
This is one of many similar pull requests to come.

In reference to Redmine 12946;
