### PR TITLE
initiate array inside map_cIDs() to fix console warning from the reli…

### DIFF
--- a/modules/reliability/php/reliability.class.inc
+++ b/modules/reliability/php/reliability.class.inc
@@ -14,7 +14,7 @@ namespace LORIS\reliability;
 
 //@codingStandardsIgnoreStart
 function map_cIDs($array){
-    $new_array;
+    $new_array = [];
     for($i = 0; $i < count($array); $i++){
         $element = $array[$i];
         $new_array[$element['CommentID']] = $element['reliability_center_id'];


### PR DESCRIPTION
…ability.class.inc

This pull request `Inside the reliability.class.inc the function map_cIDs() had an array that was not initiated. Fixes the Console Warning when user goes to Clinical Reliability on a fresh install of Loris.`.

See also: `Bug #14378`
