### PR TITLE
Making lookupCenterNameUsing configuration field a drop down

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -17,7 +17,7 @@ CREATE TABLE `ConfigSettings` (
     `Description` varchar(255) DEFAULT NULL,
     `Visible` tinyint(1) DEFAULT '0',
     `AllowMultiple` tinyint(1) DEFAULT '0',
-    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type') DEFAULT NULL,
+    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type', 'lookup_center') DEFAULT NULL,
     `Parent` int(11) DEFAULT NULL,
     `Label` varchar(255) DEFAULT NULL,
     `OrderNumber` int(11) DEFAULT NULL,
@@ -142,7 +142,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'create_nii', 'Enable creation of NIfTI files', 1, 0, 'boolean', ID, 'NIfTI file creation', 6 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'converter', 'If converter is set to dcm2mnc, the c-version of dcm2mnc will be used. If however you want to use any of the various versions of the converter, you will have to specify what it is called and the uploader will try to invoke it', 1, 0, 'text', ID, 'dcm2mnc binary to use when converting', 7 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'tarchiveLibraryDir', 'Location of storing the library of used tarchives. If this is not set, they will not be moved', 1, 0, 'text', ID, 'Path to Tarchives', 8 FROM ConfigSettings WHERE Name="imaging_pipeline";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'lookupCenterNameUsing', 'DICOM field (either PatientName or PatientID) to use to get the patient identifiers and the center name of the DICOM study', 1, 0, 'text', ID, 'Patient identifiers and center name lookup variable', 9 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'lookupCenterNameUsing', 'DICOM field (either PatientName or PatientID) to use to get the patient identifiers and the center name of the DICOM study', 1, 0, 'lookup_center', ID, 'Patient identifiers and center name lookup variable', 9 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'createCandidates', 'Enable candidate creation in the imaging pipeline', 1, 0, 'boolean', ID, 'Upload creation of candidates', 10 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'is_qsub', 'Enable use of batch management in the imaging pipeline', 1, 0, 'boolean', ID, 'Project batch management used', 11 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'DTI_volumes', 'Number of volumes in native DTI acquisitions', 1, 0, 'text', ID, 'Number of volumes in native DTI acquisitions', 13 FROM ConfigSettings WHERE Name="imaging_pipeline";

--- a/SQL/New_patches/2018-08-16_make_config_lookup_center_a_drop_down.sql
+++ b/SQL/New_patches/2018-08-16_make_config_lookup_center_a_drop_down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ConfigSettings
+  MODIFY COLUMN DataType ENUM('text','boolean','email','instrument','textarea','scan_type', 'lookup_center');
+
+UPDATE ConfigSettings
+  SET DataType='lookup_center'
+  WHERE Name='lookUpCenterNameUsing';

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -73,8 +73,8 @@ class Configuration extends \NDB_Form
         $this->tpl_data['lookup_center']   = array(
                                               ''            => '',
                                               'PatientID'   => 'PatientID',
-                                              'PatientName' => 'PatientName'
-                                            );
+                                              'PatientName' => 'PatientName',
+                                             );
     }
 
     /**

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -71,10 +71,10 @@ class Configuration extends \NDB_Form
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
         $this->tpl_data['scan_types']      = $scan_types;
         $this->tpl_data['lookup_center']   = array(
-            ''            => '',
-            'PatientID'   => 'PatientID',
-            'PatientName' => 'PatientName'
-        );
+                                              ''            => '',
+                                              'PatientID'   => 'PatientID',
+                                              'PatientName' => 'PatientName'
+                                            );
     }
 
     /**

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -70,7 +70,11 @@ class Configuration extends \NDB_Form
         $this->tpl_data['instruments']     = $instruments;
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
         $this->tpl_data['scan_types']      = $scan_types;
-
+        $this->tpl_data['lookup_center']   = array(
+            ''            => '',
+            'PatientID'   => 'PatientID',
+            'PatientName' => 'PatientName'
+        );
     }
 
     /**

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -32,6 +32,14 @@
     </select>
 {/function}
 
+{function name=createLookUpCenterNameUsing}
+    <select class="form-control" name="{$k}" {if $d eq "Yes"}disabled{/if}>
+        {foreach from=$lookup_center key=name item=label}
+            <option {if $v eq $name}selected{/if} value="{$name}">{$label}</option>
+        {/foreach}
+    </select>
+{/function}
+
 {function name=createEmail}
     <input class="form-control" type="email" name="{$k}" value="{$v}" {if $d eq "Yes"}disabled{/if}>
 {/function}
@@ -80,6 +88,8 @@
             {call createEmail k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
             {call createTextArea k=$k v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'lookup_center'}
+            {call createLookUpCenterNameUsing k=$k v=$v d=$node['Disabled']}
         {else}
             {call createText k=$k v=$v d=$node['Disabled']}
         {/if}
@@ -102,6 +112,8 @@
             {call createEmail k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
             {call createTextArea k=$id d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'lookup_center'}
+            {call createLookUpCenterNameUsing k=$id d=$node['Disabled']}
         {else}
             {call createText k=$id d=$node['Disabled']}
         {/if}


### PR DESCRIPTION
This pull request is making the 'lookupCenterNameUsing' configuration under the 'Imaging Pipeline section" of the config module a drop down instead of an open text field. The options of the drop down: PatientID, PatientName
<img width="1120" alt="screen shot 2018-08-16 at 5 08 12 pm" src="https://user-images.githubusercontent.com/1402456/44235297-fe550e00-a176-11e8-9b87-01b3fc5fea7b.png">

## How to test this PR:

1. check that this field is indeed an open text field on minor
2. pull the code, run the SQL patch and check that the field is now a drop down
3. make sure the saving is working properly and saving the proper value

See also: Redmine ticket https://redmine.cbrain.mcgill.ca/issues/15104
