### PR TITLE
Imaging Browser: Make Links to instruments customizable: Redmine 12500

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -108,6 +108,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'LivingPhantomRegex', 'Regex to be used on Living Phantom scan header', 1, 0, 'text', ID, 'Living phantom regex', 4 FROM ConfigSettings WHERE Name="imaging_modules";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'showTransferStatus', 'Show transfer status in the DICOM Archive table', 1, 0, 'boolean', ID, 'Show transfer status', 5 FROM ConfigSettings WHERE Name="imaging_modules";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'tblScanTypes', 'Scan types from the mri_scan_type table that the project wants to see displayed in Imaging Browser table', 1, 1, 'scan_type', ID, 'Imaging Browser Tabulated Scan Types', 6 FROM ConfigSettings WHERE Name="imaging_modules";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ImagingBrowserLinkedInstruments', 'Instruments that the users want to see linked from Imaging Browser', 1, 1, 'instrument', ID, 'Imaging Browser Links to Instruments', 7 FROM ConfigSettings WHERE Name="imaging_modules";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('statistics', 'Statistics module settings', 1, 0, 'Statistics', 7);
@@ -209,7 +210,8 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/./i" FROM ConfigSettings WHERE
 INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="showTransferStatus";
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=44;
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=45;
-
+INSERT INTO Config (ConfigID, Value) SELECT cs.ID, "mri_parameter_form" FROM ConfigSettings cs WHERE cs.Name="ImagingBrowserLinkedInstruments";
+INSERT INTO Config (ConfigID, Value) SELECT cs.ID, "radiology_review" FROM ConfigSettings cs WHERE cs.Name="ImagingBrowserLinkedInstruments";
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "radiology_review" FROM ConfigSettings WHERE Name="excludedMeasures";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "mri_parameter_form" FROM ConfigSettings WHERE Name="excludedMeasures";

--- a/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
+++ b/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
@@ -1,0 +1,33 @@
+-- Add Imaging Browser to Imaging Modules
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ImagingBrowserLinkedInstruments', 'Instruments that the users want to see linked from Imaging Browser', 1, 1, 'instrument', ID, 'Imaging Browser Links to Instruments', 7 FROM ConfigSettings WHERE Name="imaging_modules";
+
+-- Default imaging_browser settings for Linked instruments
+-- This will be the two tables mri_parameter_form and radiology_review; IF they exist in the database
+SET @s1 = (SELECT IF(
+    (SELECT COUNT(*)
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE table_name = 'mri_parameter_form'
+        AND table_schema = DATABASE()
+    ) > 0,
+    "INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name='ImagingBrowserLinkedInstruments'",
+    "SELECT 'No' as 'mri parameter_form table exists'"
+));
+
+PREPARE stmt1 FROM @s1;
+EXECUTE stmt1;
+DEALLOCATE PREPARE stmt1;
+
+SET @s2 = (SELECT IF(
+    (SELECT COUNT(*)
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE table_name = 'radiology_review'
+        AND table_schema = DATABASE()
+    ) > 0,
+    "INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name='ImagingBrowserLinkedInstruments'",
+    "SELECT 'No' as 'radiology_review table exists?'"
+));
+
+PREPARE stmt2 FROM @s2;
+EXECUTE stmt2;
+DEALLOCATE PREPARE stmt2;
+

--- a/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
+++ b/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
@@ -3,30 +3,31 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 
 -- Default imaging_browser settings for Linked instruments
 -- This will be the two tables mri_parameter_form and radiology_review; IF they exist in the database
+SET @s1 = (SELECT IF(
+    (SELECT COUNT(*)
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE table_name = 'mri_parameter_form'
+        AND table_schema = DATABASE()
+    ) > 0,
+    "INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name='ImagingBrowserLinkedInstruments'",
+    "SELECT 'No. It is therefore not inserted into the Configuration module under Imaging Modules' as 'mri parameter_form table exists?'"
+));
 
-SET @s1 = CONCAT("
-  SET @s2 = (SELECT IF(
-    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name = ? AND table_schema = DATABASE()) > 0,
-    \"SELECT CONCAT('INSERT INTO Config (ConfigID, Value) SELECT cs.ID, ',?,' FROM ConfigSettings cs WHERE cs.Name=\"'ImagingBrowserLinkedInstruments'\"') as 'Insertion successful:'\",
-    \"SELECT CONCAT('INSERT in Configuration Settings for the Imaging Modules of ',?,' DID NOT HAPPEN since the table does not exist') as 'Insertion successful:'\"
-  ))
-");
+PREPARE stmt1 FROM @s1;
+EXECUTE stmt1;
+DEALLOCATE PREPARE stmt1;
 
