### PR TITLE
Tool script to run before running MRI patch from PR #3327

### DIFF
--- a/tools/cleanup_mri_tables_for_19-0_release.php
+++ b/tools/cleanup_mri_tables_for_19-0_release.php
@@ -270,13 +270,13 @@ function backupEntries($selectID, $table_name, $FK_field)
 
     // create the mysqldump query to back the orphan entries to be deleted
     $sqldump = "mysqldump " .
-        "-u " . $database['username'] . " " .
-        "-h " . $database['host']     . " " .
-        "-p"  . $database['password'] . " " .
-        $database['database']         . " " .
-        $table_name                   . " " .
-        "--where='$where'"            . " " .
-        "--compact --no-create-info"  . " " .
+        "-u " . escapeshellarg($database['username']) . " " .
+        "-h " . escapeshellarg($database['host'])     . " " .
+        "-p"  . escapeshellarg($database['password']) . " " .
+        escapeshellarg($database['database'])         . " " .
+        escapeshellarg($table_name)                   . " " .
+        "--where=" . escapeshellarg($where)           . " " .
+        "--compact --no-create-info"                  . " " .
         ">> ./backup_release_19-0_upgrade.sql";
 
     system($sqldump, $retval); // execute mysqldump

--- a/tools/cleanup_mri_tables_for_19-0_release.php
+++ b/tools/cleanup_mri_tables_for_19-0_release.php
@@ -279,7 +279,14 @@ function backupEntries($selectID, $table_name, $FK_field)
         "--compact --no-create-info"  . " " .
         ">> ./backup_release_19-0_upgrade.sql";
 
-    system($sqldump); // execute mysqldump
+    system($sqldump, $retval); // execute mysqldump
+
+    // print the error of the mysqldump command and exits in case of failure
+    if ($retval != 0) {
+        print "\nCommand that failed execution: \n" . $sqldump . "\n";
+        print "\nCommand error message:\n"          . $retval  . "\n";
+        exit;
+    }
 }
 
 /**

--- a/tools/cleanup_mri_tables_for_19-0_release.php
+++ b/tools/cleanup_mri_tables_for_19-0_release.php
@@ -1,0 +1,144 @@
+<?php
+/** Script to clean up orphan entries in the imaging tables.
+ *
+ * WARNING!!
+ *  This script should be run before applying the following SQL patch
+ *  2017-11-29-Add_foreign_key_constraint_to_MRI_violation_tables.sql
+ *  located in SQL/Archive/19.0
+ *
+ * NOTES: affected "table (foreign key)" affected by the patch are:
+ *   - MRICandidateErrors (TarchiveID reference to tarchive.TarchiveID)
+ *   - mri_violations_log (TarchiveID reference to tarchive.TarchiveID)
+ *   - files (TarchiveSource reference to tarchive.TarchiveID)
+ *   - files_qcstatus (FileID reference to files.FileID)
+ *   - mri_upload (TarchiveID reference to tarchive.TarchiveID)
+ *   - mri_upload (SessionID reference to session.ID)
+ *   - mri_protocol_checks (Scan_type reference to mri_scan_type.ID)
+ *   - tarchive (SessionID reference to session.ID)
+ *
+ * What does the script do?
+ *  1) Select and display orphan entries in the imaging tables (either rows
+ *     with a TarchiveID that does not exists in the tarchive table or rows
+ *     with a FileID that does not exists in the files table
+ *  2) Ask the user whether he/she wants to delete and archive those entries
+ *       - if YES, then will backup the entries in a sql file and delete them
+ *         from the MySQL database
+ *       - if NO, then will set the TarchiveID (or FileID) in the table to NULL
+ *         so the patch can create successfully the foreign key TarchiveID
+ *         and FileID
+ *  3) Congratulations!! You are ready to run the SQL patch!
+ *
+ */
+
+require_once 'generic_includes.php';
+require_once 'Database.class.inc';
+
+$MRICandidateErrors_orphan_select_all_query = '
+    SELECT MRICandidateErrors.* 
+    FROM MRICandidateErrors LEFT JOIN tarchive USING (TarchiveID)
+    WHERE tarchive.TarchiveID IS NULL 
+      AND MRICandidateErrors.TarchiveID IS NOT NULL
+';
+
+$MRICandidateErrors_orphan_select_ID_query = '
+    SELECT MRICandidateErrors.TarchiveID 
+    FROM MRICandidateErrors LEFT JOIN tarchive USING (TarchiveID)
+    WHERE tarchive.TarchiveID IS NULL 
+      AND MRICandidateErrors.TarchiveID IS NOT NULL
+';
+
+//TODO write the other queries
+
+//TODO from here create a function to loop through the different tables and FK
+$MRICandidateErrors_orphan_list = select_orphan(
+    $MRICandidateErrors_orphan_select_all_query
+);
+
+print_orphan('MRICandidateErrors', $MRICandidateErrors_orphan_list);
+$delete = ask_to_delete(
+    'MRICandidateErrors',
+    'TarchiveID'
+);
+
+if ($delete == "Y") {
+    print "Y";
+    delete(
+        'MRICandidateErrors',
+        'TarchiveID',
+        $MRICandidateErrors_orphan_select_ID_query
+    );
+} elseif ($delete == "NO") {
+    print "N";
+    //nullify(); //TODO create a function to update the FK field to null
+} else {
+    print "todo"; //TODO repeat the question with the options
+}
+
+//TODO, implement the call to the delete below
+//delete(
+//    'MRICandidateErrors',
+//    'TarchiveID',
+//    $MRICandidateErrors_orphan_select_ID_query
+//);
+
+function select_orphan($query)
+{
+    $db = Database::singleton();
+
+    $result = $db->pselect($query, []);
+
+    return $result;
+}
+
+function print_orphan($table_name, $orphan_list)
+{
+    print "\n\n\nList of orphan entries for " . $table_name . "\n";
+    print "__________________________________________________\n";
+    print_r($orphan_list);
+}
+
+function ask_to_delete($table_name, $FK_field)
+{
+    $message = "\nDo you want to delete the orphan entries from $table_name?
+      'Y' to delete from database and keep a copy in a .sql file 
+      'N' to keep the entry but set $FK_field to NULL \n";
+
+    print $message;
+    $handle = fopen("php://stdin", "r");
+    $answer = fgets($handle);
+    $answer = str_replace("\n", "", $answer);
+    $answer = str_replace("\r", "", $answer);
+
+    return $answer;
+}
+
+function delete($table_name, $FK_field, $selectID)
+{
+    // database connection
+    $db = Database::singleton();
+
+    //TODO create the INSERT query to insert into a file so that user can go
+    // back if they want to.
+
+    // grep the IDs to delete from the database based on query
+    // stored in $selectID
+    $result = $db->pselect($selectID, []);
+    print_r($result);
+
+    // loop through the IDs and create a string out of it to be used for the
+    // delete statement
+    $IDs = "";
+    foreach ($result as $row) {
+        if ($IDs == ""){
+            $IDs = $row[$FK_field];
+        } else {
+            $IDs .= ", $row[$FK_field]";
+        }
+    }
+
+    // delete from table in $table_name where the foreign key $FK_field is in
+    // the list of IDs identified by the select above
+    $db->run("DELETE FROM $table_name WHERE $FK_field IN ($IDs)");
+}
+
+?>


