### PR TITLE
New Data Framework Implementation (Part 2)

### DIFF
--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file provides an implementation of the UserSiteMatch filter.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data\Filters;
+
+/**
+ * UserSiteMatch filters out data for any resource which is not part of one of the
+ * user's sites. An Instance using the UserSiteMatch filter must implement a
+ * getCenterIDs or getCenterID method which returns an integer (or array) of
+ * CenterIDs that the data belongs to. The data will be filtered out unless the
+ * User is a member of at least one site that the resource instance is a member of.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class UserSiteMatch implements \LORIS\Data\Filter
+{
+    /**
+     * Implements the \LORIS\Data\Filter interface
+     *
+     * @param \User                $user     The user that the data is being
+     *                                       filtered for.
+     * @param \LORIS\Data\Instance $resource The data being filtered.
+     *
+     * @return bool true if the user has a site in common with the data
+     */
+    public function filter(\User $user, \Loris\Data\Instance $resource) : bool
+    {
+        if (method_exists($resource, 'getCenterIDs')) {
+            // If the Resource belongs to multiple CenterIDs, the user can
+            // access the data if the user is part of any of thos centers.
+            $resourceSites = $resource->getCenterIDs();
+            foreach ($resourceSites as $site) {
+                if ($user->hasCenter($resourceSite)) {
+                       return true;
+                }
+            }
+            return false;
+        } else if (method_exists($resource, 'getCenterID')) {
+            $resourceSite = $resource->getCenterID();
+            return $user->hasCenter($resourceSite);
+        }
+        throw new \LorisException(
+            "Can not implement SiteMatchFilter on a resource type that has no sites."
+        );
+    }
+}

--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -15,10 +15,11 @@ namespace LORIS\Data\Filters;
 
 /**
  * UserSiteMatch filters out data for any resource which is not part of one of the
- * user's sites. An Instance using the UserSiteMatch filter must implement a
- * getCenterIDs or getCenterID method which returns an integer (or array) of
- * CenterIDs that the data belongs to. The data will be filtered out unless the
- * User is a member of at least one site that the resource instance is a member of.
+ * user's sites. For a DataInstance to be compatible with the UserSiteMatch filter,
+ * it must implement a getCenterIDs or getCenterID method which returns an integer
+ * (or array) of CenterIDs that the data belongs to. The data will be filtered out
+ * unless the User is a member of at least one site that the resource DataInstance
+ * is a member of.
  *
  * @category   Data
  * @package    Main
@@ -32,20 +33,20 @@ class UserSiteMatch implements \LORIS\Data\Filter
     /**
      * Implements the \LORIS\Data\Filter interface
      *
-     * @param \User                $user     The user that the data is being
-     *                                       filtered for.
-     * @param \LORIS\Data\Instance $resource The data being filtered.
+     * @param \User                    $user     The user that the data is being
+     *                                           filtered for.
+     * @param \LORIS\Data\DataInstance $resource The data being filtered.
      *
      * @return bool true if the user has a site in common with the data
      */
