### PR TITLE
Added isset() to check if ['install'] exists

### DIFF
--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -71,7 +71,9 @@ class Instrument_Manager extends \NDB_Menu_Filter
             $writable = true;
         }
         $this->tpl_data['writable'] = $writable;
-        if ($writable && $_POST['install'] == 'Install Instrument') {
+        if ($writable && isset($_POST['install'])
+            && $_POST['install'] == 'Install Instrument'
+        ) {
             $db       = \Database::singleton();
             $instname = basename($_FILES['install_file']['name'], '.linst');
 


### PR DESCRIPTION
This pull request `On a new install of Loris, the Admin->Instrument Manger will show console warnings.`. It `solved by checking if the $_POST['install'] variable is set before we get an undefined index.`.

See also: `Bug #14392`
