### PR TITLE
added function to get visit label to instrument class

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1408,8 +1408,8 @@ class NDB_BVL_Instrument extends NDB_Page
         $sessionID = $this->getSessionID();
 
         if (!empty($sessionID)) {
-            $t          = Timepoint::singleton($sessionID);
-            $visitLabel = $t->getVisitLabel();
+            $timepoint  = \Timepoint::singleton($sessionID);
+            $visitLabel = $timepoint->getVisitLabel();
             return $visitLabel;
         }
         return '';

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1398,6 +1398,22 @@ class NDB_BVL_Instrument extends NDB_Page
         return false;
     }
 
+    /**
+     * Gets the VisitLabel for the timepoint to which this instrument pertains
+     *
+     * @return String for the VisitLabel
+     */
+    function getVisitLabel{
+        $sessionID = $this->getSessionID();
+
+        if(!empty($sessionID)){
+            $t = Timepoint::singleton($sessionID);
+            $visitLabel = $t->getVisitLabel();
+            return $visitLabel;
+        }
+        return false;
+    }
+
 
     /**
      * Determines what the data entry status flag should be set to

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1407,8 +1407,8 @@ class NDB_BVL_Instrument extends NDB_Page
     {
         $sessionID = $this->getSessionID();
 
-        if(!empty($sessionID)){
-            $t = Timepoint::singleton($sessionID);
+        if (!empty($sessionID)) {
+            $t          = Timepoint::singleton($sessionID);
             $visitLabel = $t->getVisitLabel();
             return $visitLabel;
         }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1412,7 +1412,7 @@ class NDB_BVL_Instrument extends NDB_Page
             $visitLabel = $t->getVisitLabel();
             return $visitLabel;
         }
-        return false;
+        return '';
     }
 
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1403,7 +1403,8 @@ class NDB_BVL_Instrument extends NDB_Page
      *
      * @return String for the VisitLabel
      */
-    function getVisitLabel{
+    function getVisitLabel()
+    {
         $sessionID = $this->getSessionID();
 
         if(!empty($sessionID)){


### PR DESCRIPTION
This pull request adds a function to get the visit label of a given timepoint. It will be useful in instances where certain instrument information is different (ex:headers) for different visits. 
