### PR TITLE
[Instrument Manager] Fix warnings related to file access permissions

### DIFF
--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -275,8 +275,8 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 return '? (File not found in filesystem)';
             }
         }
-        $fp       = fopen($filename, "r");
-        $db       = \Database::singleton();
+        $fp = fopen($filename, "r");
+        $db = \Database::singleton();
 
         while (($line = fgets($fp, 4096)) !== false) {
             $pieces = explode("{@}", $line);
@@ -367,8 +367,8 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 return '? (File not found in filesystem)';
             }
         }
-        $fp       = fopen($filename, "r");
-        $db       = \Database::singleton();
+        $fp = fopen($filename, "r");
+        $db = \Database::singleton();
 
         while (($line = fgets($fp, 4096)) !== false) {
             $pieces       = explode("{@}", $line);

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -71,7 +71,8 @@ class Instrument_Manager extends \NDB_Menu_Filter
             $writable = true;
         }
         $this->tpl_data['writable'] = $writable;
-        if ($writable && $_POST['install'] == 'Install Instrument') {
+        $install = $_POST['install'] ?? '';
+        if ($writable && $install === 'Install Instrument') {
             $db       = \Database::singleton();
             $instname = basename($_FILES['install_file']['name'], '.linst');
 
@@ -267,6 +268,13 @@ class Instrument_Manager extends \NDB_Menu_Filter
     {
         $factory  = \NDB_Factory::singleton();
         $filename = $this->path . "project/instruments/$instname.linst";
+        if (!is_readable($filename)) {
+            if (file_exists($filename)) {
+                return '? (Insufficient read permissions)';
+            } else {
+                return '? (File not found in filesystem)';
+            }
+        }
         $fp       = fopen($filename, "r");
         $db       = \Database::singleton();
 
@@ -352,6 +360,13 @@ class Instrument_Manager extends \NDB_Menu_Filter
     function checkPages($instname)
     {
         $filename = $this->path . "project/instruments/$instname.linst";
+        if (!is_readable($filename)) {
+            if (file_exists($filename)) {
+                return '? (Insufficient read permissions)';
+            } else {
+                return '? (File not found in filesystem)';
+            }
+        }
         $fp       = fopen($filename, "r");
         $db       = \Database::singleton();
 


### PR DESCRIPTION
This pull request fixes a bunch of warnings that appear if instruments are not readable by the web user. 
