### PR TITLE
[User] Remove lingering uses of mt_rand

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -398,13 +398,13 @@ class User extends UserPermissions
         if (strpbrk($password, $numbers) === false) {
             $password .= substr(
                 $numbers,
-                mt_rand(0, strlen($numbers)-1),
+                random_int(0, strlen($numbers)-1),
                 1
             );
         }
 
         for ($i = strlen($password); $i < $length; $i++) {
-            $password .= substr($possible, mt_rand(0, $possible_cnt), 1);
+            $password .= substr($possible, random_int(0, $possible_cnt), 1);
         }
 
         return $password;

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -396,11 +396,7 @@ class User extends UserPermissions
         }
 
         if (strpbrk($password, $numbers) === false) {
-            $password .= substr(
-                $numbers,
-                random_int(0, strlen($numbers)-1),
-                1
-            );
+            $password .= random_int(0, 9);
         }
 
         for ($i = strlen($password); $i < $length; $i++) {


### PR DESCRIPTION
`mt_rand` generates predictable values. There are lingering references to it in this function.

This PR switches everything over to using `random_int` once and for all.

See also https://github.com/aces/Loris/pull/3045 in which I should have done this in the first place... 😅 