### PR TITLE
[Tools] Making sure the list of instruments to add is unique in assign_missing_instruments.php

### DIFF
--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -111,7 +111,7 @@ function populateVisitLabel($result, $visit_label)
         $visit_label
     );
 
-    $diff =array_diff($defined_battery, $actual_battery);
+    $diff = array_unique(array_diff($defined_battery, $actual_battery));
     if (!empty($diff)) {
         echo "\n CandID: ".$timePoint->getCandID()."  Visit Label:  ".
         $timePoint->getVisitLabel()."\nMissing Instruments:\n";


### PR DESCRIPTION
This shouldn't happen in a properly configured LORIS instance but just in case your test_battery/overrides aren't ironed out, you may want to avoid adding duplicate instruments into your flag+instrument tables