### PR TITLE
[SQL] Adding DeepQC to parameter_type table 

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1496,6 +1496,8 @@ INSERT INTO parameter_type (Name, Type, Description, RangeMin, RangeMax, SourceF
   ('Visit_label','varchar(255)','Visit_label',null,null,'visit_label','session',null,1,null),
   ('candidate_dob','date','Candidate_Dob',null,null,'DoB','candidate',null,1,null);
 
+INSERT INTO parameter_type (Name, Type) Values ("DeepQC", "double");
+
 CREATE TABLE `parameter_type_category` (
   `ParameterTypeCategoryID` int(11) unsigned NOT NULL auto_increment,
   `Name` varchar(255) default NULL,

--- a/SQL/Archive/19.1/2018-02-01_add_deepqc_parameter_type
+++ b/SQL/Archive/19.1/2018-02-01_add_deepqc_parameter_type
@@ -1,0 +1,1 @@
+INSERT INTO parameter_type (Name, Type) Values ("DeepQC", "double");


### PR DESCRIPTION
This PR adds `DeepQC` as a parameter type. In https://github.com/aces/Loris-MRI/pull/306, the most up-to date DeepQC probability is returned and used to populate or update the DeepQC value corresponding to a specific file.  

