### PR TITLE
[LorisForm/Instruments] Format indentation/cleanup of smarty template

### DIFF
--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -8,7 +8,7 @@
 	 }
 </style>
 <form method="post" name="test_form" id="test_form" {$form.enctype} {$form.action}>
-<div class="row">
+<div class="form-group">
 	{$form.hidden}
 	{$form.errors.mainError}
 	{assign var="inTable" value="FALSE"}
@@ -19,11 +19,11 @@
 				</table>
 			{/if}
 			{if $element.type eq header}
-				<div class="col-xs-12">
+				<div class="row form-group col-xs-12">
 					{$element.html}
 				</div>
 			{elseif $element.label eq $element.html}
-				<label class="lab col-xs-12">
+				<label class="row form-group col-xs-12">
 					{$element.label}
 				</label>
 			{elseif $element.type eq hidden}
@@ -40,11 +40,11 @@
 						</table>
 					{/if}
 					{if $element.error}
-			    	<div class="row form-group form-inline form-inline has-error">
+			    	<div class="row form-group form-inline has-error">
 			        {else}
-			        <div class="row form-group form-inline form-inline">
+			        <div class="row form-group form-inline">
 			        {/if}
-						<label class="lab col-sm-4 col-xs-12">
+						<label class="col-sm-4 col-xs-12">
 							{if $element.required}
 								<span style="color: #ff0000">*</span>
 							{/if}
@@ -106,11 +106,11 @@
 					</table>
 				{/if}
 				{if $element.error}
-		    	<div class="row form-group form-inline form-inline has-error">
+		    	<div class="row form-group form-inline has-error">
 		        {else}
-		        <div class="row form-group form-inline form-inline">
+		        <div class="row form-group form-inline">
 		        {/if}
-		        	<label class="lab col-sm-4 col-xs-12">
+		        	<label class="col-sm-4 col-xs-12">
 						{if $element.required}
 							<span style="color: #ff0000">*</span>
 						{/if}
@@ -151,11 +151,11 @@
 							</table>
 						{/if}
 						{if $element.error}
-				    	<div class="row form-group form-inline form-inline has-error">
+				    	<div class="row form-group form-inline has-error">
 				        {else}
-				        <div class="row form-group form-inline form-inline">
+				        <div class="row form-group form-inline">
 				        {/if}
-							<label class="lab col-sm-4 col-xs-12">
+							<label class="col-sm-4 col-xs-12">
 								{if $element.required}
 									<span style="color: #ff0000">*</span>
 								{/if}
@@ -221,7 +221,7 @@
 			        {else}
 			        <div class="row form-group form-inline">
 			        {/if}
-			        	<label class="lab col-sm-4 col-xs-12">
+			        	<label class="col-sm-4 col-xs-12">
 							{if $element.required}
 								<span style="color: #ff0000">*</span>
 							{/if}


### PR DESCRIPTION
fix https://redmine.cbrain.mcgill.ca/issues/11853

removed "lab" and duplicated "form-inline" class names - i don't think they actually do anything.

Before & after:
<img width="50%" alt="screenshot 2018-05-10 19 09 55" src="https://user-images.githubusercontent.com/17415878/39898681-d86a6c28-5485-11e8-9f60-1930d8a0096b.png"><img width="50%" alt="screenshot 2018-05-10 19 09 32" src="https://user-images.githubusercontent.com/17415878/39898694-e284e670-5485-11e8-9be4-4a26e67487f5.png">



