### PR TITLE
[login] change variable name

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -98,7 +98,7 @@ class PasswordExpiry extends \NDB_Form
      */
     function _validate($values)
     {
-        if (empty($values['password'])) {
+        if (empty($values['newPassword'])) {
             // FIXME: The way error_message is displayed in the template is inherited
             // from before this page was a "real" LORIS page, when it was all done
             // from SinglePointLogin. As a result, the usual way of displaying errors
@@ -113,15 +113,15 @@ class PasswordExpiry extends \NDB_Form
         $this->_user = \User::factory($this->_username);
         $data        = $this->_user->getData();
 
-        if (password_verify($_POST['password'], $data['Password_hash'])) {
+        if (password_verify($_POST['newPassword'], $data['Password_hash'])) {
             $this->tpl_data['error_message'] = 'You cannot keep the same password';
-            return array('password' => 'You cannot keep the same password');
+            return array('newPassword' => 'You cannot keep the same password');
         }
 
         if (!\User::isPasswordStrong(
-            $_POST['password'],
+            $_POST['newPassword'],
             array(
-             $_POST['confirm'],
+             $_POST['confirmPassword'],
              $data['UserID'],
              $data['Email'],
             ),
@@ -134,7 +134,7 @@ class PasswordExpiry extends \NDB_Form
         ) {
             $this->tpl_data['error_message'] = 'The password is weak, or'
                 . ' the passwords do not match';
-            return array('password' => 'Weak password.');
+            return array('newPassword' => 'Weak password.');
         }
 
         return true;

--- a/modules/login/templates/form_passwordexpiry.tpl
+++ b/modules/login/templates/form_passwordexpiry.tpl
@@ -13,12 +13,12 @@
       </ul>
       <form method="post">
         <div class="form-group">
-          <input type="password" name="password" size="40" class="form-control"
-                 placeholder="New Password" value="{$password}" />
+          <input type="password" name="newPassword" size="40" class="form-control"
+                 placeholder="New Password" />
         </div>
         <div class="form-group">
-          <input type="password" name="confirm" size="40" class="form-control"
-                 placeholder="Confirm Password" value="{$password}" />
+          <input type="password" name="confirmPassword" size="40" class="form-control"
+                 placeholder="Confirm Password" />
           {if $error_message}
             <span id="helpBlock" class="help-block">
                 <b class="text-danger">{$error_message}</b>
@@ -29,7 +29,7 @@
           <input type="submit" name="expiry" class="btn btn-primary btn-block"
                  value="Save"/>
         </div>
-        <input type="hidden" name="login" value="true" />
+        <input type="hidden" name="login" value="false" />
         <input type="hidden" name="username" value="{$username}" />
       </form>
     </div>


### PR DESCRIPTION
Currently, on the password expiry page, if one enters the same password that he currently has,n ot errors are reported (it should be an error) even tho the code takes this use-case into account.

The cause of this is that the code never reaches the validation function when submitting a new password on the password expiry page since it gets caught in a loop.

the following link points to the line where it should not enter when resetting an expired password
https://github.com/aces/Loris/blob/19.0-dev/php/libraries/SinglePointLogin.class.inc#L311

changing the password field name will prevent entering this function. because the $_POST['password'] will not be set on line https://github.com/aces/Loris/blob/19.0-dev/php/libraries/SinglePointLogin.class.inc#L204

Basically, in the current state, when a user is on the password-expiry page (page where the user should enter a new set of passwords) the code tries to authenticate with the "new password" rather then changing it.

The issue is only when the user enters the same password as the expired one !! any new passwword entered will actually save successfully because the code never enters that if statement linked above