### PR TITLE
[Timepoint list] Fix timepoint list duplicate entry in the table

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -111,7 +111,6 @@ class Instrument_List extends \NDB_Menu_Filter
             // FIXME: Make VisitLabel not sessionID
             $this->timePoint = \TimePoint::singleton($gets['sessionID']);
         }
-        $this->setup();
         return parent::process($request, $handler);
     }
 

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -93,7 +93,6 @@ class Timepoint_List extends \NDB_Menu
             $gets         = $request->getQueryParams();
             $this->candID = $gets['candID'];
         }
-        $this->setup();
         return parent::process($request, $handler);
     }
 


### PR DESCRIPTION
This fix a bug where the datatable displayed a duplicated row.
The second call to setup was overwriting the last row of tpl_data[Subprojects][...]

The same fix was applied to instrument_list but no symptoms where visible.

see: RM#14813