### PR TITLE
[Smarty Errors] "Go to login page" --> "Go to main page"

### DIFF
--- a/smarty/templates/403.tpl
+++ b/smarty/templates/403.tpl
@@ -1,4 +1,4 @@
 <div class="container">
     <h3>{$message}</h3>
-    <div><a href="{$baseurl}">Go to login page</a></div>
+    <div><a href="{$baseurl}">Go to main page</a></div>
 </div>

--- a/smarty/templates/404.tpl
+++ b/smarty/templates/404.tpl
@@ -1,5 +1,5 @@
 <div class="container">
     <h2>404: Page not found.</h2>
     <h3>{$message}</h3>
-    <a href="{$baseurl}">Go to login page</a></div>
+    <a href="{$baseurl}">Go to main page</a></div>
 </div>

--- a/smarty/templates/500.tpl
+++ b/smarty/templates/500.tpl
@@ -2,5 +2,5 @@
 {foreach from=$error_message item=message}
     <h2>{$message}</h2>
 {/foreach}
-    <div><a href="{$baseurl}">Go to login page</a></div>
+    <div><a href="{$baseurl}">Go to main page</a></div>
 </div>


### PR DESCRIPTION
When LORIS returns a 403, 404, or 500 error, a small template is shown to display that error. It currently says "Go to login page" when the URL actually points to baseURL. As a result this message is inaccurate when a user is already logged in as they'll be redirected to the dashboard (not logged out).