-SET @table = 'mri_parameter_form';
-
-PREPARE stmt FROM @s1;
-EXECUTE stmt USING @table;
+SET @s2 = (SELECT IF(
+    (SELECT COUNT(*)
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE table_name = 'radiology_review'
+        AND table_schema = DATABASE()
+    ) > 0,
+    "INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name='ImagingBrowserLinkedInstruments'",
+    "SELECT 'No. It is therefore not inserted into the Configuration module under Imaging Modules' as 'radiology_review table exists?'"
+));
 
 PREPARE stmt2 FROM @s2;
-EXECUTE stmt2 USING @table;
+EXECUTE stmt2;
+DEALLOCATE PREPARE stmt2;
 
-SET @table = 'radiology_review';
-
-PREPARE stmt FROM @s1;
-EXECUTE stmt USING @table;
-
-PREPARE stmt2 FROM @s2;
-EXECUTE stmt2 USING @table;
-
-
---  \"SELECT CONCAT('INSERT INTO Config (ConfigID, Value) SELECT cs.ID, ',?,' FROM ConfigSettings cs WHERE cs.Name=\"'ImagingBrowserLinkedInstruments'\"') as 'Insertion successful:'\",

--- a/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
+++ b/SQL/Archive/2018-02-15_AddCustomizableCRFsUnderLinksInImagBrowser.sql
@@ -3,31 +3,30 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 
 -- Default imaging_browser settings for Linked instruments
 -- This will be the two tables mri_parameter_form and radiology_review; IF they exist in the database
-SET @s1 = (SELECT IF(
-    (SELECT COUNT(*)
-        FROM INFORMATION_SCHEMA.TABLES
-        WHERE table_name = 'mri_parameter_form'
-        AND table_schema = DATABASE()
-    ) > 0,
-    "INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name='ImagingBrowserLinkedInstruments'",
-    "SELECT 'No' as 'mri parameter_form table exists'"
-));
 
-PREPARE stmt1 FROM @s1;
-EXECUTE stmt1;
-DEALLOCATE PREPARE stmt1;
+SET @s1 = CONCAT("
+  SET @s2 = (SELECT IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_name = ? AND table_schema = DATABASE()) > 0,
+    \"SELECT CONCAT('INSERT INTO Config (ConfigID, Value) SELECT cs.ID, ',?,' FROM ConfigSettings cs WHERE cs.Name=\"'ImagingBrowserLinkedInstruments'\"') as 'Insertion successful:'\",
+    \"SELECT CONCAT('INSERT in Configuration Settings for the Imaging Modules of ',?,' DID NOT HAPPEN since the table does not exist') as 'Insertion successful:'\"
+  ))
+");
 
-SET @s2 = (SELECT IF(
-    (SELECT COUNT(*)
-        FROM INFORMATION_SCHEMA.TABLES
-        WHERE table_name = 'radiology_review'
-        AND table_schema = DATABASE()
-    ) > 0,
-    "INSERT INTO Config (ConfigID, Value) SELECT cs.ID, 'mri_parameter_form' FROM ConfigSettings cs WHERE cs.Name='ImagingBrowserLinkedInstruments'",
-    "SELECT 'No' as 'radiology_review table exists?'"
-));
+SET @table = 'mri_parameter_form';
+
+PREPARE stmt FROM @s1;
+EXECUTE stmt USING @table;
 
 PREPARE stmt2 FROM @s2;
-EXECUTE stmt2;
-DEALLOCATE PREPARE stmt2;
+EXECUTE stmt2 USING @table;
 
+SET @table = 'radiology_review';
+
+PREPARE stmt FROM @s1;
+EXECUTE stmt USING @table;
+
+PREPARE stmt2 FROM @s2;
+EXECUTE stmt2 USING @table;
+
+
+--  \"SELECT CONCAT('INSERT INTO Config (ConfigID, Value) SELECT cs.ID, ',?,' FROM ConfigSettings cs WHERE cs.Name=\"'ImagingBrowserLinkedInstruments'\"') as 'Insertion successful:'\",

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -58,6 +58,9 @@ tblScanTypes - This setting determines which scan types are considered "NEW" for
         QC purposes. It also determines which modalities are displayed on the
         main imaging browser menu page.
 
+ImagingBrowserLinkedInstruments - This setting defines which instruments to 
+        include a link to on the viewsession page.
+
 useProjects - This setting determines whether "project" filtering dropdowns exist
         on the menu page.
 
@@ -75,8 +78,7 @@ mantis_url - This setting defines a URL for LORIS to include a link to for bug r
   `$LORIS/tools/CouchDB_Import_MRI.php` alongside all other CouchDB
   import scripts, but should logically be considered part of this module.)
 - The imaging browser module includes links to BrainBrowser to visualize data.
