### PR TITLE
[Core] Add User to hasAccess signature

### DIFF
--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -30,15 +30,14 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
 {
 
     /**
-     * _has_access returns true
-     * if the user has the specific permission
+     * Determine whether user should be granted access.
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object and check appropriate permission
-        $user =& \User::singleton();
         return ($user->hasPermission('acknowledgements_view'));
     }
 

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -25,16 +25,6 @@ namespace LORIS\brainbrowser;
 class Brainbrowser extends \NDB_Page
 {
     /**
-     * Everyone has access to the BrainBrowser module.
-     *
-     * @return boolean true if user has correct access permissions
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
-    /**
      * Override base function to include brainbrowser javascript files
      * and dependencies
      *

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -27,14 +27,16 @@ class Candidate_List extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (their own site only)
      * and users w/ multisite privs
      *
-     * @return true if user has access, false otherwise
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if user has access, false otherwise
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-        $aap  = $user->hasPermission('access_all_profiles');
+        $aap = $user->hasPermission('access_all_profiles');
+
         $this->tpl_data['access_all_profiles'] = $aap;
+
         return (
             $user->hasPermission('access_all_profiles')
             || ($user->hasStudySite() && $user->hasPermission('data_entry'))

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -34,14 +34,12 @@ class Candidate_Parameters extends \NDB_Form
     /**
      * Check user permissions
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        //create user object
-        $user =& \User::singleton();
-
         // Set global permission to control access
         // to different modules of candidate_parameters page
         $this->hasWritePermission = $user->hasPermission('candidate_parameter_edit');

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -30,12 +30,12 @@ class Configuration extends \NDB_Form
      * _has_access returns true
      * if the user has the specific permission
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         return $user->hasPermission('config');
     }
 

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -30,12 +30,12 @@ class Project extends \NDB_Form
      * _has_access returns true
      * if the user has the specific permission
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         return $user->hasPermission('config');
     }
 

--- a/modules/configuration/php/subproject.class.inc
+++ b/modules/configuration/php/subproject.class.inc
@@ -29,12 +29,12 @@ class Subproject extends \NDB_Form
     /**
      * Determine whether the user has access to configure subprojects
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         return $user->hasPermission('config');
     }
 

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -31,12 +31,12 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
      * Returns true if the user has permission to access
      * the conflict resolver module
      *
-     * @return true if user has permission
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if user has permission
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         return ($user->hasPermission('conflict_resolver'));
     }
 

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -32,12 +32,12 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     /**
      * Determine whether the user should have access to this submodule
      *
-     * @return boolean true if the user has access
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if the user has access
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         return ($user->hasPermission('conflict_resolver'));
     }
 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -40,14 +40,12 @@ class Create_Timepoint extends \NDB_Form
     /**
      * Check user permissions
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         $candidate =& \Candidate::singleton($this->identifier);
 
         // check user permissions

--- a/modules/data_integrity_flag/php/data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/data_integrity_flag.class.inc
@@ -31,13 +31,12 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
     /**
      * Check user permissions
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        //create user object
-        $user =& \User::singleton();
         return $user->hasPermission('data_integrity_flag');
     }
 

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -29,13 +29,12 @@ class Data_Team_Helper extends \NDB_Form
     /**
      * Class that returns the data team helper.
      *
-     * @return bool|object
-     * @throws \ConfigurationException
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         return ($user->hasPermission('data_team_helper'));
     }
 
@@ -576,7 +575,7 @@ class Data_Team_Helper extends \NDB_Form
      *
      * @return int
      */
-    function getInstrumentCount($test_name,
+    function getInstrumentCount(string $test_name,
         $visit_label=null,
         $candidate=null,
         $site=null,

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -575,7 +575,7 @@ class Data_Team_Helper extends \NDB_Form
      *
      * @return int
      */
-    function getInstrumentCount(string $test_name,
+    function getInstrumentCount($test_name,
         $visit_label=null,
         $candidate=null,
         $site=null,

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -26,19 +26,17 @@ namespace LORIS\datadict;
 class Datadict extends \NDB_Menu_Filter
 {
     var $AjaxModule = true;
-    /**
-     * Overloading this method to allow access to site users (their own site
-     * only) and users w/ multisite privs
-     *
-     * @note   overloaded function
-     * @return bool
-     * @access private
-     */
-    function _hasAccess()
-    {
-        // create user object
-        $user =& \User::singleton();
 
+    /**
+    * Overloading this method to allow access to site users (their own site
+    * only) and users w/ multisite privs
+    *
+    * @param \User $user The user whose access is being checked
+    *
+    * @return bool
+    */
+    function _hasAccess(\User $user) : bool
+    {
         return ($user->hasPermission('data_dict_view') ||
                 $user->hasPermission('data_dict_edit'));
     }

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -28,16 +28,16 @@ class Dataquery extends \NDB_Form
     /**
      * Check user access permission
      *
-     * @return bool|object
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         // check user permissions
         return $user->hasPermission('dataquery_view');
     }
+
     /**
      * Sets up the smarty template variables for the dataquery page.
      *

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -33,11 +33,12 @@ class Dicom_Archive extends \NDB_Menu_Filter
     /**
      * Determine whether the user has permission to view this page
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool whether the user has access
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user = \User::singleton();
         return $user->hasPermission('dicom_archive_view_allsites');
     }
 

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -57,7 +57,7 @@ class ViewDetails extends \NDB_Form
         $this->DB         = \Database::singleton();
         $this->tarchiveID = $_REQUEST['tarchiveID'] ?? '';
 
-        $user = User::singleton();
+        $user = \User::singleton();
         if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess($user))) {
             $tarchiveID = $_REQUEST['tarchiveID'];
             $this->tpl_data['archive']        = $this->_getTarchiveData(

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -38,11 +38,12 @@ class ViewDetails extends \NDB_Form
     /**
      * Determine whether the user has permission to view this page
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool whether the user has access
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user = \User::singleton();
         return $user->hasPermission('dicom_archive_view_allsites');
     }
 
@@ -56,7 +57,8 @@ class ViewDetails extends \NDB_Form
         $this->DB         = \Database::singleton();
         $this->tarchiveID = $_REQUEST['tarchiveID'] ?? '';
 
-        if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess())) {
+        $user = User::singleton();
+        if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess($user))) {
             $tarchiveID = $_REQUEST['tarchiveID'];
             $this->tpl_data['archive']        = $this->_getTarchiveData(
                 $tarchiveID,

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -31,13 +31,12 @@ class Document_Repository extends \NDB_Menu_Filter
     /**
      * Checking user permissions
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        //create user object
-        $user =& \User::singleton();
-
         return $user->hasPermission('document_repository_view')
                || $user->hasPermission('document_repository_delete');
 

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -28,12 +28,12 @@ class EditExaminer extends \NDB_Form
     /**
      * Checks if the user has access to the edit examiner form
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
-     * @throws \DatabaseException
      * @throws \LorisException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
         if (empty($_REQUEST['identifier'])) {
             throw new LorisException(
@@ -43,7 +43,6 @@ class EditExaminer extends \NDB_Form
         $DB     = \Database::singleton();
         $config = \NDB_Config::singleton();
 
-        $user         = \User::singleton();
         $userFullName = $user->getFullname();
         $userCenter   = $user->getCenterIDs();
 

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -37,7 +37,8 @@ class Examiner extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('examiner_view');
+        return $user->hasPermission('examiner_view')
+            || $user->hasPermission('examiner_multisite');
     }
 
     /**

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -31,13 +31,13 @@ class Examiner extends \NDB_Menu_Filter_Form
     /**
      * Checks if the user has access to examiner menu filter
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user = \User::singleton();
-        return $user->hasPermission('examiner_view')
-            || $user->hasPermission('examiner_multisite');
+        return $user->hasPermission('examiner_view');
     }
 
     /**

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -44,13 +44,12 @@ class CNV_Browser extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (own site only)
      * and users w/ multisite privs
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -45,13 +45,12 @@ class CpG_Browser extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (own site only)
      * and users w/ multisite privileges
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -45,13 +45,12 @@ class Genomic_Browser extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (own site only)
      * and users w/ multisite privs
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/genomic_file_uploader.class.inc
@@ -33,13 +33,12 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (own site only)
      * and users w/ multisite privileges
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/gwas_browser.class.inc
+++ b/modules/genomic_browser/php/gwas_browser.class.inc
@@ -38,13 +38,12 @@ class GWAS_Browser extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (own site only)
      * and users w/ multisite privileges
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -44,13 +44,12 @@ class SNP_Browser extends \NDB_Menu_Filter
      * Overloading this method to allow access to site users (own site only)
      * and users w/ multisite privileges
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return ($user->hasPermission('genomic_browser_view_allsites')
                 || $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -35,13 +35,12 @@ class View_Genomic_File extends \NDB_Form
     /**
     * Determine whether the user has permission to view this page
     *
+    * @param \User $user The user whose access is being checked
+    *
     * @return bool whether the user has access
     */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
-
-        // Add site control? See Imaging Browser example
         return ($user->hasPermission('genomic_browser_view_allsites') ||
                 $user->hasPermission('genomic_browser_view_site'));
     }
@@ -64,7 +63,9 @@ class View_Genomic_File extends \NDB_Form
 
         if (!empty($this->candID) || !empty($this->genomic_file_id) ) {
             $this->_setFileData();
-            $this->tpl_data['has_permission'] = ($this->_hasAccess()) ? true : false;
+            $user = User::singleton();
+            $this->tpl_data['has_permission']
+                = ($this->_hasAccess($user)) ? true : false;
         }
     }
 

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -64,8 +64,7 @@ class View_Genomic_File extends \NDB_Form
         if (!empty($this->candID) || !empty($this->genomic_file_id) ) {
             $this->_setFileData();
             $user = User::singleton();
-            $this->tpl_data['has_permission']
-                = ($this->_hasAccess($user)) ? true : false;
+            $this->tpl_data['has_permission'] = $this->_hasAccess($user);
         }
     }
 

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -41,6 +41,7 @@ class View_Genomic_File extends \NDB_Form
     */
     function _hasAccess(\User $user) : bool
     {
+        // Add site control? See Imaging Browser example
         return ($user->hasPermission('genomic_browser_view_allsites') ||
                 $user->hasPermission('genomic_browser_view_site'));
     }

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -63,7 +63,7 @@ class View_Genomic_File extends \NDB_Form
 
         if (!empty($this->candID) || !empty($this->genomic_file_id) ) {
             $this->_setFileData();
-            $user = User::singleton();
+            $user = \User::singleton();
             $this->tpl_data['has_permission'] = $this->_hasAccess($user);
         }
     }

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -28,16 +28,15 @@ class Edit_Help_Content extends \NDB_Form
      /**
      * Determine if user has permission to access this page
      *
-     * @return boolean true if access is permitted
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if access is permitted
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
-
-        // check user permissions
         return $user->hasPermission('context_help');
     }
+
      /**
       * Returns default help content of the page
       *

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -25,18 +25,18 @@ namespace LORIS\help_editor;
  */
 class Help_Editor extends \NDB_Menu_Filter
 {
-     /**
-       *  Checking user permissions
-       *
-       * @return bool
-       */
-    function _hasAccess()
+    /**
+     *  Checking user permissions
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
-
         return $user->hasPermission('context_help');
     }
+
      /**
        * Setup Variables function
        *

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -31,12 +31,12 @@ class Imaging_Browser extends \NDB_Menu_Filter
     /**
      * Determine whether the user has permission to view this page
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool whether the user hass access
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
-
         return ($user->hasPermission('imaging_browser_view_allsites')
                || ($user->hasStudySite()
                    && $user->hasPermission('imaging_browser_view_site')

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -42,12 +42,12 @@ class ViewSession extends \NDB_Form
      * Determine whether the user has permission to view the
      * imaging_browser page
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool whether the user has access
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
-
         // allow only to view own site data
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
 
@@ -88,7 +88,8 @@ class ViewSession extends \NDB_Form
         $this->sessionID = $_REQUEST['sessionID'];
 
         if (!empty($this->sessionID) && is_numeric($this->sessionID)) {
-            if ($this->_hasAccess() && isset($_POST['save_changes'])) {
+            $user = User::singleton();
+            if ($this->_hasAccess($user) && isset($_POST['save_changes'])) {
                 $this->_updateStatus($_POST);
                 $this->_updateSelected();
                 $this->_updateVisitStatus();
@@ -120,7 +121,7 @@ class ViewSession extends \NDB_Form
                                                     true  => 'True',
                                                     false => 'False',
                                                    );
-            $this->tpl_data['has_permission']    = ($this->_hasAccess()) ?
+            $this->tpl_data['has_permission']    = ($this->_hasAccess($user)) ?
                                                  true : false;
             $this->tpl_data['has_qc_permission'] = ($this->_hasQCPerm()) ?
                                                     true : false;

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -88,7 +88,7 @@ class ViewSession extends \NDB_Form
         $this->sessionID = $_REQUEST['sessionID'];
 
         if (!empty($this->sessionID) && is_numeric($this->sessionID)) {
-            $user = User::singleton();
+            $user = \User::singleton();
             if ($this->_hasAccess($user) && isset($_POST['save_changes'])) {
                 $this->_updateStatus($_POST);
                 $this->_updateSelected();

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -39,15 +39,15 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      */
     var $uploaded_file_path;
     /**
-     * The _has_access returns true
-     * if the user has the specific permission
+     * The hasAccess function ensures that the user has the imaging_uploader
+     * permission.
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user = \User::singleton();
         return $user->hasPermission('imaging_uploader');
     }
     /**

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -35,32 +35,13 @@ class Instrument_Builder extends \NDB_Form
      * Tests that, when loading the Instrument builder module, some
      * text appears in the body.
      *
-     * @return bool
-     */
-    function _hasAccess()
-    {
-        return $this->_hasPerm('instrument_builder');
-    }
-    /**
-     * Wrapper to get the user object and check the permission.
-     *
-     * @param string $perm the value of perm
+     * @param \User $user The user whose access is being checked
      *
      * @return bool
      */
-    function _hasPerm($perm)
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
-        return $user->hasPermission($perm);
-    }
-    /**
-     * Instrument builder
-     *
-     * @return void
-     */
-    function instrument_builder()// @codingStandardsIgnoreLine
-    {
-
+        return $user->hasPermission('instrument_builder');
     }
 
     /**

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -56,7 +56,12 @@ class Instrument_List extends \NDB_Menu_Filter
     */
     function _hasAccess(\User $user) : bool
     {
-        return ($user->hasPermission('access_all_profiles')
+        if (isset($_REQUEST['sessionID'])) {
+            //These variable are only for checking the permissions.
+            $TimePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
+            $candID    = $TimePoint->getCandID();
+            $Candidate =& \Candidate::singleton($candID);
+            return ($user->hasPermission('access_all_profiles')
                 || (in_array(
                     $Candidate->getData('CenterID'),
                     $user->getData('CenterIDs')
@@ -69,7 +74,6 @@ class Instrument_List extends \NDB_Menu_Filter
                    )
             );
         }
-        // check user permissions
         return false;
     }
 

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -50,18 +50,13 @@ class Instrument_List extends \NDB_Menu_Filter
     /**
     * Checking permissions
     *
+    * @param \User $user The user whose access is being checked
+    *
     * @return bool
     */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-        if (isset($_REQUEST['sessionID'])) {
-            //These variable are only for checking the permissions.
-            $TimePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
-            $candID    = $TimePoint->getCandID();
-            $Candidate =& \Candidate::singleton($candID);
-            return ($user->hasPermission('access_all_profiles')
+        return ($user->hasPermission('access_all_profiles')
                 || (in_array(
                     $Candidate->getData('CenterID'),
                     $user->getData('CenterIDs')

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -28,13 +28,15 @@ class Instrument_Manager extends \NDB_Menu_Filter
     /**
     * Checking permissions
     *
+    * @param \User $user The user whose access is being checked
+    *
     * @return bool
     */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('superuser');
     }
+
     /**
     * SetupVariables function
     *

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -106,12 +106,12 @@ class Issue extends \NDB_Form
      * Checks if the user has the ability to *view* the issue page
      * Does not govern editing abilities; those are controlled by issueIndex.js
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user    =& \User::singleton();
         $db      = \Database::singleton();
         $issueID = $_GET['issueID'];
 
@@ -129,9 +129,8 @@ class Issue extends \NDB_Form
             || (!empty($issueData['centerID']))
         ) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
 }

--- a/modules/login/php/login.class.inc
+++ b/modules/login/php/login.class.inc
@@ -28,16 +28,6 @@ namespace LORIS\login;
 class Login extends \NDB_Page
 {
     /**
-     * Determine whether the user has permission to view this page
-     *
-     * @return bool whether the user has access
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
-    /**
      * The constructor for login creates some basic tpl variables that are
      * used in the login template.
      *

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -40,18 +40,6 @@ class PasswordExpiry extends \NDB_Form
     private $_user;
 
     /**
-     * Determine whether the user has permission to view this page. This
-     * is always true, because setup/validate redirects if the user shouldn't
-     * be here.
-     *
-     * @return bool whether the user has access
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
-    /**
      * Setup sets up the LorisForm elements for the page, and redirects
      * to the main LORIS page if the PasswordExpiredForUser session variable
      * hasn't been set in SinglePointLogin (which means it shouldn't be on

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -26,16 +26,6 @@ namespace LORIS\login;
 class PasswordReset extends \NDB_Form
 {
     /**
-     * Determine whether the user has permission to view this page
-     *
-     * @return bool whether the user has access
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
-    /**
      * CommonPageSetup sets up the common form elements which
      * are on the page, regardless of HTTP request method.
      *

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -26,16 +26,6 @@ namespace LORIS\login;
 class RequestAccount extends \NDB_Form
 {
     /**
-     * Determine whether the user has permission to view this page
-     *
-     * @return bool whether the user has access
-     */
-    function _hasAccess()
-    {
-        return true;
-    }
-
-    /**
      * Sets up the form elements on the page.
      *
      * @return void

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -92,14 +92,12 @@ class Edit extends \NDB_Form
     /**
      * Check user permissions
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        //create user object
-        $user =& \User::singleton();
-
         return $user->hasPermission('media_write');
     }
 

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -37,14 +37,12 @@ class Media extends \NDB_Menu_Filter
     /**
      * Check user permissions
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
-     * @throws \ConfigurationException
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        //create user object
-        $user =& \User::singleton();
-
         // Set global permission to control access to different modules of media page
         $this->hasWritePermission = $user->hasPermission('media_write');
 

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -32,11 +32,12 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
      * Determine who has access to this page. At the moment, tied to
      * access to the Mri_Violation module.
      *
-     * @return boolean true if access is permitted
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if access is permitted
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('violated_scans_view_allsites');
     }
 

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -31,13 +31,12 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
      * violated_scans_modifications permission if they're allowed to modify
      * the mri_protocol table
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool true if they have access to this page
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return ($user->hasPermission('violated_scans_view_allsites'));

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -27,15 +27,16 @@ namespace LORIS\mri_violations;
 class Mri_Violations extends \NDB_Menu_Filter_Form
 {
     var $AjaxModule = true;
+
     /**
      * Check if user should be allowed to see this page.
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return boolean true if the user is permitted to see violated scans
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return ($user->hasPermission('violated_scans_view_allsites'));

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -26,19 +26,21 @@ namespace LORIS\mri_violations;
 class Resolved_Violations extends \NDB_Menu_Filter_Form
 {
     var $AjaxModule = true;
+
     /**
      * Check if user should be allowed to see this page.
      *
-     * @return boolean true if the user is permitted to see violated scans
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if the user is permitted to see violated scans
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return ($user->hasPermission('violated_scans_view_allsites'));
     }
+
     /**
      * Process function
      *

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -28,13 +28,12 @@ class New_Profile extends \NDB_Form
     /**
      * Tie the access to a data_entry permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool true if they have access to this page
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         $site_arr      = $user->getData('CenterIDs');
         $userInDCCSite = in_array("1", $site_arr);
         if ($user->hasStudySite() or $userInDCCSite) {

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -41,13 +41,12 @@ class Next_Stage extends \NDB_Form
     /**
      * Tie the access to a data_entry permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool true if they have access to this page
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         $timePoint =& \TimePoint::singleton($this->identifier);
 
         // check user permissions

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -29,13 +29,12 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
     /**
      * Determines whether the current user has access to the page.
      *
-     * @note   overloaded function
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool true if the user has access, false otherwise
-     * @access private
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user = \User::singleton();
         return $user->hasPermission('server_processes_manager');
     }
 

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -28,11 +28,12 @@ class Statistics extends \NDB_Form
     /**
      * Checking user's permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('data_entry');
     }
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -34,11 +34,12 @@ class Statistics_Site extends \NDB_Menu
     /**
      * Checking user's permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user     =& \User::singleton();
         $centerID = htmlspecialchars($_REQUEST['CenterID']);
         //TODO: Create a permission specific to statistics
         $accessAllProfiles = $user->hasPermission('access_all_profiles') &&

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -28,11 +28,12 @@ class Stats_Behavioural extends \NDB_Form
     /**
      * Checking user's permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('data_entry');
     }
     /**

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -34,13 +34,15 @@ class Stats_Demographic extends \NDB_Form
     /**
      * Checking user's permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('data_entry');
     }
+
     /**
      * InCenter function
      *

--- a/modules/statistics/php/stats_general.class.inc
+++ b/modules/statistics/php/stats_general.class.inc
@@ -28,13 +28,12 @@ class Stats_General extends \NDB_Form
     /**
      * Checking user's permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('data_entry');
     }
-
 }
-

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -28,13 +28,15 @@ class Stats_MRI extends \NDB_Form
     /**
      * Checking user's permission
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user =& \User::singleton();
         return $user->hasPermission('data_entry');
     }
+
     /**
      * InCenter function
      *

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -29,13 +29,12 @@ class AddSurvey extends \NDB_Form
      * Determine whether the logged in user has access to this page.
      * Tied to data_entry
      *
-     * @return boolean true if user has access to this page
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool true if user has access to this page
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $editor =& \User::singleton();
-
         return $editor->hasPermission('user_accounts');
     }
 

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -35,7 +35,7 @@ class AddSurvey extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $editor->hasPermission('user_accounts');
+        return $user->hasPermission('user_accounts');
     }
 
     /**

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -27,13 +27,12 @@ class Survey_Accounts extends \NDB_Menu_Filter
     /**
      * Determine if user has permission to access this page
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return boolean true if access is permitted
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         return $user->hasPermission('user_accounts');
     }
 

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -33,13 +33,12 @@ class Timepoint_List extends \NDB_Menu
     /**
      * Overloading this method to allow access to timepoint list
      *
-     * @return boolean
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         $candidate =& \Candidate::singleton($this->candID);
 
         // check user permissions

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -29,11 +29,12 @@ class Training extends \NDB_Form
     /**
      * Checks if the user has access to examiner forms (edit_examiner and training)
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return boolean
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        $user = \User::singleton();
         return $user->hasPermission('training');
     }
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -41,7 +41,7 @@ class Edit_User extends \NDB_Form
      * 'user_accounts_multisite' or whose site matches the site of the user they
      * are trying to edit.
      *
-     * @param \User $editor The user is accessing this page
+     * @param \User $editor The user who is accessing this page
      *
      * @return true if user has access, false otherwise.
      */

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -41,11 +41,11 @@ class Edit_User extends \NDB_Form
      * 'user_accounts_multisite' or whose site matches the site of the user they
      * are trying to edit.
      *
-     * @param \User $user The user whose access is being checked
+     * @param \User $editor The user is accessing this page
      *
      * @return true if user has access, false otherwise.
      */
-    function _hasAccess(\User $user) : bool
+    function _hasAccess(\User $editor) : bool
     {
         if (!$this->isCreatingNewUser()) {
             $user = \User::factory($this->identifier);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -41,13 +41,12 @@ class Edit_User extends \NDB_Form
      * 'user_accounts_multisite' or whose site matches the site of the user they
      * are trying to edit.
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return true if user has access, false otherwise.
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $editor = \User::singleton();
-
         if (!$this->isCreatingNewUser()) {
             $user = \User::factory($this->identifier);
         }

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -24,20 +24,6 @@ namespace LORIS\user_accounts;
 class My_Preferences extends \NDB_Form
 {
     /**
-     * Controls who's got access to this page, namely those who have the
-     * 'user_accounts' and who either have permission
-     * 'user_accounts_multisite' or whose site matches the site of the user they
-     * are trying to edit.
-     *
-     * @return true if user has access, false otherwise.
-     */
-    function _hasAccess()
-    {
-        // User can always access My Preferences page
-        return true;
-    }
-
-    /**
      * Computes the initial values this page will be filled with.
      *
      * @return array the default values for the initial state of this page.

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -29,9 +29,11 @@ class User_Accounts extends \NDB_Menu_Filter
     /**
      * Overloading this method to allow access to users account
      *
+     * @param \User $user The user whose access is being checked
+     *
      * @return boolean
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
         // create user object
         $user =& \User::singleton();

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -35,11 +35,9 @@ class User_Accounts extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        // create user object
-        $user =& \User::singleton();
-
         return $user->hasPermission('user_accounts');
     }
+
     /**
     * Setup Variables
     *

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -250,9 +250,10 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                 $_REQUEST['subtest'] = $pagename;
             }
 
-            if ($page->_hasAccess() !== true) {
+            $user = $request->getAttribute("user") ?? new \LORIS\AnonymousUser();
+            if ($page->_hasAccess($user) !== true) {
                 return (new \LORIS\Middleware\PageDecorationMiddleware(
-                    $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
+                    $user
                 ))->process(
                     $request,
                     new \LORIS\Router\NoopResponder(

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -240,7 +240,7 @@ class NDB_BVL_Instrument extends NDB_Page
             );
         }
 
-        $user   = User::singleton();
+        $user   = \User::singleton();
         $access = $obj->_hasAccess($user);
 
         // check that user has access

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -240,7 +240,8 @@ class NDB_BVL_Instrument extends NDB_Page
             );
         }
 
-        $access = $obj->_hasAccess();
+        $user   = User::singleton();
+        $access = $obj->_hasAccess($user);
 
         // check that user has access
         if ($access == false) {
@@ -265,13 +266,11 @@ class NDB_BVL_Instrument extends NDB_Page
      * If the user has ANY of the permissions listed in the config.xml file for
      * the instrument, access is granted.
      *
-     * Future improvement: call this function from display() rather than from
-     * factory()?
+     * @param \User $user The user whose access is being checked
      *
      * @return bool
-     * @access private
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
         //get config
         $config =& NDB_Config::singleton();
@@ -291,8 +290,6 @@ class NDB_BVL_Instrument extends NDB_Page
             //instrument permissions not used...
             return true; //default
         } else { //check if user has instrument's permissions
-            $user =& User::singleton();
-
             //is the instrument listed at all in instrumentPermissions?
             $instrumentListed = false;
             foreach ($instrumentPermissions["instrument"] as $instrument) {

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -619,7 +619,7 @@ class NDB_Page implements RequestHandlerInterface
         RequestHandlerInterface $handler
     ) : ResponseInterface {
         $user = $request->getAttribute("user");
-        if ($this->_hasAccess() !== true) {
+        if ($this->_hasAccess($user ?? new AnonymousUser()) !== true) {
             return (new \LORIS\Middleware\PageDecorationMiddleware($user))
                 ->process(
                     $request,
@@ -812,23 +812,15 @@ class NDB_Page implements RequestHandlerInterface
     }
 
     /**
-     * Returns false if user does not have access to page.
+     * Returns true if user has access to this page.
      *
-     * Usage: the hasAccess() function in a child class should contain
-     * something like:
+     * You do not need to overload hasAccess() if there are no access restrictions.
      *
-     *     // create user object
-     *     $user =& User::singleton();
+     * @param \User $user The user whose access is being checked
      *
-     *     return $user->hasPermission('superuser');
-     *
-     * You do not need to overload hasAccess() if there are no access restrictions
-     *
-     * @note   overloaded function
      * @return bool
-     * @access private
      */
-    function _hasAccess()
+    function _hasAccess(\User $user) : bool
     {
         return true;
     }


### PR DESCRIPTION
This updates the signature for hasAccess to include the
User whose access is being checked as an explicit parameter.

Nearly every access check previously started with a `User::singleton`
call to get the logged in user (because, obviously, it's the user whose
access is being checked) before this change.

This updates the signature to take the user as a parameter and
remove the singleton calls, which can now be done (relatively)
safely since phan is enforcing signature compatibility and checking
that the right number of parameters are passed at every call site.