### PR TITLE
[Travis] Separate testing scripts into different lines (as precursor to Travis Ubuntu upgrade)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,8 @@ before_script:
  # - "LORIS_DB_CONFIG=test/config.xml"
 
 script:
-    - travis_wait 15 npm run lint:php 
-    - travis_wait 15 npm run lint:javascript
-    - travis_wait 45 vendor/bin/phpunit --configuration test/phpunit.xml
+    - travis_wait npm run lint:php 
+    - travis_wait npm run lint:javascript
+    - travis_wait 60 vendor/bin/phpunit --configuration test/phpunit.xml
 
 dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,8 @@ before_script:
  # - "LORIS_DB_CONFIG=test/config.xml"
 
 script:
-    - npm run lint:php 
-    - npm run lint:javascript
-    - vendor/bin/phpunit --configuration test/phpunit.xml
+    - travis_wait 15 npm run lint:php 
+    - travis_wait 15 npm run lint:javascript
+    - travis_wait 45 vendor/bin/phpunit --configuration test/phpunit.xml
 
 dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,8 @@ before_script:
  # - "LORIS_DB_CONFIG=test/config.xml"
 
 script:
-    - npm run lint:php && npm run lint:javascript && vendor/bin/phpunit --configuration test/phpunit.xml
+    - npm run lint:php 
+    - npm run lint:javascript
+    - vendor/bin/phpunit --configuration test/phpunit.xml
 
 dist: precise


### PR DESCRIPTION
## This pull request is a precursor to upgrading our Travis environment from the unsupported 12.04 `precise` Ubuntu release.

Previously the decision was made to use 12.04 as our scripts would otherwise timeout. 

With the testing scripts each on their own line, we can prefix them with the [travis_wait](https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received) parameter to extend the timeout. 

With some tweaking, this will allow us to move to a modern LTS version of Ubuntu for testing. 

### The values chosen here are largely arbitrary.

## Next Steps

* Update TravisCI environment to a modern version (probably 16.04 or 18.04)

* Check whether the test timeout

* If so, increase the `travis_wait` timeout parameters