### PR TITLE
[Doc Repo] Unfixed line elements so that they scroll with the frame

### DIFF
--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -294,10 +294,20 @@ label em {
   flex-direction: row;
 }
 
-.tree_line {
+.document a {
+  margin: auto 10px;
+}
+
+.line_element_container {
+  display: flex;
+  flex-directon: column;
   width: 30px;
-  border: 1px solid #999;
-  margin: auto 0px;
+}
+
+.line_element {
+  width: 100%;
+  height: 50%;
+  border-bottom: 1px solid #999;
 }
 
 #dir-tree>tr>td:first-child {
@@ -308,7 +318,7 @@ label em {
     -webkit-box-sizing: border-box;
        -moz-box-sizing: border-box;
             box-sizing: border-box;
-    border-left:1px solid #999;
+    border-left: 1px solid #999;
     height:100%;
     overflow: auto;
     word-break: break-word;

--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -278,17 +278,6 @@ label em {
     border: 1px solid #999;
 }
 
-/*.fileDDD::before{
-    position: absolute;
-    margin-top: 20px;
-    margin-left: -30px;
-    overflow: hidden;
-    width: 30px;
-    height: 1px;
-    content: '\a0';
-    background-color: #999;
-}*/
-
 .document {
   display: flex;
   flex-direction: row;
@@ -306,7 +295,7 @@ label em {
 
 .line_element {
   width: 100%;
-  height: 50%;
+  height: 70%;
   border-bottom: 1px solid #999;
 }
 

--- a/modules/document_repository/css/document_repository.css
+++ b/modules/document_repository/css/document_repository.css
@@ -277,7 +277,8 @@ label em {
     float: left;
     border: 1px solid #999;
 }
-.fileDDD::before{
+
+/*.fileDDD::before{
     position: absolute;
     margin-top: 20px;
     margin-left: -30px;
@@ -286,7 +287,19 @@ label em {
     height: 1px;
     content: '\a0';
     background-color: #999;
+}*/
+
+.document {
+  display: flex;
+  flex-direction: row;
 }
+
+.tree_line {
+  width: 30px;
+  border: 1px solid #999;
+  margin: auto 0px;
+}
+
 #dir-tree>tr>td:first-child {
     padding: 0px;
     /*height: 100%;*/
@@ -296,7 +309,6 @@ label em {
        -moz-box-sizing: border-box;
             box-sizing: border-box;
     border-left:1px solid #999;
-    padding-left: 30px;
     height:100%;
     overflow: auto;
     word-break: break-word;

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -36,13 +36,13 @@
 <script id="file" type="x-tmpl-mustache">
     <tr class="{{ parentID }}a fileRow" {{ ^filtered }}style="display:none" {{ /filtered }}>
         <td class="blah fileColumn">
-            <div {{ ^filtered }}class="fileDDD" style="{{ margin }}"{{ /filtered }}><div class="document" style="padding-top: 8px">
-                <div class="tree_line"></div>
-		<div><a href="{/literal}{$baseurl}{literal}/document_repository/ajax/GetFile.php?File={{ Data_dir }}" target="_blank" download="{{ File_name }}">
-                        {{ File_name }}
-                </a></div>
-		<div>({{ File_size }})</div>
-            </div></div>
+            <div {{ ^filtered }}class="fileDDD" style="{{ margin }}"{{ /filtered }}>
+                <div class="document" style="padding-top: 8px">
+                    <div class="line_element_container"><div class="line_element"></div><div></div></div>
+		    <div><a href="{/literal}{$baseurl}{literal}/document_repository/ajax/GetFile.php?File={{ Data_dir }}" target="_blank" download="{{ File_name }}">{{ File_name }}</a></div>
+		    <div>({{ File_size }})</div>
+                </div>
+            </div>
         </td>
         <td>
             {{ version }}

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -19,10 +19,13 @@
     <tr id="{{ id }}a" {{ #parentID }}class="{{ parentID }}a directoryRow" style="display:none"{{ /parentID }}>
         <td class="fileColumn" colspan="10">
             {{ #indent }}
-                <div class="fileDDD" style="{{ margin }}">
-                    <span style="padding: 8px" class='directory glyphicon glyphicon-chevron-right' data-container="body" data-toggle="popover" data-placement="right" data-content="{{ Comment }}">
-                        {{ name }}
-                    </span>
+                <div class = "document" style="{{ margin }}">
+                    <div class="line_element_container"><div class="line_element"></div><div></div></div>
+                    <div class="fileDDD">
+                        <span style="padding: 8px;" class='directory glyphicon glyphicon-chevron-right' data-container="body" data-toggle="popover" data-placement="right" data-content="{{ Comment }}">
+                            {{ name }}
+                        </span>
+                    </div>
                 </div>
             {{ /indent }}
             {{ ^indent }}

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -36,10 +36,12 @@
 <script id="file" type="x-tmpl-mustache">
     <tr class="{{ parentID }}a fileRow" {{ ^filtered }}style="display:none" {{ /filtered }}>
         <td class="blah fileColumn">
-            <div {{ ^filtered }}class="fileDDD" style="{{ margin }}"{{ /filtered }}><div style="padding-top: 8px">
-                <a href="{/literal}{$baseurl}{literal}/document_repository/ajax/GetFile.php?File={{ Data_dir }}" target="_blank" download="{{ File_name }}">
+            <div {{ ^filtered }}class="fileDDD" style="{{ margin }}"{{ /filtered }}><div class="document" style="padding-top: 8px">
+                <div class="tree_line"></div>
+		<div><a href="{/literal}{$baseurl}{literal}/document_repository/ajax/GetFile.php?File={{ Data_dir }}" target="_blank" download="{{ File_name }}">
                         {{ File_name }}
-                </a>({{ File_size }})
+                </a></div>
+		<div>({{ File_size }})</div>
             </div></div>
         </td>
         <td>

--- a/modules/document_repository/templates/menu_document_repository.tpl
+++ b/modules/document_repository/templates/menu_document_repository.tpl
@@ -39,8 +39,8 @@
             <div {{ ^filtered }}class="fileDDD" style="{{ margin }}"{{ /filtered }}>
                 <div class="document" style="padding-top: 8px">
                     <div class="line_element_container"><div class="line_element"></div><div></div></div>
-		    <div><a href="{/literal}{$baseurl}{literal}/document_repository/ajax/GetFile.php?File={{ Data_dir }}" target="_blank" download="{{ File_name }}">{{ File_name }}</a></div>
-		    <div>({{ File_size }})</div>
+		    <a href="{/literal}{$baseurl}{literal}/document_repository/ajax/GetFile.php?File={{ Data_dir }}" target="_blank" download="{{ File_name }}">{{ File_name }}</a>
+		    ({{ File_size }})
                 </div>
             </div>
         </td>


### PR DESCRIPTION
This pull request address a minor bug in the front end of the Doc repo filter table: https://redmine.cbrain.mcgill.ca/issues/11267

It unfixes the horizontal lines coming before each file name or category in the tree structure of document repository so that they scroll with the frame. The root of the issue was the use of the pseudo element ::before and the position: absolute. To format a line before each filename and category, I removed the pseudo element and used div elements instead.

This PR is on minor instead of bugfix because of targeted branch on redmine ticket.
