### PR TITLE
New data framework interfaces

### DIFF
--- a/src/Data/DataInstance.php
+++ b/src/Data/DataInstance.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file defines the Instance interface.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data;
+
+/**
+ * A DataInstance represents a single record returned from a Provisioner.
+ *
+ * Resources must be serializable to JSON, but the JSON content is flexible and
+ * can be of any format that makes sense to the Instance.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+interface DataInstance
+{
+    /**
+     * DataInstances must be serializable to JSON.
+     *
+     * ToJSON must serialize this resource instance to a string of valid JSON.
+     *
+     * @return string of data in JSON format.
+     */
+    function toJSON() : string;
+};

--- a/src/Data/Filter.php
+++ b/src/Data/Filter.php
@@ -36,11 +36,11 @@ interface Filter
      * Filter returns true IFF the resource should be filtered out of the results
      * displayed to user.
      *
-     * @param \User    $user     The user that the data is being filtered
-     *                           on behalf of.
-     * @param Instance $resource The Instance being filtered.
+     * @param \User        $user     The user that the data is being filtered on
+     *                               on behalf of.
+     * @param DataInstance $resource The Instance being filtered.
      *
      * @return bool true if and only if the user should see the resource Instance
      */
-    function filter(\User $user, Instance $resource) : bool;
+    function filter(\User $user, DataInstance $resource) : bool;
 }

--- a/src/Data/Filter.php
+++ b/src/Data/Filter.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file contains a definition of the Filter interface.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+/**
+ * The LORIS\Data namespace contains interfaces and classes used to extract and
+ * filter data. It implements the framework for permission based filtering.
+ */
+namespace LORIS\Data;
+
+/**
+ * A Filter represents a ruleset for whether or not data should be filtered out
+ * of a Provisioner. It generally is used for things like verifying permissions
+ * in a Provisioner.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+interface Filter
+{
+    /**
+     * Filter returns true IFF the resource should be filtered out of the results
+     * displayed to user.
+     *
+     * @param \User    $user     The user that the data is being filtered
+     *                           on behalf of.
+     * @param Instance $resource The Instance being filtered.
+     *
+     * @return bool true if and only if the user should see the resource Instance
+     */
+    function filter(\User $user, Instance $resource) : bool;
+}

--- a/src/Data/Mapper.php
+++ b/src/Data/Mapper.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Thie file defines the \LORIS\Data\Mapper interface.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data;
+/**
+ * A Mapper represents an object that maps data from one DataInstance type to
+ * another.
+ *
+ * It can be used to add, remove, or modify data coming from a Provisioner
+ * before being returned to the caller.
+ *
+ * This may be used for anything that modifies the data such as (possibly
+ * conditional) anonymization, or dictionary translations for data submissions.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+interface Mapper
+{
+    /**
+     * Map returns a copy of $resource that has been modified in some way
+     * It must return a new DataInstance without having modified the original.
+     *
+     * The data mapping should be a pure function of the original data and
+     * the user that it's being mapped for.
+     *
+     * @param \User        $user     The user that this is being mapped on
+     *                               behalf of.
+     * @param DataInstance $resource The data being mapped from.
+     *
+     * @return DataInstance a new DataInstance with the map applied.
+     */
+    function map(\User $user, DataInstance $resource) : Instance;
+}

--- a/src/Data/Provisioner.php
+++ b/src/Data/Provisioner.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file defines the concept of a data Provisioner.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data;
+
+/**
+ * A Provisioner is something which retrieves data from a source (usually
+ * the SQL database) and applies filters or maps to the data. It represents
+ * arbitrarily structured data such as a row in a table. Implementations
+ * know the details of the data, but a Provisioner itself only deals with
+ * DataInstance objects, Filters and Mappers.
+ *
+ * Filters generally do things like site based or project based permissions to
+ * the data, while mappers do things like anonymization of data.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+interface Provisioner
+{
+    /**
+     * Filter must return a new Provisioner which is identical to this one, except
+     * any rows which do not match $filter are removed from the result set when
+     * executed.
+     *
+     * @param Filter $filter The filter to apply
+     *
+     * @return Provisioner a new data provisioner with $filter applied
+     */
+    public function filter(Filter $filter) : Provisioner;
+
+    /**
+     * Map returns a new Provisioner which is identical to this one, except
+     * with the given map applied to the DataInstance objects returned
+     * by execute.
+     *
+     * @param Mapper $map The map to apply
+     *
+     * @return Provisioner a new data provisioner with $map applied
+     */
+    public function map(Mapper $map) : Provisioner;
+
+    /**
+     * Execute must return all the rows for this provisioner, having applied
+     * appropriate maps and filters.
+     *
+     * @param \User $user The user who data is being provisioned on behalf of.
+     *
+     * @return DataInstance[]
+     */
+    public function execute(\User $user) : \Traversable;
+};


### PR DESCRIPTION
This is an attempt to split #3123 into smaller, more manageable chunks. It only defines the interfaces  that make up the data access framework, independently of the implementation (and changes Provisioner from an abstract class to an interface).

This way the design can be discussed before it's committed.

See #3123 for an implementation (which uses the DICOM Archive as an example.)

(A second PR will implement the rest of the \LORIS\Data namespace after this is merged, and a third will convert the DICOM Archive as in #3123 once that goes in. Other modules will then need to be updated separately.)