### PR TITLE
Move localizer exclusion setting into the Config module

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -149,7 +149,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'reject_thresh', 'Max number of directions that can be rejected to PASS QC', 1, 0, 'text', ID, 'Max number of DTI rejected directions for passing QC', 15 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'niak_path', 'Path to niak quarantine to use if mincdiffusion will be run (option -runMincdiffusion set when calling DTIPrep_pipeline.pl)', 1, 0, 'text', ID, 'NIAK Path', 16 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'QCed2_step', 'DTIPrep protocol step at which a secondary QCed dataset is produced (for example one without motion correction and eddy current correction would be saved at INTERLACE_outputDWIFileNameSuffix step of DTIPrep)', 1, 0, 'text', ID, 'Secondary QCed dataset', 17 FROM ConfigSettings WHERE Name="imaging_pipeline";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'scan_type_exclude_regex', 'Regex of the series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 0, 'text', ID, 'Regex of scan types to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'excluded_series_description', 'Series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 1, 'text', ID, 'Series description to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 --
 -- Filling Config table with default values
@@ -241,5 +241,6 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "adniT1" FROM ConfigSettings cs 
 INSERT INTO Config (ConfigID, Value) SELECT ID, 19 FROM ConfigSettings cs WHERE cs.Name="reject_thresh";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/opt/niak-0.6.4.1/" FROM ConfigSettings cs WHERE cs.Name="niak_path";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "INTERLACE_outputDWIFileNameSuffix" FROM ConfigSettings cs WHERE cs.Name="QCed2_step";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer|scout" FROM ConfigSettings cs WHERE cs.Name="scan_type_exclude_regex";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer" FROM ConfigSettings cs WHERE cs.Name="excluded_series_description";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "scout" FROM ConfigSettings cs WHERE cs.Name="excluded_series_description";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/issue_tracker" FROM ConfigSettings WHERE Name="issue_tracker_url";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -149,6 +149,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'reject_thresh', 'Max number of directions that can be rejected to PASS QC', 1, 0, 'text', ID, 'Max number of DTI rejected directions for passing QC', 15 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'niak_path', 'Path to niak quarantine to use if mincdiffusion will be run (option -runMincdiffusion set when calling DTIPrep_pipeline.pl)', 1, 0, 'text', ID, 'NIAK Path', 16 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'QCed2_step', 'DTIPrep protocol step at which a secondary QCed dataset is produced (for example one without motion correction and eddy current correction would be saved at INTERLACE_outputDWIFileNameSuffix step of DTIPrep)', 1, 0, 'text', ID, 'Secondary QCed dataset', 17 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'scan_type_exclude_regex', 'Regex of the series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 0, 'text', ID, 'Regex of scan types to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 --
 -- Filling Config table with default values
@@ -240,4 +241,5 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "adniT1" FROM ConfigSettings cs 
 INSERT INTO Config (ConfigID, Value) SELECT ID, 19 FROM ConfigSettings cs WHERE cs.Name="reject_thresh";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/opt/niak-0.6.4.1/" FROM ConfigSettings cs WHERE cs.Name="niak_path";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "INTERLACE_outputDWIFileNameSuffix" FROM ConfigSettings cs WHERE cs.Name="QCed2_step";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer|scout" FROM ConfigSettings cs WHERE cs.Name="scan_type_exclude_regex";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/issue_tracker" FROM ConfigSettings WHERE Name="issue_tracker_url";

--- a/SQL/Archive/20.0/2018-01-24-ScanTypeExcludeInConfig.sql
+++ b/SQL/Archive/20.0/2018-01-24-ScanTypeExcludeInConfig.sql
@@ -1,0 +1,5 @@
+-- Insert into ConfigSettings scan_type_exclude
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'scan_type_exclude', 'Series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 0, 'text', ID, 'Scan types to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
+
+-- Insert into Config default values for scan_type_exclude
+INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer, scout" FROM ConfigSettings cs WHERE cs.Name="scan_type_exclude";

--- a/SQL/Archive/20.0/2018-01-24-ScanTypeExcludeInConfig.sql
+++ b/SQL/Archive/20.0/2018-01-24-ScanTypeExcludeInConfig.sql
@@ -1,5 +1,7 @@
 -- Insert into ConfigSettings scan_type_exclude
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'scan_type_exclude_regex', 'Regex of the series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 0, 'text', ID, 'Regex of scan types to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple,
+DataType, Parent, Label, OrderNumber) SELECT 'excluded_series_description', 'Series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 1, 'text', ID, 'Series description to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 -- Insert into Config default values for scan_type_exclude
-INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer|scout" FROM ConfigSettings cs WHERE cs.Name="scan_type_exclude_regex";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer" FROM ConfigSettings cs WHERE cs.Name="excluded_series_description";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "scout" FROM ConfigSettings cs WHERE cs.Name="excluded_series_description";

--- a/SQL/Archive/20.0/2018-01-24-ScanTypeExcludeInConfig.sql
+++ b/SQL/Archive/20.0/2018-01-24-ScanTypeExcludeInConfig.sql
@@ -1,5 +1,5 @@
 -- Insert into ConfigSettings scan_type_exclude
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'scan_type_exclude', 'Series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 0, 'text', ID, 'Scan types to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'scan_type_exclude_regex', 'Regex of the series description to to be excluded from insertion into the database (typically localizers and scouts)', 1, 0, 'text', ID, 'Regex of scan types to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 -- Insert into Config default values for scan_type_exclude
-INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer, scout" FROM ConfigSettings cs WHERE cs.Name="scan_type_exclude";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "localizer|scout" FROM ConfigSettings cs WHERE cs.Name="scan_type_exclude_regex";


### PR DESCRIPTION
Until now, the exclusion of localizers were hardcoded in the tarchiveLoader in the variable $exclude.

This PR allows the possibility to configure the sequences that a user might want to exclude from the dcm2mnc command (localizers, scouts and other). In the "Imaging Pipeline" section of the Config module, it is now possible to specify the different series descriptions to be excluded from the insertion pipeline. Two default example have been set in LORIS: is `localizer` and `scout` (see screenshot below)

![screen shot 2018-02-07 at 5 45 34 pm](https://user-images.githubusercontent.com/1402456/35945591-bef997d6-0c2e-11e8-92af-024855b4acf5.png)

The imaging script will then used the values stored in the Config modules for the `excluded_series_description` config setting and create a regular expression out of those values to use afterwards when calling dcm2mnc via the `find` command which will exclude the files matching the created regular expression pattern.

See also: 
Related PR on the LORIS-MRI side: https://github.com/aces/Loris-MRI/pull/264