### PR TITLE
[Data dictionary] Improve filter results

### DIFF
--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -44,9 +44,9 @@ if ($user->hasPermission('data_dict_edit')) { //if user has edit permission
     );
 
     if ($description != $native_description) {
-      if (empty($description)) {
-        $description = ' ';
-      }
+        if (empty($description)) {
+            $description = ' ';
+        }
         $DB->replace(
             'parameter_type_override',
             array(

--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -44,6 +44,9 @@ if ($user->hasPermission('data_dict_edit')) { //if user has edit permission
     );
 
     if ($description != $native_description) {
+      if (empty($description)) {
+        $description = ' ';
+      }
         $DB->replace(
             'parameter_type_override',
             array(

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -138,9 +138,9 @@ class Datadict extends \NDB_Menu_Filter
                 if ($val == 'empty') {
                     $query .= " AND COALESCE(pto.description,pt.description) = ''";
                 } elseif ($val=='modified') {
-                    $query .= " AND pto.description IS NOT NULL";
+                    $query .= " AND pto.name IS NOT NULL";
                 } elseif ($val=='unmodified') {
-                    $query .= " AND pto.description IS NULL";
+                    $query .= " AND pto.name IS NULL";
                 } else {
                     $query .= " AND $key LIKE '$val%' ";
                 }


### PR DESCRIPTION
This pull request fixes the 'empty' filter results and lets the 'modified' and 'unmodified' filters to only depend on an instrument's presence in the parameter_type_override table. It lets all empty fields in description return as an empty string instead of NULL and queries the name column instead of description column to check for modified/unmodified

See also: https://github.com/aces/Loris/pull/3269