### PR TITLE
[User_accounts] Reject users cleanup 

### DIFF
--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -1,122 +1,63 @@
 <?php
 /**
- * Media uploader.
+ * User accounts
  *
- * Handles media upload and update actions received from a front-end ajax call
+ * Handles rejection of pending user accounts by a user that has permissions
  *
- * PHP Version 5
+ * Send DB query to remove user based on userID, checking that the
+ * user sending the request has admin permissions and the account
+ * can be removed (no password hash => has never had an activity on
+ * Loris, and is pending).
+ *
+ * PHP Version 7
  *
  * @category Loris
  * @package  User_Accounts
  * @author   Leo T. <lthomas.mcin@gmail.com>
+ *           Zaliqa Rosli <zaliqa.rosli@mcin.ca>
  * @license  Loris license
  * @link     https://github.com/aces/Loris
  */
 
-    define('NO_IDENTIFIER_SUPPLIED', 1);
-    define('USER_NOT_FOUND', 2);
-    define('INCORRECT_PERMISSION', 3);
-    define('ACCOUNT_ACTIVE', 4);
+namespace LORIS\user_accounts;
 
+// Make sure the permission is checked first to avoid malicious userID scans
+if (!(\User::singleton())->hasPermission('user_accounts')) {
+    header("HTTP/1.1 403 Forbidden");
+    header("Content-Type: text/plain");
+    exit(
+        "You do not have valid permissions for this
+         operation."
+    );
+}
 
 if (!isset($_POST['identifier'])) {
-    throw new LorisException("No identifier supplied", NO_IDENTIFIER_SUPPLIED);
-    exit(1);
-} else {
-    $identifier = $_POST["identifier"];
-    reject_user($identifier);
-}
-/**
-* Checks that logged in user has user_accounts permissions, which is
-* also included in admin permissions
-*
-* @return boolean true if user has admin permission or user accounts false otherwise
-*/
-function _hasPerm()
-{
-    $user =& User::singleton();
-    if (isset($user)) {
-        if (!$user->hasPermission('user_accounts')) {
-            return false;
-        }
-        return true;
-    }
-    return false;
+    header("HTTP/1.1 400 Bad Request");
+    header("Content-Type: text/plain");
+    exit(
+        "No identifier supplied"
+    );
 }
 
