### PR TITLE
[Instrument] Fix "Delete Instrument Data" feature

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -167,6 +167,9 @@ class NDB_BVL_Instrument extends NDB_Page
     {
         $class = "NDB_BVL_Instrument_$instrument";
 
+        // Ensure 'page' is a string.
+        $page = $page ?? '';
+
         // Make sure the instrument class has been included/required!
         $factory = NDB_Factory::singleton();
         $config  = $factory->config();

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -146,7 +146,6 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                     );
                     $instrument->clearInstrument();
                     return false;
-
                 } else {
                     return false;
                     //print "No permissions to delete";

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -451,7 +451,12 @@ class NDB_Caller
         }
 
         // save instrument form data
-        $success = $instrument->save();
+        if (!isset($_REQUEST['ClearInstrument'])) {
+            // If ClearInstrument was set, it's the control
+            // panel, not the instrument that needs to be
+            // saved.
+            $success = $instrument->save();
+        }
 
         if ($redirectToOnSuccess !== null && $success !== false) {
             header("Location: $redirectToOnSuccess");


### PR DESCRIPTION
The feature that deletes all data from a given LORIS instrument
was broken, because LORIS was incorrectly calling "Save" on
the instrument (which didn't have the correct data posted) rather
than save on the control panel.

This adds a check to ensure that the incorrect "save" isn't
called when using the "Delete instrument data" feature.