### PR TITLE
Imaging Browser: Make Links to instruments project customizable and add the DICOM download: Redmines 12500 and 12580

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -111,8 +111,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'linkedInstruments', 'Instruments that the users want to see linked from Imaging Browser', 1, 1, 'instrument', ID, 'Imaging Browser Links to Instruments', 7 FROM ConfigSettings WHERE Name="imaging_modules";
 
 
-
-
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('statistics', 'Statistics module settings', 1, 0, 'Statistics', 7);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'excludedMeasures', 'Instruments to be excluded from Statistics calculations', 1, 1, 'instrument', ID, 'Excluded instruments', 1 FROM ConfigSettings WHERE Name="statistics";
 
@@ -214,8 +212,6 @@ INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) F
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=45;
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'radiology_review' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
-
-
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "radiology_review" FROM ConfigSettings WHERE Name="excludedMeasures";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "mri_parameter_form" FROM ConfigSettings WHERE Name="excludedMeasures";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -108,6 +108,9 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'LivingPhantomRegex', 'Regex to be used on Living Phantom scan header', 1, 0, 'text', ID, 'Living phantom regex', 4 FROM ConfigSettings WHERE Name="imaging_modules";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showTransferStatus', 'Show transfer status in the DICOM Archive table', 1, 0, 'boolean', ID, 'Show transfer status', 5 FROM ConfigSettings WHERE Name="imaging_modules";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'tblScanTypes', 'Scan types from the mri_scan_type table that the project wants to see displayed in Imaging Browser table', 1, 1, 'scan_type', ID, 'Imaging Browser Tabulated Scan Types', 6 FROM ConfigSettings WHERE Name="imaging_modules";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'linkedInstruments', 'Instruments that the users want to see linked from Imaging Browser', 1, 1, 'instrument', ID, 'Imaging Browser Links to Instruments', 7 FROM ConfigSettings WHERE Name="imaging_modules";
+
+
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('statistics', 'Statistics module settings', 1, 0, 'Statistics', 7);
@@ -209,6 +212,9 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/phantom/i" FROM ConfigSettings
 INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="showTransferStatus";
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=44;
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=45;
+INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
+INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'radiology_review' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
+
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "radiology_review" FROM ConfigSettings WHERE Name="excludedMeasures";

--- a/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
+++ b/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
@@ -1,0 +1,8 @@
+-- Add Imaging Browser to Imaging Modules
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'linkedInstruments', 'Instruments that the users want to see linked from Imaging Browser', 1, 1, 'instrument', ID, 'Imaging Browser Links to Instruments', 7 FROM ConfigSettings WHERE Name="imaging_modules";
+
+-- default imaging_browser settings for Linked instruments
+INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
+INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'radiology_review' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
+
+

--- a/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
+++ b/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
@@ -4,5 +4,3 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 -- default imaging_browser settings for Linked instruments
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'radiology_review' FROM ConfigSettings cs WHERE cs.Name="linkedInstruments";
-
-

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -38,13 +38,15 @@ if ($client->initialize("../../../project/config.xml") == false) {
 }
 
 // Checks that config settings are set
-$config =& NDB_Config::singleton();
-$paths  = $config->getSetting('paths');
+$config   =& NDB_Config::singleton();
+$paths    = $config->getSetting('paths');
+$pipeline = $config->getSetting('imaging_pipeline');
 
 // Basic config validation
 $imagePath    = $paths['imagePath'];
 $DownloadPath = $paths['DownloadPath'];
 $mincPath     = $paths['mincPath'];
