### PR TITLE
[Client] Add HTTPOnly header to session cookie

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -133,7 +133,10 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        session_start();
+        session_start([
+            'cookie_httponly' => true,
+            'cookie_secure' => true
+        ]);
 
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {
@@ -141,7 +144,10 @@ class NDB_Client
             setcookie("FeedbackButtonBoolean", "");
             header("HTTP/1.1 303 See Other");
             header("Location: /");
-            session_start();
+            session_start([
+                'cookie_httponly' => true,
+                'cookie_secure' => true
+            ]);
         }
 
         /**

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -134,9 +134,7 @@ class NDB_Client
         );
         // start php session
         session_start(
-            [
-             'cookie_httponly' => true,
-            ]
+            ['cookie_httponly' => true]
         );
 
         // if exiting, destroy the php session
@@ -146,9 +144,7 @@ class NDB_Client
             header("HTTP/1.1 303 See Other");
             header("Location: /");
             session_start(
-                [
-                 'cookie_httponly' => true,
-                ]
+                ['cookie_httponly' => true]
             );
         }
 

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -133,10 +133,12 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        session_start([
-            'cookie_httponly' => true,
-            'cookie_secure' => true
-        ]);
+        session_start(
+            [
+             'cookie_httponly' => true,
+             'cookie_secure'   => true,
+            ]
+        );
 
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {
@@ -144,10 +146,12 @@ class NDB_Client
             setcookie("FeedbackButtonBoolean", "");
             header("HTTP/1.1 303 See Other");
             header("Location: /");
-            session_start([
-                'cookie_httponly' => true,
-                'cookie_secure' => true
-            ]);
+            session_start(
+                [
+                 'cookie_httponly' => true,
+                 'cookie_secure'   => true,
+                ]
+            );
         }
 
         /**

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -136,7 +136,6 @@ class NDB_Client
         session_start(
             [
              'cookie_httponly' => true,
-             'cookie_secure'   => true,
             ]
         );
 
@@ -149,7 +148,6 @@ class NDB_Client
             session_start(
                 [
                  'cookie_httponly' => true,
-                 'cookie_secure'   => true,
                 ]
             );
         }


### PR DESCRIPTION
This pull request enables the usage of the [HTTP-Only](https://www.owasp.org/index.php/HttpOnly#What_is_HttpOnly.3F) and [Secure](https://stackoverflow.com/questions/13729749/how-does-cookie-secure-flag-work) modes for our session cookies, providing defense against certain hacking attempts.
