### PR TITLE
Back up SQL from cleanup_mri_tables_for_19-0_release.php saved in project/backup now

### DIFF
--- a/tools/cleanup_mri_tables_for_19-0_release.php
+++ b/tools/cleanup_mri_tables_for_19-0_release.php
@@ -263,6 +263,11 @@ function backupEntries($selectID, $table_name, $FK_field)
     $IDs = generateIdList($selectID, $FK_field);
     $where = $FK_field . " IN (" . $IDs . ")";
 
+    // create directory where the back up will go if it does not exist yet
+    if ( !file_exists("../project/backup") ) {
+        mkdir("../project/backup");
+    }
+
     // grep database connection information from NDB_Config for mysqldump
     $config = NDB_Config::singleton();
     $config->load(__DIR__."/../project/config.xml");
@@ -287,7 +292,7 @@ function backupEntries($selectID, $table_name, $FK_field)
         escapeshellarg($table_name)               . " " .
         "--where=" . escapeshellarg($where)       . " " .
         "--compact --no-create-info"              . " " .
-        ">> ./backup_release_19-0_upgrade.sql";
+        ">> ../project/backup/backup_release_19-0_upgrade.sql";
 
     system($sqldump, $retval); // execute mysqldump
 

--- a/tools/cleanup_mri_tables_for_19-0_release.php
+++ b/tools/cleanup_mri_tables_for_19-0_release.php
@@ -264,8 +264,8 @@ function backupEntries($selectID, $table_name, $FK_field)
     $where = $FK_field . " IN (" . $IDs . ")";
 
     // create directory where the back up will go if it does not exist yet
-    if ( !file_exists("../project/backup") ) {
-        mkdir("../project/backup");
+    if ( !file_exists(__DIR__."/../project/backup") ) {
+        mkdir(__DIR__."/../project/backup");
     }
 
     // grep database connection information from NDB_Config for mysqldump
@@ -292,7 +292,7 @@ function backupEntries($selectID, $table_name, $FK_field)
         escapeshellarg($table_name)               . " " .
         "--where=" . escapeshellarg($where)       . " " .
         "--compact --no-create-info"              . " " .
-        ">> ../project/backup/backup_release_19-0_upgrade.sql";
+        ">> " . __DIR__ . "/../project/backup/backup_release_19-0_upgrade.sql";
 
     system($sqldump, $retval); // execute mysqldump
 


### PR DESCRIPTION
This pull request allows the cleanup_mri_tables_for_19-0_release.php script to save the backup SQL file in project/backup as suggested in PR https://github.com/aces/Loris/pull/3473 by @ridz1208.

Should add in the release that the backup SQL created by the script will be located in project/backup.

@ridz1208 I put you as a reviewer for this PR. Let me know if that works.