### PR TITLE
[Script/tools] Update delete_candidate/timepoint

### DIFF
--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -121,7 +121,11 @@ function showHelp()
 
     die();
 }
-
+/*
+ * All tables with entries to be deleted here are only those with FOREIGN KEY relations to `candidate`.
+ * All other tables with FOREIGN KEY relations to these tables (second-level relations) should
+ * have actions on delete specified in the database schema
+ */
 function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, $output)
 {
 

--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -169,6 +169,36 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, $output)
     $result = $DB->pselect('SELECT * FROM parameter_candidate WHERE CandID=:cid', array('cid' => $CandID));
     print_r($result);
 
+    // Print SNP_candidate_rel
+    echo "\nSNP_candidate_rel\n";
+    echo "-----------\n";
+    $result = $DB->pselect('SELECT * FROM SNP_candidate_rel WHERE CandID=:cid', array('cid' => $CandID));
+    print_r($result);
+
+    // Print CNV
+    echo "\nCNV\n";
+    echo "-----------\n";
+    $result = $DB->pselect('SELECT * FROM CNV WHERE CandID=:cid', array('cid' => $CandID));
+    print_r($result);
+    
+    // Print genomic_candidate_files_rel
+    echo "\nGenomic Candidate Files Relation\n";
+    echo "-----------\n";
+    $result = $DB->pselect('SELECT * FROM genomic_candidate_files_rel WHERE CandID=:cid', array('cid' => $CandID));
+    print_r($result);
+    
+    // Print genomic_sample_candidate_rel
+    echo "\nGenomic Sample Candidate Relation\n";
+    echo "-----------\n";
+    $result = $DB->pselect('SELECT * FROM genomic_sample_candidate_rel WHERE CandID=:cid', array('cid' => $CandID));
+    print_r($result);
+    
+    // Print issues
+    echo "\nIssues\n";
+    echo "-----------\n";
+    $result = $DB->pselect('SELECT * FROM issues WHERE candID=:cid', array('cid' => $CandID));
+    print_r($result);
+    
     // Print candidate
     echo "\nCandidate\n";
     echo "-----------\n";
@@ -189,6 +219,21 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, $output)
         //delete from parameter_candidate
         $DB->delete("parameter_candidate", array("CandID" => $CandID));
 
+        //delete from SNP_candidate_rel
+        $result = $DB->delete("SNP_candidate_rel", array("CandID" => $CandID));
+
+        //delete from CNV
+        $result = $DB->delete("CNV", array("CandID" => $CandID));
+
+        //delete from genomic_candidate_files_rel
+        $result = $DB->delete("genomic_candidate_files_rel", array("CandID" => $CandID));
+
+        //delete from genomic_sample_candidate_rel
+        $result = $DB->delete("genomic_sample_candidate_rel", array("CandID" => $CandID));
+
+        //delete from issues
+        $result = $DB->delete("issues", array("candID" => $CandID));
+
         //delete from candidate
         $DB->delete("candidate", array("CandID" => $CandID));
     } elseif ($printToSQL) {
@@ -203,6 +248,21 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, $output)
 
         //delete from parameter_candidate
         _printResultsSQL("parameter_candidate", array("CandID" => $CandID), $output, $DB);
+
+        //delete from SNP_candidate_rel
+        _printResultsSQL("SNP_candidate_rel", array("CandID" => $CandID), $output, $DB);
+
+        //delete from CNV
+        _printResultsSQL("CNV", array("CandID" => $CandID), $output, $DB);
+
+        //delete from genomic_candidate_files_rel
+        _printResultsSQL("genomic_candidate_files_rel", array("CandID" => $CandID), $output, $DB);
+
+        //delete from genomic_sample_candidate_rel
+        _printResultsSQL("genomic_sample_candidate_rel", array("CandID" => $CandID), $output, $DB);
+
+        //delete from issues
+        _printResultsSQL("issues", array("candID" => $CandID), $output, $DB);
 
         //delete from candidate
         _printResultsSQL("candidate", array("CandID" => $CandID), $output, $DB);

--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -94,7 +94,20 @@ if ($candExists == 0) {
         "not exist in the database or is set to Active='N' state.\n\n";
     die();
 }
-
+$entityType = $DB->pselectOne(
+    "SELECT Entity_type 
+      FROM candidate 
+      WHERE CandID = :cid AND PSCID = :pid AND Active ='Y'",
+    array(
+        'cid' => $CandID,
+        'pid' => $PSCID,
+    )
+);
+if ($entityType === "Scanner") {
+    echo "\nThe candidate with CandID : $CandID  and PSCID : $PSCID is a scanner ".
+        "and should not be deleted using this script.\n\n";
+    die();
+}
 /*
  * The switch to execute actions
  */

--- a/tools/delete_timepoint.php
+++ b/tools/delete_timepoint.php
@@ -134,7 +134,11 @@ function showHelp()
 
     die();
 }
-
+/*
+ * All tables with entries to be deleted here are only those with FOREIGN KEY relations to `session`.
+ * All other tables with FOREIGN KEY relations to these tables (second-level relations) should
+ * have actions on delete specified in the database schema
+ */
 function deleteTimepoint($CandID, $sessionID, $confirm, $printToSQL, $DB, $output)
 {
     echo "\n#########################################################################\n";


### PR DESCRIPTION
Updating delete scripts to address errors from testing https://github.com/aces/Loris/pull/3348.

Add additional tables that have FK relations to `candidate` and `session`. Deletion of entries in these tables will be triggered when a candidate and its timepoints are deleted.

Other tables also with FK relations that are not included here have `ON DELETE CASCADE` clauses on their constraints: https://github.com/aces/Loris/pull/3525, https://github.com/aces/Loris/pull/3522, https://github.com/aces/Loris/pull/3527

Discussion: should `mri_acquisition_dates` have an `ON DELETE CASCADE` clause added to it instead of being in the delete_timepoint.php script?