### PR TITLE
[examiner] Fix permission condition for edit examiner

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -64,11 +64,11 @@ class EditExaminer extends \NDB_Form
 
             // Access is only granted if user sites are a superset of examiner sites
             // considering that certification changes affect all sites
-            $permitted   = $user->hasPermission('examiner_view')
-                || $user->hasPermission('examiner_multisite');
-            $sameCenters
-                = empty(array_diff($centerIDs, $user->getData('CenterIDs')));
-            return $permitted && $sameCenters;
+            $permitted = $user->hasPermission('examiner_view')
+                && empty(array_diff($centerIDs, $user->getData('CenterIDs')));
+            $permittedAllSites
+                = $user->hasPermission('examiner_multisite');
+            return $permitted || $permittedAllSites;
         }
         return false;
     }

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -67,7 +67,7 @@ class EditExaminer extends \NDB_Form
             $permitted = $user->hasPermission('examiner_view')
                 && empty(array_diff($centerIDs, $user->getData('CenterIDs')));
             $permittedAllSites
-                = $user->hasPermission('examiner_multisite');
+                       = $user->hasPermission('examiner_multisite');
             return $permitted || $permittedAllSites;
         }
         return false;

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -64,10 +64,10 @@ class EditExaminer extends \NDB_Form
 
             // Access is only granted if user sites are a superset of examiner sites
             // considering that certification changes affect all sites
-            $permitted = $user->hasPermission('examiner_view')
+            $permitted         = $user->hasPermission('examiner_view')
                 && empty(array_diff($centerIDs, $user->getData('CenterIDs')));
             $permittedAllSites
-                       = $user->hasPermission('examiner_multisite');
+                = $user->hasPermission('examiner_multisite');
             return $permitted || $permittedAllSites;
         }
         return false;


### PR DESCRIPTION
addresses https://redmine.cbrain.mcgill.ca/issues/14900 and changes code from https://github.com/aces/Loris/pull/3745

Need to discuss how to replace error message "You do not have access to this page"

*note: if 'Examiner' doesn't appear in your menu when 'Add and certify examiners' only checked, run the patch from https://github.com/aces/Loris/pull/3782/*

**to test:**
1. on branch aces/20.0-release, give yourself 'Across all sites add and certify examiners' permission and notice that you can see all examiners from all sites, but don't have access to edit/certify them, even those belonging to the site you are also assigned to. this is only true if you are not affiliated with all sites.
2. on my branch, you are now able to edit/certify all examiners from all sites if have 'examiner_multisite' permission
3. if have 'examiner_view' permissions only, you should be able to see all examiners affiliated with your sites, but only able to edit ones who you share all sites with. e.g. if the examiner has Toronto and Montreal, but you only have Montreal, you will be able to see the examiner in the table, but not able to view the edit page once you click on their name
4. quickly check that nothing else changes