### PR TITLE
[datadict] Search keyword filter will now return rows for multiple words

### DIFF
--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -56,7 +56,7 @@ class Datadict extends \NDB_Menu_Filter
                           'pt.sourceFrom',
                           'pt.Name',
                           'pt.sourceField',
-                          'coalesce(pto.description,pt.description)'.
+                          'COALESCE(pto.description,pt.description)'.
                           ' as description',
                          );
 
@@ -64,9 +64,9 @@ class Datadict extends \NDB_Menu_Filter
                                'pt.sourceFrom',
                                'pt.Description',
                               );
-        $this->query        = ' FROM parameter_type pt LEFT JOIN 
+        $this->query        = " FROM parameter_type pt LEFT JOIN 
                                 parameter_type_override pto USING (Name)
-                 		        WHERE pt.Queryable=1';
+                 		        WHERE pt.Queryable=1";
 
         $this->formToFilter = array(
                                'sourceFrom'  => 'pt.sourceFrom',
@@ -76,7 +76,7 @@ class Datadict extends \NDB_Menu_Filter
         $this->searchKeyword = array(
                                 'pt.Name',
                                 'pt.sourceField',
-                                'coalesce(pto.description,pt.description)',
+                                'COALESCE(pto.description,pt.description)',
                                );
         return true;
     }
@@ -271,16 +271,16 @@ class Datadict extends \NDB_Menu_Filter
                 || strtolower(substr($key, -10)) == 'categoryid'
                 || strtolower(substr($key, -6)) == 'gender'
             ) {
-                $query .= ' AND ' . $key . ' = \'' . $val . '\' ';
+                $query .= " AND $key = '$val' ";
             } else {
                 if ($val == 'empty') {
-                    $query .= ' AND COALESCE(pto.description,pt.description) = \'\'';
+                    $query .= " AND COALESCE(pto.description,pt.description) = ''";
                 } elseif ($val=='modified') {
-                    $query .= ' AND pto.name IS NOT NULL';
+                    $query .= " AND pto.name IS NOT NULL";
                 } elseif ($val=='unmodified') {
-                    $query .= ' AND pto.name IS NULL';
+                    $query .= " AND pto.name IS NULL";
                 } else {
-                    $query .= ' AND '.$key.' LIKE \'' . $val . '%\' ';
+                    $query .= " AND $key LIKE '$val%' ";
                 }
             }
         }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -76,7 +76,7 @@ class Datadict extends \NDB_Menu_Filter
         $this->searchKeyword = array(
                                 'pt.Name',
                                 'pt.sourceField',
-                                'pt.description',
+                                'coalesce(pto.description,pt.description)',
                                );
         return true;
     }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -27,28 +27,28 @@ class Datadict extends \NDB_Menu_Filter
 {
     var $AjaxModule = true;
     /**
-    * Overloading this method to allow access to site users (their own site
-    * only) and users w/ multisite privs
-    *
-    * @note   overloaded function
-    * @return bool
-    * @access private
-    */
+     * Overloading this method to allow access to site users (their own site
+     * only) and users w/ multisite privs
+     *
+     * @note   overloaded function
+     * @return bool
+     * @access private
+     */
     function _hasAccess()
     {
         // create user object
         $user =& \User::singleton();
 
         return ($user->hasPermission('data_dict_view') ||
-                $user->hasPermission('data_dict_edit'));
+            $user->hasPermission('data_dict_edit'));
     }
     /**
-    * Setup variables function
-    *
-    * @note   Setup variables function
-    * @return bool
-    * @access private
-    */
+     * Setup variables function
+     *
+     * @note   Setup variables function
+     * @return bool
+     * @access private
+     */
     function _setupVariables()
     {
         // set the class variables
@@ -57,7 +57,7 @@ class Datadict extends \NDB_Menu_Filter
                           'pt.Name',
                           'pt.sourceField',
                           'coalesce(pto.description,pt.description)'.
-                                                   ' as description',
+                          ' as description',
                          );
 
         $this->validFilters = array(
@@ -66,7 +66,7 @@ class Datadict extends \NDB_Menu_Filter
                               );
         $this->query        = " FROM parameter_type pt LEFT JOIN 
                                 parameter_type_override pto USING (Name)
