### PR TITLE
[InstallDB] Modifying the check to see whether http or https protocol is being used.

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -273,9 +273,13 @@ class Installer
         // This is apparently the most reliable way to figure out if
         // the requery is over http or https.. $_SERVER[REQUEST_SCHEME]
         // is not reliable.
-        $RequestScheme = isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
-                            && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'
-                            ? 'https' : 'http';
+        $RequestScheme = 'http';
+        if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on')
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+            && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+        ) {
+               $RequestScheme = 'https';
+        }
 
         return $RequestScheme . '://' . $_SERVER['HTTP_HOST']
             . preg_replace("#/installdb.php#", "", $_SERVER['REQUEST_URI']);

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -273,7 +273,8 @@ class Installer
         // This is apparently the most reliable way to figure out if
         // the requery is over http or https.. $_SERVER[REQUEST_SCHEME]
         // is not reliable.
-        $RequestScheme = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on'
+        $RequestScheme = isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
+                            && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'
                             ? 'https' : 'http';
 
         return $RequestScheme . '://' . $_SERVER['HTTP_HOST']


### PR DESCRIPTION
This pull request attempts to determine whether the http or https protocol is being used. It modifies the `getBaseURL()` function to check if `$_SERVER['HTTP_X_FORWARDED_PROTO']` is set to `https` rather than `$_SERVER['HTTPS']`.

