### PR TITLE
Document Repository: use getStudySites() from the User class for cleanup

### DIFF
--- a/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
+++ b/modules/document_repository/php/NDB_Menu_Filter_document_repository.class.inc
@@ -137,15 +137,8 @@ class NDB_Menu_Filter_Document_Repository extends NDB_Menu_Filter
             }
         } else {
             // allow only to view own site data
-            $list_of_sites = array();
-            $site_arr      = $user->getData('CenterIDs');
-            foreach ($site_arr as $key => $val) {
-                $site[$key] = &Site::singleton($val);
-                if ($site[$key]->isStudySite()) {
-                    $list_of_sites[$val] = $site[$key]->getCenterName();
-                }
-                $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
-            }
+            $list_of_sites = $user->getStudySites();
+            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
         }
 
         $list_of_instruments = Utility::getAllInstruments();


### PR DESCRIPTION
this pull request is similar to #3197 but for Document Repository

Cleanup the code to use the getStudySites() in the User class that was introduced in #2996 for data team helper.
This is one of many similar pull requests to come.

In reference to Redmine 12946;
