### PR TITLE
Survey Instruments Not Loading on Internet Explorer

### DIFF
--- a/htdocs/js/modules/direct_entry.js
+++ b/htdocs/js/modules/direct_entry.js
@@ -44,6 +44,7 @@ $(document).ready(function() {
 
     ajaxSubmit = function(e) {
         var formEl = document.getElementById("test_form"),
+            documentURI,
             nextpageNode = document.getElementById("nextpage"),
             prevpageNode = document.getElementById("prevpage"),
             nextPage;
@@ -64,10 +65,10 @@ $(document).ready(function() {
         }).appendTo("#test_form");
 
         if (document.documentURI) {
-            var documentURI=document.documentURI;
+            documentURI=document.documentURI;
         }
         else {
-            var documentURI= window.location.href;
+            documentURI= window.location.href;
         }
         formEl.action = documentURI;
         //formEl.action = "submit.php?key=" + document.getElementById("key").textContent;

--- a/htdocs/js/modules/direct_entry.js
+++ b/htdocs/js/modules/direct_entry.js
@@ -44,7 +44,6 @@ $(document).ready(function() {
 
     ajaxSubmit = function(e) {
         var formEl = document.getElementById("test_form"),
-            documentURI,
             nextpageNode = document.getElementById("nextpage"),
             prevpageNode = document.getElementById("prevpage"),
             nextPage;
@@ -64,13 +63,7 @@ $(document).ready(function() {
             value: nextPage
         }).appendTo("#test_form");
 
-        if (document.documentURI) {
-            documentURI=document.documentURI;
-        }
-        else {
-            documentURI= window.location.href;
-        }
-        formEl.action = documentURI;
+        formEl.action = window.location.href;
         //formEl.action = "submit.php?key=" + document.getElementById("key").textContent;
         $("#test_form").submit();
     }

--- a/htdocs/js/modules/direct_entry.js
+++ b/htdocs/js/modules/direct_entry.js
@@ -63,7 +63,13 @@ $(document).ready(function() {
             value: nextPage
         }).appendTo("#test_form");
 
-        formEl.action = document.documentURI;
+        if (document.documentURI) {
+            var documentURI=document.documentURI;
+        }
+        else {
+            var documentURI= window.location.href;
+        }
+        formEl.action = documentURI;
         //formEl.action = "submit.php?key=" + document.getElementById("key").textContent;
         $("#test_form").submit();
     }


### PR DESCRIPTION
document.documentURI is not supported on Internet Explorer; so survey instruments are not loading on IE.(ie, when we click the next page on a survey instrument,the url is something like this: https://ibis-dev.loris.ca/undefined)

![ie_no_support_documenturi](https://user-images.githubusercontent.com/23702452/36393443-98f49934-157d-11e8-893e-2b3b0e67a468.png)


In Internet Explorer, we have to use the location.href property to get HTML document location.

This PR fixes the issue.


