### PR TITLE
[Issue Tracker/SQL] Add on update/on delete to FK constraints

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1411,7 +1411,7 @@ CREATE TABLE `issues_history` (
   `addedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueHistoryID`),
   KEY `fk_issues_comments_1` (`issueID`),
-  CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`)
+  CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments` (
@@ -1422,7 +1422,7 @@ CREATE TABLE `issues_comments` (
   `issueComment` text NOT NULL,
   PRIMARY KEY (`issueCommentID`),
   KEY `fk_issue_comments_1` (`issueID`),
-  CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`)
+  CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments_history` (
@@ -1433,7 +1433,7 @@ CREATE TABLE `issues_comments_history` (
   `editedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueCommentHistoryID`),
   KEY `fk_issues_comments_history` (`issueCommentID`),
-  CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`)
+  CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_watching` (

--- a/SQL/Archive/2018-02-28_issues_add_cascade.sql
+++ b/SQL/Archive/2018-02-28_issues_add_cascade.sql
@@ -1,5 +1,5 @@
-ALTER TABLE issues_history DROP FOREIGN KEY `fk_issue_comments_1`;
-ALTER TABLE issues_history ADD CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE issues_history DROP FOREIGN KEY `fk_issues_comments_1`;
+ALTER TABLE issues_history ADD CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 ALTER TABLE issues_comments DROP FOREIGN KEY `fk_issue_comments_1`;
 ALTER TABLE issues_comments ADD CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT;

--- a/SQL/Archive/2018-02-28_issues_add_cascade.sql
+++ b/SQL/Archive/2018-02-28_issues_add_cascade.sql
@@ -1,0 +1,8 @@
+ALTER TABLE issues_history DROP FOREIGN KEY `fk_issue_comments_1`;
+ALTER TABLE issues_history ADD CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+ALTER TABLE issues_comments DROP FOREIGN KEY `fk_issue_comments_1`;
+ALTER TABLE issues_comments ADD CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+ALTER TABLE issues_comments_history DROP FOREIGN KEY `fk_issues_comments_history`;
+ALTER TABLE issues_comments_history ADD CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`) ON DELETE CASCADE ON UPDATE RESTRICT;


### PR DESCRIPTION
Adding `ON UPDATE` and `ON DELETE` clauses for each FK constraint to `issues` within other issues tables. If an entry in `issues` is to be deleted, everything else can also follow.

This PR helps to deal with foreign key constraint errors found when running delete_candidate.php in order to test https://github.com/aces/Loris/pull/3348