### PR TITLE
[Candidate_parameters, Core] Implement Normalizing Consent 2/2

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -73,7 +73,6 @@ DROP TABLE IF EXISTS `examiners_psc_rel`;
 DROP TABLE IF EXISTS `examiners`;
 
 DROP TABLE IF EXISTS `participant_status_history`;
-DROP TABLE IF EXISTS `consent_info_history`;
 DROP TABLE IF EXISTS `family`;
 DROP TABLE IF EXISTS `participant_emails`;
 DROP TABLE IF EXISTS `participant_accounts`;
@@ -1083,9 +1082,6 @@ CREATE TABLE `participant_status` (
   `participant_suboptions` int(10) unsigned DEFAULT NULL,
   `reason_specify` text,
   `reason_specify_status` enum('dnk','not_applicable','refusal','not_answered') DEFAULT NULL,
-  `study_consent` enum('yes','no','not_answered') DEFAULT NULL,
-  `study_consent_date` date DEFAULT NULL,
-  `study_consent_withdrawal` date DEFAULT NULL,
   PRIMARY KEY (`ID`),
   UNIQUE KEY `CandID` (`CandID`),
   UNIQUE KEY `ID` (`ID`),
@@ -1125,18 +1121,6 @@ CREATE TABLE `participant_status_history` (
   `reason_specify` varchar(255) DEFAULT NULL,
   `reason_specify_status` enum('not_answered') DEFAULT NULL,
   `participant_subOptions` int(11) DEFAULT NULL,
-  PRIMARY KEY (`ID`),
-  UNIQUE KEY `ID` (`ID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE TABLE `consent_info_history` (
-  `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `CandID` int(6) NOT NULL DEFAULT '0',
-  `entry_staff` varchar(255) DEFAULT NULL,
-  `data_entry_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `study_consent` enum('yes','no','not_answered') DEFAULT NULL,
-  `study_consent_date` date DEFAULT NULL,
-  `study_consent_withdrawal` date DEFAULT NULL,
   PRIMARY KEY (`ID`),
   UNIQUE KEY `ID` (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -118,15 +118,6 @@
             </CertificationInstruments>
         </Certification>
 
-        <!-- Consent module allows addition of consent information in the candidate information page-->
-         <ConsentModule>
-            <useConsent>false</useConsent>
-            <Consent>
-                <name>study_consent</name>
-                <label>Consent to Study</label>
-            </Consent>
-        </ConsentModule>
-
     </study>
     <!-- end of study definition -->
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -273,9 +273,7 @@ if (!$anonymous) {
                                 'useEDC'      => $config->getSetting('useEDC'),
                                 'useProband'  => $config->getSetting('useProband'),
                                 'useFamilyID' => $config->getSetting('useFamilyID'),
-                                'useConsent'  => $config->getSetting(
-                                    'ConsentModule'
-                                )['useConsent'],
+                                'useConsent'  => $config->getSetting('useConsent'),
                                );
     $tpl_data['jsonParams']  = json_encode(
         array(

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -338,19 +338,18 @@ function getParticipantStatusFields()
                'reasonSpecify'         => $reason,
                'history'               => $history,
               ];
-
     return $result;
 }
 
-    /**
-     * Handles the fetching of Participant Status History
-     *
-     * @param int $candID current candidate's ID
-     *
-     * @throws DatabaseException
-     *
-     * @return array
-     */
+/**
+ * Handles the fetching of Participant Status History
+ *
+ * @param int $candID current candidate's ID
+ *
+ * @throws DatabaseException
+ *
+ * @return array
+ */
 function getParticipantStatusHistory($candID)
 {
     $db =& \Database::singleton();
@@ -381,59 +380,46 @@ function getConsentStatusFields()
 {
     $candID = $_GET['candID'];
 
-    $db =& \Database::singleton();
+    $db        = \Database::singleton();
+    $candidate = \Candidate::singleton($candID);
 
     // get pscid
-    $pscid = $db->pselectOne(
-        'SELECT PSCID FROM candidate where CandID = :candid',
-        array('candid' => $candID)
-    );
+    $pscid = $candidate->getPSCID();
 
-    $config        =& \NDB_Config::singleton();
-    $consent       = $config->getSetting('ConsentModule');
-    $consents      = [];
-    $consentStatus = [];
-    $date          = [];
-    $withdrawal    = [];
+    $consentList    = [];
+    $status         = [];
+    $date           = [];
+    $withdrawalDate = [];
 
-    $consent_details =\Utility::asArray($consent['Consent']);
-    if (!$consent_details[0]) {
-        // If only one consent, need to put in an array
-        $temp            = array();
-        $temp[]          = $consent_details;
-        $consent_details = $temp;
+    // Get list of all consent types
+    $consentDetails = \Utility::getConsentList();
+    // Get list of consents for candidate
+    $candidateConsent = $candidate->getConsents();
+
+    foreach ($consentDetails as $consentID=>$consent) {
+        $consentName = $consent['Name'];
+        $consentList[$consentName] = $consent['Label'];
+
+        if (isset($candidateConsent[$consentID])) {
+            $candidateConsentID           = $candidateConsent[$consentID];
+            $status[$consentName]         = $candidateConsentID['Status'];
+            $date[$consentName]           = $candidateConsentID['DateGiven'];
+            $withdrawalDate[$consentName] = $candidateConsentID['DateWithdrawn'];
+        } else {
+            $status[$consentName]         = null;
+            $date[$consentName]           = null;
+            $withdrawalDate[$consentName] = null;
+        }
     }
-
-    foreach ($consent_details as $consentType) {
-        $name           = $consentType['name'];
-        $consentDate    = $name . '_date';
-        $withdrawalDate = $name . '_withdrawal';
-
-        $query = "SELECT 
-                {$db->escape($name)}, 
-                {$db->escape($consentDate)},
-                {$db->escape($withdrawalDate )}         
-                FROM participant_status WHERE CandID=:candid";
-
-        $row = $db->pselectRow($query, ['candid' => $candID]);
-
-        $consents[$name]      = $consentType['label'];
-        $consentStatus[$name] = !empty($row[$name]) ? $row[$name] : null;
-        $date[$name]          = !empty($row[$consentDate]) ?
-            $row[$consentDate] : null;
-        $withdrawal[$name]    = !empty($row[$withdrawalDate]) ?
-            $row[$withdrawalDate] : null;
-    }
-
-    $history = getConsentStatusHistory($candID, $consents);
+    $history = getConsentStatusHistory($pscid);
 
     $result = [
                'pscid'           => $pscid,
                'candID'          => $candID,
-               'consentStatuses' => $consentStatus,
+               'consentStatuses' => $status,
                'consentDates'    => $date,
-               'withdrawals'     => $withdrawal,
-               'consents'        => $consents,
+               'withdrawals'     => $withdrawalDate,
+               'consents'        => $consentList,
                'history'         => $history,
               ];
 
@@ -443,34 +429,43 @@ function getConsentStatusFields()
 /**
  * Handles the fetching of Consent Status history
  *
- * @param int   $candID   current candidate's ID
- * @param array $consents consent values
+ * @param int $pscid current candidate's PSCID
  *
  * @throws DatabaseException
  *
  * @return array
  */
-function getConsentStatusHistory($candID, $consents)
+function getConsentStatusHistory($pscid)
 {
-    $db =& \Database::singleton();
+    $db = \Database::singleton();
 
-    $commentHistory = array();
+    $historyData = $db->pselect(
+        "SELECT EntryDate, DateGiven, DateWithdrawn, PSCID, 
+         ConsentName, ConsentLabel, Status, EntryStaff 
+         FROM candidate_consent_history 
+         WHERE PSCID=:pscid 
+         ORDER BY EntryDate ASC",
+        array('pscid' => $pscid)
+    );
 
-    foreach ($consents as $consent => $label) {
-        $unformattedComments = $db->pselect(
-            "SELECT entry_staff, data_entry_date, "
-            . $db->escape($consent) . ", "
-            . $db->escape($consent . '_date') . ", "
-            . $db->escape($consent . '_withdrawal')
-            ." FROM consent_info_history WHERE $consent IS NOT NULL and CandID=:cid",
-            array('cid' => $candID)
-        );
+    $formattedHistory = [];
+    foreach ($historyData as $key => $entry) {
+          $consentName  = $entry['ConsentName'];
+          $consentLabel = $entry['ConsentLabel'];
 
-        $unformattedComments['label']       = $label;
-        $unformattedComments['consentType'] = $consent;
-
-        array_push($commentHistory, $unformattedComments);
+          $history        = [
+                             'data_entry_date'            => $entry['EntryDate'],
+                             'entry_staff'                => $entry['EntryStaff'],
+                             $consentName                 => $entry['Status'],
+                             $consentName . '_date'       => $entry['DateGiven'],
+                             $consentName . '_withdrawal' => $entry['DateWithdrawn'],
+                            ];
+          $consentHistory = [
+                             $key          => $history,
+                             'label'       => $consentLabel,
+                             'consentType' => $consentName,
+                            ];
+          $formattedHistory[$key] = $consentHistory;
     }
-
-    return $commentHistory;
+    return $formattedHistory;
 }

--- a/modules/candidate_parameters/test/TestPlan.md
+++ b/modules/candidate_parameters/test/TestPlan.md
@@ -46,7 +46,7 @@
 24. Try editing the Comments field and saving.
 
 ### Consent Status Tab
-25. Check that the consent status tab only shows up if `<useConsent>true</useConsent>` in the config.xml.
+25. Check that the consent status tab only shows up if _useConsent_ is set to true in the configuration module.
 26. Tab should render with only one consent type.
 27. Add a new consent type following [the guide](https://github.com/aces/Loris/wiki/Candidate-Information-Page) on the LORIS Wiki. Does it show up in this tab when you refresh the page?
 28. Does the consent info shown in this table match what is stored in the participant_status table?

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -630,6 +630,29 @@ class Candidate
         return $vLabel;
     }
 
+    /**
+     * Returns list of consents and their respective statuses for this candidate
+     *
+     * @return array List of consents and their associated values for this candidate
+     *               The keys of the arrays are the IDs of the consents
+     */
+    public function getConsents()
+    {
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->database();
+
+        $candID = $this->getCandID();
+
+        $query = "SELECT ConsentID, Name, Status, DateGiven, DateWithdrawn
+            FROM candidate_consent_rel cc JOIN consent c USING (ConsentID)
+            WHERE CandidateID=:cid";
+        $where = array('cid' => $candID);
+        $key   = "ConsentID";
+
+        $consentList = $db->pselectWithIndexKey($query, $where, $key);
+
+        return $consentList;
+    }
 
     /**
     * Generates a new random CandID

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -90,7 +90,24 @@ class Utility
 
         return $age;
     }
+    /**
+     * Returns list of consents in the database
+     *
+     * @return array An associative array of consents, with their names and labels.
+     *               The keys of the arrays are the IDs of the consents
+     */
+    static function getConsentList()
+    {
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
 
+        $query = "SELECT ConsentID, Name, Label FROM consent";
+        $key   = "ConsentID";
+
+        $result = $DB->pselectWithIndexKey($query, array(), $key);
+
+        return $result;
+    }
     /**
      * Returns a list of sites in the database
      *

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -108,8 +108,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
                                         'useFamilyID'
                                     ),
                                     'useConsent'  => $this->Config->getSetting(
-                                        'ConsentModule'
-                                    )['useConsent'],
+                                        'useConsent'
+                                    ),
                                    );
         $tpl_data['jsonParams']  = json_encode(
             array(

--- a/test/config.xml
+++ b/test/config.xml
@@ -114,15 +114,6 @@
             </CertificationInstruments>
         </Certification>
 
-        <!-- Consent module allows addition of consent information in the candidate information page-->
-         <ConsentModule>
-            <useConsent>false</useConsent>
-            <Consent>
-                <name>study_consent</name>
-                <label>Consent to Study</label>
-            </Consent>
-        </ConsentModule>
-
     </study>
     <!-- end of study definition -->
 

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once 'generic_includes.php';
 require_once 'CouchDB.class.inc';
+require_once 'Database.class.inc';
 class CouchDBDemographicsImporter {
     var $SQLDB; // reference to the database handler, store here instead
                 // of using Database::singleton in case it's a mock.
@@ -188,17 +189,14 @@ class CouchDBDemographicsImporter {
           foreach($consents as $consentID=>$consent) {
             $consentName    = $consent['Name'];
             $consentFields  = ",
-                                cc" . $this->SQLDB->escape($consentID) . ".Status AS 
-                                  " . $this->SQLDB->escape($consentName) . ", 
-                                cc" . $this->SQLDB->escape($consentID) . ".DateGiven AS 
-                                  " . $this->SQLDB->escape($consentName . "_date") . ", 
-                                cc" . $this->SQLDB->escape($consentID) . ".DateWithdrawn AS 
-                                  " . $this->SQLDB->escape($consentName . "_withdrawal");
+                                cc" . $this->SQLDB->escape($consentID) . ".Status AS " . $consentName . ", 
+                                cc" . $this->SQLDB->escape($consentID) . ".DateGiven AS " . $consentName . "_date, 
+                                cc" . $this->SQLDB->escape($consentID) . ".DateWithdrawn AS " . $consentName . "_withdrawal";
             $fieldsInQuery .= $consentFields;
             $tablesToJoin  .= "
                                 LEFT JOIN candidate_consent_rel cc" . $this->SQLDB->escape($consentID) . " ON 
                                   (cc" . $this->SQLDB->escape($consentID) . ".CandidateID=c.CandID) AND 
-                                  cc" . $this->SQLDB->escape($consentID) . ".ConsentID=(SELECT ConsentID FROM consent WHERE Name=" . $this->SQLDB->escape($consentName) . ") ";
+                                  cc" . $this->SQLDB->escape($consentID) . ".ConsentID=(SELECT ConsentID FROM consent WHERE Name='" . $consentName . "') ";
             $groupBy     .= ",
                             cc" . $this->SQLDB->escape($consentID) . ".Status,
                             cc" . $this->SQLDB->escape($consentID) . ".DateGiven,

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -2,7 +2,6 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once 'generic_includes.php';
 require_once 'CouchDB.class.inc';
-require_once 'Database.class.inc';
 class CouchDBDemographicsImporter {
     var $SQLDB; // reference to the database handler, store here instead
                 // of using Database::singleton in case it's a mock.
@@ -75,14 +74,6 @@ class CouchDBDemographicsImporter {
             'Description' => 'Participant status comments',
             'Type' => "text",
         ),
-        'Study_consent' => array(
-            'Description' => 'Study Consent',
-            'Type' => "enum('yes','no','not_answered')",
-        ),
-        'Study_consent_withdrawal' => array(
-            'Description' => 'Study Consent Withdrawal Date',
-            'Type' => "varchar(255)",
-        ),
         'session_feedback' => array(
             'Description' => 'Behavioural feedback at the session level',
             'Type' => "varchar(255)",
@@ -150,8 +141,6 @@ class CouchDBDemographicsImporter {
                                 COALESCE(pso.Description,'Active') as Status, 
                                 ps.participant_suboptions as Status_reason, 
                                 ps.reason_specify as Status_comments, 
-                                ps.study_consent as Study_consent, 
-                                COALESCE(ps.study_consent_withdrawal,'0000-00-00') AS Study_consent_withdrawal,
                                 GROUP_CONCAT(fbe.Comment) as session_feedback";
         $tablesToJoin = " FROM session s 
                                 JOIN candidate c USING (CandID) 
@@ -162,10 +151,9 @@ class CouchDBDemographicsImporter {
                                 LEFT JOIN participant_status_options pso ON (pso.ID=ps.participant_status)
                                 LEFT JOIN feedback_bvl_thread fbt ON (fbt.CandID=c.CandID) 
                                 LEFT JOIN feedback_bvl_entry fbe ON (fbe.FeedbackID=fbt.FeedbackID)";
-
         $groupBy=" GROUP BY s.ID, 
                             c.DoB,
-							c.CandID, 
+                            c.CandID,
                             c.PSCID, 
                             s.Visit_label, 
                             s.SubprojectID, 
@@ -180,10 +168,7 @@ class CouchDBDemographicsImporter {
                             pc_comment.Value, 
                             pso.Description, 
                             ps.participant_suboptions, 
-                            ps.reason_specify, 
-                            ps.study_consent, 
-                            Study_consent_withdrawal
-                            ";
+                            ps.reason_specify";
 
         // If proband fields are being used, add proband information into the query
         if ($config->getSetting("useProband") === "true") {
@@ -196,6 +181,29 @@ class CouchDBDemographicsImporter {
             $EDCFields = ", c.EDC as EDC";
             $fieldsInQuery .= $EDCFields;
             $groupBy .= ", c.EDC";
+        }
+        // If consent is being used, add consent information into query
+        if ($config->getSetting("useConsent") === "true") {
+          $consents = \Utility::getConsentList();
+          foreach($consents as $consentID=>$consent) {
+            $consentName    = $consent['Name'];
+            $consentFields  = ",
+                                cc" . $this->SQLDB->escape($consentID) . ".Status AS 
+                                  " . $this->SQLDB->escape($consentName) . ", 
+                                cc" . $this->SQLDB->escape($consentID) . ".DateGiven AS 
+                                  " . $this->SQLDB->escape($consentName . "_date") . ", 
+                                cc" . $this->SQLDB->escape($consentID) . ".DateWithdrawn AS 
+                                  " . $this->SQLDB->escape($consentName . "_withdrawal");
+            $fieldsInQuery .= $consentFields;
+            $tablesToJoin  .= "
+                                LEFT JOIN candidate_consent_rel cc" . $this->SQLDB->escape($consentID) . " ON 
+                                  (cc" . $this->SQLDB->escape($consentID) . ".CandidateID=c.CandID) AND 
+                                  cc" . $this->SQLDB->escape($consentID) . ".ConsentID=(SELECT ConsentID FROM consent WHERE Name=" . $this->SQLDB->escape($consentName) . ") ";
+            $groupBy     .= ",
+                            cc" . $this->SQLDB->escape($consentID) . ".Status,
+                            cc" . $this->SQLDB->escape($consentID) . ".DateGiven,
+                            cc" . $this->SQLDB->escape($consentID) . ".DateWithdrawn";
+          }
         }
         $whereClause=" WHERE s.Active='Y' AND c.Active='Y' AND c.Entity_type != 'Scanner'";
 
@@ -232,6 +240,26 @@ class CouchDBDemographicsImporter {
                 'Description' => 'Project for which the candidate belongs',
                 'Type' => $projectsEnum
             );
+        }
+        // If consent is being used, update the data dictionary
+        if ($config->getSetting("useConsent") === "true") {
+          $consents = \Utility::getConsentList();
+          foreach($consents as $consent) {
+            $consentName  = $consent['Name'];
+            $consentLabel = $consent['Label'];
+            $this->Dictionary[$consentName] = array(
+                'Description' => $consentLabel,
+                'Type' => "enum('yes','no')"
+            );
+            $this->Dictionary[$consentName . "_date"] = array(
+                'Description' => $consentLabel . ' Date',
+                'Type' => "date"
+            );
+            $this->Dictionary[$consentName . "_withdrawal"] = array(
+                'Description' => $consentLabel . ' Withdrawal Date',
+                'Type' => "date"
+            );
+          }
         }
         /*
         // Add any candidate parameter fields to the data dictionary


### PR DESCRIPTION
PR 2/2: Implementation of https://github.com/aces/Loris/pull/3532 once it gets merged

1. Moves configurations from `config.xml` to _Config_ module
2. Updates _Candidate Parameters_ ajax to use new SQL tables
3. Updates _CouchDB_ import script for _DQT_
4. Remove deprecated lines from DB schema
5. Update `RBdata.sql` to incorporate new history table

**to test:**
1. Run all update scripts from https://github.com/aces/Loris/pull/3532
2. Access Profile -> Candidate Parameters -> Consent status
- test _Consent Status_ tab renders only when _useConsent_ in Config is set to Yes
- input fields in _Consent Status_ tab and their functionality remains the same
- data gets entered into new `candidate_consent_rel` table, not deprecated columns in `participant_status`
3. Test DQT results for the `demographics` instrument and consent fields
4. Resource raisinbread data (if you are okay with losing data)
