### PR TITLE
[Genomics/SQL]  Add on update/on delete to FK constraints

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1780,8 +1780,8 @@ CREATE TABLE `genomic_cpg` (
   `beta_value` decimal(4,3) DEFAULT NULL,
   PRIMARY KEY (`sample_label`,`cpg_name`),
   KEY `cpg_name` (`cpg_name`),
-  CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`),
-  CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`)
+  CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/Archive/2018-03-01_genomics_add_cascade.sql
+++ b/SQL/Archive/2018-03-01_genomics_add_cascade.sql
@@ -1,0 +1,4 @@
+ALTER TABLE genomic_cpg DROP FOREIGN KEY `genomic_cpg_ibfk_1`;
+ALTER TABLE genomic_cpg DROP FOREIGN KEY `genomic_cpg_ibfk_2`;
+ALTER TABLE genomic_cpg ADD CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE genomic_cpg ADD CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`) ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Adding `ON UPDATE` and `ON DELETE` clauses for FK constraints in `genomic_cpg` which points to `genomic_sample_candidate_rel`, which points to `candidate`. The cascade is needed when running `delete_candidate.php` that deletes tables that have FKs to `candidate`.

This PR helps to deal with foreign key constraint errors found when testing #3348.