### PR TITLE
Change links to Issue Tracker instead of (deprecated) Mantis URL

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -94,8 +94,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('www', 'Web address settings', 1, 0, 'WWW', 4);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'host', 'Host', 1, 0, 'text', ID, 'Host', 1 FROM ConfigSettings WHERE Name="www";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'url', 'Main URL where LORIS can be accessed', 1, 0, 'text', ID, 'Main LORIS URL', 2 FROM ConfigSettings WHERE Name="www";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'mantis_url', 'Bug tracker URL', 1, 0, 'text', ID, 'Bug tracker URL', 3 FROM ConfigSettings WHERE Name="www";
-
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('dashboard', 'Settings that affect the appearance of the dashboard and its charts', 1, 0, 'Dashboard', 5);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'projectDescription', 'Description of the study displayed in main dashboard panel', 1, 0, 'textarea', ID, 'Project Description', 1 FROM ConfigSettings WHERE Name="dashboard";

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -249,7 +249,7 @@ if (!$anonymous) {
 $tpl_data['lastURL'] = $_SESSION['State']->getLastURL();
 
 // bug tracking link
-$tpl_data['mantis_url'] = $config->getSetting('mantis_url');
+$tpl_data['issue_tracker_url'] = $config->getSetting('issue_tracker_url');
 
 
 //Display the links, as specified in the config file

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -67,7 +67,7 @@ useProjects - This setting determines whether "project" filtering dropdowns exis
 useEDC - This setting determines whether "EDC" filtering dropdowns exist
         on the menu page.
 
-mantis_url - This setting defines a URL for LORIS to include a link to for bug reporting
+issue_tracker_url - This setting defines a URL for LORIS to include a link to for bug reporting
         on the viewsession page.
 
 ## Interactions with LORIS

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -115,22 +115,22 @@ class Imaging_Session_ControlPanel
 
         $config =& \NDB_Config::singleton();
 
-        $this->tpl_data['issue_tracker']       = $config->getSetting('issue_tracker_url');
-        $subjectData['issue_tracker']          = $config->getSetting('issue_tracker_url');
-        $subjectData['has_permission']  = $this->_hasAccess();
-        $subjectData['status_options']  = array(
-                                           'Unrated' => '',
-                                           'Pass'    => 'Pass',
-                                           'Fail'    => 'Fail',
-                                          );
-        $subjectData['pending_options'] = array(
-                                           'Y' => 'Yes',
-                                           'N' => 'No',
-                                          );
-        $subjectData['caveat_options']  = array(
-                                           'true'  => 'True',
-                                           'false' => 'False',
-                                          );
+        $this->tpl_data['issue_tracker'] = $config->getSetting('issue_tracker_url');
+        $subjectData['issue_tracker']    = $config->getSetting('issue_tracker_url');
+        $subjectData['has_permission']   = $this->_hasAccess();
+        $subjectData['status_options']   = array(
+                                            'Unrated' => '',
+                                            'Pass'    => 'Pass',
+                                            'Fail'    => 'Fail',
+                                           );
+        $subjectData['pending_options']  = array(
+                                            'Y' => 'Yes',
+                                            'N' => 'No',
+                                           );
+        $subjectData['caveat_options']   = array(
+                                            'true'  => 'True',
+                                            'false' => 'False',
+                                           );
         $query    = "SELECT MRIQCStatus, MRIQCPending,".
                     " MRICaveat FROM session WHERE ID=:sid";
         $qcstatus = $DB->pselectRow(

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -115,8 +115,8 @@ class Imaging_Session_ControlPanel
 
         $config =& \NDB_Config::singleton();
 
-        $this->tpl_data['mantis']       = $config->getSetting('mantis_url');
-        $subjectData['mantis']          = $config->getSetting('mantis_url');
+        $this->tpl_data['issue_tracker']       = $config->getSetting('issue_tracker_url');
+        $subjectData['issue_tracker']          = $config->getSetting('issue_tracker_url');
         $subjectData['has_permission']  = $this->_hasAccess();
         $subjectData['status_options']  = array(
                                            'Unrated' => '',

--- a/smarty/templates/directentry.tpl
+++ b/smarty/templates/directentry.tpl
@@ -56,7 +56,7 @@
     {/section}
             </ul>
             
-            If this error persists, please <a target="mantis" href="{$mantis_url}">report a bug to your administrator</a>.</p>
+            If this error persists, please <a target="issue_tracker" href="{$issue_tracker_url}">report a bug to your administrator</a>.</p>
             <p><a href="javascript:history.back(-1)">Please click here to go back</a>.</p>
 {else}
 

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -236,7 +236,7 @@
                                     </ul>
 
                                     If this error persists, please
-                                    <a target="mantis" href="{$mantis_url}">
+                                    <a target="issue_tracker" href="{$issue_tracker_url}">
                                         report a bug to your administrator
                                     </a>.
                                 </p>


### PR DESCRIPTION
This pull request removes lingering references to Mantis as we now use our own internal issue tracker.
