### PR TITLE
[Candidate Parameters] Removing unused function

### DIFF
--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -61,27 +61,6 @@ class Candidate_Parameters extends \NDB_Form
     }
 
     /**
-     * Gets CandID and whether the consent tab should be displayed
-     *
-     * @throws DatabaseException
-     *
-     * @return void
-     */
-    function candidate_parameters()//@codingStandardsIgnoreLine
-    {
-        $config    =& \NDB_Config::singleton();
-        $candidate =& \Candidate::singleton($this->identifier);
-
-        // candID
-        $this->tpl_data['candID'] = $candidate->getData('CandID');
-
-        // consent
-        $consent = $config->getSetting('ConsentModule');
-
-        $this->tpl_data['useConsent'] = $consent['useConsent'];
-    }
-
-    /**
      * Gets the participant_status options from participant_status_options
      * getParticipantStatusOptions()
      *


### PR DESCRIPTION
simple cleanup.

This module do not use template. The only thing that the function was doing is populate tpl_data with useConsent and the CandID.  

The CandidateParameters component is looking in the lorishelper.configs and in the QueryString for CandID.
 