### PR TITLE
[SinglePointLogin] Adding error message for non-redirect usage

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -447,6 +447,7 @@ class SinglePointLogin
                     if ($redirect) {
                         $this->showPasswordExpiryScreen();
                     }
+                    $this->_lastError = "Password expired";
                     return false;
                 }
 


### PR DESCRIPTION
This add an error message for the case where the user's password is expired and the redirect param is false. This is useful for the rest API.  
