### PR TITLE
[CouchDB] Fix database name in libraries

### DIFF
--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -203,7 +203,7 @@ class CouchDB
             if (empty($database)) {
                 // Default to DQT
                 $config   = \NDB_Config::singleton();
-                $database = $config->getSetting("CouchDB")['database'];
+                $database = $config->getSetting("CouchDB")['dbName'];
             }
 
             $db = new CouchDB($database);

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -232,7 +232,7 @@ class NDB_Factory
     function couchDB($database = null)
     {
         if (empty($database)) {
-            $database = self::config()->getSetting("CouchDB")['database'];
+            $database = self::config()->getSetting("CouchDB")['dbName'];
         }
 
         if (!empty(self::$_couchdb[$database])) {


### PR DESCRIPTION
This corrects the name of the config setting referring to the couchDB databases in the config.xml. this name was changed from `database` to `dbName` to be differentiated from the MySQL database credentials. The first PR below shows the name change. The second shows where the changes were accidentally reverted.

Changes made: https://github.com/aces/Loris/pull/2720/files
changes partially reverted: https://github.com/aces/Loris/pull/2795/files