### PR TITLE
added permission checks

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -182,8 +182,8 @@ class Edit_User extends \NDB_Form
         $DB     = \Database::singleton();
 
         //The arrays that contain the edited permissions
-        $permissionsRemoved = array();
-        $permissionsAdded   = array();
+        $permissionsRemoved = [];
+        $permissionsAdded   = [];
 
         $editor = \User::singleton();
 
@@ -205,7 +205,7 @@ class Edit_User extends \NDB_Form
         ////Get the current permissions/////
         $current_permissionids = $user->getPermissionIDs();
 
-        $permIDs = array();
+        $permIDs = [];
         // store the permission IDs
         if (!empty($values['permID'])) {
             $permIDs = array_keys($values['permID']);
@@ -251,14 +251,14 @@ class Edit_User extends \NDB_Form
         $uid           = $user->getData('ID');
         $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
-            $DB->delete('user_psc_rel', array("UserID" => $uid));
+            $DB->delete('user_psc_rel', ["UserID" => $uid]);
             foreach ($us_curr_sites as $site) {
                 $DB->insert(
                     'user_psc_rel',
-                    array(
+                    [
                      "UserID"   => $uid,
                      "CenterID" => $site,
-                    )
+                    ]
                 );
             }
         }
@@ -266,152 +266,156 @@ class Edit_User extends \NDB_Form
         // END multi-site UPDATE
 
         // EXAMINER UPDATE
