### PR TITLE
[Statistics] Freeze "Breakdown" table headers when scrolling down

### DIFF
--- a/modules/statistics/js/table_statistics.js
+++ b/modules/statistics/js/table_statistics.js
@@ -16,13 +16,6 @@ $('#showVL').click(
         }
     }
 );
-//freezecolumn not sufficient for complex tables
-//$(document).ready(
-//    function(){
-//        $("#bigtable").DynamicTable({ "freezeColumn" : "tpcol" });
-//    }
-//);
-
 
 function updateDemographicInstrument() {
     var DemographicSite       = document.getElementById("DemographicSite");

--- a/modules/statistics/js/table_statistics.js
+++ b/modules/statistics/js/table_statistics.js
@@ -16,12 +16,12 @@ $('#showVL').click(
         }
     }
 );
-
-$(document).ready(
-    function(){
-        $("#bigtable").DynamicTable({ "freezeColumn" : "tpcol" });
-    }
-);
+//freezecolumn not sufficient for complex tables
+//$(document).ready(
+//    function(){
+//        $("#bigtable").DynamicTable({ "freezeColumn" : "tpcol" });
+//    }
+//);
 
 
 function updateDemographicInstrument() {

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -22,7 +22,6 @@
     <br><br>
     <button onClick="updateMRITab()" class="btn btn-primary btn-small">Submit Query</button>
     <br><br>
-    <div class="table-responsive">
         <table id="scandata" class="table table-primary table-bordered dynamictable">
             <thead>
             <tr class="info">
@@ -86,7 +85,6 @@
             {/foreach}
             </tbody>
         </table>
-    </div>
     {if $mri_table_exists}
         {$MRI_Done_Table}
     {else}

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -46,201 +46,201 @@
 <br>
 <table id="bigtable" class="data table table-primary table-bordered dynamictable">
     <thead>
-    <tr>
-        <th rowspan="1" id="tpcol">Subproject</th>
-        {assign var='colspan' value=count($Subcategories)}
-        {foreach key=proj item=name from=$Subprojects}
-            <th colspan="{$colspan}">{$name|capitalize}</th>
-        {/foreach}
-        <th colspan="{$colspan}">Total Across Subprojects</th>
-    </tr>
-    <tr>
-        <th>Categories</th>
-        {foreach key=proj item=name from=$Subprojects}
-            {* Go through each category once, and add the total
-               for each cohort *}
+        <tr>
+            <th rowspan="1" id="tpcol">Subproject</th>
+            {assign var='colspan' value=count($Subcategories)}
+            {foreach key=proj item=name from=$Subprojects}
+                <th colspan="{$colspan}">{$name|capitalize}</th>
+            {/foreach}
+            <th colspan="{$colspan}">Total Across Subprojects</th>
+        </tr>
+        <tr>
+            <th>Categories</th>
+            {foreach key=proj item=name from=$Subprojects}
+                {* Go through each category once, and add the total
+                   for each cohort *}
+                {foreach key=subcategory item=category from=$Subcategories}
+                    <th>{$category}</th>
+                {/foreach}
+            {/foreach}
+
+            {* And then each category once for the totals *}
             {foreach key=subcategory item=category from=$Subcategories}
                 <th>{$category}</th>
             {/foreach}
-        {/foreach}
-
-        {* And then each category once for the totals *}
-        {foreach key=subcategory item=category from=$Subcategories}
-            <th>{$category}</th>
-        {/foreach}
-    </tr>
+        </tr>
     </thead>
     <tbody>
-    <tr>
-        {foreach item=center from=$Centers}
-        {* Calculation for the colspan is:
-                 (number of subprojects + 1 for total)
-                 x
-                 (number of subcategories + 1 for percent)
-                 +1 for timepoint list
-        *}
-        {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
-        <th>{$center.LongName}</th>
-        <th colspan="{$colspan}" width="50%"><br></th>
-    </tr>
-    {foreach item=visit from=$Visits key=title}
-        <tr id="visitrow">
-            {assign var="rowtotal" value="0"}
-            <td>{$title}</td>
-            {foreach key="proj" item="value" from=$Subprojects}
-                {assign var="subtotal" value="0" }
+        <tr>
+            {foreach item=center from=$Centers}
+            {* Calculation for the colspan is:
+                     (number of subprojects + 1 for total)
+                     x
+                     (number of subcategories + 1 for percent)
+                     +1 for timepoint list
+            *}
+            {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
+            <th>{$center.LongName}</th>
+            <th colspan="{$colspan}" width="50%"><br></th>
+        </tr>
+        {foreach item=visit from=$Visits key=title}
+            <tr id="visitrow">
+                {assign var="rowtotal" value="0"}
+                <td>{$title}</td>
+                {foreach key="proj" item="value" from=$Subprojects}
+                    {assign var="subtotal" value="0" }
+                    {foreach key=sub item=subcat from=$Subcategories}
+                        {if $subcat@index eq 0}
+                            {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]}
+                            {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total}}
+                            {if $subtotal > 0 and $Numerator > 0}
+                                {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
+                            {else}
+                                {assign var="percent" value='0'}
+                            {/if}
+                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+                        {else}
+                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"}</td>
+                        {/if}
+                    {/foreach}
+                {/foreach}
+                {* Totals for row *}
                 {foreach key=sub item=subcat from=$Subcategories}
                     {if $subcat@index eq 0}
-                        {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]}
-                        {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total}}
-                        {if $subtotal > 0 and $Numerator > 0}
-                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
+                        {assign var="Numerator" value=$data[$center.ID][$visit][$Subcategories.0]}
+                        {assign var="rowtotal" value=$data[$center.ID][$visit].total}
+                        {if $rowtotal > 0 and $Numerator > 0}
+                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$rowtotal format="%.0f"}}
                         {else}
                             {assign var="percent" value='0'}
                         {/if}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
                     {else}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"}</td>
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"}</td>
                     {/if}
                 {/foreach}
