### PR TITLE
[Router] check in project modules as well

### DIFF
--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -82,7 +82,9 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $components = preg_split("/\/+?/", $path);
             $modulename = $components[0];
         }
-        if (is_dir($this->moduledir . "/" . $modulename)) {
+        if (is_dir($this->moduledir . "/" . $modulename)
+            || is_dir($this->projectdir . "/modules/" . $modulename)
+        ) {
             $uri    = $request->getURI();
             $suburi = $this->stripPrefix($modulename, $uri);
             $module = \Module::factory($modulename);


### PR DESCRIPTION
This lets the code recognize project specific modules (modules not in the `loris/modules`) as loris modules as well allowing them to load instead of getting a 404