### PR TITLE
[Examiner] (20.0 Bugfix) Grant permission when user has examiner_multisite or examiner_view

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -62,7 +62,7 @@ class EditExaminer extends \NDB_Form
                 $centerIDs[] = $row['centerID'];
             }
 
-            // Access is only granted if user sites are the same as examiner sites
+            // Access is only granted if user sites are a superset of examiner sites
             // considering that certification changes affect all sites
             $permitted = $user->hasPermission('examiner_view')
                 || $user->hasPermission('examiner_multisite');

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -2,7 +2,7 @@
 /**
  * Examiner module: Form used to update examiner certification status
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Behavioural
  * @package  Loris
@@ -15,7 +15,7 @@ namespace LORIS\examiner;
 /**
  * Examiner module: Form used to update examiner certification status
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Behavioural
  * @package  Loris

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -66,7 +66,7 @@ class EditExaminer extends \NDB_Form
             // considering that certification changes affect all sites
             $permitted   = $user->hasPermission('examiner_view')
                 || $user->hasPermission('examiner_multisite');
-            $sameCenters // lol phpcs
+            $sameCenters 
                 = empty(array_diff($centerIDs, $user->getData('CenterIDs')));
             return $permitted && $sameCenters;
         }

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -48,13 +48,8 @@ class EditExaminer extends \NDB_Form
         $userCenter   = $user->getCenterIDs();
 
         $certification = $config->getSetting('Certification');
-        if (isset($certification['EnableCertification'])) {
-            $useCertification = $certification['EnableCertification'];
-        } else {
-            $useCertification = false;
-        }
 
-        if ($useCertification) {
+        if ($certification['EnableCertification'] ?? false) {
             $cids      = $DB->pselect(
                 "SELECT epr.centerID 
                  FROM examiners e 

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -64,10 +64,10 @@ class EditExaminer extends \NDB_Form
 
             // Access is only granted if user sites are a superset of examiner sites
             // considering that certification changes affect all sites
-            $permitted = $user->hasPermission('examiner_view')
+            $permitted   = $user->hasPermission('examiner_view')
                 || $user->hasPermission('examiner_multisite');
-            $sameCenters = 
-                empty(array_diff($centerIDs, $user->getData('CenterIDs')));
+            $sameCenters // lol phpcs
+                = empty(array_diff($centerIDs, $user->getData('CenterIDs')));
             return $permitted && $sameCenters;
         }
         return false;

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -67,11 +67,13 @@ class EditExaminer extends \NDB_Form
                 $centerIDs[] = $row['centerID'];
             }
 
-            // Access is only granted if user sites are a superset of examiner sites
+            // Access is only granted if user sites are the same as examiner sites
             // considering that certification changes affect all sites
-            return $user->hasPermission('examiner_view')
-                || $user->hasPermission('examiner_multisite')
-                || empty(array_diff($centerIDs, $user->getData('CenterIDs')));
+            $permitted = $user->hasPermission('examiner_view')
+                || $user->hasPermission('examiner_multisite');
+            $sameCenters = 
+                empty(array_diff($centerIDs, $user->getData('CenterIDs')));
+            return $permitted && $sameCenters;
         }
         return false;
     }

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -66,7 +66,7 @@ class EditExaminer extends \NDB_Form
             // considering that certification changes affect all sites
             $permitted   = $user->hasPermission('examiner_view')
                 || $user->hasPermission('examiner_multisite');
-            $sameCenters 
+            $sameCenters
                 = empty(array_diff($centerIDs, $user->getData('CenterIDs')));
             return $permitted && $sameCenters;
         }

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -70,8 +70,8 @@ class EditExaminer extends \NDB_Form
             // Access is only granted if user sites are a superset of examiner sites
             // considering that certification changes affect all sites
             return $user->hasPermission('examiner_view')
-                && (($user->hasPermission('examiner_multisite')
-                || empty(array_diff($centerIDs, $user->getData('CenterIDs')))));
+                || $user->hasPermission('examiner_multisite')
+                || empty(array_diff($centerIDs, $user->getData('CenterIDs')));
         }
         return false;
     }

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -36,7 +36,7 @@ class Examiner extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         $user = \User::singleton();
-        return $user->hasPermission('examiner_view') 
+        return $user->hasPermission('examiner_view')
             || $user->hasPermission('examiner_multisite');
     }
 

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -36,7 +36,8 @@ class Examiner extends \NDB_Menu_Filter_Form
     function _hasAccess()
     {
         $user = \User::singleton();
-        return $user->hasPermission('examiner_view');
+        return $user->hasPermission('examiner_view') 
+            || $user->hasPermission('examiner_multisite');
     }
 
     /**


### PR DESCRIPTION
This pull request addresses Redmine #14719:

>>> 

    The Examiner module README says:

    The Examiner module uses the following permissions. Any one of them
    is sufficient to have access to the module.

    examiner_view
    ...
    examiner_multisite

    However when a user has just one of either view or multisite, they cannot access the module.

User's can now access the Examiner module with either of these permissions and so it is in harmony with the Readme.

### To test

* On 20.0-release, try giving yourself only the `examiner_view` permission without multisite. You should not be able to view the module.

* On this branch, you should be able to view the module with only the `examiner_view` permission
