### PR TITLE
DICOM Archive Data Framework

### DIFF
--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -58,13 +58,21 @@ class Dicom_Archive extends \NDB_Menu_Filter
 
     }
 
-    function getDataProvisioner() : \LORIS\Data\Provisioner {
+    /**
+     * Gets the data source for this menu filter.
+     *
+     * @return \LORIS\Data\Provisioner
+     */
+    function getDataProvisioner() : \LORIS\Data\Provisioner
+    {
         $provisioner = new DicomArchiveRowProvisioner();
 
         $user = \User::singleton();
 
         if ($user->hasPermission("access_all_profiles") == false) {
-            $provisioner = $provisioner->filter(new \LORIS\Data\Filters\UserSiteMatch());
+            $provisioner = $provisioner->filter(
+                new \LORIS\Data\Filters\UserSiteMatch()
+            );
         }
         $provisioner = $provisioner->map(new DICOMArchiveAnonymizer());
         return $provisioner;
@@ -98,35 +106,37 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function toJSON()
     {
-        $table = (new \LORIS\Data\Table())->withDataFrom($this->getDataProvisioner());
-        $arr = json_decode($table->toJSON(\User::singleton()), true);
-        return json_encode([
-            'Headers' => [
-                'Patient ID',
-                'Patient Name',
-                'Gender',
-                'Date Of Birth',
-                'Acquisition',
-                'Archive Location',
-                'Metadata',
-                'MRI Browser',
-                'Site',
-                'TarchiveID',
-                'SessionID',
-            ],
-            'Data' => $arr,
-
-            /* FIXME: These lines are really stupid, but left over from a
-             * previous incarnation of this module and the js front-end
-             * requires them to be returned in the JSON response. */
-            'hiddenHeaders' => [
-                'Seriesuid',
-                'Site',
-                'TarchiveID',
-                'SessionID',
-            ],
-            'form' => $this->form->form
-        ]);
+        $table = (new \LORIS\Data\Table())
+            ->withDataFrom($this->getDataProvisioner());
+        $arr   = json_decode($table->toJSON(\User::singleton()), true);
+        return json_encode(
+            [
+             'Headers'       => [
+                                 'Patient ID',
+                                 'Patient Name',
+                                 'Gender',
+                                 'Date Of Birth',
+                                 'Acquisition',
+                                 'Archive Location',
+                                 'Metadata',
+                                 'MRI Browser',
+                                 'Site',
+                                 'TarchiveID',
+                                 'SessionID',
+                                ],
+             'Data'          => $arr,
+             /* FIXME: These lines are really stupid, but left over from a
+              * previous incarnation of this module and the js front-end
+              * requires them to be returned in the JSON response. */
+             'hiddenHeaders' => [
+                                 'Seriesuid',
+                                 'Site',
+                                 'TarchiveID',
+                                 'SessionID',
+                                ],
+             'form'          => $this->form->form,
+            ]
+        );
     }
 
     /**

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -54,114 +54,21 @@ class Dicom_Archive extends \NDB_Menu_Filter
 
         $this->skipTemplate = true;
 
-        $this->_setDicomArchiveSettings();
-
-        $this->query = " FROM tarchive t
-            LEFT JOIN session s ON (s.ID=t.SessionID)
-            LEFT JOIN candidate c ON (c.CandID=s.CandID) WHERE 1=1";
-
-        $colsFirst = array();
-
-        $TransferStatus = $this->_getTransferStatusFromQuery();
-        $arrayTransfer  = array($TransferStatus . " as Transfer_Status");
-
-        $colsFirst = array_merge($colsFirst, $arrayTransfer);
-
-        $colsLast = array(
-                     't.PatientID as Patient_ID',
-                     't.PatientName as Patient_Name',
-                     't.PatientGender as Gender',
-                     't.PatientDoB as Date_of_birth',
-                     't.DateAcquired as Acquisition',
-                     't.ArchiveLocation as Archive_Location',
-                     "'View Details' as Metadata",
-                     "'View Images' as MRI_Browser",
-                     // For constructing links, not in headers array
-                     "(SELECT GROUP_CONCAT(SeriesUID) FROM tarchive_series e WHERE ".
-                     "e.TarchiveID=t.TarchiveID GROUP BY e.TarchiveID) as SeriesUID",
-                     's.CenterID as site',
-                     't.TarchiveID as TarchiveID',
-                     's.ID as SessionID',
-                    );
-
-        $this->columns = array_merge($colsFirst, $colsLast);
-
-        $this->order_by = 't.DateAcquired';
-
-        $this->headers = [];
-
-        if ($this->dicomArchiveSettings['showTransferStatus'] == 'true') {
-            array_push($this->headers, 'Transfer_Status');
-        }
-
-        $this->headers = array_merge(
-            $this->headers,
-            [
-             'Patient_ID',
-             'Patient_Name',
-             'Gender',
-             'Date_of_birth',
-             'Acquisition',
-             'Archive_Location',
-             'Metadata',
-             'MRI_Browser',
-             'Seriesuid',
-             'Site',
-             'TarchiveID',
-             'SessionID',
-            ]
-        );
-
-        // Set header as hidden from the data table
-        $this->tpl_data['hiddenHeaders'] = json_encode(
-            [
-             'Seriesuid',
-             'Site',
-             'TarchiveID',
-             'SessionID',
-            ]
-        );
-
-        $this->validFilters = array(
-                               'c.CenterID',
-                               't.PatientID',
-                               't.PatientGender',
-                               't.DateAcquired',
-                               't.PatientName',
-                               't.PatientDoB',
-                               't.ArchiveLocation',
-                              );
-
-        $this->formToFilter = array(
-                               'SiteID'      => 'c.CenterID',
-                               'PatientID'   => 't.PatientID',
-                               'Gender'      => 't.PatientGender',
-                               'Acquisition' => 't.DateAcquired',
-                               'PatientName' => 't.PatientName',
-                               'DoB'         => 't.PatientDoB',
-                               'Location'    => 't.ArchiveLocation',
-                              );
+        $this->columns = [];
 
     }
 
-    /**
-     * Override default behaviour, since the page is loaded from mediaIndex.js
-     *
-     * @return void
-     * @access public
-     */
-    function display()
-    {
-        $content = null;
-        $format  = $_REQUEST['format'] ?? '';
+    function getDataProvisioner() : \LORIS\Data\Provisioner {
+        $provisioner = new DicomArchiveRowProvisioner();
 
-        if ($format == 'json') {
-            $content = $this->toJSON();
+        $user = \User::singleton();
+
+        if ($user->hasPermission("access_all_profiles") == false) {
+            $provisioner = $provisioner->filter(new \LORIS\Data\Filters\UserSiteMatch());
         }
-
-        return $content;
+        $provisioner = $provisioner->map(new DICOMArchiveAnonymizer());
+        return $provisioner;
     }
-
     /**
      * Create a form to filter media by various criteria
      *
@@ -182,42 +89,6 @@ class Dicom_Archive extends \NDB_Menu_Filter
         $this->addBasicText('seriesuid', 'Series UI');
     }
 
-    /**
-    * Sets transfer status according to the data in the
-    * config file.
-    *
-    * @return null
-    */
-    function _setDicomArchiveSettings()
-    {
-        $config =& \NDB_Config::singleton();
-        $this->dicomArchiveSettings = $config->getSetting('imaging_modules');
-    }
-
-    /**
-    * Retrieves Transfer status.
-    * Queued if pending, date of sending if sent,
-    * else not transferred
-    *
-    * @return string $query with a status string
-    */
-    function _getTransferStatusFromQuery()
-    {
-        if ($this->dicomArchiveSettings['showTransferStatus'] == 'true') {
-            $query = "IF(
-                t.PendingTransfer, 
-                'Queued', 
-                IF (
-                    t.DateSent, 
-                    CONCAT('Sent ', t.DateSent), 
-                    'Not transferred'
-                )
-            )";
-        } else {
-            $query = "CONCAT(t.PendingTransfer, ' ', t.DateSent)";
-        }
-        return $query;
-    }
 
     /**
      * Converts the results of this menu filter to a JSON format to be retrieved
@@ -227,16 +98,35 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function toJSON()
     {
-        $result = $this->toArray();
-        $result['hiddenHeaders'] = [
-                                    'Seriesuid',
-                                    'Site',
-                                    'TarchiveID',
-                                    'SessionID',
-                                   ];
-        $result['form']          = $this->form->form;
+        $table = (new \LORIS\Data\Table())->withDataFrom($this->getDataProvisioner());
+        $arr = json_decode($table->toJSON(\User::singleton()), true);
+        return json_encode([
+            'Headers' => [
+                'Patient ID',
+                'Patient Name',
+                'Gender',
+                'Date Of Birth',
+                'Acquisition',
+                'Archive Location',
+                'Metadata',
+                'MRI Browser',
+                'Site',
+                'TarchiveID',
+                'SessionID',
+            ],
+            'Data' => $arr,
 
-        return json_encode($result);
+            /* FIXME: These lines are really stupid, but left over from a
+             * previous incarnation of this module and the js front-end
+             * requires them to be returned in the JSON response. */
+            'hiddenHeaders' => [
+                'Seriesuid',
+                'Site',
+                'TarchiveID',
+                'SessionID',
+            ],
+            'form' => $this->form->form
+        ]);
     }
 
     /**
@@ -248,44 +138,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function toArray()
     {
-        $unanonymized = parent::toArray();
-        $retVal       = array(
-                         'Headers' => $unanonymized['Headers'],
-                        );
-        $data         = array();
-
-        foreach ($unanonymized['Data'] as &$row) {
-            $val = $row[2];
-            if (!preg_match($this->dicomArchiveSettings['patientNameRegex'], $val)
-                && !preg_match($this->dicomArchiveSettings['LegoPhantomRegex'], $val)
-                && !preg_match(
-                    $this->dicomArchiveSettings['LivingPhantomRegex'],
-                    $val
-                )
-            ) {
-                $row[2] = "INVALID - HIDDEN";
-            }
-
-            $val = $row[1];
-            if (! preg_match($this->dicomArchiveSettings['patientIDRegex'], $val)) {
-                $row[1] = 'INVALID - HIDDEN';
-            }
-
-            // remove Transfer_Status column if showTransferStatus is false
-            if ($this->dicomArchiveSettings['showTransferStatus'] == 'false') {
-                array_shift($row);
-            }
-
-            $data[] = $row;
-        }
-
-        $this->_setFilterForm();
-
-        return array(
-                'Headers' => $unanonymized['Headers'],
-                'Data'    => $data,
-               );
-
+        return json_decode($this->toJSON());
     }
 
     /**

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -108,7 +108,12 @@ class Dicom_Archive extends \NDB_Menu_Filter
     {
         $table = (new \LORIS\Data\Table())
             ->withDataFrom($this->getDataProvisioner());
-        $arr   = json_decode($table->toJSON(\User::singleton()), true);
+        $arr   = array_map(
+            function ($row) {
+                return array_values($row);
+            },
+            json_decode($table->toJSON(\User::singleton()), true)
+        );
         return json_encode(
             [
              'Headers'       => [
@@ -120,6 +125,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
                                  'Archive Location',
                                  'Metadata',
                                  'MRI Browser',
+                                 'Seriesuid',
                                  'Site',
                                  'TarchiveID',
                                  'SessionID',

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This class implements a data mapper which anonymizes Patient Name
+ * or patient ID in the DICOM Archive based on the LORIS configuration.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\dicom_archive;
+use \LORIS\Data\{Mapper, DataInstance};
+
+/**
+ * A DICOMArchiveAnonymizer is a \LORIS\Data\Mapper which anonymizes improperly
+ * labeled rows in the dicom archive table.
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class DICOMArchiveAnonymizer implements Mapper
+{
+    /**
+     * Maps the Patient Name and Patient ID to 'INVALID - HIDDEN' if it doesn't
+     * meet the regular expressions defined in the LORIS configuration for valid
+     * patient names or ids.
+     *
+     * @param \User                $user     The user this data is being mapped for
+     * @param \LORIS\Data\Instance $resource The unanonymized data being mapped.
+     *
+     * @return \LORIS\Data\Instance the anonymized data
+     */
+    public function map(
+        \User $user,
+        DataInstance $resource
+    ) : DataInstance {
+
+        static $config = null;
+        if ($config === null) {
+            $config = \NDB_Config::singleton()->getSetting("imaging_modules");
+        }
+
+        $newrow = $resource->ToArray();
+        $cid    = $resource->getCenterID();
+
+        if (!preg_match($config['patientNameRegex'], $newrow['Patient Name'])
+            && !preg_match($config['LegoPhantomRegex'], $newrow['Patient Name'])
+            && !preg_match($config['LivingPhantomRegex'], $newrow['Patient Name'])
+        ) {
+            $newrow['Patient Name'] = 'INVALID - HIDDEN';
+        }
+        if (!preg_match($config['patientIDRegex'], $newrow['Patient ID'])) {
+            $newrow['Patient ID'] = 'INVALID - HIDDEN';
+        }
+        return new DICOMArchiveRow($newrow, $cid);
+    }
+}

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -48,7 +48,7 @@ class DICOMArchiveAnonymizer implements Mapper
             $config = \NDB_Config::singleton()->getSetting("imaging_modules");
         }
 
