### PR TITLE
[User] rename and better use the singleton and factory patterns

### DIFF
--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -113,7 +113,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
             //$file->setFilenamePrefix($timepoint->getVisitLabel()."-".$this->testName."-");
 
             //set the the IDs to the handler functions.
-            $user =& User::singleton();
+            $user = \User::getLoggedInUser();
             $file->setHandlerArgs(array("CommentID"=>$this->getCommentID(),
                         "candID"=>$candidate->getCandID(),
                         "PSCID"=>$candidate->getPSCID(),

--- a/htdocs/api/v0.0.1/Candidates.php
+++ b/htdocs/api/v0.0.1/Candidates.php
@@ -177,7 +177,7 @@ class Candidates extends APIBase
      */
     public function createNew($DoB, $edc, $gender, $PSCID)
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         \Candidate::createNew(
             $user->getCenterID(),
             $DoB,

--- a/htdocs/api/v0.0.2/Candidates.php
+++ b/htdocs/api/v0.0.2/Candidates.php
@@ -118,7 +118,7 @@ class Candidates extends APIBase
 
         // This version of the API does not handle candidate creation
         // when users are at multiple sites
-        $user      = \User::singleton();
+        $user      = \User::getLoggedInUser();
         $centerIDs = $user->getCenterIDs();
         $num_sites = count($centerIDs);
 

--- a/htdocs/api/v0.0.2/candidates/Visit.php
+++ b/htdocs/api/v0.0.2/candidates/Visit.php
@@ -171,7 +171,7 @@ class Visit extends \Loris\API\Candidates\Candidate
         }
         // This version of the API does not handle timepoint creation
         // when users are at multiple sites
-        $user      = \User::singleton();
+        $user      = \User::getLoggedInUser();
         $centerIDs = $user->getCenterIDs();
         $num_sites = count($centerIDs);
         if ($num_sites == 0) {

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -28,7 +28,7 @@ require_once "FeedbackMRI.class.inc";
 $DB =& Database::singleton();
 
 // user is logged in, let's continue with the show...
-$user =& User::singleton($_SESSION['State']->getUsername());
+$user = \User::getLoggedInUser();
 
 // check permissions
 if ($user->hasPermission('imaging_browser_qc')) {

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -87,7 +87,7 @@ if (!$anonymous) {
     tplFromRequest('dynamictabs');
     // draw the user information table
     try {
-        $user =& User::singleton();
+        $user = \User::getLoggedInUser();
 
         $site_arr = $user->getData('CenterIDs');
         foreach ($site_arr as $key=>$val) {

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -38,7 +38,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         // create user object and check appropriate permission
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('acknowledgements_view'));
     }
 
@@ -52,7 +52,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
     function _process($values)
     {
         // create user object and check appropriate permission
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('acknowledgements_edit')) {
             return;
         }

--- a/modules/bvl_feedback/ajax/bvl_panel_ajax.php
+++ b/modules/bvl_feedback/ajax/bvl_panel_ajax.php
@@ -15,7 +15,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-$user     =& User::singleton();
+$user     = \User::getLoggedInUser();
 $username = $user->getUsername();
 
 if (isset($_POST['candID']) && (empty($_POST['sessionID']))) {

--- a/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
@@ -14,7 +14,7 @@
 ini_set('default_charset', 'utf-8');
 require "bvl_panel_ajax.php";
 
-$user     =& User::singleton();
+$user     = \User::getLoggedInUser();
 $username = $user->getUsername();
 
 if (isset($_POST['feedbackID']) && isset($_POST['candID'])) {

--- a/modules/bvl_feedback/ajax/react_get_bvl_threads.php
+++ b/modules/bvl_feedback/ajax/react_get_bvl_threads.php
@@ -21,7 +21,7 @@ set_include_path(
 require_once __DIR__ . "/../../../vendor/autoload.php";
 require_once "NDB_Client.class.inc";
 
-$user     =& User::singleton();
+$user     = \User::getLoggedInUser();
 $username = $user->getUsername();
 
 if (isset($_POST['candID']) && !(isset($_POST['sessionID']))) {

--- a/modules/bvl_feedback/ajax/thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/thread_comment_bvl_feedback.php
@@ -16,7 +16,7 @@ ini_set('default_charset', 'utf-8');
 
 require "bvl_panel_ajax.php";
 
-$user     =& User::singleton();
+$user     = \User::getLoggedInUser();
 $username = $user->getUsername();
 
 $newEntryValues = array();

--- a/modules/candidate_list/ajax/validateProfileIDs.php
+++ b/modules/candidate_list/ajax/validateProfileIDs.php
@@ -12,7 +12,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!($user->hasPermission('access_all_profiles')
     || ($user->hasStudySite() && $user->hasPermission('data_entry')))
 ) {

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -33,7 +33,7 @@ class Candidate_List extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $aap  = $user->hasPermission('access_all_profiles');
         $this->tpl_data['access_all_profiles'] = $aap;
         return (
@@ -51,7 +51,7 @@ class Candidate_List extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $config =& \NDB_Config::singleton();
 
         $this->tpl_data['toggled_visible'] =false;
@@ -209,7 +209,7 @@ class Candidate_List extends \NDB_Menu_Filter
         \Module::factory('candidate_parameters');
 
         // create user object
-         $user    =& \User::singleton();
+         $user    = \User::getLoggedInUser();
           $config =& \NDB_Config::singleton();
         // PSC
         if ($user->hasPermission('access_all_profiles')) {

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -16,7 +16,7 @@ if (isset($_POST['tab'])) {
     $tab = $_POST['tab'];
 
     $db   =& \Database::singleton();
-    $user =& \User::singleton();
+    $user = \User::getLoggedInUser();
 
     if ($tab == "candidateInfo") {
         editCandInfoFields($db, $user);
@@ -316,7 +316,7 @@ function editParticipantStatusFields($db, $user)
 
     $id = null;
     if (!(is_null($_SESSION['State']))) {
-        $currentUser =& User::singleton($_SESSION['State']->getUsername());
+        $currentUser = \User::getLoggedInUser();
         $id          = $currentUser->getData("UserID");
     }
 
@@ -369,7 +369,7 @@ function editConsentStatusFields($db, $user)
 
     $id = null;
     if (!(is_null($_SESSION['State']))) {
-        $currentUser =& \User::singleton($_SESSION['State']->getUsername());
+        $currentUser = \User::getLoggedInUser();
         $id          = $currentUser->getData("UserID");
     }
 

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -40,7 +40,7 @@ class Candidate_Parameters extends \NDB_Form
     function _hasAccess()
     {
         //create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // Set global permission to control access
         // to different modules of candidate_parameters page

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -18,7 +18,7 @@ require_once "Database.class.inc";
 require_once 'NDB_Client.class.inc';
 require_once "Utility.class.inc";
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('config')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -12,7 +12,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('config')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -12,7 +12,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('config')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -35,7 +35,7 @@ class Configuration extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('config');
     }
 

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -35,7 +35,7 @@ class Project extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('config');
     }
 

--- a/modules/configuration/php/subproject.class.inc
+++ b/modules/configuration/php/subproject.class.inc
@@ -34,7 +34,7 @@ class Subproject extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('config');
     }
 

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -36,7 +36,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('conflict_resolver'));
     }
 
@@ -56,7 +56,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
 
         $DB =& \Database::singleton();
 
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         foreach ($values AS $key => $val) {
             // The only valid values are 1, 2 or none.  Therefore we are only
@@ -238,7 +238,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
             LEFT JOIN Project ON (candidate.ProjectID=Project.ProjectID )
             WHERE 1=1";
 
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -324,7 +324,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     {
         parent::setup();
         // Create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $config =& \NDB_Config::singleton();
 

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -37,7 +37,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('conflict_resolver'));
     }
 
@@ -86,7 +86,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
             LEFT JOIN Project ON (candidate.ProjectID=Project.ProjectID )
             WHERE 1=1";
 
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('access_all_profiles')) {
             // restrict data to own site
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -182,7 +182,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     {
         parent::setup();
         // Create user object
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $config =& \NDB_Config::singleton();
 
         // Get instruments

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -39,7 +39,7 @@ class Create_Timepoint extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $candidate =& \Candidate::singleton($this->identifier);
 
@@ -184,7 +184,7 @@ class Create_Timepoint extends \NDB_Form
         if ($visitLabelAdded) {
             $this->addRule('visitLabel', 'Visit label is required', 'required');
             // List of sites for the user
-            $user = \User::singleton();
+            $user = \User::getLoggedInUser();
             $DB   = \Database::singleton();
             $user_list_of_sites = $user->getData('CenterIDs');
             $num_sites          = count($user_list_of_sites);
@@ -218,7 +218,7 @@ class Create_Timepoint extends \NDB_Form
      */
     function _validate(array $val)
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $errors = array();
 

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -35,7 +35,7 @@ class Dashboard extends \NDB_Form
     function setup()
     {
         $DB     = \Database::singleton();
-        $user   = \User::singleton();
+        $user   = \User::getLoggedInUser();
         $config = \NDB_Config::singleton();
         $site   = explode(';', $user->getSiteNames());
 

--- a/modules/data_integrity_flag/php/data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/data_integrity_flag.class.inc
@@ -37,7 +37,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
     function _hasAccess()
     {
         //create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_integrity_flag');
     }
 
@@ -69,7 +69,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
      */
     function _insertDataFlag($req)
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $db   =& \Database::singleton();
 
         if (!isset($req['instrument'])

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -13,7 +13,7 @@
   */
 
 $DB   =& Database::singleton();
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 
 if ($_POST['action'] == 'upload') {
     $fileName    = $_FILES["file"]["name"];

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -12,7 +12,7 @@
  *  @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 
 $File = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -33,7 +33,7 @@ class Data_Release extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $Factory = \NDB_Factory::singleton();
         $DB      = $Factory->Database();

--- a/modules/data_team_helper/ajax/GetCandidates.php
+++ b/modules/data_team_helper/ajax/GetCandidates.php
@@ -18,7 +18,7 @@ ini_set('default_charset', 'utf-8');
 require_once "Database.class.inc";
 require_once "NDB_Client.class.inc";
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('data_team_helper')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/data_team_helper/ajax/GetInstruments.php
+++ b/modules/data_team_helper/ajax/GetInstruments.php
@@ -19,7 +19,7 @@ require_once "Database.class.inc";
 require_once 'NDB_Config.class.inc';
 require_once 'NDB_Client.class.inc';
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('data_team_helper')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -35,7 +35,7 @@ class Data_Team_Helper extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('data_team_helper'));
     }
 
@@ -49,7 +49,7 @@ class Data_Team_Helper extends \NDB_Form
         //initializations
         parent::setup();
         $DB       =& \Database::singleton();
-        $user     =& \User::singleton();
+        $user     = \User::getLoggedInUser();
         $config   =& \NDB_Config::singleton();
         $sanitize = array_map('htmlspecialchars', $_REQUEST);
 
@@ -177,7 +177,7 @@ class Data_Team_Helper extends \NDB_Form
      */
     function getDefaultSite()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         if ($user->hasPermission('access_all_profiles')) {
             $site_default ='All Sites';
         } else {
@@ -242,7 +242,7 @@ class Data_Team_Helper extends \NDB_Form
         }
         if ($site!='All Sites') {
             if ($site == 'All User Sites') {
-                $user           = \User::singleton();
+                $user           = \User::getLoggedInUser();
                 $siteID         = $user->getCenterIDs();
                 $where         .= " AND FIND_IN_SET(psc.CenterID, :CID)";
                 $qparams['CID'] = implode(',', $siteID);
@@ -399,7 +399,7 @@ class Data_Team_Helper extends \NDB_Form
         //filter for sites
         if ($site!='All Sites') {
             if ($site == 'All User Sites') {
-                $user           = \User::singleton();
+                $user           = \User::getLoggedInUser();
                 $siteID         = $user->getCenterIDs();
                 $where         .= " AND FIND_IN_SET(psc.CenterID, :CID)";
                 $qparams['CID'] = implode(',', $siteID);
@@ -542,7 +542,7 @@ class Data_Team_Helper extends \NDB_Form
         }
         if ($site!='All Sites') {
             if ($site == 'All User Sites') {
-                $user           = \User::singleton();
+                $user           = \User::getLoggedInUser();
                 $siteID         = $user->getCenterIDs();
                 $where         .= " AND FIND_IN_SET(psc.CenterID, :CID)";
                 $qparams['CID'] = implode(',', $siteID);
@@ -616,7 +616,7 @@ class Data_Team_Helper extends \NDB_Form
         }
         if ($site!='All Sites') {
             if ($site == 'All User Sites') {
-                $user           = \User::singleton();
+                $user           = \User::getLoggedInUser();
                 $siteID         = $user->getCenterIDs();
                 $where         .= " AND FIND_IN_SET(psc.CenterID, :CID)";
                 $qparams['CID'] = implode(',', $siteID);
@@ -688,7 +688,7 @@ class Data_Team_Helper extends \NDB_Form
         }
         if ($site!='All Sites') {
             if ($site == 'All User Sites') {
-                $user           = \User::singleton();
+                $user           = \User::getLoggedInUser();
                 $siteID         = $user->getCenterIDs();
                 $where         .= " AND FIND_IN_SET(psc.CenterID, :CID)";
                 $qparams['CID'] = implode(',', $siteID);

--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -11,7 +11,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('data_dict_edit')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -41,7 +41,7 @@ if (get_magic_quotes_gpc()) {
 }
 
 // create user object
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 
 if ($user->hasPermission('data_dict_edit')) { //if user has edit permission
     if ($DB->pselectOne(

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -37,7 +37,7 @@ class Datadict extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return ($user->hasPermission('data_dict_view') ||
                                    $user->hasPermission('data_dict_edit'));

--- a/modules/dataquery/ajax/GetDoc.php
+++ b/modules/dataquery/ajax/GetDoc.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/datadictionary.php
+++ b/modules/dataquery/ajax/datadictionary.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/getAllSessions.php
+++ b/modules/dataquery/ajax/getAllSessions.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/queryContains.php
+++ b/modules/dataquery/ajax/queryContains.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/queryEqual.php
+++ b/modules/dataquery/ajax/queryEqual.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/queryGreaterThanEqual.php
+++ b/modules/dataquery/ajax/queryGreaterThanEqual.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/queryLessThanEqual.php
+++ b/modules/dataquery/ajax/queryLessThanEqual.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/queryNotEqual.php
+++ b/modules/dataquery/ajax/queryNotEqual.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/queryStartsWith.php
+++ b/modules/dataquery/ajax/queryStartsWith.php
@@ -10,7 +10,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/retrieveCategoryDocs.php
+++ b/modules/dataquery/ajax/retrieveCategoryDocs.php
@@ -11,7 +11,7 @@
  * @link     https://www.github.com/aces/Loris/
  */
 ini_set("max_input_vars", 10000);
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/dataquery/ajax/saveQuery.php
+++ b/modules/dataquery/ajax/saveQuery.php
@@ -11,7 +11,7 @@
  * @link     https://www.github.com/aces/Loris/
  */
 ini_set("max_input_vars", 4000);
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('dataquery_view')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -21,7 +21,7 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
 
-$user = User::singleton();
+$user = User::getLoggedInUser();
 $cdb  = CouchDB::singleton();
 $qid  = $user->getUserName() . "_" . $_REQUEST['QueryName'];
 

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -33,7 +33,7 @@ class Dataquery extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // check user permissions
         return $user->hasPermission('dataquery_view');
@@ -47,7 +47,7 @@ class Dataquery extends \NDB_Form
     {
         parent::setup();
 
-        $user     = \User::singleton();
+        $user     = \User::getLoggedInUser();
         $username = $user->getUsername();
         $couch    = \CouchDB::singleton();
 

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -37,7 +37,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function _hasAccess()
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('dicom_archive_view_allsites');
     }
 

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -37,7 +37,7 @@ class ViewDetails extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('dicom_archive_view_allsites');
     }
 

--- a/modules/document_repository/ajax/GetFile.php
+++ b/modules/document_repository/ajax/GetFile.php
@@ -13,7 +13,7 @@
  *  @link     https://github.com/aces/Loris-Trunk
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('document_repository_view')
     && !$user->hasPermission('document_repository_delete')
 ) {

--- a/modules/document_repository/ajax/addCategory.php
+++ b/modules/document_repository/ajax/addCategory.php
@@ -11,7 +11,7 @@
  * @link     https://www.github.com/Jkat/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('document_repository_view')
     && !$user->hasPermission('document_repository_delete')
 ) {
@@ -57,7 +57,7 @@ if ($_POST['comments'] !== '') {
     $comments = $_POST['comments'];
 }
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 //if user has document repository permission
 if ($user->hasPermission('document_repository_view')
     || $user->hasPermission('document_repository_delete')

--- a/modules/document_repository/ajax/categoryEdit.php
+++ b/modules/document_repository/ajax/categoryEdit.php
@@ -11,7 +11,7 @@
  * @link     https://www.github.com/Jkat/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('document_repository_view')
     && !$user->hasPermission('document_repository_delete')
 ) {
@@ -36,7 +36,7 @@ if (get_magic_quotes_gpc()) {
     $comments = $_REQUEST['comments'];
 }
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 
 //if user has document repository permission
 if ($user->hasPermission('document_repository_view')

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -10,7 +10,7 @@
   * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
   * @link     https://github.com/aces/Loris
   */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('document_repository_delete')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -50,7 +50,7 @@ $dataDir  = $DB->pselectOne(
     array(':identifier' => $rid)
 );
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 
 //if user has document repository delete permission
 if ($user->hasPermission('document_repository_delete')) {

--- a/modules/document_repository/ajax/documentEditUpload.php
+++ b/modules/document_repository/ajax/documentEditUpload.php
@@ -10,7 +10,7 @@
   * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
   * @link     https://github.com/aces/Loris
   */
-$userSingleton =& User::singleton();
+$userSingleton = \User::getLoggedInUser();
 if (!$userSingleton->hasPermission('document_repository_view')
     && !$userSingleton->hasPermission('document_repository_delete')
 ) {

--- a/modules/document_repository/ajax/getFileData.php
+++ b/modules/document_repository/ajax/getFileData.php
@@ -10,7 +10,7 @@
   * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
   * @link     https://github.com/aces/Loris
   */
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('document_repository_view')
     && !$user->hasPermission('document_repository_delete')
 ) {

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -36,7 +36,7 @@ class Document_Repository extends \NDB_Menu_Filter
     function _hasAccess()
     {
         //create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return $user->hasPermission('document_repository_view')
                || $user->hasPermission('document_repository_delete');
@@ -52,7 +52,7 @@ class Document_Repository extends \NDB_Menu_Filter
     {
         parent::setup();
 
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // create the centerID map
         $db      =& \Database::singleton();
@@ -131,7 +131,7 @@ class Document_Repository extends \NDB_Menu_Filter
     function _setFilterForm()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $list_of_sites = \Utility::getSiteList(true, false);
            // allow to view all sites data through filter
@@ -176,7 +176,7 @@ class Document_Repository extends \NDB_Menu_Filter
         $this->addSelect('File_category', 'File category:', $fileCategories);
         $this->tpl_data['Sites']       = $list_of_sites;
         $this->tpl_data['Instruments'] = $list_of_instruments;
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $userID = $user->getData('UserID');
         $this->tpl_data['User'] = $userID;
         $this->addSelect('For_site', 'For Site:', $list_of_sites);

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -43,7 +43,7 @@ class EditExaminer extends \NDB_Form
         $DB     = \Database::singleton();
         $config = \NDB_Config::singleton();
 
-        $user         = \User::singleton();
+        $user         = \User::getLoggedInUser();
         $userFullName = $user->getFullname();
         $userCenter   = $user->getCenterIDs();
 

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -35,7 +35,7 @@ class Examiner extends \NDB_Menu_Filter_Form
      */
     function _hasAccess()
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('examiner_view');
     }
 
@@ -55,7 +55,7 @@ class Examiner extends \NDB_Menu_Filter_Form
             $this->useCertification = false;
         }
 
-        $user      = \User::singleton();
+        $user      = \User::getLoggedInUser();
         $centerIDs = implode(',', $user->getCenterIDs());
 
         if ($user->hasPermission('examiner_multisite')) {
@@ -135,7 +135,7 @@ class Examiner extends \NDB_Menu_Filter_Form
     function setup()
     {
         parent::setup();
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // Get site options
         if ($user->hasPermission('examiner_multisite')) {

--- a/modules/genomic_browser/ajax/genomic_file_upload.php
+++ b/modules/genomic_browser/ajax/genomic_file_upload.php
@@ -15,7 +15,7 @@
  *  @license    Loris license
  *  @link       https://github.com/aces/Loris-Trunk
  */
-$userSingleton =& User::singleton();
+$userSingleton = \User::getLoggedInUser();
 if (!$userSingleton->hasPermission('genomic_browser_view_site')
     && !$userSingleton->hasPermission('genomic_browser_view_allsites')
 ) {

--- a/modules/genomic_browser/ajax/get_genomic_file_type.php
+++ b/modules/genomic_browser/ajax/get_genomic_file_type.php
@@ -12,7 +12,7 @@
  *  @link       https://github.com/aces/Loris-Trunk
  */
 
-$userSingleton =& User::singleton();
+$userSingleton = \User::getLoggedInUser();
 if (!$userSingleton->hasPermission('genomic_browser_view_site')
     && !$userSingleton->hasPermission('genomic_browser_view_allsites')
 ) {

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -50,7 +50,7 @@ class CNV_Browser extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }
@@ -142,7 +142,7 @@ class CNV_Browser extends \NDB_Menu_Filter
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";
 
         $DB   = \Database::singleton();
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $site_arr     = implode(",", $user->getCenterIDs());
             $this->query .= " AND candidate.CenterID IN (" . $site_arr . ")";
@@ -220,7 +220,7 @@ class CNV_Browser extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // PSC
         if ($user->hasPermission('genomic_browser_view_allsites')) {

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -51,7 +51,7 @@ class CpG_Browser extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }
@@ -163,7 +163,7 @@ class CpG_Browser extends \NDB_Menu_Filter
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";
 
         $DB   = \Database::singleton();
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -262,7 +262,7 @@ class CpG_Browser extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // PSC
         if ($user->hasPermission('genomic_browser_view_allsites')) {

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -51,7 +51,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }
@@ -133,7 +133,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";
 
         $DB   = \Database::singleton();
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             // allow only to view own site data
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -197,7 +197,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // PSC
         if ($user->hasPermission('genomic_browser_view_allsites')) {

--- a/modules/genomic_browser/php/genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/genomic_file_uploader.class.inc
@@ -39,7 +39,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }
@@ -137,7 +137,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
         );
         $this->addCheckbox('caveat', 'Caveat:', $Base_options);
 
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         $this->tpl_data['user']           = $user->getUsername();
         $this->tpl_data['upload_allowed'] = $user->hasPermission(
             'genomic_data_manager'

--- a/modules/genomic_browser/php/gwas_browser.class.inc
+++ b/modules/genomic_browser/php/gwas_browser.class.inc
@@ -44,7 +44,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }
@@ -126,7 +126,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // add form elements
         $show_results_options = array(

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -50,7 +50,7 @@ class SNP_Browser extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }
@@ -150,7 +150,7 @@ class SNP_Browser extends \NDB_Menu_Filter
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";
 
         $DB   = \Database::singleton();
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('genomic_browser_view_allsites')) {
             // restrict data to own site
             $site_arr     = implode(",", $user->getCenterIDs());
@@ -245,7 +245,7 @@ class SNP_Browser extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // PSC
         if ($user->hasPermission('genomic_browser_view_allsites')) {

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -39,7 +39,7 @@ class View_Genomic_File extends \NDB_Form
     */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // Add site control? See Imaging Browser example
         return ($user->hasPermission('genomic_browser_view_allsites') ||

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -34,7 +34,7 @@ class Edit_Help_Content extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
             // check user permissions
         return $user->hasPermission('context_help');

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -33,7 +33,7 @@ class Help_Editor extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return $user->hasPermission('context_help');
     }
@@ -44,7 +44,7 @@ class Help_Editor extends \NDB_Menu_Filter
        */
     function _setupVariables()
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // the base query
         $query = " FROM help helpChild LEFT JOIN help helpParent".

--- a/modules/imaging_browser/ajax/setSortedRows.php
+++ b/modules/imaging_browser/ajax/setSortedRows.php
@@ -13,7 +13,7 @@
  */
 
 // Get LORIS user issuing the request
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!($user->hasPermission('imaging_browser_view_allsites')
     || ($user->hasStudySite()
     && $user->hasPermission('imaging_browser_view_site'))

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -35,7 +35,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return ($user->hasPermission('imaging_browser_view_allsites')
                || ($user->hasStudySite()
@@ -159,7 +159,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
         $this->query .= $where;
 
         $config =& \NDB_Config::singleton();
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $DB     = \Database::singleton();
         if (!$user->hasPermission('imaging_browser_view_allsites')) {
             $site_arr = implode(",", $user->getCenterIDs());
@@ -296,7 +296,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
     {
         parent::setup();
         // create user object
-        $user          =& \User::singleton();
+        $user          = \User::getLoggedInUser();
         $list_of_sites = array();
 
         // PSC

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -51,7 +51,7 @@ class Imaging_Session_ControlPanel
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('imaging_browser_qc');
     }
 

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -46,7 +46,7 @@ class ViewSession extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // allow only to view own site data
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
@@ -70,7 +70,7 @@ class ViewSession extends \NDB_Form
      */
     function _hasQCPerm()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return $user->hasPermission('imaging_browser_qc');
     }
@@ -425,7 +425,7 @@ class ViewSession extends \NDB_Form
             }
         }
         if (is_array($values['caveat'])) {
-            $user        = \User::singleton();
+            $user        = \User::getLoggedInUser();
             $timePoint   =& \TimePoint::singleton($this->sessionID);
             $candid      = $timePoint->getCandID();
             $visit_label = $timePoint->getData('Visit_label');

--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -18,7 +18,7 @@
  */
 
 // Get LORIS user issuing the request
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('imaging_uploader')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/imaging_uploader/ajax/read_log.php
+++ b/modules/imaging_uploader/ajax/read_log.php
@@ -12,7 +12,7 @@
  * @link     https://github.com/aces/Loris-Trunk
 */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('mri_upload')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -50,7 +50,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         // create user object
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('imaging_uploader');
     }
 
@@ -218,7 +218,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             $this
         );
 
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         //set the the IDs to the handler functions.
         $file->setHandlerArgs(array("values" => $values));
 
@@ -379,7 +379,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         ///////////////////////////////////////////////////////////////////////
         $user_name = $args['user_id'];
         if (($user_name==null) || (!(isset($user_name)))) {
-            $user      = \User::singleton();
+            $user      = \User::getLoggedInUser();
             $user_name = $user->getUsername();
         }
         ///////////////////////////////////////////////////////////////////////

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -50,7 +50,7 @@ class Instrument_Builder extends \NDB_Form
      */
     function _hasPerm($perm)
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission($perm);
     }
     /**

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -38,7 +38,7 @@ class Instrument_List extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
         $candID    = $timePoint->getCandID();
@@ -114,7 +114,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
         // display list of instruments
         if (!empty($listOfInstruments)) {
-            $user     =& \User::singleton();
+            $user     = \User::getLoggedInUser();
             $username = $user->getData('UserID');
 
             $feedback_select_inactive = null;

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -71,7 +71,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         }
 
         // BVLQC - get permission and set the tpl element
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $this->tpl_data['access']['bvl_qc']
             = $user->hasPermission('bvl_feedback');
 
@@ -279,7 +279,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         }
 
         // set the BVLQC flag
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         if (isset($_REQUEST['setBVLQCStatus'])
             && $user->hasPermission('bvl_feedback')
         ) {
@@ -350,7 +350,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         $db =& \Database::singleton();
 
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $hasAccess = $this->_hasAccessStatus();
 
@@ -455,7 +455,7 @@ class Instrument_List_ControlPanel extends \TimePoint
     function _hasAccessStatus()
     {
         // get user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // disable the button for all these users
         $currentStage = $this->getCurrentStage();
@@ -611,7 +611,7 @@ class Instrument_List_ControlPanel extends \TimePoint
     function _getSendToDCCStatusMessage()
     {
         // create user object
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $config =& \NDB_Config::singleton();
 
         // get the value of the session.Scan_done field
@@ -713,7 +713,7 @@ class Instrument_List_ControlPanel extends \TimePoint
     function _hasAccessSendToDCC()
     {
         // create user object
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $config =& \NDB_Config::singleton();
 
         // get the value of the session.Scan_done field
@@ -764,7 +764,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         $this->tpl_data['next_stage'] = $this->getNextStage();
 
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // check user permissions
         if (!$user->hasPermission('data_entry') || !in_array(

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -32,7 +32,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('superuser');
     }
     /**

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -50,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === "GET") {
 function editIssue()
 {
     $db   =& Database::singleton();
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
 
     $issueValues    = array();
     $validateValues = array();
@@ -263,7 +263,7 @@ function validateInput($values)
         $query  = "SELECT CandID FROM candidate WHERE PSCID=:PSCID";
         $params = ['PSCID' => $result['PSCID']];
 
-        $user =& User::singleton();
+        $user = \User::getLoggedInUser();
         if (!$user->hasPermission('access_all_profiles')) {
             $params['CenterID'] = implode(',', $user->getCenterIDs());
             $query .= " AND FIND_IN_SET(CenterID,:CenterID)";
@@ -322,7 +322,7 @@ function getChangedValues($issueValues, $issueID)
  */
 function updateHistory($values, $issueID)
 {
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     $db   =& Database::singleton();
 
     foreach ($values as $key => $value) {
@@ -350,7 +350,7 @@ function updateHistory($values, $issueID)
  */
 function updateComments($comment, $issueID)
 {
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     $db   =& Database::singleton();
 
     if (isset($comment) && $comment != "null") {
@@ -375,7 +375,7 @@ function updateComments($comment, $issueID)
  */
 function updateCommentHistory($issueCommentID, $newCommentValue)
 {
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     $db   =& Database::singleton();
 
     $changedValue = array(
@@ -483,7 +483,7 @@ function getComments($issueID)
  */
 function emailUser($issueID, $changed_assignee)
 {
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     $db   =& Database::singleton();
     //not sure if this is necessary
     $factory = NDB_Factory::singleton();
@@ -554,7 +554,7 @@ function getIssueFields()
 {
 
     $db    =& Database::singleton();
-    $user  =& User::singleton();
+    $user  = \User::getLoggedInUser();
     $sites = array();
 
     //get field options
@@ -715,7 +715,7 @@ ORDER BY dateAdded",
 function getIssueData($issueID=null)
 {
 
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     $db   =& Database::singleton();
 
     if (!empty($issueID)) {

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -47,7 +47,7 @@ class Issue extends \NDB_Form
     function setup()
     {
         parent::setup();
-        $user    =& \User::singleton();
+        $user    = \User::getLoggedInUser();
         $issueID = $_GET['issueID'];
 
         if ((empty($issueID)
@@ -112,7 +112,7 @@ class Issue extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user    =& \User::singleton();
+        $user    = \User::getLoggedInUser();
         $db      = \Database::singleton();
         $issueID = $_GET['issueID'];
 

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -39,7 +39,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     function _setupVariables()
     {
 
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $db   = \Database::singleton();
 
         $this->query = " FROM issues as i " .
@@ -156,7 +156,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     function setup()
     {
         parent::setup();
-        $user          =& \User::singleton();
+        $user          = \User::getLoggedInUser();
         $db            = \Database::singleton();
         $list_of_sites = array();
 
@@ -301,7 +301,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
-        $user  =& \User::singleton();
+        $user  = \User::getLoggedInUser();
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (($field != 'w.userID')

--- a/modules/issue_tracker/php/issue_tracker_controlpanel.class.inc
+++ b/modules/issue_tracker/php/issue_tracker_controlpanel.class.inc
@@ -52,7 +52,7 @@ class Issue_Tracker_ControlPanel
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         if ($user->hasPermission('issue_tracker_reporter')
             || $user->hasPermission('issue_tracker_developer')
         ) {

--- a/modules/issue_tracker/php/my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/my_issue_tracker.class.inc
@@ -40,7 +40,7 @@ class My_Issue_Tracker extends \NDB_Menu_Filter_Form
     function _setupVariables()
     {
 
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $db   = \Database::singleton();
 
         $this->query = " FROM issues as i ".
@@ -155,7 +155,7 @@ class My_Issue_Tracker extends \NDB_Menu_Filter_Form
     function setup()
     {
         parent::setup();
-        $user          =& \User::singleton();
+        $user          = \User::getLoggedInUser();
         $db            = \Database::singleton();
         $list_of_sites = array();
 
@@ -288,7 +288,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
-        $user  =& \User::singleton();
+        $user  = \User::getLoggedInUser();
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (($field != 'w.userID')

--- a/modules/issue_tracker/php/resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/resolved_issue_tracker.class.inc
@@ -39,7 +39,7 @@ class Resolved_Issue_Tracker extends \NDB_Menu_Filter_Form
     function _setupVariables()
     {
 
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $db   = \Database::singleton();
 
         $this->query = " FROM issues as i " .
@@ -155,7 +155,7 @@ class Resolved_Issue_Tracker extends \NDB_Menu_Filter_Form
     {
         parent::setup();
 
-        $user  =& \User::singleton();
+        $user  = \User::getLoggedInUser();
         $db    = \Database::singleton();
         $sites = array();
 
@@ -289,7 +289,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
-        $user  =& \User::singleton();
+        $user  = \User::getLoggedInUser();
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
             if (($field != 'w.userID')

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -83,7 +83,7 @@ class PasswordReset extends \NDB_Form
 
         // create the user object
         $username = $values['username'];
-        $user     = \User::singleton($username);
+        $user     = \User::getUserFromUsername($username);
 
         $email = $user->getData('Email');
 

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -83,7 +83,7 @@ class PasswordReset extends \NDB_Form
 
         // create the user object
         $username = $values['username'];
-        $user     =& \User::singleton($username);
+        $user     = \User::singleton($username);
 
         $email = $user->getData('Email');
 

--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -14,7 +14,7 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('media_write')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -34,7 +34,7 @@ if (isset($_GET['action'])) {
 function editFile()
 {
     $db   =& Database::singleton();
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     if (!$user->hasPermission('media_write')) {
         header("HTTP/1.1 403 Forbidden");
         exit;
@@ -80,7 +80,7 @@ function uploadFile()
 
     $db     =& Database::singleton();
     $config = NDB_Config::singleton();
-    $user   =& User::singleton();
+    $user   = \User::getLoggedInUser();
     if (!$user->hasPermission('media_write')) {
         header("HTTP/1.1 403 Forbidden");
         exit;

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -98,7 +98,7 @@ class Edit extends \NDB_Form
     function _hasAccess()
     {
         //create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return $user->hasPermission('media_write');
     }

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -43,7 +43,7 @@ class Media extends \NDB_Menu_Filter
     function _hasAccess()
     {
         //create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // Set global permission to control access to different modules of media page
         $this->hasWritePermission = $user->hasPermission('media_write');
@@ -63,7 +63,7 @@ class Media extends \NDB_Menu_Filter
     {
         parent::setup();
 
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $db   = \Database::singleton();
 
         $siteList  = array();
@@ -139,7 +139,7 @@ class Media extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         // the base query
         $query  = " FROM media m LEFT JOIN session s ON m.session_id = s.ID".
         " LEFT JOIN candidate c ON c.CandID=s.CandID";

--- a/modules/mri_violations/ajax/UpdateMRIProtocol.php
+++ b/modules/mri_violations/ajax/UpdateMRIProtocol.php
@@ -10,7 +10,7 @@
  * @license  Loris license
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-$user =& \User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('violated_scans_edit')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -31,7 +31,7 @@ $table_desc  = $DB->pselect("DESC mri_protocol", array());
 $column_name = $table_desc[$column_id]['Field'];
 
 // create user object
-$user =& \User::singleton();
+$user = \User::getLoggedInUser();
 
 if ($user->hasPermission('violated_scans_edit')) {
      $DB->update(

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -36,7 +36,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('violated_scans_view_allsites');
     }
 

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -36,7 +36,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
@@ -52,7 +52,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
     {
         // set the class variables
         // create user object
-        $user          =& \User::singleton();
+        $user          = \User::getLoggedInUser();
         $this->columns = array(
                           'mpv.CandID',
                           'mpv.PSCID',

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -35,7 +35,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return ($user->hasPermission('violated_scans_view_allsites'));
@@ -53,7 +53,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             return true;
         }
         $DB   =& \Database::singleton();
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         foreach ($values['resolvable'] AS $key=>$val) {
             $hash = $key;
             $row  = $DB->pselectRow(
@@ -160,7 +160,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
     {
         // set the class variables
         // create user object
-        $user        =& \User::singleton();
+        $user        = \User::getLoggedInUser();
         $DB          =& \Database::singleton();
         $config      =& \NDB_Config::singleton();
         $useProjects = $config->getSetting("useProjects");
@@ -353,7 +353,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
     {
         parent::setup();
         // create user object
-        $user    =& \User::singleton();
+        $user    = \User::getLoggedInUser();
         $config  =& \NDB_Config::singleton();
         $db      =& \Database::singleton();
         $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -34,7 +34,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return ($user->hasPermission('violated_scans_view_allsites'));
@@ -52,7 +52,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             return true;
         }
         $DB   =& \Database::singleton();
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         foreach ($values AS $key=>$val) {
             $hash = $key;
@@ -329,7 +329,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
     {
         parent::setup();
         // create user object
-        $user        =&        \User::singleton();
+        $user        =&        \User::getLoggedInUser();
         $config      =&        \NDB_Config::singleton();
         $minYear     = $config->getSetting('startYear')
             - $config->getSetting('ageMax');

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -33,7 +33,7 @@ class New_Profile extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $site_arr      = $user->getData('CenterIDs');
         $userInDCCSite = in_array("1", $site_arr);
@@ -53,7 +53,7 @@ class New_Profile extends \NDB_Form
     function _process($values)
     {
         // set up the arguments to Candidate::createNew
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $config =& \NDB_Config::singleton();
         $dob    = empty($values['dob1']) ? null : $values['dob1'];
 
@@ -210,7 +210,7 @@ class New_Profile extends \NDB_Form
         $this->addRule('gender', 'Gender is required', 'required');
 
         // add sites for users with more than one site affiliation
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $DB   = \Database::singleton();
         $user_list_of_sites = $user->getData('CenterIDs');
         $num_sites          = count($user_list_of_sites);
@@ -248,7 +248,7 @@ class New_Profile extends \NDB_Form
     {
         $errors = array();
         $config =& \NDB_Config::singleton();
-        $user   = \User::singleton();
+        $user   = \User::getLoggedInUser();
         if ($values['dob1'] != $values['dob2']) {
             $errors['dob1'] = 'Date of Birth fields must match.';
         }
@@ -271,7 +271,7 @@ class New_Profile extends \NDB_Form
         if ($PSCIDsettings['generation'] == 'user') {
             $db =& \Database::singleton();
             if (empty($values['psc'])) { // user is in only one site
-                $user      =& \User::singleton();
+                $user      = \User::getLoggedInUser();
                 $centerIDs = $user->getData('CenterIDs');
                 $centerID  = $centerIDs[0];
                 $site      =& \Site::singleton($centerID);

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -32,7 +32,7 @@ class Next_Stage extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $timePoint =& \TimePoint::singleton($this->identifier);
 

--- a/modules/reliability/php/reliability.class.inc
+++ b/modules/reliability/php/reliability.class.inc
@@ -52,7 +52,7 @@ class Reliability extends \NDB_Menu_Filter
     var $reliability_table;
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         if ($user->hasPermission('access_all_profiles') || $user->hasPermission('reliability_edit_all')) {
             return true;
         }
@@ -83,7 +83,7 @@ class Reliability extends \NDB_Menu_Filter
 //@codingStandardsIgnoreStart
     function _setupVariables()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // create the centerID map
         $db =& \Database::singleton();
@@ -203,7 +203,7 @@ class Reliability extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user          =& \User::singleton();
+        $user          = \User::getLoggedInUser();
         $list_of_sites = array();
 
         // allow to view all sites data through filter
@@ -552,7 +552,7 @@ class Reliability extends \NDB_Menu_Filter
 //@codingStandardsIgnoreStart
     function _swap_candidates()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         if (!($user->hasPermission('reliability_swap_candidates'))) {
             return array(
                     "error" => "You do not have permission".
@@ -678,7 +678,7 @@ class Reliability extends \NDB_Menu_Filter
      */
     function _addCandidate()
     {
-        $user   =& \User::singleton();
+        $user   = \User::getLoggedInUser();
         $DB     =& \Database::singleton();
         $params = array();
         $params['Instrument']  = $_POST['AddInstrument'];

--- a/modules/server_processes_manager/ajax/ProcessStateRequestHandler.php
+++ b/modules/server_processes_manager/ajax/ProcessStateRequestHandler.php
@@ -16,7 +16,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('server_processes_manager')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -26,7 +26,7 @@ require_once "ServerProcessesMonitor.class.inc";
 
 $pids   = explode('_', $_REQUEST['ids']);
 $type   = $_REQUEST['type'];
-$userid = User::singleton()->getUsername();
+$userid = User::getLoggedInUser()->getUsername();
 
 $serverProcessesMonitor = new ServerProcessesMonitor();
 $processesState         = $serverProcessesMonitor->getProcessesState(

--- a/modules/server_processes_manager/php/abstractserverprocess.class.inc
+++ b/modules/server_processes_manager/php/abstractserverprocess.class.inc
@@ -145,7 +145,9 @@ abstract class AbstractServerProcess
         $exitCodeFile, $exitCode, $userid,
         $startTime, $endTime, $exitText
     ) {
-        $userid = is_null($userid) ? \User::singleton()->getUsername() : $userid;
+        if (is_null($userid)) {
+            $userid = \User::getLoggedInUser()->getUsername();
+        }
 
         $this->_id           = $id;
         $this->_pid          = $pid;

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -35,7 +35,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
      */
     function _hasAccess()
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('server_processes_manager');
     }
 

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -32,7 +32,7 @@ class Statistics extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_entry');
     }
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -38,7 +38,7 @@ class Statistics_Site extends \NDB_Menu
      */
     function _hasAccess()
     {
-        $user     =& \User::singleton();
+        $user     = \User::getLoggedInUser();
         $centerID = htmlspecialchars($_REQUEST['CenterID']);
         return $user->hasCenterPermission('data_entry', $centerID);
     }

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -32,7 +32,7 @@ class Stats_Behavioural extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_entry');
     }
     /**

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -32,7 +32,7 @@ class Stats_Demographic extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_entry');
     }
     /**

--- a/modules/statistics/php/stats_general.class.inc
+++ b/modules/statistics/php/stats_general.class.inc
@@ -32,7 +32,7 @@ class Stats_General extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_entry');
     }
 

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -32,7 +32,7 @@ class Stats_MRI extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_entry');
     }
     /**

--- a/modules/statistics/php/stats_reliability.class.inc
+++ b/modules/statistics/php/stats_reliability.class.inc
@@ -36,7 +36,7 @@ class Stats_Reliability extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('data_entry');
     }
 

--- a/modules/survey_accounts/ajax/GetEmailContent.php
+++ b/modules/survey_accounts/ajax/GetEmailContent.php
@@ -13,7 +13,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('user_accounts')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -12,7 +12,7 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('user_accounts')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -34,7 +34,7 @@ class AddSurvey extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $editor =& \User::singleton();
+        $editor = \User::getLoggedInUser();
 
         return $editor->hasPermission('user_accounts');
     }

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -32,7 +32,7 @@ class Survey_Accounts extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return $user->hasPermission('user_accounts');
     }
@@ -45,7 +45,7 @@ class Survey_Accounts extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // the base query
         $query = " FROM participant_accounts p 
@@ -95,7 +95,7 @@ class Survey_Accounts extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         $this->addBasicText('PSCID', 'PSCID');
         // add form elements
         $this->addSelect(

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -33,7 +33,7 @@ class Timepoint_List extends \NDB_Menu
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $candidate =& \Candidate::singleton($_REQUEST['candID']);
 
@@ -83,7 +83,7 @@ class Timepoint_List extends \NDB_Menu
         $listOfTimePoints         = $candidate->getListOfTimePoints();
 
         if (!empty($listOfTimePoints)) {
-            $user     =& \User::singleton();
+            $user     = \User::getLoggedInUser();
             $username = $user->getData('UserID');
 
             $feedback_select_inactive = null;

--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -56,7 +56,7 @@ Class TimePoint_List_ControlPanel extends \Candidate
      */
     function display()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         $user_CenterID = $user->getData('CenterIDs');
         $cand_CenterID = $this->getData('CenterID');

--- a/modules/training/ajax/getTabContent.php
+++ b/modules/training/ajax/getTabContent.php
@@ -11,7 +11,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('training')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/training/ajax/getTabs.php
+++ b/modules/training/ajax/getTabs.php
@@ -12,7 +12,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('training')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/training/ajax/getTrainingDoc.php
+++ b/modules/training/ajax/getTrainingDoc.php
@@ -13,7 +13,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('training')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -24,7 +24,7 @@ ini_set('default_charset', 'utf-8');
 
 require_once __DIR__ . "/../../../vendor/autoload.php";
 
-$user = User::singleton();
+$user = User::getLoggedInUser();
 
 // Checks that config settings are set
 $config = NDB_Config::singleton();

--- a/modules/training/ajax/markQuiz.php
+++ b/modules/training/ajax/markQuiz.php
@@ -11,7 +11,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::getLoggedInUser();
 if (!$user->hasPermission('training')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -33,7 +33,7 @@ if ($quizCorrect == false) {
     print "incorrect";
     exit();
 } else {
-    $user = User::singleton();
+    $user = User::getLoggedInUser();
 
     $userFullName = $user->getFullname();
     $userCenter   = implode(',', $user->getCenterIDs());

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -33,7 +33,7 @@ class Training extends \NDB_Form
      */
     function _hasAccess()
     {
-        $user = \User::singleton();
+        $user = \User::getLoggedInUser();
         return $user->hasPermission('training');
     }
     /**
@@ -54,7 +54,7 @@ class Training extends \NDB_Form
 
         $certifications = array();
 
-        $user         = \User::singleton();
+        $user         = \User::getLoggedInUser();
         $userFullName = $user->getFullname();
         $userSite     = $user->getCenterIDs();
 
@@ -149,7 +149,7 @@ class Training extends \NDB_Form
      */
     function getCertificationStatus($instrumentID)
     {
-        $user         = \User::singleton();
+        $user         = \User::getLoggedInUser();
         $userFullName = $user->getFullname();
         $userCenter   = $user->getCenterIDs();
 

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -34,7 +34,7 @@ if (!isset($_POST['identifier'])) {
 */
 function _hasPerm()
 {
-    $user =& User::singleton();
+    $user = \User::getLoggedInUser();
     if (isset($user)) {
         if (!$user->hasPermission('user_accounts')) {
             return false;

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -44,7 +44,7 @@ class Edit_User extends \NDB_Form
     function _hasAccess()
     {
         // create user object
-        $editor = \User::singleton();
+        $editor = \User::getLoggedInUser();
 
         if (!$this->isCreatingNewUser()) {
             $user = \User::factory($this->identifier);
@@ -164,7 +164,7 @@ class Edit_User extends \NDB_Form
      */
     function _isEditingOwnAccount()
     {
-        $editor = \User::singleton();
+        $editor = \User::getLoggedInUser();
         return !$this->isCreatingNewUser()
             && ($editor->getUsername() == $this->identifier);
     }
@@ -183,7 +183,7 @@ class Edit_User extends \NDB_Form
         //The arrays that contain the edited permissions
         $permissionsRemoved = array();
         $permissionsAdded   = array();
-        $editor = \User::singleton();
+        $editor = \User::getLoggedInUser();
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
         //create the user
@@ -624,7 +624,7 @@ class Edit_User extends \NDB_Form
         //------------------------------------------------------------
 
         // get user permissions
-        $editor = \User::singleton();
+        $editor = \User::getLoggedInUser();
 
         // center ID
         if ($editor->hasPermission('user_accounts_multisite')) {

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -248,7 +248,7 @@ class My_Preferences extends \NDB_Form
 
         $this->identifier = $_SESSION['State']->getUsername();
 
-        $user =& \User::singleton($this->identifier);
+        $user = \User::getLoggedInUser();
 
         //get notification details
         $notifier_list     = \NDB_Notifier::getNotificationModuleServices();

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -34,7 +34,7 @@ class User_Accounts extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         return $user->hasPermission('user_accounts');
     }
@@ -47,7 +47,7 @@ class User_Accounts extends \NDB_Menu_Filter
     */
     function _setupVariables()
     {
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
         // the base query
         $query = " FROM users
             LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
@@ -105,7 +105,7 @@ class User_Accounts extends \NDB_Menu_Filter
         parent::setup();
 
         // create user object
-        $user =& \User::singleton();
+        $user = \User::getLoggedInUser();
 
         // PSC
         if ($user->hasPermission('user_accounts_multisite')) {

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -41,7 +41,7 @@ class BVL_Feedback_Panel
      */
     function __construct($candID, $sessionID=null, $commentID=null)
     {
-        $user     =& User::singleton();
+        $user     =& User::getLoggedInUser();
         $username = $user->getUsername();
         $this->_feedbackThread
             =& NDB_BVL_Feedback::Singleton(

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -41,7 +41,7 @@ class BVL_Feedback_Panel
      */
     function __construct($candID, $sessionID=null, $commentID=null)
     {
-        $user     =& User::getLoggedInUser();
+        $user     = \User::getLoggedInUser();
         $username = $user->getUsername();
         $this->_feedbackThread
             =& NDB_BVL_Feedback::Singleton(

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -197,7 +197,7 @@ class Candidate
 
         $site =& Site::singleton($centerID);
 
-        $user =& User::getLoggedInUser();
+        $user = \User::getLoggedInUser();
 
         // generate candid
         $candID = Candidate::_generateCandID();

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -197,7 +197,7 @@ class Candidate
 
         $site =& Site::singleton($centerID);
 
-        $user =& User::singleton($_SESSION['State']->getUsername());
+        $user =& User::getLoggedInUser();
 
         // generate candid
         $candID = Candidate::_generateCandID();

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -446,7 +446,7 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         // get User object
-        $user =& User::getLoggedInUser();
+        $user = \User::getLoggedInUser();
         $hasReadPermission = $user->hasPermission('access_all_profiles');
 
         $query = "SELECT c.CandID as CandID,
@@ -509,7 +509,7 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         // create user object
-        $user =& User::getLoggedInUser();
+        $user = \User::getLoggedInUser();
         $hasReadPermission = $user->hasPermission('access_all_profiles');
 
         $query   = "SELECT c.CandID as CandID, c.PSCID as PSCID";
@@ -1066,7 +1066,7 @@ class NDB_BVL_Feedback
     static function bvlFeedbackPossible($test_name)
     {
 
-        $user =& User::getLoggedInUser();
+        $user = \User::getLoggedInUser();
 
         if ($user->hasStudySite()) {
             if ($user->hasPermission('bvl_feedback')) {

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -446,7 +446,7 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         // get User object
-        $user =& User::singleton($this->_username);
+        $user =& User::getLoggedInUser();
         $hasReadPermission = $user->hasPermission('access_all_profiles');
 
         $query = "SELECT c.CandID as CandID,
@@ -509,7 +509,7 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         // create user object
-        $user =& User::singleton($this->_username);
+        $user =& User::getLoggedInUser();
         $hasReadPermission = $user->hasPermission('access_all_profiles');
 
         $query   = "SELECT c.CandID as CandID, c.PSCID as PSCID";
@@ -1066,7 +1066,7 @@ class NDB_BVL_Feedback
     static function bvlFeedbackPossible($test_name)
     {
 
-        $user =& User::singleton();
+        $user =& User::getLoggedInUser();
 
         if ($user->hasStudySite()) {
             if ($user->hasPermission('bvl_feedback')) {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -283,7 +283,7 @@ class NDB_BVL_Instrument extends NDB_Page
             //instrument permissions not used...
             return true; //default
         } else { //check if user has instrument's permissions
-            $user =& User::singleton();
+            $user =& User::getLoggedInUser();
 
             //is the instrument listed at all in instrumentPermissions?
             $instrumentListed = false;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -283,7 +283,7 @@ class NDB_BVL_Instrument extends NDB_Page
             //instrument permissions not used...
             return true; //default
         } else { //check if user has instrument's permissions
-            $user =& User::getLoggedInUser();
+            $user = \User::getLoggedInUser();
 
             //is the instrument listed at all in instrumentPermissions?
             $instrumentListed = false;

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -108,7 +108,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             if ($config->getSetting('InstrumentResetting')
                 && $this->getDataEntryStatus() != 'Complete'
             ) {
-                $user = User::singleton();
+                $user = User::getLoggedInUser();
                 if ($user->hasPermission('send_to_dcc')) {
                     $this->tpl_data['InstrumentResetting'] = true;
                 }
@@ -137,7 +137,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
         if (isset($_POST['ClearInstrument'])) {
             if (isset($_POST['deleteconfirm']) && isset($_POST['deleteconfirm2']) ) {
-                $user = User::singleton();
+                $user = User::getLoggedInUser();
                 if ($user->hasPermission('send_to_dcc')) {
                     $instrument =& NDB_BVL_Instrument::factory(
                         $_REQUEST['test_name'],
@@ -360,7 +360,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
     function _hasAccess()
     {
         // get user object
-        $user =& User::singleton();
+        $user =& User::getLoggedInUser();
 
         // make a timepoint object
         $timePoint =& TimePoint::singleton($this->getSessionID());

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -360,7 +360,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
     function _hasAccess()
     {
         // get user object
-        $user =& User::getLoggedInUser();
+        $user = \User::getLoggedInUser();
 
         // make a timepoint object
         $timePoint =& TimePoint::singleton($this->getSessionID());

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -425,7 +425,7 @@ class NDB_Caller
             header("Location: $redirectToOnSuccess");
             return "";
         }
-        $user = User::singleton();
+        $user = User::getLoggedInUser();
 
         if ($_REQUEST['sessionID']) {
             $timepoint =& TimePoint::singleton($_REQUEST['sessionID']);

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -173,7 +173,6 @@ class NDB_Client
             return false;
         }
 
-        //        User::singleton($_SESSION['State']->getUsername());
         \User::setLoggedInUser($_SESSION['State']->getUsername());
 
         // finished initializing

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -89,7 +89,7 @@ class NDB_Client
         if (!$this->_isWebClient) {
             // Set user as unix username.
             // Requires Loris to have user with this username
-            $user =& User::singleton(getenv('USER'));
+            \User::setLoggedInUser(getenv('USER'));
             return true;
         }
 
@@ -173,9 +173,9 @@ class NDB_Client
             return false;
         }
 
-        //????????????? when do we get here ?
-//        User::singleton($_SESSION['State']->getUsername());
-        User::setLoggedInUser($_SESSION['State']->getUsername());
+        //        User::singleton($_SESSION['State']->getUsername());
+        \User::setLoggedInUser($_SESSION['State']->getUsername());
+
         // finished initializing
         return true;
     }

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -173,8 +173,9 @@ class NDB_Client
             return false;
         }
 
-        $user =& User::singleton($_SESSION['State']->getUsername());
-
+        //????????????? when do we get here ?
+//        User::singleton($_SESSION['State']->getUsername());
+        User::setLoggedInUser($_SESSION['State']->getUsername());
         // finished initializing
         return true;
     }

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -257,7 +257,7 @@ class NDB_Config
         if (empty($username)) {
             $this->_siteSettings =& $this->_settings;
         } else {
-            $user     =& User::getLoggedInUser();
+            $user     = \User::getLoggedInUser();
             $siteName = Utility::getCleanString($user->getSiteNames());
             if (isset($this->_settings['sites'][$siteName])
                 && is_array($this->_settings['sites'][$siteName])

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -257,7 +257,7 @@ class NDB_Config
         if (empty($username)) {
             $this->_siteSettings =& $this->_settings;
         } else {
-            $user     =& User::singleton($username);
+            $user     =& User::getLoggedInUser();
             $siteName = Utility::getCleanString($user->getSiteNames());
             if (isset($this->_settings['sites'][$siteName])
                 && is_array($this->_settings['sites'][$siteName])
@@ -532,7 +532,7 @@ class NDB_Config
     static function checkMenuPermission($menuID)
     {
         $DB   = Database::singleton();
-        $user = User::singleton();
+        $user = User::getLoggedInUser();
 
         $perms = $DB->pselect(
             "SELECT code FROM LorisMenuPermissions

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -152,7 +152,7 @@ class NDB_Factory
             Mock::generate("User");
             $user = new MockUser();
         } else {
-            $user = User::singleton();
+            $user = User::getLoggedInUser();
         }
         self::$_user = $user;
         return $user;

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -196,7 +196,7 @@ abstract class NDB_Notifier_Abstract
      */
     private function _getLoggedInUser()
     {
-        $user       =& User::singleton();
+        $user       =& User::getLoggedInUser();
         $info_array =array();
         $info_array['ID']    = $user->getData('ID');
         $info_array['name']  = $user->getFullname();
@@ -233,7 +233,7 @@ abstract class NDB_Notifier_Abstract
     private function _get2DListToNotify()
     {
         $DB   = Database::singleton();
-        $user =& User::singleton();
+        $user =& User::getLoggedInUser();
 
         //array of sites concerned
         $sites_concerned =  $user->getCenterIDs();

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -196,7 +196,7 @@ abstract class NDB_Notifier_Abstract
      */
     private function _getLoggedInUser()
     {
-        $user       =& User::getLoggedInUser();
+        $user       = \User::getLoggedInUser();
         $info_array =array();
         $info_array['ID']    = $user->getData('ID');
         $info_array['name']  = $user->getFullname();
@@ -233,7 +233,7 @@ abstract class NDB_Notifier_Abstract
     private function _get2DListToNotify()
     {
         $DB   = Database::singleton();
-        $user =& User::getLoggedInUser();
+        $user = \User::getLoggedInUser();
 
         //array of sites concerned
         $sites_concerned =  $user->getCenterIDs();

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -741,7 +741,7 @@ class NDB_Page
      * something like:
      *
      *     // create user object
-     *     $user =& User::singleton();
+     *     $user =& User::getLoggedInUser();
      *
      *     return $user->hasPermission('superuser');
      *

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -741,7 +741,7 @@ class NDB_Page
      * something like:
      *
      *     // create user object
-     *     $user =& User::getLoggedInUser();
+     *     $user = \User::getLoggedInUser();
      *
      *     return $user->hasPermission('superuser');
      *

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -367,7 +367,7 @@ class NDB_Reliability extends NDB_Form
     function _getExaminerNames()
     {
         $db       =& Database::singleton();
-        $user     =& User::getLoggedInUser();
+        $user     = \User::getLoggedInUser();
         $centerID = $user->getCenterIDs();
 
         // UofA is a special case--they never enter their own data.

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -367,7 +367,7 @@ class NDB_Reliability extends NDB_Form
     function _getExaminerNames()
     {
         $db       =& Database::singleton();
-        $user     =& User::singleton();
+        $user     =& User::getLoggedInUser();
         $centerID = $user->getCenterIDs();
 
         // UofA is a special case--they never enter their own data.

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -79,7 +79,7 @@ class SinglePointLogin
     function save()
     {
         // get saved data to pre-populate form
-        $user =& User::factory($_POST['username']);
+        $user = \User::factory($_POST['username']);
 
         // get user's data
         $data = $user->getData();
@@ -302,7 +302,7 @@ class SinglePointLogin
             $oldhash = $row['Password_hash'];
             if (password_verify($password, $oldhash)) {
                 if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
-                    $user =& User::factory($username);
+                    $user = \User::factory($username);
                     $user->updatePassword($password);
                 }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -24,6 +24,13 @@
 class User extends UserPermissions
 {
     /**
+     * LoggedInUser static reference to the current logged user
+     *
+     * @var USER
+     */
+    private static $_loggedInUser;
+
+    /**
      * Stores user information
      *
      * @var    array
@@ -31,14 +38,111 @@ class User extends UserPermissions
      */
     var $userInfo = array();
 
-    private static $loggedInUser;
-
     /**
      * Constructor creates and empty User object.
      */
     function __construct()
     {
 
+    }
+
+    /**
+     * Static factory function returning a USER object from a given username. User is
+     * expected to be in the database already.
+     *
+     * @param string $username username used as unique key to create a user
+     *                         object and load it
+     *
+     * @throws LorisException when user is not found in the database
+     *
+     * @return User with all its loaded data
+     */
+    public static function getUserFromUsername(string $username)
+    {
+        $user = new User();
+        $user->setUsername($username);
+        $user->_load();
+
+        return $user;
+    }
+
+    /**
+     * Static factory function returning a USER object from a given id. User is
+     * expected to be in the database already.
+     *
+     * @param integer $id ID used as unique key to create a user
+     *                object and load it
+     *
+     * @throws LorisException when user is not found in the database
+     *
+     * @return User with all its loaded data
+     */
+    public static function getUserFromId($id)
+    {
+        $user = new User();
+        $user->setId($id);
+        $user->_load();
+
+        return $user;
+    }
+
+
+    /**
+     * Singleton method. Retrieve the user passed as parameter, but only
+     * 1 instance.
+     *
+     * @param string $username Identifies the user
+     *
+     * @note this was only being used to get the logged in user and has now been
+     * replaced by the getLoggedInUser() function and setLoggedInUser() function.
+     * This has only been left her for backwards compatibility and will be
+     * removed in a future iteration of loris. -Rida
+     *
+     * @return User
+     * @access public
+     * @static
+     */
+    static function &singleton($username = null)
+    {
+        error_log(
+            "The User::singleton() function has been deprecated and will be ".
+            "removed in a future iteration of loris. Make sure to use the ".
+            "getLoggedInUser(), setLoggedInUser() or User::factory() to ".
+            "achieve your needs."
+        );
+
+        if (!is_null($username)) {
+            return User::getUserFromUsername($username);
+        }
+
+        $user = User::getLoggedInUser();
+
+        return $user;
+    }
+
+    /**
+     * Static function getting the logged in user only when user.
+     *
+     * @return User the logged in user object.
+     */
+    static function &getLoggedInUser()
+    {
+        return self::$_loggedInUser;
+    }
+
+    /**
+     * Static function setting the logged in user only when user
+     * is not previously set.
+     *
+     * @param string $username name of user currently logged in
+     *
+     * @return void
+     */
+    static function setLoggedInUser(string $username)
+    {
+        if (is_null(self::$_loggedInUser)) {
+            self::$_loggedInUser = self::getUserFromUsername($username);
+        }
     }
 
     /**
@@ -53,16 +157,47 @@ class User extends UserPermissions
      */
     static function &factory($username)
     {
-        $obj = new User;
+        error_log(
+            "The User::factory() function has been deprecated and will be ".
+            "removed in a future iteration of loris. Make sure to use the ".
+            "getLoggedInUser(), setLoggedInUser() or User::factory() to ".
+            "achieve your needs."
+        );
+        $obj = User::getUserFromUsername($username);
 
-        // right off, set the username
-        $obj->userInfo['UserID'] = $username;
+        return $obj;
 
-        // get the user's permissions
-        $obj->select($username);
+    }
+
+    /**
+     * Load function fetches user information from database and sets it in the
+     * userInfo array. This function expects user to exist in the database and at
+     * least the id OR the username of the USER object to be set.
+     *
+     * @throws LorisException  If it is called without username nor id or if
+     *                         Or if the user does not exist
+     *
+     * @return void
+     */
+    private function _load()
+    {
+        if (empty($this->id)) {
+            if (!empty($this->username)) {
+                //sets the $id value, if after this step the $id is still empty
+                //then the user does not exist and an exception is thrown
+                $this->id = $this->_getIdFromUsername($this->username);
+            } else {
+                throw  new LorisException(
+                    "User::_load() function expects the username or ID to be set"
+                );
+            }
+        }
 
         // create DB object
         $DB =& Database::singleton();
+
+        // get the user's permissions
+        $this->select($this->id);
 
         // get user data from database
         $query = "SELECT users.*,
@@ -70,21 +205,25 @@ class User extends UserPermissions
             FROM users
             LEFT JOIN user_psc_rel ON (user_psc_rel.UserID=users.ID)
             LEFT JOIN psc ON (user_psc_rel.CenterID=psc.CenterID)
-            WHERE users.UserID = :UID
+            WHERE users.ID = :UID
             GROUP BY users.ID";
 
-        $row = $DB->pselectRow($query, array('UID' => $username));
+        $row = $DB->pselectRow($query, array('UID' => $this->id));
 
+        $user_cid = array();
         // get user sites
         $user_centerID_query =  $DB->pselect(
             "SELECT CenterID FROM user_psc_rel upr
                         WHERE upr.UserID= :UID",
-            array('UID' => $row['ID'])
+            array('UID' => $this->id)
         );
         $user_cid            = array();
         foreach ($user_centerID_query as $key=>$val) {
             $user_cid[$key] =$val['CenterID'];
         }
+
+        // TODO move the examiner query to an examiner class and call it
+        // from the user class
 
         // Get examiner information
         $examiner_check = $DB->pselect(
@@ -116,67 +255,89 @@ class User extends UserPermissions
                                                   );
             }
         }
+
         // store user data in object property
         $row['examiner']  = $examiner_info;
         $row['CenterIDs'] = $user_cid;
-        $obj->userInfo    = $row;
-        return $obj;
+        $this->userInfo   = $row;
     }
 
     /**
-     * Singleton method. Retrieve the user passed as parameter, but only
-     * 1 instance.
+     * Setter for user's ID
      *
-     * @param string $username Identifies the user
-     *
-     * @note this was only being used to get the logged in user and has now been
-     * replaced by the getLoggedInUser() function and setLoggedInUser() function.
-     * This has only been left her for backwards compatibility and will be
-     * removed in a future iteration of loris. -Rida
-     *
-     * @return User
-     * @access public
-     * @static
-     */
-    static function &singleton($username = null)
-    {
-        error_log(
-            "The User::getLoggedInUser() function has been deprecated and will be ".
-            "removed in a future iteration of loris. Make sure to use the ".
-            "getLoggedInUser(), setLoggedInUser() or User::factory() to ".
-            "achieve your needs."
-        );
-
-        if (!is_null($username)) {
-            return User::factory($username);
-        }
-
-        return User::getLoggedInUser();
-    }
-
-    /**
-     * Static function getting the logged in user only when user.
-     *
-     * @return $loggedInUser the logged in user object.
-     */
-    static function &getLoggedInUser()
-    {
-        return self::$loggedInUser;
-    }
-
-    /**
-     * Static function setting the logged in user only when user
-     * is not previously set.
-     *
-     * @param $username string name of user currently logged in
+     * @param integer $id identifier of user
      *
      * @return void
      */
-    static function setLoggedInUser($username)
+    public function setId($id)
     {
-        if (is_null(self::$loggedInUser)) {
-            self::$loggedInUser = self::factory($username);
+        $this->id =$id;
+    }
+
+    /**
+     * Setter for user's username
+     *
+     * @param string $username unique username of user
+     *
+     * @return void
+     */
+    public function setUsername(string $username)
+    {
+        $this->username =$username;
+    }
+
+    /**
+     * Getter for user's ID
+     *
+     * @return int the id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Getter for user's username
+     *
+     * @return string The username
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Set the ID value in the user object given the username ("UserID")
+     *
+     * @param string $username username for which the identifier is needed
+     *
+     * @note given the current extensive use of the UserID instead of the real ID
+     * this function will be particularly useful until the queries are
+     * progressively updated. -rida
+     *
+     * @throws LorisException if username is not in the database
+     *
+     * @return int
+     */
+    private function _getIdFromUsername(string $username)
+    {
+        // create DB object
+        $DB =& Database::singleton();
+
+        // get the proper ID from the database
+        $query  = "SELECT ID FROM users WHERE UserID =:uName";
+        $params = array('uName' => $username);
+
+        $id = $DB->pselectOne($query, $params);
+
+        if (empty($id)) {
+            throw new \LorisException(
+                "Username supplied is not associated with 
+                an identifier in the database"
+            );
         }
+
+        return $id;
     }
 
     /**
@@ -226,7 +387,10 @@ class User extends UserPermissions
      *
      * @param string $var Name of variable to get
      *
-     * @note   Call without any parameters to get the entire user data array
+     * @note Call without any parameters to get the entire user data array
+     *
+     * @throws LorisException
+     *
      * @return mixed
      * @access public
      */
@@ -261,25 +425,25 @@ class User extends UserPermissions
         return $this->userInfo['Real_name'];
     }
 
-    /**
-     * Get the user's id
-     *
-     * @return int
-     */
-    function getId()
-    {
-        return $this->userInfo['ID'];
-    }
-
-    /**
-     * Get the user's username
-     *
-     * @return string
-     */
-    function getUsername()
-    {
-        return $this->userInfo['UserID'];
-    }
+    //    /**
+    //     * Get the user's id
+    //     *
+    //     * @return int
+    //     */
+    //    function getId()
+    //    {
+    //        return $this->userInfo['ID'];
+    //    }
+    //
+    //    /**
+    //     * Get the user's username
+    //     *
+    //     * @return string
+    //     */
+    //    function getUsername()
+    //    {
+    //        return $this->userInfo['UserID'];
+    //    }
 
     /**
      * Get the user's sites' name

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -31,6 +31,16 @@ class User extends UserPermissions
      */
     var $userInfo = array();
 
+    private static $loggedInUser;
+
+    /**
+     * Constructor creates and empty User object.
+     */
+    function __construct()
+    {
+
+    }
+
     /**
      * Constructor
      *
@@ -113,12 +123,16 @@ class User extends UserPermissions
         return $obj;
     }
 
-
     /**
      * Singleton method. Retrieve the user passed as parameter, but only
      * 1 instance.
      *
      * @param string $username Identifies the user
+     *
+     * @note this was only being used to get the logged in user and has now been
+     * replaced by the getLoggedInUser() function and setLoggedInUser() function.
+     * This has only been left her for backwards compatibility and will be
+     * removed in a future iteration of loris. -Rida
      *
      * @return User
      * @access public
@@ -126,13 +140,44 @@ class User extends UserPermissions
      */
     static function &singleton($username = null)
     {
-        static $instance;
-        if (is_null($instance)) {
-            $instance = User::factory($username);
+        error_log(
+            "The User::getLoggedInUser() function has been deprecated and will be ".
+            "removed in a future iteration of loris. Make sure to use the ".
+            "getLoggedInUser(), setLoggedInUser() or User::factory() to ".
+            "achieve your needs."
+        );
+
+        if (!is_null($username)) {
+            return User::factory($username);
         }
-        return $instance;
+
+        return User::getLoggedInUser();
     }
 
+    /**
+     * Static function getting the logged in user only when user.
+     *
+     * @return $loggedInUser the logged in user object.
+     */
+    static function &getLoggedInUser()
+    {
+        return self::$loggedInUser;
+    }
+
+    /**
+     * Static function setting the logged in user only when user
+     * is not previously set.
+     *
+     * @param $username string name of user currently logged in
+     *
+     * @return void
+     */
+    static function setLoggedInUser($username)
+    {
+        if (is_null(self::$loggedInUser)) {
+            self::$loggedInUser = self::factory($username);
+        }
+    }
 
     /**
      * Inserts a user

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -23,12 +23,20 @@
 class UserPermissions
 {
     /**
-     * User's ID
+     * Username is used as a unique key for users
+     * This value is also found in the $userInfo variable of the user class
      *
-     * @var    int
-     * @access private
+     * @var string
      */
-    var $userID;
+    protected $username;
+
+    /**
+     * ID is used as a primary key for users
+     * This value is also found in the $userInfo variable of the user class
+     *
+     * @var int
+     */
+    protected $id;
 
     /**
      * Stores the permissions
@@ -44,21 +52,12 @@ class UserPermissions
      *
      * Fills the permissions property based on username
      *
-     * @param string $username Identifies the user
+     * @param string $id Identifies the user
      *
-     * @return void
+     * @return bool
      */
-    function select($username)
+    function select($id)
     {
-        // create DB object
-        $DB =& Database::singleton();
-
-        // get the proper ID from the database
-        $query  = "SELECT ID FROM users WHERE UserID =:UName";
-        $params = array('UName' => $username);
-
-        $this->userID = $DB->pselectOne($query, $params);
-
         // load the user's permissions
         $this->setPermissions();
 
@@ -82,7 +81,7 @@ class UserPermissions
             LEFT JOIN user_perm_rel pr
             ON (p.permID=pr.permID AND pr.userID=:UID)";
 
-        $results = $DB->pselect($query, array('UID' => $this->userID));
+        $results = $DB->pselect($query, array('UID' => $this->id));
 
         // reset the array
         $this->permissions = array();
@@ -90,7 +89,7 @@ class UserPermissions
         // fill the array
         foreach ($results AS $row) {
             if (!empty($row['userID'])
-                && $row['userID'] === $this->userID
+                && $row['userID'] === $this->id
             ) {
                 $this->permissions[$row['code']] = true;
             } else {
@@ -106,6 +105,8 @@ class UserPermissions
      * Determines if the user has a permission
      *
      * @param string $code The permission code
+     *
+     * @throws ConfigurationException on invalid permission code
      *
      * @return bool
      */
@@ -157,7 +158,7 @@ class UserPermissions
             $success = $DB->insert(
                 'user_perm_rel',
                 array(
-                 'userID' => $this->userID,
+                 'userID' => $this->id,
                  'permID' => $value,
                 )
             );
@@ -186,7 +187,7 @@ class UserPermissions
             // remove all permissions
             $success = $DB->delete(
                 'user_perm_rel',
-                array('userID' => $this->userID)
+                array('userID' => $this->id)
             );
         } else {
             // remove the permissions
@@ -194,7 +195,7 @@ class UserPermissions
                 $success = $DB->delete(
                     'user_perm_rel',
                     array(
-                     'userID' => $this->userID,
+                     'userID' => $this->id,
                      'permID' => $value,
                     )
                 );
@@ -224,7 +225,7 @@ class UserPermissions
             FROM permissions, user_perm_rel
             WHERE permissions.permID = user_perm_rel.permID AND userID = :UID";
 
-        $results = $DB->pselect($query, array('UID' => $this->userID));
+        $results = $DB->pselect($query, array('UID' => $this->id));
 
         // isolate and return numeric permission values
         $permIDs = array();
@@ -254,7 +255,7 @@ class UserPermissions
                 LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
             WHERE up.userID = :UID
                 ORDER BY p.categoryID, p.description";
-        $results = $DB->pselect($query, array('UID' => $this->userID));
+        $results = $DB->pselect($query, array('UID' => $this->id));
 
         return $results;
     }
@@ -278,7 +279,7 @@ class UserPermissions
         $DB->insert(
             'user_account_history',
             array(
-             'userID'     => $this->userID,
+             'userID'     => $this->id,
              'PermID'     => $PermID,
              'PermAction' => $permAction,
             )

--- a/tools/fix_timepoint_date_problems.php
+++ b/tools/fix_timepoint_date_problems.php
@@ -147,6 +147,9 @@ if (!empty($sessionID)) {
     }
 }
 
+// check the user $_ENV['USER']
+\User::setLoggedInUser(getenv('USER'));
+
 /*
  * The switch to execute actions
  */
@@ -248,8 +251,7 @@ switch ($action)
  */
 function addInstrument($sessionID, $testName)
 {
-    // check the user $_ENV['USER']
-    $user =& User::singleton(getenv('USER'));
+    $user = \User::getLoggedInUser();
     if($user->getUsername() == null) {
         throw new LorisException("Error: Database user named " . getenv('USER') . " does not exist. Please create and then retry script\n");
     }
@@ -329,7 +331,7 @@ function addInstrument($sessionID, $testName)
 function fixDate($candID, $dateType, $newDate, $sessionID=null)
 {
     // check the user $_ENV['USER']
-    $user =& User::singleton(getenv('USER'));
+    $user = \User::getLoggedInUser();
 
     if($user->getUsername() == null) {
         throw new LorisException("Error: Database user named " . getenv('USER') . " does not exist. Please create and then retry script\n");


### PR DESCRIPTION
This removes the singleton logic from the User and adds a deprecation warning for the factory function. new explicitly named factories were added.

The user class should start using the ID field instead of userID (username) as primary key, this Pr contains some changes to help with that.
