### PR TITLE
[README] Remove unused `master` branch from README build statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Deploy and log in with username <i>admin</i> and the password that's set up duri
 
 | Branch | Status |
 | ------ | ------ |
-| master | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
 | major  | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=major)](https://travis-ci.org/aces/Loris)
 | minor  | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=minor)](https://travis-ci.org/aces/Loris)
 | bugfix | [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=bugfix)](https://travis-ci.org/aces/Loris)


### PR DESCRIPTION
This pull request removes the perma-failing `master` branch from the README.
