### PR TITLE
Four Fun Phan Fixes (Part 4)

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -33,7 +33,6 @@ return [
 		"PhanUndeclaredTypeParameter",
 		"PhanUndeclaredConstant",
 		"PhanUndeclaredClass",
-		"PhanUndeclaredClassCatch",
 		"PhanUndeclaredStaticMethod",
 		"PhanUndeclaredExtendedClass",
 		"PhanTypeMismatchForeach",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -33,7 +33,6 @@ return [
 		"PhanUndeclaredTypeParameter",
 		"PhanUndeclaredConstant",
 		"PhanUndeclaredClass",
-		"PhanUndeclaredStaticMethod",
 		"PhanUndeclaredExtendedClass",
 		"PhanTypeMismatchForeach",
 		"PhanTypeMismatchDefault",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -44,7 +44,6 @@ return [
 		"PhanParamTooFew",
 		"PhanParamTooMany",
 		"PhanTypeArraySuspicious",
-		"PhanTypeInvalidRightOperand",
 		"PhanRedefineFunctionInternal",
 		"PhanRedefineFunction",
 	],

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -21,7 +21,6 @@ return [
         "PhanTypeExpectedObjectPropAccessButGotNull",
         "PhanTypeInvalidDimOffset",
         "PhanTypeMismatchDimAssignment",
-        "PhanTypeExpectedObjectPropAccess",
 		"PhanRedefineClass",
 		"PhanUndeclaredMethod",
 		"PhanUndeclaredVariable",

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -182,7 +182,7 @@ class ViewDetails extends \NDB_Form
                 slice_thickness_range FROM mri_protocol";
             $this->protocols = $this->DB->pselect($query, array());
             return true;
-        } catch(LorisException $e) {
+        } catch(\LorisException $e) {
             return false;
         }
     }
@@ -274,7 +274,7 @@ class ViewDetails extends \NDB_Form
             $query = "SELECT Scan_type FROM mri_scan_type WHERE ID=:ID";
             $array = $this->DB->pselectRow($query, array('ID' => $id));
             return $array['Scan_type'];
-        } catch (LorisException $e) {
+        } catch (\LorisException $e) {
             return "Unknown";
         }
     }

--- a/modules/login/php/login.class.inc
+++ b/modules/login/php/login.class.inc
@@ -69,7 +69,7 @@ class Login extends \NDB_Page
 
         try {
             $this->tpl_data['study_logo'] = $config->getSetting('studylogo');
-        } catch(ConfigurationException $e) {
+        } catch(\ConfigurationException $e) {
             $this->tpl_data['study_logo'] = '';
         }
 

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -417,20 +417,9 @@ class My_Preferences extends \NDB_Form
             array('UID' => $this->identifier)
         );
 
-        // If we are using PHP5.5+ and entry Password_has in the DB is not null
-        // use method password_verify to check if the password changed
-        if (function_exists('password_verify')
-            && !is_null($passwords['Password_hash'])
-        ) {
+        if (!is_null($passwords['Password_hash'])) {
             return !password_verify($newPassword, $passwords['Password_hash']);
-        } elseif (!function_exists('password_verify')
-            && !is_null($passwords['Password_hash'])
-        ) {
-            // If PHP version < 5.5, use old MD5Unsalt method to check for
-            // password change
-            return !\User::MD5Unsalt($newPassword, $passwords['Password_hash']);
         }
-
         return true;
     }
 

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -29,7 +29,12 @@
  */
 class BVL_Feedback_Panel
 {
-    var $_feedbackThread = '';
+    /**
+     * The feedback thread that this panel is for
+     *
+     * @var NDB_BVL_Feedback
+     */
+    var $_feedbackThread;
 
     /**
      * Creates the feedback thread for the given combination of candID,

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1041,7 +1041,7 @@ class Database
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the new row
      * @param array  $where the selection filter, joined as a boolean and
-     * @param char   $type  The type of change being tracked (*I*nsert,
+     * @param string $type  The type of change being tracked (*I*nsert,
      *                      *U*pdate or *D*elete)
      *
      * @return void As a side-effect populates history table

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -160,9 +160,9 @@ class Utility
      * Gets a list of visits used by the database as specified from
      * the Visit_Windows table
      *
-     * @return associative array of the form VisitLabel => Visit_label
+     * @return array<string, string> of the form VisitLabel => Visit_label
      */
-    static function getVisitList()
+    static function getVisitList() : array
     {
         $DB =& Database::singleton();
 

--- a/src/Http/StringStream.php
+++ b/src/Http/StringStream.php
@@ -54,7 +54,7 @@ class StringStream implements \Psr\Http\Message\StreamInterface
         try {
             $this->rewind();
             return $this->getContents();
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             return "";
         }
     }


### PR DESCRIPTION
This fixes 4 more types of error that are caught by phan. In particular:

- Places where "try/catch" was catching an undefined class type (PhanUndeclaredClassCatch)
- Places where an undeclared static method was called (PhanUndeclaredStaticMethod)
- Places where an attempt to access a property on a non-object occured (PhanTypeExpectedObjectPropAccess)
- Places where the left side of an operand and the right side weren't compatible (PhanTypeInvalidRightOperand)