### PR TITLE
[Help Editor] Use safe update instead of unsafe update

### DIFF
--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -87,7 +87,7 @@ class HelpFile
         $DB =& \Database::singleton();
 
         // insert a help file
-        $success = $DB->unsafeinsert('help', $set);
+        $success = $DB->insert('help', $set);
         // return the help ID
         return $DB->lastInsertID;
     }

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -106,7 +106,7 @@ class HelpFile
         $DB =& \Database::singleton();
 
         // update the help file
-        $success = $DB->unsafeupdate('help', $set, array('helpID' => $this->helpID));
+        $success = $DB->update('help', $set, array('helpID' => $this->helpID));
 
         return true;
     }


### PR DESCRIPTION
### Brief summary of changes

The HelpFile class has been changed to use the safe update function from the database class instead of the explicitly unsafe version.

`unsafeupdate` is to be used ["with caution, only when you know you need to insert HTML and know that you can trust it"](https://github.com/aces/Loris/blob/20.0-release/php/libraries/Database.class.inc#L442). I don't believe that data submitted by users into the help editor can be considered trusted as this is a cross-site scripting vector.

This change fixes a security issue while preserving the markup functionality of the help editor. HTML will not directly render but Markdown will. I believe this is closer to the intended functionality of the help editor.

### This resolves issue...

No reported issues but this fix mitigates a confirmed cross-site scripting exploit.

### To test this change...

This fix should preserve Markdown functionality but direct HTML will no longer directly render; bold, italics, links and headers can be created using Markdown syntax.

Note that the current implementation of the help editor takes information from the database only for instruments, therefore **to test you must edit the help content for an instrument, not a module**.

- [x] Confirm XSS is not possible on the new branch. See me if you don't know how to do cross-site scripting. 

- [x] Edit the help content for an instrument, including Markdown features like bold, italics, headers, links, etc. All of these should work as expected.

