### PR TITLE
[Media Module] Filtering candidates displayed on the drop down to the site(s) the user belongs to 

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -33,7 +33,7 @@ if (isset($_GET['action'])) {
  */
 function editFile()
 {
-    $db   =& Database::singleton();
+    $db   =& \Database::singleton();
     $user =& User::singleton();
     if (!$user->hasPermission('media_write')) {
         header("HTTP/1.1 403 Forbidden");

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -217,7 +217,7 @@ function getUploadFields()
     $sessionData = [];
 
     foreach ($sessionRecords as $record) {
-    
+
         // Populate sites
         if (!isset($sessionData[$record["PSCID"]]['sites'])) {
             $sessionData[$record["PSCID"]]['sites'] = [];
@@ -353,7 +353,7 @@ function toSelect($options, $item, $item2)
     }
 
     foreach ($options as $key => $value) {
-        if(!is_null($options[$key][$item])) {
+        if (!is_null($options[$key][$item])) {
             $selectOptions[$options[$key][$optionsVal]] = $options[$key][$item];
         }
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -194,11 +194,13 @@ function getUploadFields()
                     "f.Test_name ".
                     "FROM candidate c ".
                     "LEFT JOIN session s USING(CandID) ".
-                    "LEFT JOIN flag f ON (s.ID=f.SessionID) ";
+                    "LEFT JOIN flag f ON (s.ID=f.SessionID) ".
+                    "WHERE c.PSCID NOT LIKE 'scanner%' ".
+                    "AND f.Test_name NOT LIKE 'DDE_%' ";
 
     $siteIDs = $user->getCenterIDs();
     if (!$user->hasPermission('access_all_profiles')) {
-        $recordsQuery .= "WHERE s.CenterID IN(".implode(",", $siteIDs).") ";
+        $recordsQuery .= "AND s.CenterID IN(".implode(",", $siteIDs).") ";
     }
     $recordsQuery  .= "ORDER BY c.PSCID ASC";
     $sessionRecords = $db->pselect($recordsQuery, []);

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -187,9 +187,9 @@ function uploadFile()
 function getUploadFields()
 {
 
-    $db   =& Database::singleton();
-    $user =& User::singleton();
-
+    $db           =& Database::singleton();
+    $user         =& User::singleton();
+    $qparams      = array();
     $recordsQuery = "SELECT c.PSCID, c.CandID, s.CenterID, s.Visit_label, ".
                     "f.Test_name ".
                     "FROM candidate c ".
@@ -200,10 +200,11 @@ function getUploadFields()
 
     $siteIDs = $user->getCenterIDs();
     if (!$user->hasPermission('access_all_profiles')) {
-        $recordsQuery .= "AND s.CenterID IN(".implode(",", $siteIDs).") ";
+        $recordsQuery  .= "AND FIND_IN_SET(s.CenterID, :CID) ";
+        $qparams['CID'] = implode(",", $siteIDs);
     }
     $recordsQuery  .= "ORDER BY c.PSCID ASC";
-    $sessionRecords = $db->pselect($recordsQuery, []);
+    $sessionRecords = $db->pselect($recordsQuery, $qparams);
 
     $instrumentsList = toSelect($sessionRecords, "Test_name", null);
     $candidatesList  = toSelect($sessionRecords, "PSCID", null);

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -33,7 +33,7 @@ if (isset($_GET['action'])) {
  */
 function editFile()
 {
-    $db   =& \Database::singleton();
+    $db   =& Database::singleton();
     $user =& User::singleton();
     if (!$user->hasPermission('media_write')) {
         header("HTTP/1.1 403 Forbidden");
@@ -187,8 +187,8 @@ function uploadFile()
 function getUploadFields()
 {
 
-    $db           =& \NDB_Factory::singleton()->database();
-    $user         =& \User::singleton();
+    $db           = \NDB_Factory::singleton()->database();
+    $user         = \User::singleton();
     $qparams      = array();
     $recordsQuery = "SELECT c.PSCID, c.CandID, s.CenterID, s.Visit_label, ".
                     "f.Test_name ".

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -4,7 +4,7 @@
  *
  * Handles media upload and update actions received from a front-end ajax call
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Loris
  * @package  Media

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -187,8 +187,8 @@ function uploadFile()
 function getUploadFields()
 {
 
-    $db           =& Database::singleton();
-    $user         =& User::singleton();
+    $db           =& \NDB_Factory::singleton()->database();
+    $user         =& \User::singleton();
     $qparams      = array();
     $recordsQuery = "SELECT c.PSCID, c.CandID, s.CenterID, s.Visit_label, ".
                     "f.Test_name ".
@@ -198,7 +198,7 @@ function getUploadFields()
                     "WHERE c.PSCID NOT LIKE 'scanner%' ".
                     "AND f.Test_name NOT LIKE 'DDE_%' ";
 
-    $siteList  = Utility::getSiteList(false);
+    $siteList  = \Utility::getSiteList(false);
     $userSites = $user->getCenterIDs();
 
     if (!$user->hasPermission('access_all_profiles')) {
@@ -220,7 +220,7 @@ function getUploadFields()
     $candidatesList  = toSelect($sessionRecords, "PSCID", null);
     $candIdList      = toSelect($sessionRecords, "CandID", "PSCID");
     $visitList       = toSelect($sessionRecords, "Visit_label", null);
-    $languageList    = Utility::getLanguageList();
+    $languageList    = \Utility::getLanguageList();
     // Build array of session data to be used in upload media dropdowns
     $sessionData = [];
 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -190,7 +190,7 @@ function getUploadFields()
     $db =& Database::singleton();
     $user =& User::singleton();
     
-    $recordsQuery = "SELECT c.PSCID, c.CandID, s.Visit_Label, ".
+    $recordsQuery = "SELECT c.PSCID, c.CandID, s.CenterID, s.Visit_label, ".
                     "f.Test_name ".
                     "FROM candidate c ".
 				    "LEFT JOIN session s USING(CandID) ".
@@ -206,8 +206,7 @@ function getUploadFields()
     $instrumentsList = toSelect($sessionRecords, "Test_name", null);
     $candidatesList  = toSelect($sessionRecords, "PSCID", null);
     $candIdList      = toSelect($sessionRecords, "CandID", "PSCID");
-    $visitList       = toSelect($sessionRecords, "Visit_Label", null);
-    error_log(print_r($visitList,1));
+    $visitList       = toSelect($sessionRecords, "Visit_label", null);
     $siteList        = array();
     foreach ($siteIDs as $siteID) {
         $site = Site::singleton($siteID);
@@ -218,7 +217,6 @@ function getUploadFields()
     $sessionData    = [];
 
     foreach ($sessionRecords as $record) {
-        error_log(print_r($record,1));
         // Populate sites
         if (!isset($sessionData[$record["PSCID"]]['sites'])) {
             $sessionData[$record["PSCID"]]['sites'] = [];

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -349,10 +349,7 @@ function toSelect($options, $item, $item2)
 {
     $selectOptions = [];
 
-    $optionsVal = $item;
-    if (isset($item2)) {
-        $optionsVal = $item2;
-    }
+    $optionsVal = $item2 ?? $item;
 
     foreach ($options as $key => $value) {
         if (!is_null($options[$key][$item])) {

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -198,11 +198,21 @@ function getUploadFields()
                     "WHERE c.PSCID NOT LIKE 'scanner%' ".
                     "AND f.Test_name NOT LIKE 'DDE_%' ";
 
-    $siteIDs = $user->getCenterIDs();
+    $siteList  = Utility::getSiteList(false);
+    $userSites = $user->getCenterIDs();
+
     if (!$user->hasPermission('access_all_profiles')) {
+
         $recordsQuery  .= "AND FIND_IN_SET(s.CenterID, :CID) ";
-        $qparams['CID'] = implode(",", $siteIDs);
+        $qparams['CID'] = implode(",", $userSites);
+
+        foreach ($siteList as $siteIDKey => $siteID) {
+            if (!in_array($siteIDKey, $userSites)) {
+                unset($siteList[$siteIDKey]);
+            }
+        }
     }
+
     $recordsQuery  .= "ORDER BY c.PSCID ASC";
     $sessionRecords = $db->pselect($recordsQuery, $qparams);
 
@@ -210,12 +220,7 @@ function getUploadFields()
     $candidatesList  = toSelect($sessionRecords, "PSCID", null);
     $candIdList      = toSelect($sessionRecords, "CandID", "PSCID");
     $visitList       = toSelect($sessionRecords, "Visit_label", null);
-    $siteList        = array();
-    foreach ($siteIDs as $siteID) {
-        $site = Site::singleton($siteID);
-        $siteList[$siteID] = $site->getCenterName();
-    }
-    $languageList = Utility::getLanguageList();
+    $languageList    = Utility::getLanguageList();
     // Build array of session data to be used in upload media dropdowns
     $sessionData = [];
 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -217,6 +217,7 @@ function getUploadFields()
     $sessionData = [];
 
     foreach ($sessionRecords as $record) {
+    
         // Populate sites
         if (!isset($sessionData[$record["PSCID"]]['sites'])) {
             $sessionData[$record["PSCID"]]['sites'] = [];
@@ -346,13 +347,14 @@ function toSelect($options, $item, $item2)
 {
     $selectOptions = [];
 
-    $optionsValue = $item;
+    $optionsVal = $item;
     if (isset($item2)) {
-        $optionsValue = $item2;
+        $optionsVal = $item2;
     }
+
     foreach ($options as $key => $value) {
         if(!is_null($options[$key][$item])) {
-            $selectOptions[$options[$key][$optionsValue]] = $options[$key][$item];
+            $selectOptions[$options[$key][$optionsVal]] = $options[$key][$item];
         }
     }
 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -187,22 +187,22 @@ function uploadFile()
 function getUploadFields()
 {
 
-    $db =& Database::singleton();
+    $db   =& Database::singleton();
     $user =& User::singleton();
-    
+
     $recordsQuery = "SELECT c.PSCID, c.CandID, s.CenterID, s.Visit_label, ".
                     "f.Test_name ".
                     "FROM candidate c ".
-				    "LEFT JOIN session s USING(CandID) ".
-        			"LEFT JOIN flag f ON (s.ID=f.SessionID) ";
-	
+                    "LEFT JOIN session s USING(CandID) ".
+                    "LEFT JOIN flag f ON (s.ID=f.SessionID) ";
+
     $siteIDs = $user->getCenterIDs();
     if (!$user->hasPermission('access_all_profiles')) {
-        $recordsQuery .= "WHERE s.CenterID IN(".implode(",",$siteIDs).") ";
+        $recordsQuery .= "WHERE s.CenterID IN(".implode(",", $siteIDs).") ";
     }
-    $recordsQuery .= "ORDER BY c.PSCID ASC";
+    $recordsQuery  .= "ORDER BY c.PSCID ASC";
     $sessionRecords = $db->pselect($recordsQuery, []);
-		
+
     $instrumentsList = toSelect($sessionRecords, "Test_name", null);
     $candidatesList  = toSelect($sessionRecords, "PSCID", null);
     $candIdList      = toSelect($sessionRecords, "CandID", "PSCID");
@@ -212,9 +212,9 @@ function getUploadFields()
         $site = Site::singleton($siteID);
         $siteList[$siteID] = $site->getCenterName();
     }
-    $languageList    = Utility::getLanguageList();
+    $languageList = Utility::getLanguageList();
     // Build array of session data to be used in upload media dropdowns
-    $sessionData    = [];
+    $sessionData = [];
 
     foreach ($sessionRecords as $record) {
         // Populate sites
@@ -351,8 +351,9 @@ function toSelect($options, $item, $item2)
         $optionsValue = $item2;
     }
     foreach ($options as $key => $value) {
-        if(!is_null($options[$key][$item]))
+        if(!is_null($options[$key][$item])) {
             $selectOptions[$options[$key][$optionsValue]] = $options[$key][$item];
+        }
     }
 
     return $selectOptions;


### PR DESCRIPTION
This pull request `attempts to restrict candidates displayed on the media module only to the sites that the user belongs to`. 

To test: 
1. Assign yourself to a set of sites on a non-superuser account. Ensure that the `Media files: Uploading/Downloading/Editing` is checked.
    - If the `access_all_profile` permission is checked, you should be able to see all candidates.
2. Go to the media module, and navigate to the `Upload` tab.
3. In the PSCID drop-down, you should only be able to see candidates that belong to the site(s) that you are assigned to.

See also: [Redmine Ticket 14561](https://redmine.cbrain.mcgill.ca/issues/14561)