-        // get all fields that are related to examiners
-        $ex_curr_sites  = array();
-        $ex_prev_sites  = array();
-        $ex_radiologist = 'N';
-        $ex_pending     = 'Y';
+        if ($editor->hasPermission('examiner_multisite')) {
+            // get all fields that are related to examiners
 
-        foreach ($values as $k => $v) {
-            //examiner fields
-            if (preg_match("/^ex_[0-9]+$/", $k)) {
-                //get centerID
-                $parse_key = explode('_', $k);
-                $cid       = $parse_key[1];
-                $ex_curr_sites[$k] = $cid;
-            }
-            if ($k === 'examiner_radiologist') {
-                $ex_radiologist = $v;
-            }
-            if ($k === 'examiner_pending') {
-                $ex_pending = $v;
-            }
-        }
+            $ex_curr_sites  = [];
+            $ex_prev_sites  = [];
+            $ex_radiologist = 'N';
+            $ex_pending     = 'Y';
 
-        // first check if an update is needed then actually do it
-        if (!empty($ex_radiologist)
-            && !empty($ex_pending)
-            && !empty($ex_curr_sites)
-        ) {
-            //modify examiner radiologist to be in the binary format 0-1
-            $ex_radiologist = $ex_radiologist === 'Y' ? 1:0;
+            foreach ($values as $k => $v) {
+                //examiner fields
+                if (preg_match("/^ex_[0-9]+$/", $k)) {
+                    //get centerID
+                    $parse_key = explode('_', $k);
+                    $cid       = $parse_key[1];
+                    $ex_curr_sites[$k] = $cid;
+                }
+                if ($k === 'examiner_radiologist') {
+                    $ex_radiologist = $v;
+                }
+                if ($k === 'examiner_pending') {
+                    $ex_pending = $v;
+                }
+            }
 
-            $examinerID = $DB->pselect(
-                "SELECT e.examinerID
+            // first check if an update is needed then actually do it
+            if (!empty($ex_radiologist)
+                && !empty($ex_pending)
+                && !empty($ex_curr_sites)
+            ) {
+                //modify examiner radiologist to be in the binary format 0-1
+                $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
+
+                $examinerID = $DB->pselect(
+                    "SELECT e.examinerID
                  FROM examiners e
                  WHERE e.full_name=:fn",
-                array(
-                 "fn" => $values['Real_name'],
-                )
-            );
-
-            // If examiner not in table add him,
-            // otherwise update the radiologist field and get the current sites
-            $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
-            if (empty($examinerID)) {
-
-                $DB->insert(
-                    'examiners',
-                    array(
-                     'full_name'   => $values['Real_name'],
-                     'radiologist' => $ex_radiologist,
-                     'userID'      => $uid,
-                    )
+                    [
+                     "fn" => $values['Real_name'],
+                    ]
                 );
-                $examinerID = $examinerID = $DB->pselectOne(
-                    "SELECT examinerID
+
+                // If examiner not in table add him,
+                // otherwise update the radiologist field and get the current sites
+                $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
+                if (empty($examinerID)) {
+
+                    $DB->insert(
+                        'examiners',
+                        [
+                         'full_name'   => $values['Real_name'],
+                         'radiologist' => $ex_radiologist,
+                         'userID'      => $uid,
+                        ]
+                    );
+                    $examinerID = $examinerID = $DB->pselectOne(
+                        "SELECT examinerID
                      FROM examiners
                      WHERE full_name=:fullName",
-                    array('fullName' => $values['Real_name'])
-                );
-            } else {
-
-                $DB->update(
-                    'examiners',
-                    array(
-                     'radiologist' => $ex_radiologist,
-                     'userID'      => $uid,
-                    ),
-                    array(
-                     "full_name" => $values['Real_name'],
-                    )
-                );
-                $examinerID = $examinerID[0]['examinerID'];
-
-                //get existing sites for examiner
-                $prev_sites = $DB->pselect(
-                    "SELECT centerID
-                 FROM examiners_psc_rel epr
-                 WHERE examinerID=:eid",
-                    array("eid" => $examinerID)
-                );
-
-                //get sites where user is already an examiner at for compare
-                foreach ($prev_sites as $row => $center) {
-                    array_push($ex_prev_sites, $center['centerID']);
-                }
-            }
-
-            foreach ($ex_curr_sites as $k => $v) {
-
-                //Check if examiner already in db for site
-                $result = $DB->pselectRow(
-                    "SELECT epr.centerID
-                         FROM examiners_psc_rel epr 
-                         WHERE epr.examinerID=:eid AND epr.centerID=:cid",
-                    array(
-                     "eid" => $examinerID,
-                     "cid" => $v,
-                    )
-                );
-
-                // examiner was not previously added, add and set to active
-                if (empty($result)) {
-                    $DB->insert(
-                        'examiners_psc_rel',
-                        array(
-                         'examinerID'       => $examinerID,
-                         'centerID'         => $v,
-                         'active'           => 'Y',
-                         'pending_approval' => $ex_pending,
-                        )
+                        ['fullName' => $values['Real_name']]
                     );
                 } else {
+
+                    $DB->update(
+                        'examiners',
+                        [
+                         'radiologist' => $ex_radiologist,
+                         'userID'      => $uid,
+                        ],
+                        [
+                         "full_name" => $values['Real_name'],
+                        ]
+                    );
+                    $examinerID = $examinerID[0]['examinerID'];
+
+                    //get existing sites for examiner
+                    $prev_sites = $DB->pselect(
+                        "SELECT centerID
+                 FROM examiners_psc_rel epr
+                 WHERE examinerID=:eid",
+                        ["eid" => $examinerID]
+                    );
+
+                    //get sites where user is already an examiner at for compare
+                    foreach ($prev_sites as $row => $center) {
+                        array_push($ex_prev_sites, $center['centerID']);
+                    }
+                }
+
+                foreach ($ex_curr_sites as $k => $v) {
+
+                    //Check if examiner already in db for site
+                    $result = $DB->pselectRow(
+                        "SELECT epr.centerID
+                         FROM examiners_psc_rel epr 
+                         WHERE epr.examinerID=:eid AND epr.centerID=:cid",
+                        [
+                         "eid" => $examinerID,
+                         "cid" => $v,
+                        ]
+                    );
+
+                    // examiner was not previously added, add and set to active
+                    if (empty($result)) {
+                        $DB->insert(
+                            'examiners_psc_rel',
+                            [
+                             'examinerID'       => $examinerID,
+                             'centerID'         => $v,
+                             'active'           => 'Y',
+                             'pending_approval' => $ex_pending,
+                            ]
+                        );
+                    } else {
+                        $DB->update(
+                            'examiners_psc_rel',
+                            [
+                             'active'           => 'Y',
+                             'pending_approval' => $ex_pending,
+                            ],
+                            [
+                             'examinerID' => $examinerID,
+                             'centerID'   => $v,
+                            ]
+                        );
+                    }
+                    unset($values[$k]);
+                }
+
+                //de-activate examiner if sites where no longer checked
+                $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
+
+                foreach ($ex_inactive as $cid) {
                     $DB->update(
                         'examiners_psc_rel',
-                        array(
-                         'active'           => 'Y',
-                         'pending_approval' => $ex_pending,
-                        ),
-                        array(
+                        ["active" => 'N'],
+                        [
                          'examinerID' => $examinerID,
-                         'centerID'   => $v,
-                        )
+                         'centerID'   => $cid,
+                        ]
                     );
                 }
-                unset($values[$k]);
             }
-
-            //de-activate examiner if sites where no longer checked
-            $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
-
-            foreach ($ex_inactive as $cid) {
-                $DB->update(
-                    'examiners_psc_rel',
-                    array("active" => 'N'),
-                    array(
-                     'examinerID' => $examinerID,
-                     'centerID'   => $cid,
-                    )
-                );
-            }
+            unset($values['examiner_radiologist']);
+            unset($values['examiner_pending']);
+            //END EXAMINER UPDATE
         }
-        unset($values['examiner_radiologist']);
-        unset($values['examiner_pending']);
-        //END EXAMINER UPDATE
 
         // make the set
-        foreach ($values as $key => $value) {
+        foreach ($values as $key => $value)
+        {
             if (!empty($value)) {
                 $set[$key] = $value;
             } else {
@@ -889,6 +893,9 @@ class Edit_User extends \NDB_Form
      */
     function _validateEditUser($values)
     {
+        // get user permissions
+        $editor = \User::singleton();
+
         // create DB object
         $DB     = \Database::singleton();
         $errors = array();
@@ -1038,28 +1045,30 @@ class Edit_User extends \NDB_Form
         //======================================
         //        Validate Examiner Status
         //======================================
-        $matched =false;
-        foreach ($values as $k=>$v) {
-            if (preg_match("/^ex_[0-9]+$/", $k)) {
-                $matched =true;
-                if ($values['examiner_radiologist'] == '') {
-                    $errors['examiner_group'] = "Please specify if examiner is a " .
-                        "radiologist";
+        if ($editor->hasPermission('examiner_multisite')) {
+            $matched = false;
+            foreach ($values as $k => $v) {
+                if (preg_match("/^ex_[0-9]+$/", $k)) {
+                    $matched = true;
+                    if ($values['examiner_radiologist'] == '') {
+                        $errors['examiner_group'] = "Please specify if examiner is a " .
+                            "radiologist";
 
-                }
-                if ($values['examiner_radiologist'] !== ''
-                    && $values['examiner_pending'] == ''
-                ) {
-                    $errors['examiner_group'] = "Please set pending approval Yes ".
-                        "or No";
+                    }
+                    if ($values['examiner_radiologist'] !== ''
+                        && $values['examiner_pending'] == ''
+                    ) {
+                        $errors['examiner_group'] = "Please set pending approval Yes " .
+                            "or No";
+                    }
                 }
             }
-        }
-        if (!$matched
-            && ($values['examiner_radiologist'] !== ''
-            || $values['examiner_pending'] !== '')
-        ) {
-            $errors['examiner_sites'] = "Please select at least one examiner site.";
+            if (!$matched
+                && ($values['examiner_radiologist'] !== ''
+                || $values['examiner_pending'] !== '')
+            ) {
+                $errors['examiner_sites'] = "Please select at least one examiner site.";
+            }
         }
         return $errors;
     }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -166,7 +166,7 @@ class Edit_User extends \NDB_Form
     {
         $editor = \User::singleton();
         return !$this->isCreatingNewUser()
-        && ($editor->getUsername() == $this->identifier);
+            && ($editor->getUsername() == $this->identifier);
     }
 
     /**
@@ -182,8 +182,8 @@ class Edit_User extends \NDB_Form
         $DB     = \Database::singleton();
 
         //The arrays that contain the edited permissions
-        $permissionsRemoved = [];
-        $permissionsAdded   = [];
+        $permissionsRemoved = array();
+        $permissionsAdded   = array();
 
         $editor = \User::singleton();
 
@@ -205,7 +205,7 @@ class Edit_User extends \NDB_Form
         ////Get the current permissions/////
         $current_permissionids = $user->getPermissionIDs();
 
-        $permIDs = [];
+        $permIDs = array();
         // store the permission IDs
         if (!empty($values['permID'])) {
             $permIDs = array_keys($values['permID']);
@@ -251,14 +251,14 @@ class Edit_User extends \NDB_Form
         $uid           = $user->getData('ID');
         $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
-            $DB->delete('user_psc_rel', ["UserID" => $uid]);
+            $DB->delete('user_psc_rel', array("UserID" => $uid));
             foreach ($us_curr_sites as $site) {
                 $DB->insert(
                     'user_psc_rel',
-                    [
+                    array(
                      "UserID"   => $uid,
                      "CenterID" => $site,
-                    ]
+                    )
                 );
             }
         }
@@ -268,9 +268,8 @@ class Edit_User extends \NDB_Form
         // EXAMINER UPDATE
         if ($editor->hasPermission('examiner_multisite')) {
             // get all fields that are related to examiners
-
-            $ex_curr_sites  = [];
-            $ex_prev_sites  = [];
+            $ex_curr_sites  = array();
+            $ex_prev_sites  = array();
             $ex_radiologist = 'N';
             $ex_pending     = 'Y';
 
@@ -302,9 +301,9 @@ class Edit_User extends \NDB_Form
                     "SELECT e.examinerID
                  FROM examiners e
                  WHERE e.full_name=:fn",
-                    [
+                    array(
                      "fn" => $values['Real_name'],
-                    ]
+                    )
                 );
 
                 // If examiner not in table add him,
@@ -314,29 +313,29 @@ class Edit_User extends \NDB_Form
 
                     $DB->insert(
                         'examiners',
-                        [
+                        array(
                          'full_name'   => $values['Real_name'],
                          'radiologist' => $ex_radiologist,
                          'userID'      => $uid,
-                        ]
+                        )
                     );
                     $examinerID = $examinerID = $DB->pselectOne(
                         "SELECT examinerID
                      FROM examiners
                      WHERE full_name=:fullName",
-                        ['fullName' => $values['Real_name']]
+                        array('fullName' => $values['Real_name'])
                     );
                 } else {
 
                     $DB->update(
                         'examiners',
-                        [
+                        array(
                          'radiologist' => $ex_radiologist,
                          'userID'      => $uid,
-                        ],
-                        [
+                        ),
+                        array(
                          "full_name" => $values['Real_name'],
-                        ]
+                        )
                     );
                     $examinerID = $examinerID[0]['examinerID'];
 
@@ -345,7 +344,7 @@ class Edit_User extends \NDB_Form
                         "SELECT centerID
                  FROM examiners_psc_rel epr
                  WHERE examinerID=:eid",
-                        ["eid" => $examinerID]
+                        array("eid" => $examinerID)
                     );
 
                     //get sites where user is already an examiner at for compare
@@ -361,34 +360,34 @@ class Edit_User extends \NDB_Form
                         "SELECT epr.centerID
                          FROM examiners_psc_rel epr 
                          WHERE epr.examinerID=:eid AND epr.centerID=:cid",
-                        [
+                        array(
                          "eid" => $examinerID,
                          "cid" => $v,
-                        ]
+                        )
                     );
 
                     // examiner was not previously added, add and set to active
                     if (empty($result)) {
                         $DB->insert(
                             'examiners_psc_rel',
-                            [
+                            array(
                              'examinerID'       => $examinerID,
                              'centerID'         => $v,
                              'active'           => 'Y',
                              'pending_approval' => $ex_pending,
-                            ]
+                            )
                         );
                     } else {
                         $DB->update(
                             'examiners_psc_rel',
-                            [
+                            array(
                              'active'           => 'Y',
                              'pending_approval' => $ex_pending,
-                            ],
-                            [
+                            ),
+                            array(
                              'examinerID' => $examinerID,
                              'centerID'   => $v,
-                            ]
+                            )
                         );
                     }
                     unset($values[$k]);
@@ -400,22 +399,21 @@ class Edit_User extends \NDB_Form
                 foreach ($ex_inactive as $cid) {
                     $DB->update(
                         'examiners_psc_rel',
-                        ["active" => 'N'],
-                        [
+                        array("active" => 'N'),
+                        array(
                          'examinerID' => $examinerID,
                          'centerID'   => $cid,
-                        ]
+                        )
                     );
                 }
             }
             unset($values['examiner_radiologist']);
             unset($values['examiner_pending']);
-            //END EXAMINER UPDATE
         }
+        //END EXAMINER UPDATE
 
         // make the set
-        foreach ($values as $key => $value)
-        {
+        foreach ($values as $key => $value) {
             if (!empty($value)) {
                 $set[$key] = $value;
             } else {
@@ -893,9 +891,6 @@ class Edit_User extends \NDB_Form
      */
     function _validateEditUser($values)
     {
-        // get user permissions
-        $editor = \User::singleton();
-
         // create DB object
         $DB     = \Database::singleton();
         $errors = array();

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -891,6 +891,7 @@ class Edit_User extends \NDB_Form
      */
     function _validateEditUser($values)
     {
+        $editor = \User::singleton();
         // create DB object
         $DB     = \Database::singleton();
         $errors = array();

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1046,15 +1046,15 @@ class Edit_User extends \NDB_Form
                 if (preg_match("/^ex_[0-9]+$/", $k)) {
                     $matched = true;
                     if ($values['examiner_radiologist'] == '') {
-                        $errors['examiner_group'] = "Please specify if examiner is a " .
-                            "radiologist";
+                        $errors['examiner_group'] = "Please specify if examiner " .
+                            "is a radiologist";
 
                     }
                     if ($values['examiner_radiologist'] !== ''
                         && $values['examiner_pending'] == ''
                     ) {
-                        $errors['examiner_group'] = "Please set pending approval Yes " .
-                            "or No";
+                        $errors['examiner_group'] = "Please set pending " .
+                            "approval Yes or No";
                     }
                 }
             }
@@ -1062,7 +1062,8 @@ class Edit_User extends \NDB_Form
                 && ($values['examiner_radiologist'] !== ''
                 || $values['examiner_pending'] !== '')
             ) {
-                $errors['examiner_sites'] = "Please select at least one examiner site.";
+                $errors['examiner_sites'] = "Please select at least one examiner 
+                site.";
             }
         }
         return $errors;

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -306,6 +306,7 @@
         </div>
         {/if}
     </div>
+    {if $form.examiner_sites}
     {if $form.errors.examiner_sites}
     <div class="row form-group form-inline form-inline has-error">
         {else}
@@ -323,7 +324,8 @@
             </div>
             {/if}
         </div>
-    </div>
+    {/if}
+      {if $form.examiner_group}
     {if $form.errors.examiner_group}
     <div class="row form-group form-inline form-inline has-error">
         {else}
@@ -333,7 +335,7 @@
                 {$form.examiner_group.label}
             </label>
             <div class="col-sm-10">
-                <b>{$form.examiner_group.html}<b>
+                <b>{$form.examiner_group.html}</b>
                 </div>
                 {if $form.errors.examiner_group}
                 <div class="col-sm-offset-2 col-xs-12">
@@ -341,8 +343,8 @@
                 </div>
                 {/if}
             </div>
-        </div>
-        <div class="row form-group form-inline">
+      {/if}
+      <div class="row form-group form-inline">
            <label class="col-sm-2">
               {$form.Active.label}
           </label>


### PR DESCRIPTION
This fixes the problem where when a user does not have examiner multisite permission (and the examiner fields do not get displayed) the page still prompts for errors with message "Please select at least one examiner site." 

permission checks were added to the validate and process functions as well as "if" clauses to the template to avoid displaying empty `<div>` when the user does not have the examiner_multisite permission

For more details see redmine #14042

To test:
- Make sure you have the permission `examiner_multisite`
   - test saving a user with no data in the examiner fields (2 lines on the page, one for sites, the other for status)
   - test saving user with either or of the lines containing data -> error should occur with clear message
   - test saving user with both rows complete should save succefully

- Make sure you do NOT have examiner_multisite
   - test saving the user regardless of what his examiner status was before
   - if user was not examiner it should still be the case and no errors get thrown
   - if user was an examiner his data should still be intact but still no error gets thrown 