### PR TITLE
[Role/Permission] Adding SQL schema and DAOs (1 of 4)

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -9,6 +9,10 @@ DROP TABLE IF EXISTS `permissions_category`;
 
 DROP TABLE IF EXISTS `user_perm_rel`;
 
+DROP TABLE IF EXISTS `role`;
+DROP TABLE IF EXISTS `role_permission_rel`;
+DROP TABLE IF EXISTS `user_role_rel`;
+
 SET FOREIGN_KEY_CHECKS=1;
 --
 -- Table structure for table `permissions_category`
@@ -22,7 +26,7 @@ CREATE TABLE `permissions_category` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
-INSERT INTO `permissions_category` VALUES 
+INSERT INTO `permissions_category` VALUES
   (1,'Roles'),
   (2,'Permission');
 
@@ -113,9 +117,9 @@ INSERT INTO `permissions` VALUES
 
 
 INSERT INTO `user_perm_rel` (userID, permID)
-  SELECT u.ID, p.permID 
-  FROM users u JOIN permissions p 
-  WHERE u.userid = 'admin' 
+  SELECT u.ID, p.permID
+  FROM users u JOIN permissions p
+  WHERE u.userid = 'admin'
   ORDER BY p.permID;
 
 -- permissions for each notification module
@@ -131,3 +135,28 @@ CREATE TABLE `notification_modules_perm_rel` (
 -- populate notification perm table
 INSERT INTO notification_modules_perm_rel SELECT nm.id, p.permID FROM notification_modules nm JOIN permissions p WHERE nm.module_name='media' AND (p.code='media_write' OR p.code='media_read');
 INSERT INTO notification_modules_perm_rel SELECT nm.id, p.permID FROM notification_modules nm JOIN permissions p WHERE nm.module_name='document_repository' AND (p.code='document_repository_view' OR p.code='document_repository_delete');
+
+
+CREATE TABLE `role` (
+ `RoleID` INTEGER unsigned NOT NULL AUTO_INCREMENT,
+ `Name` varchar(255),
+ `Label` varchar(255),
+ PRIMARY KEY (`RoleID`),
+ UNIQUE KEY `UK_Name` (`Name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `role_permission_rel` (
+  `RoleID` INTEGER unsigned NOT NULL,
+  `PermissionID` INTEGER unsigned NOT NULL,
+  PRIMARY KEY  (`RoleID`,`PermissionID`),
+  CONSTRAINT `FK_role_permission_rel_RoleID` FOREIGN KEY (`RoleID`) REFERENCES `role` (`RoleID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_role_permission_rel_PermissionID` FOREIGN KEY (`PermissionID`) REFERENCES `permissions` (`permID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `user_role_rel` (
+  `UserID` INTEGER unsigned NOT NULL,
+  `RoleID` INTEGER unsigned NOT NULL,
+  PRIMARY KEY  (`UserID`,`RoleID`),
+  CONSTRAINT `FK_user_role_rel_userID` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_user_role_rel_RoleID` FOREIGN KEY (`RoleID`) REFERENCES `role` (`RoleID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/Archive/2018-03-10-permission_roles.sql
+++ b/SQL/Archive/2018-03-10-permission_roles.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `role` (
+ `RoleID` INTEGER unsigned NOT NULL AUTO_INCREMENT,
+ `Name` varchar(255),
+ `Label` varchar(255),
+ PRIMARY KEY (`RoleID`),
+ UNIQUE KEY `UK_Name` (`Name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `role_permission_rel` (
+  `RoleID` INTEGER unsigned NOT NULL,
+  `PermissionID` INTEGER unsigned NOT NULL,
+  PRIMARY KEY  (`RoleID`,`PermissionID`),
+  CONSTRAINT `FK_role_permission_rel_RoleID` FOREIGN KEY (`RoleID`) REFERENCES `role` (`RoleID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_role_permission_rel_PermissionID` FOREIGN KEY (`PermissionID`) REFERENCES `permissions` (`permID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `user_role_rel` (
+  `UserID` INTEGER unsigned NOT NULL,
+  `RoleID` INTEGER unsigned NOT NULL,
+  PRIMARY KEY  (`UserID`,`RoleID`),
+  CONSTRAINT `FK_user_role_rel_userID` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_user_role_rel_RoleID` FOREIGN KEY (`RoleID`) REFERENCES `role` (`RoleID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/libraries/Permission.class.inc
+++ b/php/libraries/Permission.class.inc
@@ -1,0 +1,215 @@
+<?php
+/**
+ * This file contains the Permission class.
+ *
+ * PHP Version 5-7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Rida Abou-Haidar <rida.loris@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * The Loris Permission class
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Rida Abou-Haidar <rida.loris@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Permission
+{
+    /**
+     * Stores Database being used
+     *
+     * @var    $DB Database
+     * @access private
+     */
+    var $DB;
+
+    /**
+     * Permission constructor.
+     *
+     * @param Database $Database database
+     */
+    function __construct($Database)
+    {
+        $this->DB = $Database;
+    }
+
+
+    /**
+     * Gets the list of permissions in the database.
+     *
+     * @return array Associative array in the form $permissionID=>$permissionName
+     */
+    function getPermissions()
+    {
+        $permissions = $this->DB->pselectColWithIndexKey(
+            "SELECT permID, code
+         FROM permissions",
+            array(),
+            "permID"
+        );
+
+        return $permissions;
+    }
+
+    /**
+     * Gets the list of permission labels in the database.
+     *
+     * @return array Associative array in the form $permissionID=>$permissionLabel
+     */
+    function getPermissionLabels()
+    {
+        $permissions = $this->DB->pselectColWithIndexKey(
+            "SELECT permID, description
+         FROM permissions",
+            array(),
+            "permID"
+        );
+
+        return $permissions;
+    }
+
+    /**
+     * Checks if the string is a permission within the database
+     *
+     * @param string $permissionName the permission to be checked
+     *
+     * @return boolean
+     */
+    function isPermission($permissionName)
+    {
+        $permissions = $this->getPermissions();
+        if (in_array($permissionName, $permissions, true)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets the ID of a permission given its name
+     *
+     * @param string $permissionName the permission name for which the ID is needed
+     *
+     * @throws LorisException if permission does not exist
+     *
+     * @return int
+     */
+    function getPermissionIDFromName($permissionName)
+    {
+        if (!$this->isPermission($permissionName)) {
+            throw new LorisException(
+                "Could not retrieve the permission ID for 
+                permission '$permissionName'"
+            );
+        }
+
+        $permissionID = $this->DB->pselectOne(
+            "SELECT permID
+         FROM permissions
+         WHERE code=:PN",
+            array("PN" => $permissionName)
+        );
+        return $permissionID;
+    }
+
+    /**
+     * Gets the NAME of a permission given its ID
+     *
+     * @param int $permissionID the permission ID for which the name is needed
+     *
+     * @throws LorisException if permission ID does not exist
+     *
+     * @return string
+     */
+    function getPermissionNameFromID($permissionID)
+    {
+        $permissionName = $this->DB->pselectOne(
+            "SELECT code
+         FROM permissions
+         WHERE permID=:PID",
+            array("PID" => $permissionID)
+        );
+
+        if (empty($permissionName)) {
+            throw new LorisException(
+                "Could not retrieve the permission name for 
+                permission ID '$permissionID'"
+            );
+        }
+        return $permissionName;
+    }
+
+    /**
+     * Gets the roles associated to a permission
+     *
+     * @param int $permissionID the permission
+     *
+     * @return array non-associative with values being the permission IDs
+     */
+    function getPermissionRoleIDs($permissionID)
+    {
+        $roles = $this->DB->pselectCol(
+            "SELECT RoleID
+         FROM role_permission_rel
+         WHERE PermissionID=:PID",
+            array("PID" => $permissionID)
+        );
+
+        return $roles;
+    }
+
+    /**
+     * Returns all the users with the permission
+     *
+     * @param int $permissionID the permission
+     *
+     * @return array Associative array ($userID=>$RealName) that have the permission
+     */
+    function getPermissionUsers($permissionID)
+    {
+        $usersWithPermission = $this->DB->pselectColWithIndexKey(
+            "SELECT upr.userID, u.Real_name
+            FROM user_perm_rel upr 
+              JOIN users u ON u.ID=upr.userID
+              WHERE upr.permId=:PID",
+            array("PID" => $permissionID),
+            "userID"
+        );
+        return $usersWithPermission;
+    }
+
+    /**
+     * Gets all the users' permissions based on their roles
+     *
+     * @param array $roleIDs role set associated with a user
+     *
+     * @return array associative array ($permissionID=>$permissionName) of
+     *               permissions associated with the given permission set
+     */
+    function getPermissionsFromRoles($roleIDs)
+    {
+        $roleObject  = new \Role($this->DB);
+        $permissions = $this->getPermissions();
+
+        $userPermissions = array();
+
+        foreach ($roleIDs as $roleID) {
+            $rolePermissions = $roleObject->getRolePermissionIDs($roleID);
+            foreach ($rolePermissions as $permissionID) {
+                //if permissions overlap between roles, this will
+                //just overwrite data with the same data
+                $userPermissions[$permissionID] = $permissions[$permissionID];
+            }
+        }
+
+        return $userPermissions;
+    }
+
+
+}

--- a/php/libraries/Role.class.inc
+++ b/php/libraries/Role.class.inc
@@ -1,0 +1,203 @@
+<?php
+/**
+ * This file contains the Role class.
+ *
+ * PHP Version 5-7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Rida Abou-Haidar <rida.loris@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * The Loris Role class
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Rida Abou-Haidar <rida.loris@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Role
+{
+    /**
+     * Stores Database being used
+     *
+     * @var    $DB Database
+     * @access private
+     */
+    var $DB;
+
+    /**
+     * Role constructor.
+     *
+     * @param Database $Database database
+     */
+    function __construct($Database)
+    {
+        $this->DB = $Database;
+    }
+
+    /**
+     * Gets the list of roles in the database.
+     *
+     * @return array Associative array in the form $roleID=>$roleName
+     */
+    function getRoles()
+    {
+
+        $roles = $this->DB->pselectColWithIndexKey(
+            "SELECT RoleID, Name
+         FROM role",
+            array(),
+            "RoleID"
+        );
+
+        return $roles;
+    }
+
+    /**
+     * Gets the list of role labelss in the database.
+     *
+     * @return array Associative array in the form $roleID=>$roleLabel
+     */
+    function getRoleLabels()
+    {
+
+        $roles = $this->DB->pselectColWithIndexKey(
+            "SELECT RoleID, Label
+         FROM role",
+            array(),
+            "RoleID"
+        );
+
+        return $roles;
+    }
+
+    /**
+     * Checks if the string is a role within the database
+     *
+     * @param string $roleName the role name to be checked
+     *
+     * @return boolean
+     */
+    function isRole($roleName)
+    {
+        $roles = $this->getRoles();
+
+        if (in_array($roleName, $roles, true)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets the ID of a role given its name
+     *
+     * @param string $roleName the role name for which the ID is needed
+     *
+     * @throws LorisException if role does not exist
+     *
+     * @return int
+     */
+    function getRoleIDFromName($roleName)
+    {
+        if (!$this->isRole($roleName)) {
+            throw new LorisException(
+                "Could not retrieve the role ID for role '$roleName'"
+            );
+        }
+
+        $roleID = $this->DB->pselectOne(
+            "SELECT RoleID
+         FROM role
+         WHERE Name=:RN",
+            array("RN" => $roleName)
+        );
+
+        return $roleID;
+    }
+
+    /**
+     * Gets the permissions associated to a role
+     *
+     * @param int $roleID the role
+     *
+     * @return array non-associative with values being the permission IDs
+     */
+    function getRolePermissionIDs($roleID)
+    {
+        $permissions = $this->DB->pselectCol(
+            "SELECT PermissionID
+         FROM role_permission_rel
+         WHERE RoleID=:RID",
+            array("RID" => $roleID)
+        );
+
+        return $permissions;
+    }
+
+    /**
+     * Returns all the users with the role
+     *
+     * @param int $roleID the role
+     *
+     * @return array Associative array ($userID=>$RealName) that have the role
+     */
+    function getRoleUsers($roleID)
+    {
+        $usersWithRole = $this->DB->pselectColWithIndexKey(
+            "SELECT urr.UserID, u.Real_name
+            FROM user_role_rel urr 
+              JOIN users u ON u.ID=urr.UserID
+              WHERE urr.RoleID=:RID",
+            array("RID" => $roleID),
+            "UserID"
+        );
+        return $usersWithRole;
+    }
+
+    /**
+     * Checks if a given role contains a given permission
+     *
+     * @param int $roleID       the ID of the role
+     * @param int $permissionID the ID of the permission
+     *
+     * @return boolean
+     */
+    function hasPermission($roleID, $permissionID)
+    {
+        $rolePermissionIDs = $this->getRolePermissionIDs($roleID);
+
+        if (in_array($permissionID, $rolePermissionIDs, true)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets all the users' roles based on their permissions
+     *
+     * @param array $permissionIDs Permission set
+     *
+     * @return array associative array ($roleID=>$roleName) of roles associated
+     *               with the given permission set
+     */
+    function getRolesFromPermissions($permissionIDs)
+    {
+        $roles     = $this->getRoles();
+        $userRoles = array();
+
+        foreach ($roles as $roleID=>$roleName) {
+            $rolePermissionIDs = $this->getRolePermissionIDs($roleID);
+            if (!array_diff($rolePermissionIDs, $permissionIDs)) {
+                $userRoles[$roleID] = $roleName;
+            }
+        }
+
+        return $userRoles;
+    }
+
+}


### PR DESCRIPTION
This adds the Role infrastructure to LORIS. This is one of 4 PRs which will ultimately result in assigning roles to users. each role has affiliated permissions and automatically checks the proper permission when selected. This change will be mainly visible in the `user_accounts` module.

 - PART 1: Add SQL tables and Data Access Object to retrieve data from the tables. Given the lack of a current standard in models in loris, these are mere DAOs and not proper models; models can be added later once a standard is established.

Original PR by @taracampbell : https://github.com/aces/Loris/pull/2642
Updated/Standardized/DAO full version : https://github.com/ridz1208/Loris/pull/9