### PR TITLE
Imaging Browser 20.0 bugfix: Fix links to instruments

### DIFF
--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -70,6 +70,9 @@ useEDC - This setting determines whether "EDC" filtering dropdowns exist
 mantis_url - This setting defines a URL for LORIS to include a link to for bug reporting
         on the "View Session" page.
 
+For downloading large DICOM files, it may be necessary to increase the
+ value of the `memory_limit` configuration option within `php.ini`.
+
 ## Interactions with LORIS
 
 - The "Selected" set by the imaging QC specialist is used by the dataquery

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -70,9 +70,6 @@ useEDC - This setting determines whether "EDC" filtering dropdowns exist
 mantis_url - This setting defines a URL for LORIS to include a link to for bug reporting
         on the "View Session" page.
 
-For downloading large DICOM files, it may be necessary to increase the
- value of the `memory_limit` configuration option within `php.ini`.
-
 ## Interactions with LORIS
 
 - The "Selected" set by the imaging QC specialist is used by the dataquery

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -33,7 +33,7 @@
     <h3>Links</h3>
     <ul>
         {foreach from=$subject.links item=link}
-            <li><a href="{$baseurl}/{$subject.candid}/{$subject.sessionID}/{$link.BEName}/?commentID={$link.CommentID}">{$link.FEName}</a></li>
+            <li><a href="{$baseurl}/instruments/{$link.BEName}/?commentID={$link.CommentID}&sessionID={$subject.sessionID}&candID={$subject.candid}">{$link.FEName}</a></li>
         {/foreach}
         {foreach from=$subject.tarchiveIDLoc key=tarchive item=tarchiveLoc}
             <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive}</a></li>


### PR DESCRIPTION
The link to the instruments was following the 
baseurl/instrument_name/?commentID&sessonid&candid format
when it should now be:
baseurl/instruments/instrument_name/?commentID&sessonid&candid

I also added one comment in the README about the DICOM download option, identical to the one in the DICOM Archive module, in case of large .tar files.
