### PR TITLE
[survey module] Remove checks for permissions when entring direct data

### DIFF
--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -251,7 +251,6 @@ class NDB_Caller
             $phpfile   = $base . "project/instruments/"
                                . "NDB_BVL_Instrument_$test_name.class.inc";
             $linstfile = $base."project/instruments/$test_name.linst";
-
             if ($this->existsAndRequire($phpfile)
                 || $test_name=='instrument_preview'
             ) {
@@ -542,6 +541,14 @@ class NDB_Caller
         );
 
         $this->instrument = $instrument;
+        $success = $instrument->save();
+        if ($redirectToOnSuccess !== null && $success !== false) {
+            header("Location: $redirectToOnSuccess");
+            return "";
+        }
+        // create an instrument status object
+        $status  = new NDB_BVL_InstrumentStatus;
+        $success = $status->select($commentID);
 
         $this->page = $instrument;
         $html       = $instrument->display();

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -255,17 +255,37 @@ class NDB_Caller
             if ($this->existsAndRequire($phpfile)
                 || $test_name=='instrument_preview'
             ) {
-                $html = $this->loadInstrument(
-                    $test_name,
-                    $subtest,
-                    $CommentID,
-                    $nextpage
-                );
-
+                if ($this->DataEntry === 'Direct') {
+                    $html = $this->loadInstrumentDirect(
+                        $test_name,
+                        $subtest,
+                        $CommentID,
+                        $nextpage
+                    );
+                } else {
+                    $html = $this->loadInstrument(
+                        $test_name,
+                        $subtest,
+                        $CommentID,
+                        $nextpage
+                    );
+                }
                 $this->type = 'instrument';
                 return $html;
             } else if (file_exists($linstfile)) {
-                $html = $this->loadInstrument($test_name, $subtest, $CommentID);
+                if ($this->DataEntry === 'Direct') {
+                    $html = $this->loadInstrumentDirect(
+                        $test_name,
+                        $subtest,
+                        $CommentID
+                    );
+                } else {
+                    $html = $this->loadInstrument(
+                        $test_name,
+                        $subtest,
+                        $CommentID
+                    );
+                }
 
                 $this->type = 'instrument';
                 return $html;
@@ -398,7 +418,7 @@ class NDB_Caller
     }
 
     /**
-    * Renders html for a quickform Instrument
+    * Renders html for an Instrument
     *
     * @param string $instrumentName      Name of the instrument to load
     * @param string $page                Page (subtest) of the instrument
@@ -478,6 +498,50 @@ class NDB_Caller
                 $instrument->freeze();
             }
         }
+
+        $this->page = $instrument;
+        $html       = $instrument->display();
+
+        return $html;
+    }
+
+    /**
+     * Renders html for a direct data entry Instrument
+     *
+     * @param string $instrumentName      Name of the instrument to load
+     * @param string $page                Page (subtest) of the instrument
+     * @param string $commentID           CommentID of the instrument to load
+     * @param string $redirectToOnSuccess URL to redirect to if the page is loaded
+     *                                    successfully.
+     *
+     * @return string HTML of the page to render.
+     */
+    function loadInstrumentDirect(
+        $instrumentName,
+        $page,
+        $commentID,
+        $redirectToOnSuccess=null
+    ) {
+        if ($page === 'finalpage') {
+            $instrument = NDB_BVL_Instrument::factory(
+                $instrumentName,
+                $commentID,
+                $page
+            );
+
+            $this->instrument = $instrument;
+            header("Location: $redirectToOnSuccess");
+            return "";
+        }
+
+        // make an instance of the instrument's object
+        $instrument = NDB_BVL_Instrument::factory(
+            $instrumentName,
+            $commentID,
+            $page
+        );
+
+        $this->instrument = $instrument;
 
         $this->page = $instrument;
         $html       = $instrument->display();

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -541,7 +541,7 @@ class NDB_Caller
         );
 
         $this->instrument = $instrument;
-        $success = $instrument->save();
+        $success          = $instrument->save();
         if ($redirectToOnSuccess !== null && $success !== false) {
             header("Location: $redirectToOnSuccess");
             return "";


### PR DESCRIPTION
This implements a new function to be used solely to load survey instruments. this function is based on the regular `loadinstrument()` function in the caller but removes all unecessary calls pertaining to regular instrument loading whn logged in. Surveys is an anonymous module and thus should not be checking for permissions or loading panels...

### Why ?
The issue was raised during release testing (https://redmine.cbrain.mcgill.ca/issues/14889) and was due to this change (https://github.com/aces/Loris/pull/3463/files#diff-1947816db4abdcdd8722747580999a6dR52) which was preventing the load of permissions when it's a public module. previously all permissions were loaded by default because of the left join in the following query (https://github.com/aces/Loris/blob/minor/php/libraries/UserPermissions.class.inc#L81)
