### PR TITLE
[media] missing comma in the sql command for 19.1-release

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -294,7 +294,7 @@ function getUploadFields()
             "comments, " .
             "file_name as fileName, " .
             "hide_file as hideFile, " .
-            "language_id as language" .
+            "language_id as language," .
             "m.id FROM media m LEFT JOIN session s ON m.session_id = s.ID " .
             "WHERE m.id = $idMediaFile",
             []


### PR DESCRIPTION
This pull request adding a missing comma in the SQL command.
19.2-release has the same issue.