### PR TITLE
[Candidate] Use true randomness in Candidate ID generation

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -694,7 +694,7 @@ class Candidate
         $db      = $factory->database();
 
         // generate a candidate id
-        $candID = rand(CANDIDATE_MIN_CANDID, CANDIDATE_MAX_CANDID);
+        $candID = random_int(CANDIDATE_MIN_CANDID, CANDIDATE_MAX_CANDID);
 
         // make sure the cand id is not used
         while ($db->pselectOne(
@@ -702,7 +702,7 @@ class Candidate
             array('CaID' => $candID)
         ) > 0) {
             // pick a new candidate id
-            $candID = rand(CANDIDATE_MIN_CANDID, CANDIDATE_MAX_CANDID);
+            $candID = random_int(CANDIDATE_MIN_CANDID, CANDIDATE_MAX_CANDID);
         }
 
         return $candID;


### PR DESCRIPTION
This pull request avoids the use of mt_rand for the generation of Candidate IDs as it does not generate truly random values. 

The output of mt_rand is predictable and thus it is feasible that this could lead to privacy/ethics concerns.