### PR TITLE
[.htaccess] removing rewrite rule

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -22,8 +22,6 @@
  RewriteRule ^([0-9]{6,6})/([0-9]+)/([a-zA-Z0-9_]+)/$ main.php?test_name=$3&candID=$1&sessionID=$2 [QSA]
  RewriteRule ^([0-9]{6,6})/([0-9]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+)/$ main.php?test_name=$3&candID=$1&sessionID=$2&subtest=$4 [QSA]
 
- # Preferences is a special case for url rewriting
- RewriteRule ^preferences/$ main.php?test_name=user_accounts&subtest=my_preferences
  # Rewrite /foo/ to appropriate module
  # Includes /foo/css/cssfile.css
  #          /foo/js/javascriptfile.js

--- a/htdocs/router.php
+++ b/htdocs/router.php
@@ -177,19 +177,6 @@ if (preg_match(
     $_REQUEST['subtest']   = $getParams[1];
 
     include_once __DIR__ . "/main.php";
-} else if (preg_match(
-    '#^preferences/$#',
-    $url
-)) {
-    // Preferences is a special case for url rewriting
-    // RewriteRule
-    //      ^preferences/$
-    //      /main.php?test_name=user_accounts&subtest=my_preferences
-
-    $_REQUEST["test_name"] = "user_accounts";
-    $_REQUEST['subtest']   = "my_preferences";
-
-    include_once __DIR__ . "/main.php";
 } else {
     return false;
 }

--- a/smarty/templates/email/notifier_custom_html.tpl
+++ b/smarty/templates/email/notifier_custom_html.tpl
@@ -43,7 +43,7 @@
                     <tr>
                         <td style="background-color:#ECF8FF">
                             <p>This is an automated message sent by the Loris system. To configure your notification settings,
-                                follow <a href="{$baseurl}/preferences/">this link to your preference page</a>.</p>
+                                follow <a href="{$baseurl}/user_accounts/my_preferences/">this link to your preference page</a>.</p>
                         </td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
This pull request  remove the rewrite rule used for my_preferences. The Loris menu now use the /test_name/subtest_name/ url since the my_preference page has been extracted from edit_user.

see: https://github.com/aces/Loris/pull/3282