-- The control panel on the viewsession page includes links to instruments
-  named "mri_parameter_form" and "radiologyreview" if they exist for the
-  currently viewed session.
+- The control panel on the viewsession page includes links to the instruments
+  as configured by the study.
 - The control panel on the viewsession page includes links to the DICOM Archive
   for any DICOM tars associated with the given session.

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -63,25 +63,34 @@ class Imaging_Session_ControlPanel
     function getData()
     {
         $DB        = \Database::singleton();
+        $config    = \NDB_Config::singleton();
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
 
         $subjectData['sessionID'] = $_REQUEST['sessionID'];
         $subjectData['candid']    = $timePoint->getCandID();
 
-        $qresult = $DB->pselectOne(
-            "SELECT CommentID FROM flag 
-            WHERE Test_name='mri_parameter_form' AND SessionID = :v_sessions_id",
-            array('v_sessions_id' => $this->sessionID)
-        );
-        $subjectData['ParameterFormCommentID'] = (empty($qresult)) ? "" : $qresult;
+        $linkedInstruments
+            = $config->getSetting('ImagingBrowserLinkedInstruments');
 
-        $qresult = $DB->pselectOne(
-            "SELECT CommentID 
-            FROM flag WHERE Test_name='radiology_review' 
-            AND SessionID = :v_sessions_id",
-            array('v_sessions_id' => $this->sessionID)
-        );
-        $subjectData['RadiologyReviewCommentID'] = (empty($qresult)) ? "" : $qresult;
+        $links = array();
+        foreach ($linkedInstruments as $k=>$v) {
+            $qresult = $DB->pselectRow(
+                "SELECT f.CommentID, tn.Full_name FROM flag f
+            JOIN test_names tn ON f.Test_name = tn.Test_name 
+            WHERE f.Test_name = :tname AND f.SessionID = :v_sessions_id",
+                array(
+                 'tname'         => $v,
+                 'v_sessions_id' => $this->sessionID,
+                )
+            );
+            $links[] = array(
+                        "FEName"    => $qresult['Full_name'],
+                        "BEName"    => $v,
+                        "CommentID" => $qresult['CommentID'],
+                       );
+        }
+        $subjectData['links']
+            = (empty($links)) ? "" : $links;
 
         $candidate =& \Candidate::singleton($timePoint->getCandID());
 
@@ -97,7 +106,7 @@ class Imaging_Session_ControlPanel
             $params['PVL']     = $timePoint->getVisitLabel();
         }
         $tarchiveIDs = $DB->pselect(
-            "SELECT TarchiveID 
+            "SELECT TarchiveID
             FROM tarchive 
             WHERE PatientName LIKE $ID",
             $params
@@ -106,12 +115,6 @@ class Imaging_Session_ControlPanel
 
         $config =& \NDB_Config::singleton();
 
-        //if table is not in database return false to not display in the template
-        $this->tpl_data['mri_param_form_table_exists']
-            = $DB->tableExists('mri_parameter_form');
-        $this->tpl_data['rad_review_table_exists']     = $DB->tableExists(
-            'radiology_review'
-        );
         $this->tpl_data['mantis']       = $config->getSetting('mantis_url');
         $subjectData['mantis']          = $config->getSetting('mantis_url');
         $subjectData['has_permission']  = $this->_hasAccess();

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -32,14 +32,11 @@
 
     <h3>Links</h3>
     <ul>
-        {if $mri_param_form_table_exists}
-            <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/mri_parameter_form/?commentID={$subject.ParameterFormCommentID}">MRI Parameter Form</a></li>
-        {/if}
-        {if $rad_review_table_exists}
-            <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/radiology_review/?commentID={$subject.RadiologyReviewCommentID}">Radiology Review</a></li>
-        {/if}
+        {foreach from=$subject.links item=link}
+            <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/{$link.BEName}/?commentID={$link.CommentID}">{$link.FEName}</a></li>
+        {/foreach}
         {foreach from=$subject.tarchiveids item=tarchive}
-        <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive.TarchiveID}</a></li>{/foreach}
+            <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive.TarchiveID}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive.TarchiveID}</a></li>{/foreach}
         {if $mantis}
             <li><a target="mantis" href="{$mantis}">Report a Bug (Mantis)</a></li>
         {/if}

--- a/modules/imaging_browser/test/imaging_browser_test_plan.md
+++ b/modules/imaging_browser/test/imaging_browser_test_plan.md
@@ -11,7 +11,7 @@
 
 ### B. ViewSession / Volume List
 
-8. Sidebar:  all links work 
+8. Sidebar:  all links work. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
 9. 3d panel overlay etc - they work.  Add panel checkbox works. 3D only or 3D+Overlay loads files if at least one image exists and is selected
 10. "Visit Level Feedback" - pops up QC window (see section E below)
 11. Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission imaging_browser_qc


### PR DESCRIPTION
admins can now customize the instruments they want to see under links in the Configution module:

![config](https://user-images.githubusercontent.com/15198379/36399691-0f206440-159b-11e8-8a2b-567df77c127e.png)

![links](https://user-images.githubusercontent.com/15198379/36399694-1155f522-159b-11e8-9143-492a7985e068.png)
