### PR TITLE
[user accounts] Fixing users being always inserted into examiner table upon save

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -311,19 +311,11 @@ class Edit_User extends \NDB_Form
                             WHERE full_name=:fullName",
                     array('fullName' => $values['Real_name'])
                 );
-//            } elseif (!empty($examinerID)
-//                && ((!empty($ex_radiologist)
-//                && !empty($ex_pending)
-//                && !empty($ex_curr_sites))
-//                || (empty($ex_radiologist)
-//                && empty($ex_pending)
-//                && empty($ex_curr_sites)))
-//            ) {
-                } elseif (!empty($examinerID)
-                  && ((!empty($ex_radiologist)
-                  && !empty($ex_pending)
-                  && !empty($ex_curr_sites))
-                  || empty($ex_curr_sites))
+            } elseif (!empty($examinerID)
+                && ((!empty($ex_radiologist)
+                && !empty($ex_pending)
+                && !empty($ex_curr_sites))
+                || empty($ex_curr_sites))
             ) {
                 // If examiner already exists in the examiner table AND
                 // radiologist, pending and current sites fields all set or

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -311,13 +311,19 @@ class Edit_User extends \NDB_Form
                             WHERE full_name=:fullName",
                     array('fullName' => $values['Real_name'])
                 );
-            } elseif (!empty($examinerID)
-                && ((!empty($ex_radiologist)
-                && !empty($ex_pending)
-                && !empty($ex_curr_sites))
-                || (empty($ex_radiologist)
-                && empty($ex_pending)
-                && empty($ex_curr_sites)))
+//            } elseif (!empty($examinerID)
+//                && ((!empty($ex_radiologist)
+//                && !empty($ex_pending)
+//                && !empty($ex_curr_sites))
+//                || (empty($ex_radiologist)
+//                && empty($ex_pending)
+//                && empty($ex_curr_sites)))
+//            ) {
+                } elseif (!empty($examinerID)
+                  && ((!empty($ex_radiologist)
+                  && !empty($ex_pending)
+                  && !empty($ex_curr_sites))
+                  || empty($ex_curr_sites))
             ) {
                 // If examiner already exists in the examiner table AND
                 // radiologist, pending and current sites fields all set or

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -254,6 +254,7 @@ class Edit_User extends \NDB_Form
         }
         unset($values['CenterIDs']);
         // END multi-site UPDATE
+
         // EXAMINER UPDATE
         if ($editor->hasPermission('examiner_multisite')) {
             // get all fields that are related to examiners
@@ -288,18 +289,14 @@ class Edit_User extends \NDB_Form
             );
 
             // START EXAMINER UPDATE
