### PR TITLE
[User Accounts] Fix editor perms

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -202,7 +202,11 @@ class Edit_User extends \NDB_Form
         $permIDs = array();
         // store the permission IDs
         if (!empty($values['permID'])) {
-            $permIDs = array_keys($values['permID']);
+            // An editor can only grant permission that he is granted of.
+            $permIDs = array_intersect(
+                array_keys($values['permID']),
+                $editor->getPermissionIDs()
+            );
         }
         unset($values['permID']);
         // store whether to send an email or not
@@ -487,6 +491,7 @@ class Edit_User extends \NDB_Form
                     }
                 }
             }
+
             if (!empty($permIDs)) {
                 $user->addPermissions($permIDs);
             }


### PR DESCRIPTION
This should prevent a user to grant permissions that he do not already own.