### PR TITLE
[LorisForm] - GroupMapping php notice cleanup

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1877,10 +1877,10 @@ class LorisForm
     {
         $name = $this->_generateName($name);
         foreach ($array as $key => $value) {
-            $this->groupMapping[$value['name']] = array(
-                                                   'groupName' => $name,
-                                                   'index'     => $key,
-                                                  );
+            $this->groupMapping[$value['name'] ?? ''] = array(
+                                                         'groupName' => $name,
+                                                         'index'     => $key,
+                                                        );
         }
         $this->form[$name] = array(
                               'type'      => 'group',

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1877,10 +1877,11 @@ class LorisForm
     {
         $name = $this->_generateName($name);
         foreach ($array as $key => $value) {
-            $this->groupMapping[$value['name'] ?? ''] = array(
-                                                         'groupName' => $name,
-                                                         'index'     => $key,
-                                                        );
+             $group_key = $value['name'] ?? $this->_generateName('');
+             $this->groupMapping[$group_key] = array(
+                                                'groupName' => $name,
+                                                'index'     => $key,
+                                               );
         }
         $this->form[$name] = array(
                               'type'      => 'group',


### PR DESCRIPTION
This pull request remove the `PHP Notice:  Undefined index: name in .../php/libraries/LorisForm.class.inc on line 1880` trigger by the absence of $name attribute of Element in the new group.
