### PR TITLE
[Utility] return a consistently sorted list of sites

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -295,6 +295,7 @@ class User extends UserPermissions
     {
         $site_list = $this->userInfo['examiner'];
         unset($site_list['pending']);
+        natcasesort($site_list);
         return $site_list;
     }
 
@@ -313,6 +314,7 @@ class User extends UserPermissions
                 $user_study_sites[$val] = $site[$key]->getCenterName();
             }
         }
+        natcasesort($user_study_sites);
         return $user_study_sites;
     }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -56,7 +56,7 @@ class User extends UserPermissions
 
         // get user data from database
         $query = "SELECT users.*,
-            GROUP_CONCAT(psc.Name SEPARATOR ';') AS Sites
+            GROUP_CONCAT(psc.Name ORDER BY psc.Name SEPARATOR ';') AS Sites
             FROM users
             LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -198,7 +198,7 @@ class Utility
         if ($study_site) {
             $query .= "WHERE Study_site='Y'";
         }
-
+        $query .= "ORDER BY Name";
         $result = $DB->pselect($query, array());
 
         // fix the array

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -198,7 +198,6 @@ class Utility
         if ($study_site) {
             $query .= "WHERE Study_site='Y'";
         }
-        $query .= "ORDER BY Name";
         $result = $DB->pselect($query, array());
 
         // fix the array
@@ -206,6 +205,7 @@ class Utility
         foreach ($result as $row) {
             $list[$row["CenterID"]] = $row["Name"];
         }
+        natcasesort($list);
         return $list;
     }
 


### PR DESCRIPTION
This adds a php natcasesort() call to return the list sorted alphabetically.

this can be tested in candidate_list menu filter where sites should now show up sorted