-    /**
-    * Query database on UserID to check that password has doesn't
-    * exist and account is still pending approval, to ensure the
-    * users with account activity can't be rejected by setting
-    * their status to pending.
-    *
-    * @param string $identifier of account to verify
-    *
-    * @return boolean true if Password_hash is null and
-    * Pending_approval is Yes, false otherwsie
-    *
-    * @throws \Lorisexception if the userID isn't found in the database.
-    */
-function _canRejectAccount($identifier)
-{
-    $DB = Database::singleton();
-    try{
-        $fields =  $DB->pselect(
-            "SELECT Password_hash, Pending_approval
-                       FROM users
-                       WHERE UserID=:id",
-            array("id" => $identifier)
-        );
-        if (is_null($fields[0]['Password_hash'])
-            && $fields[0]['Pending_approval']=="Y"
-        ) {
-            return true;
-        }
-        return false;
-    } catch (DatabaseException $e) {
-        throw new LorisException("User not found in database", USER_NOT_FOUND);
-        exit(1);
-    }
+$rejectee = \User::factory($_POST['identifier']);
+$username = $rejectee->getUsername();
+
+if (empty($username)) {
+    header("HTTP/1.1 404 Not Found");
+    header("Content-Type: text/plain");
+    exit(
+        "This account does not exist"
+    );
 }
 
+if (!Edit_User::canRejectAccount($rejectee)) {
+    header("HTTP/1.1 403 Forbidden");
+    header("Content-Type: text/plain");
+    exit(
+        "This account is active and cannot be rejected"
+    );
+}
 
-    /**
-    * Send DB query to remove user based on userID, checking that the
-    * user sending the request has admin permissions and the account
-    * can be removed (no password hash => has never had an activity on
-    * Loris, and is pending).
-    *
-    * @return void
-    */
-    // @codingStandardsIgnoreStart
-    function reject_user($identifier)
-    {
-    // @codingStandardsIgnoreEnd
-        $DB      = Database::singleton();
-        $config  = NDB_Config::singleton();
-        $baseURL = $config->getSetting('url');
-
-        $redirect = $baseURL . "/user_accounts/";
-
-    if (!_hasPerm()) {
-        throw new LorisException(
-            "You do not have the correct permissions for this 
-            operation (need admin or user accounts)",
-            INCORRECT_PERMISSION
-        );
-        exit(1);
-    } else {
-        if (!_canRejectAccount($identifier)) {
-            throw new LorisException(
-                "This account is active and connot be rejected",
-                ACCOUNT_ACTIVE
-            );
-            exit(1);
-        } else {
-            $DB->delete('users', array("UserID" => $identifier));
-            exit;
-        }
-    }
-    }
-
+(\Database::singleton())->delete('users', array("UserID" => $username));
+header("HTTP/1.1 204 No Content");
 ?>

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -42,7 +42,7 @@ if (!isset($_POST['identifier'])) {
 $rejectee = \User::factory($_POST['identifier']);
 $username = $rejectee->getUsername();
 
-if (empty($username)) {
+if (empty($username) || $rejectee instanceof \LORIS\AnonymousUser) {
     header("HTTP/1.1 404 Not Found");
     header("Content-Type: text/plain");
     exit(

--- a/modules/user_accounts/js/rejectUser.js
+++ b/modules/user_accounts/js/rejectUser.js
@@ -1,0 +1,17 @@
+$(document).ready(function() {
+    $("#btn_reject").click(function() {
+    const userID = document.getElementById("UserID").value;
+    const baseurl = loris.BaseURL;
+
+    $.ajax(baseurl + '/user_accounts/ajax/rejectUser.php', {
+      type:'POST',
+      data: {identifier: userID},
+      success: function(data, textStatus){
+        location.href = baseurl+'/user_accounts/';
+      },
+      error: function(jqXHR, textStatus, errorThrown){
+        alert(jqXHR.responseText);
+      }
+    }); 
+  }); 
+});

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -715,8 +715,14 @@ class Edit_User extends \NDB_Form
 
         // checking if the account can be rejected (no password hash
         // pending approval)
-        $this->tpl_data['can_reject'] =$this->_canRejectAccount($this->identifier);
 
+        // if new user
+        if ($this->isCreatingNewUser()) {
+            $this->tpl_data['can_reject'] = false;
+        } else {
+            $this->tpl_data['can_reject']
+                = self::canRejectAccount(\User::factory($this->identifier));
+        }
         // get the editor's permissions
 
         $perms    = $editor->getPermissionsVerbose();
@@ -810,31 +816,18 @@ class Edit_User extends \NDB_Form
     }
 
     /**
-     * Query database on UserID to check that password has doesn't
-     * exist and account is still pending approval, to ensure the
-     * users with account activity can't be rejected by setting
-     * their status to pending.
+     * This ensures that users with account activity cannot be rejected
+     * if their approval status is, for some reason, set to pending.
      *
-     * @param string $id identifier of account to verify
+     * @param \User $user The User to verify
      *
-     * @return boolean true is Password_hash is null and
-     * Pending_approval is Yes, false otherwsie
+     * @return boolean true if 'Pending_approval' is Yes and the user never
+     *                      ever logged in.
      */
-    function _canRejectAccount($id)
+    static function canRejectAccount(\User $user)
     {
-        $DB     = \Database::singleton();
-        $fields =  $DB->pselect(
-            "SELECT Password_hash, Pending_approval
-                   FROM users
-                   WHERE UserID=:id",
-            array("id" => $id)
-        );
-        if (is_null($fields[0]['Password_hash'])
-            && $fields[0]['Pending_approval']=="Y"
-        ) {
-            return true;
-        }
-        return false;
+        return $user->getData('Pending_approval') == 'Y'
+            && !$user->hasLoggedIn();
     }
 
     /**
@@ -1104,6 +1097,22 @@ class Edit_User extends \NDB_Form
             list(,$description) = each($permission[0]);
         }
         return $permission;
+    }
+
+    /**
+     * Gathers JS dependencies and merges them with the parent
+     *
+     * @return array of javascript to be inserted
+     */
+    function getJSDependencies()
+    {
+        $factory = \NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $deps    = parent::getJSDependencies();
+        return array_merge(
+            $deps,
+            array($baseURL . "/user_accounts/js/rejectUser.js")
+        );
     }
 }
 ?>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -389,33 +389,9 @@
   <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/'" value="Back" type="button" />
 </div>
 {if $can_reject}
-
 <div class="col-sm-2">
     <input type=hidden id ="UserID" value="{$form.UserID.html}">
-    <input type=hidden id = "baseurl" value="{$baseurl}">
     <input class="btn btn-sm btn-primary col-xs-12" value="Reject User" type="button" id="btn_reject"/>
-    {literal}
-    <script type="text/javascript">
-        $(document).ready(
-            function(){
-                $("#btn_reject").click(
-                    function(){
-                        var userID = document.getElementById("UserID").value;
-                        var baseurl = document.getElementById("baseurl").value;
-                        $.ajax(baseurl+'/user_accounts/ajax/rejectUser.php', {
-                            type:'POST',
-                            data: {identifier: userID},
-                            success: function(data, textStatus){
-                                location.href=baseurl+'/user_accounts/';
-                            },
-                            error: function(jqXHR, textStatus, errorThrown){
-                                alert(textStatus, errorThrown);
-                           }
-                       });       
-                    });
-            });
-        </script>
-        {/literal}
     </div>
     {/if}
 </div>

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -561,5 +561,25 @@ class User extends UserPermissions
         return $this->hasPermission($code)
             && $this->hasCenter($center_id);
     }
+
+    /**
+     * Determines if the user has ever logged in successfully
+     *
+     * @return bool
+     */
+    public function hasLoggedIn(): bool
+    {
+        $count = (\NDB_Factory::singleton()->database())->pselectOne(
+            "SELECT
+               COUNT(1)
+             FROM user_login_history
+             WHERE
+               UserID = :v_userid AND
+               Success = 'Y'
+            ",
+            array('v_userid' => $this->userInfo['UserID'])
+        );
+        return $count > 0;
+    }
 }
 ?>


### PR DESCRIPTION
replacing #3548 because i somehow deleted the branch and closed the PR

moved PR to major branch

"This PR cleans up the code merged in #2811 as requested in comments by @driusan at the bottom of the page. This is a new PR to replace #3035 which is now closed because it was too messy.

Functionality should remain the same."

to test:
1. "Request Account" on login page
2. Check user in `users` table with Active='Y', Pending='Y'
2. Reject user on admin account via "Reject User" button in "User Accounts" module
3. Check user deleted from `users` table and there are no errors
