### PR TITLE
Remove reference to a function which doesn't exist in NDB_Page

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -321,5 +321,4 @@ class New_Profile extends \NDB_Form
 
         return $errors;
     }
-
 }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -620,7 +620,9 @@ class NDB_Page implements RequestHandlerInterface
     ) : ResponseInterface {
         $user = $request->getAttribute("user");
         if ($this->_hasAccess() !== true) {
-            throw new PermissionDenied();
+            return (new \LORIS\Middleware\PageDecorationMiddleware($user))
+                ->process($request, new \LORIS\Http\StringStream("Permission Denied"))
+                ->withStatus(403);
         }
 
         // The NDB_Page object itself is sometimes required by middleware,

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -621,8 +621,10 @@ class NDB_Page implements RequestHandlerInterface
         $user = $request->getAttribute("user");
         if ($this->_hasAccess() !== true) {
             return (new \LORIS\Middleware\PageDecorationMiddleware($user))
-                ->process($request, new \LORIS\Http\StringStream("Permission Denied"))
-                ->withStatus(403);
+                ->process(
+                    $request,
+                    new \LORIS\Http\StringStream("Permission Denied")
+                )->withStatus(403);
         }
 
         // The NDB_Page object itself is sometimes required by middleware,

--- a/src/Http/StringStream.php
+++ b/src/Http/StringStream.php
@@ -15,6 +15,10 @@
  * @see https://www.php-fig.org/psr/psr-7/
  */
 namespace LORIS\Http;
+use \Psr\Http\Server\RequestHandlerInterface;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
 
 /**
  * A StringStream provides a simple wrapper over a string to convert
@@ -26,7 +30,7 @@ namespace LORIS\Http;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class StringStream implements \Psr\Http\Message\StreamInterface
+class StringStream implements \Psr\Http\Message\StreamInterface, RequestHandlerInterface
 {
     protected $stream;
     protected $size;
@@ -265,5 +269,21 @@ class StringStream implements \Psr\Http\Message\StreamInterface
             return $metadata;
         }
         return $metadata[$key];
+    }
+
+    /**
+     * A StringStream can act as a handler, which resolves to a response with
+     * itself as a body.
+     *
+     * This is primarily to allow it to be used content by middleware.
+     *
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface A response whose body consists of this string
+
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface {
+            return (new \Zend\Diactoros\Response())
+                        ->withBody($this);
     }
 }

--- a/src/Http/StringStream.php
+++ b/src/Http/StringStream.php
@@ -275,7 +275,7 @@ class StringStream implements \Psr\Http\Message\StreamInterface, RequestHandlerI
      * A StringStream can act as a handler, which resolves to a response with
      * itself as a body.
      *
-     * This is primarily to allow it to be used content by middleware.
+     * This is primarily to allow it to be used as content by middleware.
      *
      * @param ServerRequestInterface $request The PSR15 Request being handled
      *


### PR DESCRIPTION
This removes the (only) reference to an undefined "PermissionDenied"
exception, and instead replaces it with a 403 response with the
words "Permission Denied" in the body.

See also: Redmine #14722