### PR TITLE
[API] Bug fix for visit creation for users at multiple sites

### DIFF
--- a/htdocs/api/v0.0.3-dev/Candidates.php
+++ b/htdocs/api/v0.0.3-dev/Candidates.php
@@ -132,7 +132,7 @@ class Candidates extends APIBase
                 "CenterID"
             );
             $allUserSiteNames = $this->DB->pselectColWithIndexKey(
-                "SELECT CenterID, Name FROM psc WHERE CenterID =:cid",
+                "SELECT CenterID, Name FROM psc WHERE FIND_IN_SET(CenterID, :cid)",
                 array('cid' => implode(',', $centerIDs)),
                 "CenterID"
             );
@@ -146,6 +146,7 @@ class Candidates extends APIBase
             // Get the CenterID from the provided SiteName, and check if the
             // user has permission to create a candidate at this site
             $centerID = array_search($siteName, $allUserSiteNames);
+
             if ($centerID === false) {
                 $this->header("HTTP/1.1 403 Forbidden");
                 $this->error("You are not affiliated with the candidate's site");

--- a/htdocs/api/v0.0.3-dev/candidates/Visit.php
+++ b/htdocs/api/v0.0.3-dev/candidates/Visit.php
@@ -200,7 +200,7 @@ class Visit extends \Loris\API\Candidates\Candidate
                     "CenterID"
                 );
                 $allUserSiteNames = $this->DB->pselectColWithIndexKey(
-                    "SELECT CenterID, Name FROM psc WHERE CenterID =:cid",
+                    "SELECT CenterID, Name FROM psc WHERE FIND_IN_SET(CenterID, :cid)",
                     array('cid' => implode(',', $centerIDs)),
                     "CenterID"
                 );

--- a/htdocs/api/v0.0.3-dev/candidates/Visit.php
+++ b/htdocs/api/v0.0.3-dev/candidates/Visit.php
@@ -200,7 +200,8 @@ class Visit extends \Loris\API\Candidates\Candidate
                     "CenterID"
                 );
                 $allUserSiteNames = $this->DB->pselectColWithIndexKey(
-                    "SELECT CenterID, Name FROM psc WHERE FIND_IN_SET(CenterID, :cid)",
+                    "SELECT CenterID, Name FROM psc ".
+                    "WHERE FIND_IN_SET(CenterID, :cid)",
                     array('cid' => implode(',', $centerIDs)),
                     "CenterID"
                 );


### PR DESCRIPTION
bug introduced in: #3014 
when putting an imploded comma separated array through a prepared select statement, i am guessing that only the first element of the array goes through when applied within a `WHERE = ...` clause.
i changed the ` CenterID WHERE = :cid` to `WHERE FIND_IN_SET(CenterID, :cid)` to allow for all center ID's to be considered