### PR TITLE
[Timepoint/SQL] Add on update/on delete to FK constraints

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1546,7 +1546,7 @@ CREATE TABLE `parameter_session` (
   KEY `session_type` (`SessionID`,`ParameterTypeID`),
   KEY `parameter_value` (`ParameterTypeID`,`Value`(64)),
   CONSTRAINT `FK_parameter_session_2` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`),
-  CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`)
+  CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `parameter_type_override` (

--- a/SQL/Archive/2018-03-02_session_add_cascade.sql
+++ b/SQL/Archive/2018-03-02_session_add_cascade.sql
@@ -1,0 +1,3 @@
+ALTER TABLE parameter_session DROP FOREIGN KEY `FK_parameter_session_1`;
+ALTER TABLE parameter_session ADD CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+


### PR DESCRIPTION
Adding `ON UPDATE` and `ON DELETE` clauses to FK constraint in `parameter_session` which points to `session`. The cascade is needed when running delete_timepoint.php

This PR helps to deal with foreign key constraint errors found when testing #3348.
