### PR TITLE
Missing create language table in the SQL patch

### DIFF
--- a/SQL/Release_patches/19.1_To_20.0_upgrade.sql
+++ b/SQL/Release_patches/19.1_To_20.0_upgrade.sql
@@ -166,3 +166,14 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
 INSERT IGNORE INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='examiner_view' AND m.Label='Examiner';
+
+-- Adding the language table (required for the Media module)
+CREATE TABLE `language` (
+  `language_id` integer unsigned NOT NULL AUTO_INCREMENT,
+  `language_code` varchar(255) NOT NULL,
+  `language_label` varchar(255) NOT NULL,
+  PRIMARY KEY (`language_id`),
+  UNIQUE KEY (`language_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO language (language_code, language_label) VALUES ('en-CA', 'English');


### PR DESCRIPTION
This pull request adds the missing `CREATE TABLE language` and `INSERT INTO language` from the 19.0_to_20.0 SQL patch. 

Without this, Media crashes completely as it cannot find the language table

See also: https://redmine.cbrain.mcgill.ca/issues/14897

PS: I added 'Add to Release Notes' and 'Document for Release' to remember talking about this new table when drafting the release notes