### PR TITLE
[MRI Preprocessing]: Adding tables to support BIDS dataset creation on the MRI side

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -762,7 +762,7 @@ CREATE TABLE `mri_protocol_checks` (
 -- ********************************
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
  `ImagingCategory` varchar(10) NOT NULL UNIQUE,    
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -775,7 +775,7 @@ INSERT INTO `bids_category` (ImagingCategory) VALUES
 
 CREATE TABLE `bids_mri_scan_type_rel` (
   `MRIScanTypeID` int(10) unsigned NOT NULL,
-  `BIDSCategory`varchar(255) DEFAULT NULL,
+  `BIDSCategory`varchar(10) DEFAULT NULL,
   `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
   `BIDSScanType` varchar(255) DEFAULT NULL,
   `BIDSMultiEcho`varchar(255) DEFAULT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -114,6 +114,8 @@ DROP TABLE IF EXISTS `tarchive`;
 
 DROP TABLE IF EXISTS bids_mri_scan_type_rel;
 DROP TABLE IF EXISTS bids_category;
+DROP TABLE IF EXISTS bids_scan_type;
+DROP TABLE IF EXISTS bids_scan_type_subcategory;
 
 DROP TABLE IF EXISTS `history`;
 DROP TABLE IF EXISTS `Visit_Windows`;
@@ -762,35 +764,93 @@ CREATE TABLE `mri_protocol_checks` (
 -- ********************************
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
- `ImagingCategory` varchar(10) NOT NULL UNIQUE,    
+ `BIDSCategoryID`   int(3)      UNSIGNED NOT NULL AUTO_INCREMENT,
+ `BIDSCategoryName` varchar(10)          NOT NULL UNIQUE,
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `bids_category` (ImagingCategory) VALUES
+INSERT INTO `bids_category` (BIDSCategoryName) VALUES
       ('anat'),
       ('func'),
       ('dwi'),
       ('fmap');
 
-CREATE TABLE `bids_mri_scan_type_rel` (
-  `MRIScanTypeID` int(10) unsigned NOT NULL,
-  `BIDSCategory`varchar(10) DEFAULT NULL,
-  `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
-  `BIDSScanType` varchar(255) DEFAULT NULL,
-  `BIDSMultiEcho`varchar(255) DEFAULT NULL,
-  PRIMARY KEY  (`MRIScanTypeID`),
-  KEY `FK_bids_mri_scan_type_rel` (`MRIScanTypeID`),
-  CONSTRAINT `FK_bids_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_bids_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `bids_category`(`ImagingCategory`)
+CREATE TABLE `bids_scan_type_subcategory` (
+  `BIDSScanTypeSubCategoryID` int(3)       UNSIGNED NOT NULL AUTO_INCREMENT,
+  `BIDSScanTypeSubCategory`   varchar(100)          NOT NULL UNIQUE,
+  PRIMARY KEY (`BIDSScanTypeSubCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Default schema mri scan types; make the most common ones named in a BIDS compliant manner
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+INSERT INTO `bids_scan_type_subcategory` (BIDSScanTypeSubCategory) VALUES
+  ('task-rest');
+
+CREATE TABLE `bids_scan_type` (
+  `BIDSScanTypeID` int(3)       UNSIGNED NOT NULL AUTO_INCREMENT,
+  `BIDSScanType`   varchar(100)          NOT NULL UNIQUE,
+  PRIMARY KEY (`BIDSScanTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `bids_scan_type` (BIDSScanType) VALUES
+  ('bold'),
+  ('FLAIR'),
+  ('T1w'),
+  ('T2w'),
+  ('dwi');
+
+CREATE TABLE `bids_mri_scan_type_rel` (
+  `MRIScanTypeID`             int(10) UNSIGNED NOT NULL,
+  `BIDSCategoryID`            int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSScanTypeSubCategoryID` int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSScanTypeID`            int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSEchoNumber`            int(3)  UNSIGNED DEFAULT NULL,
+  PRIMARY KEY  (`MRIScanTypeID`),
+  KEY `FK_bids_mri_scan_type_rel` (`MRIScanTypeID`),
+  CONSTRAINT `FK_bids_mri_scan_type_rel`     FOREIGN KEY (`MRIScanTypeID`)             REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_bids_category`              FOREIGN KEY (`BIDSCategoryID`)            REFERENCES `bids_category`(`BIDSCategoryID`),
+  CONSTRAINT `FK_bids_scan_type_subcategory` FOREIGN KEY (`BIDSScanTypeSubCategoryID`) REFERENCES `bids_scan_type_subcategory` (`BIDSScanTypeSubCategoryID`),
+  CONSTRAINT `FK_bids_scan_type`             FOREIGN KEY (`BIDSScanTypeID`)            REFERENCES `bids_scan_type` (`BIDSScanTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Default schema scan types; make some of them named in a BIDS compliant manner
+INSERT INTO bids_mri_scan_type_rel
+  (MRIScanTypeID, BIDSCategoryID, BIDSScanTypeSubCategoryID, BIDSScanTypeID, BIDSEchoNumber)
+  VALUES
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 'flair'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='anat'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='FLAIR'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 'fMRI'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='func'),
+    (SELECT BIDSScanTypeSubCategoryID FROM bids_scan_type_subcategory WHERE BIDSScanTypeSubCategory='task-rest'),
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='bold'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 't1'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='anat'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='T1w'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 't2'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='anat'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='T2w'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 'dti'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='dwi'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='dwi'),
+    NULL
+  );
 
 -- ********************************
 -- MRI violations tables

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -762,7 +762,7 @@ CREATE TABLE `mri_protocol_checks` (
 -- ********************************
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
  `ImagingCategory` varchar(10) NOT NULL,
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -762,8 +762,8 @@ CREATE TABLE `mri_protocol_checks` (
 -- ********************************
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
- `ImagingCategory` varchar(10) NOT NULL,
+ `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `ImagingCategory` varchar(10) NOT NULL UNIQUE,    
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -780,7 +780,7 @@ CREATE TABLE `bids_mri_scan_type_rel` (
   `BIDSScanType` varchar(255) DEFAULT NULL,
   `BIDSMultiEcho`varchar(255) DEFAULT NULL,
   PRIMARY KEY  (`MRIScanTypeID`),
-  KEY `FK_bids_mri_scan_type_rel_1` (`MRIScanTypeID`),
+  KEY `FK_bids_mri_scan_type_rel` (`MRIScanTypeID`),
   CONSTRAINT `FK_bids_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `FK_bids_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `bids_category`(`ImagingCategory`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -785,7 +785,7 @@ CREATE TABLE `BIDS_mri_scan_type_rel` (
 
 
 -- Default schema mri scan types; make the most common ones named in a BIDS compliant manner
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -112,6 +112,9 @@ DROP TABLE IF EXISTS `tarchive_files`;
 DROP TABLE IF EXISTS `tarchive_series`;
 DROP TABLE IF EXISTS `tarchive`;
 
+DROP TABLE IF EXISTS BIDS_mri_scan_type_rel;
+DROP TABLE IF EXISTS BIDS_category;
+
 DROP TABLE IF EXISTS `history`;
 DROP TABLE IF EXISTS `Visit_Windows`;
 DROP TABLE IF EXISTS `test_battery`;
@@ -754,6 +757,39 @@ CREATE TABLE `mri_protocol_checks` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
+-- ********************************
+-- BIDS tables
+-- ********************************
+
+CREATE TABLE `BIDS_category` (
+ `ImagingCategory` varchar(255) NOT NULL PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `BIDS_category` VALUES
+      ('anat'),
+      ('func'),
+      ('dwi'),
+      ('fmap');
+
+CREATE TABLE `BIDS_mri_scan_type_rel` (
+  `MRIScanTypeID` int(10) unsigned NOT NULL,
+  `BIDSCategory`varchar(255) DEFAULT NULL,
+  `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
+  `BIDSScanType` varchar(255) DEFAULT NULL,
+  `BIDSMultiEcho`varchar(255) DEFAULT NULL,
+  PRIMARY KEY  (`MRIScanTypeID`),
+  KEY `FK_BIDS_mri_scan_type_rel_1` (`MRIScanTypeID`),
+  CONSTRAINT `FK_BIDS_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_BIDS_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `BIDS_category`(`ImagingCategory`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Default schema mri scan types; make the most common ones named in a BIDS compliant manner
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
 
 -- ********************************
 -- MRI violations tables

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -112,8 +112,8 @@ DROP TABLE IF EXISTS `tarchive_files`;
 DROP TABLE IF EXISTS `tarchive_series`;
 DROP TABLE IF EXISTS `tarchive`;
 
-DROP TABLE IF EXISTS BIDS_mri_scan_type_rel;
-DROP TABLE IF EXISTS BIDS_category;
+DROP TABLE IF EXISTS bids_mri_scan_type_rel;
+DROP TABLE IF EXISTS bids_category;
 
 DROP TABLE IF EXISTS `history`;
 DROP TABLE IF EXISTS `Visit_Windows`;
@@ -761,35 +761,36 @@ CREATE TABLE `mri_protocol_checks` (
 -- BIDS tables
 -- ********************************
 
-CREATE TABLE `BIDS_category` (
- `ImagingCategory` varchar(255) NOT NULL PRIMARY KEY
+CREATE TABLE `bids_category` (
+ `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `ImagingCategory` varchar(10) NOT NULL,
+ PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `BIDS_category` VALUES
+INSERT INTO `bids_category` (ImagingCategory) VALUES
       ('anat'),
       ('func'),
       ('dwi'),
       ('fmap');
 
-CREATE TABLE `BIDS_mri_scan_type_rel` (
+CREATE TABLE `bids_mri_scan_type_rel` (
   `MRIScanTypeID` int(10) unsigned NOT NULL,
   `BIDSCategory`varchar(255) DEFAULT NULL,
   `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
   `BIDSScanType` varchar(255) DEFAULT NULL,
   `BIDSMultiEcho`varchar(255) DEFAULT NULL,
   PRIMARY KEY  (`MRIScanTypeID`),
-  KEY `FK_BIDS_mri_scan_type_rel_1` (`MRIScanTypeID`),
-  CONSTRAINT `FK_BIDS_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_BIDS_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `BIDS_category`(`ImagingCategory`)
+  KEY `FK_bids_mri_scan_type_rel_1` (`MRIScanTypeID`),
+  CONSTRAINT `FK_bids_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_bids_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `bids_category`(`ImagingCategory`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-
 -- Default schema mri scan types; make the most common ones named in a BIDS compliant manner
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
 
 -- ********************************
 -- MRI violations tables

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS bids_mri_scan_type_rel;
 DROP TABLE IF EXISTS bids_category;
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
  `ImagingCategory` varchar(10) NOT NULL UNIQUE,
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -1,45 +1,47 @@
-DROP TABLE IF EXISTS BIDS_mri_scan_type_rel;
-DROP TABLE IF EXISTS BIDS_category;
+DROP TABLE IF EXISTS bids_mri_scan_type_rel;
+DROP TABLE IF EXISTS bids_category;
 
-CREATE TABLE `BIDS_category` (
- `ImagingCategory` varchar(255) NOT NULL PRIMARY KEY
+CREATE TABLE `bids_category` (
+ `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `ImagingCategory` varchar(10) NOT NULL,
+ PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `BIDS_category` VALUES
+INSERT INTO `bids_category` VALUES
       ('anat'),
       ('func'),
       ('dwi'),
       ('fmap');
 
-CREATE TABLE `BIDS_mri_scan_type_rel` (
+CREATE TABLE `bids_mri_scan_type_rel` (
   `MRIScanTypeID` int(10) unsigned NOT NULL,
   `BIDSCategory`varchar(255) DEFAULT NULL,
   `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
   `BIDSScanType` varchar(255) DEFAULT NULL,
   `BIDSMultiEcho`varchar(255) DEFAULT NULL,
   PRIMARY KEY  (`MRIScanTypeID`),
-  KEY `FK_BIDS_mri_scan_type_rel_1` (`MRIScanTypeID`),
-  CONSTRAINT `FK_BIDS_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_BIDS_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `BIDS_category`(`ImagingCategory`)
+  KEY `FK_bids_mri_scan_type_rel_1` (`MRIScanTypeID`),
+  CONSTRAINT `FK_bids_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_bids_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `bids_category`(`ImagingCategory`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Default schema scan types; make some of them named in a BIDS compliant manner
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
 
 -- CCNA EXAMPLE (THOSE LINES WILL BE REMOVED)
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '3d_t1w';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '2d_flair';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2star', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2_star';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'PD', 'echo-1' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_pd';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', 'echo-2' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_t2';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'resting_state';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-memory', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fmri_task_memory';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'B0map', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'b0_map';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map1';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map2';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '3d_t1w';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '2d_flair';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2star', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2_star';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'PD', 'echo-1' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_pd';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', 'echo-2' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_t2';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'resting_state';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-memory', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fmri_task_memory';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'B0map', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'b0_map';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map1';
+INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map2';

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -15,7 +15,7 @@ INSERT INTO `bids_category` (ImagingCategory) VALUES
 
 CREATE TABLE `bids_mri_scan_type_rel` (
   `MRIScanTypeID` int(10) unsigned NOT NULL,
-  `BIDSCategory`varchar(255) DEFAULT NULL,
+  `BIDSCategory`varchar(10) DEFAULT NULL,
   `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
   `BIDSScanType` varchar(255) DEFAULT NULL,
   `BIDSMultiEcho`varchar(255) DEFAULT NULL,

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -33,7 +33,7 @@ INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSub
 
 -- CCNA EXAMPLE (THOSE LINES WILL BE REMOVED)
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '3d_t1w';
-INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '2d_flair');
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '2d_flair';
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2star', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2_star';
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'PD', 'echo-1' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_pd';
 INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', 'echo-2' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_t2';

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -32,16 +32,3 @@ INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSub
 INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
 INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
 INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
-
--- CCNA EXAMPLE (THOSE LINES WILL BE REMOVED)
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '3d_t1w';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '2d_flair';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2star', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2_star';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'PD', 'echo-1' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_pd';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', 'echo-2' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_t2';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'resting_state';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-memory', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fmri_task_memory';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'B0map', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'b0_map';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map1';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map2';

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -1,0 +1,45 @@
+DROP TABLE IF EXISTS BIDS_mri_scan_type_rel;
+DROP TABLE IF EXISTS BIDS_category;
+
+CREATE TABLE `BIDS_category` (
+ `ImagingCategory` varchar(255) NOT NULL PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `BIDS_category` VALUES
+      ('anat'),
+      ('func'),
+      ('dwi'),
+      ('fmap');
+
+CREATE TABLE `BIDS_mri_scan_type_rel` (
+  `MRIScanTypeID` int(10) unsigned NOT NULL,
+  `BIDSCategory`varchar(255) DEFAULT NULL,
+  `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
+  `BIDSScanType` varchar(255) DEFAULT NULL,
+  `BIDSMultiEcho`varchar(255) DEFAULT NULL,
+  PRIMARY KEY  (`MRIScanTypeID`),
+  KEY `FK_BIDS_mri_scan_type_rel_1` (`MRIScanTypeID`),
+  CONSTRAINT `FK_BIDS_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_BIDS_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `BIDS_category`(`ImagingCategory`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Default schema scan types; make some of them named in a BIDS compliant manner
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+
+-- CCNA EXAMPLE (THOSE LINES WILL BE REMOVED)
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '3d_t1w';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = '2d_flair');
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2star', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2_star';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'PD', 'echo-1' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_pd';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', 'echo-2' FROM mri_scan_type mst WHERE mst.Scan_type = 'dual_t2';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'resting_state';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'task-memory', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fmri_task_memory';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'B0map', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'b0_map';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map1';
+INSERT INTO BIDS_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'fmap', 'task', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'gre_field_map2';

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -2,12 +2,12 @@ DROP TABLE IF EXISTS bids_mri_scan_type_rel;
 DROP TABLE IF EXISTS bids_category;
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
  `ImagingCategory` varchar(10) NOT NULL,
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `bids_category` VALUES
+INSERT INTO `bids_category` (ImagingCategory) VALUES
       ('anat'),
       ('func'),
       ('dwi'),

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -1,34 +1,93 @@
 DROP TABLE IF EXISTS bids_mri_scan_type_rel;
 DROP TABLE IF EXISTS bids_category;
+DROP TABLE IF EXISTS bids_scan_type;
+DROP TABLE IF EXISTS bids_scan_type_subcategory;
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
- `ImagingCategory` varchar(10) NOT NULL UNIQUE,
+ `BIDSCategoryID`   int(3)      UNSIGNED NOT NULL AUTO_INCREMENT,
+ `BIDSCategoryName` varchar(10)          NOT NULL UNIQUE,
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO `bids_category` (ImagingCategory) VALUES
+INSERT INTO `bids_category` (BIDSCategoryName) VALUES
       ('anat'),
       ('func'),
       ('dwi'),
       ('fmap');
 
+CREATE TABLE `bids_scan_type_subcategory` (
+  `BIDSScanTypeSubCategoryID` int(3)       UNSIGNED NOT NULL AUTO_INCREMENT,
+  `BIDSScanTypeSubCategory`   varchar(100)          NOT NULL UNIQUE,
+  PRIMARY KEY (`BIDSScanTypeSubCategoryID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `bids_scan_type_subcategory` (BIDSScanTypeSubCategory) VALUES
+  ('task-rest');
+
+CREATE TABLE `bids_scan_type` (
+  `BIDSScanTypeID` int(3)       UNSIGNED NOT NULL AUTO_INCREMENT,
+  `BIDSScanType`   varchar(100)          NOT NULL UNIQUE,
+  PRIMARY KEY (`BIDSScanTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `bids_scan_type` (BIDSScanType) VALUES
+  ('bold'),
+  ('FLAIR'),
+  ('T1w'),
+  ('T2w'),
+  ('dwi');
+
 CREATE TABLE `bids_mri_scan_type_rel` (
-  `MRIScanTypeID` int(10) unsigned NOT NULL,
-  `BIDSCategory`varchar(10) DEFAULT NULL,
-  `BIDSScanTypeSubCategory`varchar(255) DEFAULT NULL,
-  `BIDSScanType` varchar(255) DEFAULT NULL,
-  `BIDSMultiEcho`varchar(255) DEFAULT NULL,
+  `MRIScanTypeID`             int(10) UNSIGNED NOT NULL,
+  `BIDSCategoryID`            int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSScanTypeSubCategoryID` int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSScanTypeID`            int(3)  UNSIGNED DEFAULT NULL,
+  `BIDSEchoNumber`            int(3)  UNSIGNED DEFAULT NULL,
   PRIMARY KEY  (`MRIScanTypeID`),
   KEY `FK_bids_mri_scan_type_rel` (`MRIScanTypeID`),
-  CONSTRAINT `FK_bids_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_bids_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `bids_category`(`ImagingCategory`)
+  CONSTRAINT `FK_bids_mri_scan_type_rel`     FOREIGN KEY (`MRIScanTypeID`)             REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_bids_category`              FOREIGN KEY (`BIDSCategoryID`)            REFERENCES `bids_category`(`BIDSCategoryID`),
+  CONSTRAINT `FK_bids_scan_type_subcategory` FOREIGN KEY (`BIDSScanTypeSubCategoryID`) REFERENCES `bids_scan_type_subcategory` (`BIDSScanTypeSubCategoryID`),
+  CONSTRAINT `FK_bids_scan_type`             FOREIGN KEY (`BIDSScanTypeID`)            REFERENCES `bids_scan_type` (`BIDSScanTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Default schema scan types; make some of them named in a BIDS compliant manner
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'func', 'rest', 'bold', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'fMRI';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'FLAIR', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'flair';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T1w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't1';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'anat', NULL, 'T2w', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 't2';
-INSERT INTO bids_mri_scan_type_rel (MRIScanTypeID, BIDSCategory, BIDSScanTypeSubCategory, BIDSScanType, BIDSMultiEcho) SELECT mst.ID, 'dwi', NULL, 'dwi', NULL FROM mri_scan_type mst WHERE mst.Scan_type = 'dti';
+INSERT INTO bids_mri_scan_type_rel
+  (MRIScanTypeID, BIDSCategoryID, BIDSScanTypeSubCategoryID, BIDSScanTypeID, BIDSEchoNumber)
+  VALUES
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 'flair'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='anat'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='FLAIR'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 'fMRI'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='func'),
+    (SELECT BIDSScanTypeSubCategoryID FROM bids_scan_type_subcategory WHERE BIDSScanTypeSubCategory='task-rest'),
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='bold'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 't1'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='anat'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='T1w'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 't2'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='anat'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='T2w'),
+    NULL
+  ),
+  (
+    (SELECT ID FROM mri_scan_type WHERE Scan_type = 'dti'),
+    (SELECT BIDSCategoryID FROM bids_category WHERE BIDSCategoryName='dwi'),
+    NULL,
+    (SELECT BIDSScanTypeID FROM bids_scan_type WHERE BIDSSCanType='dwi'),
+    NULL
+  );

--- a/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
+++ b/SQL/New_patches/2018_08_27_BIDSScanTypeTable.sql
@@ -2,8 +2,8 @@ DROP TABLE IF EXISTS bids_mri_scan_type_rel;
 DROP TABLE IF EXISTS bids_category;
 
 CREATE TABLE `bids_category` (
- `BIDSCategoryID` int(3) NOT NULL AUTO_INCREMENT,
- `ImagingCategory` varchar(10) NOT NULL,
+ `BIDSCategoryID` int(11) NOT NULL AUTO_INCREMENT,
+ `ImagingCategory` varchar(10) NOT NULL UNIQUE,
  PRIMARY KEY (`BIDSCategoryID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -20,7 +20,7 @@ CREATE TABLE `bids_mri_scan_type_rel` (
   `BIDSScanType` varchar(255) DEFAULT NULL,
   `BIDSMultiEcho`varchar(255) DEFAULT NULL,
   PRIMARY KEY  (`MRIScanTypeID`),
-  KEY `FK_bids_mri_scan_type_rel_1` (`MRIScanTypeID`),
+  KEY `FK_bids_mri_scan_type_rel` (`MRIScanTypeID`),
   CONSTRAINT `FK_bids_mri_scan_type_rel` FOREIGN KEY (`MRIScanTypeID`) REFERENCES `mri_scan_type` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `FK_bids_category` FOREIGN KEY (`BIDSCategory`) REFERENCES `bids_category`(`ImagingCategory`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
### Brief summary of changes

Add tables to the database to support the creation of a BIDS dataset for imaging data.
This is mostly to be used with PR #198 (https://github.com/aces/Loris-MRI/pull/198) on the MRI side.

Essentially 2 new tables are created, `bids_mri_scan_type_rel` and `bids_category`.
The former links to the `mri_scan_type` table and creates a link between the existing acquisition protocol IDs, and all the related derivatives needed from it to create a BIDS compliant dataset/filenames. The latter defines the different BIDS categories which structures the different MRI modalities in sub-directories.

More specifically, a detailed column description per table is as follows:
1) `MRIScanTypeID`: link to the mri_scan_type ID column (e.g. `44` for `t1` images in our default schema)
2) `BIDSCategory` which would be an `enum` of types `func`, `anat`, 'dwi`', `fmap`. But since `enum` is highly discouraged by LORIS standards, a new table called `BIDS_category` is created to house the different BIDS categories. The values inside this tables are used to create the appropriate folder in which to house the `nii` images. For example, a `t1` scan would be in a folder called `anat` because it fits in the anatomical category.
3) `BIDSScanTypeSubCategory`; this is mostly for fMRI. These `func` acquisitions need extra measures to define them (that also get stored in the accompanying JSON header file), so for a resting state fMRI, files should have a `task-rest` identifier, or what I define as the `BIDSScanTypeSubCategory`. A memory task fMRI would have a value of `task-memory` in the `BIDSScanTypeSubCategory` column. Other acquisitions can leave this field blank
4) `BIDSScanType` is the `mri_scan_type` Scan_type column, but named in a BIDS compliant manner. So `t1` becomes `T1w`, `dti` becomes `dwi`, etc... this is the column that would rename our schema's Scan_type to whatever BIDS wants it to be 
5) `BIDSMultiEcho` is a column that specifies which modalities are acquired in a multi-echo fashion. This is needed because those files need to be identified in BIDS with the string `echo-1`, `echo-2`, etc... in their filenames, so fill in this information in this column

**An example set of patches for CCNA mri_scan_types entries are added for now as example to illustrate the 5 points above, but will eventually be removed**

### This resolves issue...

- [ ] Redmine? #13438 (CCNA Redmine task though...). It is not an issue, but rather a new addition to LORIS-MRI to create a BIDS dataset of the existing `assembly/` MINC files.

### To test this change...

The MRI script in the referenced PR above needs to be run after the patches here have been applied.

- An example of how CCNA tables will look like after populating the proper BIDS table with expected values is shown in the following screenshot:
![example_ccna_bidstables](https://user-images.githubusercontent.com/15198379/44873598-b0580400-ac66-11e8-84ff-bc18d8bfbe68.png)

- An example of how the BIDS files on the filesystem look like when running this script is shown in the following screenshot (this was generated using the argument `-dataset_name test` which is why the subdirectory housing the files is called `test`):
![example_ccna_files](https://user-images.githubusercontent.com/15198379/44873601-b221c780-ac66-11e8-98a8-181fbe67bec0.png)

I added the `Blocked` tag until the MRI side/script is clear as well.


