### PR TITLE
Remove create_function in LINST

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -340,13 +340,23 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             if ($comparevalue == 'NEVER_REQUIRED' && $operator == '==') {
                 return true;
             }
-            $compareFunction = create_function(
-                '$a, $b',
-                "return \$a $operator \$b;"
-            );
 
-            if (!($compareFunction($comparevalue, $userval)) ) {
-                return false;
+            switch ($operator) {
+            case '==':
+                if ($comparevalue != $userval) {
+                    return false;
+                }
+                break;
+            case '!=':
+                if ($comparevalue == $userval) {
+                    return false;
+                }
+                break;
+            default:
+                throw new \LorisException(
+                    "Unsupported operator ($operator) for XIN Rule."
+                    . " If this used to work, please file a bug report."
+                );
             }
         }
         // Nothing that was compared failed


### PR DESCRIPTION
The create_function call is deprecated and causes PHPCS
to generate errors in PHP 7.2

This replaces it with the same logic that is used from
NDB_BVL_Instrument.
