### PR TITLE
[Release Patch] fix SQL glitches

### DIFF
--- a/SQL/Archive/20.0/2018-03-02_session_add_cascade.sql
+++ b/SQL/Archive/20.0/2018-03-02_session_add_cascade.sql
@@ -1,3 +1,3 @@
 ALTER TABLE parameter_session DROP FOREIGN KEY `FK_parameter_session_1`;
-ALTER TABLE parameter_session ADD CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+ALTER TABLE parameter_session ADD CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE;
 

--- a/SQL/Archive/20.0/2018-07-04_examiner_menu.sql
+++ b/SQL/Archive/20.0/2018-07-04_examiner_menu.sql
@@ -1,2 +1,2 @@
-INSERT INTO LorisMenuPermissions (MenuID, PermID)
+INSERT IGNORE INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_view' AND m.Label='Examiner';

--- a/SQL/Release_patches/19.1_To_20.0_upgrade.sql
+++ b/SQL/Release_patches/19.1_To_20.0_upgrade.sql
@@ -163,5 +163,6 @@ UPDATE ConfigSettings
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ComputeDeepQC', 'Determines whether a call is made from LORIS-MRI to the DeepQC app for automatic QC prediction', 1, 0, 'boolean', ID, 'Compute automatic QC', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 -- default imaging_pipeline settings
-INSERT IGNORE INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";INSERT INTO LorisMenuPermissions (MenuID, PermID)
+INSERT IGNORE INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
+INSERT IGNORE INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_view' AND m.Label='Examiner';

--- a/SQL/Release_patches/19.1_To_20.0_upgrade.sql
+++ b/SQL/Release_patches/19.1_To_20.0_upgrade.sql
@@ -163,6 +163,6 @@ UPDATE ConfigSettings
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ComputeDeepQC', 'Determines whether a call is made from LORIS-MRI to the DeepQC app for automatic QC prediction', 1, 0, 'boolean', ID, 'Compute automatic QC', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 -- default imaging_pipeline settings
-INSERT IGNORE INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
 INSERT IGNORE INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_view' AND m.Label='Examiner';

--- a/SQL/Release_patches/19.1_To_20.0_upgrade.sql
+++ b/SQL/Release_patches/19.1_To_20.0_upgrade.sql
@@ -61,7 +61,9 @@ UPDATE
 SET
     `Visible` = FALSE
 WHERE
-    `Name` = 'mantis_url';-- Insert into ConfigSettings scan_type_exclude
+    `Name` = 'mantis_url';
+
+-- Insert into ConfigSettings scan_type_exclude
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple,
 DataType, Parent, Label, OrderNumber) SELECT 'excluded_series_description', 'Series description to be excluded from insertion into the database (typically localizers and scouts)', 1, 1, 'text', ID, 'Series description to exclude from imaging insertion', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
@@ -117,7 +119,7 @@ CREATE TABLE `candidate_consent_history` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE parameter_session DROP FOREIGN KEY `FK_parameter_session_1`;
-ALTER TABLE parameter_session ADD CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+ALTER TABLE parameter_session ADD CONSTRAINT `FK_parameter_session_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- Removing the config setting if_site of the imaging pipeline section as discussed during a LORIS imaging meeting
 DELETE FROM Config WHERE ConfigID=(
@@ -161,5 +163,5 @@ UPDATE ConfigSettings
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ComputeDeepQC', 'Determines whether a call is made from LORIS-MRI to the DeepQC app for automatic QC prediction', 1, 0, 'boolean', ID, 'Compute automatic QC', 18 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 -- default imaging_pipeline settings
-INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";INSERT INTO LorisMenuPermissions (MenuID, PermID)
+INSERT IGNORE INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_view' AND m.Label='Examiner';


### PR DESCRIPTION
This fixes minor issues in the release patch:

- missing semi-colon after command
- added `IGNORE` to an isert (value seems to exist already for CCNA)
