### PR TITLE
[Middleware] Move getControlPanel call to after handle()

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -75,14 +75,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
         // I don't think anyone uses this. It's not really supported
         $tpl_data['css'] = $this->Config->getSetting('css');
 
-
-        // This should be moved out of the middleware and into the modules that need it,
-        // but is currently required for backwards compatibility.
         $page = $request->getAttribute("pageclass");
-        if (method_exists($page, 'getControlPanel')) {
-            $tpl_data['control_panel'] = $page->getControlPanel();
-        }
-
         if (method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null
@@ -176,6 +169,13 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
         // calls setup which modifies the $page->FormAction value (ie in the imaging
         // browser)
         $undecorated = $handler->handle($request);
+
+        // This should be moved out of the middleware and into the modules that need it,
+        // but is currently required for backwards compatibility.
+        if (method_exists($page, 'getControlPanel')) {
+            $tpl_data['control_panel'] = $page->getControlPanel();
+        }
+
         // This seems to only be used in imaging_browser, it can probably be
         // moved to properly use OOP.
         $tpl_data['FormAction'] = $page->FormAction ?? '';

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -172,6 +172,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface {
 
         // This should be moved out of the middleware and into the modules that need it,
         // but is currently required for backwards compatibility.
+        // This should also come after the above call to handle() in order for updated data
+        // on the controlPanel to be properly displayed.
         if (method_exists($page, 'getControlPanel')) {
             $tpl_data['control_panel'] = $page->getControlPanel();
         }


### PR DESCRIPTION
addresses https://redmine.cbrain.mcgill.ca/issues/14840

In imaging browser, the left control panel is rendered by calling getControlPanel(). On clicking "Save" in the panel, the setup() function for the page updates the Visit Level QC status.  However, in `UserPageDecorationMiddleware.php`, getControlPanel() is always called before handler(), a function that calls setup(), and not after. This means that the control panel is always rendered first, then, the status updated. So, the control panel never shows the updated status.

This PR changes the order of calls so that getControlPanel() is called right after handler() which allows the controlPanel to show changes made.

note: I kept the call to getFeedbackPanel() where it is, even though it was grouped with getControlPanel(), to minimize changes and potential for another bug

to test: make sure that control panels in imaging browser, issue tracker, instrument list, and NDB_BVL_Instrument work. and that nothing else changes between 20.0-release branch and this PR branch.