### PR TITLE
[imaging browser] Insert scan type in mri_violations_log when caveat set to true

### DIFF
--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -454,7 +454,9 @@ class ViewSession extends \NDB_Form
                     $insertSet['CandID']      = $candid;
                     $insertSet['Visit_label'] = $visit_label;
                     $insertSet['CheckID']     = null;
-                    $insertSet['Scan_type']   = $file->getParameter('AcquisitionProtocolID');
+                    $insertSet['Scan_type']   = $file->getParameter(
+                        'AcquisitionProtocolID'
+                    );
                     $insertSet['Severity']    = 'warning';
                     $insertSet['Header']      = 'Manual Caveat Set by '
                         . $user->getUsername();

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -454,6 +454,7 @@ class ViewSession extends \NDB_Form
                     $insertSet['CandID']      = $candid;
                     $insertSet['Visit_label'] = $visit_label;
                     $insertSet['CheckID']     = null;
+                    $insertSet['Scan_type']   = $file->getParameter('AcquisitionProtocolID');
                     $insertSet['Severity']    = 'warning';
                     $insertSet['Header']      = 'Manual Caveat Set by '
                         . $user->getUsername();

--- a/tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php
+++ b/tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php
@@ -45,7 +45,7 @@ function selectManualCaveat()
               WHERE HEADER LIKE \"Manual Caveat Set by%\" 
               AND Scan_type IS NULL";
 
-    $result = $db->pselect($query, []);
+    $result = $db->pselect($query, array());
 
     return $result;
 }
@@ -66,19 +66,20 @@ function updateScanType($seriesUID)
     $db = Database::singleton();
 
     // select scan type for the SeriesUID given as an argument
