### PR TITLE
Remove unused variable in main.php

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -125,8 +125,7 @@ if (!empty($TestName)) {
 
     if (!empty($_REQUEST['sessionID'])) {
         try {
-            $timePoint  =& TimePoint::singleton($_REQUEST['sessionID']);
-            $argstring .= "filter%5Bm.VisitNo%5D=".$timePoint->getVisitNo()."&";
+            $timePoint = TimePoint::singleton($_REQUEST['sessionID']);
         } catch (Exception $e) {
             $tpl_data['error_message'][]
                 = "TimePoint Error (".$_REQUEST['sessionID']."): ".$e->getMessage();

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -326,7 +326,7 @@ class User extends UserPermissions
     function hasStudySite()
     {
         $site_arr = $this->getCenterIDs();
-        foreach ($site_arr as $key => $sitename) {
+        foreach ($site_arr as $sitename) {
             $site = Site::singleton($sitename);
             if ($site->isStudySite()) {
                 return true;


### PR DESCRIPTION
This removes an unused variable in main.php. (Attempting to concatenate to it was generating a PHP warning for me. Since it was unused, it's easier to remove it than fix the warning..) 