### PR TITLE
[SQL] Remove Radiological Review from Menu

### DIFF
--- a/SQL/Archive/18.0/2018-01-18-remove-radiological-review-menu.sql
+++ b/SQL/Archive/18.0/2018-01-18-remove-radiological-review-menu.sql
@@ -1,0 +1,11 @@
+WARNINGS;
+SET SQL_NOTES=1;
+
+SELECT 'Delete Menu Permission' as 'Step #1';
+DELETE FROM LorisMenuPermissions WHERE MenuID IN
+    (SELECT ID FROM LorisMenu WHERE Link = 'final_radiological_review/');
+
+SELECT 'Delete Menu Entry' as 'Step #2';
+DELETE FROM LorisMenu WHERE Link = 'final_radiological_review/';
+
+SELECT 'Patch complete' as 'Status';


### PR DESCRIPTION
See #3423 

This patch:

1. Removes menu permissions from LorisMenuPermissions for Radiological Review
2. Removes the menu item itself from LorisMenu