+$tarchivePath = $pipeline['tarchiveLibraryDir'];
 if (empty($imagePath) || empty($DownloadPath) || empty($mincPath)) {
     error_log("ERROR: Config settings are missing");
     header("HTTP/1.1 500 Internal Server Error");
@@ -92,6 +94,12 @@ if (strpos($File, "..") !== false) {
     exit(4);
 }
 
+// If $File contains "DCM_", prefix automatically inserted by the
+// LORIS-MRI pipeline, identify it as $FileExt: "DICOMTAR"
+if (strpos($File, "DCM_") ) {
+    $FileExt = "DICOMTAR";
+}
+
 switch($FileExt) {
 case 'mnc':
     $FullPath         = $mincPath . '/' . $File;
@@ -131,6 +139,12 @@ case 'xml':
 case 'nrrd':
     $FullPath         = $imagePath . '/' . $File;
     $MimeType         = 'image/vnd.nrrd';
+    $DownloadFilename = basename($File);
+    break;
+case 'DICOMTAR':
+    // ADD case for DICOMTAR
+    $FullPath         = $tarchivePath . '/' . $File;
+    $MimeType         = 'application/x-tar';
     $DownloadFilename = basename($File);
     break;
 default:

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -63,25 +63,29 @@ class Imaging_Session_ControlPanel
     function getData()
     {
         $DB        = \Database::singleton();
+        $config    = \NDB_Config::singleton();
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
 
         $subjectData['sessionID'] = $_REQUEST['sessionID'];
         $subjectData['candid']    = $timePoint->getCandID();
 
-        $qresult = $DB->pselectOne(
-            "SELECT CommentID FROM flag 
-            WHERE Test_name='mri_parameter_form' AND SessionID = :v_sessions_id",
-            array('v_sessions_id' => $this->sessionID)
-        );
-        $subjectData['ParameterFormCommentID'] = (empty($qresult)) ? "" : $qresult;
+        $linkedInstruments = $config->getSetting('linkedInstruments');
 
-        $qresult = $DB->pselectOne(
-            "SELECT CommentID 
-            FROM flag WHERE Test_name='radiology_review' 
-            AND SessionID = :v_sessions_id",
-            array('v_sessions_id' => $this->sessionID)
-        );
-        $subjectData['RadiologyReviewCommentID'] = (empty($qresult)) ? "" : $qresult;
+        foreach ($linkedInstruments as $k=>$v) {
+            $qresult   = $DB->pselectRow(
+                "SELECT f.CommentID, tn.Full_name FROM flag f
+            JOIN test_names tn ON f.Test_name = tn.Test_name 
+            WHERE f.Test_name = :tname AND f.SessionID = :v_sessions_id",
+                array(
+                 'tname'         => $v,
+                 'v_sessions_id' => $this->sessionID,
+                )
+            );
+            $instrName = $qresult['Full_name'];
+            $commentIDToInstrName[$instrName] =$qresult['CommentID'];
+        }
+        $subjectData['instrNameCommentID']
+            = (empty($commentIDToInstrName)) ? "" : $commentIDToInstrName;
 
         $candidate =& \Candidate::singleton($timePoint->getCandID());
 
@@ -96,22 +100,23 @@ class Imaging_Session_ControlPanel
             $params['PCandID'] = $timePoint->getCandID();
             $params['PVL']     = $timePoint->getVisitLabel();
         }
-        $tarchiveIDs = $DB->pselect(
-            "SELECT TarchiveID 
+        // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
+        $qresult = $DB->pselect(
+            "SELECT TarchiveID, ArchiveLocation 
             FROM tarchive 
             WHERE PatientName LIKE $ID",
             $params
         );
-        $subjectData['tarchiveids'] = $tarchiveIDs;
+
+        $tarIDToTarLoc =array();
+        foreach ($qresult as $k=>$v) {
+            $tarchiveID = $v['TarchiveID'];
+            $tarIDToTarLoc[$tarchiveID] =$v['ArchiveLocation'];
+        }
+        $subjectData['tarchiveIDLoc'] = $tarIDToTarLoc;
 
         $config =& \NDB_Config::singleton();
 
-        //if table is not in database return false to not display in the template
-        $this->tpl_data['mri_param_form_table_exists']
-            = $DB->tableExists('mri_parameter_form');
-        $this->tpl_data['rad_review_table_exists']     = $DB->tableExists(
-            'radiology_review'
-        );
         $this->tpl_data['mantis']       = $config->getSetting('mantis_url');
         $subjectData['mantis']          = $config->getSetting('mantis_url');
         $subjectData['has_permission']  = $this->_hasAccess();

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -38,8 +38,19 @@
         {if $rad_review_table_exists}
             <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/radiology_review/?commentID={$subject.RadiologyReviewCommentID}">Radiology Review</a></li>
         {/if}
-        {foreach from=$subject.tarchiveids item=tarchive}
-        <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive.TarchiveID}</a></li>{/foreach}
+
+
+        {foreach from=$subject.instrNameCommentID key=instrName item=commentID}
+            <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/{$instrName}/?commentID={$commentID}">{$instrName}</a></li>
+        {/foreach}
+
+        {foreach from=$subject.tarchiveIDLoc key=tarchive item=tarchiveLoc}
+            <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive}</a></li>
+            <li><a href="/mri/jiv/get_file.php?file={$tarchiveLoc}" class="btn btn-primary btn-small">
+                    <span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM {$tarchive}</span>
+                </a>
+            </li>
+        {/foreach}
         {if $mantis}
             <li><a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a></li>
         {/if}


### PR DESCRIPTION
As the title says: projects can now customize the instruments they want to see under links, and can download the DICOMs from Imaging Browser.

The second feature was started in #2791; but finished here.

The instruments are chosen as shown in screenshot below:
![config](https://user-images.githubusercontent.com/15198379/36281573-1a361960-126c-11e8-98b9-6aa5b86551df.png)

and

the Imaging Browser View Session Links would display:
![links](https://user-images.githubusercontent.com/15198379/36281591-2e666f70-126c-11e8-8651-2e78003d850e.png)
 