### PR TITLE
[Statistics] Fix DD Entry statistics links / Load statistics dd site pages

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -138,8 +138,9 @@ class Module
         $identifier = $_REQUEST['identifier'] ?? '';
         $commentID  = $_REQUEST['commentID'] ?? '';
         $cls        = new $className($this, $page, $identifier, $commentID, $page);
-        // Smarty needs the Module name as a parameter to autoload the right
+        // Smarty needs the Module as a reference to autoload the right
         // templates. Every type of page uses this.
+        $cls->Module = $this;
 
         // Hacks so that existing display() functions load the right template
         // for different page types.


### PR DESCRIPTION
This pull request fixes Redmine bug #13699. The loadPage function was returning an NDB_Page subclass with a null Module parameter that is called on in the display method in NDB_Menu.

This pull request fixes that by setting the Module parameter as $this Module. The link to statistics_dd_site page now works.

See also: https://redmine.cbrain.mcgill.ca/issues/13699
