### PR TITLE
Fix duplication of MRI violations when multiple subprojects per candidate

### DIFF
--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -231,17 +231,19 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                 SeriesUID,
                 md5(concat_WS(':',minc_location,PatientName,SeriesUID,time_run))
                   as hash,
-                mri_protocol_violated_scans.ID as join_id,
+                mpvs.ID as join_id,
                 p.CenterID as Site,
                 violations_resolved.Resolved as Resolved
-            FROM mri_protocol_violated_scans
+            FROM mri_protocol_violated_scans AS mpvs
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mri_protocol_violated_scans.ID
+            ON (violations_resolved.ExtID=mpvs.ID
             AND violations_resolved.TypeTable='mri_protocol_violated_scans')
             LEFT JOIN candidate c
-            ON (mri_protocol_violated_scans.CandID = c.CandID)
+            ON (mpvs.CandID = c.CandID)
             LEFT JOIN session s
-            ON (mri_protocol_violated_scans.CandID = s.CandID)
+            ON (SUBSTRING_INDEX(mpvs.PatientName,'_',-1) = s.Visit_label 
+                AND mpvs.CandID = s.CandID
+            )
             LEFT JOIN psc p
             ON (p.CenterID = c.CenterID)
             WHERE Resolved is NULL"
@@ -261,27 +263,27 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                               TimeRun
                    )
                 ) as hash,
-                mri_violations_log.LogID as join_id,
+                mrl.LogID as join_id,
                 p.CenterID as Site,
                 violations_resolved.Resolved as Resolved
-            FROM mri_violations_log
+            FROM mri_violations_log AS mrl
             LEFT JOIN mri_scan_type
-            ON (mri_scan_type.ID=mri_violations_log.Scan_type)
+            ON (mri_scan_type.ID=mrl.Scan_type)
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mri_violations_log.LogID 
+            ON (violations_resolved.ExtID=mrl.LogID 
             AND violations_resolved.TypeTable='mri_violations_log')
             LEFT JOIN candidate c
-            ON (mri_violations_log.CandID=c.CandID)
+            ON (mrl.CandID=c.CandID)
             LEFT JOIN session s
-            ON (mri_violations_log.CandID = s.CandID)
+            ON (mrl.Visit_label = s.Visit_label AND mrl.CandID=s.CandID)
             LEFT JOIN psc p
             ON (p.CenterID = c.CenterID)
             WHERE Resolved is NULL"
             . " UNION " .
             "SELECT PatientName,
                 TimeRun,
-                c.ProjectID as Project,
-                s.SubprojectID as Subproject,
+                null,
+                null,
                 MincFile,
                 null,
                 Reason,
@@ -294,18 +296,12 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                    )
                 ) as hash,
                 MRICandidateErrors.ID as join_id,
-                p.CenterID as Site,
+                null,
                 violations_resolved.Resolved as Resolved
             FROM MRICandidateErrors
             LEFT JOIN violations_resolved
             ON (violations_resolved.ExtID=MRICandidateErrors.ID 
             AND violations_resolved.TypeTable='MRICandidateErrors')
-            LEFT JOIN candidate c
-            ON (SUBSTRING_INDEX(MRICandidateErrors.PatientName,'_',1)=c.PSCID)
-            LEFT JOIN session s
-            ON (c.CandID = s.CandID)
-            LEFT JOIN psc p
-            ON (p.CenterID = c.CenterID)
             WHERE Resolved is NULL)
             as v LEFT JOIN psc site ON (site.CenterID = v.Site) 
             LEFT JOIN Project as pjct ON (v.Project = pjct.ProjectID)


### PR DESCRIPTION
This pull request fixes a bug in the MRI violations module for which it displays the same violations more than once if a candidate has visits that are spread across multiple subprojects.

Example of MRI violations before the fix for a subject belonging to two different subprojects:
![screen shot 2018-07-31 at 4 05 51 pm](https://user-images.githubusercontent.com/1402456/43484313-0174a7b4-94dc-11e8-99a5-88114b009814.png)
Same candidate MRI violations after the fix from this PR:
![screen shot 2018-07-31 at 4 07 35 pm](https://user-images.githubusercontent.com/1402456/43484328-0c05935a-94dc-11e8-926b-68ad5e782b17.png)

How to test this PR:
Pick one candidate that shows in the MRI violations module and that has multiple visits. If all these visits are all from the same subproject, manually edit one in the `session` table so that it has a different subprojectID than all other visits (could be NULL) and:
1) check that you can reproduce the bug on 20.0-release
2) check that the bug is fixed by this PR

See also: https://redmine.cbrain.mcgill.ca/issues/14960