-            {/foreach}
-            {* Totals for row *}
-            {foreach key=sub item=subcat from=$Subcategories}
-                {if $subcat@index eq 0}
-                    {assign var="Numerator" value=$data[$center.ID][$visit][$Subcategories.0]}
-                    {assign var="rowtotal" value=$data[$center.ID][$visit].total}
-                    {if $rowtotal > 0 and $Numerator > 0}
-                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$rowtotal format="%.0f"}}
-                    {else}
-                        {assign var="percent" value='0'}
-                    {/if}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
-                {else}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"}</td>
-                {/if}
-            {/foreach}
-        </tr>
-    {/foreach}
-    <tr>
-        <td class="subtotal">Site Total Across All Visits</td>
-        {assign var="totalsitetotal" value="0"}
-        {foreach key=proj item=value from=$Subprojects}
-            {assign var="sitetotal" value="0"}
-            {foreach key=sub item=subcat from=$Subcategories}
-                {if $subcat@index eq 0}
-                    {assign var="Numerator" value=$data[$proj][$center.ID][$Subcategories.0]}
-                    {assign var="sitetotal" value=$data[$proj][$center.ID].total}
-                    {if $sitetotal > 0 and $Numerator > 0}
-                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$sitetotal format="%.0f"}}
-                    {else}
-                        {assign var="percent" value='0'}
-                    {/if}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
-                {else}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"}</td>
-                {/if}
-            {/foreach}
+            </tr>
         {/foreach}
-        {foreach key=sub item=subcat from=$Subcategories}
-            {if $subcat@index eq 0}
-                {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]}
-                {assign var="totalsitetotal" value=$data[$center.ID].total}
-                {if $totalsitetotal > 0 and $Numerator > 0}
-                    {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totalsitetotal format="%.0f"}}
-                {else}
-                    {assign var="percent" value='0'}
-                {/if}
-                <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
-            {else}
-                <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"}</td>
-            {/if}
-        {/foreach}
-    </tr>
-    {/foreach}
-
-
-
-    {* Totals at the bottom *}
-    <tr>
-        {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
-        <th>Total</th>
-        <th colspan="{$colspan}" width="50%"></th>
-    </tr>
-    {foreach from=$Visits item=visit key=title}
-        <tr id="visitrow">
-            <td>{$title}</td>
-            {foreach from=$Subprojects key=proj item=value}
-                {assign var="subtotal" value="0" }
+        <tr>
+            <td class="subtotal">Site Total Across All Visits</td>
+            {assign var="totalsitetotal" value="0"}
+            {foreach key=proj item=value from=$Subprojects}
+                {assign var="sitetotal" value="0"}
                 {foreach key=sub item=subcat from=$Subcategories}
                     {if $subcat@index eq 0}
-                        {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]}
-                        {assign var="subtotal" value={$data[$proj][$visit].total}}
-                        {if $subtotal > 0 and $Numerator > 0}
-                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
+                        {assign var="Numerator" value=$data[$proj][$center.ID][$Subcategories.0]}
+                        {assign var="sitetotal" value=$data[$proj][$center.ID].total}
+                        {if $sitetotal > 0 and $Numerator > 0}
+                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$sitetotal format="%.0f"}}
                         {else}
                             {assign var="percent" value='0'}
                         {/if}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
                     {else}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"}</td>
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"}</td>
                     {/if}
                 {/foreach}
             {/foreach}
