### PR TITLE
[candidate_parameters] restore missing config

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -278,6 +278,7 @@ if (!$anonymous) {
                                 'useEDC'      => $config->getSetting('useEDC'),
                                 'useProband'  => $config->getSetting('useProband'),
                                 'useFamilyID' => $config->getSetting('useFamilyID'),
+                                'useConsent'  => $config->getSetting('ConsentModule')['useConsent'],
                                );
     $tpl_data['jsonParams']  = json_encode(
         array(

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -278,7 +278,9 @@ if (!$anonymous) {
                                 'useEDC'      => $config->getSetting('useEDC'),
                                 'useProband'  => $config->getSetting('useProband'),
                                 'useFamilyID' => $config->getSetting('useFamilyID'),
-                                'useConsent'  => $config->getSetting('ConsentModule')['useConsent'],
+                                'useConsent'  => $config->getSetting(
+                                    'ConsentModule'
+                                )['useConsent'],
                                );
     $tpl_data['jsonParams']  = json_encode(
         array(


### PR DESCRIPTION
This repairs the useConsent switch to display consent tab in candidate parameters.

This got removed accidentally in https://github.com/aces/Loris/pull/2608
