### PR TITLE
[Instruments] Add ability to load instrument JSON data from flag Data column.

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -17,7 +17,7 @@ CREATE TABLE `ConfigSettings` (
     `Description` varchar(255) DEFAULT NULL,
     `Visible` tinyint(1) DEFAULT '0',
     `AllowMultiple` tinyint(1) DEFAULT '0',
-    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type') DEFAULT NULL,
+    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type', 'lookup_center') DEFAULT NULL,
     `Parent` int(11) DEFAULT NULL,
     `Label` varchar(255) DEFAULT NULL,
     `OrderNumber` int(11) DEFAULT NULL,
@@ -142,7 +142,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'create_nii', 'Enable creation of NIfTI files', 1, 0, 'boolean', ID, 'NIfTI file creation', 6 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'converter', 'If converter is set to dcm2mnc, the c-version of dcm2mnc will be used. If however you want to use any of the various versions of the converter, you will have to specify what it is called and the uploader will try to invoke it', 1, 0, 'text', ID, 'dcm2mnc binary to use when converting', 7 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'tarchiveLibraryDir', 'Location of storing the library of used tarchives. If this is not set, they will not be moved', 1, 0, 'text', ID, 'Path to Tarchives', 8 FROM ConfigSettings WHERE Name="imaging_pipeline";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'lookupCenterNameUsing', 'DICOM field (either PatientName or PatientID) to use to get the patient identifiers and the center name of the DICOM study', 1, 0, 'text', ID, 'Patient identifiers and center name lookup variable', 9 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'lookupCenterNameUsing', 'DICOM field (either PatientName or PatientID) to use to get the patient identifiers and the center name of the DICOM study', 1, 0, 'lookup_center', ID, 'Patient identifiers and center name lookup variable', 9 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'createCandidates', 'Enable candidate creation in the imaging pipeline', 1, 0, 'boolean', ID, 'Upload creation of candidates', 10 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'is_qsub', 'Enable use of batch management in the imaging pipeline', 1, 0, 'boolean', ID, 'Project batch management used', 11 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'DTI_volumes', 'Number of volumes in native DTI acquisitions', 1, 0, 'text', ID, 'Number of volumes in native DTI acquisitions', 13 FROM ConfigSettings WHERE Name="imaging_pipeline";

--- a/SQL/New_patches/2018-08-16_make_config_lookup_center_a_drop_down.sql
+++ b/SQL/New_patches/2018-08-16_make_config_lookup_center_a_drop_down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ConfigSettings
+  MODIFY COLUMN DataType ENUM('text','boolean','email','instrument','textarea','scan_type', 'lookup_center');
+
+UPDATE ConfigSettings
+  SET DataType='lookup_center'
+  WHERE Name='lookUpCenterNameUsing';

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -70,7 +70,11 @@ class Configuration extends \NDB_Form
         $this->tpl_data['instruments']     = $instruments;
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
         $this->tpl_data['scan_types']      = $scan_types;
-
+        $this->tpl_data['lookup_center']   = array(
+                                              ''            => '',
+                                              'PatientID'   => 'PatientID',
+                                              'PatientName' => 'PatientName',
+                                             );
     }
 
     /**

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -32,6 +32,14 @@
     </select>
 {/function}
 
+{function name=createLookUpCenterNameUsing}
+    <select class="form-control" name="{$k}" {if $d eq "Yes"}disabled{/if}>
+        {foreach from=$lookup_center key=name item=label}
+            <option {if $v eq $name}selected{/if} value="{$name}">{$label}</option>
+        {/foreach}
+    </select>
+{/function}
+
 {function name=createEmail}
     <input class="form-control" type="email" name="{$k}" value="{$v}" {if $d eq "Yes"}disabled{/if}>
 {/function}
@@ -80,6 +88,8 @@
             {call createEmail k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
             {call createTextArea k=$k v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'lookup_center'}
+            {call createLookUpCenterNameUsing k=$k v=$v d=$node['Disabled']}
         {else}
             {call createText k=$k v=$v d=$node['Disabled']}
         {/if}
@@ -102,6 +112,8 @@
             {call createEmail k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
             {call createTextArea k=$id d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'lookup_center'}
+            {call createLookUpCenterNameUsing k=$id d=$node['Disabled']}
         {else}
             {call createText k=$id d=$node['Disabled']}
         {/if}

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -87,7 +87,7 @@ class HelpFile
         $DB =& \Database::singleton();
 
         // insert a help file
-        $success = $DB->unsafeinsert('help', $set);
+        $success = $DB->insert('help', $set);
         // return the help ID
         return $DB->lastInsertID;
     }
@@ -106,7 +106,7 @@ class HelpFile
         $DB =& \Database::singleton();
 
         // update the help file
-        $success = $DB->unsafeupdate('help', $set, array('helpID' => $this->helpID));
+        $success = $DB->update('help', $set, array('helpID' => $this->helpID));
 
         return true;
     }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1445,13 +1445,11 @@ class NDB_BVL_Instrument extends NDB_Page
             return 'Complete';
         }
 
-        $db =& Database::singleton();
-
         $allData = $this->loadInstanceData($this);
         foreach ($this->_requiredElements as $field) {
             // this shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
-            if (is_null($field) || $field === "") {
+            if (is_null($allData[$field]) || $allData[$field] === "") {
                 return 'Incomplete';
             }
         }
@@ -1948,7 +1946,6 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function _nullScores($scoreCols)
     {
-        $db   = Database::singleton();
         $data = $this->loadInstanceData($this);
 
         // set the scoring cols to NULL

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -416,9 +416,6 @@ class NDB_BVL_Instrument extends NDB_Page
             $this->addGroup($buttons, null, null, "&nbsp;");
         }
 
-        // get saved data to pre-populate form
-        $db = Database::singleton();
-
         $defaults = $this->loadInstanceData($this);
 
         // set the defaults (call private method _setDefaultsArray

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -26,6 +26,13 @@ class NDB_BVL_Instrument extends NDB_Page
 {
 
     /**
+     * Determines whether this instrument should load data in
+     * JSON format from the "Data" column of the flag table, or
+     * from the traditional SQL tables.
+     */
+    protected $jsonData = false;
+
+    /**
      * HTML_Quickform object
      *
      * @access private
@@ -412,13 +419,11 @@ class NDB_BVL_Instrument extends NDB_Page
         // get saved data to pre-populate form
         $db = Database::singleton();
 
-        $defaults = $db->pselect(
-            "SELECT * FROM $this->table WHERE CommentID=:CID",
-            array('CID' => $this->getCommentID())
-        );
+        $defaults = $this->loadInstanceData($this);
+
         // set the defaults (call private method _setDefaultsArray
         // which could be overridden if necessary)
-        $defaults = $this->_setDefaultsArray($defaults[0]);
+        $defaults = $this->_setDefaultsArray($defaults);
 
         // merge in the localDefaults property so that simple
         // additions to the defaults array no longer requires
@@ -741,6 +746,8 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function _save($values)
     {
+        $db = Database::singleton();
+
         // clear any fields starting with __
         foreach (array_keys($values) AS $key) {
             if (strpos($key, '__') === 0) {
@@ -748,12 +755,16 @@ class NDB_BVL_Instrument extends NDB_Page
             }
             $values = Utility::nullifyEmpty($values, $key);
         }
-        $db     =& Database::singleton();
-        $result = $db->update(
-            $this->table,
-            $values,
-            array('CommentID' => $this->getCommentID())
-        );
+
+        if ($this->jsonData !== true) {
+            // If the instrument is saving as JSON into the Data column, the
+            // table may not exist, so don't try and update it.
+            $result = $db->update(
+                $this->table,
+                $values,
+                array('CommentID' => $this->getCommentID())
+            );
+        }
 
         // Extract the old data and merge it with what was submitted so that we
         // don't overwrite data from other pages.
@@ -1439,20 +1450,15 @@ class NDB_BVL_Instrument extends NDB_Page
 
         $db =& Database::singleton();
 
-        $query = "SELECT " . join(',', $this->_requiredElements)
-            . " FROM $this->table WHERE CommentID=:CID";
-
-        $dataFields = $db->pselectRow(
-            $query,
-            array('CID' => $this->getCommentID())
-        );
-        foreach ($dataFields as $field) {
+        $allData = $this->loadInstanceData($this);
+        foreach ($this->_requiredElements as $field) {
             // this shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
             if (is_null($field) || $field === "") {
                 return 'Incomplete';
             }
         }
+
         return 'Complete';
     }
 
@@ -1492,11 +1498,15 @@ class NDB_BVL_Instrument extends NDB_Page
 
         $db =& Database::singleton();
 
-        $db->update(
-            $this->table,
-            array('Data_entry_completion_status' => $status),
-            array('CommentID' => $this->getCommentID())
-        );
+        if ($this->jsonData !== true) {
+            // FIXME: Is this even required at all? If it is, we need to
+            // handle it in the JSON data case too.
+            $db->update(
+                $this->table,
+                array('Data_entry_completion_status' => $status),
+                array('CommentID' => $this->getCommentID())
+            );
+        }
     }
 
     /**
@@ -1941,7 +1951,8 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     function _nullScores($scoreCols)
     {
-        $db =& Database::singleton();
+        $db   = Database::singleton();
+        $data = $this->loadInstanceData($this);
 
         // set the scoring cols to NULL
         foreach ($scoreCols as $key => $val) {
@@ -1950,20 +1961,14 @@ class NDB_BVL_Instrument extends NDB_Page
             // use a non-associative array. So if the key is numeric,
             // and we need to make sure we use the column name
             if (is_numeric($key)) {
-                $scores[$val] = null; //null array
+                $data[$val] = null; //null array
             } else {
-                $scores[$key] = null;
+                $data[$key] = null;
             }
 
         }
 
-        // update the scores
-        $db->update(
-            $this->table,
-            $scores,
-            array('CommentID' => $this->getCommentID())
-        );
-
+        $this->_save($data);
         return;
     }
 
@@ -2022,12 +2027,21 @@ class NDB_BVL_Instrument extends NDB_Page
      */
     static function loadInstanceData($instrumentInstance)
     {
-        $db       =& Database::singleton();
-        $defaults = $db->pselect(
-            "SELECT * FROM $instrumentInstance->table WHERE CommentID=:CID",
-            array('CID' => $instrumentInstance->getCommentID())
-        );
-        return $defaults[0];
+        $db = Database::singleton();
+
+        if ($instrumentInstance->jsonData) {
+            $jsondata = $db->pselectOne(
+                "SELECT Data FROM flag WHERE CommentID=:CID",
+                array('CID' => $instrumentInstance->getCommentID())
+            );
+            return json_decode($jsondata, true);
+        } else {
+            $defaults = $db->pselect(
+                "SELECT * FROM $instrumentInstance->table WHERE CommentID=:CID",
+                array('CID' => $instrumentInstance->getCommentID())
+            );
+            return $defaults[0];
+        }
     }
 
     /**
@@ -2081,8 +2095,7 @@ class NDB_BVL_Instrument extends NDB_Page
         $CommentID = $this->getCommentID();
 
         $pscid = $db->pselectOne(
-            "SELECT c.PSCID FROM $this->testName i
-            JOIN flag f USING (CommentID)
+            "SELECT c.PSCID FROM flag f
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
             WHERE f.CommentID=:CID",


### PR DESCRIPTION
LORIS previously saved instrument data to a "Data" column
in the flag table as a test, this change gives users the
option to experiment with using it. Loading data from the
Data column means that the instrument SQL tables are no
longer required, but should be considered experimental and
not ready for production.

To test this: set the "$jsonData" variable in an instrument
to true, and try saving and loading and generally using the
instrument. There should be no noticeable difference. If
you're feeling lucky, drop the existing table and continue
trying to save and load data from the instrument.

Note that it might be easier to use a new instrument, since
scoring functions in PHP instruments are often intertwined
with database access.
