### PR TITLE
[document_repository] Fixed multiple files with same name when uploading to document repository

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -186,6 +186,16 @@ CREATE TABLE `psc` (
 
 INSERT INTO `psc` (Name, Alias, Study_site) VALUES ('Data Coordinating Center','DCC', 'Y');
 
+CREATE TABLE `language` (
+  `language_id` integer unsigned NOT NULL AUTO_INCREMENT,
+  `language_code` varchar(255) NOT NULL,
+  `language_label` varchar(255) NOT NULL,
+  PRIMARY KEY (`language_id`),
+  UNIQUE KEY (`language_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO language (language_code, language_label) VALUES ('en-CA', 'English');
+
 CREATE TABLE `users` (
   `ID` int(10) unsigned NOT NULL auto_increment,
   `UserID` varchar(255) NOT NULL default '',
@@ -213,9 +223,11 @@ CREATE TABLE `users` (
   `Password_expiry` date NOT NULL default '1990-04-01',
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
+  `language_preference` integer unsigned default NULL,
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Email` (`Email`),
-  UNIQUE KEY `UserID` (`UserID`)
+  UNIQUE KEY `UserID` (`UserID`),
+  CONSTRAINT `FK_users_2` FOREIGN KEY (`language_preference`) REFERENCES `language` (`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
@@ -520,27 +532,26 @@ CREATE TABLE `tarchive_files` (
 
 
 CREATE TABLE `ImagingFileTypes` (
- `type` varchar(255) NOT NULL PRIMARY KEY
+ `type` varchar(12) NOT NULL PRIMARY KEY,
+ `description` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
-INSERT INTO `ImagingFileTypes` VALUES
-      ('mnc'),
-      ('obj'),
-      ('xfm'),
-      ('xfmmnc'),
-      ('imp'),
-      ('vertstat'),
-      ('xml'),
-      ('txt'),
-      ('nii'),
-      ('nii.gz'),
-      ('nrrd');
+INSERT INTO `ImagingFileTypes` (type, description) VALUES
+  ('mnc',      'MINC file'),
+  ('obj',      'MNI BIC imaging format for a surface'),
+  ('xfm',      'MNI BIC linear transformation matrix file'),
+  ('vertstat', 'MNI BIC imaging format for a field on a surface (e.g. cortical thickness)'),
+  ('xml',      'XML file'),
+  ('txt',      'text file'),
+  ('nii',      'NIfTI file'),
+  ('nrrd',     'NRRD file format (used by DTIPrep)'),
+  ('grid_0',   'MNI BIC non-linear field for non-linear transformation');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `ProtocolFile` varchar(255) NOT NULL DEFAULT '',
-  `FileType` varchar(255) DEFAULT NULL,
+  `FileType` varchar(12) DEFAULT NULL,
   `Tool` varchar(255) NOT NULL DEFAULT '',
   `InsertTime` int(10) unsigned NOT NULL DEFAULT '0',
   `md5sum` varchar(32) DEFAULT NULL,
@@ -608,7 +619,7 @@ CREATE TABLE `files` (
   `CoordinateSpace` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
   `AcquisitionProtocolID` int(10) unsigned default NULL,
-  `FileType` varchar(255) default NULL,
+  `FileType` varchar(12) default NULL,
   `PendingStaging` tinyint(1) NOT NULL default '0',
   `InsertedByUserID` varchar(255) NOT NULL default '',
   `InsertTime` int(10) unsigned NOT NULL default '0',
@@ -845,7 +856,6 @@ CREATE TABLE `document_repository` (
   `File_name` varchar(255) DEFAULT NULL,
   `File_type` varchar(20) DEFAULT NULL,
   `version` varchar(20) DEFAULT NULL,
-  `uuid` varchar(36) DEFAULT NULL,
   `File_size` bigint(20) unsigned DEFAULT NULL,
   `uploaded_by` varchar(255) DEFAULT NULL,
   `For_site` int(2) DEFAULT NULL,
@@ -1329,11 +1339,13 @@ CREATE TABLE `media` (
   `uploaded_by` varchar(255) DEFAULT NULL,
   `hide_file` tinyint(1) DEFAULT '0',
   `date_uploaded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `language_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
-  FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+  FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`),
+  CONSTRAINT `FK_media_language` FOREIGN KEY (`language_id`) REFERENCES `language` (`language_id`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
 -- issues tables
@@ -1399,7 +1411,7 @@ CREATE TABLE `issues_history` (
   `addedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueHistoryID`),
   KEY `fk_issues_comments_1` (`issueID`),
-  CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`)
+  CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments` (
@@ -1410,7 +1422,7 @@ CREATE TABLE `issues_comments` (
   `issueComment` text NOT NULL,
   PRIMARY KEY (`issueCommentID`),
   KEY `fk_issue_comments_1` (`issueID`),
-  CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`)
+  CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments_history` (
@@ -1421,7 +1433,7 @@ CREATE TABLE `issues_comments_history` (
   `editedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueCommentHistoryID`),
   KEY `fk_issues_comments_history` (`issueCommentID`),
-  CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`)
+  CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_watching` (
@@ -1534,7 +1546,7 @@ CREATE TABLE `parameter_session` (
   KEY `session_type` (`SessionID`,`ParameterTypeID`),
   KEY `parameter_value` (`ParameterTypeID`,`Value`(64)),
   CONSTRAINT `FK_parameter_session_2` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`),
-  CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`)
+  CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `parameter_type_override` (
@@ -1768,8 +1780,8 @@ CREATE TABLE `genomic_cpg` (
   `beta_value` decimal(4,3) DEFAULT NULL,
   PRIMARY KEY (`sample_label`,`cpg_name`),
   KEY `cpg_name` (`cpg_name`),
-  CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`),
-  CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`)
+  CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1333,7 +1333,6 @@ CREATE TABLE `media` (
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
   FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
-  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
 -- issues tables
@@ -1345,7 +1344,6 @@ CREATE TABLE `issues_categories` (
   `categoryName` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`categoryID`),
   UNIQUE KEY `categoryName` (`categoryName`)
-  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO issues_categories (categoryName) VALUES
   ('Behavioural Battery'),

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -186,16 +186,6 @@ CREATE TABLE `psc` (
 
 INSERT INTO `psc` (Name, Alias, Study_site) VALUES ('Data Coordinating Center','DCC', 'Y');
 
-CREATE TABLE `language` (
-  `language_id` integer unsigned NOT NULL AUTO_INCREMENT,
-  `language_code` varchar(255) NOT NULL,
-  `language_label` varchar(255) NOT NULL,
-  PRIMARY KEY (`language_id`),
-  UNIQUE KEY (`language_code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO language (language_code, language_label) VALUES ('en-CA', 'English');
-
 CREATE TABLE `users` (
   `ID` int(10) unsigned NOT NULL auto_increment,
   `UserID` varchar(255) NOT NULL default '',
@@ -223,11 +213,8 @@ CREATE TABLE `users` (
   `Password_expiry` date NOT NULL default '1990-04-01',
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
-  `language_preference` integer unsigned default NULL,
   PRIMARY KEY  (`ID`),
-  UNIQUE KEY `Email` (`Email`),
-  UNIQUE KEY `UserID` (`UserID`),
-  CONSTRAINT `FK_users_2` FOREIGN KEY (`language_preference`) REFERENCES `language` (`language_id`)
+  UNIQUE KEY `Email` (`Email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
@@ -532,26 +519,26 @@ CREATE TABLE `tarchive_files` (
 
 
 CREATE TABLE `ImagingFileTypes` (
- `type` varchar(12) NOT NULL PRIMARY KEY,
- `description` varchar(255) DEFAULT NULL
+ `type` varchar(255) NOT NULL PRIMARY KEY
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
-INSERT INTO `ImagingFileTypes` (type, description) VALUES
-  ('mnc',      'MINC file'),
-  ('obj',      'MNI BIC imaging format for a surface'),
-  ('xfm',      'MNI BIC linear transformation matrix file'),
-  ('vertstat', 'MNI BIC imaging format for a field on a surface (e.g. cortical thickness)'),
-  ('xml',      'XML file'),
-  ('txt',      'text file'),
-  ('nii',      'NIfTI file'),
-  ('nrrd',     'NRRD file format (used by DTIPrep)'),
-  ('grid_0',   'MNI BIC non-linear field for non-linear transformation');
+INSERT INTO `ImagingFileTypes` VALUES
+  ('mnc'),
+  ('obj'),
+  ('xfm'),
+  ('xfmmnc'),
+  ('imp'),
+  ('vertstat'),
+  ('xml'),
+  ('txt'),
+  ('nii'),
+  ('nii.gz'),
+  ('nrrd'),;
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `ProtocolFile` varchar(255) NOT NULL DEFAULT '',
-  `FileType` varchar(12) DEFAULT NULL,
   `Tool` varchar(255) NOT NULL DEFAULT '',
   `InsertTime` int(10) unsigned NOT NULL DEFAULT '0',
   `md5sum` varchar(32) DEFAULT NULL,
@@ -619,7 +606,6 @@ CREATE TABLE `files` (
   `CoordinateSpace` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
   `AcquisitionProtocolID` int(10) unsigned default NULL,
-  `FileType` varchar(12) default NULL,
   `PendingStaging` tinyint(1) NOT NULL default '0',
   `InsertedByUserID` varchar(255) NOT NULL default '',
   `InsertTime` int(10) unsigned NOT NULL default '0',
@@ -1344,7 +1330,6 @@ CREATE TABLE `media` (
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
   FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`),
-  CONSTRAINT `FK_media_language` FOREIGN KEY (`language_id`) REFERENCES `language` (`language_id`)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
@@ -1411,7 +1396,6 @@ CREATE TABLE `issues_history` (
   `addedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueHistoryID`),
   KEY `fk_issues_comments_1` (`issueID`),
-  CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments` (
@@ -1422,7 +1406,6 @@ CREATE TABLE `issues_comments` (
   `issueComment` text NOT NULL,
   PRIMARY KEY (`issueCommentID`),
   KEY `fk_issue_comments_1` (`issueID`),
-  CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments_history` (
@@ -1433,7 +1416,6 @@ CREATE TABLE `issues_comments_history` (
   `editedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueCommentHistoryID`),
   KEY `fk_issues_comments_history` (`issueCommentID`),
-  CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_watching` (
@@ -1441,7 +1423,6 @@ CREATE TABLE `issues_watching` (
   `issueID` int(11) unsigned NOT NULL,
   PRIMARY KEY (`userID`,`issueID`),
   KEY `fk_issues_watching_2` (`issueID`),
-  CONSTRAINT `fk_issues_watching_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
@@ -1780,8 +1761,6 @@ CREATE TABLE `genomic_cpg` (
   `beta_value` decimal(4,3) DEFAULT NULL,
   PRIMARY KEY (`sample_label`,`cpg_name`),
   KEY `cpg_name` (`cpg_name`),
-  CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -851,6 +851,7 @@ CREATE TABLE `document_repository` (
   `EARLI` tinyint(1) DEFAULT '0',
   `hide_video` tinyint(1) DEFAULT '0',
   `File_category` int(3) unsigned DEFAULT NULL,
+  `uuid` varchar(36) DEFAULT '',
   PRIMARY KEY (`record_id`),
   KEY `fk_document_repository_1_idx` (`File_category`),
   CONSTRAINT `fk_document_repository_1` FOREIGN KEY (`File_category`) REFERENCES `document_repository_categories` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -534,11 +534,12 @@ INSERT INTO `ImagingFileTypes` VALUES
   ('txt'),
   ('nii'),
   ('nii.gz'),
-  ('nrrd'),;
+  ('nrrd');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `ProtocolFile` varchar(255) NOT NULL DEFAULT '',
+  `FileType` varchar(255) DEFAULT NULL,
   `Tool` varchar(255) NOT NULL DEFAULT '',
   `InsertTime` int(10) unsigned NOT NULL DEFAULT '0',
   `md5sum` varchar(32) DEFAULT NULL,
@@ -606,6 +607,7 @@ CREATE TABLE `files` (
   `CoordinateSpace` varchar(255) default NULL,
   `OutputType` varchar(255) NOT NULL default '',
   `AcquisitionProtocolID` int(10) unsigned default NULL,
+  `FileType` varchar(255) default NULL,
   `PendingStaging` tinyint(1) NOT NULL default '0',
   `InsertedByUserID` varchar(255) NOT NULL default '',
   `InsertTime` int(10) unsigned NOT NULL default '0',
@@ -1325,11 +1327,10 @@ CREATE TABLE `media` (
   `uploaded_by` varchar(255) DEFAULT NULL,
   `hide_file` tinyint(1) DEFAULT '0',
   `date_uploaded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `language_id` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
-  FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`),
+  FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
@@ -1396,6 +1397,7 @@ CREATE TABLE `issues_history` (
   `addedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueHistoryID`),
   KEY `fk_issues_comments_1` (`issueID`),
+  CONSTRAINT `fk_issues_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments` (
@@ -1406,6 +1408,7 @@ CREATE TABLE `issues_comments` (
   `issueComment` text NOT NULL,
   PRIMARY KEY (`issueCommentID`),
   KEY `fk_issue_comments_1` (`issueID`),
+  CONSTRAINT `fk_issue_comments_1` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_comments_history` (
@@ -1416,6 +1419,7 @@ CREATE TABLE `issues_comments_history` (
   `editedBy` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`issueCommentHistoryID`),
   KEY `fk_issues_comments_history` (`issueCommentID`),
+  CONSTRAINT `fk_issues_comments_history` FOREIGN KEY (`issueCommentID`) REFERENCES `issues_comments` (`issueCommentID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `issues_watching` (
@@ -1423,6 +1427,7 @@ CREATE TABLE `issues_watching` (
   `issueID` int(11) unsigned NOT NULL,
   PRIMARY KEY (`userID`,`issueID`),
   KEY `fk_issues_watching_2` (`issueID`),
+  CONSTRAINT `fk_issues_watching_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
@@ -1527,7 +1532,7 @@ CREATE TABLE `parameter_session` (
   KEY `session_type` (`SessionID`,`ParameterTypeID`),
   KEY `parameter_value` (`ParameterTypeID`,`Value`(64)),
   CONSTRAINT `FK_parameter_session_2` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`),
-  CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+  CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `parameter_type_override` (
@@ -1761,6 +1766,8 @@ CREATE TABLE `genomic_cpg` (
   `beta_value` decimal(4,3) DEFAULT NULL,
   PRIMARY KEY (`sample_label`,`cpg_name`),
   KEY `cpg_name` (`cpg_name`),
+  CONSTRAINT `genomic_cpg_ibfk_1` FOREIGN KEY (`sample_label`) REFERENCES `genomic_sample_candidate_rel` (`sample_label`),
+  CONSTRAINT `genomic_cpg_ibfk_2` FOREIGN KEY (`cpg_name`) REFERENCES `genomic_cpg_annotation` (`cpg_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -845,6 +845,7 @@ CREATE TABLE `document_repository` (
   `File_name` varchar(255) DEFAULT NULL,
   `File_type` varchar(20) DEFAULT NULL,
   `version` varchar(20) DEFAULT NULL,
+  `uuid` varchar(36) DEFAULT NULL,
   `File_size` bigint(20) unsigned DEFAULT NULL,
   `uploaded_by` varchar(255) DEFAULT NULL,
   `For_site` int(2) DEFAULT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -214,6 +214,8 @@ CREATE TABLE `users` (
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   PRIMARY KEY  (`ID`),
+  UNIQUE KEY `Email` (`Email`),
+  UNIQUE KEY `UserID` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
@@ -523,17 +525,6 @@ CREATE TABLE `ImagingFileTypes` (
 
 
 INSERT INTO `ImagingFileTypes` VALUES
-  ('mnc'),
-  ('obj'),
-  ('xfm'),
-  ('xfmmnc'),
-  ('imp'),
-  ('vertstat'),
-  ('xml'),
-  ('txt'),
-  ('nii'),
-  ('nii.gz'),
-  ('nrrd');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1343,7 +1334,6 @@ CREATE TABLE `issues_categories` (
   `categoryName` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`categoryID`),
   UNIQUE KEY `categoryName` (`categoryName`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 INSERT INTO issues_categories (categoryName) VALUES

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -525,6 +525,17 @@ CREATE TABLE `ImagingFileTypes` (
 
 
 INSERT INTO `ImagingFileTypes` VALUES
+      ('mnc'),
+      ('obj'),
+      ('xfm'),
+      ('xfmmnc'),
+      ('imp'),
+      ('vertstat'),
+      ('xml'),
+      ('txt'),
+      ('nii'),
+      ('nii.gz'),
+      ('nrrd');
 
 CREATE TABLE `mri_processing_protocol` (
   `ProcessProtocolID` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -1322,7 +1333,6 @@ CREATE TABLE `media` (
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
   FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
-  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
 -- issues tables

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1333,6 +1333,7 @@ CREATE TABLE `media` (
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
   FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
 -- issues tables
@@ -1344,7 +1345,7 @@ CREATE TABLE `issues_categories` (
   `categoryName` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`categoryID`),
   UNIQUE KEY `categoryName` (`categoryName`)
-
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO issues_categories (categoryName) VALUES
   ('Behavioural Battery'),

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1333,6 +1333,7 @@ CREATE TABLE `media` (
   UNIQUE KEY `file_name` (`file_name`),
   FOREIGN KEY (`session_id`) REFERENCES `session` (`ID`),
   FOREIGN KEY (`instrument`) REFERENCES `test_names` (`Test_name`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ********************************
 -- issues tables
@@ -1344,6 +1345,7 @@ CREATE TABLE `issues_categories` (
   `categoryName` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`categoryID`),
   UNIQUE KEY `categoryName` (`categoryName`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO issues_categories (categoryName) VALUES
   ('Behavioural Battery'),

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -214,7 +214,6 @@ CREATE TABLE `users` (
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   PRIMARY KEY  (`ID`),
-  UNIQUE KEY `Email` (`Email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -49,6 +49,10 @@ $dataDir  = $DB->pselectOne(
     "Select Data_dir from document_repository where record_id =:identifier",
     array(':identifier' => $rid)
 );
+$version  = $DB->pselectOne(
+    "Select version from document_repository where record_id =:identifier",
+    array(':identifier' => $rid)
+);
 
 $user =& User::singleton();
 
@@ -66,5 +70,10 @@ $path = __DIR__ . "/../user_uploads/$dataDir";
 if (file_exists($path)) {
     unlink($path);
 }
+
+$rm_directory = __DIR__ . "/../user_uploads/" . $userName . "/"
+                        . str_replace(".", "_", $version);
+
+rmdir($rm_directory);
 
 ?>

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -10,18 +10,23 @@
   * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
   * @link     https://github.com/aces/Loris
   */
+
 $user =& User::singleton();
+
 if (!$user->hasPermission('document_repository_delete')) {
     header('HTTP/1.1 403 Forbidden');
     exit;
 }
 
 set_include_path(get_include_path().':../../project/libraries:../../php/libraries:');
+
 require_once 'NDB_Client.class.inc';
 require_once 'NDB_Config.class.inc';
 require_once 'Email.class.inc';
+
 $client = new NDB_Client();
 $client->initialize('../../project/config.xml');
+
 $factory = NDB_Factory::singleton();
 $baseURL = $factory->settings()->getBaseURL();
 
@@ -65,19 +70,23 @@ if ($user->hasPermission('document_repository_delete')) {
     $Notifier->notify($msg_data);
 }
 
-$path = __DIR__ . '/../user_uploads/$dataDir';
+$path = __DIR__ . '/../user_uploads/' . $dataDir;
 
 if (file_exists($path)) {
     unlink($path);
 }
 
-$rm_directory = __DIR__ . '/../user_uploads/' . $userName . '/'
-                        . str_replace('.', '_', $version);
+// Cleanup empty directories
 set_error_handler(
     function () {
         // Silence the E_WARNING when files exist in the directory.
     }
 );
+$rm_directory = __DIR__ . '/../user_uploads/'
+    . substr($dataDir, 0, strlen($dataDir)-(strlen($fileName)+1));
+rmdir($rm_directory);
+$rm_directory = __DIR__ . '/../user_uploads/'
+    . $userName . '/docs_repo/' . $fileName;
 rmdir($rm_directory);
 restore_error_handler();
 

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -12,16 +12,16 @@
   */
 $user =& User::singleton();
 if (!$user->hasPermission('document_repository_delete')) {
-    header("HTTP/1.1 403 Forbidden");
+    header('HTTP/1.1 403 Forbidden');
     exit;
 }
 
-set_include_path(get_include_path().":../../project/libraries:../../php/libraries:");
-require_once "NDB_Client.class.inc";
-require_once "NDB_Config.class.inc";
-require_once "Email.class.inc";
+set_include_path(get_include_path().':../../project/libraries:../../php/libraries:');
+require_once 'NDB_Client.class.inc';
+require_once 'NDB_Config.class.inc';
+require_once 'Email.class.inc';
 $client = new NDB_Client();
-$client->initialize("../../project/config.xml");
+$client->initialize('../../project/config.xml');
 $factory = NDB_Factory::singleton();
 $baseURL = $factory->settings()->getBaseURL();
 
@@ -31,26 +31,26 @@ $config = NDB_Config::singleton();
 $DB =& Database::singleton();
 
 $Notifier = new NDB_Notifier(
-    "document_repository",
-    "delete"
+    'document_repository',
+    'delete'
 );
 
 $rid = $_POST['id'];
 
 $fileName = $DB->pselectOne(
-    "SELECT File_name FROM document_repository WHERE record_id =:identifier",
+    'SELECT File_name FROM document_repository WHERE record_id =:identifier',
     array(':identifier' => $rid)
 );
 $userName = $DB->pselectOne(
-    "SELECT uploaded_by FROM document_repository WHERE record_id =:identifier",
+    'SELECT uploaded_by FROM document_repository WHERE record_id =:identifier',
     array(':identifier' => $rid)
 );
 $dataDir  = $DB->pselectOne(
-    "SELECT Data_dir FROM document_repository WHERE record_id =:identifier",
+    'SELECT Data_dir FROM document_repository WHERE record_id =:identifier',
     array(':identifier' => $rid)
 );
 $version  = $DB->pselectOne(
-    "SELECT version FROM document_repository WHERE record_id =:identifier",
+    'SELECT version FROM document_repository WHERE record_id =:identifier',
     array(':identifier' => $rid)
 );
 
@@ -58,21 +58,21 @@ $user =& User::singleton();
 
 //if user has document repository delete permission
 if ($user->hasPermission('document_repository_delete')) {
-    $DB->delete("document_repository", array("record_id" => $rid));
-    $msg_data['deleteDocument'] = $baseURL. "/document_repository/";
+    $DB->delete('document_repository', array('record_id' => $rid));
+    $msg_data['deleteDocument'] = $baseURL. '/document_repository/';
     $msg_data['document']       = $fileName;
 
     $Notifier->notify($msg_data);
 }
 
-$path = __DIR__ . "/../user_uploads/$dataDir";
+$path = __DIR__ . '/../user_uploads/$dataDir';
 
 if (file_exists($path)) {
     unlink($path);
 }
 
-$rm_directory = __DIR__ . "/../user_uploads/" . $userName . "/"
-                        . str_replace(".", "_", $version);
+$rm_directory = __DIR__ . '/../user_uploads/' . $userName . '/'
+                        . str_replace('.', '_', $version);
 set_error_handler(
     function () {
         // Silence the E_WARNING when files exist in the directory.

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -54,10 +54,6 @@ $dataDir  = $DB->pselectOne(
     'SELECT Data_dir FROM document_repository WHERE record_id =:identifier',
     array(':identifier' => $rid)
 );
-$version  = $DB->pselectOne(
-    'SELECT version FROM document_repository WHERE record_id =:identifier',
-    array(':identifier' => $rid)
-);
 
 $user =& User::singleton();
 

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -38,19 +38,19 @@ $Notifier = new NDB_Notifier(
 $rid = $_POST['id'];
 
 $fileName = $DB->pselectOne(
-    "Select File_name from document_repository where record_id =:identifier",
+    "SELECT File_name FROM document_repository WHERE record_id =:identifier",
     array(':identifier' => $rid)
 );
 $userName = $DB->pselectOne(
-    "Select uploaded_by from document_repository where record_id =:identifier",
+    "SELECT uploaded_by FROM document_repository WHERE record_id =:identifier",
     array(':identifier' => $rid)
 );
 $dataDir  = $DB->pselectOne(
-    "Select Data_dir from document_repository where record_id =:identifier",
+    "SELECT Data_dir FROM document_repository WHERE record_id =:identifier",
     array(':identifier' => $rid)
 );
 $version  = $DB->pselectOne(
-    "Select version from document_repository where record_id =:identifier",
+    "SELECT version FROM document_repository WHERE record_id =:identifier",
     array(':identifier' => $rid)
 );
 
@@ -73,7 +73,12 @@ if (file_exists($path)) {
 
 $rm_directory = __DIR__ . "/../user_uploads/" . $userName . "/"
                         . str_replace(".", "_", $version);
-
+set_error_handler(
+    function () {
+        // Silence the E_WARNING when files exist in the directory.
+    }
+);
 rmdir($rm_directory);
+restore_error_handler();
 
 ?>

--- a/modules/document_repository/ajax/documentEditUpload.php
+++ b/modules/document_repository/ajax/documentEditUpload.php
@@ -42,12 +42,6 @@ $db        = \Database::singleton(
     $db_config['host']
 );
 
-if ($db->isConnected()) {
-    echo "successfully connected";
-} else {
-    echo "not connected";
-}
-
 $editNotifier = new NDB_Notifier(
     "document_repository",
     "edit"

--- a/modules/document_repository/ajax/documentEditUpload.php
+++ b/modules/document_repository/ajax/documentEditUpload.php
@@ -114,8 +114,14 @@ if ($userSingleton->hasPermission('document_repository_view')
             mkdir($base_path . $puser . '/docs_repo/' . $fileName, 0777);
         }
         // Create uuid directory /base_path/user/docs_repo/fileName/uuid
-        if (!file_exists($base_path . $puser . '/docs_repo/' . $fileName . '/' . $uuid)) {
-            mkdir($base_path . $puser . '/docs_repo/' . $fileName . '/' . $uuid, 0777);
+        if (!file_exists(
+            $base_path . $puser . '/docs_repo/' . $fileName . '/' . $uuid
+        )
+        ) {
+            mkdir(
+                $base_path . $puser . '/docs_repo/' . $fileName . '/' . $uuid,
+                0777
+            );
         }
 
         $target_path = $base_path . $fileBase;
@@ -186,73 +192,6 @@ if ($userSingleton->hasPermission('document_repository_view')
 
         $editNotifier->notify($msg_data);
     }
-}
-
-/**
- * Handles the version inspection process.
- * Generates correct proceeding version in some cases.
- *
- * @param string $version the version to use for uploading file.
- * @param array  $items   the array of existing files (name & version).
- *
- * @return string $version.
- */
-function versionInspectionGenerator($version, $items)
-{
-
-    if (!preg_match('/^(\d+\.)(\d+\.)(\*|\d+)$/', $version)) {
-        $version = '0.0.1';
-    }
-
-    $versions = array();
-    foreach ($items as $item) {
-        if (preg_match('/^(\d+\.)(\d+\.)(\*|\d+)$/', $item['version'])) {
-            $versions[] = $item['version'];
-        }
-    }
-    usort($versions, 'version_compare');
-
-    if (in_array($version, $versions)) {
-        // Version in array.
-        $version = versionUpdate($versions[count($versions)-1], true);
-    } else {
-        // Version not in array.
-        if (empty($versions)) {
-            // No versions exist.
-        } else {
-            // Versions exist.
-            if (version_compare($version, $versions[count($versions)-1], '>')) {
-                // Version number is greater than greatest version existing.
-            } else {
-                // Version number is smaller than greatest version existing.
-                $version = versionUpdate($versions[count($versions)-1], true);
-            }
-        }
-    }
-
-    return $version;
-}
-
-/**
- * Increment or Decrement the version "string" supplied.
- *
- * The $increment "bool" if true will increment the version.
- * and if false will decrement the version.
- *
- * @param string $version   the version to use for uploading file.
- * @param bool   $increment the bool to decide on increment or decrement.
- *
- * @return string $version
- */
-function versionUpdate($version, $increment)
-{
-    $new_version = explode('.', $version);
-    if ($increment) {
-        $new_version[count($new_version)-1]++;
-    } else {
-        $new_version[count($new_version)-1]--;
-    }
-    return implode('.', $new_version);
 }
 
 /**

--- a/modules/document_repository/ajax/documentEditUpload.php
+++ b/modules/document_repository/ajax/documentEditUpload.php
@@ -14,20 +14,20 @@ $userSingleton =& User::singleton();
 if (!$userSingleton->hasPermission('document_repository_view')
     && !$userSingleton->hasPermission('document_repository_delete')
 ) {
-    header("HTTP/1.1 403 Forbidden");
+    header('HTTP/1.1 403 Forbidden');
     exit;
 }
 
 set_include_path(
     get_include_path().
-    ":../../project/libraries:../../php/libraries:"
+    ':../../project/libraries:../../php/libraries:'
 );
-require_once "NDB_Client.class.inc";
-require_once "NDB_Config.class.inc";
-require_once "Email.class.inc";
+require_once 'NDB_Client.class.inc';
+require_once 'NDB_Config.class.inc';
+require_once 'Email.class.inc';
 
 $client = new NDB_Client();
-$client->initialize("../../project/config.xml");
+$client->initialize('../../project/config.xml');
 
 $factory = NDB_Factory::singleton();
 $baseURL = $factory->settings()->getBaseURL();
@@ -43,13 +43,13 @@ $db        = \Database::singleton(
 );
 
 $editNotifier = new NDB_Notifier(
-    "document_repository",
-    "edit"
+    'document_repository',
+    'edit'
 );
 
 $uploadNotifier = new NDB_Notifier(
-    "document_repository",
-    "upload"
+    'document_repository',
+    'upload'
 );
 
 $action = $_POST['action'];
@@ -66,42 +66,61 @@ if ($userSingleton->hasPermission('document_repository_view')
         $pscid      = $_POST['pscid']      !== '' ? $_POST['pscid'] : null;
         $visit      = $_POST['visit']      !== '' ? $_POST['visit'] : null;
         $comments   = $_POST['comments']   !== '' ? $_POST['comments'] : null;
+        $version    = $_POST['version']    !== '' ? $_POST['version'] : null;
+        $uuid       = uuid4();
 
-        $fileSize = $_FILES["file"]["size"];
-        $fileName = $_FILES["file"]["name"];
-        $fileType = end(explode(".", $fileName));
-
+        $fileSize = $_FILES['file']['size'];
+        $fileName = $_FILES['file']['name'];
+        $fileType = '';
+        // Handle retrieving the file type.
+        if (preg_match('/\./', $fileName)) {
+            $pos = strrpos($fileName, '.', -1);
+            if ($pos+1 != strlen($fileName)) {
+                $fileType = substr(
+                    $fileName,
+                    strrpos($fileName, '.', -1)+1
+                );
+            }
+        }
         $sql_statement = $db->prepare(
-            "SELECT File_name, version FROM document_repository "
-            ."WHERE File_name=? AND uploaded_by=?"
+            'SELECT File_name, version FROM document_repository '
+            .'WHERE File_name=? AND uploaded_by=?'
         );
         $sql_statement->bindParam(1, $fileName, PDO::PARAM_STR);
         $sql_statement->bindParam(2, $puser, PDO::PARAM_STR);
         $sql_statement->execute();
         $sql_result = $sql_statement->fetchAll(PDO::FETCH_ASSOC);
 
-        $version = versionInspectionGenerator($_POST['version'] ?? '', $sql_result);
-
-        $version_underscore = str_replace(".", "_", $version);
-
         // __DIR__ is the document_repository ajax directory
         // when this script is executing. Go up a level to the
         // document_repository module directory, and use a
         // user_uploads directory as a base for user uploads
-        $base_path = __DIR__ . "/../user_uploads/";
-        $fileBase  = $puser . "/" . $version_underscore . "/" . $fileName;
+        $base_path = __DIR__ . '/../user_uploads/';
+        $fileBase  = $puser . '/docs_repo/'
+            . $fileName
+            . '/' . $uuid
+            . '/' . $fileName;
 
+        // Create user directory /base_path/user
         if (!file_exists($base_path . $puser)) {
             mkdir($base_path . $puser, 0777);
         }
-
-        if (!file_exists($base_path . $puser . "/" . $version_underscore)) {
-            mkdir($base_path . $puser . "/" . $version_underscore, 0777);
+        // Create user directory /base_path/user/docs_repo
+        if (!file_exists($base_path . $puser . '/docs_repo')) {
+            mkdir($base_path . $puser . '/docs_repo', 0777);
+        }
+        // Create filename directory /base_path/user/docs_repo/fileName
+        if (!file_exists($base_path . $puser . '/docs_repo/' . $fileName)) {
+            mkdir($base_path . $puser . '/docs_repo/' . $fileName, 0777);
+        }
+        // Create uuid directory /base_path/user/docs_repo/fileName/uuid
+        if (!file_exists($base_path . $puser . '/docs_repo/' . $fileName . '/' . $uuid)) {
+            mkdir($base_path . $puser . '/docs_repo/' . $fileName . '/' . $uuid, 0777);
         }
 
         $target_path = $base_path . $fileBase;
 
-        if (move_uploaded_file($_FILES["file"]["tmp_name"], $target_path)) {
+        if (move_uploaded_file($_FILES['file']['tmp_name'], $target_path)) {
             $success = $db->insert(
                 'document_repository',
                 array(
@@ -118,20 +137,19 @@ if ($userSingleton->hasPermission('document_repository_view')
                  'visitLabel'    => $visit,
                  'File_type'     => $fileType,
                  'version'       => $version,
+                 'uuid'          => $uuid,
                 )
             );
-            $msg_data['newDocument']
-                = $baseURL . "/document_repository/";
+            $msg_data['newDocument'] = $baseURL . '/document_repository/';
             $msg_data['document']    = $fileName;
 
             $uploadNotifier->notify($msg_data);
 
-            $header = "Location:".
-                      " $baseURL/document_repository/?uploadSuccess=true";
+            $header = 'Location: '.$baseURL
+                .'/document_repository/?uploadSuccess=true';
             header($header);
-
         } else {
-            echo "There was an error uploading the file";
+            echo 'There was an error uploading the file';
         }
     } elseif ($action == 'edit') {
         $id         = $_POST['idEdit'];
@@ -144,7 +162,7 @@ if ($userSingleton->hasPermission('document_repository_view')
         $version    = $_POST['versionEdit'];
 
         if (empty($category) && $category !== '0') {
-            header("HTTP/1.1 400 Bad Request");
+            header('HTTP/1.1 400 Bad Request');
             exit;
         }
 
@@ -160,10 +178,10 @@ if ($userSingleton->hasPermission('document_repository_view')
         $db->update('document_repository', $values, array('record_id' => $id));
 
         $fileName = $db->pselectOne(
-            "select File_name from document_repository where record_id=:record_id",
+            'SELECT File_name FROM document_repository WHERE record_id=:record_id',
             array('record_id' => $id)
         );
-        $msg_data['updatedDocument'] = $baseURL . "/document_repository/";
+        $msg_data['updatedDocument'] = $baseURL . '/document_repository/';
         $msg_data['document']        = $fileName;
 
         $editNotifier->notify($msg_data);
@@ -235,6 +253,28 @@ function versionUpdate($version, $increment)
         $new_version[count($new_version)-1]--;
     }
     return implode('.', $new_version);
+}
+
+/**
+ * Create a UUID v4 string.
+ *
+ * Source from comments:
+ * http://php.net/manual/en/function.com-create-guid.php
+ * Maybe move to Utilities class.
+ *
+ * @return string $version
+ */
+function uuid4()
+{
+    if (function_exists('com_create_guid') === true) {
+        // Windows Server
+        return trim(com_create_guid(), '{}');
+    }
+    // Linux Server
+    $data    = openssl_random_pseudo_bytes(16);
+    $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
+    $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
+    return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
 }
 
 ?>


### PR DESCRIPTION
This pull request `Allow files with duplicate name to exist and when user uploads a file to the document repository`. 

I made the mysql column "uuid" in the table "document_repository" for files to be stored in unique directories.

The uuid and file_name are used for the system directory structure when storing the files.
System Directory Structure Examples:

Note: {uuid} is unique per upload.
user_uploads/admin/text.png/{uuid}/text.png
user_uploads/admin/text.txt/{uuid}/text.txt

user_uploads/admin/text.png/{uuid}/text.png
user_uploads/admin/text.txt/{uuid}/text.txt

See also: `Bug #10847 and Bug #11243`