### PR TITLE
Fix support for old module architecture in NDB_Form.

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -75,7 +75,7 @@ class NDB_Form extends NDB_Page
         }
 
         // create a form instance
-        $obj = new $class($module, $name, $page, $identifier, '', 'test_form');
+        $obj = new $class($module, $page, $identifier, '', 'test_form');
 
         $obj->registerDefaultFilter();
 


### PR DESCRIPTION
This fixes a bug in NDB_Form that prevented one from mixing old and new module architecture in LORIS. It was discovered initially in IBIS: the final radiological review form was not populating properly.