### PR TITLE
[Imaging Uploader] Fix filename regex check

### DIFF
--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -294,7 +294,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             ///////////////////////////////////////////////////////////////////////
             $pcv  = $pscid . "_" . $candid . "_" . $visit_label;
             $pcvu = $pcv . "_";
-            if ((!preg_match("/{$pcv}\.(zip|tgz|tar.gz)/", $file_name))
+            if ((!preg_match("/^{$pcv}\.(zip|tgz|tar.gz)/", $file_name))
                 && (!preg_match("/^{$pcvu}.*(\.(zip|tgz|tar.gz))/", $file_name))
             ) {
                     $errors[] = "File name must match " . $pcv .


### PR DESCRIPTION
according to our protocol, nothing should proceed the `PSCID_CANDID_VISIT-LABEL_*` convention but the regex check did not anchor the pattern to the beginning of the file name allowing for `*PSCID_CANDID_VISIT-LABEL_*` to be entered