### PR TITLE
[SQL] Change default value of Inserting in table mri_upload to NULL.

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -711,7 +711,7 @@ CREATE TABLE `mri_upload` (
   `UploadLocation` varchar(255) NOT NULL DEFAULT '',
   `DecompressedLocation` varchar(255) NOT NULL DEFAULT '',
   `InsertionComplete` tinyint(1) NOT NULL DEFAULT '0',
-  `Inserting` tinyint(1) NOT NULL DEFAULT '0',
+  `Inserting` tinyint(1) DEFAULT NULL,
   `PatientName` varchar(255) NOT NULL DEFAULT '',
   `number_of_mincInserted` int(11) DEFAULT NULL,
   `number_of_mincCreated` int(11) DEFAULT NULL,

--- a/SQL/Archive/19.0/2018-01-26-default-inserting-is-null.sql
+++ b/SQL/Archive/19.0/2018-01-26-default-inserting-is-null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mri_upload CHANGE `Inserting` `Inserting` tinyint(1) DEFAULT NULL;


### PR DESCRIPTION
This changes the default value of column Inserting in table mri_upload from '0' to NULL. If the default value is '0', it is going to cause a bug in the initial status displayed in the mri_upload result table when a file is initially uploaded (fix for Redmine ticket #13833)