### PR TITLE
Update Imaging Browser Readme

### DIFF
--- a/modules/dicom_archive/README.md
+++ b/modules/dicom_archive/README.md
@@ -30,6 +30,8 @@ the DICOM Archive module.
 
 ## Configurations
 
+#### Database Configurations
+
 The `patientNameRegex`, `LegoPhantomRegex`, and `LivingPhantomRegex`
 configuration variables provide regular expressions to ensure that
 the DICOM has been properly anonymized. If at least one of these
@@ -43,6 +45,8 @@ Patient ID column.
 The `showTransferStatus` configuration option is obsolete and should
 not be used, but determines if a first "Transfer Status" column
 appears in the menu table.
+
+#### Install Configurations
 
 For downloading large DICOM files, it may be necessary to increase the 
  value of the `memory_limit` configuration option within `php.ini`.

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -67,8 +67,11 @@ useProjects - This setting determines whether "project" filtering dropdowns exis
 useEDC - This setting determines whether "EDC" filtering dropdowns exist
         on the menu page.
 
-mantis_url - This setting defines a URL for LORIS to include a link to for bug reporting
-        on the "View Session" page.
+mantis_url - This setting defines a URL for LORIS to include a link to "mantis" for 
+        bug reporting on the "View Session" page.
+
+For downloading large DICOM files, it may be necessary to increase the
+ value of the `memory_limit` configuration option within `php.ini`.
 
 ## Interactions with LORIS
 

--- a/modules/imaging_browser/README.md
+++ b/modules/imaging_browser/README.md
@@ -54,6 +54,8 @@ imaging_browser_qc
 
 The imaging browser has the following configurations that affect its usage
 
+#### Database Configurations
+
 tblScanTypes - This setting determines which scan types are considered "NEW" for
         QC purposes. It also determines which modalities are displayed on the
         main imaging browser menu page.
@@ -67,8 +69,10 @@ useProjects - This setting determines whether "project" filtering dropdowns exis
 useEDC - This setting determines whether "EDC" filtering dropdowns exist
         on the menu page.
 
-mantis_url - This setting defines a URL for LORIS to include a link to "mantis" for 
-        bug reporting on the "View Session" page.
+issue_tracker_url - This setting defines a URL for LORIS to include a link to the 
+        bug reporting system on the "View Session" page.
+
+#### Install Configurations
 
 For downloading large DICOM files, it may be necessary to increase the
  value of the `memory_limit` configuration option within `php.ini`.


### PR DESCRIPTION
DICOM download has a specific php.ini setting for large files. Specify this in the README (identical description as in Dicom Archive)
