### PR TITLE
[Help_editor] Add ajax/swal on save and remove success page

### DIFF
--- a/htdocs/js/helpHandler.js
+++ b/htdocs/js/helpHandler.js
@@ -18,7 +18,6 @@ $(document).ready(function() {
     if (loris.Subtest !== "") {
       getParams.subtest = loris.Subtest;
     }
-    document.cookie = 'LastUrl=; expires=Thu, 01-Jan-70 00:00:01 GMT;';
     $.get(loris.BaseURL + "/help_editor/ajax/help.php", getParams, function(content) {
       var div = document.createElement("div");
       var btn = document.createElement("BUTTON");
@@ -59,7 +58,6 @@ $(document).ready(function() {
         div.appendChild(edit);
         edit.addEventListener("click", function(e) {
           e.preventDefault();
-          document.cookie = "LastUrl = " + document.location.toString();
           window.open(loris.BaseURL + "/help_editor/edit_help_content/?section=" +
             getParams.testName + "&subsection=" + getParams.subtest, "_self");
         });

--- a/modules/help_editor/ajax/process.php
+++ b/modules/help_editor/ajax/process.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * This file contains code for editing help content.
+ * It holds the processing of adding/updating content
+ * for all modules.
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Zaliqa Rosli <zaliqa.rosli@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+
+namespace LORIS\help_editor;
+
+require_once 'Database.class.inc';
+require_once 'helpfile.class.inc';
+
+$user = \User::singleton();
+if (!$user->hasPermission('context_help')) {
+    header("HTTP/1.1 403 Forbidden");
+    exit(
+        "You do not have the correct permissions for this operation."
+    );
+}
+
+$DB = \Database::singleton();
+//Get the default values
+// Sanitize user input
+if (!empty($_POST['helpID'])
+    && !empty($_POST['title'])
+    && !empty($_POST['content'])
+) {
+    $helpID = $_POST['helpID'];
+    $help_file = HelpFile::factory($helpID);
+    // update the help file
+    $success = $help_file->update(
+        array(
+         'topic'   => $_POST['title'],
+         'content' => $_POST['content'],
+         'updated' => date(
+             'Y-m-d h:i:s',
+             time()
+         ),
+        )
+    );
+} else {
+    //content does not exist insert the help file
+    if (!empty($_POST['section'])
+        && $_POST['subsection'] != 'undefined'
+        && empty($_POST['parentID'])
+    ) { 
+        //create parent help section first
+        $parentID = HelpFile::insert(
+            array(
+             'hash'    => md5($_POST['section']),
+             'topic'   => "",
+             'content' => "Under construction",
+             'created' => date(
+                 'Y-m-d h:i:s',
+                 time()
+             ),  
+            )
+        );
+         // check errors
+    }    
+    if (!empty($_POST['section'])
+        && $_POST['subsection'] != 'undefined'
+        && !empty($_POST['parentID'])
+    ) { 
+
+        // insert the help file
+        $helpID = HelpFile::insert(
+            array(
+             'parentID' => $_POST['parentID'],
+             'hash'     => md5($_POST['subsection']),
+             'topic'    => $_POST['title'],
+             'content'  => $_POST['content'],
+             'created'  => date(
+                 'Y-m-d h:i:s',
+                 time()
+             ),  
+            )
+        );
+
+    } else if (!empty($_POST['section'])
+        && $_POST['subsection'] == 'undefined'
+    ) { 
+      //default case
+      $helpID = HelpFile::insert(
+      array(
+           'hash'    => md5($_POST['section']),
+           'topic'   => $_POST['title'],
+           'content' => $_POST['content'],
+           'created' => date(
+               'Y-m-d h:i:s',
+               time()
+           ),  
+          )
+      );
+    }
+}
+?>

--- a/modules/help_editor/ajax/process.php
+++ b/modules/help_editor/ajax/process.php
@@ -33,7 +33,7 @@ if (!empty($_POST['helpID'])
     && !empty($_POST['title'])
     && !empty($_POST['content'])
 ) {
-    $helpID = $_POST['helpID'];
+    $helpID    = $_POST['helpID'];
     $help_file = HelpFile::factory($helpID);
     // update the help file
     $success = $help_file->update(
@@ -51,7 +51,7 @@ if (!empty($_POST['helpID'])
     if (!empty($_POST['section'])
         && $_POST['subsection'] != 'undefined'
         && empty($_POST['parentID'])
-    ) { 
+    ) {
         //create parent help section first
         $parentID = HelpFile::insert(
             array(
@@ -61,15 +61,15 @@ if (!empty($_POST['helpID'])
              'created' => date(
                  'Y-m-d h:i:s',
                  time()
-             ),  
+             ),
             )
         );
          // check errors
-    }    
+    }
     if (!empty($_POST['section'])
         && $_POST['subsection'] != 'undefined'
         && !empty($_POST['parentID'])
-    ) { 
+    ) {
 
         // insert the help file
         $helpID = HelpFile::insert(
@@ -81,25 +81,25 @@ if (!empty($_POST['helpID'])
              'created'  => date(
                  'Y-m-d h:i:s',
                  time()
-             ),  
+             ),
             )
         );
 
     } else if (!empty($_POST['section'])
         && $_POST['subsection'] == 'undefined'
-    ) { 
-      //default case
-      $helpID = HelpFile::insert(
-      array(
-           'hash'    => md5($_POST['section']),
-           'topic'   => $_POST['title'],
-           'content' => $_POST['content'],
-           'created' => date(
-               'Y-m-d h:i:s',
-               time()
-           ),  
-          )
-      );
+    ) {
+        //default case
+        $helpID = HelpFile::insert(
+            array(
+             'hash'    => md5($_POST['section']),
+             'topic'   => $_POST['title'],
+             'content' => $_POST['content'],
+             'created' => date(
+                 'Y-m-d h:i:s',
+                 time()
+             ),
+            )
+        );
     }
 }
 ?>

--- a/modules/help_editor/ajax/process.php
+++ b/modules/help_editor/ajax/process.php
@@ -15,9 +15,6 @@
 
 namespace LORIS\help_editor;
 
-require_once 'Database.class.inc';
-require_once 'helpfile.class.inc';
-
 $user = \User::singleton();
 if (!$user->hasPermission('context_help')) {
     header("HTTP/1.1 403 Forbidden");
@@ -26,9 +23,8 @@ if (!$user->hasPermission('context_help')) {
     );
 }
 
-$DB = \Database::singleton();
-//Get the default values
-// Sanitize user input
+$DB = (\NDB_Factory::singleton())->database();
+
 if (!empty($_POST['helpID'])
     && !empty($_POST['title'])
     && !empty($_POST['content'])

--- a/modules/help_editor/js/help_editor_helper.js
+++ b/modules/help_editor/js/help_editor_helper.js
@@ -65,12 +65,11 @@ $("#save-help").click(function(e) {
                 location.href = document.referrer;
             });
         },
-        error: function(xhr, errStatus, errThrown) {
-            console.log("THIS IS THE STATUS:" + errStatus);
-            console.error(errThrown);
+        error: function(xhr, errorCode, errorMsg) {
+            console.error(xhr);
             swal({
                 title: "Content update unsuccessful.",
-                text: xhr.responseText,
+                text: errorCode + ": " + xhr.status + " " + errorMsg,
                 type: "error",
                 confirmButtonText: "Try again",
                 closeOnConfirm: true,

--- a/modules/help_editor/js/help_editor_helper.js
+++ b/modules/help_editor/js/help_editor_helper.js
@@ -1,5 +1,4 @@
 $(document).ready(function(){
-
 $("input[name=preview]").click(function(e) {
     if($('div.help-content').length) {
         $('div.help-content').remove();
@@ -35,7 +34,48 @@ $("input[name=preview]").click(function(e) {
      e.preventDefault();
 
 });
+$("#save-help").click(function(e) {
+    e.preventDefault();
+    var title   = $('input[name="title"]').val(),
+        content = $('textarea[name="content"]').val(),
+        section = $("#section").val(),
+        subsection = $("#subsection").val(),
+        parentID = $("#parentID").val(),
+        helpID = $("#helpID").val();
+
+    $.ajax({
+        type: 'POST',
+        url: loris.BaseURL + '/help_editor/ajax/process.php',
+        data: {
+            title: title ? title : '',
+            content: content ? content : '',
+            section: section ? section : '',
+            subsection: subsection ? subsection : '',
+            parentID: parentID ? parentID : '',
+            helpID: helpID ? helpID : '',
+        },
+        success: function() {
+            swal({
+                title: "Content update successful!",
+                type: "success",
+                confirmButtonText: "Return to " + title,
+                closeOnConfirm: false,
+            },
+            function(){
+                location.href = document.referrer;
+            });
+        },
+        error: function(xhr, errStatus, errThrown) {
+            console.log("THIS IS THE STATUS:" + errStatus);
+            console.error(errThrown);
+            swal({
+                title: "Content update unsuccessful.",
+                text: xhr.responseText,
+                type: "error",
+                confirmButtonText: "Try again",
+                closeOnConfirm: true,
+            });
+        }
+    });
 });
-function goBack() {
-    window.history.back();
-}
+});

--- a/modules/help_editor/js/help_editor_helper.js
+++ b/modules/help_editor/js/help_editor_helper.js
@@ -41,7 +41,8 @@ $("#save-help").click(function(e) {
         section = $("#section").val(),
         subsection = $("#subsection").val(),
         parentID = $("#parentID").val(),
-        helpID = $("#helpID").val();
+        helpID = $("#helpID").val(),
+        returnString = $("#return").val();
 
     $.ajax({
         type: 'POST',
@@ -58,8 +59,11 @@ $("#save-help").click(function(e) {
             swal({
                 title: "Content update successful!",
                 type: "success",
-                confirmButtonText: "Return to " + title,
+                showCancelButton: true,
+                confirmButtonText: returnString,
+                cancelButtonText: "Close",
                 closeOnConfirm: false,
+                closeOnCancel: true,
             },
             function(){
                 location.href = document.referrer;

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file contains code for editing context help section
+ * This file sets up the Edit Help Content page and form.
  *
  * PHP Version 7
  *
@@ -58,6 +58,9 @@ class Edit_Help_Content extends \NDB_Form
         if (isset($_REQUEST['helpID'])) {
             $helpID = htmlspecialchars($_REQUEST['helpID']);
         }
+        if (isset($_GET['parentID'])) {
+            $parentID = htmlspecialchars($_GET['parentID']);
+        }
         if (!empty($_REQUEST['section'])) {
             $helpID = HelpFile::hashToID(md5($_REQUEST['section']));
         }
@@ -65,9 +68,12 @@ class Edit_Help_Content extends \NDB_Form
             && $_REQUEST['subsection'] != 'undefined'
         ) {
             $helpID = HelpFile::hashToID(md5($_REQUEST['subsection']));
+            $parentID = \LORIS\help_editor\HelpFile::hashToID(md5($_GET['section']));
         }
         $this->tpl_data['section']    = $safeSection;
         $this->tpl_data['subsection'] = $safeSubsection;
+        $this->tpl_data['helpID']     = $helpID ? $helpID : '';
+        $this->tpl_data['parentID']   = $parentID ? $parentID : '';
 
         if (!empty($helpID)) {
             $help_file = HelpFile::factory($helpID);
@@ -98,119 +104,10 @@ class Edit_Help_Content extends \NDB_Form
             $defaults['content'] = 'Under Construction';
         }
 
-        if (isset($_COOKIE["LastUrl"]) ) {
-            $this->tpl_data['url'] = $_COOKIE["LastUrl"];
+        if (isset($_SERVER['HTTP_REFERER']) ) {
+            $this->tpl_data['url'] = $_SERVER['HTTP_REFERER'];
         }
         return $defaults;
-    }
-     /**
-      * Process function
-      *
-      * @param string $values the value
-      *
-      * @return void
-      */
-    function _process($values)
-    {
-        $DB = \Database::singleton();
-        //Get the default values
-
-        // Sanitize user input
-        $safeSection    = htmlspecialchars($_REQUEST['section']);
-        $safeSubsection = htmlspecialchars($_REQUEST['subsection']);
-        if (isset($_REQUEST['helpID'])) {
-            $helpID = htmlspecialchars($_REQUEST['helpID']);
-        }
-        if (isset($_REQUEST['parentID'])) {
-            $parentID = htmlspecialchars($_REQUEST['parentID']);
-        }
-
-        if (!empty($_REQUEST['section'])) {
-            $helpID = HelpFile::hashToID(md5($_REQUEST['section']));
-        }
-        if (!empty($_REQUEST['section'])
-            && $_REQUEST['subsection'] != 'undefined'
-        ) {
-            $helpID   = HelpFile::hashToID(md5($_REQUEST['subsection']));
-            $parentID = HelpFile::hashToID(md5($_REQUEST['section']));
-        }
-        if (!empty($helpID)
-            && isset($values['title'])
-            && isset($values['content'])
-        ) {
-            $help_file = HelpFile::factory($helpID);
-            // update the help file
-            $success = $help_file->update(
-                array(
-                 'topic'   => $values['title'],
-                 'content' => $values['content'],
-                 'updated' => date(
-                     'Y-m-d h:i:s',
-                     time()
-                 ),
-                )
-            );
-        } else {
-            //content does not exist insert the help file
-            if (!empty($_REQUEST['section'])
-                && $_REQUEST['subsection'] != 'undefined'
-                && empty($parentID)
-            ) {
-                //create parent help section first
-                $parentID = HelpFile::insert(
-                    array(
-                     'hash'    => md5($_REQUEST['section']),
-                     'topic'   => "",
-                     'content' => "Under construction",
-                     'created' => date(
-                         'Y-m-d h:i:s',
-                         time()
-                     ),
-                    )
-                );
-                 // check errors
-
-            }
-            if (!empty($_REQUEST['section'])
-                && $_REQUEST['subsection'] != 'undefined'
-                && !empty($parentID)
-            ) {
-
-                // insert the help file
-                $helpID = HelpFile::insert(
-                    array(
-                     'parentID' => $parentID,
-                     'hash'     => md5($_REQUEST['subsection']),
-                     'topic'    => $values['title'],
-                     'content'  => $values['content'],
-                     'created'  => date(
-                         'Y-m-d h:i:s',
-                         time()
-                     ),
-                    )
-                );
-
-            } else if (!empty($_REQUEST['section'])
-                && $_REQUEST['subsection'] == 'undefined'
-            ) {
-                //default case
-                $helpID = HelpFile::insert(
-                    array(
-                     'hash'    => md5($_REQUEST['section']),
-                     'topic'   => $values['title'],
-                     'content' => $values['content'],
-                     'created' => date(
-                         'Y-m-d h:i:s',
-                         time()
-                     ),
-                    )
-                );
-
-            }
-
-        }
-        $this->tpl_data['success'] =  true;
-
     }
 
     /**

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -67,7 +67,7 @@ class Edit_Help_Content extends \NDB_Form
         if (!empty($_REQUEST['section'])
             && $_REQUEST['subsection'] != 'undefined'
         ) {
-            $helpID = HelpFile::hashToID(md5($_REQUEST['subsection']));
+            $helpID   = HelpFile::hashToID(md5($_REQUEST['subsection']));
             $parentID = \LORIS\help_editor\HelpFile::hashToID(md5($_GET['section']));
         }
         $this->tpl_data['section']    = $safeSection;

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -68,7 +68,7 @@ class Edit_Help_Content extends \NDB_Form
             && $_REQUEST['subsection'] != 'undefined'
         ) {
             $helpID   = HelpFile::hashToID(md5($_REQUEST['subsection']));
-            $parentID = \LORIS\help_editor\HelpFile::hashToID(md5($_GET['section']));
+            $parentID = HelpFile::hashToID(md5($_GET['section']));
         }
         $this->tpl_data['section']    = $safeSection;
         $this->tpl_data['subsection'] = $safeSubsection;

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -157,7 +157,6 @@ class Help_Editor extends \NDB_Menu_Filter
             }
             $x++;
         }
-        setCookie("LastUrl", "?test_name=help_editor");
         return true;
     }
 

--- a/modules/help_editor/templates/form_edit_help_content.tpl
+++ b/modules/help_editor/templates/form_edit_help_content.tpl
@@ -33,8 +33,8 @@
         <input type="hidden" id="helpID" value="{$helpID}">
         <input type="hidden" id="parentID" value="{$parentID}">
         <input class="btn btn-sm btn-primary col-sm-offset-3" id="save-help" name="fire_away" value="Save" type="submit" />
-        <input type="button" name="reset" value="Reset" class="btn btn-sm btn-primary" onclick="location.href='{$baseurl}/help_editor/edit_help_content/?section={$section}&subsection={$subsection}'" />
+        <input type="reset" name="reset" value="Reset" class="btn btn-sm btn-primary" />
         <input class="btn btn-sm btn-primary" name="preview" value="Preview" type="button" />
-        <input class="btn btn-sm btn-primary" onclick="location.href='{$url}'" value="Return to {$module_name}" type="button" />
+        <input class="btn btn-sm btn-primary" id="return" onclick="location.href='{$url}'" value="Return to {$module_name}" type="button" />
     </div>
 </div>

--- a/modules/help_editor/templates/form_edit_help_content.tpl
+++ b/modules/help_editor/templates/form_edit_help_content.tpl
@@ -1,12 +1,5 @@
-{if $success}
-
-<p>Content was updated successful<br /></p>
-<br />
-{/if}
 <form method="post" name="edit_help_content" id="edit_help_content" enctype="multipart/form-data">
-{if not $success}
 <div class="panel panel-primary">
-   
     <div class="panel-body">
         {foreach from=$form.errors item=error}
             <font class="error">{$error}</font>
@@ -35,10 +28,13 @@
             <div class="col-xs-12"></div>
         {/foreach}
         <br>
-        <input class="btn btn-sm btn-primary col-sm-offset-3" name="fire_away" value="Save" type="submit" />
+        <input type="hidden" id="section" value="{$section}">
+        <input type="hidden" id="subsection" value="{$subsection}">
+        <input type="hidden" id="helpID" value="{$helpID}">
+        <input type="hidden" id="parentID" value="{$parentID}">
+        <input class="btn btn-sm btn-primary col-sm-offset-3" id="save-help" name="fire_away" value="Save" type="submit" />
         <input type="button" name="reset" value="Reset" class="btn btn-sm btn-primary" onclick="location.href='{$baseurl}/help_editor/edit_help_content/?section={$section}&subsection={$subsection}'" />
         <input class="btn btn-sm btn-primary" name="preview" value="Preview" type="button" />
-        {/if}
-        <input class="btn btn-sm btn-primary" onclick="goBack()" value="Return to {$module_name}" type="button" />
+        <input class="btn btn-sm btn-primary" onclick="location.href='{$url}'" value="Return to {$module_name}" type="button" />
     </div>
 </div>


### PR DESCRIPTION
Replaces https://github.com/aces/Loris/pull/3578
Fixes https://redmine.cbrain.mcgill.ca/issues/14111

- [x] Remove the confirmation page
- [x] Use an ajax call to save the content
- [x] Add swal message on error/success
- [x] Replace use of cookies with Referer header

I could only figure out how to pass the $_GET variables to the js and ajax scripts via hidden input elements on the form smarty template. Please let me know if there is a better way to do this!! It feels a little hacky but I couldn't find an alternative

<img width="1273" alt="screenshot 2018-05-07 11 49 29" src="https://user-images.githubusercontent.com/17415878/39711119-bf422d44-51ec-11e8-9e22-68687f43c85d.png">
