### PR TITLE
[Imaging Browser] Add specification

### DIFF
--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -5,6 +5,9 @@
 The imaging browser is intended to allow users to view candidate
 scan sessions collected for a study.
 
+It is used primarily by imaging specialists to do online QC of
+imaging data that has been inserted into LORIS.
+
 ## Scope
 
 The imaging browser displays images processed images which meet the

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -5,8 +5,11 @@
 The imaging browser is intended to allow users to view candidate
 scan sessions collected for a study.
 
-It is used primarily by imaging specialists to do online QC of
-imaging data that has been inserted into LORIS.
+The three primary types of users are:
+1. Imaging specialists using the modules to do online QC
+2. Project radiologists viewing images to report incidental findings
+3. Site coordinators or researchers ensuring their uploaded scans have
+   been processed and inserted into LORIS.
 
 ## Scope
 
@@ -60,3 +63,17 @@ useEDC - This setting determines whether "EDC" filtering dropdowns exist
 
 mantis_url - This setting defines a URL for LORIS to include a link to for bug reporting
         on the viewsession page.
+
+## Interactions with LORIS
+
+- The "Selected" set by the imaging QC specialist is used by the dataquery
+  module in order to determine which scan to insert when multiple scans of
+  a modality type exist for a given session. (The importer exists in
+  `$LORIS/tools/CouchDB_Import_MRI.php` alongside all other CouchDB
+  import scripts, but should logically be considered part of this module.)
+- The imaging browser module includes links to BrainBrowser to visualize data.
+- The control panel on the viewsession page includes links to instruments
+  named "mri_parameter_form" and "radiologyreview" if they exist for the
+  currently viewed session.
+- The control panel on the viewsession page includes links to the DICOM Archive
+  for any DICOM tars associated with the given session.

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -5,6 +5,8 @@
 The imaging browser is intended to allow users to view candidate
 scan sessions collected for a study.
 
+## Intended Users
+
 The three primary types of users are:
 1. Imaging specialists using the modules to do online QC
 2. Project radiologists viewing images to report incidental findings

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -1,0 +1,59 @@
+# Imaging Browser
+
+## Purpose
+
+The imaging browser is intended to allow users to view candidate
+scan sessions collected for a study.
+
+## Scope
+
+The imaging browser displays images processed images which meet the
+study's inclusion criteria. The inclusion criteria (for most images)
+is defined and enforced in the LORIS imaging pipeline scripts.  Derived
+or processed scan types are also included and have their own insertion
+criteria.
+
+NOT in scope:
+
+The imaging browser module does not display raw DICOMs or perform automated
+quality control on images. It only displays images that have already been
+inserted into LORIS.
+
+## Permissions
+
+The imaging browser module uses the following permissions. Any one of them
+(except imaging_browser_qc) is sufficient to have access to the module.
+
+imaging_browser_view_allsites
+    - This permission gives the user access to all scans in the database
+
+imaging_browser_view_site
+    - This permission gives the user access to scans from their own site only
+
+imaging_browser_phantom_allsites
+    - This permission gives the user access to phantom, but not candidate, scans
+      across the database
+
+imaging_browser_phantom_ownsite
+    - This permission gives the user access to phantom, but not candidate, data
+      only at the user's site.
+
+imaging_browser_qc
+    - This permission gives the user access to modify the quality control data
+      for the associated scans and timepoints.
+
+## Configurations
+
+The imaging browser has the following configurations that affect its usage
+
+tblScanTypes - This setting determines which scan types are considered "NEW" for
+        QC purposes.
+
+useProjects - This setting determines whether "project" filtering dropdowns exist
+        on the menu page.
+
+useEDC - This setting determines whether "EDC" filtering dropdowns exist
+        on the menu page.
+
+mantis_url - This setting defines a URL for LORIS to include a link to for bug reporting
+        on the viewsession page.

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -36,7 +36,7 @@ imaging_browser_view_allsites
     - This permission gives the user access to all scans in the database
 
 imaging_browser_view_site
-    - This permission gives the user access to scans from their own site only
+    - This permission gives the user access to scans from their own site(s) only
 
 imaging_browser_phantom_allsites
     - This permission gives the user access to phantom, but not candidate, scans
@@ -44,7 +44,7 @@ imaging_browser_phantom_allsites
 
 imaging_browser_phantom_ownsite
     - This permission gives the user access to phantom, but not candidate, data
-      only at the user's site.
+      at the user's site(s).
 
 imaging_browser_qc
     - This permission gives the user access to modify the quality control data
@@ -55,7 +55,8 @@ imaging_browser_qc
 The imaging browser has the following configurations that affect its usage
 
 tblScanTypes - This setting determines which scan types are considered "NEW" for
-        QC purposes.
+        QC purposes. It also determines which modalities are displayed on the
+        main imaging browser menu page.
 
 useProjects - This setting determines whether "project" filtering dropdowns exist
         on the menu page.

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -15,10 +15,10 @@ The three primary types of users are:
 
 ## Scope
 
-The imaging browser displays images processed images which meet the
-study's inclusion criteria. The inclusion criteria (for most images)
-is defined and enforced in the LORIS imaging pipeline scripts.  Derived
-or processed scan types are also included and have their own insertion
+The imaging browser displays processed images which meet the study's
+inclusion criteria. The inclusion criteria (for most images) is defined
+and enforced in the LORIS imaging pipeline scripts.  Derived or
+processed scan types are also included and have their own insertion
 criteria.
 
 NOT in scope:


### PR DESCRIPTION
This adds a brief specification for the imaging browser as discussed in the LORIS meeting. It serves as a template for other modules.

The specification should be a markdown file of the following form:

```
# Module Name

## Purpose

[A paragraph or two about what the module is for. Who uses it?
What do they get out of it?]

## Intended Users

[A paragraph or list describing who is expected to use this module and why.]

## Scope

[A paragraph or two about the scope of the module. How does it accomplish its purpose?
More importantly, what *doesn't* it do that someone might expect?]

## Permissions

[A list of what permissions affect the behaviour of this module. What do they change?]

## Configurations

[A list of what configurations affect the behaviour of this module or are required to
setup the module. They may be either PHP or LORIS configurations. What do they
affect and why?]

## Interactions with LORIS

[Describe briefly how the module interacts with other LORIS modules or features of LORIS.]
```

This puts it in the README for the imaging_browser because there was no README that previously existed, but I'm open to suggests for better locations for the spec.
