### PR TITLE
Remove create_function call from LorisForm

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1388,6 +1388,7 @@ class LorisForm
                 return $this->getValue($ruleElement) != '';
             }
             return true;
+        case '<>': // Fallthrough, it's the same operator..
         case '!=':
             if ($this->getValue($controlElement) != $format['value']) {
                 return $this->getValue($ruleElement) != '';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1374,39 +1374,56 @@ class LorisForm
             $format['value'] = '';
         }
 
-        // confirm that the operator is in the set of valid operators
-        $validOperators = array(
-                           '==',
-                           '===',
-                           '!=',
-                           '<>',
-                           '!==',
-                           '<',
-                           '>',
-                           '<=',
-                           '>=',
-                          );
-        if (!in_array($format['operator'], $validOperators)) {
+        $controlElement = $elements[1];
+        $ruleElement = $elements[0];
+
+        switch ($format['operator']) {
+        case '==':
+            if ($this->getValue($controlElement) == $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '===':
+            if ($this->getValue($controlElement) === $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '!=':
+            if ($this->getValue($controlElement) != $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '!==':
+            if ($this->getValue($controlElement) !== $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '<':
+            if ($this->getValue($controlElement) < $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '>':
+            if ($this->getValue($controlElement) > $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '<=':
+            if ($this->getValue($controlElement) <= $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        case '>=':
+            if ($this->getValue($controlElement) <= $format['value']) {
+                return $this->getValue($ruleElement) != '';
+            }
+            return true;
+        default:
             throw new LorisException(
                 "operator is not a valid operator from the set "
                 . join(', ', $this->validOperators)
             );
         }
-
-        // create the comparison function, based on the defined operator
-        $compareFunction = create_function(
-            '$a,$b',
-            "return (\$a $format[operator] \$b);"
-        );
-
-        // check the case where the controller operator value is true
-        if ($compareFunction($this->getValue($elements[1]), $format['value'])) {
-            return $this->getValue($elements[0]) != '';
-        }
-
-        // if controller operator value is false, validate true
-        return true;
-    }
 
     /**
      * Reimplements the HTML_Quickform API.

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1375,7 +1375,7 @@ class LorisForm
         }
 
         $controlElement = $elements[1];
-        $ruleElement = $elements[0];
+        $ruleElement    = $elements[0];
 
         switch ($format['operator']) {
         case '==':
@@ -1425,6 +1425,7 @@ class LorisForm
                 . join(', ', $this->validOperators)
             );
         }
+    }
 
     /**
      * Reimplements the HTML_Quickform API.


### PR DESCRIPTION
create_function was deprecated in PHP 7.2. This removes one instance of it in the LorisForm logic  that is used (as far as I can tell) for instruments with conditional requirements. It should be backwards compatible and have no functional change..