-        $newrow = $resource->ToArray();
+        $newrow = json_decode($resource->toJSON(), true);
         $cid    = $resource->getCenterID();
 
         if (!preg_match($config['patientNameRegex'], $newrow['Patient Name'])

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -13,7 +13,8 @@
  * @link       https://www.github.com/aces/Loris/
  */
 namespace LORIS\dicom_archive;
-use \LORIS\Data\{Mapper, DataInstance};
+use \LORIS\Data\{Mapper, DataInstance
+};
 
 /**
  * A DICOMArchiveAnonymizer is a \LORIS\Data\Mapper which anonymizes improperly

--- a/modules/dicom_archive/php/dicomarchiverow.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverow.class.inc
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This class implements a data Instance which represents a single
+ * row in the dicom archive menu table.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\dicom_archive;
+
+/**
+ * A DICOMArchiveRow represents a row in the DICOM Archive menu table.
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class DICOMArchiveRow implements \LORIS\Data\DataInstance
+{
+    protected $DBRow;
+    protected $CenterID;
+
+    /**
+     * Create a new DICOMArchiveRow
+     *
+     * @param array   $row The row (in the same format as \Database::pselectRow
+     *                     returns
+     * @param integer $cid The centerID affiliated with this row.
+     */
+    public function __construct(array $row, $cid)
+    {
+        $this->DBRow    = $row;
+        $this->CenterID = $cid;
+    }
+
+    /**
+     * Implements \LORIS\Data\Instance interface for this row.
+     *
+     * @return array the row data.
+     */
+    public function toJSON() : string
+    {
+        return json_encode($this->DBRow);
+    }
+
+    /**
+     * Returns the CenterID for this row, for filters such as
+     * \LORIS\Data\Filters\UserSiteMatch to match again.
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID()
+    {
+        return $this->CenterID;
+    }
+}

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -45,6 +45,8 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
             t.ArchiveLocation as Archive_Location,
             'View Details' as Metadata,
             'View Images' as `MRI Browser`,
+            (SELECT GROUP_CONCAT(SeriesUID) FROM tarchive_series e WHERE
+                    e.TarchiveID=t.TarchiveID GROUP BY e.TarchiveID) as SeriesUID,
             s.CenterID as Site,
             t.TarchiveID as TarchiveID,
             s.ID as SessionID,

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This file implements a data provisioner to get all possible rows
+ * for the dicom archive menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\dicom_archive;
+
+/**
+ * This class implements a data provisioner to get all possible rows
+ * for the dicom archive menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
+{
+    /**
+     * Create a DicomArchiveRowProvisioner, which gets rows for the dicom_archive
+     * menu table.
+     */
+    function __construct()
+    {
+        parent::__construct(
+            "SELECT t.PatientID as `Patient ID`,
+            t.PatientName as `Patient Name`,
+            t.PatientGender as Gender,
+            t.PatientDoB as `Date of birth`,
+            t.DateAcquired as Acquisition,
+            t.ArchiveLocation as Archive_Location,
+            'View Details' as Metadata,
+            'View Images' as `MRI Browser`,
+            s.CenterID as Site,
+            t.TarchiveID as TarchiveID,
+            s.ID as SessionID,
+            s.CenterID
+            FROM tarchive t
+                  LEFT JOIN session s ON (s.ID=t.SessionID)
+                  LEFT JOIN candidate c ON (c.CandID=s.CandID)
+            WHERE c.Active='Y' AND s.Active='Y'",
+            array()
+        );
+    }
+
+    /**
+     * Returns an instance of a DICOMArchiveRow object for a given
+     * table row.
+     *
+     * @param array $row The database row from the LORIS Database class.
+     *
+     * @return \LORIS\Data\DataInstance An instance representing this row.
+     */
+    public function getInstance($row) : \LORIS\Data\DataInstance
+    {
+            $cid = $row['CenterID'];
+            unset($row['CenterID']);
+            return new DICOMArchiveRow($row, $cid);
+    }
+}

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -52,7 +52,7 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
             FROM tarchive t
                   LEFT JOIN session s ON (s.ID=t.SessionID)
                   LEFT JOIN candidate c ON (c.CandID=s.CandID)
