### PR TITLE
[Travis] Remove PHP 7.0 from Travis, add PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
         - vendor
 
 php:
-    - "7"
     - "7.1"
+    - "7.2"
 
 sudo: false
 

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1388,10 +1388,7 @@ class LorisForm
                 return $this->getValue($ruleElement) != '';
             }
             return true;
-<<<<<<< HEAD
         case '<>': // Fallthrough, it's the same operator..
-=======
->>>>>>> Remove create_function call from LorisForm
         case '!=':
             if ($this->getValue($controlElement) != $format['value']) {
                 return $this->getValue($ruleElement) != '';
@@ -1428,10 +1425,7 @@ class LorisForm
                 . join(', ', $this->validOperators)
             );
         }
-<<<<<<< HEAD
     }
-=======
->>>>>>> Remove create_function call from LorisForm
 
     /**
      * Reimplements the HTML_Quickform API.

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1388,7 +1388,10 @@ class LorisForm
                 return $this->getValue($ruleElement) != '';
             }
             return true;
+<<<<<<< HEAD
         case '<>': // Fallthrough, it's the same operator..
+=======
+>>>>>>> Remove create_function call from LorisForm
         case '!=':
             if ($this->getValue($controlElement) != $format['value']) {
                 return $this->getValue($ruleElement) != '';
@@ -1425,7 +1428,10 @@ class LorisForm
                 . join(', ', $this->validOperators)
             );
         }
+<<<<<<< HEAD
     }
+=======
+>>>>>>> Remove create_function call from LorisForm
 
     /**
      * Reimplements the HTML_Quickform API.

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -340,13 +340,28 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             if ($comparevalue == 'NEVER_REQUIRED' && $operator == '==') {
                 return true;
             }
-            $compareFunction = create_function(
-                '$a, $b',
-                "return \$a $operator \$b;"
-            );
 
-            if (!($compareFunction($comparevalue, $userval)) ) {
-                return false;
+            switch ($operator) {
+            case '==':
+                if ($comparevalue != $userval) {
+                    return false;
+                }
+                break;
+            case '!=':
+                if ($comparevalue == $userval) {
+                    return false;
+                }
+                break;
+            default:
+                throw new \LorisException(
+                    "Unsupported operator ($operator) for XIN Rule."
+                    . " If this used to work, please file a bug report."
+                );
+            }
+
+            if ($this->XINDebug) {
+                //debugging code
+                echo "'$controller' $operator '$value'<br>";
             }
         }
         // Nothing that was compared failed

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -358,11 +358,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     . " If this used to work, please file a bug report."
                 );
             }
-
-            if ($this->XINDebug) {
-                //debugging code
-                echo "'$controller' $operator '$value'<br>";
-            }
         }
         // Nothing that was compared failed
         return true;

--- a/tools/score_instrument.php
+++ b/tools/score_instrument.php
@@ -22,13 +22,6 @@
 set_include_path(get_include_path().":../project/libraries:../php/libraries:");
 require_once __DIR__ . "/../vendor/autoload.php";
 
-if (version_compare(phpversion(),'4.3.0','<'))
-{
-    define('STDIN',fopen("php://stdin","r"));
-    register_shutdown_function( create_function( '' , 'fclose(STDIN);
-                fclose(STDOUT); fclose(STDERR); fclose($logfp); return true;' ) );
-}
-
 /**
  * HELP SCREEN
  * display and stop processing if action=help


### PR DESCRIPTION
PHP 7.0 only has 2 days of support left, and PHP 7.2
is the latest PHP release as of today.

See: http://php.net/supported-versions.php