### PR TITLE
[document_repository] Fixed multiple files with same name when uploading to document repository

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -864,6 +864,7 @@ CREATE TABLE `document_repository` (
   `EARLI` tinyint(1) DEFAULT '0',
   `hide_video` tinyint(1) DEFAULT '0',
   `File_category` int(3) unsigned DEFAULT NULL,
+  `UUID` varchar(36) DEFAULT '',
   PRIMARY KEY (`record_id`),
   KEY `fk_document_repository_1_idx` (`File_category`),
   CONSTRAINT `fk_document_repository_1` FOREIGN KEY (`File_category`) REFERENCES `document_repository_categories` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION

--- a/SQL/Archive/19.2/2018-06-05_Add_UUID_column_to_document_repository.sql
+++ b/SQL/Archive/19.2/2018-06-05_Add_UUID_column_to_document_repository.sql
@@ -1,0 +1,1 @@
+ALTER TABLE document_repository ADD `UUID` varchar(36) DEFAULT '';

--- a/modules/document_repository/ajax/documentDelete.php
+++ b/modules/document_repository/ajax/documentDelete.php
@@ -10,18 +10,23 @@
   * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
   * @link     https://github.com/aces/Loris
   */
+
 $user =& User::singleton();
+
 if (!$user->hasPermission('document_repository_delete')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }
 
 set_include_path(get_include_path().":../../project/libraries:../../php/libraries:");
+
 require_once "NDB_Client.class.inc";
 require_once "NDB_Config.class.inc";
 require_once "Email.class.inc";
+
 $client = new NDB_Client();
 $client->initialize("../../project/config.xml");
+
 $factory = NDB_Factory::singleton();
 $baseURL = $factory->settings()->getBaseURL();
 
@@ -66,5 +71,19 @@ $path = __DIR__ . "/../user_uploads/$dataDir";
 if (file_exists($path)) {
     unlink($path);
 }
+
+// Cleanup empty directories
+set_error_handler(
+    function () {
+        // Silence the E_WARNING when files exist in the directory.
+    }
+);
+$rm_directory = __DIR__ . '/../user_uploads/'
+    . substr($dataDir, 0, strlen($dataDir)-(strlen($fileName)+1));
+rmdir($rm_directory);
+$rm_directory = __DIR__ . '/../user_uploads/'
+    . $userName . '/' . $fileName;
+rmdir($rm_directory);
+restore_error_handler();
 
 ?>

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -65,6 +65,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
              'EARLI'         => '0',
              'hide_video'    => '0',
              'File_category' => '9999999',
+             'UUID'          => 'dc987d5c-6e5d-11e8-adc0-fa7ae01bbebc',
             )
         );
 


### PR DESCRIPTION
This pull request allow files with duplicate name to exist and when user uploads a file to the document repository.

I made the mysql column "uuid" in the table "document_repository" for files to be stored in unique directories.

The uuid and file_name are used for the system directory structure when storing the files.
System Directory Structure Examples:

Note: {uuid} is unique per upload.
user_uploads/admin/text.png/{uuid}/text.png
user_uploads/admin/text.txt/{uuid}/text.txt

user_uploads/admin/text.png/{uuid}/text.png
user_uploads/admin/text.txt/{uuid}/text.txt

See also: Bug #10847 and Bug #11243