-            WHERE c.Active='Y' AND s.Active='Y'",
+            WHERE COALESCE(c.Active, 'Y')='Y' AND COALESCE(s.Active, 'Y')='Y'",
             array()
         );
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -171,6 +171,7 @@ class Database
             $password
         );
         $this->_PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+        $this->_PDO->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
         $this->_preparedStoreHistory = $this->_PDO->prepare(
             "INSERT INTO history (tbl, col, new, old,"

--- a/src/Data/Mapper.php
+++ b/src/Data/Mapper.php
@@ -44,5 +44,5 @@ interface Mapper
      *
      * @return DataInstance a new DataInstance with the map applied.
      */
-    function map(\User $user, DataInstance $resource) : Instance;
+    function map(\User $user, DataInstance $resource) : DataInstance;
 }

--- a/src/Data/ProvisionerInstance.php
+++ b/src/Data/ProvisionerInstance.php
@@ -18,7 +18,7 @@ namespace LORIS\Data;
  * A ProvisionerInstance is an abstract base class which can be used to
  * provide most details for an implementation of the Provisioner interface.
  *
- * In order to use this class, the getAllRecords function must be
+ * In order to use this class, the getAllInstances function must be
  * implemented.
  *
  * @category   Data
@@ -85,14 +85,14 @@ abstract class ProvisionerInstance implements Provisioner
     }
 
     /**
-     * GetAllRecords must be implemented by concrete implementations of this
+     * GetAllInstances must be implemented by concrete implementations of this
      * class. It must return all rows known about for this Provisioner (without
      * respect to the User accessing the data), which then gets mapped and
      * filtered by execute.
      *
      * @return Traversable of all resources provided by this data source.
      */
