### PR TITLE
[phan/dashboard/media] Fix function redeclaration errors

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -39,8 +39,7 @@ return [
 		"PhanNonClassMethodCall",
 		"PhanTypeVoidAssignment",
 		"PhanTypeArraySuspicious",
-		"PhanRedefineFunctionInternal",
-		"PhanRedefineFunction",
+        "PhanRedefineFunctionInternal",
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [

--- a/modules/dashboard/ajax/get_scan_line_data.php
+++ b/modules/dashboard/ajax/get_scan_line_data.php
@@ -35,7 +35,7 @@ $scanEndDate        = $DB->pselectOne(
     array()
 );
 $scanData['labels']
-    = createChartLabels($scanStartDate, $scanEndDate);
+    = createLineChartLabels($scanStartDate, $scanEndDate);
 $list_of_sites      = Utility::getAssociativeSiteList(true, false);
 foreach ($list_of_sites as $siteID => $siteName) {
     $scanData['datasets'][] = array(
@@ -56,7 +56,7 @@ return 0;
  *
  * @return array
  */
-function createChartLabels($startDate, $endDate)
+function createLineChartLabels($startDate, $endDate)
 {
     $startDateYear  = substr($startDate, 0, 4);
     $endDateYear    = substr($endDate, 0, 4);

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -46,7 +46,7 @@ function editFile()
     $idMediaFile = $req['idMediaFile'];
 
     if (!$idMediaFile) {
-        showError("Error! Invalid media file ID!");
+        showMediaError("Error! Invalid media file ID!");
     }
 
     $updateValues = [
@@ -58,7 +58,7 @@ function editFile()
     try {
         $db->update('media', $updateValues, ['id' => $idMediaFile]);
     } catch (DatabaseException $e) {
-        showError("Could not update the file. Please try again!");
+        showMediaError("Could not update the file. Please try again!");
     }
 
 }
@@ -90,12 +90,12 @@ function uploadFile()
     $mediaPath = $config->getSetting('mediaPath');
 
     if (!isset($mediaPath)) {
-        showError("Error! Media path is not set in Loris Settings!");
+        showMediaError("Error! Media path is not set in Loris Settings!");
         exit;
     }
 
     if (!file_exists($mediaPath)) {
-        showError("Error! The upload folder '$mediaPath' does not exist!");
+        showMediaError("Error! The upload folder '$mediaPath' does not exist!");
         exit;
     }
 
@@ -110,7 +110,7 @@ function uploadFile()
 
     // If required fields are not set, show an error
     if (!isset($_FILES) || !isset($pscid) || !isset($visit) || !isset($site)) {
-        showError("Please fill in all required fields!");
+        showMediaError("Please fill in all required fields!");
         return;
     }
     $fileName  = preg_replace('/\s/', '_', $_FILES["file"]["name"]);
@@ -118,7 +118,7 @@ function uploadFile()
     $extension = pathinfo($fileName)['extension'];
 
     if (!isset($extension)) {
-        showError("Please make sure your file has a valid extension!");
+        showMediaError("Please make sure your file has a valid extension!");
         return;
     }
 
@@ -136,7 +136,7 @@ function uploadFile()
     );
 
     if (!isset($sessionID) || count($sessionID) < 1) {
-        showError(
+        showMediaError(
             "Error! A session does not exist for candidate '$pscid'' " .
             "and visit label '$visit'."
         );
@@ -171,10 +171,10 @@ function uploadFile()
             }
             $uploadNotifier->notify(array("file" => $fileName));
         } catch (DatabaseException $e) {
-            showError("Could not upload the file. Please try again!");
+            showMediaError("Could not upload the file. Please try again!");
         }
     } else {
-        showError("Could not upload the file. Please try again!");
+        showMediaError("Could not upload the file. Please try again!");
     }
 }
 
@@ -338,7 +338,7 @@ function getUploadFields()
  *
  * @return void
  */
-function showError($message)
+function showMediaError($message)
 {
     if (!isset($message)) {
         $message = 'An unknown error occurred!';


### PR DESCRIPTION
This fixes the phan errors about function redeclarations.

These are mostly harmless and caused by different ajax endpoints
using the same function names with no namespacing, but it's better
to ensure we don't accidentally redeclare autoloaded functions in
a more dangerous context in the future.