### PR TITLE
2017 12 11 replace deprecated each

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     # Download a Selenium Web Driver release
     - wget "http://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar"
 
-    - php -S localhost:8000 -t htdocs htdocs/router.php 2>1 > /dev/null &
+    - php -S localhost:8000 -t htdocs router.php 2>1 > /dev/null &
 
     # Extracting firefox and setting PATH variable...
     - tar -xjf /tmp/firefox-44.0.tar.bz2 --directory /tmp

--- a/modules/server_processes_manager/test/TestPlan
+++ b/modules/server_processes_manager/test/TestPlan
@@ -5,13 +5,17 @@ This test plan should be executed by someone with decent knowledge of the MRI up
 
 1. Log in with a user that does not have the "View and manage server processes" permission. 
    Check that when logged in there is no Sevrer Processes Manager sub menu in the Admin menu.
+   [Automation Test]
 2. Log in with a user that has the "View and manage server processes" permission. 
    Check that there is a Server Processes Manager sub menu in the Admin menu.
-3. Check the contents of the server processes page and remember the number of entries.
+   [Automation Test]
+3. Check three filters, input correct data and click the show data button.Then check the table.
+   [Automation Test]
+4. Check the contents of the server processes page and remember the number of entries.
    Make sure that the ImagingUploader Auto-Launch is set to Yes (Config module, Study section).
    Using the Imaging uploader, upload an invalid scan (i.e. a .tar.gz file that is *not* a scan)
    When the upload fails, verify that no new entrires were created in the server processes table.
