### PR TITLE
Fix router errors in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     # Download a Selenium Web Driver release
     - wget "http://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar"
 
-    - php -S localhost:8000 -t htdocs htdocs/router.php 2>1 > /dev/null &
+    - php -S localhost:8000 -t htdocs router.php 2>1 > /dev/null &
 
     # Extracting firefox and setting PATH variable...
     - tar -xjf /tmp/firefox-44.0.tar.bz2 --directory /tmp


### PR DESCRIPTION
Fix a bug where Travis is not able to find the htdocs/router.php file,
because it's looking for htdocs/htdocs/router.php. I'm not sure how or
why this started breaking consistently across all versions of PHP being
run by Travis, but it seems to be the case. This takes out the htdocs/
portion of the path used as a router since it seems to be duplicated by
the -t (docroot) of the PHP built in web server.