### PR TITLE
Added case for when certificationInstruments inside the getCertificat…

### DIFF
--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -116,16 +116,17 @@ class Training extends \NDB_Form
         $certificationConfig      = $config->getSetting("Certification");
         $certificationInstruments = $certificationConfig['CertificationInstruments'];
         $instruments = array();
-        if (trim($certificationInstruments) != "") {
+
+        if (isset($certificationInstruments['test'])) {
             $certificationInstruments['test']
                 = \Utility::toArray($certificationInstruments['test']);
             foreach ($certificationInstruments['test'] as $certificationInstrument) {
                 $test_key = $certificationInstrument['@']['value'];
                 $testID   = $DB->selectOne(
                     "SELECT ID
-                 FROM test_names
-                 WHERE Test_name
-                 LIKE '%$test_key%'"
+             FROM test_names
+             WHERE Test_name
+             LIKE '%$test_key%'"
                 );
                 $instruments[$testID] = $certificationInstrument['#'];
             }

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -122,7 +122,7 @@ class Training extends \NDB_Form
                 = \Utility::toArray($certificationInstruments['test']);
             foreach ($certificationInstruments['test'] as $certificationInstrument) {
                 $test_key = $certificationInstrument['@']['value'];
-                $testID   = $DB->selectOne(
+                $testID   = $DB->pselectOne(
                     "SELECT ID
                            FROM test_names
                            WHERE Test_name

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -115,19 +115,20 @@ class Training extends \NDB_Form
         // Get the instruments requiring certification from the config
         $certificationConfig      = $config->getSetting("Certification");
         $certificationInstruments = $certificationConfig['CertificationInstruments'];
-        $certificationInstruments['test']
-            = \Utility::toArray($certificationInstruments['test']);
         $instruments = array();
-
-        foreach ($certificationInstruments['test'] as $certificationInstrument) {
-            $test_key = $certificationInstrument['@']['value'];
-            $testID   = $DB->selectOne(
-                "SELECT ID
+        if (trim($certificationInstruments) != "") {
+            $certificationInstruments['test']
+                = \Utility::toArray($certificationInstruments['test']);
+            foreach ($certificationInstruments['test'] as $certificationInstrument) {
+                $test_key = $certificationInstrument['@']['value'];
+                $testID   = $DB->selectOne(
+                    "SELECT ID
                  FROM test_names
                  WHERE Test_name
                  LIKE '%$test_key%'"
-            );
-            $instruments[$testID] = $certificationInstrument['#'];
+                );
+                $instruments[$testID] = $certificationInstrument['#'];
+            }
         }
 
         return $instruments;

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -124,9 +124,9 @@ class Training extends \NDB_Form
                 $test_key = $certificationInstrument['@']['value'];
                 $testID   = $DB->selectOne(
                     "SELECT ID
-             FROM test_names
-             WHERE Test_name
-             LIKE '%$test_key%'"
+                           FROM test_names
+                           WHERE Test_name
+                           LIKE '%$test_key%'"
                 );
                 $instruments[$testID] = $certificationInstrument['#'];
             }


### PR DESCRIPTION
…ionInstruments() function has empty string and fixes console warning

This pull request `Fresh install of Loris will output a console warning when going to Clinical->Training. Fixed by checking if the variable $certificationInstruments is a blank string inside the function getCertificationInstruments() and resulting in the warning as no array was created.`.

See also: `Bug #14380`