-            // If examiner not in table add him,
-            // otherwise update the radiologist field and get the current sites
             if (!empty($ex_radiologist)
                 && !empty($ex_pending)
                 && !empty($ex_curr_sites)
                 && empty($examinerID)
             ) {
+                // If examiner not in table and radiologist, pending and current
+                // sites fields set add the examiner to the examiner table
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $values         = \Utility::nullifyEmpty(
-                    $values,
-                    'examiner_radiologist'
-                );
                 $DB->insert(
                     'examiners',
                     array(
@@ -322,11 +319,10 @@ class Edit_User extends \NDB_Form
                 && empty($ex_pending)
                 && empty($ex_curr_sites)))
             ) {
+                // If examiner already exists in the examiner table AND
+                // radiologist, pending and current sites fields all set or
+                // unset update the examiner table with new values
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $values         = \Utility::nullifyEmpty(
-                    $values,
-                    'examiner_radiologist'
-                );
                 $DB->update(
                     'examiners',
                     array(
@@ -346,69 +342,67 @@ class Edit_User extends \NDB_Form
                             WHERE examinerID=:eid",
                     array("eid" => $examinerID)
                 );
+            }
+            //get sites where user is already an examiner at for compare
+            foreach ($prev_sites as $row => $center) {
+                array_push($ex_prev_sites, $center['centerID']);
+            }
 
-                //get sites where user is already an examiner at for compare
-                foreach ($prev_sites as $row => $center) {
-                    array_push($ex_prev_sites, $center['centerID']);
-                }
+            foreach ($ex_curr_sites as $k => $v) {
 
-                foreach ($ex_curr_sites as $k => $v) {
+                //Check if examiner already in db for site
+                $result = $DB->pselectRow(
+                    "SELECT epr.centerID
+                           FROM examiners_psc_rel epr 
+                           WHERE epr.examinerID=:eid AND epr.centerID=:cid",
+                    array(
+                     "eid" => $examinerID,
+                     "cid" => $v,
+                    )
+                );
 
-                    //Check if examiner already in db for site
-                    $result = $DB->pselectRow(
-                        "SELECT epr.centerID
-                               FROM examiners_psc_rel epr 
-                               WHERE epr.examinerID=:eid AND epr.centerID=:cid",
+                // examiner was not previously added, add and set to active
+                if (empty($result)) {
+                    $DB->insert(
+                        'examiners_psc_rel',
                         array(
-                         "eid" => $examinerID,
-                         "cid" => $v,
+                         'examinerID'       => $examinerID,
+                         'centerID'         => $v,
+                         'active'           => 'Y',
+                         'pending_approval' => $ex_pending,
                         )
                     );
-
-                    // examiner was not previously added, add and set to active
-                    if (empty($result)) {
-                        $DB->insert(
-                            'examiners_psc_rel',
-                            array(
-                             'examinerID'       => $examinerID,
-                             'centerID'         => $v,
-                             'active'           => 'Y',
-                             'pending_approval' => $ex_pending,
-                            )
-                        );
-                    } else {
-                        $DB->update(
-                            'examiners_psc_rel',
-                            array(
-                             'active'           => 'Y',
-                             'pending_approval' => $ex_pending,
-                            ),
-                            array(
-                             'examinerID' => $examinerID,
-                             'centerID'   => $v,
-                            )
-                        );
-                    }
-                    unset($values[$k]);
-                }
-
-                //de-activate examiner if sites where no longer checked
-                $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
-                foreach ($ex_inactive as $cid) {
+                } else {
                     $DB->update(
                         'examiners_psc_rel',
-                        array("active" => 'N'),
+                        array(
+                         'active'           => 'Y',
+                         'pending_approval' => $ex_pending,
+                        ),
                         array(
                          'examinerID' => $examinerID,
-                         'centerID'   => $cid,
+                         'centerID'   => $v,
                         )
                     );
                 }
+                unset($values[$k]);
+            }
+
+            //de-activate examiner if sites where no longer checked
+            $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
+            foreach ($ex_inactive as $cid) {
+                $DB->update(
+                    'examiners_psc_rel',
+                    array("active" => 'N'),
+                    array(
+                     'examinerID' => $examinerID,
+                     'centerID'   => $cid,
+                    )
+                );
             }
         }
         unset($values['examiner_radiologist']);
         unset($values['examiner_pending']);
-
         //END EXAMINER UPDATE
 
         // make the set

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -296,13 +296,13 @@ class Edit_User extends \NDB_Form
                 && empty($examinerID)
             ) {
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
+                $values         = \Utility::nullifyEmpty($values, 'examiner_radiologist');
                 $DB->insert(
                     'examiners',
                     array(
-                        'full_name'   => $values['Real_name'],
-                        'radiologist' => $ex_radiologist,
-                        'userID'      => $uid,
+                     'full_name'   => $values['Real_name'],
+                     'radiologist' => $ex_radiologist,
+                     'userID'      => $uid,
                     )
                 );
                 $examinerID = $examinerID = $DB->pselectOne(
@@ -312,24 +312,23 @@ class Edit_User extends \NDB_Form
                     array('fullName' => $values['Real_name'])
                 );
             } elseif (!empty($examinerID)
-                      && ((!empty($ex_radiologist)
-                          && !empty($ex_pending)
-                          && !empty($ex_curr_sites)
-                         ) || (empty($ex_radiologist)
-                          && empty($ex_pending)
-                          && empty($ex_curr_sites)
-                         ))
+                && ((!empty($ex_radiologist)
+                && !empty($ex_pending)
+                && !empty($ex_curr_sites))
+                || (empty($ex_radiologist)
+                && empty($ex_pending)
+                && empty($ex_curr_sites)))
             ) {
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
+                $values         = \Utility::nullifyEmpty($values, 'examiner_radiologist');
                 $DB->update(
                     'examiners',
                     array(
-                        'radiologist' => $ex_radiologist,
-                        'userID'      => $uid,
+                     'radiologist' => $ex_radiologist,
+                     'userID'      => $uid,
                     ),
                     array(
-                        "full_name" => $values['Real_name'],
+                     "full_name" => $values['Real_name'],
                     )
                 );
                 $examinerID = $examinerID[0]['examinerID'];
@@ -355,8 +354,8 @@ class Edit_User extends \NDB_Form
                                FROM examiners_psc_rel epr 
                                WHERE epr.examinerID=:eid AND epr.centerID=:cid",
                         array(
-                            "eid" => $examinerID,
-                            "cid" => $v,
+                         "eid" => $examinerID,
+                         "cid" => $v,
                         )
                     );
 
@@ -365,22 +364,22 @@ class Edit_User extends \NDB_Form
                         $DB->insert(
                             'examiners_psc_rel',
                             array(
-                                'examinerID'       => $examinerID,
-                                'centerID'         => $v,
-                                'active'           => 'Y',
-                                'pending_approval' => $ex_pending,
+                             'examinerID'       => $examinerID,
+                             'centerID'         => $v,
+                             'active'           => 'Y',
+                             'pending_approval' => $ex_pending,
                             )
                         );
                     } else {
                         $DB->update(
                             'examiners_psc_rel',
                             array(
-                                'active'           => 'Y',
-                                'pending_approval' => $ex_pending,
+                             'active'           => 'Y',
+                             'pending_approval' => $ex_pending,
                             ),
                             array(
-                                'examinerID' => $examinerID,
-                                'centerID'   => $v,
+                             'examinerID' => $examinerID,
+                             'centerID'   => $v,
                             )
                         );
                     }
