### PR TITLE
[instrument_list] Remove superglobal access

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -16,6 +16,7 @@
  * @package behavioural
  */
 namespace LORIS\instrument_list;
+
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Server\RequestHandlerInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -48,6 +49,29 @@ class Instrument_List extends \NDB_Menu_Filter
     protected $candidate;
 
     /**
+     * Sets the timepoint that is being accessed on this page
+     *
+     * @param \TimePoint $timepoint The timepoint object.
+     *
+     * @return void
+     */
+    public function setTimePoint(\TimePoint $timepoint)
+    {
+        $this->timePoint = $timepoint;
+    }
+
+    /**
+     * Sets the candidate is being accessed on this page
+     *
+     * @param \Candidate $candidate The candidate object.
+     *
+     * @return void
+     */
+    public function setCandidate(\Candidate $candidate)
+    {
+        $this->candidate = $candidate;
+    }
+    /**
     * Checking permissions
     *
     * @return bool
@@ -55,27 +79,27 @@ class Instrument_List extends \NDB_Menu_Filter
     function _hasAccess()
     {
         // create user object
-        $user =& \User::singleton();
-        if (isset($_REQUEST['sessionID'])) {
-            //These variable are only for checking the permissions.
-            $TimePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
-            $candID    = $TimePoint->getCandID();
-            $Candidate =& \Candidate::singleton($candID);
-            return ($user->hasPermission('access_all_profiles')
-                || (in_array(
-                    $Candidate->getData('CenterID'),
-                    $user->getData('CenterIDs')
-                )
-                   )
-                || (in_array(
-                    $TimePoint->getData('CenterID'),
-                    $user->getData('CenterIDs')
-                )
-                   )
-            );
+        $user      =& \User::singleton();
+        $timePoint = $this->timePoint;
+        if ($timePoint === null) {
+            throw new \LorisException("Page requires a timepoint to load");
         }
-        // check user permissions
-        return false;
+        $candidate = $this->candidate;
+        if ($candidate === null) {
+            throw new \LorisException("Page requires a candidate to load");
+        }
+
+        //These variable are only for checking the permissions.
+        return ($user->hasPermission('access_all_profiles')
+            || (in_array(
+                $candidate->getData('CenterID'),
+                $user->getData('CenterIDs')
+            )) || (in_array(
+                $timePoint->getData('CenterID'),
+                $user->getData('CenterIDs')
+            )
+            )
+        );
     }
 
     /**
@@ -101,33 +125,13 @@ class Instrument_List extends \NDB_Menu_Filter
         ServerRequestInterface $request,
         RequestHandlerInterface $handler
     ) : ResponseInterface {
-        $gets = $request->getQueryParams();
-
-        $attribute = $request->getAttribute("CandID");
-        if ($attribute !== null) {
-            $this->candidate = \Candidate::singleton($attribute);
-        } else {
-            $this->candidate = \Candidate::singleton($gets['candID']);
+        $this->candidate = $request->getAttribute("Candidate");
+        $this->timePoint = $request->getAttribute("timePoint");
+        if ($this->candidate == null || $this->timePoint === null) {
+            // This shouldn't happen, the module level router verifies that
+            // the candidate exists before getting here.
+            throw new \LorisException("Timepoint list requires a timepoint.");
         }
-
-        $attribute = $request->getAttribute("TimePoint");
-        if ($attribute !== null) {
-            $this->timePoint = $attribute;
-        } else {
-            // FIXME: Make VisitLabel not sessionID
-            $this->timePoint = \TimePoint::singleton($gets['sessionID']);
-        }
-
-        $request = $request->withAttribute(
-            'Candidate',
-            $this->candidate
-        );
-
-        $request = $request->withAttribute(
-            'TimePoint',
-            $this->timePoint
-        );
-
         return parent::process($request, $handler);
     }
 
@@ -316,7 +320,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
         // assert that a battery has already been selected
         if (is_null($this->timePoint)) {
-            throw new Exception("No battery selected");
+            throw new \Exception("No battery selected");
         }
 
         // craft the select query

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -49,7 +49,7 @@ class Instrument_List extends \NDB_Menu_Filter
     protected $candidate;
 
     /**
-     * Sets the timepoint that is being accessed on this page
+     * Sets the timepoint that is being accessed on this page.
      *
      * @param \TimePoint $timepoint The timepoint object.
      *
@@ -61,7 +61,7 @@ class Instrument_List extends \NDB_Menu_Filter
     }
 
     /**
-     * Sets the candidate is being accessed on this page
+     * Sets the candidate that is being accessed on this page.
      *
      * @param \Candidate $candidate The candidate object.
      *
@@ -127,7 +127,7 @@ class Instrument_List extends \NDB_Menu_Filter
     ) : ResponseInterface {
         $this->candidate = $request->getAttribute("Candidate");
         $this->timePoint = $request->getAttribute("timePoint");
-        if ($this->candidate == null || $this->timePoint === null) {
+        if ($this->candidate === null || $this->timePoint === null) {
             // This shouldn't happen, the module level router verifies that
             // the candidate exists before getting here.
             throw new \LorisException("Timepoint list requires a timepoint.");

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -41,11 +41,45 @@ class Module extends \Module
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $resp = parent::handle($request);
-        if ($resp->getStatusCode() != 404) {
-            return $resp;
+        try {
+            $resp = parent::handle($request);
+            // hasAccess from the parent returns a 403
+            if ($resp->getStatusCode() != 404) {
+                return $resp;
+            }
+        } catch (\LorisException $e) {
+            // Calling hasAccess from the loader would have failed with
+            // an exception saying it needs a timepoint/candidate if loading
+            // the instrument_list page, which we set below.
         }
+
+        // Falling back to instrument_list, ensure that the CandID
+        // and SessionID are valid, and if so attach the models to
+        // the request.
         $page = $this->loadPage("instrument_list");
+
+        $gets = $request->getQueryParams();
+
+        $attribute = $request->getAttribute("CandID");
+        if ($attribute !== null) {
+            $candidate = \Candidate::singleton($attribute);
+        } else {
+            $candidate = \Candidate::singleton($gets['candID'] ?? '');
+        }
+        $request = $request->withAttribute("Candidate", $candidate);
+
+        $attribute = $request->getAttribute("timePoint");
+        if ($attribute === null) {
+            $request = $request->withAttribute(
+                "timePoint",
+                \TimePoint::singleton($gets['sessionID'])
+            );
+        }
+
+        // We need to set the internal page properties for hasAccess to succeed.
+        $page->setCandidate($candidate);
+        $page->setTimePoint($request->getAttribute("timePoint"));
+
         return $page->process($request, $page);
 
     }


### PR DESCRIPTION
This refactors the fix in #3721 in order to remove references
to superglobals. Instead, the variables are instantiated on the
module level from the PSR object so that the page can assume
they exist.