### PR TITLE
[Travis] Remove excessively slow tests

### DIFF
--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -160,6 +160,8 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
       */
     function testGenomicBrowserFilterEachTab()
     {
+        $this->markTestSkipped("Skipping long test");
+        return;
         // test filter in Profiles Tab
         $this->_testFilter("/genomic_browser/", "PSCID", "MTL001", "1 rows");
         $this->_testFilter("/genomic_browser/", "DCCID", "300001", "1 rows");

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -102,6 +102,8 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
       */
     function testFilters()
     {
+        $this->markTestSkipped("Skipping long test");
+        return;
         $this->_testFilter("/server_processes_manager/", "pid", "317", "1 rows");
         $this->_testFilter("/server_processes_manager/", "type", "mri_upload", "51");
         $this->_testFilter(

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -116,6 +116,8 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function testUserAccountEdits()
     {
+        $this->markTestSkipped("Skipping excessively slow test");
+        return;
         $this->_verifyUserModification(
             'user_accounts',
             'UnitTester',


### PR DESCRIPTION
Using johnkary/phpunit-speedtrap gave the following results:

You should really fix these slow tests (>500ms)...
 1. 64094ms to run UserAccountsIntegrationTest:testUserAccountEdits
 2. 55984ms to run Server_Processes_ManagerTest:testFilters
 3. 55709ms to run GenomicBrowserTestIntegrationTest:testGenomicBrowserFilterEachTab
 4. 39978ms to run MriViolationsTestIntegrationTest:testNotResolvedSearchButton
 5. 38136ms to run MriViolationsTestIntegrationTest:testResolvedSearchButton
 6. 34670ms to run AcknowledgementsIntegrationTest:testFilterWithData
 7. 30160ms to run Issue_TrackerTest:testIssueTrackerFilter
 8. 27171ms to run DicomArchiveTestIntegrationTest:testClearBtn
 9. 26956ms to run DicomArchiveTestIntegrationTest:testdicomArchiveFilterClearBtn
 10. 25331ms to run UserAccountsIntegrationTest:testMyPreferencesEdits
...and there are 184 more above your threshold hidden from view

This skips the 3 slowest tests to speed up the build time and avoid timeouts
until they can be resolved.