-            {assign var="finaltotal" value="0" }
             {foreach key=sub item=subcat from=$Subcategories}
                 {if $subcat@index eq 0}
-                    {assign var="Numerator" value=$data[$visit][$Subcategories.0]}
-                    {assign var="finaltotal" value=$data[$visit].total}
-                    {if $finaltotal > 0 and $Numerator > 0}
-                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$finaltotal format="%.0f"}}
+                    {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]}
+                    {assign var="totalsitetotal" value=$data[$center.ID].total}
+                    {if $totalsitetotal > 0 and $Numerator > 0}
+                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totalsitetotal format="%.0f"}}
                     {else}
                         {assign var="percent" value='0'}
                     {/if}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"} ({$percent}%)</td>
+                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
                 {else}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"}</td>
+                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"}</td>
                 {/if}
             {/foreach}
         </tr>
-    {/foreach}
+        {/foreach}
 
-    <tr>
-        <td class="total">Grand Total</td>
-        {foreach key=proj item=name from=$Subprojects}
-            {* Calculate the total instead of just looking it up, because of the potential
-               for invalid visit labels throwing off the lookup, or some visits intentionally
-               being excluded from stats *}
-            {assign var="total" value="0"}
+
+
+        {* Totals at the bottom *}
+        <tr>
+            {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
+            <th>Total</th>
+            <th colspan="{$colspan}" width="50%"></th>
+        </tr>
+        {foreach from=$Visits item=visit key=title}
+            <tr id="visitrow">
+                <td>{$title}</td>
+                {foreach from=$Subprojects key=proj item=value}
+                    {assign var="subtotal" value="0" }
+                    {foreach key=sub item=subcat from=$Subcategories}
+                        {if $subcat@index eq 0}
+                            {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]}
+                            {assign var="subtotal" value={$data[$proj][$visit].total}}
+                            {if $subtotal > 0 and $Numerator > 0}
+                                {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
+                            {else}
+                                {assign var="percent" value='0'}
+                            {/if}
+                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+                        {else}
+                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"}</td>
+                        {/if}
+                    {/foreach}
+                {/foreach}
+                {assign var="finaltotal" value="0" }
+                {foreach key=sub item=subcat from=$Subcategories}
+                    {if $subcat@index eq 0}
+                        {assign var="Numerator" value=$data[$visit][$Subcategories.0]}
+                        {assign var="finaltotal" value=$data[$visit].total}
+                        {if $finaltotal > 0 and $Numerator > 0}
+                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$finaltotal format="%.0f"}}
+                        {else}
+                            {assign var="percent" value='0'}
+                        {/if}
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"} ({$percent}%)</td>
+                    {else}
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"}</td>
+                    {/if}
+                {/foreach}
+            </tr>
+        {/foreach}
+
+        <tr>
+            <td class="total">Grand Total</td>
+            {foreach key=proj item=name from=$Subprojects}
+                {* Calculate the total instead of just looking it up, because of the potential
+                   for invalid visit labels throwing off the lookup, or some visits intentionally
+                   being excluded from stats *}
+                {assign var="total" value="0"}
+                {foreach key=sub item=subcat from=$Subcategories}
+                    {if $subcat@index eq 0}
+                        {assign var="Numerator" value=$data[$proj][$Subcategories.0]}
+                        {assign var="total" value=$data[$proj].total}
+                        {if $total > 0 and $Numerator > 0}
+                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$total format="%.0f"}}
+                        {else}
+                            {assign var="percent" value='0'}
+                        {/if}
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"} ({$percent}%)</td>
+                    {else}
+                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"}</td>
+                    {/if}
+                {/foreach}
+            {/foreach}
+            {* Totals for grand total *}
             {foreach key=sub item=subcat from=$Subcategories}
                 {if $subcat@index eq 0}