-4. Upload a valid scan using the correct CandID, PSCID and Visit Label on the imaging_upload page.
+5. Upload a valid scan using the correct CandID, PSCID and Visit Label on the imaging_upload page.
    After the progress bar reaches 100%, access the server processes manager page and check that a new
    entry for the upload was created in the process tables. 
    Using a Unix shell on the server on which the upload was done, do a tail -f on each of the process 

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Server_processes_manager module automated integration tests
+ *
+ * PHP Version 7
+ *
+ * @category Test
+ * @package  Loris
+ * @author   Wang Shen <wangshen.mcin@gmail.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
+require_once __DIR__ .
+    "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
+
+/**
+ * Server_processes_manager module automated integration tests
+ *
+ * PHP Version 7
+ *
+ * @category Test
+ * @package  Loris
+ * @author   Wang Shen <wangshen.mcin@gmail.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+class Server_Processes_ManagerTest extends LorisIntegrationTest
+{
+    /**
+     * UI elements and locations
+     * breadcrumb - ''
+     * Table headers
+     */
+    private $_loadingUI
+        =  array(
+            'Server  Processes  Manager' => '#bc2 > a:nth-child(2) > div',
+            //table headers
+            'No.'                        => '#dynamictable > thead > tr',
+            'Pid'                        => '#dynamictable > thead > tr',
+            'Type'                       => '#dynamictable > thead > tr',
+            'Stdout File'                => '#dynamictable > thead > tr',
+            'Stderr File'                => '#dynamictable > thead > tr',
+            'Exit Code File'             => '#dynamictable > thead > tr',
+            'Exit Code'                  => '#dynamictable > thead > tr',
+            'Userid'                     => '#dynamictable > thead > tr',
+            'Start Time'                 => '#dynamictable > thead > tr',
+            'End Time'                   => '#dynamictable > thead > tr',
+           );
+    /**
+     * Tests that the page does not load if the user does not have correct
+     * permissions
+     *
+     * @return void
+     */
+    function testLoadsWithoutPermissionRead()
+    {
+        $this->setupPermissions(array(""));
+        $this->safeGet($this->url . "/server_processes_manager/");
+        $bodyText = $this->webDriver->findElement(
+            WebDriverBy::cssSelector("body")
+        )->getText();
+        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->resetPermissions();
+    }
+    /**
+     * Tests that the page does not load if the user does not have correct
+     * permissions
+     *
+     * @return void
+     */
+    function testDoesNotLoadWithPermission()
+    {
+        $this->setupPermissions(array("server_processes_manager"));
+        $this->safeGet($this->url . "/server_processes_manager/");
+        $bodyText = $this->webDriver->findElement(
+            WebDriverBy::cssSelector("body")
+        )->getText();
+        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->resetPermissions();
+    }
+    /**
+      * Testing UI elements when page loads
+      *
+      * @return void
+      */
+    function testPageUIs()
+    {
+        $this->safeGet($this->url . "/server_processes_manager/");
+        sleep(1);
+        foreach ($this->_loadingUI as $key => $value) {
+            $text = $this->webDriver->executescript(
+                "return document.querySelector('$value').textContent"
+            );
+            $this->assertContains($key, $text);
+        }
+    }
+    /**
+      * Testing React filter in this page.
+      *
+      * @return void
+      */
+    function testFilters()
+    {
+        $this->_testFilter("/server_processes_manager/", "pid", "317", "1 rows");
+        $this->_testFilter("/server_processes_manager/", "type", "mri_upload", "51");
+        $this->_testFilter(
+            "/server_processes_manager/",
+            "userid",
+            "admin",
+            "51"
+        );
+    }
+    /**
+      * This function could test filter function in each Tabs.
+      *
+      * @param string $url            this is for the url which needs to be tested.
+      * @param string $filter         the filter which needs to be tested.
+      * @param string $testData       the test data.
+      * @param string $expectDataRows the expect rows in the table.
+      *
+      * @return void
+      */
+    function _testFilter($url,$filter,$testData,$expectDataRows)
+    {
+        $this->safeGet($this->url . $url);
+        sleep(1);
+        $this->safeFindElement(
+            WebDriverBy::Name($filter)
+        )->sendKeys($testData);
+        //click show data button
+        $this->webDriver->executescript(
+            "document.querySelector('#filter').click()"
+        );
+        sleep(1);
+        $this->webDriver->getPageSource();
+        $text = $this->webDriver->executescript(
+            "return document.querySelector('#datatable > div >".
+            " div.table-header.panel-heading').textContent"
+        );
+        //click clear form
+        $this->webDriver->executescript(
+            "document.querySelector('#server_processes > div:nth-child(3)".
+            " > div > div:nth-child(2) > input').click()"
+        );
+
+        $this->assertContains($expectDataRows, $text);
+    }
+}
+?>

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -180,16 +180,12 @@ class Edit_User extends \NDB_Form
     {
         $config = \NDB_Config::singleton();
         $DB     = \Database::singleton();
-
         //The arrays that contain the edited permissions
         $permissionsRemoved = array();
         $permissionsAdded   = array();
-
         $editor = \User::singleton();
-
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
-
         //create the user
         if (!is_null($this->identifier)) {
             $user = \User::factory($this->identifier);
@@ -201,29 +197,24 @@ class Edit_User extends \NDB_Form
                 ? $values['Email'] : $values['UserID'];
             $user         = \User::factory($effectiveUID);
         }
-
         ////Get the current permissions/////
         $current_permissionids = $user->getPermissionIDs();
-
         $permIDs = array();
         // store the permission IDs
         if (!empty($values['permID'])) {
             $permIDs = array_keys($values['permID']);
         }
         unset($values['permID']);
-
         // store whether to send an email or not
         if (!empty($values['SendEmail'])) {
             $send = $values['SendEmail'];
         }
         unset($values['SendEmail']);
-
         //store the supervisors emails
         if (!empty($values['supervisorEmail'])) {
             $supervisorEmails = $values['supervisorEmail'];
         }
         unset($values['supervisorEmail']);
-
         // make user name match email address
         if (!empty($values['NA_UserID'])) {
             $values['UserID'] = $values['Email'];
@@ -232,21 +223,18 @@ class Edit_User extends \NDB_Form
             $values['UserID'] = trim($values['UserID']);
         }
         unset($values['NA_UserID']);
-
         // generate new password
         if (!empty($values['NA_Password'])) {
             $values['Password_hash']   = \User::newPassword();
             $values['Password_expiry'] = '1990-04-01';
         }
         unset($values['NA_Password']);
-
         // If editing a user and nothing was specified in the password text field
         // remove Password_md5 from the value set, otherwise Password_md5
         // will be set to '' by the system
         if ($values['Password_hash'] == '' && !$this->isCreatingNewUser()) {
             unset($values['Password_hash']);
         }
-
         // multi-site UPDATE
         $uid           = $user->getData('ID');
         $us_curr_sites = $values['CenterIDs'];
@@ -264,14 +252,12 @@ class Edit_User extends \NDB_Form
         }
         unset($values['CenterIDs']);
         // END multi-site UPDATE
