### PR TITLE
[Candidate] Sanitize candidate comments

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -144,7 +144,7 @@ class Candidate
             $params = array_map(
                 function ($string) {
                     return htmlentities($string, ENT_QUOTES, 'UTF-8');
-                }, 
+                },
                 $params
             );
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -139,6 +139,15 @@ class Candidate
                     $params[$row['Description']] = $row['Value'];
                 }
             }
+            // Sanitize values coming from the parameter_candidate table before
+            // injecting them into the HTML table.
+            $params = array_map(
+                function ($string) {
+                    return htmlentities($string, ENT_QUOTES, 'UTF-8');
+                }, 
+                $params
+            );
+
             $this->candidateInfo['DisplayParameters'] = $params;
         }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -135,18 +135,16 @@ class Candidate
                      'PTName'    => $parameter_type,
                     )
                 );
+                // Sanitize values coming from the parameter_candidate table 
+                // before injecting them into the HTML table.
                 if (!empty($row['Value'])) {
-                    $params[$row['Description']] = $row['Value'];
+                    $params[$row['Description']] = htmlentities(
+                        $row['Value'],
+                        ENT_QUOTES,
+                        'UTF-8'
+                    );
                 }
             }
-            // Sanitize values coming from the parameter_candidate table before
-            // injecting them into the HTML table.
-            $params = array_map(
-                function ($string) {
-                    return htmlentities($string, ENT_QUOTES, 'UTF-8');
-                },
-                $params
-            );
 
             $this->candidateInfo['DisplayParameters'] = $params;
         }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -135,7 +135,7 @@ class Candidate
                      'PTName'    => $parameter_type,
                     )
                 );
-                // Sanitize values coming from the parameter_candidate table 
+                // Sanitize values coming from the parameter_candidate table
                 // before injecting them into the HTML table.
                 if (!empty($row['Value'])) {
                     $params[$row['Description']] = htmlentities(


### PR DESCRIPTION
## Background

Before injecting values from the DB into the front-end HTML, they must be sanitized to prevent cross-site scripting (XSS) attacks. To **sanitize on output** of the information - **instead of on _input_** to the DB - is considered best-practice in the context of XSS attack mitigations (as opposed to SQLi prevention, for example).

This PR addresses an issue where such an attack was possible.

## This improves LORIS by...

Patching a XSS attack vector.

## To test

- [ ] See me for information if you don't know how to test this one.