### PR DESCRIPTION
This pull request adds a tool script that need to be run before running the MRI patch sent in PR #3327.

This script will look for orphan entries of the following pairs of `table` => `foreign key`:
- `MRICandidateErrors` => `TarchiveID`
- `mri_violations_log` => `TarchiveID`
- `files` => `TarchiveSource`
- `files_qcstatus` => `FileID`
- `mri_upload` => `TarchiveID`
- `mri_upload` => `SessionID`
- `mri_protocol_checks` => `ScanType`
- `tarchive` => `SessionID`

Take the example of table `files_qcstatus` that links to the `files` table using the `FileID` foreign key. If there is an entry for `FileID` 3 in `files_qcstatus` but not in the `files` table, [this SQL patch](SQL/Archive/19.0/2017-11-29-Add_foreign_key_constraint_to_MRI_violation_tables.sql) from PR #3327 will fail creating the `FileID` foreign key due to this entry with no corresponding `FileID` in the table of origin. This applies to all pairs of `table` => `foreign key` listed above.

Therefore, before running the SQL patch that will create the missing foreign keys on the MRI side, we need to make that no orphan entries can be found in the tables listed above. This script takes care of this. It will:
- fetch orphan entries in those tables
- print orphan entries in the terminal
- ask whether the user want to delete those entries (after proper backup) or update their foreign key to be NULL (the update becomes interesting when dealing with files_qcstatus table as the correct FileID can be repopulated based on the SeriesUID and EchoTime of the file)
- depending on the user's answer ('y' or 'n')
> - if 'y', backup the orphan entries using mysqldump into files `backup_release_19-0_upgrade.sql` in the current directory
> - if 'n', update the foreign key value to NULL for the orphan entries  

Here is a screenshot of part of the script's output:
![screen shot 2018-01-22 at 3 45 47 pm](https://user-images.githubusercontent.com/1402456/35243663-b3e8a17a-ff8b-11e7-943c-ff5a3d1f4c84.png)

Here is a screenshot of the output when no orphan were found:
![screen shot 2018-01-22 at 3 49 07 pm](https://user-images.githubusercontent.com/1402456/35243705-dd5c47b4-ff8b-11e7-9250-b7becd92f2e0.png)

