### PR TITLE
[Create Timepoint] Sanitize CandID in href

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -81,11 +81,6 @@ class Create_Timepoint extends \NDB_Form
         );
 
         $this->tpl_data['success'] = true;
-        $this->tpl_data['candID']  = htmlentities(
-            $this->identifier,
-            ENT_QUOTES,
-            'UTF-8'
-        );
 
         // freeze it, just in case
         $this->form->freeze();
@@ -114,7 +109,7 @@ class Create_Timepoint extends \NDB_Form
         );
         $this->tpl_data['candID'] = $sanitizedIdentifier;
 
-        $this->addHidden('candID', $sanitizedIdentifier;
+        $this->addHidden('candID', $sanitizedIdentifier);
 
         $candidate   =& \Candidate::singleton($this->identifier);
         $subprojList = null;

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -81,6 +81,11 @@ class Create_Timepoint extends \NDB_Form
         );
 
         $this->tpl_data['success'] = true;
+        $this->tpl_data['candID'] = htmlentities(
+            $this->identifier, 
+            ENT_QUOTES,
+            'UTF-8'
+        );
 
         // freeze it, just in case
         $this->form->freeze();

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -81,8 +81,8 @@ class Create_Timepoint extends \NDB_Form
         );
 
         $this->tpl_data['success'] = true;
-        $this->tpl_data['candID'] = htmlentities(
-            $this->identifier, 
+        $this->tpl_data['candID']  = htmlentities(
+            $this->identifier,
             ENT_QUOTES,
             'UTF-8'
         );

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -107,9 +107,14 @@ class Create_Timepoint extends \NDB_Form
         }
 
         // cand ID
-        $this->tpl_data['candID'] = $this->identifier;
+        $sanitizedIdentifier      = htmlentities(
+            $this->identifier,
+            ENT_QUOTES,
+            'UTF-8'
+        );
+        $this->tpl_data['candID'] = $sanitizedIdentifier;
 
-        $this->addHidden('candID', $this->identifier);
+        $this->addHidden('candID', $sanitizedIdentifier;
 
         $candidate   =& \Candidate::singleton($this->identifier);
         $subprojList = null;


### PR DESCRIPTION
Redmine #13790

While CandID comes from the database and is expected to be trusted, this PR explicitly sanitizes the candID variable before it is injected into the href element.
