### PR TITLE
Added spec/README for conflict resolver module

### DIFF
--- a/modules/conflict_resolver/README.md
+++ b/modules/conflict_resolver/README.md
@@ -12,11 +12,13 @@ have double data entry enabled.
 The conflict resolver is usually used by data entry staff to resolve
 double data entry conflicts.
 
-Some studies may have protocols which involve supervisors or committees
-deciding how to properly resolve conflicts, and different studies may
-have different policies of if the same or different data entry staff
-is responsible for conflict resolution, but such policies are not
-enforced by LORIS.
+Some studies may have protocols which involve supervisors or
+committees deciding how to properly resolve conflicts. For example,
+studies may adopt different policies regarding the personnel that
+should be responsible for conflict resolution (which could be the
+same data entry staff that performed the double data entry or a
+different data entry staff). Such policies are not enforced by
+LORIS.
 
 ## Scope
 
@@ -52,7 +54,8 @@ by looking into the `conflicts_unresolved` table, which instruments
 must populate upon the "Data Entry" flag being set to Complete.
 This is done by the base `NDB_BVL_Instrument` class and shouldn't
 need to be specifically set up for any instrument (other than as
-mentioned in the configurations setting.)
+described for the `DoubleDataEntryInstruments` configuration setting
+above).
 
 Since the module doesn't know every scoring algorithm for every
 instrument, after resolution it loads a copy of the instrument

--- a/modules/conflict_resolver/README.md
+++ b/modules/conflict_resolver/README.md
@@ -9,7 +9,14 @@ have double data entry enabled.
 
 ## Intended Users
 
-The conflict resolver is used by data entry staff.
+The conflict resolver is usually used by data entry staff to resolve
+double data entry conflicts.
+
+Some studies may have protocols which involve supervisors or committees
+deciding how to properly resolve conflicts, and different studies may
+have different policies of if the same or different data entry staff
+is responsible for conflict resolution, but such policies are not
+enforced by LORIS.
 
 ## Scope
 
@@ -33,7 +40,7 @@ a member.
 ## Configurations
 
 The `DoubleDataEntryInstruments` setting determines whether or not
-a instrument gets flagged for conflicts. This is not directly used
+an instrument gets flagged for conflicts. This is not directly used
 by the module, but the base instrument class uses this to determine
 whether or not to populate the conflicts table upon data entry
 completion.
@@ -51,3 +58,8 @@ Since the module doesn't know every scoring algorithm for every
 instrument, after resolution it loads a copy of the instrument
 itself to re-call the instrument's save (and implicitly, `score()`)
 function so that all dependent fields are recalculated.
+
+If the `conflicts_unresolved` table somehow becomes out of sync
+with the data in LORIS, the `tools/recreate_conflicts.php` script
+can be used to re-compare single and double data entry values
+and repopulate the `conflicts_unresolved` table.

--- a/modules/conflict_resolver/README.md
+++ b/modules/conflict_resolver/README.md
@@ -24,13 +24,13 @@ LORIS.
 
 The module only provides data entry conflict resolution and triggers
 the recalculation of fields which are dependent on the data that's
-been changed (ie. score fields, age, etc). It does not do the initial
+been changed (i.e. score fields, age, etc). It does not do the initial
 data entry on the instruments themselves, only the resolution.
 
 It is up to any given study's internal policy to determine if
 resolution should be done by the same person or a different person
-than the person who did the initial data entry and not enforced by
-LORIS.
+than the person who did the initial data entry. The adopted policy
+will not be enforced by LORIS.
 
 ## Permissions
 

--- a/modules/conflict_resolver/README.md
+++ b/modules/conflict_resolver/README.md
@@ -1,0 +1,53 @@
+# Conflict Resolver
+
+## Purpose
+
+The conflict resolver is intended to allow the resolution of conflicts
+(different data entry for a given field between the "single data
+entry" and "double data entry" variations) for instruments which
+have double data entry enabled.
+
+## Intended Users
+
+The conflict resolver is used by data entry staff.
+
+## Scope
+
+The module only provides data entry conflict resolution and triggers
+the recalculation of fields which are dependent on the data that's
+been changed (ie. score fields, age, etc). It does not do the initial
+data entry on the instruments themselves, only the resolution.
+
+It is up to any given study's internal policy to determine if
+resolution should be done by the same person or a different person
+than the person who did the initial data entry and not enforced by
+LORIS.
+
+## Permissions
+
+Accessing the module requires the `conflict_resolver` permission.
+
+A user should only see conflicts at the sites at which the user is
+a member.
+
+## Configurations
+
+The `DoubleDataEntryInstruments` setting determines whether or not
+a instrument gets flagged for conflicts. This is not directly used
+by the module, but the base instrument class uses this to determine
+whether or not to populate the conflicts table upon data entry
+completion.
+
+## Interactions with LORIS
+
+The conflict resolver module determines which fields are in conflict
+by looking into the `conflicts_unresolved` table, which instruments
+must populate upon the "Data Entry" flag being set to Complete.
+This is done by the base `NDB_BVL_Instrument` class and shouldn't
+need to be specifically set up for any instrument (other than as
+mentioned in the configurations setting.)
+
+Since the module doesn't know every scoring algorithm for every
+instrument, after resolution it loads a copy of the instrument
+itself to re-call the instrument's save (and implicitly, `score()`)
+function so that all dependent fields are recalculated.


### PR DESCRIPTION
This adds a README for the conflict resolver outlining the purpose of the module, following the template set out by the imaging_browser module.