-    public function filter(\User $user, \Loris\Data\Instance $resource) : bool
+    public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
         if (method_exists($resource, 'getCenterIDs')) {
             // If the Resource belongs to multiple CenterIDs, the user can
             // access the data if the user is part of any of thos centers.
             $resourceSites = $resource->getCenterIDs();
             foreach ($resourceSites as $site) {
-                if ($user->hasCenter($resourceSite)) {
+                if ($user->hasCenter($site)) {
                        return true;
                 }
             }

--- a/src/Data/MapIterator.php
+++ b/src/Data/MapIterator.php
@@ -30,6 +30,13 @@ class MapIterator extends \IteratorIterator
     protected $mapper;
     protected $user;
 
+    /**
+     * Create a MapIterator
+     *
+     * @param array  $rows   The Iterator being mapped from
+     * @param Mapper $mapper The mapper to apply
+     * @param \User  $user   The user to use when calling the Mapper
+     */
     public function __construct($rows, Mapper $mapper, \User $user)
     {
         parent::__construct($rows);
@@ -37,6 +44,12 @@ class MapIterator extends \IteratorIterator
         $this->user   = $user;
     }
 
+    /**
+     * Overrides the \IteratorIterator \Iterator interface to apply
+     * the map passed in the constructor.
+     *
+     * @return DataInstance
+     */
     public function current()
     {
         $row = parent::current();

--- a/src/Data/MapIterator.php
+++ b/src/Data/MapIterator.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file defines a MapIterator implementation.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data;
+
+/**
+ * A MapIterator is a type of iterator which extends another
+ * iterator in order to apply a map to the data before returning
+ * it to the caller.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class MapIterator extends \IteratorIterator
+{
+    protected $mapper;
+    protected $user;
+
+    public function __construct($rows, Mapper $mapper, \User $user)
+    {
+        parent::__construct($rows);
+        $this->mapper = $mapper;
+        $this->user   = $user;
+    }
+
+    public function current()
+    {
+        $row = parent::current();
+        return $this->mapper->Map($this->user, $row);
+    }
+}

--- a/src/Data/ProvisionerInstance.php
+++ b/src/Data/ProvisionerInstance.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * This file defines a helper for implementing the \LORIS\\Data\Provisioner
+ * interface.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data;
+
+/**
+ * A ProvisionerInstance is an abstract base class which can be used to
+ * provide most details for an implementation of the Provisioner interface.
+ *
+ * In order to use this class, the getAllRecords function must be
+ * implemented.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+abstract class ProvisionerInstance implements Provisioner
+{
+    /**
+     * The parent which this provisioner is derived from to apply
+     * $this->modifier to.
+     */
+    private $parent = null;
+
+    /**
+     * Filters (and Mappers) to apply to the data from this Provisioner
+     * before returning it to the user.
+     *
+     * Filters and Maps are lazily evaluated, and applied in the order that
+     * they were added to the Provisioner.
+     *
+     * (Since filters can only be created by calling filter or map on
+     * an existing provisioner, we only need to store the new filter and
+     * a reference to the parent.)
+     *
+     * A Modifier which implements both Filter and Mapper first gets Filtered,
+     * and then Mapped.
+     *
+     * @var Filter | Mapper
+     */
+    protected $modifier;
+
+    /**
+     * Implements the filter method for the Provisioner interface.
+     *
+     * @param Filter $filter The filter to apply
+     *
+     * @return Provisioner a new data provisioner with $filter applied
+     */
+    public function filter(Filter $filter) : Provisioner
+    {
+        $d           = clone $this;
+        $d->parent   = &$this;
+        $d->modifier = $filter;
+        return $d;
+    }
+
+    /**
+     * Implements the map method for the Provisioner interface.
+     *
+     * @param Mapper $map The map to apply
+     *
+     * @return Provisioner a new data provisioner with $map applied
+     */
+    public function map(Mapper $map) : Provisioner
+    {
+        $d           = clone $this;
+        $d->parent   = &$this;
+        $d->modifier = $map;
+        return $d;
+    }
+
+    /**
+     * getAllRecords must be implemented by concrete implementations of this
+     * class. It must return all rows known about for this Provisioner (without
+     * respect to the User accessing the data), which then gets mapped and
+     * filtered by execute.
+     *
+     * @return Traversable of all resources provided by this data source.
+     */
+    abstract protected function getAllRecords() : \Traversable;
+
+    /**
+     * Implements the execute function for the Provisioner interface.
+     *
+     * @param \User $user The user who data is being provisioned on behalf of.
+     *
+     * @return Instance[]
+     */
+    public function execute(\User $user) : \Traversable
+    {
+        $rows = new \EmptyIterator();
+        if ($this->parent != null) {
+            $rows = $this->parent->execute($user);
+        } else {
+            $rows = $this->getAllRecords();
+        }
+
+        if ($this->modifier !== null && !($this->modifier instanceof Filter) && !($this->modifier instanceof Mapper)) {
+            throw new \Exception("Invalid modifier on provisioner");
+        }
+
+        // If it implements both Filter and Mapper, run the filter first so that the mapping
+        // is less expensive.
+        if ($this->modifier instanceof Filter) {
+            $callback = function ($current, $key, $iterator) use ($user) {
+                return $this->modifier->filter($user, $current);
+            };
+
+            if ($rows instanceof \Iterator) {
+                $rows = new \CallbackFilterIterator($rows, $callback);
+            } else {
+                // Convert non-iterator traversables to iterators.
+                $rows = new \CallbackFilterIterator(new \IteratorIterator($rows), $callback);
+            }
+
+        }
+
+        if ($this->modifier instanceof Mapper) {
+            // Convert rows to an iterator where current() returns the map, not the existing
+            // value.
+            $rows = new MapIterator($rows, $this->modifier, $user);
+        }
+
+        return $rows;
+    }
+};

--- a/src/Data/ProvisionerInstance.php
+++ b/src/Data/ProvisionerInstance.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file defines a helper for implementing the \LORIS\\Data\Provisioner
+ * This file defines a helper for implementing the \LORIS\Data\Provisioner
  * interface.
  *
  * PHP Version 7

--- a/src/Data/Provisioners/DBRowProvisioner.php
+++ b/src/Data/Provisioners/DBRowProvisioner.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * File defines a DBRowProvisioner, which is a type of provisioner that
+ * gets data from an SQL database
+ */
+namespace LORIS\Data\Provisioners;
+
+abstract class DBRowProvisioner extends \LORIS\Data\ProvisionerInstance
+{
+    private $iteratorCache = null;
+    protected $query;
+    protected $params;
+    function __construct($query, $params)
+    {
+        $this->query  = $query;
+        $this->params = $params;
+    }
+
+    public abstract function getInstance($row) : \LORIS\Data\Instance;
+
+    function getAllInstances() : \Traversable
+    {
+        $DB      = \Database::singleton();
+        $stmt    = $DB->prepare($this->query);
+        $results = $stmt->execute($this->params);
+
+        if ($results === false) {
+            throw new \Exception("Invalid SQL statement: " . $this->query);
+        }
+
+        $iterator = new class($stmt, $this) extends \IteratorIterator {
+        protected $outer;
+        public function __construct($rows, &$self)
+        {
+            parent::__construct($rows);
+            $this->outer = &$self;
+        }
+
+        public function current()
+        {
+            $row = parent::current();
+            return $this->outer->getInstance($row);
+        }
+        };
+        return $iterator;
+    }
+}
+

--- a/src/Data/Provisioners/DBRowProvisioner.php
+++ b/src/Data/Provisioners/DBRowProvisioner.php
@@ -75,7 +75,7 @@ abstract class DBRowProvisioner extends \LORIS\Data\ProvisionerInstance
      */
     function getAllInstances() : \Traversable
     {
-        $DB      = \Database::singleton();
+        $DB      = (\NDB_Factory::singleton())->database();
         $stmt    = $DB->prepare($this->query);
         $results = $stmt->execute($this->params);
 

--- a/src/Data/Provisioners/DBRowProvisioner.php
+++ b/src/Data/Provisioners/DBRowProvisioner.php
@@ -2,22 +2,77 @@
 /**
  * File defines a DBRowProvisioner, which is a type of provisioner that
  * gets data from an SQL database
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
  */
 namespace LORIS\Data\Provisioners;
+use \LORIS\Data\DataInstance;
 
+/**
+ * A DBRowProvisioner is an instance of ProvisionerInstance which
+ * takes an SQL query and the bind parameters to go with it, and
+ * executes it against the LORIS database.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
 abstract class DBRowProvisioner extends \LORIS\Data\ProvisionerInstance
 {
-    private $iteratorCache = null;
     protected $query;
     protected $params;
-    function __construct($query, $params)
+
+    /**
+     * Construct a DB Row provisioner from the given SQL query and
+     * bind parameters.
+     *
+     * @param string $query  The SQL query to prepare and run
+     * @param array  $params The prepared statement bind parameters
+     */
+    function __construct(string $query, array $params)
     {
         $this->query  = $query;
         $this->params = $params;
     }
 
-    public abstract function getInstance($row) : \LORIS\Data\Instance;
+    /**
+     * Convert a single row from the query to a DataInstance suitable for use
+     * by filters and mappers.
+     *
+     * This must be implemented by users of this class in order to convert
+     * the database row to a suitable DataInstance model.
+     *
+     * @param array $row The database row returned from the PDO
+     *
+     * @return DataInstance The row converted to a DataInstance
+     */
+    public abstract function getInstance($row) : DataInstance;
 
+    /**
+     * GetAllInstances implements the abstract method from
+     * ProvisionerInstance by executing the query, and calling getInstance
+     * on the result to convert it from a PHP array to a DataInstance
+     * model.
+     *
+     * This is lazily evaluated, such that only one row of the Traversable
+     * is handled at a time.
+     *
+     * getAllInstances prepares a new query for each call to ensure that
+     * the cursor used by the PDO does not conflict with multiple calls
+     * to the function, and to make the code more deterministic.
+     *
+     * @return \Traversable which returns DataInstance for row when traversed.
+     */
     function getAllInstances() : \Traversable
     {
         $DB      = \Database::singleton();
@@ -28,14 +83,28 @@ abstract class DBRowProvisioner extends \LORIS\Data\ProvisionerInstance
             throw new \Exception("Invalid SQL statement: " . $this->query);
         }
 
+        // Wrap an \IteratorIterator to convert from a PDOStatement row to
+        // a DataInstance.
         $iterator = new class($stmt, $this) extends \IteratorIterator {
         protected $outer;
+        /**
+         * Constructor creates a closure over the PDO statement and outer class
+         * in order to have access to getInstance()
+         *
+         * @param PDOStatement     $rows The PDOStatement being traversed.
+         * @param DBRowProvisioner $self The outer class being closed over.
+         */
         public function __construct($rows, &$self)
         {
             parent::__construct($rows);
             $this->outer = &$self;
         }
 
+        /**
+         * Override IteratorIterator to call the closure's getInstance
+         *
+         * @return DataInstance
+         */
         public function current()
         {
             $row = parent::current();


### PR DESCRIPTION
This builds on #3502 in order to provide an implementation of the interfaces defined therein for common use cases in LORIS.

In particular, it defines a UserSiteMatch filter, and a DBRowProvisioner, which can be used to either get data from a database in accordance with the framework, or filter out DataInstances where the data model being retrieved does not match the User's site (if the data model includes a getCenterID or getCenterIDs function.)

(Note: this PR shows the interfaces in the diff. It'll be become smaller when rebased after #3502 is merged..)

(Part 3 will convert the dicom archive as a sample usage, or see #3123 to see how it all fits together.)