### PR TITLE
[README] Specify that PHP 7.2 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
  * LINUX (supported on Ubuntu 14+ and [CentOS 6.5](https://github.com/aces/Loris/blob/master/README.CentOS6.md))
  * Apache2
  * MySQL 5.7 
- * PHP <b>7</b>  
+ * PHP <b>7.2</b>  
  * Package manager (for LINUX distributions)
  * Composer : should be run with --no-dev option
 
 <b>Important:</b>
- * If you are upgrading your LORIS, you'll also want to upgrade to both PHP >= 7.1.3 and MySQL 5.7, since these dependency versions were not supported in the last release. 
+ * If you are upgrading your LORIS, you'll also want to upgrade to both PHP 7.2 and MySQL 5.7, since these dependency versions were not supported in the last release. 
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
  * Composer : should be run with --no-dev option
 
 <b>Important:</b>
- * If you are upgrading your LORIS, you'll also want to upgrade to both PHP 7 and MySQL 5.7, since these dependency versions were not supported in the last release. 
+ * If you are upgrading your LORIS, you'll also want to upgrade to both PHP >= 7.1.3 and MySQL 5.7, since these dependency versions were not supported in the last release. 
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.


### PR DESCRIPTION
_From Redmine #14288_

When updating my old VM, I tried to run `composer install` and got many errors. This is because our dependencies require PHP >= 7.1.3. We should clarify this in the install process.

Problem 1
- Installation request for doctrine/instantiator 1.1.0 -> satisfiable by doctrine/instantiator[1.1.0].
- doctrine/instantiator 1.1.0 requires php ^7.1 -> your PHP version (7.0.29) does not satisfy that requirement.
Problem 2
- Installation request for phan/phan 0.12.2 -> satisfiable by phan/phan[0.12.2].
- phan/phan 0.12.2 requires ext-ast ^0.1.5 -> the requested PHP extension ast is missing from your system.
Problem 3
- Installation request for symfony/config v4.0.4 -> satisfiable by symfony/config[v4.0.4].
- symfony/config v4.0.4 requires php ^7.1.3 -> your PHP version (7.0.29) does not satisfy that requirement.
Problem 4
- Installation request for symfony/console v4.0.5 -> satisfiable by symfony/console[v4.0.5].
- symfony/console v4.0.5 requires php ^7.1.3 -> your PHP version (7.0.29) does not satisfy that requirement.
Problem 5
- Installation request for symfony/dependency-injection v4.0.4 -> satisfiable by symfony/dependency-injection[v4.0.4].
- symfony/dependency-injection v4.0.4 requires php ^7.1.3 -> your PHP version (7.0.29) does not satisfy that requirement.
Problem 6
- Installation request for symfony/filesystem v4.0.4 -> satisfiable by symfony/filesystem[v4.0.4].
- symfony/filesystem v4.0.4 requires php ^7.1.3 -> your PHP version (7.0.29) does not satisfy that requirement.
Problem 7
- Installation request for symfony/yaml v4.0.4 -> satisfiable by symfony/yaml[v4.0.4].
- symfony/yaml v4.0.4 requires php ^7.1.3 -> your PHP version (7.0.29) does not satisfy that requirement.
Problem 8
- doctrine/instantiator 1.1.0 requires php ^7.1 -> your PHP version (7.0.29) does not satisfy that requirement.
- phpunit/phpunit-mock-objects 5.0.6 requires doctrine/instantiator ^1.0.5 -> satisfiable by doctrine/instantiator[1.1.0].
- Installation request for phpunit/phpunit-mock-objects 5.0.6 -> satisfiable by phpunit/phpunit-mock-objects[5.0.6].
