### PR TITLE
[Survey Accounts] Change empty array output to empty string for subtest value 

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -108,6 +108,9 @@ class DirectDataEntryMainPage
                 )
             );
         }
+        if ($this->Subtest === array()) {
+            $this->Subtest = "";   
+        }
 
         $totalPages        = $DB->pselectOne(
             "SELECT COUNT(*)+1 from instrument_subtests WHERE Test_name=:TN",

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -109,7 +109,7 @@ class DirectDataEntryMainPage
             );
         }
         if ($this->Subtest === array()) {
-            $this->Subtest = "";   
+            $this->Subtest = "";
         }
 
         $totalPages        = $DB->pselectOne(


### PR DESCRIPTION
Instruments that were otherwise displaying normally would not display in Survey mode due to pselectOne returning an empty array instead of the desired empty string. A check is now included to account for that. 