@@ -394,8 +393,8 @@ class Edit_User extends \NDB_Form
                         'examiners_psc_rel',
                         array("active" => 'N'),
                         array(
-                            'examinerID' => $examinerID,
-                            'centerID'   => $cid,
+                         'examinerID' => $examinerID,
+                         'centerID'   => $cid,
                         )
                     );
                 }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -326,11 +326,11 @@ class Edit_User extends \NDB_Form
                 $DB->update(
                     'examiners',
                     array(
-                        'radiologist' => $ex_radiologist,
-                        'userID' => $uid,
+                     'radiologist' => $ex_radiologist,
+                     'userID' => $uid,
                     ),
                     array(
-                        "full_name" => $values['Real_name'],
+                     "full_name" => $values['Real_name'],
                     )
                 );
                 $examinerID = $examinerID[0]['examinerID'];
@@ -342,7 +342,7 @@ class Edit_User extends \NDB_Form
                             WHERE examinerID=:eid",
                     array("eid" => $examinerID)
                 );
-                
+
                 //get sites where user is already an examiner at for compare
                 foreach ($prev_sites as $row => $center) {
                     array_push($ex_prev_sites, $center['centerID']);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -295,7 +295,6 @@ class Edit_User extends \NDB_Form
                 && !empty($ex_curr_sites)
                 && empty($examinerID)
             ) {
-                print_r("radio, pending, curr site not empty + examiner empty");
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
                 $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
                 $DB->insert(
@@ -321,8 +320,6 @@ class Edit_User extends \NDB_Form
                           && empty($ex_curr_sites)
                          ))
             ) {
-                print_r('other situation');
-                print_r($ex_radiologist);
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
                 $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
                 $DB->update(

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -308,7 +308,7 @@ class Edit_User extends \NDB_Form
                      'userID'      => $uid,
                     )
                 );
