### PR TITLE
Fix signature compatibility errors detected by phan

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -8,9 +8,7 @@ return [
 	// This is false on the assumption that that's a typo.
 	// It doesn't seem to have any effect on LORIS's codebase anyways.
 	"quick_mode" => false,
-	// FIXME: analyze signature compatibility should be true, but
-	// there's too many other things to fix first.
-	"analyze_signature_compatibility" => false,
+	"analyze_signature_compatibility" => true,
 	// FIXME: allow_missing_properties should be false, but there's
 	// too many other things to fix first.
 	"allow_missing_properties" => true,
@@ -51,7 +49,7 @@ return [
 	"directory_list" => [
 		/* This doesn't include php/installer, because there's
 		   (intentionally) classes in the installer namespace
-                   which redeclare classes from php/libraries, in order
+           which redeclare classes from php/libraries, in order
 		   to bootstrap the installer before the config/database
 		   is set up */
 		"php/libraries",

--- a/htdocs/api/v0.0.1/Login.php
+++ b/htdocs/api/v0.0.1/Login.php
@@ -149,11 +149,11 @@ class Login extends APIBase
      * Since this isn't a real resource, it just returns the
      * empty string.
      *
-     * @return empty string
+     * @return string
      */
     function calculateETag()
     {
-        return;
+        return "";
     }
 
     /**

--- a/htdocs/api/v0.0.2/Login.php
+++ b/htdocs/api/v0.0.2/Login.php
@@ -149,11 +149,11 @@ class Login extends APIBase
      * Since this isn't a real resource, it just returns the
      * empty string.
      *
-     * @return empty string
+     * @return string
      */
     function calculateETag()
     {
-        return;
+        return "";
     }
 
     /**

--- a/htdocs/api/v0.0.2/projects/Project.php
+++ b/htdocs/api/v0.0.2/projects/Project.php
@@ -85,12 +85,12 @@ class Project extends \Loris\API\APIBase
     /**
      * Handles a GET request for a project data
      *
-     * @return none but populates $this->JSON
+     * @return void
      */
     function handleGET()
     {
         if (!empty($this->JSON)) {
-            return $this->JSON;
+            return;
         }
         $JSONArray = [
                       "Meta" => [

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -148,8 +148,6 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
                               );
 
         $this->tpl_data['citation_policy'] = $config->getSetting('citation_policy');
-
-        return true;
     }
 
     /**
@@ -205,8 +203,6 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
         $this->addBasicDate('addstart_date', 'Start Date:', $dateOptions);
         $this->addBasicDate('addend_date', 'End Date:', $dateOptions);
         $this->addSelect('addpresent', 'Present?', $present);
-
-        return true;
     }
 
     /**

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -101,7 +101,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      * Sets up all the class variables needed for the
      * acknowledgements menu filter
      *
-     * @return true on success
+     * @return void
      */
     function _setupVariables()
     {
@@ -157,7 +157,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -46,7 +46,7 @@ class Candidate_List extends \NDB_Menu_Filter
      * Sets up all the class variables needed for the candidate_list menu
      * filter
      *
-     * @return true on success
+     * @return void
      */
     function _setupVariables()
     {
@@ -198,7 +198,7 @@ class Candidate_List extends \NDB_Menu_Filter
     /**
      * Create the form for the candidate_list menu page
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -52,12 +52,11 @@ class Candidate_Parameters extends \NDB_Form
     /**
      * Override default behaviour, since the page is loaded from index.js
      *
-     * @return void
-     * @access public
+     * @return string
      */
     function display()
     {
-        return null;
+        return "";
     }
 
     /**

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -46,7 +46,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
      *
      * @param array $values The values submitted from the form
      *
-     * @return none
+     * @return bool
      */
     function _process($values)
     {
@@ -179,7 +179,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
      * Sets up the class variables required to render the query for the
      * conflict resolver
      *
-     * @return none
+     * @return void
      */
     function _setupVariables()
     {
@@ -318,7 +318,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     /**
      * Sets up the smarty menu filter items for the conflict resolver
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -45,7 +45,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     /**
      * Sets up the query for the resolved_conflicts submodule
      *
-     * @return none
+     * @return void
      */
     function _setupVariables()
     {
@@ -176,7 +176,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     /**
      * Adds the form elements required for the filter
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/data_integrity_flag/php/data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/data_integrity_flag.class.inc
@@ -44,8 +44,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
     /**
      * Displays the menu page
      *
-     * @return void
-     * @access public
+     * @return string
      */
     function display()
     {
@@ -106,7 +105,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
     /**
      * Build a list of media to display in Data Table
      *
-     * @return bool
+     * @return void
      * @throws \DatabaseException
      */
     function _setupVariables()
@@ -144,7 +143,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
-     * @return a json encoded string of the headers and data from this table
+     * @return string a json encoded string of the headers and data from this table
      */
     function toJSON()
     {

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -29,7 +29,7 @@ class Data_Release extends \NDB_Menu_Filter
     /**
      * Setup variables
      *
-     * @return None
+     * @return void
      */
     function _setupVariables()
     {

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -42,7 +42,7 @@ class Data_Team_Helper extends \NDB_Form
     /**
      * Sets up main parameters
      *
-     * @return NULL
+     * @return void
      */
     function setup()
     {

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -46,8 +46,7 @@ class Datadict extends \NDB_Menu_Filter
     * Setup variables function
     *
     * @note   Setup variables function
-    * @return bool
-    * @access private
+    * @return void
     */
     function _setupVariables()
     {
@@ -84,7 +83,7 @@ class Datadict extends \NDB_Menu_Filter
     /**
     * Set Filter Form
     *
-    * @return none
+    * @return void
     */
     function setup()
     {

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -45,7 +45,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
      * Set up the variables required by NDB_Menu_Filter class for constructing
      * a query
      *
-     * @return null
+     * @return void
      */
     function _setupVariables()
     {
@@ -102,7 +102,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
-     * @return a json encoded string of the headers and data from this table
+     * @return string a json encoded string of the headers and data from this table
      */
     function toJSON()
     {
@@ -161,7 +161,7 @@ class Dicom_Archive extends \NDB_Menu_Filter
      * Overrides base getJSDependencies() to add support for dicom specific
      * React column formatters.
      *
-     * @return an array of extra JS files that this page depends on
+     * @return array of extra JS files that this page depends on
      */
     function getJSDependencies()
     {

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -44,7 +44,7 @@ class ViewDetails extends \NDB_Form
     /**
     * Sets up main parameters
     *
-    * @return NULL
+    * @return void
     */
     function setup()
     {
@@ -298,7 +298,7 @@ class ViewDetails extends \NDB_Form
     /**
      * Overrides base getJSDependencies() to add additional JS files
      *
-     * @return an array of extra JS files that this page depends on
+     * @return array of extra JS files that this page depends on
      */
     function getJSDependencies()
     {

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -46,7 +46,7 @@ class Document_Repository extends \NDB_Menu_Filter
     /**
      * Function _setupVariables
      *
-     * @return none
+     * @return void
      */
     function _setupVariables()
     {
@@ -125,7 +125,7 @@ class Document_Repository extends \NDB_Menu_Filter
     /**
      * Set filter form function
      *
-     * @return bool
+     * @return void
      */
     function _setFilterForm()
     {
@@ -290,11 +290,11 @@ class Document_Repository extends \NDB_Menu_Filter
      * filter table, it doesn't
      * use pagination
      *
-     * @return void
+     * @return array
      */
     function _getList()
     {
-        return;
+        return array();
     }
 
     /**
@@ -387,9 +387,9 @@ class Document_Repository extends \NDB_Menu_Filter
     /**
      * SetDataTableRows function
      *
-     * @param string $count the value of count
+     * @param int $count the number of data rows
      *
-     * @return bool
+     * @return void
      */
     function _setDataTableRows($count)
     {

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -42,7 +42,7 @@ class Examiner extends \NDB_Menu_Filter_Form
     /**
      * Sets the menu filter class variables.
      *
-     * @return boolean
+     * @return void
      */
     function _setupVariables()
     {
@@ -130,7 +130,7 @@ class Examiner extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return null
+     * @return void
      */
     function setup()
     {
@@ -206,7 +206,7 @@ class Examiner extends \NDB_Menu_Filter_Form
      *
      * @param array $values add examiner form values
      *
-     * @return void
+     * @return bool
      */
     function _process($values)
     {
@@ -267,6 +267,7 @@ class Examiner extends \NDB_Menu_Filter_Form
         );
 
         header("Location: {$baseurl}/examiner/", true, 303);
+        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -58,8 +58,7 @@ class CNV_Browser extends \NDB_Menu_Filter
     /**
      * Function _setupVariables
      *
-     * @note   overloaded function
-     * @return bool
+     * @return void
     */
     function _setupVariables()
     {
@@ -209,7 +208,7 @@ class CNV_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -60,8 +60,7 @@ class CpG_Browser extends \NDB_Menu_Filter
     /**
      * Function _setupVariables
      *
-     * @note   overloaded function
-     * @return bool
+     * @return void
     */
     function _setupVariables()
     {
@@ -253,7 +252,7 @@ class CpG_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -60,7 +60,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
      * Function _setupVariables
      *
      * @note   overloaded function
-     * @return bool
+     * @return void
     */
     function _setupVariables()
     {
@@ -190,7 +190,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/genomic_browser/php/genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/genomic_file_uploader.class.inc
@@ -48,8 +48,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
     /**
      * Function _setupVariables
      *
-     * @note   overloaded function
-     * @return bool
+     * @return void
     */
     function _setupVariables()
     {
@@ -111,7 +110,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/genomic_browser/php/gwas_browser.class.inc
+++ b/modules/genomic_browser/php/gwas_browser.class.inc
@@ -52,8 +52,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
     /**
      * Function _setupVariables
      *
-     * @note   overloaded function
-     * @return bool
+     * @return void
     */
     function _setupVariables()
     {
@@ -118,7 +117,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -59,8 +59,7 @@ class SNP_Browser extends \NDB_Menu_Filter
     /**
      * Function _setupVariables
      *
-     * @note   overloaded function
-     * @return bool
+     * @return void
     */
     function _setupVariables()
     {
@@ -233,7 +232,7 @@ class SNP_Browser extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -42,7 +42,7 @@ class Edit_Help_Content extends \NDB_Form
      /**
       * Returns default help content of the page
       *
-      * @return default array
+      * @return array
       */
     function _getDefaults()
     {
@@ -105,7 +105,7 @@ class Edit_Help_Content extends \NDB_Form
      /**
       * Process function
       *
-      * @param string $values the value
+      * @param array $values the values being processed
       *
       * @return void
       */

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -40,7 +40,7 @@ class Help_Editor extends \NDB_Menu_Filter
      /**
        * Setup Variables function
        *
-       * @return bool
+       * @return void
        */
     function _setupVariables()
     {
@@ -89,7 +89,7 @@ class Help_Editor extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {
@@ -98,15 +98,14 @@ class Help_Editor extends \NDB_Menu_Filter
         // add form elements
         $this->addBasicText('topic', 'Help topic:');
         $this->addBasicText('keyword', 'Search keyword');
-
-        return true;
     }
+
      /**
        * SetDataTableRows
        *
-       * @param string $count the value of count
+       * @param int $count the value of count
        *
-       * @return bool
+       * @return void
        */
     function _setDataTableRows($count)
     {

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -50,7 +50,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
      * Set up the variables required by NDB_Menu_Filter class for constructing
      * a query
      *
-     * @return null
+     * @return void
      */
     function _setupVariables()
     {
@@ -290,7 +290,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
     /**
      * Setup $this->tpl_data for use by Smarty
      *
-     * @return null
+     * @return void
      */
     function setup()
     {
@@ -422,7 +422,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
      * @param string $field        filter field
      * @param string $val          filter value
      *
-     * @return null
+     * @return string the new query
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
@@ -473,7 +473,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
      *         will be used for the Navigation Links in  the viewSession
      *         page.
      *
-     * @return associative array
+     * @return array
      */
     function toArray()
     {

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -78,7 +78,7 @@ class ViewSession extends \NDB_Form
     /**
      * Sets up main parameters
      *
-     * @return NULL
+     * @return void
      */
     function setup()
     {
@@ -739,7 +739,7 @@ class ViewSession extends \NDB_Form
     /**
      * Get js Dependencies
      *
-     * @return string
+     * @return array
      */
     function getJSDependencies()
     {

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -57,7 +57,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     /**
      * Sets up the Filter Variables
      *
-     * @return boolean
+     * @return void
      */
     function _setupVariables()
     {
@@ -106,7 +106,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      /**
      * Sets up the smarty menu filter items for the imaging uploader
      *
-     * @return none
+     * @return void
      */
     function setup()
     {
@@ -658,7 +658,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
-     * @return a json encoded string of the headers and data from this table
+     * @return string a json encoded string of the headers and data from this table
      */
     function toJSON()
     {

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -35,7 +35,7 @@ class Instrument_Builder extends \NDB_Form
      * Tests that, when loading the Instrument builder module, some
      * text appears in the body.
      *
-     * @return void
+     * @return bool
      */
     function _hasAccess()
     {

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -31,8 +31,7 @@ class Issue extends \NDB_Form
     /**
     * Override default behaviour, since the page is loaded from issueIndex.js
     *
-    * @return void
-    * @access public
+    * @return string
     */
     function display()
     {

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -297,7 +297,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      * @param string $field        filter field
      * @param string $val          filter value
      *
-     * @return null
+     * @return string
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
@@ -341,7 +341,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      *         will be used for the Navigation Links in  the viewSession
      *         page.
      *
-     * @return associative array
+     * @return array
      */
     function toArray()
     {

--- a/modules/issue_tracker/php/my_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/my_issue_tracker.class.inc
@@ -35,7 +35,7 @@ class My_Issue_Tracker extends \NDB_Menu_Filter_Form
      * Set up the variables required by NDB_Menu_Filter class for constructing
      * a query
      *
-     * @return null
+     * @return void
      */
     function _setupVariables()
     {
@@ -284,7 +284,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      * @param string $field        filter field
      * @param string $val          filter value
      *
-     * @return null
+     * @return string
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
@@ -350,7 +350,7 @@ WHERE Parent IS NOT NULL ORDER BY Label",
      *         will be used for the Navigation Links in  the viewSession
      *         page.
      *
-     * @return associative array
+     * @return array
      */
     function toArray()
     {

--- a/modules/issue_tracker/php/resolved_issue_tracker.class.inc
+++ b/modules/issue_tracker/php/resolved_issue_tracker.class.inc
@@ -34,7 +34,7 @@ class Resolved_Issue_Tracker extends \NDB_Menu_Filter_Form
      * Set up the variables required by NDB_Menu_Filter class for constructing
      * a query
      *
-     * @return null
+     * @return void
      */
     function _setupVariables()
     {
@@ -285,7 +285,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
      * @param string $field        filter field
      * @param string $val          filter value
      *
-     * @return null
+     * @return string
      */
     function _addValidFilters($prepared_key, $field, $val)
     {
@@ -330,7 +330,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
      *         will be used for the Navigation Links in  the viewSession
      *         page.
      *
-     * @return associative array
+     * @return array
      */
     function toArray()
     {

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -146,7 +146,7 @@ class PasswordExpiry extends \NDB_Form
      *
      * @param array $values The values that were submitted to the page.
      *
-     * @return none
+     * @return void
      */
     function _process($values)
     {

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -57,7 +57,7 @@ class Media extends \NDB_Menu_Filter
     /**
      * Create a form to filter media by various criteria
      *
-     * @return bool
+     * @return void
      */
     function setup()
     {
@@ -134,7 +134,7 @@ class Media extends \NDB_Menu_Filter
     /**
      * Build a list of media to display in Data Table
      *
-     * @return bool
+     * @return void
      * @throws \DatabaseException
      */
     function _setupVariables()
@@ -219,7 +219,7 @@ class Media extends \NDB_Menu_Filter
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
-     * @return a json encoded string of the headers and data from this table
+     * @return string a json encoded string of the headers and data from this table
      */
     function toJSON()
     {

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -46,7 +46,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
     /**
      * Set up the class variables and query to generate the menu filter
      *
-     * @return none but as a side-effect modify internal class variables
+     * @return void but as a side-effect modify internal class variables
      */
     function _setupVariables()
     {
@@ -127,7 +127,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -43,9 +43,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
     /**
      * Process function
      *
-     * @param string $values the value of values
+     * @param array $values the values being processed
      *
-     * @return boolean true if the user is permitted to see violated scans
+     * @return bool true if the user is permitted to see violated scans
      */
     function _process($values)
     {
@@ -154,7 +154,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
      * Set up the class and smarty variables to use for the menu filter to
      * generate the proper query for the menu filter
      *
-     * @return none
+     * @return void
      */
     function _setupVariables()
     {
@@ -339,7 +339,6 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                               );
 
         $this->EqualityFilters[] = 'v.Site';
-        return true;
     }
 
     /**
@@ -347,7 +346,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -42,9 +42,9 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
     /**
      * Process function
      *
-     * @param string $values the value of values
+     * @param array $values the value of values
      *
-     * @return boolean true if the user is permitted to see violated scans
+     * @return bool true if the user is permitted to see violated scans
      */
     function _process($values)
     {
@@ -143,7 +143,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
      * Set up the class and smarty variables to use for the menu filter to
      * generate the proper query for the menu filter
      *
-     * @return none
+     * @return void
      */
     function _setupVariables()
     {
@@ -316,14 +316,15 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                                'v.SeriesUID',
                                'v.Resolved',
                               );
-        return true;
+        return;
     }
+
     /**
      * Does the setup required for this page. By default, sets up elements
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/reliability/php/reliability.class.inc
+++ b/modules/reliability/php/reliability.class.inc
@@ -58,7 +58,6 @@ class Reliability extends \NDB_Menu_Filter
         }
         return false;
     }
-//@codingStandardsIgnoreEnd
     /**
      * GetSiteID Load
      *
@@ -78,9 +77,8 @@ class Reliability extends \NDB_Menu_Filter
     /**
      * _SetupVariables function
      *
-     * @return string
+     * @return void
      */
-//@codingStandardsIgnoreStart
     function _setupVariables()
     {
         $user =& \User::singleton();
@@ -188,7 +186,7 @@ class Reliability extends \NDB_Menu_Filter
                                'ProjectID'             => 'candidate.ProjectID',
                                     // 'Lock_record' => 'session.Lock_record'
                               );
-        return true;
+        return;
     }
 
     /**
@@ -722,7 +720,7 @@ class Reliability extends \NDB_Menu_Filter
     /**
      * Override toJSON to append a calculated field to the default JSON object
      *
-     * @return a json encoded string of the headers and data from this table
+     * @return string a json encoded string of the headers and data from this table
      */
     function toJSON()
     {

--- a/modules/server_processes_manager/php/defaultdatabaseprovider.class.inc
+++ b/modules/server_processes_manager/php/defaultdatabaseprovider.class.inc
@@ -28,7 +28,7 @@ class DefaultDatabaseProvider implements IDatabaseProvider
     /**
      * Gets access to the database through the Database::singleton() method.
      *
-     * @return Database an instance of the database.
+     * @return \Database an instance of the database.
      * @throws \DatabaseException if connection to the database cannot be established
      */
     public function getDatabase()

--- a/modules/server_processes_manager/php/idatabaseprovider.class.inc
+++ b/modules/server_processes_manager/php/idatabaseprovider.class.inc
@@ -28,7 +28,7 @@ interface IDatabaseProvider
     /**
       * Gets a database object used to access the database.
       *
-      * @return a database object used to access the database.
+      * @return \Database object used to access the database.
       */
     function getDatabase();
 }

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -42,7 +42,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
     /**
      * Sets up the filter and result table layout.
      *
-     * @return bool true if the set up is successful, false otherwise.
+     * @return void
      */
     function _setupVariables()
     {
@@ -81,7 +81,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
                                'userid' => 'userid',
                               );
 
-        return true;
+        return;
     }
 
 
@@ -90,7 +90,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {
@@ -100,7 +100,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
         $this->addBasicText('type', 'Type:');
         $this->addBasicText('userid', 'UserId:');
 
-        return true;
+        return;
     }
     /**
      * Gathers JS dependecies and merge them with the parent

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -130,7 +130,7 @@ class Statistics_DD_Site extends statistics_site
      * @param string $projectID  the value of projectID
      * @param string $instrument the value of instrument
      *
-     * @return string
+     * @return array
      */
     function _getResults($centerID, $projectID, $instrument)
     {
@@ -150,7 +150,7 @@ class Statistics_DD_Site extends statistics_site
                 AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID",
             $this->query_vars
         );
-            return $result;
+        return $result;
     }
 
     /**

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -87,7 +87,7 @@ class Statistics_Mri_Site extends Statistics_Site
      * @param string $projectID the value of projectID
      * @param string $issue     the value of issue
      *
-     * @return void
+     * @return array
      */
     function _getResults($centerID, $projectID, $issue)
     {

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -121,7 +121,7 @@ class Statistics_Site extends \NDB_Form
      * @param string $projectID  the value of projectID
      * @param string $instrument the value of instrument
      *
-     * @return void
+     * @return array
      */
     function _getResults($centerID, $projectID, $instrument)
     {

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -42,7 +42,7 @@ class AddSurvey extends \NDB_Form
     /**
      * Return default values for QuickForm elements on this page
      *
-     * @return associative array of FieldName => Default Value mapping
+     * @return array (associative) of FieldName => Default Value mapping
      */
     function _getDefaults()
     {

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -41,7 +41,7 @@ class Survey_Accounts extends \NDB_Menu_Filter
      * Setup internal class variables which are required by NDB_Meny_Filter
      * for generating the query which the table data is based on
      *
-     * @return none
+     * @return void
      */
     function _setupVariables()
     {
@@ -90,7 +90,7 @@ class Survey_Accounts extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -69,7 +69,7 @@ class Timepoint_List extends \NDB_Menu
     /**
      * Setup function
      *
-     * @return null
+     * @return void
      */
     function setup()
     {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -72,7 +72,7 @@ class Edit_User extends \NDB_Form
     /**
      * Computes the initial values this page will be filled with.
      *
-     * @return the default values for the initial state of this page.
+     * @return array the default values for the initial state of this page.
      */
     function _getDefaults()
     {

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -40,7 +40,7 @@ class My_Preferences extends \NDB_Form
     /**
      * Computes the initial values this page will be filled with.
      *
-     * @return the default values for the initial state of this page.
+     * @return array the default values for the initial state of this page.
      */
     function _getDefaults()
     {

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -42,8 +42,7 @@ class User_Accounts extends \NDB_Menu_Filter
     * Setup Variables
     *
     * @note   Setup Variables
-    * @return bool
-    * @access private
+    * @return void
     */
     function _setupVariables()
     {
@@ -90,7 +89,6 @@ class User_Accounts extends \NDB_Menu_Filter
                                'email'     => 'users.Email',
                                'pending'   => 'users.Pending_approval',
                               );
-        return true;
     }
 
     /**
@@ -98,7 +96,7 @@ class User_Accounts extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @return none
+     * @return void
      */
     function setup()
     {

--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -28,10 +28,10 @@ class AnonymousUser extends \User
     /**
      * An anonymous user is not a member of any site.
      *
-     * @return array of site names
+     * @return string The empty string
      */
-    public function getSiteNames() : array
+    public function getSiteNames() : string
     {
-        return array();
+        return "";
     }
 }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2265,12 +2265,14 @@ class LorisFormElement
     }
 
     /**
-     * Stub. Does nothing.
+     * Stub. Does nothing. Child classes may return nearly any type
+     * as relevant for the value of their element type.
      *
-     * @return void
+     * @return array|string|bool|null
      */
     function getValue()
     {
+        return null;
     }
 };
 
@@ -2332,7 +2334,8 @@ class LorisFormFileElement extends LorisFormElement
      * Extracts the value of the file as represented in PHP $_FILES
      * superglobal. This seems to be how QuickForm handled it.
      *
-     * @return array of the form used by $_FILES superglobal
+     * @return array|false of the form used by $_FILES superglobal or false
+     *         on failure
      */
     function getValue()
     {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -361,10 +361,9 @@ class NDB_BVL_Instrument extends NDB_Page
 
 
     /**
-     * Method to display the form - usually not overridden as it
-     * includes all the base code that any instrument will require.
+     * Method to display the form for an instrument
      *
-     * @return void
+     * @return string
      * @access public
      */
     function display()
@@ -493,7 +492,7 @@ class NDB_BVL_Instrument extends NDB_Page
      * Attempts to validate the form (using the defined rules) and
      * saves the validated data into the database
      *
-     * @return false if failure to save data
+     * @return bool false if failure to save data
      * @access public
      */
     function save()
@@ -1139,8 +1138,8 @@ class NDB_BVL_Instrument extends NDB_Page
      * @param array $elements The value of all the elements on the current page
      *                        to validate.
      *
-     * @return associative array of errors (fieldname => errormessage) or true
-     *         if no errors.
+     * @return array|true associative array of errors (fieldname => errormessage)
+     *         or true if no errors.
      */
     function XINValidate($elements)
     {
@@ -1210,7 +1209,7 @@ class NDB_BVL_Instrument extends NDB_Page
      * @param string $group   Empty if a non-grouped element is registering the rule.
      *                        Otherwise, name of the group registering the rule.
      *
-     * @return none
+     * @return void
      */
     function XINRegisterRule($elname, $rules, $message="", $group="")
     {

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -146,7 +146,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      * @param array $elements The value of all the elements on the current page
      *                        to validate.
      *
-     * @return associative array of errors (fieldname => errormessage) or true
+     * @return array associative array of errors (fieldname => errormessage) or true
      *         if no errors.
      */
     function XINValidate($elements)
@@ -374,7 +374,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
     * @param string $group   Empty if a non-grouped element is registering the rule.
     *                        Otherwise, name of the group registering the rule.
     *
-    * @return none
+    * @return void
     */
     function XINRegisterRule($elname, $rules, $message="", $group="")
     {
@@ -770,7 +770,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      *                         data URL, so we shouldn't check that the file exists
      *                         on the filesystem. (Used by preview)
      *
-     * @return null Registers all instrument rules as a side-effect.
+     * @return void but registers all instrument rules as a side-effect.
      */
     function loadInstrumentRules($filename, $base64 = false)
     {

--- a/php/libraries/NDB_BVL_Instrument_instrument_preview.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_instrument_preview.class.inc
@@ -34,7 +34,7 @@ class NDB_BVL_Instrument_Instrument_Preview
      *
      * @return void
      */
-    function setup($commentID, $page)
+    function setup($commentID=null, $page=null)
     {
         $this->commentID = $commentID;
         $this->page      = $page;
@@ -69,7 +69,7 @@ class NDB_BVL_Instrument_Instrument_Preview
     /**
      * Overwrites the save function to not save data since this is only a preview.
      *
-     * @return none
+     * @return bool
      */
     function save()
     {
@@ -92,7 +92,7 @@ class NDB_BVL_Instrument_Instrument_Preview
                 }
             }
         }
-        return;
+        return false;
     }
 
     /**
@@ -101,7 +101,7 @@ class NDB_BVL_Instrument_Instrument_Preview
      * @param array $values Unused, but required so that function as same signature
      *                      as base class
      *
-     * @return none
+     * @return void
      */
     function _save($values)
     {
@@ -113,7 +113,7 @@ class NDB_BVL_Instrument_Instrument_Preview
      *
      * @param string $status ignored
      *
-     * @return none
+     * @return void
      */
     function _setDataEntryCompletionStatus($status)
     {

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -111,7 +111,7 @@ class NDB_Menu extends NDB_Page
     /**
      * Displays the menu page
      *
-     * @return void
+     * @return string
      * @access public
      */
     function display()

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -689,7 +689,7 @@ class NDB_Menu_Filter extends NDB_Menu
     /**
      * Displays the menu page
      *
-     * @return void
+     * @return string
      * @access public
      */
     function display()
@@ -747,7 +747,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * Suitable for serializing to JSON, CSV, etc..
      *
-     * @return associative array
+     * @return array
      */
     function toArray()
     {
@@ -775,7 +775,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
-     * @return a json encoded string of the headers and data from this table
+     * @return string a json encoded string of the headers and data from this table
      */
     function toJSON()
     {

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -86,8 +86,7 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
      *
      * @param array $values form values
      *
-     * @return void
-     * @access private
+     * @return bool true if successful
      */
     function _process($values)
     {

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -41,7 +41,7 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Reference to the HTML QuickForm
      *
-     * @var LorisForm
+     * @var \LorisForm
      */
     var $form;
 
@@ -684,7 +684,7 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Displays the form
      *
-     * @return a string of the content to be inserted into the template
+     * @return string of the content to be inserted into the template
      */
     function display()
     {

--- a/php/libraries/NDB_Reliability.class.inc
+++ b/php/libraries/NDB_Reliability.class.inc
@@ -86,7 +86,7 @@ class NDB_Reliability extends NDB_Form
     /**
      * Displays the form
      *
-     * @return void
+     * @return string
      * @access public
      */
     function display()

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -194,7 +194,7 @@ class Project
      * @note If the database value is null then the return value will be the sum of
      * all this project's subproject recruitment target.
      *
-     * @return int This project's name
+     * @return int
      */
     public function getRecruitmentTarget() : int
     {

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -194,15 +194,15 @@ class Project
      * @note If the database value is null then the return value will be the sum of
      * all this project's subproject recruitment target.
      *
-     * @return string This project's name
+     * @return int This project's name
      */
-    public function getRecruitmentTarget()
+    public function getRecruitmentTarget() : int
     {
         if (empty($this->_recruitmentTarget)) {
             $total = array_reduce(
                 $this->getSubprojects(),
                 function ($carry, $item) {
-                    return $carry + $item->_recruitmentTarget;
+                    return (int )($carry + $item->_recruitmentTarget);
                 },
                 0
             );
@@ -210,7 +210,7 @@ class Project
             // database.
             $this->_recruitmentTarget = $total;
         }
-        return $this->_recruitmentTarget;
+        return (int )$this->_recruitmentTarget;
     }
 
     /**

--- a/php/libraries/ProjectDefault.class.inc
+++ b/php/libraries/ProjectDefault.class.inc
@@ -65,15 +65,15 @@ class ProjectDefault extends Project
     /**
      * Get the project's recruitment target.
      *
-     * @return integer The sum of all subprojects recruitment target
+     * @return int The sum of all subprojects recruitment target
      */
-    public function getRecruitmentTarget()
+    public function getRecruitmentTarget() : int
     {
         if (empty($this->recruitmentTarget)) {
             $total = array_reduce(
                 $this->getSubprojects(),
                 function ($carry, $item) {
-                    return $carry + $item->recruitmentTarget;
+                    return (int )($carry + $item->recruitmentTarget);
                 },
                 0
             );
@@ -81,7 +81,7 @@ class ProjectDefault extends Project
             // database.
             $this->recruitmentTarget = $total;
         }
-        return $this->recruitmentTarget;
+        return (int) $this->recruitmentTarget;
     }
 
     /**

--- a/src/Http/EmptyStream.php
+++ b/src/Http/EmptyStream.php
@@ -57,10 +57,11 @@ class EmptyStream implements \Psr\Http\Message\StreamInterface
     /**
      * Stub to implements PSR7 StreamInterface. No-op
      *
-     * @return void
+     * @return null
      */
     public function detach()
     {
+        return null;
     }
 
     /**
@@ -141,11 +142,11 @@ class EmptyStream implements \Psr\Http\Message\StreamInterface
      *
      * @param string $string The string to write to the stream
      *
-     * @return void
+     * @return int The number of bytes written (always 0)
      */
-    public function write($string)
+    public function write($string) : int
     {
-        return;
+        return 0;
     }
 
     /**


### PR DESCRIPTION
This increases the coverage of phan to detect incompatible
signatures between parent and child classes. (These are primarily
caused by invalid doc comments, where phan extracts the variable
types from, or previous ambiguity between how to denote something
that returns no value. phan insists on "void", while the codebase
had a mixture of "void", "none", or "null".)

When there's disagreement between a child and parent class about
what the return value should be, this change sides with the parent
(which may not always be correct, but can be fixed in a future
change if any errors are detected.)