### PR TITLE
[Core] .htaccess - Redirect base URL requests to be routed through index.php

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -13,7 +13,9 @@ RewriteRule ^([a-zA-Z0-9_-]+)reliability([a-zA-Z0-9_-]*) main.php?test_name=$1re
 
 # Everything else gets rewritten to be handled by index.php, unless it's a file that's served
 # directly from apache
-RewriteCond "%{REQUEST_FILENAME}" "!-f"
+RewriteCond "%{REQUEST_FILENAME}" "!-f" [OR]
+# Redirect homepage URLs to also use index.php
+RewriteCond "%{REQUEST_FILENAME}" "(\/main\.php)$"
 RewriteRule ^(.*)$ index.php?lorispath=$1 [QSA,L]
 </IfModule>
 


### PR DESCRIPTION
### The Problem
currently, most existing LORIS instances have their apache configurations set so that
 `main.php` is the entry point for all HTTP requests

as of 20.0, .htaccess was modified so that all everything gets routed through `index.php` so long as the `REQUEST_FILENAME` is not a findable file by apache

the issue is that `REQUEST_FILENAME` gets set to be the equal to the full path of `main.php` whenever there is no specifier placed after the LORIS base URL (read [here](https://serverfault.com/questions/443430/rewrite-the-base-url-with-mod-rewrite)) which causes the RewriteCond to fail and default the request through `main.php`

this is problematic for login & dashboard since they are home pages, and ultimately results in their setup functions never getting called / tpl_data never getting assigned:
login:
![image](https://user-images.githubusercontent.com/6571449/41991526-adfe1ed6-7a13-11e8-9bd0-9da92b6183fe.png)

dashboard:
![image](https://user-images.githubusercontent.com/6571449/41991510-9f4b6470-7a13-11e8-8fa2-57ea7c741e57.png)

### What it does
this modification to .htaccess allows users to upgrade without having to modify their apache configurations

### How it does
Reroute any request ending in `/main.php` to `index.php`

### How to test
0. Before checking out this branch, follow steps 1-4
1. Find your apache configuration files (should be in a location like `/etc/apache2/sites-available/loris.conf` or just run `apache2ctl -V | grep SERVER_CONFIG_FILE`)
2. Open your configuration file and search for `DirectoryIndex`, set all occurrences of this entry to `DirectoryIndex main.php index.html` if it is not already set, you will probably need `sudo` for this
3. Run `sudo service apache2 restart`
4. Certify that login & dashboard are now ugly as shown above
5. Checkout this branch and hard refresh on both login and dashboard and verify that fix works
