### PR TITLE
[New Profile] Fixed array index access

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -291,7 +291,7 @@ class New_Profile extends \NDB_Form
                 $errors['PSCID'] = 'PSCID does not match the required structure';
             } elseif ($db->pselectOne(
                 "SELECT count(PSCID) FROM candidate WHERE PSCID=:V_PSCID",
-                array('V_PSCID' => $values[PSCID])
+                array('V_PSCID' => $values['PSCID'])
             ) > 0
             ) {
                     $errors['PSCID'] = 'PSCID has already been registered';


### PR DESCRIPTION
Code was attempting to access a php constant instead of using a string as array index value.

NOTE: when testing this you may find that new profile is broken due to a function being called on a string. This is a separate issue I will solve in another PR.