-                $examinerID = $examinerID = $DB->pselectOne(
+                $examinerID = $DB->pselectOne(
                     "SELECT examinerID
                             FROM examiners
                             WHERE full_name=:fullName",

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -326,11 +326,11 @@ class Edit_User extends \NDB_Form
                 $DB->update(
                     'examiners',
                     array(
-                     'radiologist' => $ex_radiologist,
-                     'userID'      => $uid,
+                        'radiologist' => $ex_radiologist,
+                        'userID' => $uid,
                     ),
                     array(
-                     "full_name" => $values['Real_name'],
+                        "full_name" => $values['Real_name'],
                     )
                 );
                 $examinerID = $examinerID[0]['examinerID'];
@@ -342,12 +342,12 @@ class Edit_User extends \NDB_Form
                             WHERE examinerID=:eid",
                     array("eid" => $examinerID)
                 );
+                
+                //get sites where user is already an examiner at for compare
+                foreach ($prev_sites as $row => $center) {
+                    array_push($ex_prev_sites, $center['centerID']);
+                }
             }
-            //get sites where user is already an examiner at for compare
-            foreach ($prev_sites as $row => $center) {
-                array_push($ex_prev_sites, $center['centerID']);
-            }
-
             foreach ($ex_curr_sites as $k => $v) {
 
                 //Check if examiner already in db for site

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -278,9 +278,6 @@ class Edit_User extends \NDB_Form
                 }
             }
 
