### PR TITLE
Adding description to ImagingFileTypes table

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -464,16 +464,17 @@ CREATE TABLE `ImagingFileTypes` (
 
 INSERT INTO `ImagingFileTypes` VALUES
   ('mnc',      'MINC file'),
-  ('obj',      '3D imaging format'),
-  ('xfm',      'transformation matrix file'),
+  ('obj',      'MNI BIC imaging format for a surface'),
+  ('xfm',      'MNI BIC linear transformation matrix file'),
   ('xfmmnc',   NULL),
   ('imp',      'audition impulse file'),
-  ('vertstat', 'file describing the cortical thickness in a single column'),
+  ('vertstat', 'MNI BIC imaging format for a field on a surface (e.g. cortical thickness)'),
   ('xml',      'XML file'),
   ('txt',      'text file'),
   ('nii',      'NIfTI file'),
   ('nii.gz',   'compressed NIfTI file'),
-  ('nrrd',     'NRRD file format (used by DTIPrep)');
+  ('nrrd',     'NRRD file format (used by DTIPrep)'),
+  ('grid_0',   'MNI BIC non-linear field for non-linear transformation');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -466,7 +466,6 @@ INSERT INTO `ImagingFileTypes` VALUES
   ('mnc',      'MINC file'),
   ('obj',      'MNI BIC imaging format for a surface'),
   ('xfm',      'MNI BIC linear transformation matrix file'),
-  ('xfmmnc',   NULL),
   ('imp',      'audition impulse file'),
   ('vertstat', 'MNI BIC imaging format for a field on a surface (e.g. cortical thickness)'),
   ('xml',      'XML file'),

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -457,22 +457,23 @@ CREATE TABLE `Visit_Windows` (
 
 
 CREATE TABLE `ImagingFileTypes` (
- `type` varchar(255) NOT NULL PRIMARY KEY
+ `type` varchar(255) NOT NULL PRIMARY KEY,
+ `description` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 INSERT INTO `ImagingFileTypes` VALUES
-      ('mnc'),
-      ('obj'),
-      ('xfm'),
-      ('xfmmnc'),
-      ('imp'),
-      ('vertstat'),
-      ('xml'),
-      ('txt'),
-      ('nii'),
-      ('nii.gz'),
-      ('nrrd');
+  ('mnc',      'MINC file'),
+  ('obj',      '3D imaging format'),
+  ('xfm',      'transformation matrix file'),
+  ('xfmmnc',   NULL),
+  ('imp',      'audition impulse file'),
+  ('vertstat', 'file describing the cortical thickness in a single column'),
+  ('xml',      'XML file'),
+  ('txt',      'text file'),
+  ('nii',      'NIfTI file'),
+  ('nii.gz',   'compressed NIfTI file'),
+  ('nrrd',     'NRRD file format (used by DTIPrep)');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -471,7 +471,6 @@ INSERT INTO `ImagingFileTypes` VALUES
   ('xml',      'XML file'),
   ('txt',      'text file'),
   ('nii',      'NIfTI file'),
-  ('nii.gz',   'compressed NIfTI file'),
   ('nrrd',     'NRRD file format (used by DTIPrep)'),
   ('grid_0',   'MNI BIC non-linear field for non-linear transformation');
 

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -457,7 +457,7 @@ CREATE TABLE `Visit_Windows` (
 
 
 CREATE TABLE `ImagingFileTypes` (
- `type` varchar(255) NOT NULL PRIMARY KEY,
+ `type` varchar(12) NOT NULL PRIMARY KEY,
  `description` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -477,7 +477,7 @@ INSERT INTO `ImagingFileTypes` VALUES
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `ProtocolFile` varchar(255) NOT NULL DEFAULT '',
-  `FileType` varchar(255) DEFAULT NULL,
+  `FileType` varchar(12) DEFAULT NULL,
   `Tool` varchar(255) NOT NULL DEFAULT '',
   `InsertTime` int(10) unsigned NOT NULL DEFAULT '0',
   `md5sum` varchar(32) DEFAULT NULL,
@@ -545,7 +545,7 @@ CREATE TABLE `files` (
   `CoordinateSpace` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
   `AcquisitionProtocolID` int(10) unsigned default NULL,
-  `FileType` varchar(255) default NULL,
+  `FileType` varchar(12) default NULL,
   `PendingStaging` tinyint(1) NOT NULL default '0',
   `InsertedByUserID` varchar(255) NOT NULL default '',
   `InsertTime` int(10) unsigned NOT NULL default '0',

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -462,7 +462,7 @@ CREATE TABLE `ImagingFileTypes` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
-INSERT INTO `ImagingFileTypes` VALUES
+INSERT INTO `ImagingFileTypes` (type, description) VALUES
   ('mnc',      'MINC file'),
   ('obj',      'MNI BIC imaging format for a surface'),
   ('xfm',      'MNI BIC linear transformation matrix file'),

--- a/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
+++ b/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
@@ -1,0 +1,47 @@
+-- ALTER ImagingFileTypes table to add a `description` column
+ALTER TABLE ImagingFileTypes
+  ADD `description` VARCHAR(255) DEFAULT NULL;
+
+UPDATE ImagingFileTypes
+  SET description='MINC file'
+  WHERE type='mnc';
+
+UPDATE ImagingFileTypes
+  SET description='3D imaging format'
+  WHERE type='obj';
+
+UPDATE ImagingFileTypes
+  SET description='transformation matrix file'
+  WHERE type='xfm';
+
+UPDATE ImagingFileTypes
+  SET description=NULL
+  WHERE type='xfmmnc';
+
+UPDATE ImagingFileTypes
+  SET description='audition impulse file'
+  WHERE type='imp';
+
+UPDATE ImagingFileTypes
+  SET description='file describing the cortical thickness in a single column'
+  WHERE type='vertstat';
+
+UPDATE ImagingFileTypes
+  SET description='XML file'
+  WHERE type='xml';
+
+UPDATE ImagingFileTypes
+  SET description='text file'
+  WHERE type='txt';
+
+UPDATE ImagingFileTypes
+  SET description='NIfTI file'
+  WHERE type='nii';
+
+UPDATE ImagingFileTypes
+  SET description='compressed NIfTI file'
+  WHERE type='nii.gz';
+
+UPDATE ImagingFileTypes
+  SET description='NRRD file format (used by DTIPrep)'
+  WHERE type='nrrd';

--- a/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
+++ b/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
@@ -1,6 +1,24 @@
--- ALTER ImagingFileTypes table to add a `description` column
+-- Disable Foreign key to be able to change type
+-- of FileType to VARCHAR(12) in files, 
+-- mri_processing_protocol and ImagingFileType
+SET FOREIGN_KEY_CHECKS=0;
+
+-- ALTER files to drop the FK_files_FileTypes
+ALTER TABLE files
+  MODIFY `FileType` VARCHAR(12);
+
+-- ALTER mri_processing_protocol to drop the 
+-- FK_mri_processing_protocol_FileTypes
+ALTER TABLE mri_processing_protocol 
+  MODIFY `FileType` VARCHAR(12);
+
+-- ALTER ImagingFileTypes table to add a `description` column 
 ALTER TABLE ImagingFileTypes
+  MODIFY `type` VARCHAR(12) NOT NULL,
   ADD `description` VARCHAR(255) DEFAULT NULL;
+
+-- Re-enable the forein keys
+SET FOREIGN_KEY_CHECKS=1;
 
 -- ADD description to the different type
 UPDATE ImagingFileTypes

--- a/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
+++ b/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
@@ -48,3 +48,6 @@ UPDATE ImagingFileTypes
 
 INSERT INTO ImagingFileTypes
   VALUES ('grid_0', 'MNI BIC non-linear field for non-linear transformation');
+
+DELETE FROM ImagingFileTypes
+  WHERE type='xfmmnc';

--- a/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
+++ b/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
@@ -61,7 +61,7 @@ UPDATE ImagingFileTypes
   SET description='NRRD file format (used by DTIPrep)'
   WHERE type='nrrd';
 
-INSERT INTO ImagingFileTypes
+INSERT INTO ImagingFileTypes (type, description)
   VALUES ('grid_0', 'MNI BIC non-linear field for non-linear transformation');
 
 -- DELETE xfmmnc entry as no one understand what it is referring to

--- a/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
+++ b/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
@@ -2,6 +2,7 @@
 ALTER TABLE ImagingFileTypes
   ADD `description` VARCHAR(255) DEFAULT NULL;
 
+-- ADD description to the different type
 UPDATE ImagingFileTypes
   SET description='MINC file'
   WHERE type='mnc';
@@ -39,15 +40,19 @@ UPDATE ImagingFileTypes
   WHERE type='nii';
 
 UPDATE ImagingFileTypes
-  SET description='compressed NIfTI file'
-  WHERE type='nii.gz';
-
-UPDATE ImagingFileTypes
   SET description='NRRD file format (used by DTIPrep)'
   WHERE type='nrrd';
 
 INSERT INTO ImagingFileTypes
   VALUES ('grid_0', 'MNI BIC non-linear field for non-linear transformation');
 
+-- DELETE xfmmnc entry as no one understand what it is referring to
 DELETE FROM ImagingFileTypes
   WHERE type='xfmmnc';
+
+-- MAP .nii.gz file type in files table to .nii and delete .nii
+UPDATE files
+  SET FileType='nii'
+  WHERE FileType='nii.gz';
+DELETE FROM ImagingFileTypes
+  WHERE type='nii.gz';

--- a/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
+++ b/SQL/Archive/19.2/2018-01-30_Add_description_to_ImagingFileTypes.sql
@@ -45,3 +45,6 @@ UPDATE ImagingFileTypes
 UPDATE ImagingFileTypes
   SET description='NRRD file format (used by DTIPrep)'
   WHERE type='nrrd';
+
+INSERT INTO ImagingFileTypes
+  VALUES ('grid_0', 'MNI BIC non-linear field for non-linear transformation');


### PR DESCRIPTION
This pull request adds a description column to the `ImagingFileTypes` table. 

The `ImagingFileType` table stores all file type related to imaging and is linked to the `FileType` column of the`files` table. In the near future, additional file types will be added and some of them might seem obscure so having the capability to add a description for the file type will come in handy.
