### PR TITLE
[conflict_resolver] Restore "Resolved Conflicts" to the correct link instead of redirecting to the main page

### DIFF
--- a/modules/conflict_resolver/templates/menu_conflict_resolver.tpl
+++ b/modules/conflict_resolver/templates/menu_conflict_resolver.tpl
@@ -73,7 +73,7 @@
 <div id="tabs" style="background: white">
     <ul class="nav nav-tabs ">
         <li class="active"><a id="onLoad">Unresolved Conflicts</a></li>
-        <li><a href="{$baseurl}/conflict_resolver/resolved_conflicts">Resolved Conflicts</a></li>
+        <li><a href="{$baseurl}/conflict_resolver/resolved_conflicts/">Resolved Conflicts</a></li>
     </ul>
     <div class="tab-content">
         <div class="tab-pane active">

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -113,7 +113,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
     {
         $this->safeGet(
             $this->url
-            . "/conflict_resolver/?submenu=resolved_conflicts"
+            . "/conflict_resolver/resolved_conflicts/"
         );
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -147,7 +147,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
          $this->setupPermissions(array("conflict_resolver"));
          $this->safeGet(
              $this->url
-             . "/conflict_resolver/?submenu=resolved_conflicts"
+             . "/conflict_resolver/resolved_conflicts/"
          );
          $bodyText = $this->webDriver->findElement(
              WebDriverBy::cssSelector("body")

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -5,13 +5,52 @@
         colors="true">
     <testsuites>
         <testsuite name='LorisUnitTests'>
+            <directory>./unittests/</directory>
+            <directory>./unittests/api</directory>
         </testsuite>
 
         <testsuite name='LorisCoreIntegrationTests'>
+            <directory>./integrationtests/</directory>
         </testsuite>
 
         <testsuite name='LorisModuleIntegrationTests'>
+            <directory>../modules/acknowledgements/test/</directory>
+            <directory>../modules/brainbrowser/test/</directory>
+            <directory>../modules/candidate_list/test/</directory>
+            <directory>../modules/candidate_parameters/test/</directory>
+            <directory>../modules/configuration/test/</directory>
             <directory>../modules/conflict_resolver/test/</directory>
+            <directory>../modules/create_timepoint/test/</directory>
+            <directory>../modules/dashboard/test/</directory>
+            <directory>../modules/data_integrity_flag/test/</directory>
+            <directory>../modules/data_team_helper/test/</directory>
+            <directory>../modules/datadict/test/</directory>
+            <directory>../modules/dicom_archive/test/</directory>
+            <directory>../modules/document_repository/test/</directory>
+            <directory>../modules/examiner/test/</directory>
+            <directory>../modules/genomic_browser/test/</directory>
+            <directory>../modules/help_editor/test/</directory>
+            <directory>../modules/imaging_browser/test/</directory>
+            <directory>../modules/imaging_uploader/test/</directory>
+            <directory>../modules/instrument_builder/test/</directory>
+            <directory>../modules/instrument_list/test/</directory>
+            <directory>../modules/instrument_manager/test/</directory>
+            <directory>../modules/mri_upload/test/</directory>
+            <directory>../modules/mri_violations/test/</directory>
+            <directory>../modules/new_profile/test/</directory>
+            <directory>../modules/next_stage/test/</directory>
+            <directory>../modules/reliability/test/</directory>
+            <directory>../modules/statistics/test/</directory>
+            <directory>../modules/survey_accounts/test/</directory>
+            <directory>../modules/timepoint_flag/test/</directory>
+            <directory>../modules/timepoint_list/test/</directory>
+            <directory>../modules/training/test/</directory>
+            <directory>../modules/user_accounts/test/</directory>
+            <directory>../modules/media/test/</directory>
+            <directory>../modules/issue_tracker/test/</directory>
+            <directory>../modules/server_processes_manager/test/</directory>
+            <directory>../test/test_instrument/</directory>
+            <directory>../modules/bvl_feedback/test/</directory>
         </testsuite>
 
     </testsuites>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -5,52 +5,13 @@
         colors="true">
     <testsuites>
         <testsuite name='LorisUnitTests'>
-            <directory>./unittests/</directory>
-            <directory>./unittests/api</directory>
         </testsuite>
 
         <testsuite name='LorisCoreIntegrationTests'>
-            <directory>./integrationtests/</directory>
         </testsuite>
 
         <testsuite name='LorisModuleIntegrationTests'>
-            <directory>../modules/acknowledgements/test/</directory>
-            <directory>../modules/brainbrowser/test/</directory>
-            <directory>../modules/candidate_list/test/</directory>
-            <directory>../modules/candidate_parameters/test/</directory>
-            <directory>../modules/configuration/test/</directory>
             <directory>../modules/conflict_resolver/test/</directory>
-            <directory>../modules/create_timepoint/test/</directory>
-            <directory>../modules/dashboard/test/</directory>
-            <directory>../modules/data_integrity_flag/test/</directory>
-            <directory>../modules/data_team_helper/test/</directory>
-            <directory>../modules/datadict/test/</directory>
-            <directory>../modules/dicom_archive/test/</directory>
-            <directory>../modules/document_repository/test/</directory>
-            <directory>../modules/examiner/test/</directory>
-            <directory>../modules/genomic_browser/test/</directory>
-            <directory>../modules/help_editor/test/</directory>
-            <directory>../modules/imaging_browser/test/</directory>
-            <directory>../modules/imaging_uploader/test/</directory>
-            <directory>../modules/instrument_builder/test/</directory>
-            <directory>../modules/instrument_list/test/</directory>
-            <directory>../modules/instrument_manager/test/</directory>
-            <directory>../modules/mri_upload/test/</directory>
-            <directory>../modules/mri_violations/test/</directory>
-            <directory>../modules/new_profile/test/</directory>
-            <directory>../modules/next_stage/test/</directory>
-            <directory>../modules/reliability/test/</directory>
-            <directory>../modules/statistics/test/</directory>
-            <directory>../modules/survey_accounts/test/</directory>
-            <directory>../modules/timepoint_flag/test/</directory>
-            <directory>../modules/timepoint_list/test/</directory>
-            <directory>../modules/training/test/</directory>
-            <directory>../modules/user_accounts/test/</directory>
-            <directory>../modules/media/test/</directory>
-            <directory>../modules/issue_tracker/test/</directory>
-            <directory>../modules/server_processes_manager/test/</directory>
-            <directory>../test/test_instrument/</directory>
-            <directory>../modules/bvl_feedback/test/</directory>
         </testsuite>
 
     </testsuites>


### PR DESCRIPTION
This pull request fixing the link for conflict_resolver tab.