### PR TITLE
[Core] Remove _setupPage function

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -212,7 +212,7 @@ try {
 } finally {
     // Set dependencies if they are not set
     if (!isset($tpl_data['jsfiles']) || !isset($tpl_data['cssfiles'])) {
-        $page = new NDB_Page();
+        $page = (new NDB_Page(new Module(""), '', '', '', ''));
         $tpl_data['jsfiles']  = $page->getJSDependencies();
         $tpl_data['cssfiles'] = $page->getCSSDependencies();
     }

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -157,17 +157,11 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // enums should match with acknowledgements table
         $present = array(

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -205,17 +205,11 @@ class Candidate_List extends \NDB_Menu_Filter
     /**
      * Create the form for the candidate_list menu page
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         // Relying on a side-effect of the the server process module to autoload
         // its namespace.
         \Module::factory('candidate_parameters');

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -42,17 +42,11 @@ class Configuration extends \NDB_Form
      /**
      * Loads the main configuration module page.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $config =& \NDB_Config::singleton();
         $DB     =& \Database::singleton();
 
@@ -200,5 +194,4 @@ class Configuration extends \NDB_Form
             [$baseURL . "/configuration/css/configuration.css"]
         );
     }
-
 }

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -51,9 +51,9 @@ class Project extends \NDB_Form
     *
     * @return none
     */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $factory     = \NDB_Factory::singleton();
         $config      = $factory->config();
         $configs     = \NDB_Config::singleton();

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -43,12 +43,6 @@ class Project extends \NDB_Form
     /**
     * Loads the project page.
     *
-    * @param string $name       The test name being accessed
-    * @param string $page       The subtest being accessed (may be null)
-    * @param string $identifier The identifier for the data to load on this page
-    * @param string $commentID  The CommentID to load the data for
-    * @param string $formname   The name to give this form
-    *
     * @return none
     */
     function setup()

--- a/modules/configuration/php/subproject.class.inc
+++ b/modules/configuration/php/subproject.class.inc
@@ -41,17 +41,11 @@ class Subproject extends \NDB_Form
     /**
      * Loads the subproject management submodule
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $factory = \NDB_Factory::singleton();
         $config  = $factory->config();
 

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -318,17 +318,11 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     /**
      * Sets up the smarty menu filter items for the conflict resolver
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         // Create user object
         $user =& \User::singleton();
 

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -176,17 +176,11 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     /**
      * Adds the form elements required for the filter
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         // Create user object
         $user   =& \User::singleton();
         $config =& \NDB_Config::singleton();

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -90,17 +90,11 @@ class Create_Timepoint extends \NDB_Form
      * Does the setup required for this page.
      * Particularly creates all the form elements.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $config =& \NDB_Config::singleton();
         if (!empty($_GET['subprojectID']) && is_numeric($_GET['subprojectID'])) {

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -42,18 +42,12 @@ class Data_Team_Helper extends \NDB_Form
     /**
      * Sets up main parameters
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return NULL
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
         //initializations
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $DB       =& \Database::singleton();
         $user     =& \User::singleton();
         $config   =& \NDB_Config::singleton();

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -84,12 +84,6 @@ class Datadict extends \NDB_Menu_Filter
     /**
     * Set Filter Form
     *
-    * @param string $name       The test name being accessed
-    * @param string $page       The subtest being accessed (may be null)
-    * @param string $identifier The identifier for the data to load on this page
-    * @param string $commentID  The CommentID to load the data for
-    * @param string $formname   The name to give this form
-    *
     * @return none
     */
     function setup()

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -92,9 +92,9 @@ class Datadict extends \NDB_Menu_Filter
     *
     * @return none
     */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // list of feedback statuses
         $instruments = \Utility::getAllInstruments();

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -41,17 +41,11 @@ class Dataquery extends \NDB_Form
     /**
      * Sets up the smarty template variables for the dataquery page.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return unknown
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $user     = \User::singleton();
         $username = $user->getUsername();

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -46,7 +46,7 @@ class ViewDetails extends \NDB_Form
     *
     * @return NULL
     */
-    function __construct()
+    function setup()
     {
         $this->DB = \Database::singleton();
 

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -46,17 +46,11 @@ class Document_Repository extends \NDB_Menu_Filter
     /**
      * Setup variables function
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $user =& \User::singleton();
 

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -255,17 +255,11 @@ class EditExaminer extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $DB = \Database::singleton();
 
         // Get the certification history from the database

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -130,17 +130,11 @@ class Examiner extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return null
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $user = \User::singleton();
 
         // Get site options

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -213,17 +213,11 @@ class CNV_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user = \User::singleton();

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -263,9 +263,9 @@ class CpG_Browser extends \NDB_Menu_Filter
      *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user = \User::singleton();

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -255,12 +255,6 @@ class CpG_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
     function setup()

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -190,17 +190,11 @@ class Genomic_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user = \User::singleton();

--- a/modules/genomic_browser/php/genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/genomic_file_uploader.class.inc
@@ -111,17 +111,11 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // ------------------------------------------------------------
         // ----------------- Genomic Files Filters --------------------

--- a/modules/genomic_browser/php/gwas_browser.class.inc
+++ b/modules/genomic_browser/php/gwas_browser.class.inc
@@ -119,17 +119,11 @@ class GWAS_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user = \User::singleton();

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -238,17 +238,11 @@ class SNP_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user = \User::singleton();

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -51,17 +51,11 @@ class View_Genomic_File extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $this->DB = \Database::singleton();
 

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -212,17 +212,11 @@ class Edit_Help_Content extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $this->addBasicText('title', 'Title');
         $this->addBasicTextArea(

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -90,17 +90,11 @@ class Help_Editor extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // add form elements
         $this->addBasicText('topic', 'Help topic:');

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -298,17 +298,11 @@ class Imaging_Browser extends \NDB_Menu_Filter
     /**
      * Setup $this->tpl_data for use by Smarty
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return null
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         // create user object
         $user          =& \User::singleton();
         $list_of_sites = array();

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -78,17 +78,11 @@ class ViewSession extends \NDB_Form
     /**
      * Sets up main parameters
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return NULL
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $this->DB = \Database::singleton();
 
         $this->sessionID = $_REQUEST['sessionID'];

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -106,17 +106,11 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      /**
      * Sets up the smarty menu filter items for the imaging uploader
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
-       */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+     */
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $phantomOtions = [
                           'N' => 'No',
                           'Y' => 'Yes',

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -58,7 +58,6 @@ class Instrument_List extends \NDB_Menu_Filter
                 )
                    )
         );
-
     }
 
     /**
@@ -90,7 +89,8 @@ class Instrument_List extends \NDB_Menu_Filter
     */
     function setup()
     {
-        parent::setup()
+        parent::setup();
+
         // set template data
         $this->tpl_data['candID']    = $_REQUEST['candID'];
         $this->tpl_data['sessionID'] = $_REQUEST['sessionID'];
@@ -124,6 +124,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
             $x            = -1;
             $prevSubgroup = null;
+
             foreach ($listOfInstruments as $instrument) {
                 // print the sub group header row
                 if ($instrument['Sub_group'] != $prevSubgroup) {
@@ -193,6 +194,7 @@ class Instrument_List extends \NDB_Menu_Filter
                 $this->tpl_data[$Ins][$x][$i]['feedbackCount']
                     =       (empty($feedback_count))
                              ? $feedback_status : $feedback_count;
+
                 if (!empty($feedback_status)) {
                     $this->tpl_data[$Ins][$x][$i]['feedbackStatus']
                         = $feedback_status;
@@ -216,6 +218,7 @@ class Instrument_List extends \NDB_Menu_Filter
         $this->tpl_data['display']
             = array_merge($candidate->getData(), $timePoint->getData());
     }
+
     /**
      * Used by the NDB_caller class when loading a page.
      * Call the display function of the appropriate modules feedback panel.
@@ -291,13 +294,13 @@ class Instrument_List extends \NDB_Menu_Filter
         } else {
             $query .= ", Full_name";
         }
-        //print_r($query);
+
         // get the list of instruments
         $rows = $DB->pselect($query, $qparams);
 
         // return all the data selected
         return $rows;
-    } // end getBatteryInstrumentList()
+    }
 
     /**
      * Include the column formatter required to display the feedback link colours

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -89,7 +89,7 @@ class Instrument_List extends \NDB_Menu_Filter
     */
     function setup()
     {
-        parent::setup();
+        // Don't call parent setup, we don't want it to try to run any SQL
 
         // set template data
         $this->tpl_data['candID']    = $_REQUEST['candID'];

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -90,11 +90,11 @@ class Instrument_List extends \NDB_Menu_Filter
     */
     function setup()
     {
+        parent::setup()
         // set template data
         $this->tpl_data['candID']    = $_REQUEST['candID'];
         $this->tpl_data['sessionID'] = $_REQUEST['sessionID'];
 
-        $this->_setupPage(null, null, null, null, 'filter');
         // get behavioral battery for this visit (time point)
         $battery = new \NDB_BVL_Battery;
         $success = $battery->selectBattery($_REQUEST['sessionID']);

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -42,17 +42,11 @@ class Issue extends \NDB_Form
     /**
      * Sets up the smarty menu filter items
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $user    =& \User::singleton();
         $issueID = $_GET['issueID'];
 

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -151,17 +151,11 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     /**
      * Sets up the smarty menu filter items
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $user          =& \User::singleton();
         $db            = \Database::singleton();
         $list_of_sites = array();

--- a/modules/issue_tracker/php/my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/my_issue_tracker.class.inc
@@ -150,17 +150,11 @@ class My_Issue_Tracker extends \NDB_Menu_Filter_Form
     /**
      * Sets up the smarty menu filter items
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $user          =& \User::singleton();
         $db            = \Database::singleton();
         $list_of_sites = array();

--- a/modules/issue_tracker/php/resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/resolved_issue_tracker.class.inc
@@ -149,17 +149,11 @@ class Resolved_Issue_Tracker extends \NDB_Menu_Filter_Form
     /**
      * Sets up the smarty menu filter items
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $user  =& \User::singleton();
         $db    = \Database::singleton();

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -29,17 +29,11 @@ class Edit extends \NDB_Form
      * Entry point for /media/edit/
      * Checks if file id is provided and otherwise redirects to /media/ page
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $db      =& \Database::singleton();
         $factory = \NDB_Factory::singleton();

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -57,17 +57,11 @@ class Media extends \NDB_Menu_Filter
     /**
      * Create a form to filter media by various criteria
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this     page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return bool
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $user =& \User::singleton();
         $db   = \Database::singleton();

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -97,17 +97,11 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $this->addBasicText(
             'TarchiveID',

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -127,17 +127,11 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $config      =& \NDB_Config::singleton();
         $minYear     = $config->getSetting('startYear')
             - $config->getSetting('ageMax');

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -347,17 +347,11 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         // create user object
         $user    =& \User::singleton();
         $config  =& \NDB_Config::singleton();

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -323,17 +323,11 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         // create user object
         $user        =&        \User::singleton();
         $config      =&        \NDB_Config::singleton();

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -116,17 +116,11 @@ class New_Profile extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $config    =& \NDB_Config::singleton();
         $startYear = $config->getSetting('startYear');

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -111,20 +111,14 @@ class Next_Stage extends \NDB_Form
 
     }
     /**
-     * Override the form's setupPage to add elements to the page (after LorisForm
-     * has been initialized in the parent.)
-     *
-     * @param string $name       See NDB_Page
-     * @param string $page       See NDB_Page
-     * @param string $identifier See NDB_Page
-     * @param string $commentID  See NDB_Page
-     * @param string $formname   See NDB_Page
+     * Add elements to the page (after LorisForm has been
+     * initialized in the parent.)
      *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
         $timePoint =& \TimePoint::singleton($this->identifier);
         $config    =& \NDB_Config::singleton();
 

--- a/modules/reliability/php/reliability.class.inc
+++ b/modules/reliability/php/reliability.class.inc
@@ -196,17 +196,11 @@ class Reliability extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user          =& \User::singleton();

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -90,17 +90,11 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $this->addBasicText('pid', 'PID:');
         $this->addBasicText('type', 'Type:');

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -39,17 +39,11 @@ class Statistics extends \NDB_Form
     /**
      * Sets up page template for the tabs on the statistics page.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this     page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return void
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $DB =& \Database::singleton();
         $this->tpl_data['StatsTabs'] = $DB->pselect(

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -56,17 +56,11 @@ class Stats_Behavioural extends \NDB_Form
     /**
      * Stats_behavioural function
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this     page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return void
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $DB          =& \Database::singleton();
         $config      = \NDB_Config::singleton();

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -138,17 +138,11 @@ class Stats_Demographic extends \NDB_Form
     /**
      * Stats_demographic function
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this     page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return void
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $DB          =& \Database::singleton();
         $config      = \NDB_Config::singleton();

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -139,17 +139,11 @@ class Stats_MRI extends \NDB_Form
     /**
      * Sets up the template for the MRI tab
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this     page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $DB          =& \Database::singleton();
         $config      = \NDB_Config::singleton();

--- a/modules/statistics/php/stats_reliability.class.inc
+++ b/modules/statistics/php/stats_reliability.class.inc
@@ -43,17 +43,11 @@ class Stats_Reliability extends \NDB_Form
     /**
      * Reliability tab setup
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this     page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return void
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $DB          =& \Database::singleton();
         $config      = \NDB_Config::singleton();

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -244,17 +244,11 @@ class AddSurvey extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $this->redirect = "test_name=$this->name";
         $this->addBasicText("CandID", "DCCID");

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -88,17 +88,11 @@ class Survey_Accounts extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user =& \User::singleton();

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -544,19 +544,12 @@ class Edit_User extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
-        // @codingStandardsIgnoreEnd
         $this->redirect = "test_name=$this->name";
 
         ///get the value for additional_user_info flag

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -238,17 +238,11 @@ class My_Preferences extends \NDB_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         $this->identifier = $_SESSION['State']->getUsername();
 

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -98,17 +98,11 @@ class User_Accounts extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
      * @return none
      */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
+    function setup()
     {
-        parent::_setupPage($name, $page, $identifier, $commentID, $formname);
+        parent::setup();
 
         // create user object
         $user =& \User::singleton();

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -141,7 +141,6 @@ class Module
             throw new \LorisException("You do not have access to this page.", 403);
         }
         $cls->setup();
-        //$cls->_setupPage($this->name, $page, $identifier, $commentID, $formname);
 
 
         // Handles form submission

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -98,6 +98,11 @@ class Module
         $this->name = $name;
     }
 
+    /**
+     * Return the name of this module.
+     *
+     * @return string The module name
+     */
     public function getName() : string
     {
         return $this->name;

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -133,7 +133,6 @@ class Module
 
         $identifier = isset($_REQUEST['identifier']) ? $_REQUEST['identifier'] : '';
         $commentID  = isset($_REQUEST['commentID']) ? $_REQUEST['commentID'] : '';
-        $formname   = $page;
         $cls        = new $className($this, $page, $identifier, $commentID, $page);
         // Smarty needs the Module name as a parameter to autoload the right
         // templates. Every type of page uses this.

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -98,7 +98,8 @@ class Module
         $this->name = $name;
     }
 
-    public function getName() : string {
+    public function getName() : string
+    {
         return $this->name;
     }
 
@@ -125,22 +126,20 @@ class Module
     {
         $className = "\LORIS\\" . $this->name . "\\$page";
 
-
         $identifier = isset($_REQUEST['identifier']) ? $_REQUEST['identifier'] : '';
         $commentID  = isset($_REQUEST['commentID']) ? $_REQUEST['commentID'] : '';
         $formname   = $page;
-        $cls = new $className($this, $page, $identifier, $commentID, $page);
+        $cls        = new $className($this, $page, $identifier, $commentID, $page);
         // Smarty needs the Module name as a parameter to autoload the right
         // templates. Every type of page uses this.
 
         // Hacks so that existing display() functions load the right template
         // for different page types.
-        $cls->menu     = $page;
+        $cls->menu = $page;
         if (!$cls->_hasAccess()) {
             throw new \LorisException("You do not have access to this page.", 403);
         }
         $cls->setup();
-
 
         // Handles form submission
         if (method_exists($cls, 'save')) {

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -93,9 +93,13 @@ class Module
      *
      * @param string $name The name of the module
      */
-    protected function __construct($name)
+    public function __construct($name)
     {
         $this->name = $name;
+    }
+
+    public function getName() : string {
+        return $this->name;
     }
 
     /**
@@ -121,25 +125,24 @@ class Module
     {
         $className = "\LORIS\\" . $this->name . "\\$page";
 
-        $cls = new $className();
+
+        $identifier = isset($_REQUEST['identifier']) ? $_REQUEST['identifier'] : '';
+        $commentID  = isset($_REQUEST['commentID']) ? $_REQUEST['commentID'] : '';
+        $formname   = $page;
+        $cls = new $className($this, $page, $identifier, $commentID, $page);
         // Smarty needs the Module name as a parameter to autoload the right
         // templates. Every type of page uses this.
-        $cls->Module = $this->name;
 
         // Hacks so that existing display() functions load the right template
         // for different page types.
         $cls->menu     = $page;
         $cls->template = $page;
-
-        $identifier = isset($_REQUEST['identifier']) ? $_REQUEST['identifier'] : '';
-        $commentID  = isset($_REQUEST['commentID']) ? $_REQUEST['commentID'] : '';
-        $formname   = $page;
-        $cls->setup();
-        $cls->_setupPage($this->name, $page, $identifier, $commentID, $formname);
-
         if (!$cls->_hasAccess()) {
             throw new \LorisException("You do not have access to this page.", 403);
         }
+        $cls->setup();
+        //$cls->_setupPage($this->name, $page, $identifier, $commentID, $formname);
+
 
         // Handles form submission
         if (method_exists($cls, 'save')) {

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -136,7 +136,6 @@ class Module
         // Hacks so that existing display() functions load the right template
         // for different page types.
         $cls->menu     = $page;
-        $cls->template = $page;
         if (!$cls->_hasAccess()) {
             throw new \LorisException("You do not have access to this page.", 403);
         }

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -131,8 +131,8 @@ class Module
     {
         $className = "\LORIS\\" . $this->name . "\\$page";
 
-        $identifier = isset($_REQUEST['identifier']) ? $_REQUEST['identifier'] : '';
-        $commentID  = isset($_REQUEST['commentID']) ? $_REQUEST['commentID'] : '';
+        $identifier = $_REQUEST['identifier'] ?? '';
+        $commentID  = $_REQUEST['commentID'] ?? '';
         $cls        = new $className($this, $page, $identifier, $commentID, $page);
         // Smarty needs the Module name as a parameter to autoload the right
         // templates. Every type of page uses this.

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -311,7 +311,8 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function setup($commentID = null, $page = null)
     {
-        $this->_setupPage(null, $page, null, $commentID, 'test_form');
+        // Is this even valid?
+        parent::__construct(null, $page, null, $commentID, 'test_form');
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -205,7 +205,7 @@ class NDB_BVL_Instrument extends NDB_Page
         }
 
         // Sets up page variables such as $this->commentID and $this->form
-        //$obj->setup($commentID, $page);
+        $obj->setup($commentID, $page);
 
         // Adds all of the form element and form rules to the page after
         // having instantiated the form above

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -184,7 +184,13 @@ class NDB_BVL_Instrument extends NDB_Page
         if (file_exists($base."project/instruments/$instrument.linst")
         ) {
             include_once 'NDB_BVL_Instrument_LINST.class.inc';
-            $obj = new \Loris\Behavioural\NDB_BVL_Instrument_LINST(new Module($instrument), $page, $commentID, $commentID, 'test_form');
+            $obj = new \Loris\Behavioural\NDB_BVL_Instrument_LINST(
+                new Module($instrument),
+                $page,
+                $commentID,
+                $commentID,
+                'test_form'
+            );
         } else {
             if (!class_exists($class)
                 && ($guarantee_exists === true
@@ -196,7 +202,13 @@ class NDB_BVL_Instrument extends NDB_Page
                 include_once $base."project/instruments/$class.class.inc";
             }
             // Now go ahead and instantiate it
-            $obj = new $class(new Module($instrument), $page, $commentID, $commentID, 'test_form');
+            $obj = new $class(
+                new Module($instrument),
+                $page,
+                $commentID,
+                $commentID,
+                'test_form'
+            );
         }
 
         // if a script is loading this form without a commentID, display all fields

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -184,7 +184,7 @@ class NDB_BVL_Instrument extends NDB_Page
         if (file_exists($base."project/instruments/$instrument.linst")
         ) {
             include_once 'NDB_BVL_Instrument_LINST.class.inc';
-            $obj = new \Loris\Behavioural\NDB_BVL_Instrument_LINST();
+            $obj = new \Loris\Behavioural\NDB_BVL_Instrument_LINST(new Module($instrument), $page, $commentID, $commentID, 'test_form');
         } else {
             if (!class_exists($class)
                 && ($guarantee_exists === true
@@ -196,8 +196,7 @@ class NDB_BVL_Instrument extends NDB_Page
                 include_once $base."project/instruments/$class.class.inc";
             }
             // Now go ahead and instantiate it
-            $obj = new $class;
-            // Now go ahead and instantiate it
+            $obj = new $class(new Module($instrument), $page, $commentID, $commentID, 'test_form');
         }
 
         // if a script is loading this form without a commentID, display all fields
@@ -206,7 +205,7 @@ class NDB_BVL_Instrument extends NDB_Page
         }
 
         // Sets up page variables such as $this->commentID and $this->form
-        $obj->setup($commentID, $page);
+        //$obj->setup($commentID, $page);
 
         // Adds all of the form element and form rules to the page after
         // having instantiated the form above
@@ -309,11 +308,15 @@ class NDB_BVL_Instrument extends NDB_Page
      * @access   public
      * @abstract
      */
+    /*
     function setup($commentID = null, $page = null)
     {
-        // Is this even valid?
-        parent::__construct(null, $page, null, $commentID, 'test_form');
+
+        $this->commentID = $commentID;
+        $this->page = $page;
+        $this->form = new \LorisForm('test_form');
     }
+     */
 
     /**
      * Method to compute scores - by default will run a script named

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -311,6 +311,26 @@ class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
+     * Sets up basic data, such as the HTML_Quickform object, and so on.
+     *
+     * @param string $commentID The CommentID identifying the data to load
+     * @param string $page      If a multipage form, the page to show
+     *
+     * @return   void
+     * @access   public
+     * @abstract
+     */
+    /*
+    function setup($commentID = null, $page = null)
+    {
+
+        $this->commentID = $commentID;
+        $this->page = $page;
+        $this->form = new \LorisForm('test_form');
+    }
+     */
+
+    /**
      * Method to compute scores - by default will run a script named
      * after the testName in the instrument directory if it exists,
      * but any instrument with a scoring algorithm to implement can override
@@ -2366,6 +2386,12 @@ class NDB_BVL_Instrument extends NDB_Page
                         if (isset($el['elements'][0]['label'])) {
                             $el['label'] = $el['elements'][0]['label'];
                         }
+                        //unset($el['elements']);
+                        //unset($el['delimiter']);
+                        //$label = $el['label'];
+                        //$el = $this->_toJSONParseSmarty($el['elements'][0]);
+                        //$el['label'] = $label;
+                        //$el = $this->_toJSONParseSmarty($el);
                     }
                 };
                 array_map($mapFunc, $formArray['elements']);

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -311,26 +311,6 @@ class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
-     * Sets up basic data, such as the HTML_Quickform object, and so on.
-     *
-     * @param string $commentID The CommentID identifying the data to load
-     * @param string $page      If a multipage form, the page to show
-     *
-     * @return   void
-     * @access   public
-     * @abstract
-     */
-    /*
-    function setup($commentID = null, $page = null)
-    {
-
-        $this->commentID = $commentID;
-        $this->page = $page;
-        $this->form = new \LorisForm('test_form');
-    }
-     */
-
-    /**
      * Method to compute scores - by default will run a script named
      * after the testName in the instrument directory if it exists,
      * but any instrument with a scoring algorithm to implement can override
@@ -2386,12 +2366,6 @@ class NDB_BVL_Instrument extends NDB_Page
                         if (isset($el['elements'][0]['label'])) {
                             $el['label'] = $el['elements'][0]['label'];
                         }
-                        //unset($el['elements']);
-                        //unset($el['delimiter']);
-                        //$label = $el['label'];
-                        //$el = $this->_toJSONParseSmarty($el['elements'][0]);
-                        //$el['label'] = $label;
-                        //$el = $this->_toJSONParseSmarty($el);
                     }
                 };
                 array_map($mapFunc, $formArray['elements']);

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -145,6 +145,7 @@ class NDB_BVL_Instrument extends NDB_Page
     var $WrapperTextElements           = array();
     var $WrapperNumericElements        = array();
     var $WrapperDateWithStatusElements = array();
+
     /**
      * Factory generates a new instrument instance of type
      * $instrument, and runs the setup() method on that new
@@ -320,15 +321,11 @@ class NDB_BVL_Instrument extends NDB_Page
      * @access   public
      * @abstract
      */
-    /*
     function setup($commentID = null, $page = null)
     {
-
         $this->commentID = $commentID;
-        $this->page = $page;
-        $this->form = new \LorisForm('test_form');
+        $this->page      = $page;
     }
-     */
 
     /**
      * Method to compute scores - by default will run a script named

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -114,7 +114,6 @@ class NDB_Caller
              $mname = $test_name;
         }
         try {
-
             // This will throw an exception if the module name doesn't exist, so
             // below this we can assume a valid module.
             $m = Module::factory($mname);

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -64,10 +64,8 @@ class NDB_Form extends NDB_Page
         }
 
         // create a form instance
-        $obj = new $class;
+        $obj = new $class($name, $page, $identifier, null, 'test_form');
 
-        // set the local variables
-        $obj->_setupPage($name, $page, $identifier, null, 'test_form');
         $obj->registerDefaultFilter();
 
         $access = $obj->_hasAccess();

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -164,20 +164,5 @@ class NDB_Form extends NDB_Page
     {
         return true;
     }
-
-    /**
-     * Resets the form
-     *
-     * Usage: Call this function if you do not want to display the frozen form
-     * after saving but just want to dump a message and maybe some links
-     *
-     * @return void
-     * @access private
-     */
-    function _resetForm()
-    {
-        $this->_setupPage(null, null, null, null, 'test_form');
-        // $this->form = new HTML_QuickForm('test_form');
-    }
 }
 ?>

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -63,8 +63,19 @@ class NDB_Form extends NDB_Page
             throw new Exception("The form class ($name) is not defined.");
         }
 
+        // create a new menu object
+        try {
+            if (isset($_REQUEST['test_name'])) {
+                $module = \Module::factory($_REQUEST['test_name']);
+            } else {
+                $module = \Module::factory($name);
+            }
+        } catch(\LorisModuleMissingException $e) {
+            $module = new Module($name);
+        }
+
         // create a form instance
-        $obj = new $class($name, $page, $identifier, null, 'test_form');
+        $obj = new $class($module, $name, $page, $identifier, '', 'test_form');
 
         $obj->registerDefaultFilter();
 

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -39,7 +39,8 @@ class NDB_Menu extends NDB_Page
      */
     var $mode;
 
-    public function __construct(\Module $module, string $page, $identifier, $commentID, $formname) {
+    public function __construct(\Module $module, string $page, $identifier, $commentID, $formname)
+    {
         parent::__construct($module, $page, $identifier, $commentID, $formname);
         $this->menu = $module->getName();
     }
@@ -65,15 +66,15 @@ class NDB_Menu extends NDB_Page
         }
 
         // create a new menu object
-       try {
+        try {
             if (isset($_REQUEST['test_name'])) {
                 $module = \Module::factory($_REQUEST['test_name']);
             } else {
                 $module = \Module::factory($menu);
             }
-       } catch(\ModuleMissingException $e) {
+        } catch(\ModuleMissingException $e) {
             $module = new Module($menu);
-       }
+        }
 
         $obj = new $class($module, $menu, '', '', 'menu');
 

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -98,32 +98,6 @@ class NDB_Menu extends NDB_Page
     }
 
     /**
-     * Override the menu pages to use the new LorisForm HTML_QuickForm replacement.
-     * Menus can be done more easily than forms because they rarely have rules, so
-     * this can be done before the LorisForm rule functionality is fully implemented.
-     *
-     * After support for forms is implemented, this override should be removed.
-     *
-     * @param string $name       See NDB_Page
-     * @param string $page       See NDB_Page
-     * @param string $identifier See NDB_Page
-     * @param string $commentID  See NDB_Page
-     * @param string $formname   See NDB_Page
-     *
-     * @return none
-     */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
-    {
-        $this->form = new LorisForm($formname);
-
-        $this->name       = $name;
-        $this->page       = $page;
-        $this->identifier = $identifier;
-        $this->commentID  = $commentID;
-        $this->defaults   = array();
-
-    }
-    /**
      * Displays the menu page
      *
      * @return void

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -39,6 +39,10 @@ class NDB_Menu extends NDB_Page
      */
     var $mode;
 
+    public function __construct(\Module $module, string $page, $identifier, $commentID, $formname) {
+        parent::__construct($module, $page, $identifier, $commentID, $formname);
+        $this->menu = $module->getName();
+    }
     /**
      * Generates a new menu instance
      *
@@ -61,21 +65,19 @@ class NDB_Menu extends NDB_Page
         }
 
         // create a new menu object
-
-        try {
+       try {
             if (isset($_REQUEST['test_name'])) {
                 $module = \Module::factory($_REQUEST['test_name']);
             } else {
                 $module = \Module::factory($menu);
             }
-        } catch(\Exception $e) {
+       } catch(\ModuleMissingException $e) {
             $module = new Module($menu);
-        }
+       }
 
         $obj = new $class($module, $menu, '', '', 'menu');
 
         // set the local variables
-        $obj->menu = $menu;
         $obj->mode = $mode;
         $access    = $obj->_hasAccess();
 
@@ -89,18 +91,6 @@ class NDB_Menu extends NDB_Page
         $obj->setTemplateVar('baseurl', $settings->getBaseURL());
 
         return $obj;
-    }
-
-    /**
-     * Calls other member functions to do all the work necessary to create the menu
-     *
-     * @note   overloaded function
-     * @return void
-     * @access public
-     */
-    function setup()
-    {
-        return true;
     }
 
     /**

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -115,7 +115,7 @@ class NDB_Menu extends NDB_Page
             return "";
         }
         // dump the html for the menu
-        $smarty = new Smarty_neurodb($this->Module);
+        $smarty = new Smarty_neurodb($this->Module->getName());
         $smarty->assign('mode', $this->mode);
         $smarty->assign($this->getTemplateData());
         $html = $smarty->fetch("menu_$this->menu.tpl");

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -61,13 +61,19 @@ class NDB_Menu extends NDB_Page
         }
 
         // create a new menu object
-        $obj = new $class;
 
-        if (isset($_REQUEST['test_name'])) {
-            $obj->Module = $_REQUEST['test_name'];
-        } else {
-            $obj->Module = $menu;
+        try {
+            if (isset($_REQUEST['test_name'])) {
+                $module = \Module::factory($_REQUEST['test_name']);
+            } else {
+                $module = \Module::factory($menu);
+            }
+        } catch(\Exception $e) {
+            $module = new Module($menu);
         }
+
+        $obj = new $class($module, $menu, '', '', 'menu');
+
         // set the local variables
         $obj->menu = $menu;
         $obj->mode = $mode;

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -39,8 +39,22 @@ class NDB_Menu extends NDB_Page
      */
     var $mode;
 
-    public function __construct(\Module $module, string $page, $identifier, $commentID, $formname)
-    {
+    /**
+     * Create a new NDB_Menu page
+     *
+     * @param Module $module     The test name being accessed
+     * @param string $page       The subtest being accessed (may be null)
+     * @param string $identifier The identifier for the data to load on this page
+     * @param string $commentID  The CommentID to load the data for
+     * @param string $formname   The name to give this form
+     */
+    public function __construct(
+        \Module $module,
+        string $page,
+        string $identifier,
+        string $commentID,
+        string $formname
+    ) {
         parent::__construct($module, $page, $identifier, $commentID, $formname);
         $this->menu = $module->getName();
     }
@@ -113,4 +127,4 @@ class NDB_Menu extends NDB_Page
         return $html;
     }
 }
-?>
+

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -86,7 +86,7 @@ class NDB_Menu extends NDB_Page
             } else {
                 $module = \Module::factory($menu);
             }
-        } catch(\ModuleMissingException $e) {
+        } catch(\LorisModuleMissingException $e) {
             $module = new Module($menu);
         }
 

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -134,6 +134,7 @@ class NDB_Menu_Filter extends NDB_Menu
     function setup()
     {
         parent::setup();
+
         // setup the menu's variables
         $success = $this->_setupVariables();
 

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -715,7 +715,7 @@ class NDB_Menu_Filter extends NDB_Menu
         );
 
         // dump the html for the menu
-        $smarty = new Smarty_neurodb($this->Module);
+        $smarty = new Smarty_neurodb($this->Module->getName());
         $smarty->assign('mode', $this->mode);
         $smarty->assign('form', $this->form->toArray());
         $smarty->assign($this->getTemplateData());

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -133,11 +133,11 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function setup()
     {
+        parent::setup();
 
         // setup the menu's variables
         $success = $this->_setupVariables();
 
-        parent::setup();
         // set the headers if necessary
         if (!is_array($this->headers) || count($this->headers) == 0) {
             foreach ($this->columns as $value) {

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -133,11 +133,11 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function setup()
     {
-        parent::setup();
 
         // setup the menu's variables
         $success = $this->_setupVariables();
 
+        parent::setup();
         // set the headers if necessary
         if (!is_array($this->headers) || count($this->headers) == 0) {
             foreach ($this->columns as $value) {

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -133,6 +133,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function setup()
     {
+        parent::setup();
         // setup the menu's variables
         $success = $this->_setupVariables();
 
@@ -145,7 +146,6 @@ class NDB_Menu_Filter extends NDB_Menu
         }
 
         // start the filter form
-        $this->_setupPage($this->menu, null, null, null, 'filter');
         $this->registerDefaultFilter();
 
         // $this->form = new HTML_QuickForm('filter');

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -93,19 +93,5 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
     {
         return true;
     }
-
-    /**
-     * Resets the form
-     *
-     * Usage: Call this function if you do not want to display the frozen form
-     * after saving but just want to dump a message and maybe some links
-     *
-     * @return void
-     * @access private
-     */
-    function _resetForm()
-    {
-        $this->form = new LorisForm('test_form');
-    }
 }
 ?>

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -87,7 +87,7 @@ class NDB_Page
     function __construct(\Module $module, string $page, $identifier, $commentID, $formname)
     {
         $this->Module = $module;
-        $this->name = $module->getName(); // for legacy purposes. FIXME: remove this.
+        $this->name   = $module->getName(); // for legacy purposes. FIXME: remove this.
 
         $this->form       = new LorisForm($formname);
         $this->page       = $page;

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -75,7 +75,7 @@ class NDB_Page
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param string $name       The test name being accessed
+     * @param Module $module     The test name being accessed
      * @param string $page       The subtest being accessed (may be null)
      * @param string $identifier The identifier for the data to load on this page
      * @param string $commentID  The CommentID to load the data for
@@ -83,11 +83,15 @@ class NDB_Page
      *
      * @return none
      */
-
-    function __construct(\Module $module, string $page, $identifier, $commentID, $formname)
-    {
+    function __construct(
+        \Module $module,
+        string $page,
+        string $identifier,
+        string $commentID,
+        string $formname
+    ) {
         $this->Module = $module;
-        $this->name   = $module->getName(); // for legacy purposes. FIXME: remove this.
+        $this->name   = $module->getName(); // for legacy purposes.
 
         $this->form       = new LorisForm($formname);
         $this->page       = $page;

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -94,6 +94,8 @@ class NDB_Page
         $this->identifier = $identifier;
         $this->commentID  = $commentID;
         $this->defaults   = array();
+
+        $this->template = $page;
     }
     /**
      * Safely sets a smarty template variable.

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -71,6 +71,31 @@ class NDB_Page
     protected $tpl_data = array();
 
     /**
+     * Does the setup required for this page. By default, sets up elements
+     * that are common to every type of page. May be overridden by a specific
+     * page or specific page type.
+     *
+     * @param string $name       The test name being accessed
+     * @param string $page       The subtest being accessed (may be null)
+     * @param string $identifier The identifier for the data to load on this page
+     * @param string $commentID  The CommentID to load the data for
+     * @param string $formname   The name to give this form
+     *
+     * @return none
+     */
+
+    function __construct(\Module $module, string $page, $identifier, $commentID, $formname)
+    {
+        $this->Module = $module;
+        $this->name = $module->getName(); // for legacy purposes. FIXME: remove this.
+
+        $this->form       = new LorisForm($formname);
+        $this->page       = $page;
+        $this->identifier = $identifier;
+        $this->commentID  = $commentID;
+        $this->defaults   = array();
+    }
+    /**
      * Safely sets a smarty template variable.
      *
      * @param string $name  The name of the template variable to set
@@ -92,29 +117,6 @@ class NDB_Page
     function getTemplateData()
     {
         return $this->tpl_data;
-    }
-
-    /**
-     * Does the setup required for this page. By default, sets up elements
-     * that are common to every type of page. May be overridden by a specific
-     * page or specific page type.
-     *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
-     * @return none
-     */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
-    {
-        $this->form       = new LorisForm($formname);
-        $this->name       = $name;
-        $this->page       = $page;
-        $this->identifier = $identifier;
-        $this->commentID  = $commentID;
-        $this->defaults   = array();
     }
 
 

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -33,32 +33,6 @@ class NDB_Reliability extends NDB_Form
      */
     var $reliability_center_id;
 
-
-    /**
-     * Override the default page form to use HTML_QuickForm instead of
-     * LorisForm. Reliability instruments aren't yet ready to use LorisForm,
-     * as they depend on a type of QuickForm renderer that is not implemented
-     * by LorisForm. This should be removed once that is fixed..
-     *
-     * @param string $name       The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param string $formname   The name to give this form
-     *
-     * @return none
-     */
-    function _setupPage($name, $page, $identifier, $commentID, $formname)
-    {
-        $this->form       = new LorisForm($formname);
-        $this->name       = $name;
-        $this->page       = $page;
-        $this->identifier = $identifier;
-        $this->commentID  = $commentID;
-        $this->defaults   = array();
-    }
-
-
     /**
      * Generates a new form instance and runs the appropriate method
      *
@@ -83,10 +57,7 @@ class NDB_Reliability extends NDB_Form
         }
 
         // create a form instance
-        $obj = new $class;
-
-        // set the local variables
-        $obj->_setupPage($name, $page, $identifier, null, 'test_form');
+        $obj = new $class($name, $page, $identifier, null, 'test_form');
 
         $obj->reliability_center_id = $reliability_center_id;
 

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -41,7 +41,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends \PHPUnit_Framework_TestCase
         $this->Client->makeCommandLine();
         $this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
-        $this->i = $this->getMockBuilder("\Loris\Behavioural\NDB_BVL_Instrument_LINST")->setMethods(array("getFullName"))->getMock();
+        $this->i = $this->getMockBuilder("\Loris\Behavioural\NDB_BVL_Instrument_LINST")->disableOriginalConstructor()->setMethods(array("getFullName"))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->form = $this->QuickForm;
         $this->i->testName = "Test";

--- a/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
@@ -42,7 +42,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends \PHPUnit_Framework_TestCase
         $this->Client->makeCommandLine();
         $this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
-        $this->i = $this->getMockBuilder("\NDB_BVL_Instrument")->setMethods(array("getFullName"))->getMock();
+        $this->i = $this->getMockBuilder("\NDB_BVL_Instrument")->disableOriginalConstructor()->setMethods(array("getFullName"))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->form = $this->QuickForm;
         $this->i->testName = "Test";
@@ -364,7 +364,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends \PHPUnit_Framework_TestCase
     }
 
     function testPageGroup() {
-        $this->i = $this->getMockBuilder("\NDB_BVL_Instrument")->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
+        $this->i = $this->getMockBuilder("\NDB_BVL_Instrument")->disableOriginalConstructor()->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->method('getSubtestList')->willReturn(
             array(

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -36,7 +36,8 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testResetFilters() {
         $method = array('_resetFilters');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMock('NDB_Menu_Filter', $this->_getAllMethodsExcept($method));
+        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
+        $stub->form = new LorisForm();
 
         // Reset calls
         $this->Session->expects($this->exactly(2))
@@ -58,7 +59,7 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testSetSearchKeyword() {
         $method = array('_setSearchKeyword');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMock('NDB_Menu_Filter', $this->_getAllMethodsExcept($method));
+        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
 
         $stub->_setSearchKeyword('abc');
 
@@ -80,7 +81,7 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testSetFilters() {
         $method = array('_setFilters');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMock('NDB_Menu_Filter', $this->_getAllMethodsExcept($method));
+        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
 
         $stub->form = new LorisForm('filter');
         $stub->form->applyFilter('__ALL__', 'trim');
@@ -132,7 +133,7 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testSetFilterSortOrder() {
         $method = array('_setFilterSortOrder');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMock('NDB_Menu_Filter', $this->_getAllMethodsExcept($method));
+        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
 
         $stub->headers = array('FakeField', "FakeField2");
         $stub->formToFilter = array(

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -36,8 +36,10 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testResetFilters() {
         $method = array('_resetFilters');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
-        $stub->form = new LorisForm();
+        $stub = $this->getMockBuilder('NDB_Menu_Filter')
+            ->setMethods($allOtherMethods)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // Reset calls
         $this->Session->expects($this->exactly(2))
@@ -59,7 +61,10 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testSetSearchKeyword() {
         $method = array('_setSearchKeyword');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
+        $stub = $this->getMockBuilder('NDB_Menu_Filter')
+            ->setMethods($allOtherMethods)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $stub->_setSearchKeyword('abc');
 
@@ -81,7 +86,10 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testSetFilters() {
         $method = array('_setFilters');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
+        $stub = $this->getMockBuilder('NDB_Menu_Filter')
+            ->setMethods($allOtherMethods)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $stub->form = new LorisForm('filter');
         $stub->form->applyFilter('__ALL__', 'trim');
@@ -133,7 +141,10 @@ class NDB_Menu_Filter_Test extends PHPUnit_Framework_TestCase
     function testSetFilterSortOrder() {
         $method = array('_setFilterSortOrder');
         $allOtherMethods = $this->_getAllMethodsExcept($method);
-        $stub = $this->getMockBuilder('NDB_Menu_Filter', $this->_getAllMethodsExcept($method))->disableOriginalConstructor()->getMock();
+        $stub = $this->getMockBuilder('NDB_Menu_Filter')
+            ->setMethods($allOtherMethods)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $stub->headers = array('FakeField', "FakeField2");
         $stub->formToFilter = array(

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -53,7 +53,7 @@ foreach ($files AS $file) {
     echo "Requiring file...\n";
     include_once $file;
     echo "Instantiating new object...\n";
-    $obj =new $className;
+    $obj =new $className(new Module(""), "", "", "", "");
     echo "Initializing instrument object...\n";
     $obj->setup(null, null);
 


### PR DESCRIPTION
The modularization of LORIS modules had an unfortunate side-effect of re-ordering some of the setup logic, since most modules overrode the _setupPage() function to ensure that LorisForm was instantiated before setting template variables (which may get overridden after _setupPage is called if they did it another way). This also had the annoying side-effect or requiring all 5 parameters just to pass to the parent call.

Since the _setupPage function in the base NDB_Page class was used as a pseudo-constructor, this pull request moves it to a real constructor. The result is that setup() can be called directly and _setupPage can be removed.

This makes it possible to ensure that hasAccess is checked *before* the setup() function call (some of the hasAccess functions require the identifier attribute which was previously set in the base setupPage, which is now in the constructor.) and prevent the possibility of leaking any data on the "You do not have access page" if setupPage did something which generated a warning, since it's now never called at all if the user doesn't have access.

It also removes the ambiguity of the difference between setup and setupPage.