### PR TITLE
[Tools] Normalizing mri_protocol: split up comma-separated values 

### DIFF
--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -45,29 +45,26 @@ function cartesian($input) {
 }
 
 // Get the list of unique IDs from the mri_protocol table
-$mp_idx = $DB->pselect("SELECT ID FROM mri_protocol", array());
-$idx = array();
-foreach($mp_idx as $num => $value) {
-    array_push($idx, $value["ID"]);
-}
-
+$mp_rows = $DB->pselect("SELECT * FROM mri_protocol", array());
 $total_commas = 0;
 
 // insert new rows for comma separated values
-foreach ($idx as $id) {
-    $num_commas = 0;
-    $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol mp WHERE mp.ID=:id", array('id' => $id));
-    foreach($mp_data as $key => $value) {
-        $mp_data[$key] = explode(",", $value);
-        if (sizeof($mp_data[$key]) > 1) {
-            $num_commas += sizeof($mp_data[$key]) - 1;
+foreach ($mp_rows as $row) {
+    $num_commas = 0; 
+    foreach($row as $key => $value) {
+        if ($key == "ID") {
+            $id = $row[$key];
+        }
+        $row[$key] = explode(",", $value);
+        if (sizeof($row[$key]) > 1) {
+            $num_commas += sizeof($row[$key]) - 1;
         }
     }
-    $total_commas += $num_commas;
-    if ($num_commas == 0) {
-        continue;
+    $total_commas += $num_commas; 
+    if ($num_commas == 0) {  
+        continue; 
     }
-    $all_mp_combinations = cartesian($mp_data);
+    $all_mp_combinations = cartesian($row);
     foreach ($all_mp_combinations as $mp_combination) {
         unset($mp_combination["ID"]);
         $DB->insert("mri_protocol", $mp_combination);
@@ -77,7 +74,7 @@ foreach ($idx as $id) {
 }
 
 if ($total_commas == 0) {
-    echo("No commas have been detected. The mri_protocol table has been unaltered.\n\n"); 
+    echo("No commas have been detected. The mri_protocol table has been unaltered.\n\n");
 } else {
     echo("All mri_protocol entries are now unique and not comma-separated.\n\n");
 }

--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -44,8 +44,8 @@ function cartesian($input) {
     return $result;
 }
 
-// Get the list of unique IDs from the mri_protocol_3_3 table
-$mp_idx = $DB->pselect("SELECT ID FROM mri_protocol_3", array());
+// Get the list of unique IDs from the mri_protocol table
+$mp_idx = $DB->pselect("SELECT ID FROM mri_protocol", array());
 $idx = array();
 foreach($mp_idx as $num => $value) {
     array_push($idx, $value["ID"]);
@@ -53,20 +53,20 @@ foreach($mp_idx as $num => $value) {
 
 // insert new rows for comma separated values
 foreach ($idx as $id) {
-    $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol_3 mp WHERE mp.ID=:id", array('id' => $id));
+    $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol mp WHERE mp.ID=:id", array('id' => $id));
     foreach($mp_data as $key => $value) {
        $mp_data[$key] = explode(",", $value);
     }
     $all_mp_combinations = cartesian($mp_data);
     foreach ($all_mp_combinations as $mp_combination) {
         unset($mp_combination["ID"]);
-        $DB->insert("mri_protocol_3", $mp_combination);
+        $DB->insert("mri_protocol", $mp_combination);
     }
     // remove the row for the original ID
-    $DB->delete("mri_protocol_3", array("ID" => $id));
+    $DB->delete("mri_protocol", array("ID" => $id));
 }
 
-echo("All mri_protocol_3 entries are now unique and not comma-separated.\n\n");
+echo("All mri_protocol entries are now unique and not comma-separated.\n\n");
 
 
 

--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -51,11 +51,21 @@ foreach($mp_idx as $num => $value) {
     array_push($idx, $value["ID"]);
 }
 
+$total_commas = 0;
+
 // insert new rows for comma separated values
 foreach ($idx as $id) {
+    $num_commas = 0;
     $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol mp WHERE mp.ID=:id", array('id' => $id));
     foreach($mp_data as $key => $value) {
-       $mp_data[$key] = explode(",", $value);
+        $mp_data[$key] = explode(",", $value);
+        if (sizeof($mp_data[$key]) > 1) {
+            $num_commas += sizeof($mp_data[$key]) - 1;
+        }
+    }
+    $total_commas += $num_commas;
+    if ($num_commas == 0) {
+        continue;
     }
     $all_mp_combinations = cartesian($mp_data);
     foreach ($all_mp_combinations as $mp_combination) {
@@ -66,7 +76,11 @@ foreach ($idx as $id) {
     $DB->delete("mri_protocol", array("ID" => $id));
 }
 
-echo("All mri_protocol entries are now unique and not comma-separated.\n\n");
+if ($total_commas == 0) {
+    echo("No commas have been detected. The mri_protocol table has been unaltered.\n\n"); 
+} else {
+    echo("All mri_protocol entries are now unique and not comma-separated.\n\n");
+}
 
 
 

--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -66,6 +66,8 @@ foreach ($idx as $id) {
     $DB->delete("mri_protocol", array("ID" => $id)); 
 }
 
+echo("All mri_protocol entries are now unique and not comma-separated."); 
+
  
   
 ?>

--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -71,9 +71,9 @@ function split_commas($table_name) {
         $DB->delete($table_name, array("ID" => $id));
     }
     if ($total_commas == 0) {
-        echo("No commas have been detected. The $table_name table has been unaltered.\n\n");
+        echo("$table_name: No commas have been detected in $table_name. The table has been unaltered.\n\n");
     } else {
-        echo("All $table_name entries are now unique and not comma-separated.\n\n");
+        echo("$table_name: All $table_name entries are now unique and not comma-separated.\n\n");
     }
 }
 

--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This script is the first step to normalizing the mri_protocol table for projects which store 
+ * comma-separated values. This script splits up cells containing commas by creating new rows for 
+ * each value and maintaining unique combinations of values. 
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Liza Levitis <llevitis.mcin@gmail.com>
+ * @license  Loris license
+ * @link     https://www.github.com/aces/Loris
+ */
+
+require_once 'generic_includes.php';
+require_once 'Database.class.inc';
+require_once 'Utility.class.inc';
+
+$DB = \Database::singleton(); 
+
+/* 
+ * Converts an array of arrays of values for different fields into  
+ * an array of unique combinations of the different values. 
+ */ 
+function cartesian($input) {
+    // filter out empty values
+    $result = array(array());
+    foreach ($input as $key => $values) {
+        $append = array();
+        foreach($result as $product) {
+            foreach($values as $item) {
+                $product[$key] = $item;
+                // remove $key with empty value so that 
+                // an empty string isn't inserted into the database instead of a default NULL value
+                if ($product[$key] == "") { 
+                    unset($product[$key]); 
+                }
+                $append[] = $product;
+            }
+        }
+        $result = $append;
+    }
+    return $result;
+}
+
+// Get the list of unique IDs from the mri_protocol table
+$mp_idx = $DB->pselect("SELECT ID FROM mri_protocol", array()); 
+$idx = array(); 
+foreach($mp_idx as $num => $value) { 
+    array_push($idx, $value["ID"]);  
+}
+
+// insert new rows for comma separated values 
+foreach ($idx as $id) { 
+    $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol mp WHERE mp.ID=:id", array('id' => $id));
+    foreach($mp_data as $key => $value) {
+       $mp_data[$key] = explode(",", $value); 
+    } 
+    $all_mp_combinations = cartesian($mp_data); 
+    foreach ($all_mp_combinations as $mp_combination) {
+        unset($mp_combination["ID"]);
+        $DB->insert("mri_protocol", $mp_combination); 
+    } 
+    // remove the row for the original ID 
+    $DB->delete("mri_protocol", array("ID" => $id)); 
+}
+
+ 
+  
+?>

--- a/tools/normalize_protocol_split_rows.php
+++ b/tools/normalize_protocol_split_rows.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * This script is the first step to normalizing the mri_protocol table for projects which store 
- * comma-separated values. This script splits up cells containing commas by creating new rows for 
- * each value and maintaining unique combinations of values. 
+ * This script is the first step to normalizing the  table for projects which store
+ * comma-separated values. This script splits up cells containing commas by creating new rows for
+ * each value and maintaining unique combinations of values.
  *
  * PHP Version 7
  *
@@ -17,12 +17,12 @@ require_once 'generic_includes.php';
 require_once 'Database.class.inc';
 require_once 'Utility.class.inc';
 
-$DB = \Database::singleton(); 
+$DB = \Database::singleton();
 
-/* 
- * Converts an array of arrays of values for different fields into  
- * an array of unique combinations of the different values. 
- */ 
+/*
+ * Converts an array of arrays of values for different fields into
+ * an array of unique combinations of the different values.
+ */
 function cartesian($input) {
     // filter out empty values
     $result = array(array());
@@ -31,10 +31,10 @@ function cartesian($input) {
         foreach($result as $product) {
             foreach($values as $item) {
                 $product[$key] = $item;
-                // remove $key with empty value so that 
+                // remove $key with empty value so that
                 // an empty string isn't inserted into the database instead of a default NULL value
-                if ($product[$key] == "") { 
-                    unset($product[$key]); 
+                if ($product[$key] == "") {
+                    unset($product[$key]);
                 }
                 $append[] = $product;
             }
@@ -44,30 +44,30 @@ function cartesian($input) {
     return $result;
 }
 
-// Get the list of unique IDs from the mri_protocol table
-$mp_idx = $DB->pselect("SELECT ID FROM mri_protocol", array()); 
-$idx = array(); 
-foreach($mp_idx as $num => $value) { 
-    array_push($idx, $value["ID"]);  
+// Get the list of unique IDs from the mri_protocol_3_3 table
+$mp_idx = $DB->pselect("SELECT ID FROM mri_protocol_3", array());
+$idx = array();
+foreach($mp_idx as $num => $value) {
+    array_push($idx, $value["ID"]);
 }
 
-// insert new rows for comma separated values 
-foreach ($idx as $id) { 
-    $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol mp WHERE mp.ID=:id", array('id' => $id));
+// insert new rows for comma separated values
+foreach ($idx as $id) {
+    $mp_data = $DB->pselectRow("SELECT * FROM mri_protocol_3 mp WHERE mp.ID=:id", array('id' => $id));
     foreach($mp_data as $key => $value) {
-       $mp_data[$key] = explode(",", $value); 
-    } 
-    $all_mp_combinations = cartesian($mp_data); 
+       $mp_data[$key] = explode(",", $value);
+    }
+    $all_mp_combinations = cartesian($mp_data);
     foreach ($all_mp_combinations as $mp_combination) {
         unset($mp_combination["ID"]);
-        $DB->insert("mri_protocol", $mp_combination); 
-    } 
-    // remove the row for the original ID 
-    $DB->delete("mri_protocol", array("ID" => $id)); 
+        $DB->insert("mri_protocol_3", $mp_combination);
+    }
+    // remove the row for the original ID
+    $DB->delete("mri_protocol_3", array("ID" => $id));
 }
 
-echo("All mri_protocol entries are now unique and not comma-separated."); 
+echo("All mri_protocol_3 entries are now unique and not comma-separated.\n\n");
 
- 
-  
+
+
 ?>


### PR DESCRIPTION
This script serves as the first step to normalizing the mri_protocol. Some projects store comma-separated values for multiple fields, so `normalize_protocol_split_rows` creates arrays of unique combinations from each row and inserts new rows with unique values. It then deletes the original row containing comma-separated values. The subsequent step to fully normalizing the mri_protocol will be a 2nd PR containing a patch to replace all %_range columns with %_min & %_max columns and a script to populate the new columns. 

IMPORTANT NOTE: this should not be merged unless there are PR on the LORIS-MRI side to account for these changes and ready to be merged.