### PR TITLE
[Core: Database] Add type declarations to function signatures

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -73,7 +73,7 @@ class Database
      *
      * @param string  $database     the database to select
      * @param string  $username     the username with which to log into
-     *                                      the database server
+     *                              the database server
      * @param string  $password     the password that matches the username
      * @param string  $host         the name of the database server
      * @param boolean $trackChanges boolean determining if changes should be
@@ -134,11 +134,11 @@ class Database
      *
      * @param string      $database     the database to select
      * @param string|null $username     the username with which to log into
-     *                              the database server
+     *                                  the database server
      * @param string|null $password     the password that matches the username
      * @param string|null $host         the name of the database server
      * @param boolean     $trackChanges whether to use the trackChanges
-     *                              mechanism on this connection
+     *                                  mechanism on this connection
      *
      * @return bool True if DB connection established. False otherwise.
      * @access public
@@ -910,7 +910,7 @@ class Database
      * Runs a query as a prepared statement and returns the value of the first
      * column of the first row.
      *
-     * FIXME This function does not have have a return type declaration because
+     * FIXME This function does not have a return type declaration because
      * the function pselectRow will sometimes return a string and sometimes
      * return an array. This behaviour should be made consistent (i.e. perhaps
      * returning an array of a single element) so that we can properly enforce

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -146,7 +146,7 @@ class Database
      * @access public
      */
     function connect(
-        string $database,
+        $database,
         string $username,
         string $password,
         string $host,

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file represents an SQL database abstraction layer for use in Loris
  *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -147,9 +147,9 @@ class Database
      */
     function connect(
         $database,
-        string $username,
-        string $password,
-        string $host,
+        ?string $username,
+        ?string $password,
+        ?string $host,
         bool   $trackChanges = true
     ) : bool {
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -345,14 +345,14 @@ class Database
      * @param bool   $ignore     determines whether the insert throws and error or
      *                           is discarded when value exists in DB
      *
-     * @return void
+     * @return bool
      */
     private function _realinsert(
         string $table,
         array  $set,
         bool   $autoescape = true,
         bool   $ignore = false
-    ): void {
+    ): bool {
 
         if ($autoescape === true) {
             $set = $this->_HTMLEscapeArray($set);
@@ -370,7 +370,7 @@ class Database
 
         if (DEBUG) {
             fwrite(STDERR, $query."\n");
-            return;
+            return true;
         }
 
         // There is no where clause for an insert, so add a fake
@@ -526,7 +526,7 @@ class Database
 
         if (DEBUG) {
             fwrite(STDERR, $query.$where."\n");
-            return;
+            return true;
         }
 
         if (preg_match("/=NULL/", $where)) {
@@ -667,7 +667,7 @@ class Database
         }
 
         if (!empty($options['nofetch']) && $options['nofetch'] == true) {
-            return;
+            return array();
         }
 
         $rows = $prepared->fetchAll(PDO::FETCH_ASSOC);
@@ -912,14 +912,20 @@ class Database
 
     /**
      * Runs a query as a prepared statement and returns the value of the first
-     * column of the first row
+     * column of the first row.
+     *
+     * FIXME This function does not have have a return type declaration because
+     * the function pselectRow will sometimes return a string and sometimes
+     * return an array. This behaviour should be made consistent (i.e. perhaps
+     * returning an array of a single element) so that we can properly enforce
+     * types.
      *
      * @param string $query  The SQL statement to run
      * @param array  $params Values to use for binding in the prepared statement
      *
-     * @return array The value returned by the query.
+     * @return mixed The value returned by the query.
      */
-    function pselectOne(string $query, array $params): array
+    function pselectOne(string $query, array $params)
     {
         $result = $this->pselectRow($query, $params);
         if (is_array($result) && count($result)) {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -953,7 +953,7 @@ class Database
             if ($item===null || $item==='') {
                 $output[] = "`$key`=NULL";
             } else {
-                $item     = $this->quote($item);
+                $item     = $this->quote((string) $item);
                 $output[] = "`$key`=$item";
             }
         }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -496,7 +496,7 @@ class Database
     private function _realupdate(
         string $table,
         array $set,
-        string $i_where,
+        array $i_where,
         bool $autoescape = true
     ): bool {
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -689,7 +689,7 @@ class Database
      *               row returned by the query, and each element is an associative
      *               array representing the row in the format ColumnName => Value
      */
-    function pselect(string $query, array $params): array
+    function pselect(string $query, array $params)
     {
         $this->_printQuery($query, $params);
         $stmt   = $this->prepare($query);
@@ -723,7 +723,7 @@ class Database
         string $query,
         array $params,
         string $uniqueKey
-    ): array {
+    ) {
 
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
@@ -807,7 +807,7 @@ class Database
      * @return array Associative array of form rowID=>value containing all values
      *               for the only column of the select statement
      */
-    function pselectCol(string $query, array $params): array
+    function pselectCol(string $query, array $params)
     {
         $unprocessed = $this->pselect($query, $params);
 
@@ -851,7 +851,7 @@ class Database
         string $query,
         array $params,
         string $uniqueKey
-    ): array {
+    ) {
 
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
@@ -921,7 +921,7 @@ class Database
      * @param string $query  The SQL statement to run
      * @param array  $params Values to use for binding in the prepared statement
      *
-     * @return mixed The value returned by the query.
+     * @return mixed The value returned by the query: array, string, or false.
      */
     function pselectOne(string $query, array $params)
     {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -69,7 +69,9 @@ class Database
 
     /**
      * Singleton design pattern implementation - creates the object
-     * and also connects to the database if necessary
+     * and also connects to the database if necessary.
+     * NOTE There is no return type declaration for this function as it returns
+     * the type `Database` which is not supported by PHPs built in return types.
      *
      * @param string  $database     the database to select
      * @param string  $username     the username with which to log into
@@ -89,7 +91,7 @@ class Database
         string $password     = null,
         string $host         = null,
         bool   $trackChanges = true
-    ): object {
+    ) {
 
         static $connections = array();
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -128,19 +128,17 @@ class Database
     }
 
     /**
-     * Creates the connection to the database
-     *
      * Creates the connection to the database server and selects the
      * desired database.  the connection is stored in the Database
      * object, and should never be accessed directly by the user.
      *
-     * @param string  $database     the database to select
-     * @param string  $username     the username with which to log into
+     * @param string       $database     the database to select
+     * @param string|null  $username     the username with which to log into
      *                              the database server
-     * @param string  $password     the password that matches the username
-     * @param string  $host         the name of the database server
-     * @param boolean $trackChanges whether to use the trackChanges mechanism on
-     *                              this connection (defaults to true)
+     * @param string|null  $password     the password that matches the username
+     * @param string|null  $host         the name of the database server
+     * @param boolean      $trackChanges whether to use the trackChanges 
+     *                              machanism on this connection
      *
      * @return bool True if DB connection established. False otherwise.
      * @access public

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -73,11 +73,11 @@ class Database
      * NOTE There is no return type declaration for this function as it returns
      * the type `Database` which is not supported by PHPs built in return types.
      *
-     * @param string  $database     the database to select
-     * @param string  $username     the username with which to log into
+     * @param string|null  $database     the database to select
+     * @param string|null  $username     the username with which to log into
      *                              the database server
-     * @param string  $password     the password that matches the username
-     * @param string  $host         the name of the database server
+     * @param string|null  $password     the password that matches the username
+     * @param string|null  $host         the name of the database server
      * @param boolean $trackChanges boolean determining if changes should be
      *                              logged to the history table
      *
@@ -972,7 +972,7 @@ class Database
      *                          (ie " AND ")
      * @param array  $dataArray The array representing the WHERE condition to be
      *                          glued together into a string
-     * @param array  $exec_vals The values which are being bound to the query. Used
+     * @param array|null  $exec_vals The values which are being bound to the query. Used
      *                          to generate the prepared variable name.
      * @param string $prefix    A prefix to apply to prepared variable names.
      *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -71,12 +71,12 @@ class Database
      * NOTE There is no return type declaration for this function as it returns
      * the type `Database` which is not supported by PHPs built in return types.
      *
-     * @param string|null $database     the database to select
-     * @param string|null $username     the username with which to log into
+     * @param string  $database     the database to select
+     * @param string  $username     the username with which to log into
      *                                      the database server
-     * @param string|null $password     the password that matches the username
-     * @param string|null $host         the name of the database server
-     * @param boolean     $trackChanges boolean determining if changes should be
+     * @param string  $password     the password that matches the username
+     * @param string  $host         the name of the database server
+     * @param boolean $trackChanges boolean determining if changes should be
      *                              logged to the history table
      *
      * @return object Database
@@ -84,20 +84,20 @@ class Database
      * @access public
      */
     static function &singleton(
-        string $database     = null,
-        string $username     = null,
-        string $password     = null,
-        string $host         = null,
+        string $database     = '',
+        string $username     = '',
+        string $password     = '',
+        string $host         = '',
         bool   $trackChanges = true
     ) {
 
         static $connections = array();
 
         // if no arguments, try to get the first connection or choke
-        if (is_null($database)
-            && is_null($username)
-            && is_null($password)
-            && is_null($host)
+        if (empty($database)
+            && empty($username)
+            && empty($password)
+            && empty($host)
         ) {
             if (!empty($connections)) {
                 reset($connections);
@@ -132,13 +132,13 @@ class Database
      * desired database.  the connection is stored in the Database
      * object, and should never be accessed directly by the user.
      *
-     * @param string       $database     the database to select
-     * @param string|null  $username     the username with which to log into
+     * @param string      $database     the database to select
+     * @param string|null $username     the username with which to log into
      *                              the database server
-     * @param string|null  $password     the password that matches the username
-     * @param string|null  $host         the name of the database server
-     * @param boolean      $trackChanges whether to use the trackChanges 
-     *                              machanism on this connection
+     * @param string|null $password     the password that matches the username
+     * @param string|null $host         the name of the database server
+     * @param boolean     $trackChanges whether to use the trackChanges
+     *                              mechanism on this connection
      *
      * @return bool True if DB connection established. False otherwise.
      * @access public

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -10,8 +10,6 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-// Require strict typing
-declare(strict_types=1);
 define("DEBUG", false);
 
 /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -11,6 +11,8 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 define("DEBUG", false);
+// Require strict typing
+declare(strict_types=1);
 
 /**
  * Database abstraction layer presents a unified interface to database
@@ -77,17 +79,18 @@ class Database
      * @param boolean $trackChanges boolean determining if changes should be
      *                              logged to the history table
      *
-     * @return Database
+     * @return object Database
      * @throws DatabaseException
      * @access public
      */
     static function &singleton(
-        $database=null,
-        $username=null,
-        $password=null,
-        $host=null,
-        $trackChanges=true
-    ) {
+        string $database     = null,
+        string $username     = null,
+        string $password     = null,
+        string $host         = null,
+        bool   $trackChanges = true
+    ): object 
+    {
         static $connections = array();
 
         // if no arguments, try to get the first connection or choke
@@ -143,13 +146,13 @@ class Database
      * @access public
      */
     function connect(
-        $database,
-        $username,
-        $password,
-        $host,
-        $trackChanges = true
-    ) : bool {
-
+        string $database,
+        string $username,
+        string $password,
+        string $host,
+        bool   $trackChanges = true
+    ) : bool 
+    {
         $this->_trackChanges = $trackChanges;
         $this->_databaseName = $database;
 
@@ -233,7 +236,7 @@ class Database
      * @return boolean
      * @access public
      */
-    function isConnected()
+    function isConnected(): bool
     {
         try {
             if (!$this->_PDO) {
@@ -257,9 +260,9 @@ class Database
      *
      * @return void
      */
-    public function insert($table, $set)
+    public function insert(string $table, array $set): void
     {
-        return $this->_realinsert($table, $set, true);
+        $this->_realinsert($table, $set, true);
     }
 
     /**
@@ -274,9 +277,9 @@ class Database
      *
      * @return void
      */
-    public function unsafeinsert($table, $set)
+    public function unsafeinsert(string $table, array $set): void
     {
-        return $this->_realinsert($table, $set, false);
+        $this->_realinsert($table, $set, false);
     }
 
     /**
@@ -290,10 +293,10 @@ class Database
      *
      * @return void
      */
-    public function insertIgnore($table, $set)
+    public function insertIgnore(string $table, array $set): void
     {
         $ignore = true;
-        return $this->_realinsert($table, $set, true, $ignore);
+        $this->_realinsert($table, $set, true, $ignore);
     }
 
     /**
@@ -310,7 +313,7 @@ class Database
      *
      * @return array A copy of $set with the HTML characters escaped
      */
-    private function _HTMLEscapeArray($set)
+    private function _HTMLEscapeArray(array $set): array
     {
         $retVal = array();
         foreach ($set as $key => $val) {
@@ -342,7 +345,12 @@ class Database
      *
      * @return void
      */
-    private function _realinsert($table, $set, $autoescape = true, $ignore = false)
+    private function _realinsert(
+        string $table,
+        array  $set,
+        bool   $autoescape = true,
+        bool   $ignore = false
+    ): void
     {
         if ($autoescape === true) {
             $set = $this->_HTMLEscapeArray($set);
@@ -391,7 +399,7 @@ class Database
      *
      * @return string ID of the last inserted row
      */
-    public function getLastInsertId()
+    public function getLastInsertId(): string
     {
         return $this->lastInsertID;
     }
@@ -408,7 +416,7 @@ class Database
      * @return void
      * @access public
      */
-    function replace($table, $set)
+    function replace(string $table, array $set): void
     {
         $query  = "REPLACE INTO $table SET ";
         $query .= $this->_implodeWithKeys(', ', $set);
@@ -442,9 +450,9 @@ class Database
      *
      * @return void
      */
-    public function update($table, $set, $i_where)
+    public function update(string $table, array $set, array $i_where): void
     {
-        return $this->_realupdate($table, $set, $i_where, true);
+        $this->_realupdate($table, $set, $i_where, true);
     }
 
     /**
@@ -460,9 +468,13 @@ class Database
      *
      * @return void
      */
-    public function unsafeupdate($table, $set, $i_where)
+    public function unsafeupdate(
+        string $table, 
+        array $set, 
+        array $i_where
+    ): void
     {
-        return $this->_realupdate($table, $set, $i_where, false);
+        $this->_realupdate($table, $set, $i_where, false);
     }
     /**
      * Updates a row
@@ -475,10 +487,16 @@ class Database
      * @param bool   $autoescape determines whether the values to be set should
      *                           automatically have the html escaped
      *
-     * @return void
+     * @return bool Always true. An exception should be thrown if something goes
+     *              wrong.
      * @access public
      */
-    private function _realupdate($table, $set, $i_where, $autoescape = true)
+    private function _realupdate(
+        string $table, 
+        array $set, 
+        string $i_where, 
+        bool $autoescape = true
+    ): bool
     {
         if ($autoescape === true) {
             $set = $this->_HTMLEscapeArray($set);
@@ -543,7 +561,7 @@ class Database
      * @return void
      * @access public
      */
-    function delete($table, $where)
+    function delete(string $table, array $where): void
     {
         $query  = "DELETE FROM $table WHERE ";
         $where  = $this->_implodeWithKeys(' AND ', $where);
@@ -587,7 +605,7 @@ class Database
      * @return void (As a side-effect updates affected and lastInsertID
      *              if applicable.)
      */
-    function run($query)
+    function run(string $query): void
     {
         $this->_printQuery($query);
         $result = $this->_PDO->exec($query);
@@ -634,7 +652,11 @@ class Database
      * @return array An array of rows in the format ColName => Value after
      *               executing the statement.
      */
-    function execute($prepared, $params, $options = array())
+    function execute(
+        object $prepared, 
+        array $params, 
+        array $options = array()
+    ): array
     {
         $execRun = $prepared->execute($params);
         if ($execRun === false) {
@@ -667,7 +689,7 @@ class Database
      *               row returned by the query, and each element is an associative
      *               array representing the row in the format ColumnName => Value
      */
-    function pselect($query, $params)
+    function pselect(string $query, array $params): array
     {
         $this->_printQuery($query, $params);
         $stmt   = $this->prepare($query);
@@ -697,7 +719,11 @@ class Database
      *                  nested array is an associative array representing the row in
      *                  the format ColumnName => Value
      */
-    function pselectWithIndexKey($query, $params, $uniqueKey)
+    function pselectWithIndexKey(
+        string $query, 
+        array $params, 
+        string $uniqueKey
+    ): array
     {
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
@@ -781,7 +807,7 @@ class Database
      * @return array Associative array of form rowID=>value containing all values
      *               for the only column of the select statement
      */
-    function pselectCol($query, $params)
+    function pselectCol(string $query, array $params): array
     {
         $unprocessed = $this->pselect($query, $params);
 
@@ -821,7 +847,11 @@ class Database
      * @return array Associative array of form uniqueKey=>value containing all
      *               value for the non-uniqueKey element of the select statement
      */
-    function pselectColWithIndexKey($query, $params, $uniqueKey)
+    function pselectColWithIndexKey(
+        string $query, 
+        array $params, 
+        string $uniqueKey
+    ): array
     {
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
@@ -885,9 +915,9 @@ class Database
      * @param string $query  The SQL statement to run
      * @param array  $params Values to use for binding in the prepared statement
      *
-     * @return mixed The value returned by the query.
+     * @return array The value returned by the query.
      */
-    function pselectOne($query, $params)
+    function pselectOne(string $query, array $params): array
     {
         $result = $this->pselectRow($query, $params);
         if (is_array($result) && count($result)) {
@@ -908,7 +938,7 @@ class Database
      *
      * @return string
      */
-    function _implodeWithKeys($glue, $dataArray)
+    function _implodeWithKeys(string $glue, array $dataArray): string 
     {
         $output = array();
         if (!is_array($dataArray) || count($dataArray)==0) {
@@ -942,8 +972,12 @@ class Database
      *                appropriate variable names generated for data binding.
      */
     private function _implodeAsPrepared(
-        $glue, $dataArray, &$exec_vals = null, $prefix=''
-    ) {
+        string $glue, 
+        array $dataArray, 
+        array &$exec_vals = null, 
+        string $prefix = ''
+    ): string
+    {
         if (!is_array($dataArray) || count($dataArray)==0) {
             return '';
         }
@@ -967,7 +1001,7 @@ class Database
      *
      * @return string The value appropriately quoted/escaped
      */
-    function quote($value)
+    function quote(string $value): string
     {
         return $this->_PDO->quote($value);
     }
@@ -986,7 +1020,12 @@ class Database
      *
      * @return void As a side-effect populates history table
      */
-    protected function trackChanges($table, $set, $where, $type='U')
+    protected function trackChanges(
+        string $table, 
+        array $set, 
+        string $where, 
+        string $type = 'U'
+    ): void
     {
         // Tracking changes on the history table would result in an
         // infinite loop
@@ -1104,10 +1143,10 @@ class Database
      *                       They will be replaced in the print statement so that the
      *                       user knows what parameters were used.
      *
-     * @return null As a side-effect, prints to the screen if config option is
+     * @return void As a side-effect, prints to the screen if config option is
      *              enabled
      */
-    function _printQuery($query, $params=null)
+    function _printQuery(string $query, array $params = array()): void
     {
         if (!$this->_showQueries) {
             return;
@@ -1125,7 +1164,7 @@ class Database
      *
      * @return integer The number of rows affected
      */
-    function getAffected()
+    function getAffected(): int
     {
         return $this->affected;
     }
@@ -1145,7 +1184,7 @@ class Database
      *
      * @return void
      */
-    function setFakeTableData($tableName, $rowData)
+    function setFakeTableData(string $tableName, array $rowData): void
     {
         $originalTableQuery = $this->_PDO->query("SHOW CREATE TABLE $tableName");
 
@@ -1188,7 +1227,7 @@ class Database
      *
      * @return boolean true if the table exists
      */
-    function tableExists($test_name)
+    function tableExists(string $test_name): bool
     {
         $config   =& NDB_Config::singleton();
         $database = $config->getSetting('database');
@@ -1219,7 +1258,7 @@ class Database
      *
      * @return boolean true if the table has a the given column
      */
-    function columnExists($test_name,$column)
+    function columnExists(string $test_name, string $column): bool
     {
         $config   =& NDB_Config::singleton();
         $database = $config->getSetting('database');
@@ -1250,7 +1289,7 @@ class Database
      *
      * @return string surrounded by backticks and with special characters escaped.
      */
-    function escape($tableName)
+    function escape(string $tableName): string
     {
         //with help from
         // http://php.net/manual/en/function.mysql-real-escape-string.php
@@ -1291,7 +1330,7 @@ class Database
      * @return bool `true`, if in transaction
      * @throws DatabaseException
      */
-    public function inTransaction()
+    public function inTransaction(): bool
     {
         return $this->_PDO->inTransaction();
     }
@@ -1302,7 +1341,7 @@ class Database
      * @return bool `true`, on success
      * @throws DatabaseException
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         if ($this->inTransaction()) {
             throw new DatabaseException(
@@ -1326,7 +1365,7 @@ class Database
      * @return bool `true`, on success
      * @throws DatabaseException
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         if (!$this->inTransaction()) {
             throw new DatabaseException(
@@ -1348,7 +1387,7 @@ class Database
      * @return bool `true`, on success
      * @throws DatabaseException
      */
-    public function commit()
+    public function commit(): bool
     {
         if (!$this->inTransaction()) {
             throw new DatabaseException(

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -73,12 +73,12 @@ class Database
      * NOTE There is no return type declaration for this function as it returns
      * the type `Database` which is not supported by PHPs built in return types.
      *
-     * @param string|null  $database     the database to select
-     * @param string|null  $username     the username with which to log into
-     *                              the database server
-     * @param string|null  $password     the password that matches the username
-     * @param string|null  $host         the name of the database server
-     * @param boolean $trackChanges boolean determining if changes should be
+     * @param string|null $database     the database to select
+     * @param string|null $username     the username with which to log into
+     *                                      the database server
+     * @param string|null $password     the password that matches the username
+     * @param string|null $host         the name of the database server
+     * @param boolean     $trackChanges boolean determining if changes should be
      *                              logged to the history table
      *
      * @return object Database
@@ -968,16 +968,19 @@ class Database
      * Helper function to generate the string for the WHERE part of an update
      * or delete query. Generates the string in a prepared statement format.
      *
-     * @param string $glue      The glue used to combine parts of the dataArray
-     *                          (ie " AND ")
-     * @param array  $dataArray The array representing the WHERE condition to be
-     *                          glued together into a string
-     * @param array|null  $exec_vals The values which are being bound to the query. Used
-     *                          to generate the prepared variable name.
-     * @param string $prefix    A prefix to apply to prepared variable names.
+     * @param string     $glue      The glue used to combine parts of the
+     *                          dataArray (ie " AND ")
+     * @param array      $dataArray The array representing the WHERE condition
+     *                          to be glued together into a string
+     * @param array|null $exec_vals The values which are being bound to the
+     *                          query. Used to generate the prepared variable
+     *                          name.
+     * @param string     $prefix    A prefix to apply to prepared variable
+     *                          names.
      *
-     * @return string A string that can be used to generate a prepared statement with
-     *                appropriate variable names generated for data binding.
+     * @return string A string that can be used to generate a prepared statement
+     *                with appropriate variable names generated for data
+     *                binding.
      */
     private function _implodeAsPrepared(
         string $glue,

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -653,7 +653,7 @@ class Database
      *               executing the statement.
      */
     function execute(
-        object $prepared,
+        $prepared,
         array $params,
         array $options = array()
     ): array {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -89,8 +89,8 @@ class Database
         string $password     = null,
         string $host         = null,
         bool   $trackChanges = true
-    ): object 
-    {
+    ): object {
+
         static $connections = array();
 
         // if no arguments, try to get the first connection or choke
@@ -151,8 +151,8 @@ class Database
         string $password,
         string $host,
         bool   $trackChanges = true
-    ) : bool 
-    {
+    ) : bool {
+
         $this->_trackChanges = $trackChanges;
         $this->_databaseName = $database;
 
@@ -350,8 +350,8 @@ class Database
         array  $set,
         bool   $autoescape = true,
         bool   $ignore = false
-    ): void
-    {
+    ): void {
+
         if ($autoescape === true) {
             $set = $this->_HTMLEscapeArray($set);
         }
@@ -469,11 +469,11 @@ class Database
      * @return void
      */
     public function unsafeupdate(
-        string $table, 
-        array $set, 
+        string $table,
+        array $set,
         array $i_where
-    ): void
-    {
+    ): void {
+
         $this->_realupdate($table, $set, $i_where, false);
     }
     /**
@@ -492,12 +492,12 @@ class Database
      * @access public
      */
     private function _realupdate(
-        string $table, 
-        array $set, 
-        string $i_where, 
+        string $table,
+        array $set,
+        string $i_where,
         bool $autoescape = true
-    ): bool
-    {
+    ): bool {
+
         if ($autoescape === true) {
             $set = $this->_HTMLEscapeArray($set);
         }
@@ -653,11 +653,11 @@ class Database
      *               executing the statement.
      */
     function execute(
-        object $prepared, 
-        array $params, 
+        object $prepared,
+        array $params,
         array $options = array()
-    ): array
-    {
+    ): array {
+
         $execRun = $prepared->execute($params);
         if ($execRun === false) {
             $err = $prepared->errorInfo();
@@ -720,11 +720,11 @@ class Database
      *                  the format ColumnName => Value
      */
     function pselectWithIndexKey(
-        string $query, 
-        array $params, 
+        string $query,
+        array $params,
         string $uniqueKey
-    ): array
-    {
+    ): array {
+
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
                 "The pselectWithIndexKey() function expects the uniqueKey parameter 
@@ -848,11 +848,11 @@ class Database
      *               value for the non-uniqueKey element of the select statement
      */
     function pselectColWithIndexKey(
-        string $query, 
-        array $params, 
+        string $query,
+        array $params,
         string $uniqueKey
-    ): array
-    {
+    ): array {
+
         if (is_null($uniqueKey) || empty($uniqueKey)) {
             throw new LorisException(
                 "The pselectColWithIndexKey() function expects the uniqueKey
@@ -938,7 +938,7 @@ class Database
      *
      * @return string
      */
-    function _implodeWithKeys(string $glue, array $dataArray): string 
+    function _implodeWithKeys(string $glue, array $dataArray): string
     {
         $output = array();
         if (!is_array($dataArray) || count($dataArray)==0) {
@@ -972,12 +972,12 @@ class Database
      *                appropriate variable names generated for data binding.
      */
     private function _implodeAsPrepared(
-        string $glue, 
-        array $dataArray, 
-        array &$exec_vals = null, 
+        string $glue,
+        array $dataArray,
+        array &$exec_vals = null,
         string $prefix = ''
-    ): string
-    {
+    ): string {
+
         if (!is_array($dataArray) || count($dataArray)==0) {
             return '';
         }
@@ -1021,12 +1021,12 @@ class Database
      * @return void As a side-effect populates history table
      */
     protected function trackChanges(
-        string $table, 
-        array $set, 
-        string $where, 
+        string $table,
+        array $set,
+        string $where,
         string $type = 'U'
-    ): void
-    {
+    ): void {
+
         // Tracking changes on the history table would result in an
         // infinite loop
         if (!$this->_trackChanges || $table == 'history') {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -981,7 +981,7 @@ class Database
     private function _implodeAsPrepared(
         string $glue,
         array $dataArray,
-        array &$exec_vals = null,
+        ?array &$exec_vals = null,
         string $prefix = ''
     ): string {
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -10,9 +10,9 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-define("DEBUG", false);
 // Require strict typing
 declare(strict_types=1);
+define("DEBUG", false);
 
 /**
  * Database abstraction layer presents a unified interface to database

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -19,7 +19,12 @@ class FakePDO extends PDO
 }
 
 class FakeDatabase extends Database {
-    protected function trackChanges($table, $set, $where, $type='U') {
+    protected function trackChanges(
+        string $table, 
+        array $set, 
+        string $where, 
+        string $type='U'
+    ):void {
     }
 }
 


### PR DESCRIPTION
### Brief summary of changes

Type declarations and return type declarations are added to all function signatures in the Database class. This follows a discussion about moving toward the universal use of PHP's typing features to prevent notices, warnings, and other nasty behaviour resulting from type coercion. 

I tried not to alter any functionality by following the return types already listed in the PHP Docs for each function:
* In some cases where the documentation conflicted with the actual return type, the documentation was amended and the functionality preserved. 
* Functions that were documented as returning void but had a return statement were changed to not return anything.
* ~~Default values were largely left as is even in cases where another might arguably be better (e.g. Strings set to `null` instead of the empty string)~~ 
    * This has been changed based on feedback by @driusan .

### Further work to be done

Some of the functions were not given return types (notably all `pselect*` functions) because they return mixed types. We need to refactor these functions to behave consistently.


### This resolves issue...

Nothing concrete but many potential issues arising from PHP's type coercion.

**Related PRs:** 
_A check means it's merged_
- [x] [[Core: Database] Add exception on fetchAll failure case ](https://github.com/aces/Loris/pull/3880)
- [x] [[Data Team Helper] Ensure test_name is always a string](#3909)
- [x] [[Core: Database] Add type check to HTMLEscapeArray](#3947)
- [x] [[Statistics] Change pselect calls to pass array()s, not null ](https://github.com/aces/Loris/pull/4003)
- [x] [[Statistics] Change *more* pselect calls to pass array()s, not null ](https://github.com/aces/Loris/pull/4009)
### To test this change...

**Important** if you get an error about a return type like `...must be an instance of void, none returned`, that means the version of PHP being used by your Apache is older than PHP 7.1. As of the last release we require >= 7.2 so be sure to correct this.

- [ ] The Database class should work as before. If it doesn't, it has been used improperly and the calling classes should be modified to use it as documented.