-
         // EXAMINER UPDATE
         // get all fields that are related to examiners
         $ex_curr_sites  = array();
         $ex_prev_sites  = array();
         $ex_radiologist = 'N';
         $ex_pending     = 'Y';
-
         foreach ($values as $k => $v) {
             //examiner fields
             if (preg_match("/^ex_[0-9]+$/", $k)) {
@@ -287,7 +273,6 @@ class Edit_User extends \NDB_Form
                 $ex_pending = $v;
             }
         }
-
         // first check if an update is needed then actually do it
         if (!empty($ex_radiologist)
             && !empty($ex_pending)
@@ -295,8 +280,7 @@ class Edit_User extends \NDB_Form
         ) {
             //modify examiner radiologist to be in the binary format 0-1
             $ex_radiologist = $ex_radiologist === 'Y' ? 1:0;
-
-            $examinerID = $DB->pselect(
+            $examinerID     = $DB->pselectOne(
                 "SELECT e.examinerID
                  FROM examiners e
                  WHERE e.full_name=:fn",
@@ -304,12 +288,10 @@ class Edit_User extends \NDB_Form
                  "fn" => $values['Real_name'],
                 )
             );
-
             // If examiner not in table add him,
             // otherwise update the radiologist field and get the current sites
             $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
             if (empty($examinerID)) {
-
                 $DB->insert(
                     'examiners',
                     array(
@@ -318,14 +300,13 @@ class Edit_User extends \NDB_Form
                      'userID'      => $uid,
                     )
                 );
-                $examinerID = $examinerID = $DB->pselectOne(
+                $examinerID = $DB->pselectOne(
                     "SELECT examinerID
                      FROM examiners
                      WHERE full_name=:fullName",
                     array('fullName' => $values['Real_name'])
                 );
             } else {
-
                 $DB->update(
                     'examiners',
                     array(
@@ -336,24 +317,16 @@ class Edit_User extends \NDB_Form
                      "full_name" => $values['Real_name'],
                     )
                 );
-                $examinerID = $examinerID[0]['examinerID'];
-
                 //get existing sites for examiner
-                $prev_sites = $DB->pselect(
+                $ex_prev_sites = $DB->pselectCol(
                     "SELECT centerID
                  FROM examiners_psc_rel epr
                  WHERE examinerID=:eid",
                     array("eid" => $examinerID)
                 );
-
-                //get sites where user is already an examiner at for compare
-                foreach ($prev_sites as $row => $center) {
-                    array_push($ex_prev_sites, $center['centerID']);
-                }
             }
 
             foreach ($ex_curr_sites as $k => $v) {
-
                 //Check if examiner already in db for site
                 $result = $DB->pselectRow(
                     "SELECT epr.centerID
@@ -364,7 +337,6 @@ class Edit_User extends \NDB_Form
                      "cid" => $v,
                     )
                 );
-
                 // examiner was not previously added, add and set to active
                 if (empty($result)) {
                     $DB->insert(
@@ -391,10 +363,8 @@ class Edit_User extends \NDB_Form
                 }
                 unset($values[$k]);
             }
-
             //de-activate examiner if sites where no longer checked
             $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
-
             foreach ($ex_inactive as $cid) {
                 $DB->update(
                     'examiners_psc_rel',
@@ -409,7 +379,6 @@ class Edit_User extends \NDB_Form
         unset($values['examiner_radiologist']);
         unset($values['examiner_pending']);
         //END EXAMINER UPDATE
-
         // make the set
         foreach ($values as $key => $value) {
             if (!empty($value)) {
@@ -418,7 +387,6 @@ class Edit_User extends \NDB_Form
                 $set[$key] = null;
             }
         }
-
         // update the user
         if ($this->isCreatingNewUser()) {
             // insert a new user
@@ -439,7 +407,6 @@ class Edit_User extends \NDB_Form
             $user    = \User::factory($this->identifier);
             $success = $user->update($set);
         }
-
         // prepend two random characters
         if (isset($set['Password_hash'])) {
             // Update CouchDB. Must do before password is salted/hashed.
@@ -447,7 +414,6 @@ class Edit_User extends \NDB_Form
                 ? $values['Password_expiry'] : null;
             $user->updatePassword($set['Password_hash'], $expiry);
         }
-
         // update the user permissions if applicable
         // If the user is editing his/her own account, skip the part where
         // changes to the permissions are handled (there should not be any
@@ -455,7 +421,6 @@ class Edit_User extends \NDB_Form
         // disabled)
         if (!$this->_isEditingOwnAccount()) {
             $success = $user->removePermissions();
-
             // Check for new permissions
             if (!empty($permIDs)) {
                 foreach ($permIDs as $permID) {
@@ -470,7 +435,6 @@ class Edit_User extends \NDB_Form
                     }
                 }
             }
-
             if (!empty($current_permissionids)) {
                 // Check for permissions that are to be deleted
                 foreach ($current_permissionids as $currentPermID) {
@@ -483,7 +447,6 @@ class Edit_User extends \NDB_Form
                     }
                 }
             }
-
             // send the selected supervisors an email
             // (only if permissions have changed for the user)
             if (isset($supervisorEmails)) {
@@ -505,31 +468,25 @@ class Edit_User extends \NDB_Form
                     }
                 }
             }
-
             if (!empty($permIDs)) {
                 $user->addPermissions($permIDs);
             }
         }
-
         // send the user an email
         if (!empty($send)) {
             // create an instance of the config object
             $config = \NDB_Config::singleton();
-
             // send the user an email
             $msg_data['study']    = $config->getSetting('title');
             $msg_data['url']      = $config->getSetting('url');
             $msg_data['realname'] = $values['Real_name'];
             $msg_data['username'] = $user->getUsername();
             $msg_data['password'] = $values['Password_hash'];
-
             $template = (is_null($this->identifier))
                 ? 'new_user.tpl' : 'edit_user.tpl';
             \Email::send($values['Email'], $template, $msg_data);
         }
-
         $this->tpl_data['success'] = true;
-
         if ($this->isCreatingNewUser()) {
             $baseURL  = $config->getSetting('url');
             $redirect = $baseURL

--- a/modules/user_accounts/test/TestPlan.md
+++ b/modules/user_accounts/test/TestPlan.md
@@ -1,32 +1,37 @@
-                             User Account module - Test plan
-                             ===============================
+`User Account` module - Test plan
+===============================
 
-1. Make sure you do not have access to the User Account page if you do not have at least one of these permissions:
-      - There can be only one Highlander.
-      - User management / Survey module.
-2. If you have access to the User Module, you should see all the users if you have permission 'Across all sites edit 
-   create users'. Otherwise, only the users that belong to your site are shown.
-3. Check that the Clear Form button works.
-4. Search according to all criteria: site, user name, active, full name, pending approval, email and examiner. 
-5. Check that if Site is set to 'All' in the filter, users that have a different site than the user logged in are 
-   returned by the search (if any).
-6. Try to add a user with a user name already taken: check that you can't.
+1. Make sure you do not have access to the `User Accounts` page if you do not have at least one of these permissions:
+      - `There can be only one Highlander`.
+      - `User management`
+2. The User Module should display only users belonging to the same site as the active user, unless they have the permission `Across all sites create and edit users`.
+3. Click the `Clear Form` button and verify it resets all filters.
+4. Verify that searching functions with all criteria: 
+    * site, 
+    * user name, 
+    * active, 
+    * full name, 
+    * pending approval, 
+    * email,
+    * examiner. 
+5. The `All` option in the site filter should displays users from all sites, even if they are different from the active user.
+6. Ensure adding a new user with the same name as an existing user fails.
 
-When creating or editing a user: (subtest: edit_user)
+When creating or editing a user: (subtest: `edit_user`)
 ========================================================
 
-7. Check that password rules are enforced.
-8. Check that saving fails if you do not enter at least these informations:
-      - User name.
-      - Password (and confirm password).
-      - First name.
-      - Last name.
+7. Ensure password strength rules are enforced.
+8. Form submission (the `Save` Button) should fail if any of the following fields are blank:
+      - User name,
+      - Password (and confirm password),
+      - First name,
+      - Last name,
       - Email.
-9. Check that if password and confirmed password do not match you get an error.
-10. Check that if you do not enter an email address that is syntactically valid you get an error.
-10a. Check that when creating a new user, there is an additional "Confirm email" text field on the page and that you 
-     get an error message if email and confirmed email don't match when submitting the form. 
-10b. Make sure that the confirm email text field is not on the edit user page (only on the create new user page).
+9. If password and confirmed password do not match, an error should be displayed.
+10. Email fields containing submitted with invalid formats should generate an error. 
+     
+* Ensure the confirm email text field is not displayed on the edit user page (and only on the create new user page).
+
 11. For an existing active user, edit the user's account and click 'Generate new password' and check 'Send email'.
     Save. Check that an email is sent to the user with the new password. Check that the password rules are enforced 
     for this new password. Check that after logging in, the user is immediately asked to update his/her password.
@@ -35,7 +40,7 @@ When creating or editing a user: (subtest: edit_user)
 12a. Check that when creating a new user, leading and trailing spaces in the username are stripped.
 12b. Check that you can create a new user with name 00 (double zero).
 12c. Check that you can delete one of the additional fields (organization, fax, etc...) that was previously set and that the save is performed.
-13. Check that if modifying a password for a user an email is sent to that user containing the new password (requires
+13. Check that if generating a new password for a user an email is sent to that user containing the new password (requires
     email server).
 14. Check that when editing a user account it is not possible to set the password to its actual value (i.e. it needs to change).
 15. Check that if the 'Display additional information' entry is set to false in the Configuration module, fields Degree,

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -765,6 +765,38 @@ class Database
     }
 
     /**
+     * Runs a query as a prepared statement and returns the values of the first
+     * column in the select statement. If multiple columns are given, only the first
+     * will be returned.
+     *
+     * @param string $query  The SQL SELECT query to be run
+     * @param array  $params Values to use for binding to prepared statement
+     *
+     * @return array Associative array of form rowID=>value containing all values
+     *               for the first element of the select statement
+     */
+    function pselectCol($query, $params)
+    {
+        $unprocessed = $this->pselect($query, $params);
+
+        $result = array();
+        foreach ($unprocessed as $k=>$row) {
+            $colNumber = count($row);
+            if ($colNumber !== 1) {
+                throw new DatabaseException(
+                    "The pselectCol() function expects only one column in the 
+                    SELECT clause of the query, $colNumber were passed.",
+                    $query
+                );
+            }
+            // Note: reset() rewinds array's internal pointer to the first element
+            // and returns the value of the first array element.
+            $result[$k] =reset($row);
+        }
+        return $result;
+    }
+
+    /**
      * Runs a query as a prepared statement and returns the value of the first
      * column of the first row
      *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -646,9 +646,11 @@ class Database
     function selectOne($query)
     {
         $result = null;
-        $this->select($query, $result);
+        $this->selectRow($query, $result);
         if (is_array($result) && count($result)) {
-            list(,$result) = each($result[0]);
+            foreach ($result as $key => $value) {
+                $result = $value;
+            }
         }
         return $result;
     }
@@ -809,8 +811,9 @@ class Database
     {
         $result = $this->pselectRow($query, $params);
         if (is_array($result) && count($result)) {
-
-            list(,$result) = each($result);
+            foreach ($result as $key => $value) {
+                $result = $value;
+            }
         }
         return $result;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -648,9 +648,8 @@ class Database
         $result = null;
         $this->selectRow($query, $result);
         if (is_array($result) && count($result)) {
-            foreach ($result as $key => $value) {
-                $result = $value;
-            }
+            $valueArray = array_values($result)
+            $result = $valueArray[0];
         }
         return $result;
     }
@@ -811,9 +810,8 @@ class Database
     {
         $result = $this->pselectRow($query, $params);
         if (is_array($result) && count($result)) {
-            foreach ($result as $key => $value) {
-                $result = $value;
-            }
+            $valueArray = array_values($result);
+            $result = $valueArray[0];
         }
         return $result;
     }

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -49,6 +49,7 @@
             <directory>../modules/user_accounts/test/</directory>
             <directory>../modules/media/test/</directory>
             <directory>../modules/issue_tracker/test/</directory>
+            <directory>../modules/server_processes_manager/test/</directory>
             <directory>../test/test_instrument/</directory>
         </testsuite>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
 var webpack = require('webpack');
 var path = require('path');
+var fs = require('fs');
 
-var config = {
+var config = [{
   entry: {
     './htdocs/js/components/DynamicDataTable.js': './jsx/DynamicDataTable.js',
     './htdocs/js/components/PaginationLinks.js': './jsx/PaginationLinks.js',
@@ -84,8 +85,17 @@ var config = {
   externals: {
     react: 'React'
   },
+  node: {
+    fs: "empty"
+  },
   devtool: 'source-map',
   plugins: [new webpack.optimize.UglifyJsPlugin({mangle: false})]
-};
+}];
+
+// Support project overrides
+if (fs.existsSync('./project/webpack-project.config.js')) {
+  var projConfig = require('./project/webpack-project.config.js');
+  config.push(projConfig);
+}
 
 module.exports = config;


### PR DESCRIPTION
Replaced deprecated pseudo function each() from php/libraires/Database.class.inc
See https://redmine.cbrain.mcgill.ca/issues/13175

For test, install new instance and run tools/config_to_db.php script

Or run the following code 

```
<?php

include "/var/www/Loris/php/libraries/Database.class.inc";
include "/var/www/Loris/php/libraries/NDB_Factory.class.inc";

$name = "ageMax";
$db = new Database();
$db->connect("database", "dbuser", "password", "host");
           $configID = $db->pselectone(
                "SELECT ID 
                 FROM ConfigSettings 
                 WHERE Name=:name",
                array('name' => $name)
            );

                $dbParentKey = $db->pselectone(
                    "SELECT Name 
                     FROM ConfigSettings 
                     WHERE ID=(SELECT Parent FROM ConfigSettings WHERE Name=:name)",
                    array('name' => $name)
                );
     $allowMultiple = $db->pselectone(
        "SELECT AllowMultiple 
         FROM ConfigSettings 
         WHERE ID=:configID",
        array('configID' => $configID)
    );

$config = "configID $configID \n";
$parentkey = "parent $dbParentKey \n";
$allow = "multiple $allowMultiple \n";

echo $config;
echo $parentkey;
echo $allow;

## output should be
#configID 7 
#parent study 
#multiple 0 

?>
```