### PR TITLE
[New Profile] Ensure Site object isn't overwritten

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -299,10 +299,10 @@ class New_Profile extends \NDB_Form
         }
 
         // validate site entered
-        $site = $values['psc'];
+        $psc = $values['psc'];
         $user_list_of_sites = $user->getData('CenterIDs');
         $num_sites          = count($user_list_of_sites);
-        if ($num_sites > 1 && (empty($site) || !$user->hasCenter($site))) {
+        if ($num_sites > 1 && (empty($psc) || !$user->hasCenter($psc))) {
             $errors['psc'] = "Site must be selected from the available dropdown.";
         }
 


### PR DESCRIPTION
In the case of user defined PSCID, candidates were not able to be created due to a variable holding a reference to the Site object being overwritten.

To test this fix, set PSCID to `user` in your `config.xml`, and attempt to create a new candidate.

Clarification: Line 277 of the file changed assigns `$site` by reference, and then reassigns it on line 302. This causes the site object's value to change to `$value['psc']` which is potentially dangerous.