### PR TITLE
API Dicom download for phatoms: add missing candID

### DIFF
--- a/htdocs/api/v0.0.3-dev/candidates/visits/Dicoms.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/Dicoms.php
@@ -92,8 +92,9 @@ class Dicoms extends \Loris\API\Candidates\Candidate\Visit
             ]
         );
         if ($cand_info['Entity_type'] == 'Scanner') {
-            $ID            = ":PVL";
-            $params['PVL'] = $this->VisitLabel;
+            $ID                 = ":PVL";
+            $params['PCandID']  = $this->CandID;
+            $params['PVL']      = $this->VisitLabel;
         } else {
             $ID = "LOWER(CONCAT(:PPSCID, '_', :PCandID, '_', :PVL, '%'))";
             $params['PPSCID']  = $cand_info['PSCID'];


### PR DESCRIPTION
The API DICOM download was missing the CandID for the **phantom cases**, so add it in order for the query to get all its needed parameters, and therefore for the download to work.

To test, please try to download a DICOM from a phantom scan before and after this PR change.

Thanks to Mark Pratti for reporting this!