-    $scan_type_list = $db->pselect(
+    $scan_type_list = $db->pselectCol(
         "SELECT AcquisitionProtocolID FROM files WHERE SeriesUID=:seriesUID",
         array('seriesUID' => $seriesUID)
     );
 
     // update mri_violations_log if only one scan type found
     if (count($scan_type_list) == 1) {
-        $scan_type = $scan_type_list[0]['AcquisitionProtocolID'];
+        $scan_type = $scan_type_list[0];
         print "Updating scan type to $scan_type for SeriesUID $seriesUID \n";
-        $query = "UPDATE mri_violations_log
-                  SET Scan_type=$scan_type
-                  WHERE SeriesUID=\"$seriesUID\"";
-        $db->run($query);
+        $db->update(
+            'mri_violations_log',
+            array('Scan_type'=>$scan_type),
+            array('SeriesUID'=>$seriesUID)
+        );
     } elseif (count($scan_type_list) == 0) {
         print "Could not find any scan type for SeriesUID $seriesUID \n";
     } else {

--- a/tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php
+++ b/tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This script is written for a one time use only to update the scan_type
+ * previously not inserted into the mri_violations_log table when manually
+ * setting the caveat MRI QC flag to true in the imaging browser.
+ *
+ * This script updates the scan_type field mri_violations_log based on the
+ * SeriesUID for each caveat flag reported manually when QCing images.
+ *
+ * affected table:
+ * - mri_violations_log
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
+ * @license  Loris license
+ * @link     https://github.com/aces/Loris
+ */
+require_once __DIR__ . '/../generic_includes.php';
+require_once 'Database.class.inc';
+
+// select all SeriesUID missing data from mri_violations_log
+$seriesUIDs_list = selectManualCaveat();
+// loop through all SeriesUID to update the Scan_type field in
+// mri_violations_log
+foreach ($seriesUIDs_list as $seriesUID) {
+    updateScanType($seriesUID['SeriesUID']);
+}
+
+/**
+ * Selects all SeriesUIDs for which Scan_type is set to NULL and Headers set
+ * to "Manual Caveat Set by%" in the mri_violations_log.
+ *
+ * @return array of seriesUID without Scan_type set in mri_violations_log
+ * @throws DatabaseException
+ */
+function selectManualCaveat()
+{
+    $db = Database::singleton();
+
+    $query = "SELECT DISTINCT(SeriesUID) 
+              FROM mri_violations_log 
+              WHERE HEADER LIKE \"Manual Caveat Set by%\" 
+              AND Scan_type IS NULL";
+
+    $result = $db->pselect($query, []);
+
+    return $result;
+}
+
+/**
+ * Select the scan type associated to the SeriesUID in the files table and
+ * updates the mri_violations_log table with found scan type if only one scan
+ * type was found for the SeriesUID. Otherwise, prints proper message for the
+ * user.
+ *
+ * @param string $seriesUID SeriesUID
+ *
+ * @return nothing
+ * @throws DatabaseException
+ */
+function updateScanType($seriesUID)
+{
+    $db = Database::singleton();
+
+    // select scan type for the SeriesUID given as an argument
+    $scan_type_list = $db->pselect(
+        "SELECT AcquisitionProtocolID FROM files WHERE SeriesUID=:seriesUID",
+        array('seriesUID' => $seriesUID)
+    );
+
+    // update mri_violations_log if only one scan type found
+    if (count($scan_type_list) == 1) {
+        $scan_type = $scan_type_list[0]['AcquisitionProtocolID'];
+        print "Updating scan type to $scan_type for SeriesUID $seriesUID \n";
+        $query = "UPDATE mri_violations_log
+                  SET Scan_type=$scan_type
+                  WHERE SeriesUID=\"$seriesUID\"";
+        $db->run($query);
+    } elseif (count($scan_type_list) == 0) {
+        print "Could not find any scan type for SeriesUID $seriesUID \n";
+    } else {
+        print "Found more than one scan type for SeriesUID $seriesUID\n";
+    }
+}
+
+?>


### PR DESCRIPTION
## Purpose of the PR:
This pull request fix a bug found when testing the MRI violations module that actually comes from the imaging browser module.

## Description of the bug:
When the user sets the Caveat to TRUE on the view session page of the imaging browser, the `Scan_type` was not being inserted into the `mri_violations_log` table with the rest of the entry. 

## This PR includes:
- the bug fix to the view session page of the imaging browser module
- a script to back populate `Scan_type` entries in the `mri_violations_log` table when possible (meaning when only one `Scan_type` was found in the `files` table for a given `SeriesUID`

## How to test this PR:

### make sure you can replicate the bug on 20.0-release branch

1.  go to a view session page of the imaging browser; set Caveat to TRUE for some images and save the QC
2. go to the MRI violation module, look for the entries for the proper patient name and the 'type of problem' set to 'Protocol Violation'. Click on the Protocol Violation link to go to the following page and make sure Scan type is empty for Headers corresponding to "Manual Caveat Set by $user" as shown in the screenshot below:

![screen shot 2018-07-11 at 9 46 16 am](https://user-images.githubusercontent.com/1402456/42587461-c88f400e-8508-11e8-832a-871dd7f29b52.png)

### checkout the branch of this PR

3. repeat step 1. above
4. repeat step 2. above and make sure that the Scan type has been properly set for the new entries in the violation checks

### test the script called `Update_scan_type_of_mri_violations_log_when_manual_caveat.php` in `tools/single_use`

5. before testing, make sure you have the followings in your mri_violations_log table:
- at least one entry with `Header like "Manual Caveat Set by%"`, Scan_type=NULL and a valid `SeriesUID` (meaning a `SeriesUID` that can be found in the `files` table and associated to only one `AcquisitionProtocolID`)
- at least one entry with `Header like "Manual Caveat Set by%"`, `Scan_type=NULL` and a `SeriesUID` that cannot be found in the `files` table
- at least one entry with `Header like "Manual Caveat Set by%"`, `Scan_type=NULL` and a `SeriesUID` that returns more than one `AcquisitionProtocolID` from the `files` table
- at least one entry with `Header like "Manual Caveat Set by%"` and `Scan_type` NOT NULL
6. Checks that the script properly updates the Scan type field in `mri_violations_log` and writes out proper message for the different cases mentioned in 5. 

See also: Redmine ticket: https://redmine.cbrain.mcgill.ca/issues/14890
