### PR TITLE
[document_repository] Fix incorrectly initialized variable

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -16,7 +16,6 @@ return [
 	"scalar_implicit_cast" => false,
 	"ignore_undeclared_variables_in_global_scope" => false,
 	"suppress_issue_types" => [
-        "PhanTypeExpectedObjectPropAccessButGotNull",
         "PhanTypeInvalidDimOffset",
         "PhanTypeMismatchDimAssignment",
 		"PhanRedefineClass",

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -313,7 +313,7 @@ class Document_Repository extends \NDB_Menu_Filter
         $dbresult = $DB->pselect($query, array());
         foreach ($dbresult as $row) {
             $results[] =$row;
-            $tree      = null;
+            $tree      = new stdClass();
             foreach ($results as $result) {
                 $thisref = &$refs->{$result['id']};
                 if (empty($thisref)) {


### PR DESCRIPTION
A variable in the document repository was initialized as null, but then treated as an object. This changes it to be initialized as an object.

Fixes the only PhanTypeExpectedObjectPropAccessButGotNull error.