### PR TITLE
Added Edit, Add and Remove button options to the Panel Header

### DIFF
--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -41,17 +41,55 @@ class Panel extends React.Component {
         "glyphicon pull-right glyphicon-chevron-up"
     );
 
+    let pencilGlyph;
+    if (this.props.edit) {
+      pencilGlyph = (
+        <span
+          className="glyphicon pull-right glyphicon-pencil"
+          style={{marginRight:'10px', cursor: 'pointer'}}
+          onClick={this.props.edit}
+        /> 
+      );
+    } 
+
+    let plusGlyph;
+    if (this.props.add) {
+      plusGlyph = (
+        <span
+          className="glyphicon pull-right glyphicon-plus"
+          style={{marginRight:'10px', cursor: 'pointer'}}
+          onClick={this.props.add}
+        />
+      );
+    }
+
+    let removeGlyph;
+    if (this.props.cancel) {
+      removeGlyph = (
+        <span
+          className="glyphicon pull-right glyphicon-remove"
+          style={{marginRight:'10px', cursor: 'pointer'}}
+          onClick={this.props.cancel}
+        />
+      );
+    }
+
     // Add panel header, if title is set
     const panelHeading = this.props.title ? (
       <div
         className="panel-heading"
-        onClick={this.toggleCollapsed}
-        data-toggle="collapse"
-        data-target={'#' + this.props.id}
-        style={{cursor: 'pointer'}}
       >
+        <span 
+          className={glyphClass}
+          onClick={this.toggleCollapsed}
+          data-toggle="collapse"
+          data-target={'#' + this.props.id}
+          style={{cursor: 'pointer'}}
+        />
+        {pencilGlyph}
+        {plusGlyph}
+        {removeGlyph}
         {this.props.title}
-        <span className={glyphClass}></span>
       </div>
     ) : '';
 
@@ -71,7 +109,9 @@ class Panel extends React.Component {
 Panel.propTypes = {
   id: React.PropTypes.string,
   height: React.PropTypes.string,
-  title: React.PropTypes.string
+  title: React.PropTypes.string,
+  edit: React.PropTypes.func,
+  add: React.PropTypes.func
 };
 Panel.defaultProps = {
   initCollapsed: false,


### PR DESCRIPTION
This pull request adds the options of presenting an add, edit, or cancel button to the panel header. These buttons will then trigger the function that was passed to it through props.

Adding this functionality means that the chevron icon must be clicked to activate the panel dropdown toggle, as opposed to being able to click anywhere on the panel header to toggle the dropdown.

![screenshot from 2018-01-31 12-42-36](https://user-images.githubusercontent.com/7550451/35638117-3fe0f1ba-0684-11e8-9c79-417252187683.png)
