### PR TITLE
Fixing the display of the INVALID - HIDDEN patient name field 

### DIFF
--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -256,14 +256,14 @@ class Dicom_Archive extends \NDB_Menu_Filter
 
         foreach ($unanonymized['Data'] as &$row) {
             $val = $row[2];
-            if (!preg_match($this->dicomArchiveSettings['patientNameRegex'], $val)
-                && !preg_match($this->dicomArchiveSettings['LegoPhantomRegex'], $val)
-                && !preg_match(
+            if (! preg_match($this->dicomArchiveSettings['patientNameRegex'], $val)
+                or !preg_match($this->dicomArchiveSettings['LegoPhantomRegex'], $val)
+                or !preg_match(
                     $this->dicomArchiveSettings['LivingPhantomRegex'],
                     $val
                 )
             ) {
-                $row[2] = "INVALID - HIDDEN";
+                $row[2] = 'INVALID - HIDDEN';
             }
 
             $val = $row[1];

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -142,20 +142,20 @@ class ViewDetails extends \NDB_Form
         $config =& \NDB_Config::singleton();
         $dicomArchiveSettings = $config->getSetting('imaging_modules');
 
-        if ((preg_match(
+        if ((!preg_match(
             $dicomArchiveSettings['patientNameRegex'],
             $this->tpl_data['archive']['PatientName']
-        )) || (preg_match(
+        )) || (!preg_match(
             $dicomArchiveSettings['LegoPhantomRegex'],
             $this->tpl_data['archive']['PatientName']
-        )) || (preg_match(
+        )) || (!preg_match(
             $dicomArchiveSettings['LivingPhantomRegex'],
             $this->tpl_data['archive']['PatientName']
         ))) {
-            $this->tpl_data['archive']['patientNameValid'] = 1;
-        } else {
             $this->tpl_data['archive']['patientNameValid'] = 0;
             $this->tpl_data['archive']['PatientName']      = "INVALID - HIDDEN";
+        } else {
+            $this->tpl_data['archive']['patientNameValid'] = 1;
         }
 
         if (preg_match(


### PR DESCRIPTION
The logic based on the regex did not work to hide patient name information field. This PR fixes this for both the DICOM archive main page and the DICOM archive view details page.

Bug found during the testing round. 
Redmine ticket of the bug: https://redmine.cbrain.mcgill.ca/issues/13787