### PR TITLE
Fixed Statistics Permissions

### DIFF
--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -44,7 +44,7 @@ class Statistics_Site extends \NDB_Menu
         $accessAllProfiles = $user->hasPermission('access_all_profiles') &&
             $user->hasPermission('data_entry');
         return $user->hasCenterPermission('data_entry', $centerID) ||
-            $accessAlProfiles;
+            $accessAllProfiles;
 
     }
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -41,7 +41,11 @@ class Statistics_Site extends \NDB_Menu
         $user     =& \User::singleton();
         $centerID = htmlspecialchars($_REQUEST['CenterID']);
         //TODO: Create a permission specific to statistics
-        return $user->hasCenterPermission('data_entry', $centerID);
+        $accessAllProfiles = $user->hasPermission('access_all_profiles') &&
+            $user->hasPermission('data_entry');
+        return $user->hasCenterPermission('data_entry', $centerID) ||
+            $accessAlProfiles;
+
     }
 
     /**


### PR DESCRIPTION
#### This PR fixes the Statistics Site Permissions to allow access to Users with Access All Profiles Permission.

### How to test:
- Make a non-super-user test user and give them data entry permission.
- Add and remove 'Across all sites access candidate profiles' permission and ensure that in both cases the Statistics Site page can be accessed from the dashboard's 'Incomplete Forms' link.
- Remove 'Data Entry' Permission and ensure that the Statistics Site page cannot be viewed.

Refer to Dashboard TestPlan item 11 for further clarification:
https://github.com/aces/Loris/blob/20.0-release/modules/dashboard/test/TestPlan.md

Redmine Ticket:
https://redmine.cbrain.mcgill.ca/issues/14946