### PR TITLE
[Database] Make pselectRow more exceptional

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -307,11 +307,11 @@ class Candidate
 
         $row = $db->pselectRow($query, $candidateIDs);
 
-        if ($row === null) {
-            return false;
+        if ($row !== null) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -307,7 +307,7 @@ class Candidate
 
         $row = $db->pselectRow($query, $candidateIDs);
 
-        if (!empty($row)) {
+        if ($row === null) {
             return true;
         }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -307,11 +307,7 @@ class Candidate
 
         $row = $db->pselectRow($query, $candidateIDs);
 
-        if ($row !== null) {
-            return true;
-        }
-
-        return false;
+        return $row !== null;
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -308,11 +308,10 @@ class Candidate
         $row = $db->pselectRow($query, $candidateIDs);
 
         if ($row === null) {
-            return true;
+            return false;
         }
 
-        return false;
-
+        return true;
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -753,10 +753,7 @@ class Database
                 "Attempt to use pselectRow on a query that returns multiple rows"
             );
         }
-        if (isset($rows[0])) {
-            return $rows[0];
-        }
-        return null;
+        return $rows[0] ?? null;
     }
 
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -742,16 +742,21 @@ class Database
      * @param string $query  The SQL SELECT query to be run
      * @param array  $params Values to use for binding to prepared statement
      *
-     * @return array Associative array of form ColumnName => Value for each column
-     *               in the first row of the query
+     * @return ?array Associative array of form ColumnName => Value for each column
+     *                in the first row of the query
      */
-    function pselectRow($query, $params)
+    function pselectRow(string $query, array $params) : ?array
     {
-        $rows = $this->pselect($query . " LIMIT 1", $params);
+        $rows = $this->pselect($query . " LIMIT 2", $params);
+        if (count($rows) > 1) {
+            throw new \DomainException(
+                "Attempt to use pselectRow on a query that returns multiple rows"
+            );
+        }
         if (isset($rows[0])) {
             return $rows[0];
         }
-        return $rows;
+        return null;
     }
 
     /**

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -369,7 +369,7 @@ class NDB_BVL_Feedback
         // new DB Object
         $db =& Database::singleton();
 
-        $query   = "SELECT Status FROM feedback_bvl_thread WHERE";
+        $query   = "SELECT MAX(Status) FROM feedback_bvl_thread WHERE";
         $qparams = array();
         if (!empty($this->_feedbackObjectInfo['CandID'])) {
             $query         .= " CandID = :CID";

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -412,7 +412,7 @@ class CandidateTest extends TestCase
     {
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
-            ->willReturn(false);
+            ->willReturn(null);
 
         $this->assertFalse(Candidate::candidateExists(123, 'Test'));
     }


### PR DESCRIPTION
This makes pselectRow error out in more invalid cases. In particular,
it throws an exception if called on a query that returns more than
one row (and as a result, also adds this behaviour to pselectOne) since
there's no way to know which row was intended. It also returns null,
not an empty array, if no rows are matched.

This improves LORIS by making latent errors more obvious
and exposing problems that might otherwise go unnoticed.

