### PR TITLE
[LorisForm] Returning 401 error when accessing instrument instead of 500

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -175,7 +175,7 @@ try {
         $tpl_data['control_panel'] = $caller->controlPanel;
     }
     if (isset($caller->feedbackPanel)) {
-        if (is_null($user)) {
+        if (!isset($user)) {
             throw new Exception(401);
         }
         if ($user->hasPermission('bvl_feedback')) {

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -174,14 +174,17 @@ try {
     if (isset($caller->controlPanel)) {
         $tpl_data['control_panel'] = $caller->controlPanel;
     }
-
-    if (isset($caller->feedbackPanel) && $user->hasPermission('bvl_feedback')) {
-        $tpl_data['bvl_feedback']   = NDB_BVL_Feedback::bvlFeedbackPossible(
-            $TestName
-        );
-        $tpl_data['feedback_panel'] = $caller->feedbackPanel;
+    if (isset($caller->feedbackPanel)) {
+        if (is_null($user)) {
+            throw new Exception(401);
+        }
+        if ($user->hasPermission('bvl_feedback')) {
+            $tpl_data['bvl_feedback']   = NDB_BVL_Feedback::bvlFeedbackPossible(
+                $TestName
+            );
+            $tpl_data['feedback_panel'] = $caller->feedbackPanel;
+        }
     }
-
     if (isset($caller->page)) {
         $tpl_data['jsfiles']  = $caller->page->getJSDependencies();
         $tpl_data['cssfiles'] = $caller->page->getCSSDependencies();
@@ -216,6 +219,12 @@ try {
         $errorPage = new Smarty_neurodb;
         $errorPage->assign($tpl_data);
         $tpl_data['workspace'] = $errorPage->fetch('403.tpl');
+        break;
+    case 401:
+        header("HTTP/1.1 401 Unauthorized");
+        $errorPage = new Smarty_neurodb;
+        $errorPage->assign($tpl_data);
+        $tpl_data['workspace'] = $errorPage->fetch('401.tpl');
         break;
     default:
         header("HTTP/1.1 500 Internal Server Error");

--- a/smarty/templates/401.tpl
+++ b/smarty/templates/401.tpl
@@ -1,0 +1,4 @@
+<div class="container">
+    <h2>Access is denied due to invalid credentials.</h2>
+    <div><a href="{$baseurl}">Go to login page</a></div>
+</div>

--- a/smarty/templates/401.tpl
+++ b/smarty/templates/401.tpl
@@ -1,4 +1,4 @@
 <div class="container">
-    <h2>Access is denied due to invalid credentials.</h2>
+    <h2>You must log in to view this page.</h2>
     <div><a href="{$baseurl}">Go to login page</a></div>
 </div>


### PR DESCRIPTION
This pull request attempts to fix https://redmine.cbrain.mcgill.ca/issues/14445. 

It redirects to a 401 error rather than a 500 error when a user tries to access an instrument when they are not logged in (ie. tries to go back a page after they have logged out).

