### PR TITLE
[media] Remove unused code

### DIFF
--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -209,7 +209,7 @@ class Media extends \NDB_Menu_Filter
         if ($this->hasWritePermission) {
             array_push($this->headers, 'Edit Metadata');
         }
-        
+
         return true;
     }
 

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -209,23 +209,7 @@ class Media extends \NDB_Menu_Filter
         if ($this->hasWritePermission) {
             array_push($this->headers, 'Edit Metadata');
         }
-
-        $this->validFilters = [
-                               'c.PSCID',
-                               'm.instrument',
-                               's.Visit_label',
-                               's.CenterID',
-                               'm.hide_file',
-                               'l.language_id',
-                              ];
-        $this->formToFilter = [
-                               'pscid'       => 'c.PSCID',
-                               'instrument'  => 'm.instrument',
-                               'visit_label' => 's.Visit_label',
-                               'for_site'    => 's.CenterID',
-                               'hide_file'   => 'm.hide_file',
-                               'language'    => 'l.language_id',
-                              ];
+        
         return true;
     }
 


### PR DESCRIPTION
This removes the `validFilters` and `formToFilter` variables which seem to be unused when using react

@driusan are these actually not used ?
