### PR TITLE
Updated the getDirectInstruments() function to have  initiated outsid…

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -730,6 +730,7 @@ class Utility
     static function getDirectInstruments()
     {
         $DB            =& Database::singleton();
+        $instruments   = array();
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true",
             array()


### PR DESCRIPTION
This pull request `In a fresh install of Loris, the Admin "Survey Module" will show console warnings to the user.`. It `Updated the getDirectInstruments() function to have $instruments initiated outside the foreach loop and solved the warnings`.

See also: `Bug #14388`