### PR TITLE
[Dicom archive] Apply filters dicom achive to mri violations

### DIFF
--- a/modules/dicom_archive/templates/form_viewDetails.tpl
+++ b/modules/dicom_archive/templates/form_viewDetails.tpl
@@ -3,7 +3,9 @@
   <tr>
     <th>Acquisition ID</th>
     <td>
-      <a href="{$baseurl}/mri_violations/?PatientName={$archive.PatientName}&filter=true">{$archive.DicomArchiveID}</a>
+      <a href="{$baseurl}/mri_violations/?PatientName={$archive.PatientName}&filter=true" class="dicom_archive"
+         data-patientname="{$archive.PatientName}">
+         {$archive.DicomArchiveID}
       </a>
     </td>
   </tr>


### PR DESCRIPTION
This reuse the existing function that intercept the onClick of serieUID to send a postr request instead of a get.

This apply the filter in the mri_violation page instead of just populating the fields.

IBIS reaalllllly want this :)