### PR TITLE
[Dashboard] fixing count of "pending" users

### DIFF
--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -198,7 +198,7 @@ class Dashboard extends \NDB_Form
             && $user->hasPermission('user_accounts')
         ) {
             $this->tpl_data['pending_users']      = $DB->pselectOne(
-                "SELECT COUNT(*) FROM users 
+                "SELECT COUNT(DISTINCT users.UserID) FROM users 
                 LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
 		        WHERE users.Pending_approval='Y' 
                 AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
@@ -208,7 +208,7 @@ class Dashboard extends \NDB_Form
         } elseif ($user->hasPermission('user_accounts')) {
             $site_arr = $user->getCenterIDs();
             $this->tpl_data['pending_users'] = $DB->pselectOne(
-                "SELECT COUNT(*) FROM users 
+                "SELECT COUNT(DISTINCT users.UserID) FROM users 
                 LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
 		        WHERE users.Pending_approval='Y' AND upr.CenterID IN (:CID)",
                 array('CID' => implode(",", $site_arr))


### PR DESCRIPTION
This Fixes the query displaying the number of pending requests. The error was that the `LEFT JOIN on user_psc_rel` was creating user duplication. Because it is necessary to exclude DCC site requests, the query was just complemented with a "Distinct" selection