### PR TITLE
Reports statistics demographic statistics fix

### DIFF
--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -28,11 +28,8 @@ class Stats_Demographic extends \NDB_Form
 
     /**
      * The default params
-     *
-     * @var    array
-     * @access private
      */
-    var $params = null;
+    protected $params = null;
 
     /**
      * Checking user's permission

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -25,6 +25,15 @@ namespace LORIS\statistics;
  */
 class Stats_Demographic extends \NDB_Form
 {
+
+    /**
+     * The default params
+     *
+     * @var    array
+     * @access private
+     */
+    var $params = null;
+
     /**
      * Checking user's permission
      *
@@ -226,11 +235,6 @@ class Stats_Demographic extends \NDB_Form
         $this->tpl_data['Projects']    = $projects;
         $this->tpl_data['Subprojects'] = $subprojects;
         $this->tpl_data['Visits']      = $Visits;
-
-        // PREVENT Undefined property Console Output
-        if (!isset($this->params)) {
-            $this->params = null;
-        }
 
         //REGISTERED CANDIDATES ROW
         $result = $DB->pselect(

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -227,6 +227,11 @@ class Stats_Demographic extends \NDB_Form
         $this->tpl_data['Subprojects'] = $subprojects;
         $this->tpl_data['Visits']      = $Visits;
 
+        // PREVENT Undefined property Console Output
+        if (!isset($this->params)) {
+            $this->params = null;
+        }
+
         //REGISTERED CANDIDATES ROW
         $result = $DB->pselect(
             "SELECT s.subprojectid as rowid,


### PR DESCRIPTION
This pull request `Prevents console warning when going to Reports->Statistics and clicking on the Demographic Statistics when using a fresh installed version of Loris`. It `becomes fixed by checking if $params has been set and prevent undefined property.`.

See also: `Bug #14381`
