### PR TITLE
[Conflict Detector] Making some functions static in Conflict Detector class

### DIFF
--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -34,8 +34,11 @@ class ConflictDetector
      * @return array An array of differences between the 2 data entry
      *               points.
      */
-    static function detectConflictsForCommentIds($instrumentName, $commentId1, $commentId2)
-    {
+    static function detectConflictsForCommentIds(
+        $instrumentName,
+        $commentId1,
+        $commentId2
+    ) {
         $diffResult = array();
 
         // Get data entry status for $commentId1

--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -34,7 +34,7 @@ class ConflictDetector
      * @return array An array of differences between the 2 data entry
      *               points.
      */
-    function detectConflictsForCommentIds($instrumentName, $commentId1, $commentId2)
+    static function detectConflictsForCommentIds($instrumentName, $commentId1, $commentId2)
     {
         $diffResult = array();
 
@@ -80,7 +80,7 @@ class ConflictDetector
      *
      * @return null As a side-effect inserts into database.
      */
-    function recordUnresolvedConflicts($diffResult)
+    static function recordUnresolvedConflicts($diffResult)
     {
         $db =& Database::singleton();
 


### PR DESCRIPTION
recreate_conflicts.php script is spitting out warning after warning because we're statically calling some non-static functions in ConflictDetector.class.inc