### PR TITLE
Replace hack with slightly less egregious hack

### DIFF
--- a/htdocs/main.css
+++ b/htdocs/main.css
@@ -29,9 +29,11 @@ html, body {
 	font-family: verdana, sans-serif;
 	font-size: 90%;
 }
+
 #page {
     min-height: 100%;
     position: relative;
+    padding-top: 50px;
 }
 
 

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -205,8 +205,6 @@
 
             {/if}
             {if $dynamictabs neq "dynamictabs"}
-            {* Add enough spacing to get below the menu *}
-                <br><br><br>
             <div class="page-content inset">
 
                 {if $console}


### PR DESCRIPTION
This removes a \<br> tag spacing hack and replaces it with CSS to ensure that the page content doesn't get covered by the menu header.