### PR TITLE
[Core: Database] Add exception on fetchAll failure case

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -635,10 +635,10 @@ class Database
         }
 
         $rows = $prepared->fetchAll(PDO::FETCH_ASSOC);
-        // The fetchAll function will return an empty set if no results are 
+        // The fetchAll function will return an empty set if no results are
         // found and FALSE on "failure". We don't expect this case so an
         // exception is thrown.
-        if ($rows === false) {
+        if (is_bool($rows)) {
             $err = $prepared->errorInfo();
             throw new DatabaseException($err[2], $prepared->queryString, $params);
         }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -635,6 +635,13 @@ class Database
         }
 
         $rows = $prepared->fetchAll(PDO::FETCH_ASSOC);
+        // The fetchAll function will return an empty set if no results are 
+        // found and FALSE on "failure". We don't expect this case so an
+        // exception is thrown.
+        if ($rows === false) {
+            $err = $prepared->errorInfo();
+            throw new DatabaseException($err[2], $prepared->queryString, $params);
+        }
         return $rows;
     }
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -638,7 +638,7 @@ class Database
         // The fetchAll function will return an empty set if no results are
         // found and FALSE on "failure". We don't expect this case so an
         // exception is thrown.
-        if (is_bool($rows)) {
+        if (is_bool($rows) && $rows === false) {
             $err = $prepared->errorInfo();
             throw new DatabaseException($err[2], $prepared->queryString, $params);
         }


### PR DESCRIPTION
### Brief summary of changes

In an effort to take advantage of PHP's type system, we should add type declarations to our code, especially in the core classes.

The [PDO documentation](https://secure.php.net/manual/en/pdostatement.fetchall.php) says that `fetchAll` returns the empty set when no data in the DB matches a given query and FALSE on failure. However we do not distinguish this in our codebase and so a FALSE value is allowed to bubble up through subsequent DB calls.

This makes it so that these functions must sometimes return the Bool type (in addition to String, Array, and Null) meaning we cannot use return type declarations.

Following a discussion in #3854, this PR adds an exception when the `fetchAll` class fails. This will allow us to remove Bool as one of the return types. 

This is likely to break some things (I found it by debugging a failing test in #3878) so it is issued to `major`.

### Related issues

- https://github.com/aces/Loris/pull/3854
- https://github.com/aces/Loris/pull/3878

