### PR TITLE
Survey Instruments Not Loading on Internet Explorer

### DIFF
--- a/htdocs/js/modules/direct_entry.js
+++ b/htdocs/js/modules/direct_entry.js
@@ -63,7 +63,7 @@ $(document).ready(function() {
             value: nextPage
         }).appendTo("#test_form");
 
-        formEl.action = document.documentURI;
+        formEl.action = window.location.href;
         //formEl.action = "submit.php?key=" + document.getElementById("key").textContent;
         $("#test_form").submit();
     }


### PR DESCRIPTION
documentURI is not supported on Internet Explorer; so survey instruments are not loading on IE.(ie, when we click the next page on a survey instrument,the url is something like this: https://ibis-dev.loris.ca/undefined)

we have to use the location.href property to get HTML document location.

This PR fixes the issue.
