### PR TITLE
[User Accounts] Only allow Examiner flag to be set for study sites

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -692,7 +692,10 @@ class Edit_User extends \NDB_Form
         if ($editor->hasPermission('examiner_multisite')) {
             //get site aliases
             $DB      =& \Database::singleton();
-            $aliases = $DB->pselect("SELECT CenterID, Alias FROM psc ", array());
+            $aliases = $DB->pselect(
+                "SELECT CenterID, Alias FROM psc WHERE Study_site='Y'",
+                array()
+            );
 
             foreach ($aliases as $row) {
                 $groupA[] = $this->createCheckbox(


### PR DESCRIPTION
The edit_user page previously listed all sites as sites that a user may be an examiner at, not just study sites.

Fixes Redmine #11483.