### PR TITLE
[Tools/Normalize_consent] Remove validation for consent status "no"

### DIFF
--- a/tools/single_use/Normalize_Consent_Data.php
+++ b/tools/single_use/Normalize_Consent_Data.php
@@ -118,15 +118,6 @@ foreach ($consentList as $consentName=>$consentLabel) {
                        [CandID] => " . $candID . "
                        All 'yes' statuses must have a consent date.");
         }
-        // Check if consent status is no and consent date given, but withdrawal date is empty
-        if($status === "no" && !empty($date)) {
-            if(empty($withdrawal)) {
-                array_push($errors, "The date of withdrawal is missing for " . $consentName . ":
-                           [ID]     => " . $consentID . "
-                           [CandID] => " . $candID . "
-                           All 'no' statuses with given consent date must have a withdrawal date.");
-            }
-        }
         // Check for zero dates
         if($date === "0000-00-00" || $withdrawal === "0000-00-00") {
             array_push($errors, "Zero dates found in participant_status for " . $consentName . ":

--- a/tools/single_use/Normalize_Consent_Data.php
+++ b/tools/single_use/Normalize_Consent_Data.php
@@ -99,8 +99,8 @@ foreach ($consentList as $consentName=>$consentLabel) {
         $consentID  = $entry['ID'];
         $candID     = $entry['CandID'];
         // Check if consent status is not_answered
-        if($status === "not_answered") {
-            array_push($errors, "Deprecated consent status 'not_answered' found for " . $consentName . ":
+        if($status === "not_answered" || $status === "") {
+            array_push($errors, "Deprecated consent status 'not_answered' or empty string found for " . $consentName . ":
                        [ID]     => " . $consentID . "
                        [CandID] => " . $candID . "
                        Please change to a valid status or remove data.");


### PR DESCRIPTION
### Brief summary of changes

Initially, we assumed that consent date would only be given if status=yes. Therefore, if status=no but there is a consent date, it is assumed that consent was withdrawn, thus, a withdrawn date is required. The script validates there being a withdrawn date for withdrawn consent. However, IBIS also takes consent date for status=no, breaking down our assumption on withdrawal. This PR removes that validation.

Edit: also adds check for empty consent status as found in IBIS data

### To test this change...

- [ ] @sruthymathew123 running the script on IBIS