### PR TITLE
[lorisform] library and parser invading error_logs

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -825,7 +825,8 @@ class LorisForm
     function dateHTML($el)
     {
         if (array_key_exists('options', $el)
-            && ((strtolower($el['options']['format']) == 'y'))
+            && (isset($el['options']['format'])
+            && strtolower($el['options']['format']) == 'y')
         ) {
             return $this->yearHTML($el);
         }
@@ -850,7 +851,7 @@ class LorisForm
         $value    = $this->getValue($el['name']);
         $format   = 'date';
 
-        if (array_key_exists('options', $el)) {
+        if (array_key_exists('options', $el) && isset($el['options']['format'])) {
             $elOptions = $el['options'];
             $elFormat  = strtolower($elOptions['format']);
 

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -69,9 +69,10 @@ foreach ($files AS $file) {
         echo "Building instrument page '$subtest[Name]'...\n";
         $obj->_setupForm();
     }
-    
+
     if (is_array($obj->getFullName())) {
-        echo "Could not find row for $matches[1] in table test_names, please populate test_names, instrument_subtests\n";
+        echo "Could not find row for $matches[1] in table test_names, 
+        please populate test_names, instrument_subtests\n";
         continue;
     }
 
@@ -105,7 +106,7 @@ if (empty($output)) {
  * @param LorisFormElement $elements   The element to parse.
  * @param String           $groupLabel The group label
  *
- * @return LINST formated element.
+ * @return string LINST formated element.
  */
 function parseElements($elements, $groupLabel="")
 {
@@ -151,7 +152,10 @@ function parseElements($elements, $groupLabel="")
 
         case "date":
             $options = "{@}";
-            if (array_key_exists('options', $element)) {
+            if (array_key_exists('options', $element)
+                && isset($el['options']['minYear'])
+                && isset($el['options']['maxYear'])
+            ) {
                 $options = $element['options']['minYear']
                     ."{@}"
                     .$element['options']['maxYear'];


### PR DESCRIPTION
This adds array variable checks to avoid PHP notices in the error logs.

This PR should be rebased on aces/bugfix after release of 19.0

command to reproduce:
`cd /var/www/loris/tools; find ../project/instruments/NDB_BVL_Instrument*.class.inc | php lorisform_parser.php`

notices avoided:

```
PHP Notice:  Undefined index: format in /var/www/loris/php/libraries/LorisForm.class.inc on line 828
PHP Notice:  Undefined index: format in /var/www/loris/php/libraries/LorisForm.class.inc on line 855
PHP Notice:  Undefined index: minYear in /var/www/loris/tools/lorisform_parser.php on line 155
PHP Notice:  Undefined index: maxYear in /var/www/loris/tools/lorisform_parser.php on line 157
```