### PR TITLE
[Data Team Helper] Ensure test_name is always a string

### DIFF
--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -331,11 +331,11 @@ class Data_Team_Helper extends \NDB_Form
      * Get the list of fieldnames in conflict for the given test_name
      * from conflict_unresolved
      *
-     * @param string       $test_name   the value of test name
-     * @param string       $visit_label the value of visit label
-     * @param string       $candidate   the value of candidate
-     * @param int|string   $site        the id or default value of the site
-     * @param int|null     $project     the id of the project or can be null
+     * @param string     $test_name   the value of test name
+     * @param string     $visit_label the value of visit label
+     * @param string     $candidate   the value of candidate
+     * @param int|string $site        the id or default value of the site
+     * @param int|null   $project     the id of the project or can be null
      *
      * @return unknown
      */

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -331,7 +331,7 @@ class Data_Team_Helper extends \NDB_Form
      * Get the list of fieldnames in conflict for the given test_name
      * from conflict_unresolved
      *
-     * @param unknown_type $test_name   the value of test name
+     * @param string       $test_name   the value of test name
      * @param string       $visit_label the value of visit label
      * @param string       $candidate   the value of candidate
      * @param int|string   $site        the id or default value of the site
@@ -339,7 +339,7 @@ class Data_Team_Helper extends \NDB_Form
      *
      * @return unknown
      */
-    function instrumentInConflict($test_name,
+    function instrumentInConflict(string $test_name,
         $visit_label=null,
         $candidate=null,
         $site=null,

--- a/modules/data_team_helper/php/data_team_helper.class.inc
+++ b/modules/data_team_helper/php/data_team_helper.class.inc
@@ -761,15 +761,15 @@ class Data_Team_Helper extends \NDB_Form
      * @param string|null $full_name    the value of full name
      * @param string|null $subprojectID the value of subproject ID
      *
-     * @return mixed|Non
+     * @return string
      * @throws \DatabaseException
      */
-    function getTestNameusingMappedName($full_name, $subprojectID = null)
+    function getTestNameusingMappedName($full_name, $subprojectID = null): string
     {
         $DB     =& \Database::singleton();
         $values = array();
 
-        $test_name = null;
+        $test_name = '';
         if ((!(is_null($full_name)))) {
             if ($DB->ColumnExists('test_battery', 'Test_name_display')) {
                 $sqlSelectOne = "SELECT Test_name".

--- a/modules/data_team_helper/test/data_team_helperTest.php
+++ b/modules/data_team_helper/test/data_team_helperTest.php
@@ -75,6 +75,4 @@ class DataTeamHelperTestIntegrationTest extends LorisIntegrationTest
           );
           $this->resetPermissions();
     }
-
 }
-?>

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -724,17 +724,15 @@ class Utility
      * @note    Function comment written by Dave, not the author of this function.
      * @cleanup
      */
-    static function getTestNameUsingFullName($fullname)
+    static function getTestNameUsingFullName($fullname): string
     {
-        $test_name = '';
-        $db        =& Database::singleton();
-        //print_r($instument);
+        $test_name  = '';
+        $db         =& Database::singleton();
         $instrument = $db->pselect(
             "SELECT Test_name FROM test_names WHERE Full_name =:fname",
             array('fname' => $fullname)
         );
         if (is_array($instrument) && count($instrument)) {
-            //$full_name = $names[0]
             list(,$test_name) = each($instrument[0]);
         }
         return $test_name;


### PR DESCRIPTION
### Brief summary of changes

Just ensure that `test_name` is a string. Shouldn't be too controversial.

This type coercion is causing issues with #3878 which is why it needs to be fixed.

### To test this change...

This shouldn't alter the behaviour of LORIS. I'm not really sure how `data_team_helper` works but it should work the same!
