### PR TITLE
[timepoint_list] Remove invalid buttons from timepoint_list page

### DIFF
--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -64,13 +64,12 @@ Class TimePoint_List_ControlPanel extends \Candidate
         $this->tpl_data['candID'] = $this->getData('CandID');
 
         $this->tpl_data['isDataEntryPerson']
-            = $user->hasCenterPermission("data_entry", $cand_CenterID)
-            || $user->isUserDCC();
+            = $user->hasCenterPermission("data_entry", $cand_CenterID);
 
         $this->tpl_data['candidate_parameters_view']
-            = $user->hasPermission('candidate_parameter_view');
+            = $user->hasCenterPermission('candidate_parameter_view', $cand_CenterID);
         $this->tpl_data['candidate_parameters_edit']
-            = $user->hasPermission('candidate_parameter_edit');
+            = $user->hasCenterPermission('candidate_parameter_edit', $cand_CenterID);
 
         //set the baseurl of the tpl_data
         $factory  = \NDB_Factory::singleton();


### PR DESCRIPTION
This removes the buttons that the test plan says are invalid on the timepoint_list page

See also: Redmine #14723