### PR TITLE
[Instruments] Remove reference to deprecated PHP function "create_function"

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1332,18 +1332,26 @@ class NDB_BVL_Instrument extends NDB_Page
         //to pop a required rule)
         $valFlag = array();
         foreach ($values AS $value) {
-            $compareFunction = create_function(
-                '$a, $b',
-                "return (\$a $operator \$b);"
-            );
+            switch ($operator) {
+            case '==':
+                if ($controller != $value) {
+                    $valFlag[] = false;
+                }
+                break;
+            case '!=':
+                if ($controller == $value) {
+                    $valFlag[] = false;
+                }
+                break;
+            default:
+                throw new \LorisException(
+                    "Unsupported operator ($operator) for XIN Rule."
+                    . " If this used to work, please file a bug report."
+                );
+            }
             if ($this->XINDebug) {
                 //debugging code
                 echo "'$controller' $operator '$value'<br>";
-            }
-            if (!$compareFunction($controller, $value)) {
-                // IF one of the conditions is not  met then this rule
-                // does not need to be run.
-                $valFlag[] = false;
             }
         }
         //For conditions
@@ -1352,7 +1360,6 @@ class NDB_BVL_Instrument extends NDB_Page
         }
         return $is_required;
     }
-
 
     /**
      * Get a the value of $field from the instrument table.


### PR DESCRIPTION
This removes a reference to the PHP function "create_function", which was
deprecated in PHP 7.2 in XIN rule evaluation. (create_function was essentially
an `eval`).

Unfortunately, it was used in XIN rules to create a function which can take
an arbitrary operator for comparison, but there is no way to know which operators
instruments are actually using. This adds the known operators after talking
to a couple projects, but throws an exception requesting a bug report for
anyone who was not covered by these cases.