### PR TITLE
[Media] removed html line breaks from markdown file

### DIFF
--- a/modules/media/help/Setup.md
+++ b/modules/media/help/Setup.md
@@ -14,15 +14,20 @@ Ubuntu: $GROUP$ = www-data
 CentOS: $GROUP$ = apache
 ```
 
-To find the `user` of your web server, run:<br/> 
+To find the `user` of your web server, run:
+ 
 `ps aux | grep 'apache' | egrep -v 'grep|Ss' | awk '{ print $1 }' | sort | uniq`
 
-To find the `group` of your web server, run:<br/>
+To find the `group` of your web server, run:
+
 `ps aux | grep 'apache' | egrep -v 'grep|Ss' | awk '{ print $1 }' | sort | uniq | xargs groups`
 
-To see if your web server's user or group owns the upload path, run:<br/> 
+To see if your web server's user or group owns the upload path, run:
+ 
 `ls -ld /data/uploads | awk '{ print "user:" $3 ", group:" $4 }'`
 
-If neither owns the folder, you should run the following two commands:<br/>
-`sudo chown <unix-user>:<web-server-group> /data/uploads`<br/>
+If neither owns the folder, you should run the following two commands:>
+
+`sudo chown <unix-user>:<web-server-group> /data/uploads`>
+
 `chmod 775 /data/uploads`

--- a/modules/media/help/Setup.md
+++ b/modules/media/help/Setup.md
@@ -27,7 +27,7 @@ To see if your web server's user or group owns the upload path, run:
 `ls -ld /data/uploads | awk '{ print "user:" $3 ", group:" $4 }'`
 
 If neither owns the folder, you should run the following two commands:
-
-`sudo chown <unix-user>:<web-server-group> /data/uploads`
-
-`chmod 775 /data/uploads`
+```
+sudo chown <unix-user>:<web-server-group> /data/uploads
+sudo chmod 775 /data/uploads
+```

--- a/modules/media/help/Setup.md
+++ b/modules/media/help/Setup.md
@@ -26,8 +26,8 @@ To see if your web server's user or group owns the upload path, run:
  
 `ls -ld /data/uploads | awk '{ print "user:" $3 ", group:" $4 }'`
 
-If neither owns the folder, you should run the following two commands:>
+If neither owns the folder, you should run the following two commands:
 
-`sudo chown <unix-user>:<web-server-group> /data/uploads`>
+`sudo chown <unix-user>:<web-server-group> /data/uploads`
 
 `chmod 775 /data/uploads`


### PR DESCRIPTION
This pull request removes the html line breaks <br/> from the Setup markdown file in the media module.
