### PR TITLE
[Smarty, Public Layout] Add NoOpener attribute for WordPress links

### DIFF
--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -33,7 +33,7 @@
           {$study_title}
         </div>
         <div class="github-logo">
-          <a href="https://github.com/aces/Loris" target="_blank">
+          <a href="https://github.com/aces/Loris" target="_blank" rel="noopener">
             <img src="{$baseurl}/images/GitHub-Mark-Light-64px.png" alt="Github"/>
           </a>
         </div>
@@ -46,7 +46,7 @@
   </section>
 
   <footer class="footer">
-    Powered by <a href="http://www.loris.ca/" target="_blank">LORIS</a>
+    Powered by <a href="http://www.loris.ca/" target="_blank" rel="noopener">LORIS</a>
     | GPL-3.0 &copy; {$currentyear} <br/>
     Developed at
     <a href="http://www.mni.mcgill.ca" target="_blank">


### PR DESCRIPTION
The noopener attribute prevents the linked domain from having control over the calling domain. 

We control www.loris.ca but it runs on WordPress which is notoriously difficult to secure and for that reason should be treated as potentially hostile.

In any case, there's no use case for the WordPress site to access Javascript on every LORIS instance so we should disable it.

See also:
* https://paragonie.com/blog/2017/12/2018-guide-building-secure-php-software#rel-attribute
* https://mathiasbynens.github.io/rel-noopener/