-                 		WHERE pt.Queryable=1";
+                 		        WHERE pt.Queryable=1";
 
         $this->formToFilter = array(
                                'sourceFrom'  => 'pt.sourceFrom',
@@ -82,10 +82,10 @@ class Datadict extends \NDB_Menu_Filter
     }
 
     /**
-    * Set Filter Form
-    *
-    * @return none
-    */
+     * Set Filter Form
+     *
+     * @return none
+     */
     function setup()
     {
         parent::setup();
@@ -113,16 +113,108 @@ class Datadict extends \NDB_Menu_Filter
     }
 
     /**
-    * Add query filters
-    *
-    * @param string $prepared_key the query string
-    * @param string $key          the key of filter
-    * @param string $val          the value of filter
-    *
-    * @note   Get base query
-    * @return string
-    * @access private
-    */
+     * Builds the filter array to be used in this filter menu. The end result
+     * should be that all the NDB_Menu_Filter attributes required for the query
+     * to work are set up.
+     *
+     * Generally, it does the following:
+     *   1. Reset filters (if applicable)
+     *   2. Set up the (new) filters
+     *   3. Set up the search keyword
+     *   4. Set the search order (if applicable)
+     *
+     * The end result should be that $this->filter and $this->having are setup
+     * properly so that the query can be constructed by $this->_getList()
+     *
+     * @return none
+     */
+    function _setupFilters()
+    {
+        // 1. Reset filters
+        if (isset($_REQUEST['reset'])) {
+            // erase filter data from the session
+            $this->_resetFilters(true);
+        }
+
+        // 2. After resetting filters (if applicable), set the new
+        // filters using the appropriate method.
+        if ($_SERVER['REQUEST_METHOD'] === 'GET'
+            || ($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($_POST['filter']))
+        ) {
+            // If it's a GET request (ie just reloading the page with
+            // previous filters or clicking on a sort column, use
+            // the filters that were saved into the session.
+            // OR a post request with no new defined filters (ie a second
+            // form on the page)
+            $savedFilters = $_SESSION['State']->getProperty('filter');
+            $this->_setFilters($savedFilters);
+
+            // Also set the form defaults based on the saved query, so that
+            // the filters values remain populated correctly in the front-end,
+            // not just in the query..
+            $defaults = $this->_getDefaults();
+            if (is_array($savedFilters)) {
+                $this->_setDefaults(array_merge($defaults, $savedFilters));
+            } else {
+                $this->_setDefaults($defaults);
+            }
+        } else if ($_SERVER['REQUEST_METHOD'] === 'POST'
+            && isset($_POST['filter'])
+        ) {
+            // If it's a POST, set the filters based on the
+            // request and save them into the session so that future
+            // GET requests have access to them.
+            $newFilters = $this->_setFilters($_POST);
+            if (!empty($newFilters)) {
+                $_SESSION['State']->setProperty('filter', $newFilters);
+            }
+        }
+
+        // 3. Set the search keyword (if applicable)
+        $key = null;
+        if (isset($_REQUEST['keyword'])) {
+            // It was included in the request, so save it.
+            $key = $_REQUEST['keyword'];
+            // Check if multiple keyword search
+            if (preg_match("/\\s/", $key)
+            ) {
+                $key = explode(" ", $key);
+                foreach ($key as &$k) {
+                    $k = '.*'.$k;
+                }
+                unset($k);
+            }
+            $_SESSION['State']->setProperty('keyword', $key);
+        } else {
+            // It was not included, so get the keyword from the session
+            $key = $_SESSION['State']->getProperty('keyword');
+        }
+
+        // Set the keyword after getting it from the appropriate place
+        if (!empty($key)) {
+            $this->_setSearchKeyword($key);
+
+        }
+
+        // 4. If the user clicked on a sort column, set the order.
+        //    It's likely a GET request even though it modifies the data,
+        //    so just use $_REQUEST.
+        if (isset($_REQUEST['filter']['order'])) {
+            $this->_setFilterSortOrder($_REQUEST['filter']['order']);
+        }
+    }
+
+    /**
+     * Add query filters
+     *
+     * @param string $prepared_key the query string
+     * @param string $key          the key of filter
+     * @param string $val          the value of filter
+     *
+     * @note   Get base query
+     * @return string
+     * @access private
+     */
     function _addValidFilters($prepared_key, $key, $val)
     {
         $query = '';
@@ -148,6 +240,179 @@ class Datadict extends \NDB_Menu_Filter
         }
         return $query;
 
