### PR TITLE
[tools] Removed log warning for data dictionary builder

### DIFF
--- a/tools/data_dictionary_builder.php
+++ b/tools/data_dictionary_builder.php
@@ -169,7 +169,7 @@ foreach ($instruments AS $instrument) {
             //for HTML_QuickForm versions of standard HTML Form Elements...
         default:
             //continue; // jump straight to validity for debugging
-            if (preg_match("/^Examiner/", $bits[1])) {
+            if (isset($bits[1]) && preg_match("/^Examiner/", $bits[1])) {
                 // Treat examiner specially, since it's a select box but we need
                 // to treat it as a varchar. derive_timepoint_variables will derive
                 // the name from the examiner id


### PR DESCRIPTION
This removes the following warning from the error log
`PHP Notice:  Undefined offset: 1 in /var/www/ccna/tools/data_dictionary_builder.php on line 172`
