### PR TITLE
[Core] Remove assignment by reference NDB_Caller

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -470,7 +470,7 @@ class NDB_Caller
         $user = User::singleton();
 
         if ($_REQUEST['sessionID']) {
-            $timepoint = TimePoint::singleton($_REQUEST['sessionID']);
+            $timepoint =& TimePoint::singleton($_REQUEST['sessionID']);
         }
 
         // make an instance of the instrument's object

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -330,7 +330,7 @@ class NDB_Caller
     function loadMenu($menu, $mode)
     {
         // make an instance of the menu's object
-        $menu =& NDB_Menu::factory($menu, $mode);
+        $menu = NDB_Menu::factory($menu, $mode);
 
         $success = $menu->setup();
 
@@ -457,7 +457,7 @@ class NDB_Caller
         $redirectToOnSuccess=null
     ) {
         if ($page === 'finalpage') {
-            $instrument =& NDB_BVL_Instrument::factory(
+            $instrument = NDB_BVL_Instrument::factory(
                 $instrumentName,
                 $commentID,
                 $page
@@ -467,14 +467,14 @@ class NDB_Caller
             header("Location: $redirectToOnSuccess");
             return "";
         }
-        $user =& User::singleton();
+        $user = User::singleton();
 
         if ($_REQUEST['sessionID']) {
-            $timepoint =& TimePoint::singleton($_REQUEST['sessionID']);
+            $timepoint = TimePoint::singleton($_REQUEST['sessionID']);
         }
 
         // make an instance of the instrument's object
-        $instrument =& NDB_BVL_Instrument::factory(
+        $instrument = NDB_BVL_Instrument::factory(
             $instrumentName,
             $commentID,
             $page


### PR DESCRIPTION
This removes the assignment by reference from NDB_Caller class as it is deprecated in PHP 5+

Notice: `PHP Notice:  Only variables should be assigned by reference in /var/www/loris/php/libraries/NDB_Caller.class.inc `
