### PR TITLE
[Genomic Browser] Add design specification for that module

### DIFF
--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -21,17 +21,20 @@ been added to variable ID and some annotation columns. An uploader
 
 Permission Code               	| Description
 -------------------------------	| -----------------------------------------------------------------------
-genomic_browser_view_site     	| Allow to view genomic data of Candidates from that user own site(s)
-genomic_browser_view_allsites 	| Allow to view genomic data of Candidates from all sites
-genomic_data_manager 		| Allow for genomic file uploading (see [File Upload](#file_upload_link))
+genomic_browser_view_site     	| Allow to view genomic data of Candidates from that
+                                  user own site(s)
+genomic_browser_view_allsites 	| Allow to view genomic data of Candidates from all
+                                  sites
+genomic_data_manager 		| Allow for genomic file uploading 
+                                  (see [File Upload](#file_upload_link))
 
 ## Configurations
 
 Config name 	| Description
 ---------------	| ------------------------------------------------------------------
 GenomicDataPath | The to a directory readable and writable by www-data. This 
-                | directory should contain a `genomic_uploader` directory that is 
-                | also readable and writable by www-data.
+                  directory should contain a `genomic_uploader` directory that is 
+                  also readable and writable by www-data.
 
 ## Interactions with LORIS There are foreign keys on the candidate table.
 

--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -20,21 +20,16 @@ been added to variable ID and some annotation columns. An uploader
 ## Permissions
 
 Permission Code               	| Description
--------------------------------	| -----------------------------------------------------------------------
-genomic_browser_view_site     	| Allow to view genomic data of Candidates from that
-                                  user own site(s)
-genomic_browser_view_allsites 	| Allow to view genomic data of Candidates from all
-                                  sites
-genomic_data_manager 		| Allow for genomic file uploading 
-                                  (see [File Upload](#file_upload_link))
+-------------------------------	| --------------------------------------------------
+genomic_browser_view_site     	| Allow to view genomic data of Candidates from that user own site(s)
+genomic_browser_view_allsites 	| Allow to view genomic data of Candidates from all sites 
+genomic_data_manager 		| Allow for genomic file uploading (see [File Upload](#file_upload_link))
 
 ## Configurations
 
 Config name 	| Description
 ---------------	| ------------------------------------------------------------------
-GenomicDataPath | The to a directory readable and writable by www-data. This 
-                  directory should contain a `genomic_uploader` directory that is 
-                  also readable and writable by www-data.
+GenomicDataPath | The to a directory readable and writable by www-data. This directory should contain a `genomic_uploader` directory that is also readable and writable by www-data.
 
 ## Interactions with LORIS There are foreign keys on the candidate table.
 
@@ -43,8 +38,12 @@ GenomicDataPath | The to a directory readable and writable by www-data. This
 
 Tab | Description
 --- | -----------
-[Profile](#profile_link) | [GWAS](#gwas_link) | [SNP](#snp_link) | [CNV](#cnv_link) |
-[CPG](#cpg_link) | [File Upload](#file_upload_link) |
+[Profile](#profile_link) |  
+[GWAS](#gwas_link) |  
+[SNP](#snp_link) |  
+[CNV](#cnv_link) |  
+[CPG](#cpg_link) |  
+[File Upload](#file_upload_link) |  
 
 
 <a name="profile_link"></a> ## Profile

--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -1,9 +1,15 @@
-# Genomic Module 
-(Beta version)
+# Genomic Module (Beta version)
 
 ## Purpose
 
-The Genomic Browser module is intended to allow researchers to see what kind of data is available for each of their study's candidates (see [Profile](#profile_link)). For each type of data ([SNP](#snp_link), [CNV](#cnv_link), [CPG](#cpg_link)) A distinct tab is provided to allow for browsing and filtering each individual values of each candidate for each of the variables of that type. Filtering is based on provided annotations. Links to specific external databases (UCSC, dbSNP) have been added to variable ID and some annotation columns. An uploader
+The Genomic Browser module is intended to allow researchers to see what
+kind of data is available for each of their study's candidates (see
+[Profile](#profile_link)). For each type of data ([SNP](#snp_link),
+[CNV](#cnv_link), [CPG](#cpg_link)) A distinct tab is provided to allow
+for browsing and filtering each individual values of each candidate
+for each of the variables of that type. Filtering is based on provided
+annotations. Links to specific external databases (UCSC, dbSNP) have
+been added to variable ID and some annotation columns. An uploader
 
 ## Intended Users
 
@@ -13,76 +19,71 @@ The Genomic Browser module is intended to allow researchers to see what kind of 
 
 ## Permissions
 
-Permission Code | Description
---------------- | -----------
-genomic_browser_view_site | Allow to view genomic data of Candidates from that user own site(s)
-genomic_browser_view_allsites | Allow to view genomic data of Candidates from all sites
-genomic_data_manager | Allow for genomic file uploading (see [File Upload](#file_upload_link))
+Permission Code | Description --------------- | -----------
+genomic_browser_view_site | Allow to view genomic data of Candidates
+from that user own site(s) genomic_browser_view_allsites | Allow to
+view genomic data of Candidates from all sites genomic_data_manager |
+Allow for genomic file uploading (see [File Upload](#file_upload_link))
 
 ## Configurations
 
-Config name | Description
------------ | -----------
-GenomicDataPath | The to a directory readable and writable by www-data. This directory should contain a `genomic_uploader` directory that is also readable and writable by www-data.
+Config name | Description ----------- | ----------- GenomicDataPath |
+The to a directory readable and writable by www-data. This directory
+should contain a `genomic_uploader` directory that is also readable and
+writable by www-data.
 
-## Interactions with LORIS
-There are foreign keys on the candidate table.
-
-
-## More...
-This module use tabs for each data modality
-
-Tab | Description
---- | -----------
-[Profile](#profile_link) |
-[GWAS](#gwas_link) |
-[SNP](#snp_link) |
-[CNV](#cnv_link) |
-[CPG](#cpg_link) |
-[File Upload](#file_upload_link) |
+## Interactions with LORIS There are foreign keys on the candidate table.
 
 
-<a name="profile_link"></a>
-## Profile
+## More...  This module use tabs for each data modality
 
-<a name="gwas_link"></a>
-## GWAS
-
-<a name="snp_link"></a>
-## SNP
-
-<a name="cnv_link"></a>
-## CNV
-
-<a name="cpg_link"></a>
-## CPG tab
-
-To use the methylation tab, the genomic_cpg_annotaion table should be filled with data from the Illumina HumanMethylation450k probe annotations file. This file can be found at ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/ProductFiles/HumanMethylation450/HumanMethylation450_15017482_v1-2.csv. We provide a script,  `modules/genomic_browser/tools/HumanMethylation450k_annotations_to_sql` to transforme the csv file from Illumina's FTP to into a mysql transaction file. The output of the tool can be piped to mysql. The process should take between 5 to 10 minutes. 
-
-This exemple script is a python3 script. 
-
-usage :
-```
-python3 HumanMethylation450k_annotations_to_sql.py <annotation_file> | mysql -u <user> -p <database>
-```
+Tab | Description --- | ----------- [Profile](#profile_link)
+| [GWAS](#gwas_link) | [SNP](#snp_link) | [CNV](#cnv_link) |
+[CPG](#cpg_link) | [File Upload](#file_upload_link) |
 
 
-<a name="file_upload_link"></a>
-## Files
+<a name="profile_link"></a> ## Profile
 
-The uploading functionnality require a genomic_uploader directory under the GenomicDataPath directory specified in the ConfigSettings. This directory needs to be accessible w/r to the apache user. It's recommended that this configSetting be soft-linked to a directory under the /data/ 
+<a name="gwas_link"></a> ## GWAS
 
-To enable uploading of large files via the genomic file uploader, update apache configurations to increase size and time limits.  (Sample values suggested below)
+<a name="snp_link"></a> ## SNP
+
+<a name="cnv_link"></a> ## CNV
+
+<a name="cpg_link"></a> ## CPG tab
+
+To use the methylation tab, the genomic_cpg_annotaion
+table should be filled with data from the Illumina
+HumanMethylation450k probe annotations file. This file can be found at
+ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/ProductFiles/HumanMethylation450/HumanMethylation450_15017482_v1-2.csv.
+We provide a script,
+`modules/genomic_browser/tools/HumanMethylation450k_annotations_to_sql`
+to transforme the csv file from Illumina's FTP to into a mysql transaction
+file. The output of the tool can be piped to mysql. The process should
+take between 5 to 10 minutes.
+
+This exemple script is a python3 script.
+
+usage : ``` python3 HumanMethylation450k_annotations_to_sql.py
+<annotation_file> | mysql -u <user> -p <database> ```
+
+
+<a name="file_upload_link"></a> ## Files
+
+The uploading functionnality require a genomic_uploader directory under
+the GenomicDataPath directory specified in the ConfigSettings. This
+directory needs to be accessible w/r to the apache user. It's recommended
+that this configSetting be soft-linked to a directory under the /data/
+
+To enable uploading of large files via the genomic file uploader, update
+apache configurations to increase size and time limits.  (Sample values
+suggested below)
 
 Apache configuration file to update : /etc/php5/apache2/php.ini
 
 Sample values:
 
-```
-session.gc_maxlifetime = 10800 
-max_input_time = 10800 
-max_execution_time = 10800 
-upload_max_filesize = 1024M 
-post_max_size = 1024M
-```
+``` session.gc_maxlifetime = 10800 max_input_time = 10800
+max_execution_time = 10800 upload_max_filesize = 1024M post_max_size =
+1024M ```
 

--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -19,26 +19,28 @@ been added to variable ID and some annotation columns. An uploader
 
 ## Permissions
 
-Permission Code | Description --------------- | -----------
-genomic_browser_view_site | Allow to view genomic data of Candidates
-from that user own site(s) genomic_browser_view_allsites | Allow to
-view genomic data of Candidates from all sites genomic_data_manager |
-Allow for genomic file uploading (see [File Upload](#file_upload_link))
+Permission Code               	| Description
+-------------------------------	| -----------------------------------------------------------------------
+genomic_browser_view_site     	| Allow to view genomic data of Candidates from that user own site(s)
+genomic_browser_view_allsites 	| Allow to view genomic data of Candidates from all sites
+genomic_data_manager 		| Allow for genomic file uploading (see [File Upload](#file_upload_link))
 
 ## Configurations
 
-Config name | Description ----------- | ----------- GenomicDataPath |
-The to a directory readable and writable by www-data. This directory
-should contain a `genomic_uploader` directory that is also readable and
-writable by www-data.
+Config name 	| Description
+---------------	| ------------------------------------------------------------------
+GenomicDataPath | The to a directory readable and writable by www-data. This 
+                | directory should contain a `genomic_uploader` directory that is 
+                | also readable and writable by www-data.
 
 ## Interactions with LORIS There are foreign keys on the candidate table.
 
 
 ## More...  This module use tabs for each data modality
 
-Tab | Description --- | ----------- [Profile](#profile_link)
-| [GWAS](#gwas_link) | [SNP](#snp_link) | [CNV](#cnv_link) |
+Tab | Description
+--- | -----------
+[Profile](#profile_link) | [GWAS](#gwas_link) | [SNP](#snp_link) | [CNV](#cnv_link) |
 [CPG](#cpg_link) | [File Upload](#file_upload_link) |
 
 

--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -31,6 +31,8 @@ Config name 	| Description
 ---------------	| ------------------------------------------------------------------
 GenomicDataPath | The to a directory readable and writable by www-data. This directory should contain a `genomic_uploader` directory that is also readable and writable by www-data.
 
+The file upload feature require special configurations (see [File Upload](#file_upload_link))
+
 ## Interactions with LORIS There are foreign keys on the candidate table.
 
 
@@ -46,15 +48,20 @@ Tab | Description
 [File Upload](#file_upload_link) |  
 
 
-<a name="profile_link"></a> ## Profile
+<a name="profile_link"></a>
+## Profile
 
-<a name="gwas_link"></a> ## GWAS
+<a name="gwas_link"></a>
+## GWAS
 
-<a name="snp_link"></a> ## SNP
+<a name="snp_link"></a>
+## SNP
 
-<a name="cnv_link"></a> ## CNV
+<a name="cnv_link"></a>
+## CNV
 
-<a name="cpg_link"></a> ## CPG tab
+<a name="cpg_link"></a>
+## CPG tab
 
 To use the methylation tab, the genomic_cpg_annotaion
 table should be filled with data from the Illumina
@@ -72,7 +79,8 @@ usage : ``` python3 HumanMethylation450k_annotations_to_sql.py
 <annotation_file> | mysql -u <user> -p <database> ```
 
 
-<a name="file_upload_link"></a> ## Files
+<a name="file_upload_link"></a>i
+## Files
 
 The uploading functionnality require a genomic_uploader directory under
 the GenomicDataPath directory specified in the ConfigSettings. This

--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -1,6 +1,61 @@
-# Genomic Module
+# Genomic Module 
+(Beta version)
 
-## Methylation tab
+## Purpose
+
+The Genomic Browser module is intended to allow researchers to see what kind of data is available for each of their study's candidates (see [Profile](#profile_link)). For each type of data ([SNP](#snp_link), [CNV](#cnv_link), [CPG](#cpg_link)) A distinct tab is provided to allow for browsing and filtering each individual values of each candidate for each of the variables of that type. Filtering is based on provided annotations. Links to specific external databases (UCSC, dbSNP) have been added to variable ID and some annotation columns. An uploader
+
+## Intended Users
+
+
+## Scope
+
+
+## Permissions
+
+Permission Code | Description
+--------------- | -----------
+genomic_browser_view_site | Allow to view genomic data of Candidates from that user own site(s)
+genomic_browser_view_allsites | Allow to view genomic data of Candidates from all sites
+genomic_data_manager | Allow for genomic file uploading (see [File Upload](#file_upload_link))
+
+## Configurations
+
+Config name | Description
+----------- | -----------
+GenomicDataPath | The to a directory readable and writable by www-data. This directory should contain a `genomic_uploader` directory that is also readable and writable by www-data.
+
+## Interactions with LORIS
+There are foreign keys on the candidate table.
+
+
+## More...
+This module use tabs for each data modality
+
+Tab | Description
+--- | -----------
+[Profile](#profile_link) |
+[GWAS](#gwas_link) |
+[SNP](#snp_link) |
+[CNV](#cnv_link) |
+[CPG](#cpg_link) |
+[File Upload](#file_upload_link) |
+
+
+<a name="profile_link"></a>
+## Profile
+
+<a name="gwas_link"></a>
+## GWAS
+
+<a name="snp_link"></a>
+## SNP
+
+<a name="cnv_link"></a>
+## CNV
+
+<a name="cpg_link"></a>
+## CPG tab
 
 To use the methylation tab, the genomic_cpg_annotaion table should be filled with data from the Illumina HumanMethylation450k probe annotations file. This file can be found at ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/ProductFiles/HumanMethylation450/HumanMethylation450_15017482_v1-2.csv. We provide a script,  `modules/genomic_browser/tools/HumanMethylation450k_annotations_to_sql` to transforme the csv file from Illumina's FTP to into a mysql transaction file. The output of the tool can be piped to mysql. The process should take between 5 to 10 minutes. 
 
@@ -11,18 +66,15 @@ usage :
 python3 HumanMethylation450k_annotations_to_sql.py <annotation_file> | mysql -u <user> -p <database>
 ```
 
+
+<a name="file_upload_link"></a>
 ## Files
 
-In order to enable file uploading functionality, you must create a `genomic_uploader` directory in the `GenomicDataPath` directory (specified in the ConfigSettings). This directory needs to have read and write permissions for the apache user. It's recommended that this directory is soft-linked to a directory under `/data`.
+The uploading functionnality require a genomic_uploader directory under the GenomicDataPath directory specified in the ConfigSettings. This directory needs to be accessible w/r to the apache user. It's recommended that this configSetting be soft-linked to a directory under the /data/ 
 
-The Methylation file parser is expecting a csv file where the first column value is the cpg_name (probe_id) and each next column header is the PSCID of that sample.
+To enable uploading of large files via the genomic file uploader, update apache configurations to increase size and time limits.  (Sample values suggested below)
 
-Ex: 
-Cpg Name,MTL001,MTL002,MTL003,OTT001,OTT002,OTT003
-cg00004192,0.801189261,0.0301716141,0.8076612619,0.9952436145,0.8506495436,0.7583490037
-cg00021762,0.747602724,0.4233800573,0.1582679939,0.5039519868,0.2587142177,0.2294365754
-
-To enable uploading of large files via the genomic file uploader, update apache configurations to increase size and time limits. This can be done by editing the `php.ini` file which can be found by running the command `php --ini`.
+Apache configuration file to update : /etc/php5/apache2/php.ini
 
 Sample values:
 
@@ -33,3 +85,4 @@ max_execution_time = 10800
 upload_max_filesize = 1024M 
 post_max_size = 1024M
 ```
+


### PR DESCRIPTION
This adds a document describing the design of genomic_browser following the format in #3286 .