### PR TITLE
[Database] replace deprecated each

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -648,9 +648,8 @@ class Database
         $result = null;
         $this->selectRow($query, $result);
         if (is_array($result) && count($result)) {
-            foreach ($result as $key => $value) {
-                $result = $value;
-            }
+            $valueArray = array_values($result);
+            $result     = $valueArray[0];
         }
         return $result;
     }
@@ -811,9 +810,8 @@ class Database
     {
         $result = $this->pselectRow($query, $params);
         if (is_array($result) && count($result)) {
-            foreach ($result as $key => $value) {
-                $result = $value;
-            }
+            $valueArray = array_values($result);
+            $result     = $valueArray[0];
         }
         return $result;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -646,9 +646,11 @@ class Database
     function selectOne($query)
     {
         $result = null;
-        $this->select($query, $result);
+        $this->selectRow($query, $result);
         if (is_array($result) && count($result)) {
-            list(,$result) = each($result[0]);
+            foreach ($result as $key => $value) {
+                $result = $value;
+            }
         }
         return $result;
     }
@@ -809,8 +811,9 @@ class Database
     {
         $result = $this->pselectRow($query, $params);
         if (is_array($result) && count($result)) {
-
-            list(,$result) = each($result);
+            foreach ($result as $key => $value) {
+                $result = $value;
+            }
         }
         return $result;
     }


### PR DESCRIPTION
replace `each()` with `array_values()` in `pselectone()`

redmind ticket 13175