### PR TITLE
[Instrument Manager] Fix missing validation step when SQL tables do not match Linst files

### DIFF
--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -338,15 +338,15 @@ class Instrument_Manager extends \NDB_Menu_Filter
      * checks whether all of the fields defined in the .linst file are present
      * in the SQL schema and vice-versa.  If the table is found to be consistent
      * it is considered valid and a String confirming this will be returned and
-     * eventually output in the front-end table.  Otherwise an error will be 
+     * eventually output in the front-end table.  Otherwise an error will be
      * returned and displayed to the user.
      *
+     * @param string $instname the value of instname
+     *
+     * @return bool
+     *
      * @see Example linst file: docs/instruments/test_all_fields.linst
-    *
-    * @param string $instname the value of instname
-    *
-    * @return bool
-    */
+     */
     function checkTable($instname)
     {
         $factory  = \NDB_Factory::singleton();
@@ -428,19 +428,19 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 break;
             }
         }
-        // For every value in the `Field` column in the SQL schema, ensure a 
-        // matching value exists in the linst file.  This is done to check 
+        // For every value in the `Field` column in the SQL schema, ensure a
+        // matching value exists in the linst file.  This is done to check
         // whether a question has been deleted from the linst file but is still
         // present in the back-end.
         $sqlSelect = "SELECT COLUMN_NAME".
             " FROM information_schema.columns".
             " WHERE TABLE_SCHEMA=:dbname".
             " AND TABLE_NAME=:tablename";
-        $result      = $db->pselect(
+        $result    = $db->pselect(
             $sqlSelect,
             array(
-                'dbname'     => $factory->settings()->dbName(),
-                'tablename'  => $instname,
+             'dbname'    => $factory->settings()->dbName(),
+             'tablename' => $instname,
             )
         );
         // Get all fields present in DB but absent in linst file.
@@ -452,7 +452,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         }
         $diff = array_diff($columns_in_database, $linst_field_names);
         // Filter the difference by checking whether it contains values that are
