### PR TITLE
[20.0][Create Timepoint] Actually check visit label in validation function

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -281,7 +281,9 @@ class TimePoint
                     $visitLabelSetting['labelSet']['item']
                 );
                 foreach ($items as $item) {
-                    if ($item['#'] == $visitLabel) $isValid = true;
+                    if ($item['#'] == $visitLabel) {
+                        $isValid = true;
+                    }
                 }
             }
         }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -272,6 +272,28 @@ class TimePoint
             );
         }
 
+        $config =& \NDB_Config::singleton();
+        $visitLabelSettings = $config->getSetting('visitLabel');
+        $isValid            = false;
+        foreach (\Utility::toArray($visitLabelSettings) as $visitLabelSetting) {
+            if ($visitLabelSetting['@']['subprojectID'] == $subprojectID) {
+                $items = \Utility::toArray(
+                    $visitLabelSetting['labelSet']['item']
+                );
+                foreach ($items as $item) {
+                    error_log(print_r($item, true));
+                    error_log(print_r($visitLabel, true));
+                    if ($item['#'] == $visitLabel) { $isValid = true;
+                    }
+                }
+            }
+        }
+        if (!$isValid) {
+            throw new \LorisException(
+                'This visit label is not valid for this subproject.'
+            );
+        }
+
         $candidate =& \Candidate::singleton($candid);
 
         $timePointArray = $candidate->getListOfVisitLabels();

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -281,10 +281,7 @@ class TimePoint
                     $visitLabelSetting['labelSet']['item']
                 );
                 foreach ($items as $item) {
-                    error_log(print_r($item, true));
-                    error_log(print_r($visitLabel, true));
-                    if ($item['#'] == $visitLabel) { $isValid = true;
-                    }
+                    if ($item['#'] == $visitLabel) $isValid = true;
                 }
             }
         }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -283,6 +283,7 @@ class TimePoint
                 foreach ($items as $item) {
                     if ($item['#'] == $visitLabel) {
                         $isValid = true;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
This PR addresses [Redmine #14782](https://redmine.cbrain.mcgill.ca/issues/14782).
Specifically, if a user selects a subproject and visit label, and then switches the subproject to one where its no longer valid and clicks 'Create Timepoint' quickly enough, they can create a timepoint with an invalid visit label (this issue would also be solved by reactifying this module, but we can't do that before 20.0 is released).

I added a check to `isValidVisitLabel()` in `TimePoint.class.inc` to see if the submitted Visit Label is assigned to the submitted subproject by checking the config setting (XML).

To test this PR follow the steps outlined in the redmine ticket.