### PR TITLE
[CouchDB] Adding support for multiple databases on different servers

### DIFF
--- a/modules/dataquery/ajax/GetDoc.php
+++ b/modules/dataquery/ajax/GetDoc.php
@@ -21,8 +21,16 @@ $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
 header("Content-Type: application/json");
 
-$cdb   = \NDB_Factory::singleton()->couchDB();
-$docID = urlencode($_REQUEST['DocID']);
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$docID       = urlencode($_REQUEST['DocID']);
 
 $results = $cdb->getDoc(
     $docID

--- a/modules/dataquery/ajax/datadictionary.php
+++ b/modules/dataquery/ajax/datadictionary.php
@@ -20,7 +20,15 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
 
-$cdb = \NDB_Factory::singleton()->couchDB();
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
 
 if ($_REQUEST['category']) {
     $category = urlencode($_REQUEST['category']);

--- a/modules/dataquery/ajax/getAllSessions.php
+++ b/modules/dataquery/ajax/getAllSessions.php
@@ -19,7 +19,15 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb            = \NDB_Factory::singleton()->couchDB();
+$config         = \NDB_Config::singleton();
+$couchConfig    = $config->getSetting('CouchDB');
+$cdb            = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
 $results        = $cdb->queryView(
     "DQG-2.0",
     "sessions",

--- a/modules/dataquery/ajax/queryContains.php
+++ b/modules/dataquery/ajax/queryContains.php
@@ -19,7 +19,15 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb            = \NDB_Factory::singleton()->couchDB();
+$config         = \NDB_Config::singleton();
+$couchConfig    = $config->getSetting('CouchDB');
+$cdb            = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
 $category       = $_REQUEST['category'];
 $fieldName      = $_REQUEST['field'];
 $value          = $_REQUEST['value'];

--- a/modules/dataquery/ajax/queryEqual.php
+++ b/modules/dataquery/ajax/queryEqual.php
@@ -19,10 +19,18 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb       = \NDB_Factory::singleton()->couchDB();
-$category  = $_REQUEST['category'];
-$fieldName = $_REQUEST['field'];
-$value     = $_REQUEST['value'];
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$category    = $_REQUEST['category'];
+$fieldName   = $_REQUEST['field'];
+$value       = $_REQUEST['value'];
 
 if (!is_numeric($value) && $value !== "null") {
     $value = "\"$value\"";

--- a/modules/dataquery/ajax/queryGreaterThanEqual.php
+++ b/modules/dataquery/ajax/queryGreaterThanEqual.php
@@ -20,11 +20,19 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
 
-$cdb       = \NDB_Factory::singleton()->couchDB();
-$category  = $_REQUEST['category'];
-$fieldName = $_REQUEST['field'];
-$value     = $_REQUEST['value'];
-$value     = is_numeric($value) ? $value : "\"$value\"";
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$category    = $_REQUEST['category'];
+$fieldName   = $_REQUEST['field'];
+$value       = $_REQUEST['value'];
+$value       = is_numeric($value) ? $value : "\"$value\"";
 
 $results = $cdb->queryView(
     "DQG-2.0",

--- a/modules/dataquery/ajax/queryLessThanEqual.php
+++ b/modules/dataquery/ajax/queryLessThanEqual.php
@@ -19,11 +19,19 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb       = \NDB_Factory::singleton()->couchDB();
-$category  = $_REQUEST['category'];
-$fieldName = $_REQUEST['field'];
-$value     = $_REQUEST['value'];
-$value     = is_numeric($value) ? $value : "\"$value\"";
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$category    = $_REQUEST['category'];
+$fieldName   = $_REQUEST['field'];
+$value       = $_REQUEST['value'];
+$value       = is_numeric($value) ? $value : "\"$value\"";
 
 $results = $cdb->queryView(
     "DQG-2.0",

--- a/modules/dataquery/ajax/queryNotEqual.php
+++ b/modules/dataquery/ajax/queryNotEqual.php
@@ -19,10 +19,18 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb       = \NDB_Factory::singleton()->couchDB();
-$category  = $_REQUEST['category'];
-$fieldName = $_REQUEST['field'];
-$value     = $_REQUEST['value'];
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$category    = $_REQUEST['category'];
+$fieldName   = $_REQUEST['field'];
+$value       = $_REQUEST['value'];
 // There's no way to do "not" in an index, so we need to
 // get all the values of the field name, and then iterate
 // through them and exclude the ones where the value is

--- a/modules/dataquery/ajax/queryStartsWith.php
+++ b/modules/dataquery/ajax/queryStartsWith.php
@@ -19,11 +19,19 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb       = \NDB_Factory::singleton()->couchDB();
-$category  = $_REQUEST['category'];
-$fieldName = $_REQUEST['field'];
-$value     = $_REQUEST['value'];
-$results   = $cdb->queryView(
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$category    = $_REQUEST['category'];
+$fieldName   = $_REQUEST['field'];
+$value       = $_REQUEST['value'];
+$results     = $cdb->queryView(
     "DQG-2.0",
     "search",
     array(

--- a/modules/dataquery/ajax/retrieveCategoryDocs.php
+++ b/modules/dataquery/ajax/retrieveCategoryDocs.php
@@ -20,10 +20,18 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
-$cdb      = \NDB_Factory::singleton()->couchDB();
-$category = $_REQUEST['DocType'];
-$sessions = json_decode($_REQUEST['Sessions']);
-$keys     = array_map(
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$category    = $_REQUEST['DocType'];
+$sessions    = json_decode($_REQUEST['Sessions']);
+$keys        = array_map(
     function ($row) use ($category) {
         return array_merge(array($category), $row);
     },

--- a/modules/dataquery/ajax/saveQuery.php
+++ b/modules/dataquery/ajax/saveQuery.php
@@ -21,9 +21,17 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize(__DIR__ . "/../../../project/config.xml");
 
-$user = User::singleton();
-$cdb  = \NDB_Factory::singleton()->couchDB();
-$qid  = $user->getUserName() . "_" . $_REQUEST['QueryName'];
+$user        = User::singleton();
+$config      = \NDB_Config::singleton();
+$couchConfig = $config->getSetting('CouchDB');
+$cdb         = \NDB_Factory::singleton()->couchDB(
+    $couchConfig['dbName'],
+    $couchConfig['hostname'],
+    $couchConfig['port'],
+    $couchConfig['admin'],
+    $couchConfig['adminpass']
+);
+$qid         = $user->getUserName() . "_" . $_REQUEST['QueryName'];
 
 if ($_REQUEST['SharedQuery'] === "true") {
     $qid = "global:" . $qid;

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -47,9 +47,17 @@ class Dataquery extends \NDB_Form
     {
         parent::setup();
 
-        $user     = \User::singleton();
-        $username = $user->getUsername();
-        $couch    = \NDB_Factory::singleton()->couchDB();
+        $user        = \User::singleton();
+        $username    = $user->getUsername();
+        $config      = \NDB_Config::singleton();
+        $couchConfig = $config->getSetting('CouchDB');
+        $couch       = \NDB_Factory::singleton()->couchDB(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
 
         $update = $couch->queryView(
             "DQG-2.0",

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -164,6 +164,26 @@ class CouchDB
     private $_database = '';
 
     /**
+     * Keep the host name
+     */
+    private $_host = '';
+
+    /**
+     * Keep the port number
+     */
+    private $_port = '';
+
+    /**
+     * Keep the user name
+     */
+    private $_user = '';
+
+    /**
+     * Keep the password value
+     */
+    private $_password = '';
+
+    /**
      * Boolean true if we are currently doing a bulk transaction.
      */
     var $bulk = false;
@@ -178,10 +198,24 @@ class CouchDB
      * Private Constructor for CouchDB
      *
      * @param string $database The couchDB database name
+     * @param string $host     The couchDB host name
+     * @param string $port     The couchDB port number
+     * @param string $user     The couchDB user name
+     * @param string $password The couchDB password
      */
-    private function __construct($database = '')
-    {
+    private function __construct(
+        string $database = '',
+        string $host = '',
+        string $port = '',
+        string $user = '',
+        string $password = ''
+    ) {
+
         $this->_database = $database;
+        $this->_host     = $host;
+        $this->_port     = $port;
+        $this->_user     = $user;
+        $this->_password = $password;
     }
 
     /**
@@ -193,20 +227,83 @@ class CouchDB
      *       which calls this.
      *
      * @param string $database The couchDB database name
+     * @param string $host     The couchDB host name
+     * @param string $port     The couchDB port number
+     * @param string $user     The couchDB user name
+     * @param string $password The couchDB password
+     *
+     * @throws ConfigurationException When not all parameters are passed and it
+     *                                is not a backwards support deprecated case
      *
      * @return CouchDB A Loris CouchDB wrapper object
      */
-    static function &getInstance($database = null)
-    {
-        if (empty(self::$_instances[$database])) {
+    static function &getInstance(
+        string $database = null,
+        string $host = null,
+        string $port = null,
+        string $user = null,
+        string $password = null
+    ) {
 
-            if (empty($database)) {
+        if (empty(self::$_instances[$database])) {
+            if (empty($database)
+                && empty($host)
+                && empty($port)
+                && empty($user)
+                && empty($password)
+            ) {
+                // check if no parameters are passed
+                // deprecated behaviour, backwards compatible until next major
                 // Default to DQT
-                $config   = \NDB_Config::singleton();
-                $database = $config->getSetting("CouchDB")['dbName'];
+                $config      = \NDB_Config::singleton();
+                $couchConfig = $config->getSetting("CouchDB");
+
+                $database = $couchConfig['dbName'];
+                $host     = $couchConfig['hostname'];
+                $port     = $couchConfig['port'];
+                $user     = $couchConfig['admin'];
+                $password = $couchConfig['adminpass'];
+                error_log(
+                    "LORIS Deprecation Warning: CouchDB::getInstance() will no 
+                    longer auto-loading CouchDB credentials, make sure to specify 
+                    all necessary parameters in the function call."
+                );
+            } else if (!empty($database)
+                && empty($host)
+                && empty($port)
+                && empty($user)
+                && empty($password)
+            ) {
+                // check if only database name given (assume the rest same as dqt)
+                // deprecated behaviour, backwards compatible until next major
+                // Default to DQT
+                $config      = \NDB_Config::singleton();
+                $couchConfig = $config->getSetting("CouchDB");
+
+                $host     = $couchConfig['hostname'];
+                $port     = $couchConfig['port'];
+                $user     = $couchConfig['admin'];
+                $password = $couchConfig['adminpass'];
+                error_log(
+                    "LORIS Deprecation Warning: CouchDB::getInstance() will no 
+                    longer support accepting only a database name, make sure to 
+                    specify all necessary parameters in the function call."
+                );
+            } else if (empty($database)
+                || empty($host)
+                || empty($port)
+                || empty($user)
+                || empty($password)
+            ) {
+                // check if only some parameters given but not all AND does not
+                // enter any of the above IF statements. this behavior was never
+                // supported and should be an error.
+                throw new ConfigurationException(
+                    "CouchDB::getInstance() requires all parameters to be supplied."
+                );
             }
 
-            $db = new CouchDB($database);
+            $db = new CouchDB($database, $host, $port, $user, $password);
             $db->SocketHandler = new SocketWrapper();
 
             self::$_instances[$database] = $db;
@@ -239,12 +336,9 @@ class CouchDB
      */
     function _getURL($url, $op = 'GET', $headers = array())
     {
-        $config      = NDB_Config::singleton();
-        $couchconfig = $config->getSetting('CouchDB');
-
         $handler = $this->SocketHandler;
-        $handler->setHost($couchconfig['hostname']);
-        $handler->setPort($couchconfig['port']);
+        $handler->setHost($this->_host);
+        $handler->setPort($this->_port);
 
         $handler->open();
         $handler->write("$op $url HTTP/1.0\r\n");
@@ -274,19 +368,16 @@ class CouchDB
      */
     function _getRelativeURL($url, $op = 'GET')
     {
-        $config      = NDB_Config::singleton();
-        $couchconfig = $config->getSetting('CouchDB');
-
         $handler = $this->SocketHandler;
-        $handler->setHost($couchconfig['hostname']);
-        $handler->setPort($couchconfig['port']);
+        $handler->setHost($this->_host);
+        $handler->setPort($this->_port);
 
         $handler->open();
         $handler->write($this->_constructURL($op, $url) . " HTTP/1.0\r\n");
         $handler->write(
             "Authorization: Basic "
             . base64_encode(
-                $couchconfig['admin'] . ":" . $couchconfig['adminpass']
+                $this->_user . ":" . $this->_password
             )
             . "\r\n"
         );
@@ -335,12 +426,9 @@ class CouchDB
      */
     function _postURL($url, $data, $headers = array(), $printValue = false)
     {
-        $config      = NDB_Config::singleton();
-        $couchconfig = $config->getSetting('CouchDB');
-
         $handler = $this->SocketHandler;
-        $handler->setHost($couchconfig['hostname']);
-        $handler->setPort($couchconfig['port']);
+        $handler->setHost($this->_host);
+        $handler->setPort($this->_port);
 
         $handler->open();
         $handler->write($url . " HTTP/1.0\r\n");
@@ -350,9 +438,7 @@ class CouchDB
         $handler->write(
             "Authorization: Basic "
             . base64_encode(
-                $couchconfig['admin']
-                . ":"
-                . $couchconfig['adminpass']
+                $this->_user . ":" . $this->_password
             )
             . "\r\n"
         );

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -120,6 +120,8 @@ class NDB_Factory
         }
 
         self::$config = $config;
+        // NDB_Config::singleton() is already loading the config file
+        // in a better way. this needs to be modified
         $config->load($configfile);
         return $config;
     }
@@ -226,13 +228,75 @@ class NDB_Factory
      * Returns a reference to a Loris CouchDB database wrapper.
      *
      * @param string $database The couchDB database name
+     * @param string $host     The couchDB host name
+     * @param string $port     The couchDB port number
+     * @param string $user     The couchDB user name
+     * @param string $password The couchDB password
      *
      * @return CouchDB CouchDB singleton
      */
-    function couchDB($database = null)
-    {
-        if (empty($database)) {
-            $database = self::config()->getSetting("CouchDB")['dbName'];
+    function couchDB(
+        string $database = null,
+        string $host = null,
+        string $port = null,
+        string $user = null,
+        string $password = null
+    ) {
+        if (empty($database)
+            && empty($host)
+            && empty($port)
+            && empty($user)
+            && empty($password)
+        ) {
+            // check if no parameters are passed
+            // deprecated behaviour, backwards compatible until next major
+            // Default to DQT
+            $config      = \NDB_Config::singleton();
+            $couchConfig = $config->getSetting("CouchDB");
+
+            $database = $couchConfig['dbName'];
+            $host     = $couchConfig['hostname'];
+            $port     = $couchConfig['port'];
+            $user     = $couchConfig['admin'];
+            $password = $couchConfig['adminpass'];
+            error_log(
+                "LORIS Deprecation Warning: NDB_Factory::CouchDB() will no 
+                 longer support accepting only a database name, make sure to 
+                 specify all necessary parameters in the function call."
+            );
+        } else if (!empty($database)
+            && empty($host)
+            && empty($port)
+            && empty($user)
+            && empty($password)
+        ) {
+            // check if only database name given (assume the rest same as dqt)
+            // deprecated behaviour, backwards compatible until next major
+            // Default to DQT
+            $config      = \NDB_Config::singleton();
+            $couchConfig = $config->getSetting("CouchDB");
+
+            $host     = $couchConfig['hostname'];
+            $port     = $couchConfig['port'];
+            $user     = $couchConfig['admin'];
+            $password = $couchConfig['adminpass'];
+            error_log(
+                "LORIS Deprecation Warning: NDB_Factory::CouchDB() will no 
+                 longer support accepting only a database name, make sure to 
+                 specify all necessary parameters in the function call."
+            );
+        } else if (empty($database)
+            || empty($host)
+            || empty($port)
+            || empty($user)
+            || empty($password)
+        ) {
+            // check if only some parameters given but not all AND does not
+            // enter any of the above IF statements. this behavior was never
+            // supported and should be an error.
+            throw new ConfigurationException(
+                "NDB_Factory::CouchDB() requires all parameters to be supplied."
+            );
         }
 
         if (!empty(self::$_couchdb[$database])) {
@@ -252,7 +316,13 @@ class NDB_Factory
             );
             self::$_couchdb[$database] = new MockCouchDBWrap();
         } else {
-            self::$_couchdb[$database] = CouchDB::getInstance($database);
+            self::$_couchdb[$database] = CouchDB::getInstance(
+                $database,
+                $host,
+                $port,
+                $user,
+                $password
+            );
         }
         return self::$_couchdb[$database];
     }

--- a/tools/CouchDB_Confirm_Integrity.php
+++ b/tools/CouchDB_Confirm_Integrity.php
@@ -48,8 +48,17 @@ class CouchDBIntegrityChecker
      */
     function __construct()
     {
-        $this->SQLDB   = \Database::singleton();
-        $this->CouchDB = \NDB_Factory::singleton()->couchDB();
+        $factory       = \NDB_Factory::singleton();
+        $config        = \NDB_Config::singleton();
+        $couchConfig   = $config->getSetting('CouchDB');
+        $this->SQLDB   = $factory->Database();
+        $this->CouchDB = $factory->couchDB(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
     }
 
     /**

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -101,8 +101,17 @@ class CouchDBDemographicsImporter {
     );
 
     function __construct() {
-        $this->SQLDB = \Database::singleton();
-        $this->CouchDB = \NDB_Factory::singleton()->couchDB();
+        $factory       = \NDB_Factory::singleton();
+        $config        = \NDB_Config::singleton();
+        $couchConfig   = $config->getSetting('CouchDB');
+        $this->SQLDB   = $factory->Database();
+        $this->CouchDB = $factory->couchDB(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
     }
 
     function _getSubproject($id) {

--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -12,8 +12,17 @@ class CouchDBInstrumentImporter
 
     function __construct()
     {
-        $this->SQLDB   = \Database::singleton();
-        $this->CouchDB = \NDB_Factory::singleton()->couchDB();
+        $factory       = \NDB_Factory::singleton();
+        $config        = \NDB_Config::singleton();
+        $couchConfig   = $config->getSetting('CouchDB');
+        $this->SQLDB   = $factory->Database();
+        $this->CouchDB = $factory->couchDB(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
     }
 
     function UpdateDataDicts($Instruments)

--- a/tools/CouchDB_Import_RadiologicalReview.php
+++ b/tools/CouchDB_Import_RadiologicalReview.php
@@ -80,8 +80,17 @@ class CouchDBRadiologicalReviewImporter {
     );
 
     function __construct() {
-        $this->SQLDB   = \Database::singleton();
-        $this->CouchDB = \NDB_Factory::singleton()->couchDB();
+        $factory       = \NDB_Factory::singleton();
+        $config        = \NDB_Config::singleton();
+        $couchConfig   = $config->getSetting('CouchDB');
+        $this->SQLDB   = $factory->Database();
+        $this->CouchDB = $factory->couchDB(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
     }
 
     function run() {

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -28,9 +28,17 @@ class CouchDBMRIImporter
      */
     function __construct()
     {
-        $factory       = NDB_Factory::singleton();
+        $factory       = \NDB_Factory::singleton();
+        $config        = \NDB_Config::singleton();
+        $couchConfig   = $config->getSetting('CouchDB');
         $this->SQLDB   = $factory->Database();
-        $this->CouchDB = $factory->couchDB();
+        $this->CouchDB = $factory->couchDB(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
     }
 
     /**


### PR DESCRIPTION
This builds on https://github.com/aces/Loris/pull/2795 to extend the functionality to be able to support multiple databases on different servers. This is backwards compatible as it will revert to the DQT credentials if none are passed. this throws deprecation warnings and exceptions when parameters are not properly passed

This is removing the "auto-load" of credentials from the libraries and explicitely passing them when instantiating a couchDB instance. 