### PR TITLE
[Instrument list] Populate the timepoint tpl_data for modules

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -64,6 +64,12 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
         }
         $tpl_data['candID']      = $candID ?? '';
 
+        $timepoint = $request->getAttribute('TimePoint');
+        if (!empty($timepoint)) {
+            $tpl_data['timePoint'] = $timepoint->getData();
+            $tpl_data['sessionID'] = $timepoint->getSessionID();
+        }
+
         // Stuff that probably shouldn't be here, but exists because it was in
         // main.php
 

--- a/src/Router/ModuleRouter.php
+++ b/src/Router/ModuleRouter.php
@@ -82,6 +82,21 @@ class ModuleRouter extends PrefixRouter
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
+        $gets = $request->getQueryParams();
+        if (!empty($gets['candID'])) {
+            $request = $request->withAttribute(
+                'Candidate',
+                (\NDB_Factory::singleton())->candidate($gets['candID'])
+            );
+        }
+
+        if (!empty($gets['sessionID'])) {
+            $request = $request->withAttribute(
+                'TimePoint',
+                \TimePoint::singleton($gets['sessionID'])
+            );
+        }
+
         if ($this->module->isPublicModule() !== true) {
             // Add the authentication middleware for the current user (which was
             // added to the requset by the base router), and handle the request.


### PR DESCRIPTION
This  fix the missing timepoint data in the candidate profile table of the instrument_list module

The ModuleRouteur is now in charge of adding candidate and timepoint objects to the request.

see: RM#