### PR TITLE
[Help_editor] Fixes "Return to .." href location

### DIFF
--- a/htdocs/js/helpHandler.js
+++ b/htdocs/js/helpHandler.js
@@ -63,7 +63,7 @@ $(document).ready(function() {
         div.appendChild(edit);
         edit.addEventListener("click", function(e) {
           e.preventDefault();
-          document.cookie = "LastUrl = " + document.location.toString();
+          document.cookie = "LastUrl = " + document.location.toString() + "; path=/";
           window.open(loris.BaseURL + "/help_editor/edit_help_content/?section=" +
             getParams.testName + "&subsection=" + getParams.subtest, "_self");
         });

--- a/modules/help_editor/js/help_editor_helper.js
+++ b/modules/help_editor/js/help_editor_helper.js
@@ -34,6 +34,3 @@ $("input[name=preview]").click(function(e) {
 
 });
 });
-function goBack() {
-    window.history.back();
-}

--- a/modules/help_editor/templates/form_edit_help_content.tpl
+++ b/modules/help_editor/templates/form_edit_help_content.tpl
@@ -1,6 +1,6 @@
 {if $success}
 
-<p>Content was updated successful<br /></p>
+<p>Content was updated successfully!<br /></p>
 <br />
 {/if}
 <form method="post" name="edit_help_content" id="edit_help_content" enctype="multipart/form-data">
@@ -39,6 +39,6 @@
         <input type="button" name="reset" value="Reset" class="btn btn-sm btn-primary" onclick="location.href='{$baseurl}/help_editor/edit_help_content/?section={$section}&subsection={$subsection}'" />
         <input class="btn btn-sm btn-primary" name="preview" value="Preview" type="button" />
         {/if}
-        <input class="btn btn-sm btn-primary" onclick="goBack()" value="Return to {$module_name}" type="button" />
+        <input class="btn btn-sm btn-primary" onclick="location.href='{$url}'" value="Return to {$module_name}" type="button" />
     </div>
 </div>


### PR DESCRIPTION
Fixes https://redmine.cbrain.mcgill.ca/issues/14111. Ideally would like to completely remove the "success" page and add a sweet alert but fixing this should be sufficient for now.

tpl_data['url'] comes from $_COOKIE["LastUrl"] as set by document.cookie