### PR TITLE
Update Data Dict README to follow template of imaging browser

### DIFF
--- a/modules/datadict/README
+++ b/modules/datadict/README
@@ -1,4 +1,0 @@
-The data dictionary module is used for viewing and modifying the parameter_type
-table which contains LORIS's data dictionary. If the user has the data_dict_edit
-permission, they are able to override the description to customize the data
-dictionary

--- a/modules/datadict/README.md
+++ b/modules/datadict/README.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 The data dictionary module is used for viewing and modifying the
-LORIS data dictionary.
+LORIS data dictionary descriptions.
 
 ## Scope
 
@@ -28,16 +28,24 @@ modify the description of, rows in the data dictionary.
 
 ## Configuration
 
-None
+The `parameter_type` table must be populated to use this module.
+The data comes from two sources:
+
+1. The LORIS imaging pipeline scripts, which must be setup separately
+2. The `tools/data_dictionary_builder.php` script, which loads the
+   behavioural data dictionary based on the `ip_output.txt` file created
+   by `tools/lorisform_parser.php`
 
 ## Interactions with LORIS
 
 The content for the data dictionary module comes from the
-`parameter_type` table, which most often is populated for instruments
-by the `lorisform_parser.php` script.
+`parameter_type` table.
 
 Modified entries are saved in the separate `parameter_type_override`
 table, and the "data dictionary" used by LORIS is the coalesce of
 the two tables, with `parameter_type_override` taking priority.
 This allows the `parameter_type` table itself to be regenerated
 when instruments change without losing the user modified values.
+
+The data query module uses the customized data dictionary descriptions
+from this module.

--- a/modules/datadict/README.md
+++ b/modules/datadict/README.md
@@ -7,11 +7,11 @@ LORIS data dictionary.
 
 ## Scope
 
-The displays (and depending on permissions) manages the data
-dictionary for things already stored in the LORIS `parameter_type`
-table. This table is generally autopopulated and provides a dictionary
-for imaging headers (populated by the imaging pipeline) and behavioural
-instrument (populated by the `lorisform_parser.php` script).
+The module displays and manages the data dictionary for things
+already stored in the LORIS `parameter_type` table. This table is
+generally autopopulated and provides a dictionary for imaging headers
+(populated by the imaging pipeline) and behavioural instrument
+(populated by the `lorisform_parser.php` script).
 
 It does not provide a way to enter new things into the data dictionary,
 or describe the data dictionary for arbitrary SQL tables which are

--- a/modules/datadict/README.md
+++ b/modules/datadict/README.md
@@ -7,14 +7,14 @@ LORIS data dictionary descriptions.
 
 ## Scope
 
-The module displays and manages the data dictionary for things
+The module displays and manages the data dictionary for fields
 already stored in the LORIS `parameter_type` table. This table is
 generally autopopulated and provides a dictionary for imaging headers
 (populated by the imaging pipeline) and behavioural instrument
 (populated by the `lorisform_parser.php` script).
 
-It does not provide a way to enter new things into the data dictionary,
-or describe the data dictionary for arbitrary SQL tables which are
+It does not provide a way to enter new fields into the data dictionary,
+or describe the data dictionary for arbitrary SQL fields which are
 not stored in the `parameter_type` table, such as instrument flags
 or candidate/session data.
 

--- a/modules/datadict/README.md
+++ b/modules/datadict/README.md
@@ -1,0 +1,43 @@
+# Data Dictionary
+
+## Purpose
+
+The data dictionary module is used for viewing and modifying the
+LORIS data dictionary.
+
+## Scope
+
+The displays (and depending on permissions) manages the data
+dictionary for things already stored in the LORIS `parameter_type`
+table. This table is generally autopopulated and provides a dictionary
+for imaging headers (populated by the imaging pipeline) and behavioural
+instrument (populated by the `lorisform_parser.php` script).
+
+It does not provide a way to enter new things into the data dictionary,
+or describe the data dictionary for arbitrary SQL tables which are
+not stored in the `parameter_type` table, such as instrument flags
+or candidate/session data.
+
+## Permission
+
+The `data_dict_view` permission allows the user to view the LORIS
+data dictionary.
+
+The `data_dict_edit` permission allows the user to both view, and
+modify the description of, rows in the data dictionary.
+
+## Configuration
+
+None
+
+## Interactions with LORIS
+
+The content for the data dictionary module comes from the
+`parameter_type` table, which most often populated for instruments
+by the `lorisform_parser.php` script.
+
+Modified entries are saved in the separate the `parameter_type_override`
+table, and the "data dictionary" used by LORIS is the coalesce of
+the two, with `parameter_type_override` taking priority. This allows
+the `parameter_type` table itself to be regenerated when instruments
+change without losing the user modified values.

--- a/modules/datadict/README.md
+++ b/modules/datadict/README.md
@@ -33,11 +33,11 @@ None
 ## Interactions with LORIS
 
 The content for the data dictionary module comes from the
-`parameter_type` table, which most often populated for instruments
+`parameter_type` table, which most often is populated for instruments
 by the `lorisform_parser.php` script.
 
-Modified entries are saved in the separate the `parameter_type_override`
+Modified entries are saved in the separate `parameter_type_override`
 table, and the "data dictionary" used by LORIS is the coalesce of
-the two, with `parameter_type_override` taking priority. This allows
-the `parameter_type` table itself to be regenerated when instruments
-change without losing the user modified values.
+the two tables, with `parameter_type_override` taking priority.
+This allows the `parameter_type` table itself to be regenerated
+when instruments change without losing the user modified values.


### PR DESCRIPTION
This updates the data_dict module's README to follow the same
format as the other module specs.

The content that was previously there is reused.