+    }
+
+    /**
+     * Constructs the base filter (WHERE clause) to use for this
+     * menu.
+     *
+     * @return array contains a 'clause' key which contains the text
+     *               for the SQL query and 'params' which contains the
+     *               parameters to use bind for a prepared query.
+     */
+    function _getBaseFilter()
+    {
+        $qparams     = array();
+        $WhereClause = '';
+        // add filters to query
+        if (is_array($this->filter) && count($this->filter) > 0) {
+            foreach ($this->filter as $field => $val) {
+                $prepared_key = Utility::getCleanString($field);
+                $query_piece  = $this->_addValidFilters($prepared_key, $field, $val);
+                if (!empty($query_piece)) {
+                    $WhereClause .= $query_piece;
+
+                    if (in_array($field, $this->CheckboxFilters)) {
+                        continue;
+                    }
+                    if ($prepared_key != 'pending') {
+                        $qparams["v_$prepared_key"] = $val;
+                    }
+                }
+            }
+        }
+
+        if (isset($this->searchKeyword)
+            && is_array($this->searchKeyword)
+            && count($this->searchKeyword) > 0
+            && !empty($this->searchKey['keyword'])
+        ) {
+            $WhereClause .= " AND (";
+            $fields       = array();
+
+            $qparams['v_searchkey'] = $this->searchKey['keyword'];
+
+            foreach ($this->searchKeyword as $field) {
+                if (isset($qparams['v_searchkey'])
+                    && is_array(($qparams['v_searchkey']))
+                ) {
+                    $fields[] = " $field REGEXP :v_searchkey";
+                } else {
+                    $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
+                }
+            }
+            $WhereClause .= join(" OR ", $fields);
+            $WhereClause .= ")";
+
+        }
+
+        // add GROUP BY if applicable
+        if (!empty($this->group_by)) {
+            $WhereClause .= " GROUP BY $this->group_by ";
+        }
+        // add HAVING clause (for restricting aggregates)
+        if (!empty($this->having)) {
+            // Can't use Database::_implodeWithKeys, because the function
+            // puts `` around the fieldname, causing it to treat the
+            // aggregate function as a fieldname instead of a function
+            $first = true;
+            foreach ($this->having as $key => $val) {
+                if ($val !== '' and $val != null) {
+                    $prepared_key = Utility::getCleanString($key);
+                    if ($first == false) {
+                        $WhereClause .= ' AND ';
+                    } else {
+                        $WhereClause .= ' HAVING ';
+                    }
+                    $first = false;
+
+                    if (isset($qparams['v_searchkey'])
+                        && is_array(($qparams['v_searchkey']))
+                    ) {
+                        // Multiple keyword search
+                        $WhereClause .= "$key REGEXP :v_$prepared_key";
+                    } else {
+                        // Single keyword search
+                        $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";
+                    }
+                    $qparams["v_$prepared_key"] = $val;
+                }
+            }
+        }
+
+        return array(
+                'clause' => $WhereClause,
+                'params' => $qparams,
+               );
+    }
+
+    /**
+     * Returns the number of pages that this menu has.
+     *
+     * @param string $query The query used to build the data in the table.
+     *
+     * @return integer The number of pages that the query returns
+     */
+    function _getNumberPages($query)
+    {
+        $wheredetails = $this->_getBaseFilter();
+        $db           = \Database::singleton();
+        if (empty($this->group_by) && empty($this->having)) {
+            $query = "SELECT COUNT(*)" . $this->query . $wheredetails['clause'];
+        } else {
+            $query = "SELECT COUNT(*) FROM ($query) as tmptable";
+        }
+        $params =  $wheredetails['params'];
+        if (isset($params['v_searchkey'])
+            && is_array(($params['v_searchkey']))
+        ) {
+            // Multiple keyword search
+            $params = array('v_searchkey' => implode('|', $params['v_searchkey']));
+
+            $this->TotalItems = $db->pselectOne($query, $params);
+        } else {
+            // Single keyword search
+            $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
+        }
+    }
+
+    /**
+     * Returns the full list of candidates, users, etc.
+     *
+     * @return array
+     * @access private
+     */
+    function _getFullList()
+    {
+        // create DB object
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+
+        $qparams = array();
+        // add the base query
+        $query  = '';
+        $query .= $this->_getBaseQuery();
+
+        $filterdetails = $this->_getBaseFilter();
+        $query        .= $filterdetails['clause'];
+        $qparams       = $filterdetails['params'];
+        // apply ORDER BY filters
+        $query .= " ORDER BY ";
+        if (!empty($this->filter['order'])) {
+            $query .= $this->filter['order']['field']
+                ." ".$this->filter['order']['fieldOrder'].", ";
+        }
+        $query .= $this->order_by;
+
+        if (!empty($this->limit)) {
+            $query .= " LIMIT $this->limit";
+        }
+
+        // get the list
+        $this->_getNumberPages($query);
+
+        if (isset($qparams['v_searchkey'])
+            && is_array(($qparams['v_searchkey']))
+        ) {
+            // Multiple keyword search
+            $params = array('v_searchkey' => implode('|', $qparams['v_searchkey']));
+            $result = $DB->pselect($query, $params);
+        } else {
+            // Single keyword search
+            $result = $DB->pselect($query, $qparams);
+        }
+
+        return $result;
     }
 
     /**

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -175,16 +175,57 @@ class Datadict extends \NDB_Menu_Filter
         if (isset($_REQUEST['keyword'])) {
             // It was included in the request, so save it.
             $key = $_REQUEST['keyword'];
-            // Check if multiple keyword search
-            if (preg_match("/\\s/", $key)
+            // Check if any quoted keyword
+            if (preg_match_all(
+                '\"[\w\s]+\"|\\\'[\w\s]+\\\'|[\w\s]+',
+                $key,
+                $keywords
+            )
             ) {
-                $key = explode(" ", $key);
-                foreach ($key as &$k) {
+                $keywords = array_filter(
+                    array_map(
+                        function ($item) {
+                            return trim($item, ' ');
+                        },
+                        $keywords[0]
+                    )
+                );
+            }
+            if (is_array($keywords)) {
+                // Quoted keyword(s) exist.
+                $keywords_extra = array();
+                foreach ($keywords as &$keyword) {
+                    if (preg_match('\"[\w\s]+\"', $keyword)) {
+                        // Handle the quoted keyword.
+                        $keyword = '(?i)^' . $keyword . '$';
+                    } else if (preg_match('/\\s/', $keyword)) {
+                        // Handle multiple keywords.
+                        $split_keywords = explode(' ', $keyword);
+                        foreach ($split_keywords as &$split_keyword) {
+                            $split_keyword = '.*'.$split_keyword;
+                        }
+                        unset($split_keyword);
+                        $keywords       = array_diff($keywords, $keyword);
+                        $keywords_extra = array_merge(
+                            $keywords_extra,
+                            $split_keywords
+                        );
+                    }
+                }
+                $keywords = array_merge($keywords, $keywords_extra);
+            } else if (preg_match('/\\s/', $key)
+            ) {
+                // Check if multiple keyword search
+                $keywords = explode(' ', $key);
+                foreach ($keywords as &$k) {
                     $k = '.*'.$k;
                 }
                 unset($k);
+            } else {
+                $keywords = $key;
             }
-            $_SESSION['State']->setProperty('keyword', $key);
+            $_SESSION['State']->setProperty('keyword', $keywords);
+            $key = $keywords;
         } else {
             // It was not included, so get the keyword from the session
             $key = $_SESSION['State']->getProperty('keyword');

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -64,9 +64,9 @@ class Datadict extends \NDB_Menu_Filter
                                'pt.sourceFrom',
                                'pt.Description',
                               );
-        $this->query        = " FROM parameter_type pt LEFT JOIN 
+        $this->query        = ' FROM parameter_type pt LEFT JOIN 
                                 parameter_type_override pto USING (Name)
-                 		        WHERE pt.Queryable=1";
+                 		        WHERE pt.Queryable=1';
 
         $this->formToFilter = array(
                                'sourceFrom'  => 'pt.sourceFrom',
@@ -174,14 +174,16 @@ class Datadict extends \NDB_Menu_Filter
         $key = null;
         if (isset($_REQUEST['keyword'])) {
             // It was included in the request, so save it.
-            $key = $_REQUEST['keyword'];
-            // Check if any quoted keyword
+            $key      = $_REQUEST['keyword'];
+            $keyword  = null;
+            $keywords = null;
             if (preg_match_all(
-                '\"[\w\s]+\"|\\\'[\w\s]+\\\'|[\w\s]+',
+                '/\".[^"]+\"|[^"]+/m',
                 $key,
                 $keywords
             )
             ) {
+                // Any Quoted keyword.
                 $keywords = array_filter(
                     array_map(
                         function ($item) {
@@ -195,27 +197,30 @@ class Datadict extends \NDB_Menu_Filter
                 // Quoted keyword(s) exist.
                 $keywords_extra = array();
                 foreach ($keywords as &$keyword) {
-                    if (preg_match('\"[\w\s]+\"', $keyword)) {
+                    if (preg_match('/\"[^"]+\"/m', $keyword)) {
                         // Handle the quoted keyword.
-                        $keyword = '(?i)^' . $keyword . '$';
-                    } else if (preg_match('/\\s/', $keyword)) {
+                        $keyword = str_replace('"', "", $keyword);
+                    } else {
                         // Handle multiple keywords.
                         $split_keywords = explode(' ', $keyword);
                         foreach ($split_keywords as &$split_keyword) {
                             $split_keyword = '.*'.$split_keyword;
                         }
+                        $keyword = null;
                         unset($split_keyword);
-                        $keywords       = array_diff($keywords, $keyword);
                         $keywords_extra = array_merge(
                             $keywords_extra,
                             $split_keywords
                         );
                     }
                 }
-                $keywords = array_merge($keywords, $keywords_extra);
+                $keywords = array_filter($keywords);
+                $keywords = is_array($keywords)
+                    ? array_merge($keywords, $keywords_extra)
+                    : array_merge([$keyword], $keywords_extra);
             } else if (preg_match('/\\s/', $key)
             ) {
-                // Check if multiple keyword search
+                // Multiple keyword search.
                 $keywords = explode(' ', $key);
                 foreach ($keywords as &$k) {
                     $k = '.*'.$k;
@@ -224,8 +229,8 @@ class Datadict extends \NDB_Menu_Filter
             } else {
                 $keywords = $key;
             }
-            $_SESSION['State']->setProperty('keyword', $keywords);
             $key = $keywords;
+            $_SESSION['State']->setProperty('keyword', $keywords);
         } else {
             // It was not included, so get the keyword from the session
             $key = $_SESSION['State']->getProperty('keyword');
@@ -266,16 +271,16 @@ class Datadict extends \NDB_Menu_Filter
                 || strtolower(substr($key, -10)) == 'categoryid'
                 || strtolower(substr($key, -6)) == 'gender'
             ) {
-                $query .= " AND $key = '$val' ";
+                $query .= ' AND ' . $key . ' = \'' . $val . '\' ';
             } else {
                 if ($val == 'empty') {
-                    $query .= " AND COALESCE(pto.description,pt.description) = ''";
+                    $query .= ' AND COALESCE(pto.description,pt.description) = \'\'';
                 } elseif ($val=='modified') {
-                    $query .= " AND pto.name IS NOT NULL";
+                    $query .= ' AND pto.name IS NOT NULL';
                 } elseif ($val=='unmodified') {
-                    $query .= " AND pto.name IS NULL";
+                    $query .= ' AND pto.name IS NULL';
                 } else {
-                    $query .= " AND $key LIKE '$val%' ";
+                    $query .= ' AND $key LIKE \'' . $val . '%\' ';
                 }
             }
         }
@@ -307,7 +312,7 @@ class Datadict extends \NDB_Menu_Filter
                         continue;
                     }
                     if ($prepared_key != 'pending') {
-                        $qparams["v_$prepared_key"] = $val;
+                        $qparams['v_'.$prepared_key] = $val;
                     }
                 }
             }
@@ -318,28 +323,35 @@ class Datadict extends \NDB_Menu_Filter
             && count($this->searchKeyword) > 0
             && !empty($this->searchKey['keyword'])
         ) {
-            $WhereClause .= " AND (";
+            $WhereClause .= ' AND (';
             $fields       = array();
 
             $qparams['v_searchkey'] = $this->searchKey['keyword'];
 
             foreach ($this->searchKeyword as $field) {
-                if (isset($qparams['v_searchkey'])
-                    && is_array(($qparams['v_searchkey']))
-                ) {
-                    $fields[] = " $field REGEXP :v_searchkey";
-                } else {
-                    $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
+                foreach ($qparams['v_searchkey'] as $i => $value) {
+                    if (isset($qparams['v_searchkey'])
+                        && is_array(($qparams['v_searchkey']))
+                    ) {
+                        if (strpos($qparams['v_searchkey'][$i], '.*') !== false) {
+                            $fields[] = ' ' . $field . ' REGEXP :v_searchkey_' .$i;
+                        } else {
+                            $fields[] = ' ' . $field . ' = :v_searchkey_' . $i;
+                        }
+                    } else {
+                        $fields[] = ' ' . $field
+                            . ' LIKE CONCAT(\'%\', :v_searchkey_' . $i . ', \'%\')';
+                    }
                 }
             }
-            $WhereClause .= join(" OR ", $fields);
-            $WhereClause .= ")";
+            $WhereClause .= join(' OR ', $fields);
+            $WhereClause .= ')';
 
         }
 
         // add GROUP BY if applicable
         if (!empty($this->group_by)) {
-            $WhereClause .= " GROUP BY $this->group_by ";
+            $WhereClause .= ' GROUP BY ' . $this->group_by;
         }
         // add HAVING clause (for restricting aggregates)
         if (!empty($this->having)) {
@@ -361,16 +373,16 @@ class Datadict extends \NDB_Menu_Filter
                         && is_array(($qparams['v_searchkey']))
                     ) {
                         // Multiple keyword search
-                        $WhereClause .= "$key REGEXP :v_$prepared_key";
+                        $WhereClause .= $key . ' REGEXP :v_' . $prepared_key;
                     } else {
                         // Single keyword search
-                        $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";
+                        $WhereClause .= $key
+                            . ' LIKE CONCAT(:v_' . $prepared_key . ', \'%\')';
                     }
-                    $qparams["v_$prepared_key"] = $val;
+                    $qparams['v_'.$prepared_key] = $val;
                 }
             }
         }
-
         return array(
                 'clause' => $WhereClause,
                 'params' => $qparams,
@@ -389,16 +401,26 @@ class Datadict extends \NDB_Menu_Filter
         $wheredetails = $this->_getBaseFilter();
         $db           = \Database::singleton();
         if (empty($this->group_by) && empty($this->having)) {
-            $query = "SELECT COUNT(*)" . $this->query . $wheredetails['clause'];
+            $query = 'SELECT COUNT(*)' . $this->query . $wheredetails['clause'];
         } else {
-            $query = "SELECT COUNT(*) FROM ($query) as tmptable";
+            $query = 'SELECT COUNT(*) FROM ('.$query.') as tmptable';
         }
         $params =  $wheredetails['params'];
         if (isset($params['v_searchkey'])
             && is_array(($params['v_searchkey']))
         ) {
             // Multiple keyword search
-            $params = array('v_searchkey' => implode('|', $params['v_searchkey']));
+            if (count($params['v_searchkey']) > 0) {
+                $params_searchkeys = array();
+                foreach ($params['v_searchkey'] as $i => $value) {
+                    $params_searchkeys['v_searchkey_'.$i] = $value;
+                }
+            }
+            if (isset($params_searchkeys)) {
+                $params = $params_searchkeys;
+            } else {
+                $params = array('v_searchkey' => $params['v_searchkey']);
+            }
 
             $this->TotalItems = $db->pselectOne($query, $params);
         } else {
@@ -428,15 +450,15 @@ class Datadict extends \NDB_Menu_Filter
         $query        .= $filterdetails['clause'];
         $qparams       = $filterdetails['params'];
         // apply ORDER BY filters
-        $query .= " ORDER BY ";
+        $query .= ' ORDER BY ';
         if (!empty($this->filter['order'])) {
             $query .= $this->filter['order']['field']
-                ." ".$this->filter['order']['fieldOrder'].", ";
+                .' '.$this->filter['order']['fieldOrder'].', ';
         }
         $query .= $this->order_by;
 
         if (!empty($this->limit)) {
-            $query .= " LIMIT $this->limit";
+            $query .= ' LIMIT '.$this->limit;
         }
 
         // get the list
@@ -446,7 +468,17 @@ class Datadict extends \NDB_Menu_Filter
             && is_array(($qparams['v_searchkey']))
         ) {
             // Multiple keyword search
-            $params = array('v_searchkey' => implode('|', $qparams['v_searchkey']));
+            if (count($qparams['v_searchkey']) > 0) {
+                $params_searchkeys = array();
+                foreach ($qparams['v_searchkey'] as $i => $value) {
+                    $params_searchkeys['v_searchkey_'.$i] = $value;
+                }
+            }
+            if (isset($params_searchkeys)) {
+                $params = $params_searchkeys;
+            } else {
+                $params = array('v_searchkey' => $qparams['v_searchkey']);
+            }
             $result = $DB->pselect($query, $params);
         } else {
             // Single keyword search
@@ -470,8 +502,8 @@ class Datadict extends \NDB_Menu_Filter
         return array_merge(
             $deps,
             array(
-             $baseURL . "/datadict/js/columnFormatter.js",
-             $baseURL . "/datadict/js/datadict_helper.js",
+             $baseURL . '/datadict/js/columnFormatter.js',
+             $baseURL . '/datadict/js/datadict_helper.js',
             )
         );
     }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -280,7 +280,7 @@ class Datadict extends \NDB_Menu_Filter
                 } elseif ($val=='unmodified') {
                     $query .= ' AND pto.name IS NULL';
                 } else {
-                    $query .= ' AND $key LIKE \'' . $val . '%\' ';
+                    $query .= ' AND '.$key.' LIKE \'' . $val . '%\' ';
                 }
             }
         }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -76,7 +76,7 @@ class Datadict extends \NDB_Menu_Filter
         $this->searchKeyword = array(
                                 'pt.Name',
                                 'pt.sourceField',
-                                'pto.description',
+                                'pt.description',
                                );
         return true;
     }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -353,16 +353,6 @@ class NDB_Menu_Filter extends NDB_Menu
         if (isset($_REQUEST['keyword'])) {
             // It was included in the request, so save it.
             $key = $_REQUEST['keyword'];
-            // Check if multiple keyword search
-            if ($_REQUEST['test_name'] == 'datadict'
-                && preg_match("/\\s/", $key)
-            ) {
-                $key = explode(" ", $key);
-                foreach ($key as &$k) {
-                    $k = '.*'.$k;
-                }
-                unset($k);
-            }
             $_SESSION['State']->setProperty('keyword', $key);
         } else {
             // It was not included, so get the keyword from the session
@@ -547,20 +537,13 @@ class NDB_Menu_Filter extends NDB_Menu
             $WhereClause .= " AND (";
             $fields       = array();
 
-            $qparams['v_searchkey'] = $this->searchKey['keyword'];
-
             foreach ($this->searchKeyword as $field) {
-                if ($_REQUEST['test_name'] == 'datadict'
-                    && isset($qparams['v_searchkey'])
-                    && is_array(($qparams['v_searchkey']))
-                ) {
-                    $fields[] = " $field REGEXP :v_searchkey";
-                } else {
-                    $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
-                }
+                $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
             }
             $WhereClause .= join(" OR ", $fields);
-            $WhereClause .= ")";
+
+            $qparams['v_searchkey'] = $this->searchKey['keyword'];
+            $WhereClause           .= ")";
 
         }
 
@@ -584,16 +567,7 @@ class NDB_Menu_Filter extends NDB_Menu
                     }
                     $first = false;
 
-                    if ($_REQUEST['test_name'] == 'datadict'
-                        && isset($qparams['v_searchkey'])
-                        && is_array(($qparams['v_searchkey']))
-                    ) {
-                        // Multiple keyword search
-                        $WhereClause .= "$key REGEXP :v_$prepared_key";
-                    } else {
-                        // Single keyword search
-                        $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";
-                    }
+                    $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";
                     $qparams["v_$prepared_key"] = $val;
                 }
             }
@@ -622,19 +596,7 @@ class NDB_Menu_Filter extends NDB_Menu
         } else {
             $query = "SELECT COUNT(*) FROM ($query) as tmptable";
         }
-        $params =  $wheredetails['params'];
-        if ($_REQUEST['test_name'] == 'datadict'
-            && isset($params['v_searchkey'])
-            && is_array(($params['v_searchkey']))
-        ) {
-            // Multiple keyword search
-            $params = array('v_searchkey' => implode('|', $params['v_searchkey']));
-
-            $this->TotalItems = $db->pselectOne($query, $params);
-        } else {
-            // Single keyword search
-            $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
-        }
+        $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
     }
 
     /**
@@ -855,17 +817,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // get the list
         $this->_getNumberPages($query);
 
-        if ($_REQUEST['test_name'] == 'datadict'
-            && isset($qparams['v_searchkey'])
-            && is_array(($qparams['v_searchkey']))
-        ) {
-            // Multiple keyword search
-            $params = array('v_searchkey' => implode('|', $qparams['v_searchkey']));
-            $result = $DB->pselect($query, $params);
-        } else {
-            // Single keyword search
-            $result = $DB->pselect($query, $qparams);
-        }
+        $result = $DB->pselect($query, $qparams);
 
         return $result;
     }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -549,7 +549,7 @@ class NDB_Menu_Filter extends NDB_Menu
 
             foreach ($this->searchKeyword as $field) {
                 if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
-                    $fields[] = " $field REGEXP CONCAT(:v_searchkey)";
+                    $fields[] = " $field REGEXP :v_searchkey";
                 } else {
                     $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
                 }
@@ -581,7 +581,7 @@ class NDB_Menu_Filter extends NDB_Menu
 
                     if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
                         // Multiple keyword search
-                        $WhereClause .= "$key REGEXP CONCAT(:v_$prepared_key)";
+                        $WhereClause .= "$key REGEXP :v_$prepared_key";
                     } else {
                         // Single keyword search
                         $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -353,6 +353,14 @@ class NDB_Menu_Filter extends NDB_Menu
         if (isset($_REQUEST['keyword'])) {
             // It was included in the request, so save it.
             $key = $_REQUEST['keyword'];
+            // Check if multiple keyword search
+            if (preg_match("/\\s/", $key)) {
+                $key = explode(" ", $key);
+                foreach ($key as &$k) {
+                    $k = '.*'.$k;
+                }
+                unset($k);
+            }
             $_SESSION['State']->setProperty('keyword', $key);
         } else {
             // It was not included, so get the keyword from the session
@@ -536,13 +544,18 @@ class NDB_Menu_Filter extends NDB_Menu
         ) {
             $WhereClause .= " AND (";
             $fields       = array();
-            foreach ($this->searchKeyword as $field) {
-                $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
-            }
-            $WhereClause .= join(" OR ", $fields);
 
             $qparams['v_searchkey'] = $this->searchKey['keyword'];
-            $WhereClause           .= ")";
+
+            foreach ($this->searchKeyword as $field) {
+                if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
+                    $fields[] = " $field REGEXP CONCAT(:v_searchkey)";
+                } else {
+                    $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
+                }
+            }
+            $WhereClause .= join(" OR ", $fields);
+            $WhereClause .= ")";
 
         }
 
@@ -566,7 +579,13 @@ class NDB_Menu_Filter extends NDB_Menu
                     }
                     $first = false;
 
-                    $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";
+                    if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
+                        // Multiple keyword search
+                        $WhereClause .= "$key REGEXP CONCAT(:v_$prepared_key)";
+                    } else {
+                        // Single keyword search
+                        $WhereClause .= "$key LIKE CONCAT(:v_$prepared_key, '%')";
+                    }
                     $qparams["v_$prepared_key"] = $val;
                 }
             }
@@ -595,8 +614,15 @@ class NDB_Menu_Filter extends NDB_Menu
         } else {
             $query = "SELECT COUNT(*) FROM ($query) as tmptable";
         }
-        $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
-
+        $params =  $wheredetails['params'];
+        if (isset($params['v_searchkey']) && is_array(($params['v_searchkey']))) {
+            // Multiple keyword search
+            $params = array('v_searchkey' => implode('|', $params['v_searchkey']));
+            $this->TotalItems = $db->pselectOne($query, $params);
+        } else {
+            // Single keyword search
+            $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
+        }
     }
 
     /**
@@ -761,8 +787,11 @@ class NDB_Menu_Filter extends NDB_Menu
         );
 
         $MappedData = array();
-        foreach ($data as $row) {
-            $MappedData[] = array_values($row);
+
+        if (is_array($data)) {
+            foreach ($data as $row) {
+                $MappedData[] = array_values($row);
+            }
         }
 
         return array(
@@ -792,6 +821,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // create DB object
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
+        $result  = '';
 
         $qparams = array();
         // add the base query
@@ -816,7 +846,14 @@ class NDB_Menu_Filter extends NDB_Menu
         // get the list
         $this->_getNumberPages($query);
 
-        $result = $DB->pselect($query, $qparams);
+        if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
+            // Multiple keyword search
+            $params = array('v_searchkey' => implode('|', $qparams['v_searchkey']));
+            $result = $DB->pselect($query, $params);
+        } else {
+            // Single keyword search
+            $result = $DB->pselect($query, $qparams);
+        }
 
         return $result;
     }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -548,7 +548,9 @@ class NDB_Menu_Filter extends NDB_Menu
             $qparams['v_searchkey'] = $this->searchKey['keyword'];
 
             foreach ($this->searchKeyword as $field) {
-                if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
+                if (isset($qparams['v_searchkey'])
+                    && is_array(($qparams['v_searchkey']))
+                ) {
                     $fields[] = " $field REGEXP :v_searchkey";
                 } else {
                     $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
@@ -579,7 +581,9 @@ class NDB_Menu_Filter extends NDB_Menu
                     }
                     $first = false;
 
-                    if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
+                    if (isset($qparams['v_searchkey'])
+                        && is_array(($qparams['v_searchkey']))
+                    ) {
                         // Multiple keyword search
                         $WhereClause .= "$key REGEXP :v_$prepared_key";
                     } else {
@@ -618,6 +622,7 @@ class NDB_Menu_Filter extends NDB_Menu
         if (isset($params['v_searchkey']) && is_array(($params['v_searchkey']))) {
             // Multiple keyword search
             $params = array('v_searchkey' => implode('|', $params['v_searchkey']));
+
             $this->TotalItems = $db->pselectOne($query, $params);
         } else {
             // Single keyword search

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -354,7 +354,9 @@ class NDB_Menu_Filter extends NDB_Menu
             // It was included in the request, so save it.
             $key = $_REQUEST['keyword'];
             // Check if multiple keyword search
-            if (preg_match("/\\s/", $key)) {
+            if ($_REQUEST['test_name'] == 'datadict'
+                && preg_match("/\\s/", $key)
+            ) {
                 $key = explode(" ", $key);
                 foreach ($key as &$k) {
                     $k = '.*'.$k;
@@ -548,7 +550,8 @@ class NDB_Menu_Filter extends NDB_Menu
             $qparams['v_searchkey'] = $this->searchKey['keyword'];
 
             foreach ($this->searchKeyword as $field) {
-                if (isset($qparams['v_searchkey'])
+                if ($_REQUEST['test_name'] == 'datadict'
+                    && isset($qparams['v_searchkey'])
                     && is_array(($qparams['v_searchkey']))
                 ) {
                     $fields[] = " $field REGEXP :v_searchkey";
@@ -581,7 +584,8 @@ class NDB_Menu_Filter extends NDB_Menu
                     }
                     $first = false;
 
-                    if (isset($qparams['v_searchkey'])
+                    if ($_REQUEST['test_name'] == 'datadict'
+                        && isset($qparams['v_searchkey'])
                         && is_array(($qparams['v_searchkey']))
                     ) {
                         // Multiple keyword search
@@ -619,7 +623,10 @@ class NDB_Menu_Filter extends NDB_Menu
             $query = "SELECT COUNT(*) FROM ($query) as tmptable";
         }
         $params =  $wheredetails['params'];
-        if (isset($params['v_searchkey']) && is_array(($params['v_searchkey']))) {
+        if ($_REQUEST['test_name'] == 'datadict'
+            && isset($params['v_searchkey'])
+            && is_array(($params['v_searchkey']))
+        ) {
             // Multiple keyword search
             $params = array('v_searchkey' => implode('|', $params['v_searchkey']));
 
@@ -793,10 +800,8 @@ class NDB_Menu_Filter extends NDB_Menu
 
         $MappedData = array();
 
-        if (is_array($data)) {
-            foreach ($data as $row) {
-                $MappedData[] = array_values($row);
-            }
+        foreach ($data as $row) {
+            $MappedData[] = array_values($row);
         }
 
         return array(
@@ -826,7 +831,6 @@ class NDB_Menu_Filter extends NDB_Menu
         // create DB object
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
-        $result  = '';
 
         $qparams = array();
         // add the base query
@@ -851,7 +855,10 @@ class NDB_Menu_Filter extends NDB_Menu
         // get the list
         $this->_getNumberPages($query);
 
-        if (isset($qparams['v_searchkey']) && is_array(($qparams['v_searchkey']))) {
+        if ($_REQUEST['test_name'] == 'datadict'
+            && isset($qparams['v_searchkey'])
+            && is_array(($qparams['v_searchkey']))
+        ) {
             // Multiple keyword search
             $params = array('v_searchkey' => implode('|', $qparams['v_searchkey']));
             $result = $DB->pselect($query, $params);

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -536,7 +536,6 @@ class NDB_Menu_Filter extends NDB_Menu
         ) {
             $WhereClause .= " AND (";
             $fields       = array();
-
             foreach ($this->searchKeyword as $field) {
                 $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
             }
@@ -761,7 +760,6 @@ class NDB_Menu_Filter extends NDB_Menu
         );
 
         $MappedData = array();
-
         foreach ($data as $row) {
             $MappedData[] = array_values($row);
         }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -596,6 +596,7 @@ class NDB_Menu_Filter extends NDB_Menu
             $query = "SELECT COUNT(*) FROM ($query) as tmptable";
         }
         $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
+        
     }
 
     /**

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -596,7 +596,7 @@ class NDB_Menu_Filter extends NDB_Menu
             $query = "SELECT COUNT(*) FROM ($query) as tmptable";
         }
         $this->TotalItems = $db->pselectOne($query, $wheredetails['params']);
-        
+
     }
 
     /**


### PR DESCRIPTION
This pull request `fixes filtering when searching with multiple words for keywords. Before no results were returned and now results are returned. Also fixes another bug where description column was never searched.`. 

Inside NDB_Menu_Filter.class.inc `I added a case for when the keyword variable has multiple words or text and used REGEXP for the mysql query`.

See also: `Bug #12910`