### PR TITLE
Remove flaky test in candidate_list module

### DIFF
--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -339,24 +339,4 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
             $this->assertContains($key, $text);
         }
     }
-    /**
-      * Testing link of PSCID
-      *
-      * @return void
-      */
-    function testPSCIDLink()
-    {
-        $this->safeGet($this->url . "/candidate_list/");
-        //find PSCID link and click
-        $this->webDriver->executescript(
-            "document.querySelectorAll('#dynamictable > tbody > tr >".
-            " td.dynamictableFrozenColumn > a')[0].click()"
-        );
-        //make sure that breadcrumb contains DCCID
-        $text = $this->webDriver->executescript(
-            "return document.querySelector('#bc2 > a:nth-child(3)>div').textContent"
-        );
-        $this->assertContains('Candidate Profile ', $text);
-    }
 }
-?>


### PR DESCRIPTION
90% of the random failures seem to be caused by the candidate_list testPSCIDLink
test. This removes the test, since the overhead of restarting Travis takes away
more value than it adds.