### PR TITLE
[API] Fix loading instruments from API

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -169,6 +169,8 @@ class NDB_BVL_Instrument extends NDB_Page
 
         // Ensure 'page' is a string.
         $page = $page ?? '';
+        // Ensure 'commentID' is a string.
+        $commentID = $commentID ?? '';
 
         // Make sure the instrument class has been included/required!
         $factory = NDB_Factory::singleton();


### PR DESCRIPTION
This fixes Redmine issue 14918 where an API request for instrument data fails with 500 error.

the error was due to a `NULL` value being passed where a string is expected in NDB_Page. the solution was to mimic the existing code above for the `page` variable and setting `commentId=''`
