### PR TITLE
[Database] Deleting empty queries

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -6,8 +6,6 @@ DROP TABLE IF EXISTS `acknowledgements`;
 DROP TABLE IF EXISTS `data_release_permissions`;
 DROP TABLE IF EXISTS `data_release`;
 
-DROP TABLE IF EXISTS `empty_queries`;
-
 DROP TABLE IF EXISTS `ExternalLinks`;
 DROP TABLE IF EXISTS `ExternalLinkTypes`;
 
@@ -1820,18 +1818,6 @@ INSERT INTO `ExternalLinks` (LinkTypeID, LinkText, LinkURL) VALUES
   ((SELECT LinkTypeID from ExternalLinkTypes WHERE LinkType='StudyLinks'), 'Loris Website', 'http://www.loris.ca'),
   ((SELECT LinkTypeID from ExternalLinkTypes WHERE LinkType='StudyLinks'), 'GitHub', 'https://github.com/aces/Loris'),
   ((SELECT LinkTypeID from ExternalLinkTypes WHERE LinkType='dashboard'), 'Loris Website', 'http://www.loris.ca');
-
--- ********************************
--- empty_queries
--- ********************************
-
-
-CREATE TABLE `empty_queries` (
-  `ID` int(11) NOT NULL AUTO_INCREMENT,
-  `query` text NOT NULL,
-  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`ID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
 -- data_release

--- a/SQL/Archive/19.0/2017-11-13_RemoveEmptyQueries.sql
+++ b/SQL/Archive/19.0/2017-11-13_RemoveEmptyQueries.sql
@@ -1,0 +1,1 @@
+DROP TABLE empty_queries;

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -394,8 +394,6 @@ class Database
                 "Replace statement did not execute successfully.",
                 $query
             );
-        } elseif ($result === 0) {
-            $this->insert('empty_queries', array('query' => $query));
         }
 
         $this->affected = $result;
@@ -545,8 +543,6 @@ class Database
                 $query,
                 $where
             );
-        } elseif ($result === 0) {
-            $this->insert('empty_queries', array('query' => $query));
         }
 
         $this->affected = $result;
@@ -671,8 +667,6 @@ class Database
                 "Could not run query $query"
                 . print_r($this->_PDO->errorInfo(), true)
             );
-        } elseif ($result === 0) {
-            $this->insert('empty_queries', array('query' => $query));
         }
 
         $this->affected = $result;


### PR DESCRIPTION
This pull request remove the table that stores all the `emptyness`... all of it.

It drop the `empty_queries` table and remove the conditions where queries that affect no rows are stored in a table. This is removed for the lack of a use case.
