### PR TITLE
[Tools] Script to move TE_range & TR_range data to normalized TE & TR tables 

### DIFF
--- a/SQL/Archive/19.1/2018-02-06_normalized_mri_protocol_ranges.sql
+++ b/SQL/Archive/19.1/2018-02-06_normalized_mri_protocol_ranges.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `mri_protocol_TE` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Scan_type` int(10) unsigned NOT NULL default '0',
+  `TE_min` int(11) NOT NULL default '0',
+  `TE_max` int(11) NOT NULL default '0',
+  PRIMARY KEY  (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `mri_protocol_TR` (
+  `ID` int(11) NOT NULL AUTO_INCREMENT,
+  `Scan_type` int(10) unsigned NOT NULL default '0',
+  `TR_min` int(11) NOT NULL default '0',
+  `TR_max` int(11) NOT NULL default '0',
+  PRIMARY KEY  (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tools/normalize_mri_protocol.php
+++ b/tools/normalize_mri_protocol.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Script which populates the normalized mri_protocol_TE and mri_protocol_TR tables with
+ * TE_range & TR_range data from the mri_protocol table, respectively.
+ *
+ *
+ * PHP version 7
+ *
+ * @category Behavioural
+ * @package  Main
+ * @author   Liza Levitis  <llevitis.mcin@gmail.com>
+ * @license  Loris License
+ * @link     https://github.com/llevitis/Loris
+ */
+
+set_include_path(
+    get_include_path().":".
+    __DIR__."/../project/libraries:".
+    __DIR__."/../php/libraries:"
+);
+
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "NDB_Client.class.inc";
+$client = new NDB_Client();
+$client->makeCommandLine();
+$client->initialize();
+
+$DB =& Database::singleton();
+
+## Get the list of scan types in the mri_protocol table
+
+$st_result = $DB->pselect("SELECT DISTINCT Scan_type FROM mri_protocol ORDER BY Scan_type", array());
+$scan_types_list = array();
+for ($i=0; $i < sizeof($st_result); $i++) {
+    $scan_types_list[$i] = $st_result[$i]["Scan_type"];
+}
+echo("The following are the scan types in the mri_protocol table:\n");
+foreach ($scan_types_list as $scan_type) {
+    print_r("$scan_type\n");
+}
+
+function _getRange($scan_type, $protocol_type) {
+    $DB =& Database::singleton();
+    $params =
+        array(
+            'Scan_type' => $scan_type
+        );
+    if ($protocol_type == "TR") {
+        $protocol_range = $DB->pselect("SELECT TR_range FROM mri_protocol WHERE Scan_type=:Scan_type", $params);
+    }
+    if ($protocol_type == "TE") {
+        $protocol_range = $DB->pselect("SELECT TE_range FROM mri_protocol WHERE Scan_type=:Scan_type", $params);
+    }
+    return $protocol_range;
+}
+
+function _populateTables($scan_type) {
+    $DB =& Database::singleton();
+    # populate the mri_protocol_TE table
+    $te_range = _getRange($scan_type, "TE");
+    foreach ($te_range as $arr) {
+        $protocolRanges = explode(",", $arr["TE_range"]);
+        foreach ($protocolRanges as $range) {
+            $rangeTrimmed = trim($range);
+            if (strpos($rangeTrimmed, "-")) { // range X-Y
+                $array = explode("-", $rangeTrimmed);
+                $left = (float)trim($array[0]);
+                $right = (float)trim($array[1]);
+                $x = $DB->insert("mri_protocol_TE", array('Scan_type' => $scan_type, 'TE_min' => $left, 'TE_max' => $right));
+            } else {
+                $x = $DB->insert("mri_protocol_TE", array('Scan_type' => $scan_type, 'TE_min' => $rangeTrimmed, 'TE_max' => $rangeTrimmed));
+            }
+        }
+    }
+    $tr_range = _getRange($scan_type, "TR");
+    foreach ($tr_range as $arr) {
+        $protocolRanges = explode(",", $arr["TR_range"]);
+        foreach ($protocolRanges as $range) {
+            $rangeTrimmed = trim($range);
+            if (strpos($rangeTrimmed, "-")) { // range X-Y
+                $array = explode("-", $rangeTrimmed);
+                $left = (float)trim($array[0]);
+                $right = (float)trim($array[1]);
+                $x = $DB->insert("mri_protocol_TR", array('Scan_type' => $scan_type, 'TR_min' => $left, 'TR_max' => $right));
+            } else {
+                $x = $DB->insert("mri_protocol_TR", array('Scan_type' => $scan_type, 'TR_min' => $rangeTrimmed, 'TR_max' => $rangeTrimmed));
+            }
+        }
+    }
+}
+
+foreach ($scan_types_list as $scan_type) {
+    _populateTables($scan_type);
+}
+
+?>


### PR DESCRIPTION
Currently, the TE_range & TR_range values in the mri_protocol table are stored as varchars where either individual values, comma-separated values, hyphen-separated ranges (single or comma-separated multiple ones) can be the values. This makes querying for the QC module (#3338) quite messy, so I have added a patch for two new normalized tables - mri_protocol_TE & mri_protocol_TR. It allows us to just deal with one range per row. The normalize_mri_protocol.php script populates the tables data from the mri_protocol table. 

It is admittedly redundant to store duplicate data across several tables, but this is the quickest interim solution. A more long-term solution is to fully normalize the mri_protocol table and tweak code that uses it accordingly. 

#3338 has been updated to use these changes.