### PR TITLE
[Help Editor] Remove unused 'indent' variable

### DIFF
--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -25,7 +25,6 @@ namespace LORIS\help_editor;
 
 class Edit_Help_Content extends \NDB_Form
 {
-    var $indent = "&nbsp;&nbsp;&nbsp;&nbsp;";
      /**
      * Determine if user has permission to access this page
      *
@@ -36,7 +35,7 @@ class Edit_Help_Content extends \NDB_Form
         // create user object
         $user = \User::singleton();
 
-            // check user permissions
+        // check user permissions
         return $user->hasPermission('context_help');
     }
      /**


### PR DESCRIPTION
This pull request removes the unused `$indent` variable from `help_editor`. Also fixed some spacing,