### PR TITLE
[create_timepoint][20.0] Validation for VisitLabel accessing wrong variable therefore breaks on CCNA

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -281,7 +281,7 @@ class TimePoint
                     $visitLabelSetting['labelSet']['item']
                 );
                 foreach ($items as $item) {
-                    if ($item['#'] == $visitLabel) {
+                    if ($item['@']['value'] == $visitLabel) {
                         $isValid = true;
                         break;
                     }


### PR DESCRIPTION
This PR addresses the following Redmine issue: https://redmine.cbrain.mcgill.ca/issues/14913

When creating a timepoint in CCNA, the error message 'This visit label is not valid for this subproject.' is always displayed, even for VALID visitLabels.

After looking into this I realized that the validation function `isValidVisitLabel` in the Timepoint class accesses the wrong variable. It gets from config the front-end label of the visit item rather than the actual key used in the backend.
On Loris, it doesn't actually look like there's a problem because both the label and key are the same ('V1' === 'V1'), however in CCNA they are not the same ('Initial Assessment - Screening'  != 'Initial_Assessment_Screening'). 

Please refer to the redmine issue for an example of this, and feel free to come talk to me if it is still unclear.