-        // added/populated automatically by LORIS, and therefore need not and 
+        // added/populated automatically by LORIS, and therefore need not and
         // should not be present in .linst forms.
         $diff = array_filter($diff, array($this, "filterDefaultColumns"));
         if (!empty($diff)) {
@@ -535,7 +535,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     /** This function checks whether the column_name parameter exists in a list
      * of default column names.  These defaults represent values that are 
      * automatically created and populated by LORIS upon creating or uploading
-     * a linst form.  
+     * a linst form.
      * This function is used by array_filter above to do table validation.
      *
      * @param string $column_name A column name in an instrument table.
@@ -545,12 +545,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
     function filterDefaultColumns($column_name): Bool
     {
         $defaults = array(
-            'CommentID',
-            'UserID',
-            'Testdate',
-            'Data_entry_completion_status'
-        );
-        // Negate in_array because we DON'T want default values, and so we 
+                     'CommentID',
+                     'UserID',
+                     'Testdate',
+                     'Data_entry_completion_status',
+                    );
+        // Negate in_array because we DON'T want default values, and so we
         // should return false on a match.
         return !in_array($column_name, $defaults);
     }

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -542,7 +542,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      *
      * @return bool True if $column_name matches a default. False otherwise.
      */
-    function filterDefaultColumns($column_name): String 
+    function filterDefaultColumns($column_name): Bool
     {
         $defaults = array(
             'CommentID',

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -334,7 +334,14 @@ class Instrument_Manager extends \NDB_Menu_Filter
         return null;
     }
     /**
-    * CheckTable function
+     * This function validates an uploaded LORIS instrument ("linst") file.  It
+     * checks whether all of the fields defined in the .linst file are present
+     * in the SQL schema and vice-versa.  If the table is found to be consistent
+     * it is considered valid and a String confirming this will be returned and
+     * eventually output in the front-end table.  Otherwise an error will be 
+     * returned and displayed to the user.
+     *
+     * @see Example linst file: docs/instruments/test_all_fields.linst
     *
     * @param string $instname the value of instname
     *
@@ -347,10 +354,15 @@ class Instrument_Manager extends \NDB_Menu_Filter
         $fp       = fopen($filename, "r");
         $db       = \Database::singleton();
 
+        $linst_field_names = array();
+
+        // Loop over every line of the .linst file and validate that its
+        // structure matches the SQL table schema in the back-end.
         while (($line = fgets($fp, 4096)) !== false) {
             $pieces = explode("{@}", $line);
             $type   = $pieces[0];
             $name   = $pieces[1];
+            $linst_field_names[] = $name;
             if ($name == 'Examiner') {
                 continue;
             }
@@ -415,6 +427,36 @@ class Instrument_Manager extends \NDB_Menu_Filter
             default:
                 break;
             }
+        }
+        // For every value in the `Field` column in the SQL schema, ensure a 
+        // matching value exists in the linst file.  This is done to check 
+        // whether a question has been deleted from the linst file but is still
+        // present in the back-end.
+        $sqlSelect = "SELECT COLUMN_NAME".
+            " FROM information_schema.columns".
+            " WHERE TABLE_SCHEMA=:dbname".
+            " AND TABLE_NAME=:tablename";
+        $result      = $db->pselect(
+            $sqlSelect,
+            array(
+                'dbname'     => $factory->settings()->dbName(),
+                'tablename'  => $instname,
+            )
+        );
+        // Get all fields present in DB but absent in linst file.
+        $columns_in_database = array();
+        foreach ($result as $key=>$value_array) {
+            // Extract the information we want from the nested arrays returned
+            // by the call to pselect.
+            $columns_in_database[] = $value_array['COLUMN_NAME'];
+        }
+        $diff = array_diff($columns_in_database, $linst_field_names);
+        // Filter the difference by checking whether it contains values that are
+        // added/populated automatically by LORIS, and therefore need not and 
+        // should not be present in .linst forms.
+        $diff = array_filter($diff, array($this, "filterDefaultColumns"));
+        if (!empty($diff)) {
+            return "Invalid: DB contains values not in linst";
         }
 
         return "Appears Valid";
@@ -489,5 +531,27 @@ class Instrument_Manager extends \NDB_Menu_Filter
             $db_config['host'],
             false
         );
+
+    /** This function checks whether the column_name parameter exists in a list
+     * of default column names.  These defaults represent values that are 
+     * automatically created and populated by LORIS upon creating or uploading
+     * a linst form.  
+     * This function is used by array_filter above to do table validation.
+     *
+     * @param string $column_name A column name in an instrument table.
+     *
+     * @return bool True if $column_name matches a default. False otherwise.
+     */
+    function filterDefaultColumns($column_name): String 
+    {
+        $defaults = array(
+            'CommentID',
+            'UserID',
+            'Testdate',
+            'Data_entry_completion_status'
+        );
+        // Negate in_array because we DON'T want default values, and so we 
+        // should return false on a match.
+        return !in_array($column_name, $defaults);
     }
 }

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -341,13 +341,13 @@ class Instrument_Manager extends \NDB_Menu_Filter
      * eventually output in the front-end table.  Otherwise an error will be
      * returned and displayed to the user.
      *
-     * @param string $instname the value of instname
+     * @param string $instname The instrument's name.
      *
-     * @return bool
+     * @return string A messsage representing the status of the table entry.
      *
      * @see Example linst file: docs/instruments/test_all_fields.linst
      */
-    function checkTable($instname)
+    function checkTable($instname): String
     {
         $factory  = \NDB_Factory::singleton();
         $filename = $this->path . "project/instruments/$instname.linst";


### PR DESCRIPTION
## Background

The instrument manager does some validation in instruments installed in LORIS. It checks whether the back-end SQL schema matches that specified in a Loris Instrument (`linst`) file. Linst files are created via the instrument manager and installed by front-end users in the instrument manager or manually in the back-end.

## Issue

From Redmine:

>Here is the test case :
"Take a second sample .linst instrument file, load it via the Instrument Manager.
Then alter the linst file so that it doesn't exactly match the instrument table already loaded in mysql. (type, number of fields, fieldname spelling) Check that function CheckTable performs the appropriate checks (catches these discrepancies) on the instrument builder files and validates them properly - eg "Table Valid" column is valid when instrument fields match up and "Pages Valid" is valid when subpages are valid. [Manual Testing]"

> For a table to be valid, all the rows in the linst fuile must match a row in the table definition. So removing a row in the file wont make the validation fail.

Basically, if the back-end schema contains fields that do not exist in the linst file, flag this as an error in the validation step. Although outlined in the test plan, the Instrument Manager did not do this.

## This improves LORIS by

Implementing the validation that should have been there already based on the test plan.

I also added comments to the code.

## To Test

* Checkout this branch 

* Upload a linst file via the instrument manager (you can use docs/instruments/test_all_fields.linst)

* Verify that it uploads properly and its status is "Appears Valid" under the `Table Valid` column.

* Under `project/instruments/$YOUR_INST.linst`, delete one of the fields. 

* Return to instrument manager and check that the `Table Valid` status displays "Invalid: DB contains values not in linst"

## Redmine

* Bug #14814 filed by @xlecours 