### PR TITLE
[Candidate_list] Change EDC field to a date field

### DIFF
--- a/modules/candidate_list/js/candidate_list_helper.js
+++ b/modules/candidate_list/js/candidate_list_helper.js
@@ -30,4 +30,9 @@ $(function(){
             changeMonth: true,
             changeYear: true
         });
+        $('input[name=edc]').datepicker({
+            dateFormat: 'yy-mm-dd',
+            changeMonth: true,
+            changeYear: true
+        });
 });


### PR DESCRIPTION
addresses https://redmine.cbrain.mcgill.ca/issues/14926

test: 
1. on 20.0-release branch, go to candidate_list, click 'Advanced' in menu filter, and notice that EDC is a text field
2. on my branch, go to candidate_list, click 'Advanced' in menu filter, and notice that EDC is now a date picker, similar to the 'Date of Birth' field
 