### PR TITLE
stats_behavioural.class.inc setup() function may not initiate  and pr…

### DIFF
--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -108,8 +108,10 @@ class Stats_Behavioural extends \NDB_Form
             $Param_Project       ='AND (c.ProjectID IS NULL OR c.ProjectID=:pid) ';
             $this->params['pid'] = htmlspecialchars($_REQUEST['BehaviouralProject']);
         } else {
-            $Param_Project = '';
+            $currentProject = '';
+            $Param_Project  = '';
         }
+
         $subprojects = \Utility::getSubprojectsForProject($currentProject);
 
         $this->tpl_data['Subprojects'] = $subprojects;
@@ -125,6 +127,11 @@ class Stats_Behavioural extends \NDB_Form
 
         $Visits = \Utility::getExistingVisitLabels($currentProject);
         $this->tpl_data['Visits'] = $Visits;
+
+        // PREVENT Undefined property Console Output
+        if (!isset($this->params)) {
+            $this->params = null;
+        }
 
         //---- BEHAVIORAL STATS -----
         $result = $DB->pselect(


### PR DESCRIPTION
…event undefined property from ->params

This pull request `fixes console warnings as the $currentProject may not be initiated inside the setup() function in the stats_behavioral.class.inc and added check if $this->params is set to prevent "undefined property" console output`.

See also: `Bug #14382`
