### PR TITLE
[CSS] Cleanup css warnings & errors in [docs] and [htdocs]

### DIFF
--- a/docs/config/main.css
+++ b/docs/config/main.css
@@ -24,7 +24,7 @@
 
 body {
    	margin: 5px 10px 10px 5px;
-	background-color: ligthgrey; 
+	background-color: lightgray;
 	font-family: verdana, sans-serif;
 	font-size: 70%;
 }
@@ -123,9 +123,8 @@ table.listColorCoded {
 
 table.list th, table.tbl th, table.std th, table.listColorCoded th {
     text-align: center;
-    border-width: 1px;
-    border-style: outset;
-	font-weight: normal;
+    border: 1px outset;
+    font-weight: normal;
     }
 table.list th, table.tbl th, table.std th {
     border-color: #D1D1CD;
@@ -208,7 +207,7 @@ td.tabox {
 /* fancy table for mri_browser and dicom archive visit list */
 table.fancytable {
   margin: 1em 1em 1em 0;
-  background: #FF;
+  background: #FFFFFF;
   border-collapse: collapse;
   text-align: center;
 }
@@ -240,7 +239,7 @@ table.fancytable caption {
 /* fancy table with ALIGN LEFT  */
 table.fancytableleft {
   margin: 1em 1em 1em 0;
-  background: #FF;
+  background: #FFFFFF;
   border-collapse: collapse;
   text-align: left;
 }
@@ -269,30 +268,26 @@ table.fancytableleft caption {
    font-family:Verdana,sans-serif;
    color:white;
    background-color:#08245b;
-   border-style:ridge;
-   border-color:#FFFFFF;
-   border-width:1px;
+   border: 1px ridge #FFFFFF;
 }
 
 
 
 input.text {
-  font-family:TrebuchetMS;
-  font-size:9pt;
-  font-weight:bold;
-  background-color:336699;
-  border-color:336699;
-  border-style:inset;
-  border-width:2px;
-  color:FFFFFF;
+  font-family: TrebuchetMS, serif;
+  font-size: 9pt;
+  font-weight: bold;
+  background-color: #336699;
+  border: 2px inset #336699;
+  color: #FFFFFF;
 }
 
 td.red {
 background: #D29E93;
-color:black;
-padding:3px;
-text-align:left;
-vertical-align:top;
+color: black;
+padding: 3px;
+text-align: left;
+vertical-align: top;
 border-bottom: 1px solid #CCCCCC;
 }
 

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -104,7 +104,7 @@ table th{
     left:0;
     top:auto;
     word-wrap: break-word;
-    border-right: 0px none black;
+    border-right: 0 none black;
     border-top-width:3px; /*only relevant for first row*/
 }
 .colm-static{
@@ -118,8 +118,8 @@ table th{
 .headerColm {
   background: #1c70b6;
   padding: 8px;
-  border-bottom-width: 2px;
   border: 1px solid #ddd;
+  border-bottom-width: 2px;
   text-align: left;
   color: white;
   font-weight: bold;
@@ -150,15 +150,13 @@ html, body {
  *	CSS for intrument forms
  */
 .has-error .form-control {
-    border: 3px solid;
-    border-color: #b94a48;
+    border: 3px solid #b94a48;
 }
 .has-error, .form-error {
 color: #b94a48;
 }
 .has-warning .form-control {
-	border: 3px solid;
-	border-color: #c09853;
+    border: 3px solid #c09853;
 }
 .warning {
 	color: #c09853;
@@ -289,7 +287,7 @@ div.navbar div.container div.navbar-brand {
 /** Ellipsis styling **/
 .ellipsis > .dropdown-toggle {
   border: none;
-  padding: 0px;
+  padding: 0;
   background: inherit;
 }
 .ellipsis:hover .dropdown-menu {
@@ -390,7 +388,7 @@ a.btn.btn-primary {
 }
 
 .downloadCSV {
-    margin: 20px 0px;
+    margin: 20px 0;
 }
 .perPage {
     width: 75px;
@@ -400,13 +398,13 @@ a.btn.btn-primary {
     background-color: #DCDCDC;
 }
 #dynamictable {
-    margin-bottom: 0px;
+    margin-bottom: 0;
 }
 .rowsPerPage {
     color: black;
 }
 .pagination-table {
-  margin: 0px;
+  margin: 0;
 }
 
 .left.carousel-control {
@@ -445,4 +443,18 @@ a.btn.btn-primary {
 /* Break long strings to fit them in the popup */
 .sweet-alert p {
   word-wrap: break-word;
+}
+/* Loader customizations */
+
+.loader {
+    margin: auto;
+    border: 8px solid #FFFFFF; /* White */
+    border-top: 8px solid #3498db; /* Blue */
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }

--- a/htdocs/css/c3.css
+++ b/htdocs/css/c3.css
@@ -56,7 +56,7 @@
   fill: #aaa;
 }
 .c3-xgrid, .c3-ygrid {
-  stroke-dasharray: 3 3;
+  stroke-dasharray: 3;
 }
 .c3-xgrid-focus {
 }
@@ -136,7 +136,7 @@
   opacity: 0.75;
   fill: white;
   stroke: lightgray;
-  stroke-width: 1
+  stroke-width: 1px
 }
 
 /*-- Tooltip --*/

--- a/htdocs/css/jquery-ui-1.10.4.custom.css
+++ b/htdocs/css/jquery-ui-1.10.4.custom.css
@@ -601,7 +601,7 @@ button.ui-button::-moz-focus-inner {
 	height: 100%;
 }
 .ui-progressbar .ui-progressbar-overlay {
-	background: url("images/animated-overlay.gif");
+	background: url("loris-jquery/images/animated-overlay.gif");
 	height: 100%;
 	filter: alpha(opacity=25);
 	opacity: 0.25;
@@ -684,10 +684,8 @@ button.ui-button::-moz-focus-inner {
 	background: none;
 	color: inherit;
 	padding: 0;
-	margin: .2em 0;
 	vertical-align: middle;
-	margin-left: .4em;
-	margin-right: 22px;
+	margin: .2em 22px .2em .4em;
 }
 .ui-spinner-button {
 	width: 16px;
@@ -798,7 +796,7 @@ body .ui-tooltip {
 }
 .ui-widget-content {
 	border: 1px solid #aaaaaa;
-	background: #c9c9c9 url("images/ui-bg_inset-soft_50_c9c9c9_1x100.png") 50% bottom repeat-x;
+	background: #c9c9c9 url("overcast/images/ui-bg_inset-soft_50_c9c9c9_1x100.png") 50% bottom repeat-x;
 	color: #333333;
 }
 .ui-widget-content a {
@@ -806,7 +804,7 @@ body .ui-tooltip {
 }
 .ui-widget-header {
 	border: 1px solid #bbbbbb;
-	background: #dddddd url("images/ui-bg_glass_35_dddddd_1x400.png") 50% 50% repeat-x;
+	background: #dddddd url("overcast/images/ui-bg_glass_35_dddddd_1x400.png") 50% 50% repeat-x;
 	color: #444444;
 	font-weight: bold;
 }
@@ -820,7 +818,7 @@ body .ui-tooltip {
 .ui-widget-content .ui-state-default,
 .ui-widget-header .ui-state-default {
 	border: 1px solid #cccccc;
-	background: #eeeeee url("images/ui-bg_glass_60_eeeeee_1x400.png") 50% 50% repeat-x;
+	background: #eeeeee url("overcast/images/ui-bg_glass_60_eeeeee_1x400.png") 50% 50% repeat-x;
 	font-weight: bold;
 	color: #3383bb;
 }
@@ -837,7 +835,7 @@ body .ui-tooltip {
 .ui-widget-content .ui-state-focus,
 .ui-widget-header .ui-state-focus {
 	border: 1px solid #bbbbbb;
-	background: #f8f8f8 url("images/ui-bg_glass_100_f8f8f8_1x400.png") 50% 50% repeat-x;
+	background: #f8f8f8 url("overcast/images/ui-bg_glass_100_f8f8f8_1x400.png") 50% 50% repeat-x;
 	font-weight: bold;
 	color: #599fcf;
 }
@@ -856,7 +854,7 @@ body .ui-tooltip {
 .ui-widget-content .ui-state-active,
 .ui-widget-header .ui-state-active {
 	border: 1px solid #999999;
-	background: #999999 url("images/ui-bg_inset-hard_75_999999_1x100.png") 50% 50% repeat-x;
+	background: #999999 url("overcast/images/ui-bg_inset-hard_75_999999_1x100.png") 50% 50% repeat-x;
 	font-weight: bold;
 	color: #ffffff;
 }
@@ -873,7 +871,7 @@ body .ui-tooltip {
 .ui-widget-content .ui-state-highlight,
 .ui-widget-header .ui-state-highlight {
 	border: 1px solid #ffffff;
-	background: #eeeeee url("images/ui-bg_flat_55_eeeeee_40x100.png") 50% 50% repeat-x;
+	background: #eeeeee url("overcast/images/ui-bg_flat_55_eeeeee_40x100.png") 50% 50% repeat-x;
 	color: #444444;
 }
 .ui-state-highlight a,
@@ -885,7 +883,7 @@ body .ui-tooltip {
 .ui-widget-content .ui-state-error,
 .ui-widget-header .ui-state-error {
 	border: 1px solid #c0402a;
-	background: #c0402a url("images/ui-bg_flat_55_c0402a_40x100.png") 50% 50% repeat-x;
+	background: #c0402a url("overcast/images/ui-bg_flat_55_c0402a_40x100.png") 50% 50% repeat-x;
 	color: #ffffff;
 }
 .ui-state-error a,
@@ -931,27 +929,27 @@ body .ui-tooltip {
 }
 .ui-icon,
 .ui-widget-content .ui-icon {
-	background-image: url("images/ui-icons_999999_256x240.png");
+	background-image: url("overcast/images/ui-icons_999999_256x240.png");
 }
 .ui-widget-header .ui-icon {
-	background-image: url("images/ui-icons_999999_256x240.png");
+	background-image: url("overcast/images/ui-icons_999999_256x240.png");
 }
 .ui-state-default .ui-icon {
-	background-image: url("images/ui-icons_70b2e1_256x240.png");
+	background-image: url("overcast/images/ui-icons_70b2e1_256x240.png");
 }
 .ui-state-hover .ui-icon,
 .ui-state-focus .ui-icon {
-	background-image: url("images/ui-icons_3383bb_256x240.png");
+	background-image: url("overcast/images/ui-icons_3383bb_256x240.png");
 }
 .ui-state-active .ui-icon {
-	background-image: url("images/ui-icons_454545_256x240.png");
+	background-image: url("overcast/images/ui-icons_454545_256x240.png");
 }
 .ui-state-highlight .ui-icon {
-	background-image: url("images/ui-icons_3383bb_256x240.png");
+	background-image: url("overcast/images/ui-icons_3383bb_256x240.png");
 }
 .ui-state-error .ui-icon,
 .ui-state-error-text .ui-icon {
-	background-image: url("images/ui-icons_fbc856_256x240.png");
+	background-image: url("overcast/images/ui-icons_fbc856_256x240.png");
 }
 
 /* positioning */
@@ -1164,15 +1162,15 @@ body .ui-tooltip {
 
 /* Overlays */
 .ui-widget-overlay {
-	background: #eeeeee url("images/ui-bg_flat_0_eeeeee_40x100.png") 50% 50% repeat-x;
+	background: #eeeeee url("overcast/images/ui-bg_flat_0_eeeeee_40x100.png") 50% 50% repeat-x;
 	opacity: .8;
 	filter: Alpha(Opacity=80);
 }
 .ui-widget-shadow {
 	margin: -4px 0 0 -4px;
 	padding: 4px;
-	background: #aaaaaa url("images/ui-bg_flat_0_aaaaaa_40x100.png") 50% 50% repeat-x;
+	background: #aaaaaa url("overcast/images/ui-bg_flat_0_aaaaaa_40x100.png") 50% 50% repeat-x;
 	opacity: .6;
 	filter: Alpha(Opacity=60);
-	border-radius: 0px;
+	border-radius: 0;
 }

--- a/htdocs/css/jqueryslidemenu.css
+++ b/htdocs/css/jqueryslidemenu.css
@@ -1,5 +1,5 @@
 .Account{
-float:right;
+    float:right;
 }
 .site{
     padding-top:8px;
@@ -9,9 +9,8 @@ float:right;
 }
 
 .jqueryslidemenu{
-font:Verdana-sans-serif;
-
-z-index:10;
+    font-family: Verdana-sans-serif, serif;
+    z-index:10;
 }
 
 .jqueryslidemenu ul{
@@ -30,7 +29,7 @@ display: inline;
 float: left;
 background: #064785;
 z-index:10;
-font-size:10;
+font-size:10px;
 }
 
 /*Top level menu link items style*/

--- a/htdocs/css/panel.css
+++ b/htdocs/css/panel.css
@@ -46,19 +46,19 @@ Author: Evan McIlroy <evanmcilroy@gmail.com>*/
 .navbar{
     background-color: #064785;
     border-width: 0 0 1px;
-    border-radius: 0px;
+    border-radius: 0;
 }
 
 .navbar-toggle{
-	margin-top: 0px;
-	margin-bottom: 0px;
-	margin-right: 0px;
-	border: 0px;
-	border-radius: 0px;
+	margin-top: 0;
+	margin-bottom: 0;
+	margin-right: 0;
+	border: 0;
+	border-radius: 0;
 }
 
 .panel-heading a:after {
-    font-family:'Glyphicons Halflings';
+    font-family: 'Glyphicons Halflings', serif;
     content:"\e114";
     float: right;
     color: #FFF;
@@ -74,14 +74,11 @@ Author: Evan McIlroy <evanmcilroy@gmail.com>*/
 }
 
 .navbar{
-    margin-bottom:0px;
+    margin-bottom:0;
 }
 
 .panel-group{
-    margin-top:10px;
-    margin-bottom:10px;
-    margin-left:5px;
-    margin-right:5px;
+    margin: 10px 5px;
 }
 
 .navmenu{
@@ -95,14 +92,13 @@ Author: Evan McIlroy <evanmcilroy@gmail.com>*/
 .panel-wrapper{
   margin-right: -500px;
   margin-top: 50px;
-  right: 0px;
+  right: 0;
   width: 500px;
   background: #F5F5F5;
   position: fixed;
   height: 100%;
-  border-left-style: solid;
-  border-left-width: 2px;
   border-color: #064785;
+  border-left: 2px solid;
   overflow-y: scroll;
   z-index: 1000;
   transition: all 0.4s ease 0s;
@@ -123,7 +119,7 @@ Author: Evan McIlroy <evanmcilroy@gmail.com>*/
 }
 
 .inactive_panel_page{
-    padding-right: 0px;
+    padding-right: 0;
 }
 
 .bvl_table_icons {
@@ -134,8 +130,7 @@ Author: Evan McIlroy <evanmcilroy@gmail.com>*/
 
 .feedback_entries_body{
     border-style: solid;
-    border-style-top: none;
-
+    border-top-style: none;
 }
 
 .feedback_entries{

--- a/htdocs/css/public_layout.css
+++ b/htdocs/css/public_layout.css
@@ -2,28 +2,28 @@
   font-family: 'PT Sans';
   font-weight: 400;
   font-style: normal;
-  src: url('/fonts/PT-Sans-regular/PT-Sans-regular.eot');
-  src: url('/fonts/PT-Sans-regular/PT-Sans-regular.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/PT-Sans-regular/PT-Sans-regular.eot');
+  src: url('../fonts/PT-Sans-regular/PT-Sans-regular.eot?#iefix') format('embedded-opentype'),
   local('PT Sans'),
   local('PT-Sans-regular'),
-  url('/fonts/PT-Sans-regular/PT-Sans-regular.woff2') format('woff2'),
-  url('/fonts/PT-Sans-regular/PT-Sans-regular.woff') format('woff'),
-  url('/fonts/PT-Sans-regular/PT-Sans-regular.ttf') format('truetype'),
-  url('/fonts/PT-Sans-regular/PT-Sans-regular.svg#PTSans') format('svg');
+  url('../fonts/PT-Sans-regular/PT-Sans-regular.woff2') format('woff2'),
+  url('../fonts/PT-Sans-regular/PT-Sans-regular.woff') format('woff'),
+  url('../fonts/PT-Sans-regular/PT-Sans-regular.ttf') format('truetype'),
+  url('../fonts/PT-Sans-regular/PT-Sans-regular.svg#PTSans') format('svg');
 }
 
 @font-face {
   font-family: 'PT Sans';
   font-weight: 700;
   font-style: normal;
-  src: url('/fonts/PT-Sans-700/PT-Sans-700.eot');
-  src: url('/fonts/PT-Sans-700/PT-Sans-700.eot?#iefix') format('embedded-opentype'),
+  src: url('../fonts/PT-Sans-700/PT-Sans-700.eot');
+  src: url('../fonts/PT-Sans-700/PT-Sans-700.eot?#iefix') format('embedded-opentype'),
   local('PT Sans Bold'),
   local('PT-Sans-700'),
-  url('/fonts/PT-Sans-700/PT-Sans-700.woff2') format('woff2'),
-  url('/fonts/PT-Sans-700/PT-Sans-700.woff') format('woff'),
-  url('/fonts/PT-Sans-700/PT-Sans-700.ttf') format('truetype'),
-  url('/fonts/PT-Sans-700/PT-Sans-700.svg#PTSans') format('svg');
+  url('../fonts/PT-Sans-700/PT-Sans-700.woff2') format('woff2'),
+  url('../fonts/PT-Sans-700/PT-Sans-700.woff') format('woff'),
+  url('../fonts/PT-Sans-700/PT-Sans-700.ttf') format('truetype'),
+  url('../fonts/PT-Sans-700/PT-Sans-700.svg#PTSans') format('svg');
 }
 
 /* Stylesheet for login, reset password and request account pages */

--- a/htdocs/css/simple-sidebar.css
+++ b/htdocs/css/simple-sidebar.css
@@ -85,8 +85,7 @@
 }
 
 .content-header h1 {
-  margin: 0;
-  margin-left: 20px;
+  margin: 0 0 0 20px;
   line-height: 65px;
   display: inline-block;
 }


### PR DESCRIPTION
This pull request cleanups css warnings & errors in the "docs" and "htdocs" directories.

Example of the fixes:

- When writing css it's redundant to write "px" when the measurement is zero. 
- Font families should include a generic font when using a custom font as a fallback. 
- Multiple css properties such as margin for bottom, top, left, and right can be optimized into one margin property.

Please test where the css is used in multiple browsers.