### PR TITLE
[Instruments] 404 

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -6,8 +6,8 @@
 RewriteRule ^([a-zA-Z_-]+)/ajax/([a-zA-Z0-9_.-]+)$ AjaxHelper.php?Module=$1&script=$2 [QSA,L]
 
 # Instruments and reliability still use main.php, for now
-RewriteRule ^instruments/([a-zA-Z0-9_-]+)/$ main.php?test_name=$1 [QSA,L]
-RewriteRule ^instruments/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)/$ main.php?test_name=$1&subtest=$2 [QSA,L]
+RewriteRule ^instruments/([a-zA-Z0-9_-]+)/$ main.php?test_name=$1 [QSA,END]
+RewriteRule ^instruments/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)/$ main.php?test_name=$1&subtest=$2 [QSA,END]
 
 RewriteRule ^([a-zA-Z0-9_-]+)reliability([a-zA-Z0-9_-]*) main.php?test_name=$1reliability$2 [QSA,L]
 

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -3,13 +3,13 @@
 
 # FIXME: The /module/$name/ajax directory needs to be replaced with real NDB_Pages that
 # remove the page decoration middlewares, but for now we need to keep this helper script.
-RewriteRule ^([a-zA-Z_-]+)/ajax/([a-zA-Z0-9_.-]+)$ AjaxHelper.php?Module=$1&script=$2 [QSA,L]
+RewriteRule ^([a-zA-Z_-]+)/ajax/([a-zA-Z0-9_.-]+)$ AjaxHelper.php?Module=$1&script=$2 [QSA,END]
 
 # Instruments and reliability still use main.php, for now
 RewriteRule ^instruments/([a-zA-Z0-9_-]+)/$ main.php?test_name=$1 [QSA,END]
 RewriteRule ^instruments/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)/$ main.php?test_name=$1&subtest=$2 [QSA,END]
 
-RewriteRule ^([a-zA-Z0-9_-]+)reliability([a-zA-Z0-9_-]*) main.php?test_name=$1reliability$2 [QSA,L]
+RewriteRule ^([a-zA-Z0-9_-]+)reliability([a-zA-Z0-9_-]*) main.php?test_name=$1reliability$2 [QSA,END]
 
 # Everything else gets rewritten to be handled by index.php, unless it's a file that's served
 # directly from apache


### PR DESCRIPTION
This fix a bug where instruments could not be loaded (404 Not Found)
Introduce in #3768 , every main.php request were redirect to index.php that do not support instruments loading. 

In htdocs/.htacces the rule for instruments was redirecting to main.php with a [L|last] flag assuming there would be no more rewriting. reading http://httpd.apache.org/docs/current/rewrite/flags.html#flag_l there is a mention that while no more rule will apply for that url, the redirected url (main.php in this case) will still be run through the rewriting process.

Using the [END] flag will exit/stop the rewriting completely\

see: RM#14848 