### PR TITLE
[JSX] Added Modal Window Component to Tabs.js

### DIFF
--- a/jsx/Tabs.js
+++ b/jsx/Tabs.js
@@ -175,24 +175,24 @@ class Modal extends React.Component {
 
   render() {
     // Render nothing if the "show" prop is false
-    if(!this.props.show) {
+    if (!this.props.show) {
       return null;
-    }   
+    } 
 
-    //White Modal Window
-    const modalStyle = { 
+    // White Modal Window
+    const modalStyle = {
       position: 'relative',
-      maxWidth: 1000,        
+      maxWidth: 1000,
       maxHeight: '100%',
       margin: '0 auto',
       backgroundColor: '#fff',
       padding: 30,
       borderRadius: 10,
       overflowY: 'auto',
-      zIndex: 9999,
-    };  
+      zIndex: 9999
+    };
 
-    //Grey Background
+    // Black Background with Alpha Channel
     const backdropStyle = {
       position: 'fixed',
       zIndex: 9998,
@@ -206,14 +206,20 @@ class Modal extends React.Component {
 
     return (
     <div style={backdropStyle} onClick={this.props.onClose}>
-      <div style={modalStyle} onClick={(e) => {e.stopPropagation()}}>
+      <div 
+        style={modalStyle} 
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+      >
         {this.props.children}
       </div>
     </div>
-    ); 
+    );
   }
 }
-Modal.propTypes = { 
+
+Modal.propTypes = {
   onClose: React.PropTypes.func.isRequired,
   show: React.PropTypes.bool,
   children: React.PropTypes.node

--- a/jsx/Tabs.js
+++ b/jsx/Tabs.js
@@ -177,7 +177,7 @@ class Modal extends React.Component {
     // Render nothing if the "show" prop is false
     if (!this.props.show) {
       return null;
-    } 
+    }
 
     // White Modal Window
     const modalStyle = {
@@ -206,10 +206,10 @@ class Modal extends React.Component {
 
     return (
     <div style={backdropStyle} onClick={this.props.onClose}>
-      <div 
-        style={modalStyle} 
-        onClick={(e) => {
-          e.stopPropagation()
+      <div
+        style={modalStyle}
+        onClick={e => {
+          e.stopPropagation();
         }}
       >
         {this.props.children}

--- a/jsx/Tabs.js
+++ b/jsx/Tabs.js
@@ -171,7 +171,56 @@ TabPane.propTypes = {
   activeTab: React.PropTypes.string
 };
 
+class Modal extends React.Component {
+
+  render() {
+    // Render nothing if the "show" prop is false
+    if(!this.props.show) {
+      return null;
+    }   
+
+    //White Modal Window
+    const modalStyle = { 
+      position: 'relative',
+      maxWidth: 1000,        
+      maxHeight: '100%',
+      margin: '0 auto',
+      backgroundColor: '#fff',
+      padding: 30,
+      borderRadius: 10,
+      overflowY: 'auto',
+      zIndex: 9999,
+    };  
+
+    //Grey Background
+    const backdropStyle = {
+      position: 'fixed',
+      zIndex: 9998,
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: 'rgba(0,0,0,0.3)',
+      padding: 50
+    };
+
+    return (
+    <div style={backdropStyle} onClick={this.props.onClose}>
+      <div style={modalStyle} onClick={(e) => {e.stopPropagation()}}>
+        {this.props.children}
+      </div>
+    </div>
+    ); 
+  }
+}
+Modal.propTypes = { 
+  onClose: React.PropTypes.func.isRequired,
+  show: React.PropTypes.bool,
+  children: React.PropTypes.node
+};
+
 export {
   Tabs,
-  TabPane
+  TabPane,
+  Modal
 };


### PR DESCRIPTION
This pull request adds a component to Tabs.js that creates a wrapper for a Modal Window that can be used for forms or datatables with tab-like functionality.

![modal window](https://user-images.githubusercontent.com/7550451/36118465-22714504-100b-11e8-88c9-e63b21a3ec65.png)
