### PR TITLE
Better error message when removing examiner role from user account

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -276,128 +276,125 @@ class Edit_User extends \NDB_Form
                 }
             }
 
-            // first check if an update is needed then actually do it
-            if (!empty($ex_radiologist)
-                && !empty($ex_pending)
-                && !empty($ex_curr_sites)
-            ) {
-                //modify examiner radiologist to be in the binary format 0-1
-                $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
+            //modify examiner radiologist to be in the binary format 0-1
+            $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
 
-                $examinerID = $DB->pselect(
-                    "SELECT e.examinerID
-                 FROM examiners e
-                 WHERE e.full_name=:fn",
+            $examinerID = $DB->pselect(
+                "SELECT e.examinerID
+             FROM examiners e
+             WHERE e.full_name=:fn",
+                array(
+                 "fn" => $values['Real_name'],
+                )
+            );
+
+
+            // START EXAMINER UPDATE
+            // If examiner not in table add him,
+            // otherwise update the radiologist field and get the current sites
+            $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
+            if (empty($examinerID)) {
+
+                $DB->insert(
+                    'examiners',
                     array(
-                     "fn" => $values['Real_name'],
+                     'full_name'   => $values['Real_name'],
+                     'radiologist' => $ex_radiologist,
+                     'userID'      => $uid,
+                    )
+                );
+                $examinerID = $examinerID = $DB->pselectOne(
+                    "SELECT examinerID
+                 FROM examiners
+                 WHERE full_name=:fullName",
+                    array('fullName' => $values['Real_name'])
+                );
+            } else {
+
+                $DB->update(
+                    'examiners',
+                    array(
+                     'radiologist' => $ex_radiologist,
+                     'userID'      => $uid,
+                    ),
+                    array(
+                     "full_name" => $values['Real_name'],
+                    )
+                );
+                $examinerID = $examinerID[0]['examinerID'];
+
+                //get existing sites for examiner
+                $prev_sites = $DB->pselect(
+                    "SELECT centerID
+             FROM examiners_psc_rel epr
+             WHERE examinerID=:eid",
+                    array("eid" => $examinerID)
+                );
+
+                //get sites where user is already an examiner at for compare
+                foreach ($prev_sites as $row => $center) {
+                    array_push($ex_prev_sites, $center['centerID']);
+                }
+            }
+
+            foreach ($ex_curr_sites as $k => $v) {
+
+                //Check if examiner already in db for site
+                $result = $DB->pselectRow(
+                    "SELECT epr.centerID
+                     FROM examiners_psc_rel epr 
+                     WHERE epr.examinerID=:eid AND epr.centerID=:cid",
+                    array(
+                     "eid" => $examinerID,
+                     "cid" => $v,
                     )
                 );
 
-                // If examiner not in table add him,
-                // otherwise update the radiologist field and get the current sites
-                $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
-                if (empty($examinerID)) {
-
+                // examiner was not previously added, add and set to active
+                if (empty($result)) {
                     $DB->insert(
-                        'examiners',
+                        'examiners_psc_rel',
                         array(
-                         'full_name'   => $values['Real_name'],
-                         'radiologist' => $ex_radiologist,
-                         'userID'      => $uid,
+                         'examinerID'       => $examinerID,
+                         'centerID'         => $v,
+                         'active'           => 'Y',
+                         'pending_approval' => $ex_pending,
                         )
-                    );
-                    $examinerID = $examinerID = $DB->pselectOne(
-                        "SELECT examinerID
-                     FROM examiners
-                     WHERE full_name=:fullName",
-                        array('fullName' => $values['Real_name'])
                     );
                 } else {
-
-                    $DB->update(
-                        'examiners',
-                        array(
-                         'radiologist' => $ex_radiologist,
-                         'userID'      => $uid,
-                        ),
-                        array(
-                         "full_name" => $values['Real_name'],
-                        )
-                    );
-                    $examinerID = $examinerID[0]['examinerID'];
-
-                    //get existing sites for examiner
-                    $prev_sites = $DB->pselect(
-                        "SELECT centerID
-                 FROM examiners_psc_rel epr
-                 WHERE examinerID=:eid",
-                        array("eid" => $examinerID)
-                    );
-
-                    //get sites where user is already an examiner at for compare
-                    foreach ($prev_sites as $row => $center) {
-                        array_push($ex_prev_sites, $center['centerID']);
-                    }
-                }
-
-                foreach ($ex_curr_sites as $k => $v) {
-
-                    //Check if examiner already in db for site
-                    $result = $DB->pselectRow(
-                        "SELECT epr.centerID
-                         FROM examiners_psc_rel epr 
-                         WHERE epr.examinerID=:eid AND epr.centerID=:cid",
-                        array(
-                         "eid" => $examinerID,
-                         "cid" => $v,
-                        )
-                    );
-
-                    // examiner was not previously added, add and set to active
-                    if (empty($result)) {
-                        $DB->insert(
-                            'examiners_psc_rel',
-                            array(
-                             'examinerID'       => $examinerID,
-                             'centerID'         => $v,
-                             'active'           => 'Y',
-                             'pending_approval' => $ex_pending,
-                            )
-                        );
-                    } else {
-                        $DB->update(
-                            'examiners_psc_rel',
-                            array(
-                             'active'           => 'Y',
-                             'pending_approval' => $ex_pending,
-                            ),
-                            array(
-                             'examinerID' => $examinerID,
-                             'centerID'   => $v,
-                            )
-                        );
-                    }
-                    unset($values[$k]);
-                }
-
-                //de-activate examiner if sites where no longer checked
-                $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
-
-                foreach ($ex_inactive as $cid) {
                     $DB->update(
                         'examiners_psc_rel',
-                        array("active" => 'N'),
+                        array(
+                         'active'           => 'Y',
+                         'pending_approval' => $ex_pending,
+                        ),
                         array(
                          'examinerID' => $examinerID,
-                         'centerID'   => $cid,
+                         'centerID'   => $v,
                         )
                     );
                 }
+                unset($values[$k]);
             }
-            unset($values['examiner_radiologist']);
-            unset($values['examiner_pending']);
+
+            //de-activate examiner if sites where no longer checked
+            $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
+            foreach ($ex_inactive as $cid) {
+                $DB->update(
+                    'examiners_psc_rel',
+                    array("active" => 'N'),
+                    array(
+                     'examinerID' => $examinerID,
+                     'centerID'   => $cid,
+                    )
+                );
+            }
         }
+        unset($values['examiner_radiologist']);
+        unset($values['examiner_pending']);
+
         //END EXAMINER UPDATE
+
         // make the set
         foreach ($values as $key => $value) {
             if (!empty($value)) {
@@ -1027,12 +1024,12 @@ class Edit_User extends \NDB_Form
                 }
             }
             if (!$matched
-                && ($values['examiner_radiologist'] !== ''
-                || $values['examiner_pending'] !== '')
+                && (($values['examiner_radiologist'] !== ''
+                || $values['examiner_pending'] !== ''))
             ) {
-                $errors['examiner_sites'] = "Please select at least one examiner 
-                site or reset the 'Examiner status' fields below (i.e. 
-                'Radiologist' and 'Pending Approval') to nothing.";
+                $errors['examiner_sites'] = "Please select at least one examiner
+                site or clear the 'Examiner status' fields below (i.e.
+                'Radiologist' and 'Pending Approval').";
             }
         }
         return $errors;

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -288,7 +288,6 @@ class Edit_User extends \NDB_Form
                 )
             );
 
-
             // START EXAMINER UPDATE
             // If examiner not in table add him,
             // otherwise update the radiologist field and get the current sites

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1031,7 +1031,8 @@ class Edit_User extends \NDB_Form
                 || $values['examiner_pending'] !== '')
             ) {
                 $errors['examiner_sites'] = "Please select at least one examiner 
-                site.";
+                site or reset the 'Examiner status' fields blow (i.e. 
+                'Radiologist' and 'Pending Approval') to nothing.";
             }
         }
         return $errors;

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1031,7 +1031,7 @@ class Edit_User extends \NDB_Form
                 || $values['examiner_pending'] !== '')
             ) {
                 $errors['examiner_sites'] = "Please select at least one examiner 
-                site or reset the 'Examiner status' fields blow (i.e. 
+                site or reset the 'Examiner status' fields below (i.e. 
                 'Radiologist' and 'Pending Approval') to nothing.";
             }
         }


### PR DESCRIPTION
This pull request improves the error message when removing the examiner role without clearing the fields "Radiologist" and "Pending Approval" of the "Examiner Status" row. Removal of all examiner roles works but needs to have those fields cleared out as well.

See also: https://redmine.cbrain.mcgill.ca/issues/14716
