### PR TITLE
[tools/Normalise_Consent_Data.php] Modify insert statement

### DIFF
--- a/tools/single_use/Normalise_Consent_Data.php
+++ b/tools/single_use/Normalise_Consent_Data.php
@@ -156,10 +156,19 @@ if (empty($configValue)) {
     array_push($errors, "useConsent's Config value missing from Config table.
                Run SQL/New_patches/2018-03-01_normalise_consent.sql");
 }
+// Check new consent tables exist
 if (!$db->tableExists('consent') || !$db->tableExists('candidate_consent_rel') || !$db->tableExists('candidate_consent_history')) {
     array_push($errors, "New, normalized consent tables do not exist.
                Run SQL/New_patches/2018-03-01_normalise_consent.sql");
 }
+// Check rel and history tables are empty
+$consentRelResult     = $db->pselect("SELECT * FROM candidate_consent_rel", array());
+$consentHistoryResult = $db->pselect("SELECT * FROM candidate_consent_history", array());
+
+if(!empty($consentRelResult) || !empty($consentHistoryResult)) {
+    array_push($errors, "This is a single use script. New tables candidate_consent_rel and candidate_consent_history need to be empty. Delete entries in order to proceed.\n\n");
+}
+
 //////////////////
 // THROW ERRORS //
 //////////////////
@@ -239,25 +248,7 @@ print_r($dataArray);
 
 // Populate candidate_consent_rel
 foreach ($dataArray as $consentValues) {
-    $candidateID    = $consentValues['CandidateID'];
-    $consentID      = $consentValues['ConsentID'];
-    $query          = "SELECT CandidateID, ConsentID FROM candidate_consent_rel
-                       WHERE CandidateID=:cid AND ConsentID=:conid";
-    $duplicateEntry = $db->pselect(
-                          $query,
-                          array(
-                             'cid'   => $candidateID,
-                             'conid' => $consentID,
-                          )
-                      );
-    if(!empty($duplicateEntry)) {
-        print_r("This is a single use script.
-The data which you are trying to import already exists in
-`candidate_consent_rel` table, and cannot be overridden.\n\n");
-        die();
-    } else {
-        $db->insert('candidate_consent_rel', $consentValues);
-    }
+    $db->insert('candidate_consent_rel', $consentValues);
 }
 echo "\nConsent data insert complete.\n";
 

--- a/tools/single_use/Normalise_Consent_Data.php
+++ b/tools/single_use/Normalise_Consent_Data.php
@@ -239,7 +239,25 @@ print_r($dataArray);
 
 // Populate candidate_consent_rel
 foreach ($dataArray as $consentValues) {
-    $db->insert('candidate_consent_rel', $consentValues);
+    $candidateID    = $consentValues['CandidateID'];
+    $consentID      = $consentValues['ConsentID'];
+    $query          = "SELECT CandidateID, ConsentID FROM candidate_consent_rel
+                       WHERE CandidateID=:cid AND ConsentID=:conid";
+    $duplicateEntry = $db->pselect(
+                          $query,
+                          array(
+                             'cid'   => $candidateID,
+                             'conid' => $consentID,
+                          )
+                      );
+    if(!empty($duplicateEntry)) {
+        print_r("This is a single use script.
+The data which you are trying to import already exists in
+`candidate_consent_rel` table, and cannot be overridden.\n\n");
+        die();
+    } else {
+        $db->insert('candidate_consent_rel', $consentValues);
+    }
 }
 echo "\nConsent data insert complete.\n";
 


### PR DESCRIPTION
while testing https://github.com/aces/Loris/pull/3855, I noticed that the script was throwing a DBException when inserting data that already exists in `candidate_consent_rel` from previous runs of the script (because SQL can't duplicate primary keys). 

![screenshot from 2018-07-30 14-15-50](https://user-images.githubusercontent.com/17415878/43416063-41ad91a6-9405-11e8-831f-353fad2df79c.png)

this script should be single use anyways so this PR adds an extra check to notify the user that they cannot import/replace existing data

**to test:**
1. On 20.0-branch:
  - run `php Normalise_Consent_Data.php` with data already in `candidate_consent_rel` table and notice the error in screenshot above
  - Call `DELETE FROM candidate_consent_rel`, run the script again and notice there are no issues
2. On my PR branch:
  - run the script again both with and without data in `candidate_consent_rel` table. Inserting the data in either case should not throw the error, but instead gives you the status of the import