-    abstract protected function getAllRecords() : \Traversable;
+    abstract protected function getAllInstances() : \Traversable;
 
     /**
      * Implements the execute function for the Provisioner interface.

--- a/src/Data/ProvisionerInstance.php
+++ b/src/Data/ProvisionerInstance.php
@@ -107,7 +107,7 @@ abstract class ProvisionerInstance implements Provisioner
         if ($this->_parent != null) {
             $rows = $this->_parent->execute($user);
         } else {
-            $rows = $this->getAllRecords();
+            $rows = $this->getAllInstances();
         }
 
         if ($this->modifier !== null

--- a/src/Data/Table.php
+++ b/src/Data/Table.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This file implements the Table class.
+ *
+ * A Table Represents a table displayed on the frontend to a user. It's
+ * a thin wrapper around a Provisioner to ease creation of frontend
+ * data tables.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data;
+/**
+ * A Table Represents a table displayed on the frontend to a user. It's
+ * a thin wrapper around a Provisioner to ease creation of frontend
+ * data tables.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class Table
+{
+    /**
+     * The data Provisioner used for this table.
+     *
+     * @var \LORIS\Data\Provisioner
+     */
+    protected $dataProvider;
+
+    /**
+     * Returns a new Table which is identical to this one, except gets its
+     * data from the DataProvisioner provided.
+     *
+     * @param Provisioner $provisioner The provisioner which acquires data for this
+     *  table.
+     *
+     *  @return Table identical to this one with the data coming from $provisioner.
+     */
+    public function withDataFrom(Provisioner $provisioner) : Table
+    {
+        $t = clone $this;
+        $t->dataProvider = &$provisioner;
+        return $t;
+    }
+
+    /**
+     * Get rows returns all rows that the data provider provides, filtering them
+     * for $user.
+     *
+     * @param \User $user The user who is attempting to load the table.
+     *
+     * @return \LORIS\Data\Instance[] of all the filtered data.
+     */
+    public function getRows(\User $user) : \Traversable
+    {
+        return $this->dataProvider->execute($user);
+    }
+
+    /**
+     * Returns a PHP array which mirror's the format of toJSON (rather than
+     * an array of data Instances, as getRows returns.)
+     *
+     * @param \User $user The user who is attempting to load the table.
+     *
+     * @return array an associative array representation of the table data.
+     */
+    public function toArray(\User $user) : array
+    {
+        $allRows = $this->getRows($user);
+
+        $results = [];
+        foreach ($allRows as $row) {
+            $results[] = json_decode($row->toJSON($user), true);
+        }
+        return $results;
+    }
+
+    /**
+     * Serializes this table to JSON for $user.
+     *
+     * @param \User $user The user who is attempting to load the table.
+     *
+     * @return string of valid JSON representing this data.
+     */
+    public function toJSON(\User $user) : string
+    {
+        return json_encode($this->toArray($user));
+    }
+
+    /**
+     * Filter returns a new table with Filter added as a filter.
+     *
+     * @param Filter $filter The filter to add to the data
+     *
+     * @return Table that is identical to this table with $filter applied.
+     */
+    public function filter(Filter $filter) : Table
+    {
+        $t = clone $this;
+        $t->dataProvider = $this->dataProvider->Filter($filter);
+        return $t;
+    }
+}


### PR DESCRIPTION
This updates the DICOM Archive module to use the new DICOM Archive framework as a first use case. It removes the custom generated NDB_Menu_Filter SQL and converts it to a DBRowProvisioner.

Note that I'm not entirely happy with the amount of serializing and deserializing from JSON required to modify/annotate responses at various parts (because of the fact that the interface only has toJSON and no array equivalent, while the pre-interface class had both toArray and toJSON, so it could delay the serialization until the last minute).

(Note: benchmarks were very flawed because I had accidentally changed the query between versions, so I removed them.)