### PR TITLE
[Scripts] Fix_canadidate_age.php - PHP Fatal error

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -76,7 +76,7 @@ class NDB_Page
      * page or specific page type.
      *
      * @param Module $module     The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
+     * @param string $page       The subtest being accessed (may be an empty string)
      * @param string $identifier The identifier for the data to load on this page
      * @param string $commentID  The CommentID to load the data for
      * @param string $formname   The name to give this form

--- a/tools/fix_candidate_age.php
+++ b/tools/fix_candidate_age.php
@@ -62,7 +62,7 @@ foreach ($instruments as $inst=>$fullName) {
     foreach ($DBInstTable as $k => $row) {
         // Get Instrument Instance
         try {
-            $instrument = NDB_BVL_Instrument::factory($inst, $row['CommentID'], null, false);
+            $instrument = NDB_BVL_Instrument::factory($inst, $row['CommentID'], '', false);
         } catch (LorisException $e) {
             echo "$inst instrument row with CommentID: ".$row['CommentID']." was ".
                 " Ignored for one of the following reasons:\n".


### PR DESCRIPTION
This pull request fixes Redmine Bug #13701 by getting rid of the null argument. Comments regarding the null have also been modified.

See also:  https://redmine.cbrain.mcgill.ca/issues/13701