### PR TITLE
Added On Duplicate Update Function to Database Class

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -160,15 +160,9 @@ function uploadFile()
              ];
 
     if (move_uploaded_file($_FILES["file"]["tmp_name"], $mediaPath . $fileName)) {
-        $existingFiles = getFilesList();
-        $idMediaFile   = array_search($fileName, $existingFiles);
         try {
-            // Override db record if file_name already exists
-            if ($idMediaFile) {
-                $db->update('media', $query, ['id' => $idMediaFile]);
-            } else {
-                $db->insert('media', $query);
-            }
+            // Insert or override db record if file_name already exists
+            $db->insertOnDuplicateKeyUpdate('media', $query);
             $uploadNotifier->notify(array("file" => $fileName));
         } catch (DatabaseException $e) {
             showError("Could not upload the file. Please try again!");

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -162,7 +162,7 @@ function uploadFile()
     if (move_uploaded_file($_FILES["file"]["tmp_name"], $mediaPath . $fileName)) {
         try {
             // Insert or override db record if file_name already exists
-            $db->insertOnDuplicateKeyUpdate('media', $query);
+            $db->insertOnDuplicateUpdate('media', $query);
             $uploadNotifier->notify(array("file" => $fileName));
         } catch (DatabaseException $e) {
             showError("Could not upload the file. Please try again!");

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -300,7 +300,7 @@ class Database
      *
      * This will attempt to insert a row into the database. If there is a duplicate
      * value for any unique key, the row where the duplicate is present will be
-     * updated. HTML from nay field in the row will *not* be automatically escaped.
+     * updated. HTML from any field in the row will *not* be automatically escaped.
      *
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the row

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -287,7 +287,7 @@ class Database
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the row
      *
-     * @return none
+     * @return void
      */
     public function insertOnDuplicateUpdate($table, $set)
     {
@@ -305,7 +305,7 @@ class Database
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the row
      *
-     * @return none
+     * @return void
      */
     public function unsafeInsertOnDuplicateUpdate($table, $set)
     {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -295,7 +295,7 @@ class Database
     }
 
     /**
-     * Insert row into the database or  update on duplicate key without validating
+     * Insert row into the database or update on duplicate key without validating
      * input.
      *
      * This will attempt to insert a row into the database. If there is a duplicate
@@ -339,8 +339,8 @@ class Database
      *
      * @param string $table             the table into which to insert the row
      * @param array  $set               the values with which to fill the new row
-     * @param bool   $autoescape        determines whether the values to be set 
-                                        should automatically have the html escaped
+     * @param bool   $autoescape        determines whether the values to be set
+     *                                  should automatically have the html escaped
      * @param bool   $ignore            determines whether the insert throws and
      *                                  error or is discarded when value exists in DB
      * @param bool   $onDuplicateUpdate determines whether the row should be updated
@@ -354,8 +354,7 @@ class Database
         $autoescape = true,
         $ignore = false,
         $onDuplicateUpdate = false
-    )
-    {
+    ) {
         if ($ignore && $onDuplicateUpdate) {
             throw new DatabaseException(
                 'The Database::_realinsert() function does not accept both ignore

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -278,6 +278,41 @@ class Database
     }
 
     /**
+     * Insert row into the database or update on duplicate key.
+     *
+     * This will attempt to insert a row into the database. If there is a duplicate
+     * value for any unique key, the row where the duplicate is present will be
+     * updated.
+     *
+     * @param string $table the table into which to insert the row
+     * @param array  $set   the values with which to fill the row
+     *
+     * @return none
+     */
+    public function insertOnDuplicateUpdate($table, $set)
+    {
+        return $this->_realinsert($table, $set, true, false, true);
+    }
+
+    /**
+     * Insert row into the database or  update on duplicate key without validating
+     * input.
+     *
+     * This will attempt to insert a row into the database. If there is a duplicate
+     * value for any unique key, the row where the duplicate is present will be
+     * updated. HTML from nay field in the row will *not* be automatically escaped.
+     *
+     * @param string $table the table into which to insert the row
+     * @param array  $set   the values with which to fill the row
+     *
+     * @return none
+     */
+    public function unsafeInsertOnDuplicateUpdate($table, $set)
+    {
+        return $this->_realinsert($table, $set, false, false, true);
+    }
+
+    /**
      * Escapes the HTML from an array that is about to be inserted into the database
      *
      * @param array $set The array to be inserted as a new row
@@ -302,17 +337,31 @@ class Database
      *
      * Inserts a single row into the specified table, containing the values specified
      *
-     * @param string $table      the table into which to insert the row
-     * @param array  $set        the values with which to fill the new row
-     * @param bool   $autoescape determines whether the values to be set should
-     *                           automatically have the html escaped
-     * @param bool   $ignore     determines whether the insert throws and error or
-     *                           is discarded when value exists in DB
+     * @param string $table             the table into which to insert the row
+     * @param array  $set               the values with which to fill the new row
+     * @param bool   $autoescape        determines whether the values to be set 
+                                        should automatically have the html escaped
+     * @param bool   $ignore            determines whether the insert throws and
+     *                                  error or is discarded when value exists in DB
+     * @param bool   $onDuplicateUpdate determines whether the row should be updated
+     *                                  upon unique key duplication
      *
      * @return none
      */
-    private function _realinsert($table, $set, $autoescape = true, $ignore = false)
+    private function _realinsert(
+        $table,
+        $set,
+        $autoescape = true,
+        $ignore = false,
+        $onDuplicateUpdate = false
+    )
     {
+        if ($ignore && $onDuplicateUpdate) {
+            throw new DatabaseException(
+                'The Database::_realinsert() function does not accept both ignore
+                and onDuplicateUpdate parameters.'
+            );
+        }
         if ($autoescape === true) {
             $set = $this->_HTMLEscapeArray($set);
         }
@@ -326,6 +375,13 @@ class Database
 
         $exec_params = array();
         $prepQ      .= $this->_implodeAsPrepared(",", $set, $exec_params);
+
+        if ($onDuplicateUpdate) {
+            $prepQ .= ' ON DUPLICATE KEY UPDATE ';
+            $prepQ .= $this->_implodeAsPrepared(",", $set, $exec_params);
+            $query .= ' ON DUPLICATE KEY UPDATE ';
+            $query .= $this->_implodeWithKeys(', ', $set);
+        }
 
         if (DEBUG) {
             fwrite(STDERR, $query."\n");
@@ -433,6 +489,7 @@ class Database
     {
         return $this->_realupdate($table, $set, $i_where, false);
     }
+
     /**
      * Updates a row
      *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -341,7 +341,7 @@ class Database
      * @param array  $set               the values with which to fill the new row
      * @param bool   $autoescape        determines whether the values to be set
      *                                  should automatically have the html escaped
-     * @param bool   $ignore            determines whether the insert throws and
+     * @param bool   $ignore            determines whether the insert throws an
      *                                  error or is discarded when value exists in DB
      * @param bool   $onDuplicateUpdate determines whether the row should be updated
      *                                  upon unique key duplication


### PR DESCRIPTION
This pull request adds two new methods to the database class: `insertOnDuplicateUpdate()` and `unsafeInsertOnDuplicateUpdate()`

These methods will attempt to `insert` a new row into the database given the query array passed as an argument. However, if one of the values to be inserted is a duplicate value for a unique key column, the query will be changed to an `update` statement for the row where the duplicate was found.

The `unsafe` version of the method will not escape insertion of HTML characters or JSON objects.

Reference:
https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html

This PR also includes a use-case in the media module, which consolidates a few lines of code using the new function.


How to test:
1. Go to `Media` module and click on the `Upload` tab.
2. Upload a file according the naming convention stated at the top of the form.
3. Confirm that the file was uploaded by finding the entry in the `Media` module filter.
5. Click the `edit` button, edit a field (e.g. data) and click `Update`.
6. Ensure that the file was properly edited by checking the entry in the `Media` module filter.