-            //modify examiner radiologist to be in the binary format 0-1
-            $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-
             $examinerID = $DB->pselect(
                 "SELECT e.examinerID
              FROM examiners e
@@ -293,33 +290,49 @@ class Edit_User extends \NDB_Form
             // START EXAMINER UPDATE
             // If examiner not in table add him,
             // otherwise update the radiologist field and get the current sites
-            $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
-            if (empty($examinerID)) {
-
+            if (!empty($ex_radiologist)
+                && !empty($ex_pending)
+                && !empty($ex_curr_sites)
+                && empty($examinerID)
+            ) {
+                print_r("radio, pending, curr site not empty + examiner empty");
+                $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
+                $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
                 $DB->insert(
                     'examiners',
                     array(
-                     'full_name'   => $values['Real_name'],
-                     'radiologist' => $ex_radiologist,
-                     'userID'      => $uid,
+                        'full_name'   => $values['Real_name'],
+                        'radiologist' => $ex_radiologist,
+                        'userID'      => $uid,
                     )
                 );
                 $examinerID = $examinerID = $DB->pselectOne(
                     "SELECT examinerID
-                 FROM examiners
-                 WHERE full_name=:fullName",
+                            FROM examiners
+                            WHERE full_name=:fullName",
                     array('fullName' => $values['Real_name'])
                 );
-            } else {
-
+            } elseif (!empty($examinerID)
+                      && ((!empty($ex_radiologist)
+                          && !empty($ex_pending)
+                          && !empty($ex_curr_sites)
+                         ) || (empty($ex_radiologist)
+                          && empty($ex_pending)
+                          && empty($ex_curr_sites)
+                         ))
+            ) {
+                print_r('other situation');
+                print_r($ex_radiologist);
+                $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
+                $values = \Utility::nullifyEmpty($values, 'examiner_radiologist');
                 $DB->update(
                     'examiners',
                     array(
-                     'radiologist' => $ex_radiologist,
-                     'userID'      => $uid,
+                        'radiologist' => $ex_radiologist,
+                        'userID'      => $uid,
                     ),
                     array(
-                     "full_name" => $values['Real_name'],
+                        "full_name" => $values['Real_name'],
                     )
                 );
                 $examinerID = $examinerID[0]['examinerID'];
@@ -327,8 +340,8 @@ class Edit_User extends \NDB_Form
                 //get existing sites for examiner
                 $prev_sites = $DB->pselect(
                     "SELECT centerID
-             FROM examiners_psc_rel epr
-             WHERE examinerID=:eid",
+                            FROM examiners_psc_rel epr
+                            WHERE examinerID=:eid",
                     array("eid" => $examinerID)
                 );
 
@@ -336,59 +349,59 @@ class Edit_User extends \NDB_Form
                 foreach ($prev_sites as $row => $center) {
                     array_push($ex_prev_sites, $center['centerID']);
                 }
-            }
 
-            foreach ($ex_curr_sites as $k => $v) {
+                foreach ($ex_curr_sites as $k => $v) {
 
-                //Check if examiner already in db for site
-                $result = $DB->pselectRow(
-                    "SELECT epr.centerID
-                     FROM examiners_psc_rel epr 
-                     WHERE epr.examinerID=:eid AND epr.centerID=:cid",
-                    array(
-                     "eid" => $examinerID,
-                     "cid" => $v,
-                    )
-                );
-
-                // examiner was not previously added, add and set to active
-                if (empty($result)) {
-                    $DB->insert(
-                        'examiners_psc_rel',
+                    //Check if examiner already in db for site
+                    $result = $DB->pselectRow(
+                        "SELECT epr.centerID
+                               FROM examiners_psc_rel epr 
+                               WHERE epr.examinerID=:eid AND epr.centerID=:cid",
                         array(
-                         'examinerID'       => $examinerID,
-                         'centerID'         => $v,
-                         'active'           => 'Y',
-                         'pending_approval' => $ex_pending,
+                            "eid" => $examinerID,
+                            "cid" => $v,
                         )
                     );
-                } else {
+
+                    // examiner was not previously added, add and set to active
+                    if (empty($result)) {
+                        $DB->insert(
+                            'examiners_psc_rel',
+                            array(
+                                'examinerID'       => $examinerID,
+                                'centerID'         => $v,
+                                'active'           => 'Y',
+                                'pending_approval' => $ex_pending,
+                            )
+                        );
+                    } else {
+                        $DB->update(
+                            'examiners_psc_rel',
+                            array(
+                                'active'           => 'Y',
+                                'pending_approval' => $ex_pending,
+                            ),
+                            array(
+                                'examinerID' => $examinerID,
+                                'centerID'   => $v,
+                            )
+                        );
+                    }
+                    unset($values[$k]);
+                }
+
+                //de-activate examiner if sites where no longer checked
+                $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
+                foreach ($ex_inactive as $cid) {
                     $DB->update(
                         'examiners_psc_rel',
+                        array("active" => 'N'),
                         array(
-                         'active'           => 'Y',
-                         'pending_approval' => $ex_pending,
-                        ),
-                        array(
-                         'examinerID' => $examinerID,
-                         'centerID'   => $v,
+                            'examinerID' => $examinerID,
+                            'centerID'   => $cid,
                         )
                     );
                 }
-                unset($values[$k]);
-            }
-
-            //de-activate examiner if sites where no longer checked
-            $ex_inactive = array_diff($ex_prev_sites, $ex_curr_sites);
-            foreach ($ex_inactive as $cid) {
-                $DB->update(
-                    'examiners_psc_rel',
-                    array("active" => 'N'),
-                    array(
-                     'examinerID' => $examinerID,
-                     'centerID'   => $cid,
-                    )
-                );
             }
         }
         unset($values['examiner_radiologist']);

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -327,7 +327,7 @@ class Edit_User extends \NDB_Form
                     'examiners',
                     array(
                      'radiologist' => $ex_radiologist,
-                     'userID' => $uid,
+                     'userID'      => $uid,
                     ),
                     array(
                      "full_name" => $values['Real_name'],

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -296,7 +296,10 @@ class Edit_User extends \NDB_Form
                 && empty($examinerID)
             ) {
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $values         = \Utility::nullifyEmpty($values, 'examiner_radiologist');
+                $values         = \Utility::nullifyEmpty(
+                    $values,
+                    'examiner_radiologist'
+                );
                 $DB->insert(
                     'examiners',
                     array(
@@ -320,7 +323,10 @@ class Edit_User extends \NDB_Form
                 && empty($ex_curr_sites)))
             ) {
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
-                $values         = \Utility::nullifyEmpty($values, 'examiner_radiologist');
+                $values         = \Utility::nullifyEmpty(
+                    $values,
+                    'examiner_radiologist'
+                );
                 $DB->update(
                     'examiners',
                     array(


### PR DESCRIPTION
This PR fixes the issue that whenever a user has the examiner_multisite permission and creates a new user, the new user will always be added to the examiner table even if no examiner options were set. 

This bug was found by @ZainVirani so assigning him to be a reviewer to this new PR.