### PR TITLE
[Database] Change return type of pselectOne to null

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -806,6 +806,8 @@ class Database
         if (is_array($result) && count($result)) {
             $valueArray = array_values($result);
             $result     = $valueArray[0];
+        } else {
+            return null;
         }
         return $result;
     }


### PR DESCRIPTION
This is meant to prevent `pselectOne()` from returning an empty array when the result is not in the database. Given that on success the function is expecting a value, it is less error prone to return null when nothing is return instead of an empty array.

functions `pselectRow()` and `pselect()` already expect an array to be returned and thus can be left as they are.

This helps avoid countless errors and warnings of all sorts in the error log when the result of a `pselectOne` is processed without first doing something like
```
$result = $DB->pselectOne(SOMETHING)
if (!is_array($result)) {
    //do what I want to do
}
```
