### PR TITLE
[Core] FileUpload class - removing pass by reference

### DIFF
--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -148,7 +148,7 @@ class File_Upload
     function preProcessFile()
     {
         if (!$this->isCLImport) {
-            $this->file =& $this->form->getElement($this->fieldName);
+            $this->file = $this->form->getElement($this->fieldName);
             if (!method_exists($this->file, "isUploadedFile")) {
                 return false;
             }


### PR DESCRIPTION
Get rid of : `PHP Notice:  Only variables should be assigned by reference in /var/www/loris_1/php/libraries/File_Upload.class.inc on line 151` by removing the `&` 