### PR TITLE
[Tools] updating date zeros removal script

### DIFF
--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -106,11 +106,18 @@ foreach ($field_names as $key=>$field)
             " SET ".$db->escape($field['COLUMN_NAME'])."=NULL".$autoUpdateSQL.
             " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
     } else {
-	echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
-	    "A date '1000-01-01' will be entered instead of '0000-00-00' values.\n"; 
-        $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
-            " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01'".$autoUpdateSQL.
-            " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00';\n";
+        echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
+            "A date '1000-01-01' will be entered instead of '0000-00-00' values.\n";
+
+        if ($field['DATA_TYPE'] == 'date') {
+            $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
+                " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01'".$autoUpdateSQL.
+                " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00';\n";
+        } else if (($field['DATA_TYPE'] == 'datetime' || $field['DATA_TYPE'] == 'timestamp')) {
+            $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
+                " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01 00:00:00'".$autoUpdateSQL.
+                " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
+        }
     }
 
 }

--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -113,11 +113,15 @@ foreach ($field_names as $key=>$field)
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00';\n";
-        } else if (($field['DATA_TYPE'] == 'datetime' || $field['DATA_TYPE'] == 'timestamp')) {
+        } else if ($field['DATA_TYPE'] == 'datetime') {
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01 00:00:00'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
-        }
+        } else if ($field['DATA_TYPE'] == 'timestamp') { 
+            $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
+                " SET ".$db->escape($field['COLUMN_NAME'])."='1970-01-01 00:00:01'".$autoUpdateSQL.
+                " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
+        }    
     }
 
 }

--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -106,18 +106,21 @@ foreach ($field_names as $key=>$field)
             " SET ".$db->escape($field['COLUMN_NAME'])."=NULL".$autoUpdateSQL.
             " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
     } else {
-        echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
-            "A date '1000-01-01' will be entered instead of '0000-00-00' values.\n";
-
         if ($field['DATA_TYPE'] == 'date') {
+            echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
+                "A date '1000-01-01' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00';\n";
         } else if ($field['DATA_TYPE'] == 'datetime') {
+            echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
+                "A date '1000-01-01' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01 00:00:00'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
-        } else if ($field['DATA_TYPE'] == 'timestamp') { 
+        } else if ($field['DATA_TYPE'] == 'timestamp') {
+            echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
+                "A date '1970-01-01' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1970-01-01 00:00:01'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";

--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -114,13 +114,13 @@ foreach ($field_names as $key=>$field)
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00';\n";
         } else if ($field['DATA_TYPE'] == 'datetime') {
             echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
-                "A datetime '1000-01-01' will be entered instead of '0000-00-00' values.\n";
+                "A datetime '1000-01-01 00:00:00' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01 00:00:00'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
         } else if ($field['DATA_TYPE'] == 'timestamp') {
             echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
-                "A timestamp '1970-01-01' will be entered instead of '0000-00-00' values.\n";
+                "A timestamp '1970-01-01 00:00:01' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1970-01-01 00:00:01'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";

--- a/tools/DB_date_zeros_removal.php
+++ b/tools/DB_date_zeros_removal.php
@@ -44,16 +44,16 @@ echo "\n#################################################################\n\n".
 $database_name= $database['database'];
 
 $field_names = $db->pselect("
-                      SELECT 
+                      SELECT
                           TABLE_NAME,
                           COLUMN_NAME,
                           COLUMN_DEFAULT,
                           DATA_TYPE,
                           IS_NULLABLE,
                           COLUMN_TYPE,
-                          EXTRA 
-                      FROM INFORMATION_SCHEMA.COLUMNS 
-                      WHERE DATA_TYPE IN ('date','timestamp','datetime') 
+                          EXTRA
+                      FROM INFORMATION_SCHEMA.COLUMNS
+                      WHERE DATA_TYPE IN ('date','timestamp','datetime')
                           AND TABLE_SCHEMA=:dbn",
     array("dbn"=>$database['database'])
 );
@@ -114,17 +114,17 @@ foreach ($field_names as $key=>$field)
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00';\n";
         } else if ($field['DATA_TYPE'] == 'datetime') {
             echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
-                "A date '1000-01-01' will be entered instead of '0000-00-00' values.\n";
+                "A datetime '1000-01-01' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1000-01-01 00:00:00'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
         } else if ($field['DATA_TYPE'] == 'timestamp') {
             echo "COLUMN ".$field['COLUMN_NAME']." in TABLE ".$field['TABLE_NAME']." is NOT NULLABLE. ".
-                "A date '1970-01-01' will be entered instead of '0000-00-00' values.\n";
+                "A timestamp '1970-01-01' will be entered instead of '0000-00-00' values.\n";
             $nonNullUpdates .= "UPDATE ".$db->escape($database['database']).".".$db->escape($field['TABLE_NAME']).
                 " SET ".$db->escape($field['COLUMN_NAME'])."='1970-01-01 00:00:01'".$autoUpdateSQL.
                 " WHERE CAST(".$db->escape($field['COLUMN_NAME'])." AS CHAR(20))='0000-00-00 00:00:00';\n";
-        }    
+        }
     }
 
 }


### PR DESCRIPTION
This PR updates the `DB_date_zeros_removal.php` script. At present, the script doesn't check if not nullable fields are date times or timestamps, so this is modified. 