### PR TITLE
[Login] Replace incorrect placeholder on login page

### DIFF
--- a/modules/login/templates/form_login.tpl
+++ b/modules/login/templates/form_login.tpl
@@ -13,7 +13,7 @@
           {/if}
           <form method="POST" action="{$action}">
             <div class="form-group">
-              <input type="text" name="username" class="form-control" placeholder="Email" value="{$username}"/>
+              <input type="text" name="username" class="form-control" placeholder="Username" value="{$username}"/>
             </div>
             <div class="form-group">
               <input type="password" name="password" class="form-control" placeholder="Password" aria-describedby="helpBlock" />


### PR DESCRIPTION
The login page was prompting for "Email" when it was, in fact, expecting a username.

This updates the prompt to be correct.

Fixes Redmine #13586.