### PR TITLE
[Imaging Browser] DICOM Tar download as original name

### DIFF
--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -153,7 +153,7 @@ case 'DICOMTAR':
     $FullPath         = $tarchivePath . '/' . $File;
     $MimeType         = 'application/x-tar';
     $DownloadFilename = basename($File);
-    $saveAs = $_GET['saveAs'];
+    $saveAs           = $_GET['saveAs'];
     break;
 default:
     $FullPath         = $DownloadPath . '/' . $File;
@@ -170,10 +170,10 @@ if (!file_exists($FullPath)) {
 
 header("Content-type: $MimeType");
 if (!empty($DownloadFilename)) {
-   
-   if ($FileExt === 'DICOMTAR' && !empty($saveAs)) {
+
+    if ($FileExt === 'DICOMTAR' && !empty($saveAs)) {
         header("Content-Disposition: attachment; filename=$saveAs");
-    
+
     } else {
 
         header("Content-Disposition: attachment; filename=$DownloadFilename");

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -66,7 +66,6 @@ if ($imagePath === '/' || $DownloadPath === '/'
 // Now get the file and do file validation.
 // Resolve the filename before doing anything.
 $File = Utility::resolvePath($_GET['file']);
-
 // Extra sanity checks, just in case something went wrong with path resolution.
 // File validation
 if (strpos($File, ".") === false) {
@@ -154,6 +153,7 @@ case 'DICOMTAR':
     $FullPath         = $tarchivePath . '/' . $File;
     $MimeType         = 'application/x-tar';
     $DownloadFilename = basename($File);
+    $saveAs = $_GET['saveAs'];
     break;
 default:
     $FullPath         = $DownloadPath . '/' . $File;
@@ -170,8 +170,14 @@ if (!file_exists($FullPath)) {
 
 header("Content-type: $MimeType");
 if (!empty($DownloadFilename)) {
+   
+   if ($FileExt === 'DICOMTAR' && !empty($saveAs)) {
+        header("Content-Disposition: attachment; filename=$saveAs");
+    
+    } else {
 
-    header("Content-Disposition: attachment; filename=$DownloadFilename");
+        header("Content-Disposition: attachment; filename=$DownloadFilename");
+    }
 }
 $fp = fopen($FullPath, 'r');
 fpassthru($fp);

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -105,21 +105,26 @@ class Imaging_Session_ControlPanel
             $params['PCandID'] = $timePoint->getCandID();
             $params['PVL']     = $timePoint->getVisitLabel();
         }
+        
         // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
         $qresult = $DB->pselect(
-            "SELECT TarchiveID, ArchiveLocation 
-            FROM tarchive 
-            WHERE PatientName LIKE $ID",
-            $params
-        );
-
+            "SELECT t.TarchiveID, t.ArchiveLocation, 
+                SUBSTRING_INDEX(mu.UploadLocation, '/', -1) AS originalFileName,
+                t.PatientName
+            FROM tarchive t INNER JOIN mri_upload mu ON t.PatientName=mu.PatientName 
+            WHERE t.sessionID=mu.sessionID AND t.PatientName LIKE $ID",
+            $params); 
+        
         $tarIDToTarLoc =array();
         foreach ($qresult as $v) {
             $tarchiveID = $v['TarchiveID'];
-            $tarIDToTarLoc[$tarchiveID] = $v['ArchiveLocation'];
+            $tarIDToTarLoc[$tarchiveID]['ArchiveLocation'] = $v['ArchiveLocation'];
+            $tarIDToTarLoc[$tarchiveID]['originalFileName'] =
+            $v['originalFileName'];
+            $tarIDToTarLoc[$tarchiveID]['PatientName'] = $v['PatientName'];
         }
         $subjectData['tarchiveIDLoc'] = $tarIDToTarLoc;
-
+        
         $config =& \NDB_Config::singleton();
 
         //if table is not in database return false to not display in the template
@@ -168,7 +173,7 @@ class Imaging_Session_ControlPanel
         $NavBar = new MRINavigation($this->sessionID);
         $subjectData['nextTimepoint']['URL'] = $NavBar->nextLink();
         $subjectData['prevTimepoint']['URL'] = $NavBar->prevLink();
-
+        error_log(print_r($_GET));
         return $subjectData;
     }
     /**

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -105,7 +105,7 @@ class Imaging_Session_ControlPanel
             $params['PCandID'] = $timePoint->getCandID();
             $params['PVL']     = $timePoint->getVisitLabel();
         }
-        
+
         // To enable DICOM download: Add pair: tarchiveID, ArchiveLocation
         $qresult = $DB->pselect(
             "SELECT t.TarchiveID, t.ArchiveLocation, 
@@ -113,18 +113,18 @@ class Imaging_Session_ControlPanel
                 t.PatientName
             FROM tarchive t INNER JOIN mri_upload mu ON t.PatientName=mu.PatientName 
             WHERE t.sessionID=mu.sessionID AND t.PatientName LIKE $ID",
-            $params); 
-        
+            $params
+        );
+
         $tarIDToTarLoc =array();
         foreach ($qresult as $v) {
             $tarchiveID = $v['TarchiveID'];
-            $tarIDToTarLoc[$tarchiveID]['ArchiveLocation'] = $v['ArchiveLocation'];
-            $tarIDToTarLoc[$tarchiveID]['originalFileName'] =
-            $v['originalFileName'];
-            $tarIDToTarLoc[$tarchiveID]['PatientName'] = $v['PatientName'];
+            $tarIDToTarLoc[$tarchiveID]['ArchiveLocation']  = $v['ArchiveLocation'];
+            $tarIDToTarLoc[$tarchiveID]['originalFileName'] = $v['originalFileName'];
+            $tarIDToTarLoc[$tarchiveID]['PatientName']      = $v['PatientName'];
         }
         $subjectData['tarchiveIDLoc'] = $tarIDToTarLoc;
-        
+
         $config =& \NDB_Config::singleton();
 
         //if table is not in database return false to not display in the template
@@ -173,7 +173,6 @@ class Imaging_Session_ControlPanel
         $NavBar = new MRINavigation($this->sessionID);
         $subjectData['nextTimepoint']['URL'] = $NavBar->nextLink();
         $subjectData['prevTimepoint']['URL'] = $NavBar->prevLink();
-        error_log(print_r($_GET));
         return $subjectData;
     }
     /**

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -37,7 +37,7 @@
         {/foreach}
         {foreach from=$subject.tarchiveIDLoc key=tarchive item=tarchiveLoc}
             <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive}</a></li>
-            <li><a href="/mri/jiv/get_file.php?file={$tarchiveLoc}" class="btn btn-primary btn-small">
+            <li><a href="/mri/jiv/get_file.php?file={$tarchiveLoc['ArchiveLocation']}&saveAs={$tarchiveLoc['originalFileName']}" class="btn btn-primary btn-small">
                     <span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM {$tarchive}</span>
                 </a>
             </li>


### PR DESCRIPTION
## Summary

This pull request will download the tar file generated by the imaging pipeline as the original name (with which it was uploaded with).

The original file name is queried and sent as a GET parameter to get_file.php, and the file is downloaded with that name.

Made for CAP, but as suggested by others, this maybe useful for LORIS.

## Testing Instructions
To test you will need an imaging sandbox.

1. Go to the DICOM Archive module to see a list of potential tarchives that are present in your DB.
2. Ensure that the file actually exists in your VM (under `/data/{projectName}/data/tarchive/{year}/{fileName.tar}`.
3. Select the 'View Images' under the `MRI Browser` column for a given candidate.
4. In the side panel, ensure that a `Download DICOM` button is present under the `Links` header.
5. Click `Download DICOM {#}` to download the tar file. It should automatically be downloaded as `PatientName_CandID_VL_%`, where the ending could be anything, but it will be the same name as the name it was initially uploaded with. To ensure, you could head to the `Imaging Uploader` module and verify that that is indeed the case for that candidate and visit.

## Questions
The query used to retrieve the `UploadLocation` does a join on the `mri_upload` table. Thus, this assumes every tar file processed by the pipeline will also exist in the `mri_upload` table. To the imaging experts: is this assumption valid? If the file only exists in the `tarchive` table, and not in the `mri_upload`, then the query result will be empty.

To the security gurus: How should I be sanitizing the `_GET` parameter, is that still necessary in this case, as it is only used in the php `header(...)` function? 

## References
See also: `[PR 293](https://github.com/aces/Loris-MRI/pull/293)`, previously closed as it was decided to implement modifying the name at the time of download rather than the imaging pipeline.