-                    {assign var="Numerator" value=$data[$proj][$Subcategories.0]}
-                    {assign var="total" value=$data[$proj].total}
-                    {if $total > 0 and $Numerator > 0}
-                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$total format="%.0f"}}
+                    {assign var="Numerator" value=$data[$Subcategories.0]}
+                    {assign var="totaltotal" value=$data.total}
+                    {if $totaltotal > 0 and $Numerator > 0}
+                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totaltotal format="%.0f"}}
                     {else}
                         {assign var="percent" value='0'}
                     {/if}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"} ({$percent}%)</td>
+                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"} ({$percent}%)</td>
                 {else}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"}</td>
+                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"}</td>
                 {/if}
             {/foreach}
-        {/foreach}
-        {* Totals for grand total *}
-        {foreach key=sub item=subcat from=$Subcategories}
-            {if $subcat@index eq 0}
-                {assign var="Numerator" value=$data[$Subcategories.0]}
-                {assign var="totaltotal" value=$data.total}
-                {if $totaltotal > 0 and $Numerator > 0}
-                    {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totaltotal format="%.0f"}}
-                {else}
-                    {assign var="percent" value='0'}
-                {/if}
-                <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"} ({$percent}%)</td>
-            {else}
-                <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"}</td>
-            {/if}
-        {/foreach}
-    </tr>
+        </tr>
     </tbody>
 </table>

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -44,7 +44,8 @@
 </div>
 
 <br>
-<table id="bigtable" class="data table table-primary table-bordered">
+<table id="bigtable" class="data table table-primary table-bordered dynamictable">
+    <thead>
     <tr>
         <th rowspan="1" id="tpcol">Subproject</th>
         {assign var='colspan' value=count($Subcategories)}
@@ -68,6 +69,8 @@
             <th>{$category}</th>
         {/foreach}
     </tr>
+    </thead>
+    <tbody>
     <tr>
         {foreach item=center from=$Centers}
         {* Calculation for the colspan is:
@@ -239,4 +242,5 @@
             {/if}
         {/foreach}
     </tr>
+    </tbody>
 </table>


### PR DESCRIPTION
### Changes:

1. `table_statistics.js`: Remove freezing of first **column** in "#bigtable" because a) _without_ frozen header, it doesn't do anything. b) _with_ frozen header, it doesn't work.
2. `table_statistics.tpl`: Add "dynamictable" class name to "#bigtable" to  enable frozen header scrolling. in order for this to work, the table needs a `<thead>` element, which I added. this also happens to fix a javascript error.
3. `form_stats_MRI.tpl`: Remove "table-responsive" div to stop existing frozen header from skipping as you scroll.

### This resolves:

- [x] Redmine #14745 https://redmine.cbrain.mcgill.ca/issues/14745.

### This PR improves LORIS by:

1. Let's "Breakdown" tables in Demographic and Imaging Statistics have frozen headers when scrolling down.
2. Fixes skipping of frozen headers for MRI table (the first table in Imaging Statistics).
3. Removes error `Uncaught TypeError: Cannot read property 'top' of undefined
    at jquery.dynamictable.js:266`.

### To test:

_*disclaimer: headers on freezing gets misaligned with the rest of the table when viewing on OS. seems fine on Ubuntu. this is a separate bug that needs fixing and is related to PR https://github.com/aces/Loris/pull/3605_

1. Look at Demographics Statistics and Imaging Statistics on **20.0-release** branch:
- Headers on second table of each tab don't freeze
- There is an error in your console
- Notice the above mentioned separate bug for first tables in Behavioural and Imaging Statistics if testing on a Mac 
2. Checkout my branch **2018-06-20_StatsFloatingHeader** and see that headers for the same tables now freeze. There are no errors in your console.
3. Check for any skipping for all frozen headers.