### PR TITLE
[Instrument list] Populate the timepoint tpl_data for modules

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -111,6 +111,17 @@ class Instrument_List extends \NDB_Menu_Filter
             // FIXME: Make VisitLabel not sessionID
             $this->timePoint = \TimePoint::singleton($gets['sessionID']);
         }
+
+        $request = $request->withAttribute(
+            'Candidate',
+            $this->candidate
+        );
+
+        $request = $request->withAttribute(
+            'TimePoint',
+            $this->timePoint
+        );
+
         return parent::process($request, $handler);
     }
 

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -64,6 +64,11 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
         }
         $tpl_data['candID']      = $candID ?? '';
 
+        $timepoint = $request->getAttribute("TimePoint");
+        if (!empty($timepoint)) {
+            $tpl_data['timePoint'] = $timepoint->getData();
+        }
+
         // Stuff that probably shouldn't be here, but exists because it was in
         // main.php
 
@@ -198,7 +203,6 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
 
         $smarty = new \Smarty_neurodb;
         $smarty->assign($tpl_data);
-
         return $undecorated->withBody(new \LORIS\Http\StringStream($smarty->fetch("main.tpl")));
     }
 }


### PR DESCRIPTION
This fix the missing timepoint data in the candidate profile table of the instrument_list module

The ModuleRouteur is now in charge of adding candidate and timepoint objects to the request.

see: RM#14805
