### PR TITLE
[Core: Login, User Accounts] Allow certain users to access the system in a time window basis

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -228,6 +228,8 @@ CREATE TABLE `users` (
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   `language_preference` integer unsigned default NULL,
+  `active_from` date default NULL,
+  `active_to` date default NULL,
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Email` (`Email`),
   UNIQUE KEY `UserID` (`UserID`),

--- a/SQL/New_patches/2018-08-22_user_activeFrom-activeTo.sql
+++ b/SQL/New_patches/2018-08-22_user_activeFrom-activeTo.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users 
+	ADD COLUMN active_from DATE 
+	AFTER language_preference;
+
+ALTER TABLE users 
+	ADD COLUMN active_to DATE 
+	AFTER active_from;
+
+

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -783,6 +783,33 @@ class Edit_User extends \NDB_Form
 
         //------------------------------------------------------------
 
+	// active time windows
+	$this->addSelect('ActiveTW','Active Time Windows', array('Y' => 'YesTW', 'N' => 'NoTW'));
+
+	$dateOptions = array(
+				'language'	=>	'en',
+				'format'	=>	'YMd',
+				'addEmptyOption' =>	'true'
+			);
+
+	$dateAttributes = ['class' => 'form-control input-sm input-date'];
+
+
+	$this->addBasicDate(
+				'active_from',
+				'Active from',
+				$dateOptions,
+				$dateAttributes
+			);
+
+
+	$this->addBasicDate(
+				'active_to',
+				'Active to',
+				$dateOptions,
+				$dateAttributes
+			);
+
         // checking if the account can be rejected (no password hash
         // pending approval)
 
@@ -1086,6 +1113,18 @@ class Edit_User extends \NDB_Form
                 'Radiologist' and 'Pending Approval').";
             }
         }
+
+        //======================================
+	//	Validate Active time Windows (from - to)
+	//
+	//	Note: the only validation included for the moment
+	//	is that the time form which the user is active 
+	//	should be less or equal to the time to it will be active. 
+        //======================================
+
+	if(($values['active_to'] != NULL) && ($values['active_from'] > $values['active_to'])){
+		$errors['active_timeWindows'] = "Please notice that the <i>\"Active from\"</i> date should be lesser or equal to the <i>\"Active to\"</i> date.";
+	}
         return $errors;
     }
 

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -783,32 +783,29 @@ class Edit_User extends \NDB_Form
 
         //------------------------------------------------------------
 
-	// active time windows
-	$this->addSelect('ActiveTW','Active Time Windows', array('Y' => 'YesTW', 'N' => 'NoTW'));
+        // active time windows
 
-	$dateOptions = array(
-				'language'	=>	'en',
-				'format'	=>	'YMd',
-				'addEmptyOption' =>	'true'
-			);
+        $dateOptions = array(
+                        'language'       => 'en',
+                        'format'         => 'YMd',
+                        'addEmptyOption' => 'true',
+                       );
 
-	$dateAttributes = ['class' => 'form-control input-sm input-date'];
+        $dateAttributes = ['class' => 'form-control input-sm input-date'];
 
+        $this->addBasicDate(
+            'active_from',
+            'Active from',
+            $dateOptions,
+            $dateAttributes
+        );
 
-	$this->addBasicDate(
-				'active_from',
-				'Active from',
-				$dateOptions,
-				$dateAttributes
-			);
-
-
-	$this->addBasicDate(
-				'active_to',
-				'Active to',
-				$dateOptions,
-				$dateAttributes
-			);
+        $this->addBasicDate(
+            'active_to',
+            'Active to',
+            $dateOptions,
+            $dateAttributes
+        );
 
         // checking if the account can be rejected (no password hash
         // pending approval)
@@ -1115,16 +1112,20 @@ class Edit_User extends \NDB_Form
         }
 
         //======================================
-	//	Validate Active time Windows (from - to)
-	//
-	//	Note: the only validation included for the moment
-	//	is that the time form which the user is active 
-	//	should be less or equal to the time to it will be active. 
+        //    Validate Active time Windows (from - to)
+        //
+        //    Note: the only validation included for the moment
+        //    is that the time form which the user is active
+        //    should be less or equal to the time to it will be active.
         //======================================
 
-	if(($values['active_to'] != NULL) && ($values['active_from'] > $values['active_to'])){
-		$errors['active_timeWindows'] = "Please notice that the <i>\"Active from\"</i> date should be lesser or equal to the <i>\"Active to\"</i> date.";
-	}
+        if (($values['active_to'] != null)
+            && ($values['active_from'] > $values['active_to'])
+        ) {
+            $errors['active_timeWindows']
+                = 'Please notice that the "Active from" 
+                date should be lesser or equal to the "Active to" date.';
+        }
         return $errors;
     }
 

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -34,6 +34,7 @@
         The form you submitted contains data entry errors
     </div>
     {/if}
+
     <div class="panel panel-default">
       <div class="panel-body">
        <h3>Password Rules</h3>
@@ -352,6 +353,41 @@
               {$form.Active.html}
           </div>
       </div>
+
+
+	{if $form.errors.active_timeWindows}
+	    <div class="alert alert-danger" role="alert">
+		{$form.errors.active_timeWindows}
+	    </div>
+    	{/if}
+
+
+	
+	{if $form.errors.active_timeWindows}
+		<div class="row form-group form-inline form-inline has-error">
+	{else}
+		<div class="row form-group form-inline">
+	{/if}
+		<label class="col-sm-2">
+			{$form.active_from.label}
+		 </label>
+		 <div class="col-sm-10">
+			{$form.active_from.html}
+		 </div>
+	</div>
+	{if $form.errors.active_timeWindows}
+		<div class="row form-group form-inline form-inline has-error">
+	{else}
+		<div class="row form-group form-inline">
+	{/if}
+		<label class="col-sm-2">
+			{$form.active_to.label}
+		 </label>
+		 <div class="col-sm-10">
+			{$form.active_to.html}
+		 </div>
+	</div>
+
       <div class="row form-group form-inline">
        <label class="col-sm-2">
           {$form.Pending_approval.label}
@@ -391,6 +427,7 @@
   <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/'" value="Back" type="button" />
 </div>
 {if $can_reject}
+
 <div class="col-sm-2">
     <input type=hidden id ="UserID" value="{$form.UserID.html}">
     <input class="btn btn-sm btn-primary col-xs-12" value="Reject User" type="button" id="btn_reject"/>

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -299,7 +299,10 @@ class SinglePointLogin
                         Password_expiry < NOW() as Expired,
                         Active,
                         Pending_approval,
-                        Password_hash
+                        Password_hash,
+			active_from,
+			active_to
+
                     FROM users
                   WHERE UserID = :username
                   GROUP BY UserID";
@@ -328,6 +331,26 @@ class SinglePointLogin
                     return false;
                 }
 
+		// check if the account is longer active
+		$date = new DateTime();
+		$currentDay = $date->getTimestamp();
+		
+		if(($row['active_to'] != NULL) && ($currentDay > strtotime($row['active_to']))){
+			$this->_lastError = "Your account has expired."
+                        . " Please contact your project administrator to re-activate"
+                        . " this account.";
+                	return false;
+
+		}
+
+		// check if the account is active		
+		if(($row['active_from'] != NULL) && ($currentDay < strtotime($row['active_from']))){
+			$this->_lastError = "Your account is not active yet. According to our records it will be active from ".$row['active_from']."."
+                        . " Please contact your project administrator";
+                	return false;
+
+		}
+
                 if ($row['Pending_approval'] == 'Y') {
                     $this->_lastError = "Your account has not yet been activated."
                         . " Please contact your project administrator to activate"
@@ -335,6 +358,8 @@ class SinglePointLogin
                     $this->insertFailedDetail("user account pending", $setArray);
                     return false;
                 }
+
+		
 
                 // save the new password if the last password expired
                 if ($row['Expired']) {

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -331,25 +331,31 @@ class SinglePointLogin
                     return false;
                 }
 
-		// check if the account is longer active
-		$date = new DateTime();
-		$currentDay = $date->getTimestamp();
-		
-		if(($row['active_to'] != NULL) && ($currentDay > strtotime($row['active_to']))){
-			$this->_lastError = "Your account has expired."
+                // check if the account is longer active
+                $date       = new DateTime();
+                $currentDay = $date->getTimestamp();
+
+                if (($row['active_to'] != null)
+                    && ($currentDay > strtotime($row['active_to']))
+                ) {
+                    $this->_lastError = "Your account has expired."
                         . " Please contact your project administrator to re-activate"
                         . " this account.";
-                	return false;
+                    return false;
 
-		}
+                }
 
-		// check if the account is active		
-		if(($row['active_from'] != NULL) && ($currentDay < strtotime($row['active_from']))){
-			$this->_lastError = "Your account is not active yet. According to our records it will be active from ".$row['active_from']."."
+                // check if the account is active
+                if (($row['active_from'] != null)
+                    && ($currentDay < strtotime($row['active_from']))
+                ) {
+                    $this->_lastError = "Your account is not active yet."
+                        ." According to our records it will be active from 
+			{$row['active_from']}"
                         . " Please contact your project administrator";
-                	return false;
+                    return false;
 
-		}
+                }
 
                 if ($row['Pending_approval'] == 'Y') {
                     $this->_lastError = "Your account has not yet been activated."
@@ -358,8 +364,6 @@ class SinglePointLogin
                     $this->insertFailedDetail("user account pending", $setArray);
                     return false;
                 }
-
-		
 
                 // save the new password if the last password expired
                 if ($row['Expired']) {
@@ -425,12 +429,12 @@ class SinglePointLogin
     }
 
      /**
-     * Inserts the login (or failed-login) detail into the user_login_history
-     *
-     * @param String $description description for the failed-login
-     * @param Array  $setArray    contains data to be inserted
-     *
-     * @return null
+      * Inserts the login (or failed-login) detail into the user_login_history
+      *
+      * @param String $description description for the failed-login
+      * @param Array  $setArray    contains data to be inserted
+      *
+      * @return null
       */
     function insertFailedDetail($description, $setArray)
     {


### PR DESCRIPTION
### Brief summary of changes

For the project we are working at CHU Sainte-Justine we realize we will need to set (for a given user) access to the system but only for a given time window (due to policies of data access and privacy). It's a specific requirement of our project that could be useful for others. 
The way it was implemented (following @ridz1208 recommendations. Very helpful!! Thanks!) should not break/interfere others functionalities of the system. 

The changes are all additions limited to the following files:

php/libraries/SinglePointLogin.class.inc
modules/user_accounts/templates/form_edit_user.tpl
modules/user_accounts/php/edit_user.class.inc

Also it's necessary to add two fields on the Users table:

SQL/New_patches/2018-08-22_user_activeFrom-activeTo.sql

### This resolves issue...

- [ ] Redmine? # -

- [ ] Github? # -

### To test this change...

1. To access the system with a user with permissions to add/modify another.
2. To modify the user access time windows filling the new fields 'Active from' and/or 'Active to' that should shows up between the fields 'Active' and 'Pending approval'. NULLs are allowed, which will mean that there is not restrictions.
3. According to the dates set the user modified should not be able to access the system (due to expired/no yet active user).

![image](https://user-images.githubusercontent.com/37309344/44554134-c6614400-a6fd-11e8-92d6-80934e8b2af3.png)

![image2](https://user-images.githubusercontent.com/37309344/44554143-ceb97f00-a6fd-11e8-88af-9c946a970dba.png)

All suggestions/modifications are very welcome! Thanks.
CSJ team.