### PR TITLE
Correction in returned object in Candidate DICOMs

### DIFF
--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -759,42 +759,46 @@ object of the form:
         "Visit" : $VisitLabel,
     },
     "DicomTars" : 
-        [{
-        "Tarname" : "DCM_yyyy-mm-dd_ImagingUpload-hh-mm-abc123.tar",
-        "SeriesInfo" :
-            [{
-            "SeriesDescription" : "MPRAGE_ipat2",
-            "SeriesNumber" : "2",
-            "EchoTime" : "2.98",
-            "RepetitionTime" : "2300",
-            "InversionTime" : "900",
-            "SliceThickness" : "1",
-            "Modality" : "MR",
-            "SeriesUID" : "1.2.3.4.1107",
-            },
-            {
-            "SeriesDescription" : "BOLD Resting State",
-            "SeriesNumber" : "5",
-            "EchoTime" : "30",
-            "RepetitionTime" : "2100",
-            "InversionTime" : NULL,
-            "SliceThickness" : "3.5",
-            "Modality" : "MR",
-            "SeriesUID" : "3.4.5.6.1507",
-            }],
-        "Tarname" : "DCM_yyyy-mm-dd_ImagingUpload-hh-mm-def456.tar",
-        "SeriesInfo" :
-            [{
-            "SeriesDescription" : "MPRAGE_ipat2",
-            "SeriesNumber" : "2",
-            "EchoTime" : "2.98",
-            "RepetitionTime" : "2300",
-            "InversionTime" : "900",
-            "SliceThickness" : "1",
-            "Modality" : "MR",
-            "SeriesUID" : "1.7.8.9.1296",
-            }],
-    }],    
+    [
+        {
+            "Tarname" : "DCM_yyyy-mm-dd_ImagingUpload-hh-mm-abc123.tar",
+            "SeriesInfo" :
+                [{
+                    "SeriesDescription" : "MPRAGE_ipat2",
+                    "SeriesNumber" : "2",
+                    "EchoTime" : "2.98",
+                    "RepetitionTime" : "2300",
+                    "InversionTime" : "900",
+                    "SliceThickness" : "1",
+                    "Modality" : "MR",
+                    "SeriesUID" : "1.2.3.4.1107",
+                    },
+                    {
+                    "SeriesDescription" : "BOLD Resting State",
+                    "SeriesNumber" : "5",
+                    "EchoTime" : "30",
+                    "RepetitionTime" : "2100",
+                    "InversionTime" : NULL,
+                    "SliceThickness" : "3.5",
+                    "Modality" : "MR",
+                    "SeriesUID" : "3.4.5.6.1507",
+                }],
+        },
+        {
+            "Tarname" : "DCM_yyyy-mm-dd_ImagingUpload-hh-mm-def456.tar",
+            "SeriesInfo" :
+                [{
+                "SeriesDescription" : "MPRAGE_ipat2",
+                "SeriesNumber" : "2",
+                "EchoTime" : "2.98",
+                "RepetitionTime" : "2300",
+                "InversionTime" : "900",
+                "SliceThickness" : "1",
+                "Modality" : "MR",
+                "SeriesUID" : "1.7.8.9.1296",
+                }],
+        },
+    ]    
 }
 ```
 

--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -782,7 +782,7 @@ object of the form:
                     "SliceThickness" : "3.5",
                     "Modality" : "MR",
                     "SeriesUID" : "3.4.5.6.1507",
-                }],
+                }]
         },
         {
             "Tarname" : "DCM_yyyy-mm-dd_ImagingUpload-hh-mm-def456.tar",
@@ -796,8 +796,8 @@ object of the form:
                 "SliceThickness" : "1",
                 "Modality" : "MR",
                 "SeriesUID" : "1.7.8.9.1296",
-                }],
-        },
+                }]
+        }
     ]    
 }
 ```


### PR DESCRIPTION
Small correction in the json replied by the end-point GET /candidates/$CandID/$Visit/dicoms. Closing '}'s for the objects inside the array DicomTars were missing.

This pull request `fix a small typo in the API documentation`.
