### PR TITLE
[tools] Zero date removal tool explicitly declare field NULL

### DIFF
--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -67,7 +67,9 @@ foreach ($field_names as $key=>$field) {
         $autoUpdateFields[$field['TABLE_NAME']][]= $field['COLUMN_NAME'];
     }
 }
-
+print_r($field_names);
+print_r($autoUpdateFields);
+exit();
 // BEGIN building script
 
 //save old variables
@@ -90,10 +92,10 @@ foreach ($field_names as $key=>$field)
 
     if ($field['COLUMN_DEFAULT']=='0000-00-00') {
         echo "The script will modify the date schema for TABLE: `".$field['TABLE_NAME']."` FIELD: `".$field['COLUMN_NAME']."` to default to NULL\n";
-        $alters .= "ALTER TABLE ".$db->escape($field['TABLE_NAME'])." MODIFY ".$db->escape($field['COLUMN_NAME'])." ".$field['COLUMN_TYPE']." DEFAULT NULL;\n";
+        $alters .= "ALTER TABLE ".$db->escape($field['TABLE_NAME'])." MODIFY ".$db->escape($field['COLUMN_NAME'])." ".$field['COLUMN_TYPE']." NULL DEFAULT NULL;\n";
     } else if ($field['COLUMN_DEFAULT']=='0000-00-00 00:00:00') {
         echo "The script will modify the date schema for TABLE: `".$field['TABLE_NAME']."` FIELD: `".$field['COLUMN_NAME']."` to default to NULL\n";
-        $alters .= "ALTER TABLE ".$db->escape($field['TABLE_NAME'])." MODIFY ".$db->escape($field['COLUMN_NAME'])." ".$field['COLUMN_TYPE']." DEFAULT NULL;\n";
+        $alters .= "ALTER TABLE ".$db->escape($field['TABLE_NAME'])." MODIFY ".$db->escape($field['COLUMN_NAME'])." ".$field['COLUMN_TYPE']." NULL DEFAULT NULL;\n";
     }
 
 

--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -67,9 +67,7 @@ foreach ($field_names as $key=>$field) {
         $autoUpdateFields[$field['TABLE_NAME']][]= $field['COLUMN_NAME'];
     }
 }
-print_r($field_names);
-print_r($autoUpdateFields);
-exit();
+
 // BEGIN building script
 
 //save old variables


### PR DESCRIPTION
This adds the explicit `NULL` clause to the field definition to override the `NOT NULL` default on timestamp fields


see https://github.com/aces/Loris/pull/3532 for bug from @llevitis 