### PR TITLE
Added README for data team helper module

### DIFF
--- a/modules/data_team_helper/README.md
+++ b/modules/data_team_helper/README.md
@@ -1,0 +1,29 @@
+# Data Team Helper
+
+## Purpose
+
+The Data Team Helper module is intended to provide a dashboard to
+make it easier for the data entry staff of a LORIS project to access
+all the unfinished data entry.
+
+## Scope
+
+The data team helper provides links to unfinished data in other
+LORIS modules in a centralized place. In particular, it links to
+open feedback, unresolved conflict, and candidate instruments where
+the data entry (or double data entry) has not yet been completed.
+
+## Permissions
+
+Accessing the module requires the `data_team_helper` permission.
+
+## Configurations
+
+There are no configurations for this module.
+
+## Interactions with LORIS
+
+The Data Team Helper module links to the feedback module, the
+conflict resolver, and the data entry for particular instruments.
+
+

--- a/modules/data_team_helper/README.md
+++ b/modules/data_team_helper/README.md
@@ -26,4 +26,6 @@ There are no configurations for this module.
 The Data Team Helper module links to the feedback module, the
 conflict resolver, and the data entry for particular instruments.
 
+Note: The Data Team Helper module is listed as "Quality Control"
+in the default LORIS menu.
 


### PR DESCRIPTION
This adds a README/spec for the data team helper module, following the format of other modules.