### PR TITLE
[Router] Fix routing to subpages

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -237,7 +237,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
         $path     = trim($request->getURI()->getPath(), "/");
         if (!empty($path)) {
             // There is a subpage
-            $pagename = explode("@", $path)[0];
+            $pagename = explode("/", $path)[0];
         }
 
         try {


### PR DESCRIPTION
The default module router is supposed to delegate to the page
based on the first component of the path of the URL. A typo
means that it was using '@' instead of '/' to determine path
components, so it would only delegate to pages that have an
exact match.