### PR TITLE
[Tools] Fix score_instrument.php case for scoring all instruments

### DIFF
--- a/tools/score_instrument.php
+++ b/tools/score_instrument.php
@@ -33,11 +33,15 @@ if (version_compare(phpversion(),'4.3.0','<'))
  * HELP SCREEN
  * display and stop processing if action=help
  */
-if (empty($argv[1]) || $argv[1] == 'help' || !in_array($argv[2], array('all','one')) || ($argv[2]=='one' && (empty($argv[3]) || empty($argv[4])))) {
+if (empty($argv[1]) || $argv[1] == 'help' ||
+    ($argv[2] && !in_array($argv[2], array('all','one'))) ||
+    ($argv[2]=='one' && (empty($argv[3]) || empty($argv[4])))
+    ) {
     fwrite(STDERR, "Usage: \n\n");
     fwrite(STDERR, "score_instrument.php help - displays this msg\n");
     fwrite(STDERR, "score_instrument.php <test_name> one <candID> <sessionID>\n");
     fwrite(STDERR, "score_instrument.php <test_name> all \n");
+    fwrite(STDERR, "score_instrument.php all \n");
     return;
 }
 


### PR DESCRIPTION
the usage conditions for score_instrument.php didn't allow for `php score_instrument.php all` since it was failing `!in_array($argv[2], array('all', 'one'))`

this PR simply adds the condition that `$argv[2]` is actually set before exiting the script with the help screen and adds `php score_instrument.php all` as an acceptable use case

to test: run `php score_instrument.php all` and go grab a coffee since this script can take a while if you have a lot of candidates or instruments