### PR TITLE
[install] can't load the installdb.php page  - fix typo

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -133,7 +133,7 @@ class Installer
         if (function_exists('json_encode') == false) {
             $this->_lastErr = "JSON functions do not appear to be accessible "
                 . "in your PHP installation. If you're running on Debian or "
-                , "Ubuntu, please install the php-json package.";
+                . "Ubuntu, please install the php-json package.";
             return false;
         }
 


### PR DESCRIPTION
This pull request fixes a typo, "," to " ."