### PR TITLE
[User Accounts] Prevent password autocompletion in edit user form

### DIFF
--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -28,7 +28,7 @@
 });
 </script>
 {/literal}
-<form method="post" name="edit_user">
+<form method="post" name="edit_user" autocomplete="off">
     {if $form.errors}
     <div class="alert alert-danger" role="alert">
         The form you submitted contains data entry errors


### PR DESCRIPTION
## Brief summary of changes

This PR adds the `autocomplete="off"` attribute to the form in the Edit User section of User Accounts.

### This PR improves LORIS by...

Preventing a frustrating error during tasks such as e.g. changing user permissions during testing. Often a user or developer will be editing a user's permissions and have their action fail because of a mismatched password error. Now that won't happen.

### To test this change...

- [x] With password autocompletion enabled in your browser, try editing a user's permissions. You'll likely get an error about passwords not matching even if you don't touch the password -- this is because the form has autcoompleted.

- [x] Check out this branch and do the same. The password field should be blank and this form shouldn't get in your way anymore.

- [x] Remember to delete the files in `smarty/templates_c` if the above step doesn't occurred. As this changes the smarty template, the files will need to be re-compiled.