### PR TITLE
Added README for candidate list module

### DIFF
--- a/modules/candidate_list/README.md
+++ b/modules/candidate_list/README.md
@@ -5,16 +5,21 @@
 The candidate list is intended to provide a menu from which users
 can access specific candidates while browsing LORIS data.
 
+It is referred to as "Access Profiles" in the LORIS menus.
+
 ## Intended Users
 
-The candidate list is primarily used by data entry staff to use in
-order to access the `timepoint_list` module (and `instrument_list`
+The candidate list is primarily used by data entry staff in order
+to access the `timepoint_list` module (and `instrument_list`
 from there) in order to access the candidate and perform data entry.
+
+Other user groups may use it for filtering candidate profiles for
+reviewing candidate data status.
 
 ## Scope
 
-The `candidate_list` module provides a list of candidates, as well
-as linking to other relevant LORIS modules where applicable.
+The `candidate_list` module provides a list of candidates and links
+to other relevant LORIS modules where applicable.
 
 ## Permissions
 
@@ -24,7 +29,7 @@ permission.
 
 Users with the `access_all_profiles` permission can see every
 candidate in LORIS, while users with only the `data_entry` permission
-can only see candidates at study sites where they are affiliated.
+can exclusively see candidates at study sites where they are affiliated.
 
 ## Configurations
 
@@ -33,7 +38,8 @@ The `useProjects` configuration affects whether the table has a
 dropdown for that column.
 
 The `useEDC` configuration variable has a similar function for the
-"EDC" column.
+"EDC" ("EDC" stands for "Expected Date Of Confinement" which refers
+to the pregnancy due date) column.
 
 ## Interactions with LORIS
 

--- a/modules/candidate_list/README.md
+++ b/modules/candidate_list/README.md
@@ -9,7 +9,7 @@ can access specific candidates while browsing LORIS data.
 
 The candidate list is primarily used by data entry staff to use in
 order to access the `timepoint_list` module (and `instrument_list`
-from there) in order to access the candidate and perform data entry
+from there) in order to access the candidate and perform data entry.
 
 ## Scope
 
@@ -28,17 +28,17 @@ can only see candidates at study sites where they are affiliated.
 
 ## Configurations
 
-The "useProjects" configuration affects whether the table has a
+The `useProjects` configuration affects whether the table has a
 "Project" column for the candidate, and whether there is a filter
 dropdown for that column.
 
-The "useEDC" configuration variable has a similar function for the
-EDC column.
+The `useEDC` configuration variable has a similar function for the
+"EDC" column.
 
 ## Interactions with LORIS
 
 The "Scan Done" column indicates whether or not a scan was performed
-for that candidate. When a scan was performed (ie it has the value
+for that candidate. When a scan was performed (i.e. it has the value
 "Y"), clicking the table cell links to the `imaging_browser` module
 prefiltered for that candidate.
 
@@ -49,4 +49,3 @@ who have the `data_entry` permission, a separate form appears for
 the user to type the CandID/PSCID combo in order to access the
 candidate.  This is intended to prevent data entry errors caused
 by accidentally clicking on the wrong row before doing data entry.
-

--- a/modules/candidate_list/README.md
+++ b/modules/candidate_list/README.md
@@ -1,0 +1,52 @@
+# Candidate List
+
+## Purpose
+
+The candidate list is intended to provide a menu from which users
+can access specific candidates while browsing LORIS data.
+
+## Intended Users
+
+The candidate list is primarily used by data entry staff to use in
+order to access the `timepoint_list` module (and `instrument_list`
+from there) in order to access the candidate and perform data entry
+
+## Scope
+
+The `candidate_list` module provides a list of candidates, as well
+as linking to other relevant LORIS modules where applicable.
+
+## Permissions
+
+Accessing the `candidate_list` module requires either the `data_entry`
+permission and at least one study site, or the `access_all_profiles`
+permission.
+
+Users with the `access_all_profiles` permission can see every
+candidate in LORIS, while users with only the `data_entry` permission
+can only see candidates at study sites where they are affiliated.
+
+## Configurations
+
+The "useProjects" configuration affects whether the table has a
+"Project" column for the candidate, and whether there is a filter
+dropdown for that column.
+
+The "useEDC" configuration variable has a similar function for the
+EDC column.
+
+## Interactions with LORIS
+
+The "Scan Done" column indicates whether or not a scan was performed
+for that candidate. When a scan was performed (ie it has the value
+"Y"), clicking the table cell links to the `imaging_browser` module
+prefiltered for that candidate.
+
+Clicking on the cell in the PSCID column takes the user to the
+`timepoint_list` page for that candidate. The link is only clickable
+if the user does *not* have the `data_entry` permission. For users
+who have the `data_entry` permission, a separate form appears for
+the user to type the CandID/PSCID combo in order to access the
+candidate.  This is intended to prevent data entry errors caused
+by accidentally clicking on the wrong row before doing data entry.
+


### PR DESCRIPTION
This adds a README for the candidate list module, following
the template of the imaging browser.
