### PR TITLE
Reupload of an MRI fails despite the reupload being valid.

### DIFF
--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -33,6 +33,8 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
 
     /**
      * ID of the uploaded file in mri_upload table (if upload successful).
+     * If the file is a reupload of an existing file, then it will be set to
+     * the ID of the original upload.
      */
     var $mri_upload_id;
 
@@ -453,6 +455,8 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             );
             if (!empty($id)) {
                 $db->update('mri_upload', $values, array('UploadID' => $id));
+                $this->mri_upload_id = $id;
+
                 return true;
             }
         }

--- a/modules/imaging_uploader/test/TestPlan.md
+++ b/modules/imaging_uploader/test/TestPlan.md
@@ -66,11 +66,18 @@
     (PSCID and visit label should be correct though). Check that an appropriate message is written in the Console 
     Output.
     [Manual Testing]
-18. Upload a valid, anonymized .tar.gz DICOM archive but with a PSCID that does not match the one in the archive 
+18. First, set the config setting 'ImagingUploader auto launch' to 'Yes'. Then, edit your prod file (in
+	<LORIS MRI code dir>/dicom-archive/.loris-mri) and comment out the definition of the @db array. Once these operations
+	are done, upload any valid scan: check in the server processes manager that this fails with an error code of 4.
+	Now try to upload the scan again. When the system asks you if you want to overwrite the existing 
+	archive, answer 'Yes'. Check that this reupload fails with error code 4 (and not 2). 
+	Related to Redmine#14093 and PR#3555.
+	[Manual Testing]
+19. Upload a valid, anonymized .tar.gz DICOM archive but with a PSCID that does not match the one in the archive 
     (CandID and visit label should be correct though). Check that an appropriate message is written in the Console 
     Output.
     [Automation Testing]
-19. Upload a valid, anonymized .tar.gz DICOM archive but with a visit label that does not match the one in the 
+20. Upload a valid, anonymized .tar.gz DICOM archive but with a visit label that does not match the one in the 
     archive (CandID and PSCID should be correct though). Check that an appropriate message is written in the Console 
     Output.
     [Automation Testing]


### PR DESCRIPTION
With the 'ImagingUploader auto launch' set to yes, and when re-uploading a scan that was not processed successfully by the MRI pipeline, the pipeline exits with an error code of 2 and complains that no profile file was passed on the command line. The error lies in the imaging uploader, which did not set the ID of the uploaded file on a re-upload (it was only set for an *initial* upload). This is a fix for 
 [https://redmine.cbrain.mcgill.ca/issues/14093](url)