### PR TITLE
[Install] Adding installdb.php to apache file

### DIFF
--- a/docs/config/apache2-site
+++ b/docs/config/apache2-site
@@ -16,7 +16,7 @@
 
 	php_value include_path .:/usr/share/php:%LORISROOT%/project/libraries:%LORISROOT%/php/libraries
 
-	DirectoryIndex main.php index.html
+	DirectoryIndex main.php index.html installdb.php
 
 	ErrorLog %LOGDIRECTORY%/loris-error.log
 


### PR DESCRIPTION
One of the required steps for install is to run the installdb.php from the front end but it doesnt seem to be reachable without adding it to apache
