### PR TITLE
[Core] Remove deprecated call to create_function in isPasswordStrong

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -421,6 +421,14 @@ class User extends UserPermissions
         $values = array(),
         $operators = array()
     ) {
+        // FIXME: This should be cleaned up to more cleanly separate
+        // concerns. The "values" and "operators" are the same at
+        // every call site, and some of them are only required because
+        // the function is static despite working with instance data.
+        // (ie the second value/operator pair is always the UserID of
+        // the user whose password is being checked, the third is their
+        // email, and the first is the "Confirm" password which has
+        // nothing to do with whether the password is strong or not..)
         $CharTypes = 0;
         // less than 6 characters
         if (strlen($password) < 8) {
@@ -447,18 +455,27 @@ class User extends UserPermissions
 
         // compare password to values
         foreach ($values as $key => $value) {
-            $function = create_function(
-                '$a, $b',
-                'return $a ' . $operators[$key] . ' $b;'
-            );
-            // if the comparison fails
-            if (!$function($password, $value)) {
-                return false;
+            switch ($operators[$key]) {
+            case '==':
+                // They must be equal, so the whole thing is false
+                // if they're not.
+                if ($password != $value) {
+                    return false;
+                }
+                break;
+            case '!=':
+                if ($password == $value) {
+                    return false;
+                }
+                break;
+            default:
+                throw new \LorisException("Invalid operator in isPasswordStrong");
             }
         }
 
         return true;
     }
+
     /**
      * Check if user belongs to DCC
      *

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -430,7 +430,7 @@ class User extends UserPermissions
         // email, and the first is the "Confirm" password which has
         // nothing to do with whether the password is strong or not..)
         $CharTypes = 0;
-        // less than 6 characters
+        // less than 8 characters
         if (strlen($password) < 8) {
             return false;
         }


### PR DESCRIPTION
This removes a call to create_function from the User::isPasswordStrong
function, which was deprecated in PHP 7.2. (create_function is effectively
an eval, and strongly discouraged even without being deprecated.)