### PR TITLE
[20.0][genomic_browser] Link bug

### DIFF
--- a/modules/genomic_browser/templates/menu_cnv_browser.tpl
+++ b/modules/genomic_browser/templates/menu_cnv_browser.tpl
@@ -10,7 +10,7 @@
         <li class="statsTab"><a class="statsTabLink" href="{$baseurl}/genomic_browser/snp_browser/">SNP</a></li>
         <li class="statsTab active"><a class="statsTabLink" id="onLoad"><strong>CNV</strong></a></li>
         <li class="statsTab"><a class="statsTabLink" href="{$baseurl}/genomic_browser/cpg_browser/">Methylation</a></li>
-        <li class="statsTab"><a class="statsTabLink" href="{$baseurl}/genomic_browser/genomic_file_uploade/">Files</a></li>
+        <li class="statsTab"><a class="statsTabLink" href="{$baseurl}/genomic_browser/genomic_file_uploader/">Files</a></li>
       </ul>
       <br>
     </div>


### PR DESCRIPTION
This pull request `updates the link to the genomic browser from the CNV tab`. 
There was a small typo, added `r` to the end of the link.

To test:
Before checking out the branch, go to the genomic browser, and hit the `CNV` tab. 
Then try to navigate to the `Files` tab, and it should error out, due to a redirect to an invalid link.
After checking out the branch, bug should be fixed.

See also: [Redmine Ticket 14908](https://redmine.cbrain.mcgill.ca/issues/14908)
Bug found by @christinerogers 


