### PR TITLE
[New Feature] Adding the SQL patch for the EEG tables

### DIFF
--- a/SQL/0000-00-05-ElectrophysiologyTables.sql
+++ b/SQL/0000-00-05-ElectrophysiologyTables.sql
@@ -1,0 +1,289 @@
+--
+-- Table structure for the electrophysiology component of LORIS
+--
+
+
+-- Create a physiological_modality table
+CREATE TABLE `physiological_modality` (
+  `PhysiologicalModalityID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `PhysiologicalModality`   VARCHAR(50)         NOT NULL UNIQUE,
+  PRIMARY KEY (`PhysiologicalModalityID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Create a physiological_output_type table
+CREATE TABLE `physiological_output_type` (
+  `PhysiologicalOutputTypeID` INT(5)      UNSIGNED NOT NULL AUTO_INCREMENT,
+  `OutputTypeName`            VARCHAR(20)          NOT NULL UNIQUE,
+  `OutputTypeDescription`     VARCHAR(255),
+  PRIMARY KEY (`PhysiologicalOutputTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Create a physiological_file table
+-- Note that the field InsertedByUser refers to the Linux User that ran the script
+-- and not a LORIS user
+CREATE TABLE `physiological_file` (
+  `PhysiologicalFileID`       INT(10)    UNSIGNED  NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalModalityID`   INT(5)     UNSIGNED  DEFAULT NULL,
+  `PhysiologicalOutputTypeID` INT(5)     UNSIGNED  NOT NULL,
+  `SessionID`                 INT(10)    UNSIGNED  NOT NULL,
+  `InsertTime`                TIMESTAMP            NOT NULL      DEFAULT CURRENT_TIMESTAMP,
+  `FileType`                  VARCHAR(12)          DEFAULT NULL,
+  `AcquisitionTime`           DATETIME             DEFAULT '1970-01-01 00:00:01',
+  `InsertedByUser`            VARCHAR(50)          NOT NULL,
+  `FilePath`                  VARCHAR(255)         NOT NULL,
+  PRIMARY KEY (`PhysiologicalFileID`),
+  CONSTRAINT `FK_session_ID`
+    FOREIGN KEY (`SessionID`)
+    REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_ImagingFileTypes_type`
+    FOREIGN KEY (`FileType`)
+    REFERENCES `ImagingFileTypes` (`type`),
+  CONSTRAINT `FK_phys_modality_ModID`
+    FOREIGN KEY (`PhysiologicalModalityID`)
+    REFERENCES `physiological_modality` (`PhysiologicalModalityID`),
+  CONSTRAINT `FK_phys_output_type_TypeID`
+    FOREIGN KEY (`PhysiologicalOutputTypeID`)
+    REFERENCES `physiological_output_type` (`PhysiologicalOutputTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_parameter_file table that will store all JSON
+-- information that accompanies the BIDS physiological dataset
+CREATE TABLE `physiological_parameter_file` (
+  `PhysiologicalParameterFileID` INT(10) UNSIGNED NOT NULL  AUTO_INCREMENT,
+  `PhysiologicalFileID`          INT(10) UNSIGNED NOT NULL,
+  `ParameterTypeID`              INT(10) UNSIGNED NOT NULL,
+  `InsertTime`                   TIMESTAMP        NOT NULL  DEFAULT CURRENT_TIMESTAMP,
+  `Value`                        VARCHAR(255),
+  PRIMARY KEY (`PhysiologicalParameterFileID`),
+  CONSTRAINT `FK_phys_file_FileID`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE,
+  CONSTRAINT `FK_param_type_ParamTypeID`
+    FOREIGN KEY (`ParameterTypeID`)
+    REFERENCES `parameter_type` (`ParameterTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_status_type table
+CREATE TABLE `physiological_status_type` (
+  `PhysiologicalStatusTypeID` INT(5)      UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ChannelStatus`             VARCHAR(10)          NOT NULL UNIQUE,
+  PRIMARY KEY (`PhysiologicalStatusTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_channel_type table
+CREATE TABLE `physiological_channel_type` (
+  `PhysiologicalChannelTypeID` INT(5)       UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `ChannelTypeName`            VARCHAR(255)          NOT NULL      UNIQUE,
+  `ChannelDescription`         VARCHAR(255)          DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalChannelTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_channel table that will store all information from
+CREATE TABLE `physiological_channel` (
+  `PhysiologicalChannelID`     INT(10)    UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`        INT(10)    UNSIGNED NOT NULL,
+  `PhysiologicalChannelTypeID` INT(5)     UNSIGNED NOT NULL,
+  `PhysiologicalStatusTypeID`  INT(5)     UNSIGNED DEFAULT NULL,
+  `InsertTime`                 TIMESTAMP           NOT NULL      DEFAULT CURRENT_TIMESTAMP,
+  `Name`                       VARCHAR(50)         NOT NULL,
+  `Description`                VARCHAR(255)        DEFAULT NULL,
+  `SamplingFrequency`          INT(6)              DEFAULT NULL,
+  `LowCutoff`                  DECIMAL(8,3)        DEFAULT NULL,
+  `HighCutoff`                 DECIMAL(8,3)        DEFAULT NULL,
+  `ManualFlag`                 DECIMAL(5,4)        DEFAULT NULL,
+  `Notch`                      INT(6)              DEFAULT NULL,
+  `Reference`                  VARCHAR(255)        DEFAULT NULL,
+  `StatusDescription`          VARCHAR(255)        DEFAULT NULL,
+  `Unit`                       VARCHAR(255)        DEFAULT NULL,
+  `FilePath`                   VARCHAR(255)        DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalChannelID`),
+  CONSTRAINT `FK_phys_file_FileID_2`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE,
+  CONSTRAINT `FK_phys_channel_type_TypeID`
+    FOREIGN KEY (`PhysiologicalChannelTypeID`)
+    REFERENCES `physiological_channel_type` (`PhysiologicalChannelTypeID`),
+  CONSTRAINT `FK_phys_status_type_TypeID`
+    FOREIGN KEY (`PhysiologicalStatusTypeID`)
+    REFERENCES `physiological_status_type` (`PhysiologicalStatusTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Create physiololgical_electrode_type table
+CREATE TABLE `physiological_electrode_type` (
+  `PhysiologicalElectrodeTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ElectrodeType`                VARCHAR(50)     NOT NULL UNIQUE,
+  PRIMARY KEY (`PhysiologicalElectrodeTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Create physiological_electrode_material table
+CREATE TABLE `physiological_electrode_material` (
+  `PhysiologicalElectrodeMaterialID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ElectrodeMaterial`                VARCHAR(50)     NOT NULL UNIQUE,
+  PRIMARY KEY (`PhysiologicalElectrodeMaterialID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Create a physiological_electrode table
+CREATE TABLE `physiological_electrode` (
+  `PhysiologicalElectrodeID`          INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`               INT(10) UNSIGNED NOT NULL,
+  `PhysiologicalElectrodeTypeID`      INT(5)  UNSIGNED DEFAULT NULL,
+  `PhysiologicalElectrodeMaterialID`  INT(5)  UNSIGNED DEFAULT NULL,
+  `InsertTime`                        TIMESTAMP        NOT NULL      DEFAULT CURRENT_TIMESTAMP,
+  `Name`                              VARCHAR(50)      NOT NULL,
+  `X`                                 DECIMAL(12,6)    NOT NULL,
+  `Y`                                 DECIMAL(12,6)    NOT NULL,
+  `Z`                                 DECIMAL(12,6)    NOT NULL,
+  `Impedance`                         INT(10)          DEFAULT NULL,
+  `FilePath`                          VARCHAR(255)     DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalElectrodeID`),
+  CONSTRAINT `FK_phys_file_FileID_3`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE,
+  CONSTRAINT `FK_phys_elec_type_ID`
+    FOREIGN KEY (`PhysiologicalElectrodeTypeID`)
+    REFERENCES `physiological_electrode_type` (`PhysiologicalElectrodeTypeID`),
+  CONSTRAINT `FK_phys_elec_material_ID`
+  FOREIGN KEY (`PhysiologicalElectrodeMaterialID`)
+  REFERENCES `physiological_electrode_material` (`PhysiologicalElectrodeMaterialID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create physiological_task_event table that will store all information
+-- regarding the task executed during the physiological recording
+CREATE TABLE `physiological_task_event` (
+  `PhysiologicalTaskEventID` INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `InsertTime`               TIMESTAMP        NOT NULL      DEFAULT CURRENT_TIMESTAMP,
+  `Onset`                    DECIMAL(11,6)    NOT NULL,
+  `Duration`                 DECIMAL(11,6)    NOT NULL,
+  `EventCode`                INT(10)          DEFAULT NULL,
+  `EventValue`               INT(10)          DEFAULT NULL,
+  `EventSample`              INT(10)          DEFAULT NULL,
+  `EventType`                VARCHAR(50)      DEFAULT NULL,
+  `TrialType`                VARCHAR(255)     DEFAULT NULL,
+  `ResponseTime`             TIME             DEFAULT NULL,
+  `FilePath`                 VARCHAR(255)     DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalTaskEventID`),
+  CONSTRAINT `FK_phys_file_FileID_4`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create physiological_archive which will store archives of all the files for
+-- Front-end download
+CREATE TABLE `physiological_archive` (
+  `PhysiologicalArchiveID`   INT(10) UNSIGNED NOT NULL   AUTO_INCREMENT,
+  `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `InsertTime`               TIMESTAMP        NOT NULL   DEFAULT CURRENT_TIMESTAMP,
+  `Blake2bHash`              VARCHAR(128)     NOT NULL,
+  `FilePath`                 VARCHAR(255)     NOT NULL,
+  PRIMARY KEY (`PhysiologicalArchiveID`),
+  CONSTRAINT `FK_phys_file_FileID_5`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Insert into physiological_output_type
+INSERT INTO physiological_output_type
+  (`OutputTypeName`, `OutputTypeDescription`)
+  VALUES
+  ('raw',         'raw dataset'),
+  ('derivatives', 'derivative/processed dataset');
+
+-- Insert into physiological_channel_type
+INSERT INTO physiological_channel_type
+  (`ChannelTypeName`, `ChannelDescription`)
+  VALUES
+  ('EEG',              'ElectoEncephaloGram: EEG sensors'                    ),
+  ('VEOG',             'Vertical ElectroOculoGram (eyes)'                    ),
+  ('HEOG',             'Horizontal ElectOculoGram'                           ),
+  ('EOG',              'Generic EOG channel, if HEOG or VEOG information not available'),
+  ('ECG',              'ElectroCardioGram (heart)'                           ),
+  ('EMG',              'ElectroMyoGram (muscle)'                             ),
+  ('TRIG',             'System Triggers'                                     ),
+  ('REF',              'Reference electrode'                                 ),
+  ('GRD',              'Ground electrode'                                    ),
+  ('MISC',             'Miscellaneous'                                       ),
+  ('MEGMAG',           'MEG magnetometer'                                    ),
+  ('MEGGRADAXIAL',     'MEG axial gradiometer'                               ),
+  ('MEGGRADPLANAR',    'MEG planar gradiometer'                              ),
+  ('MEGGREFMAG',       'MEG reference magnetometer'                          ),
+  ('MEGREFGRADAXIAL',  'MEG reference axial gradiometer'                     ),
+  ('MEGREFGRADPLANAR', 'MEG reference planar gradiometer'                    ),
+  ('MEGOTHER',         'Any other type of MEG sensor'                        ),
+  ('ECOG',             'Electrode channel: electrocortigogram (intracranial)'),
+  ('SEEG',             'Electrode channel: stereo-electroencephalogram (intracranial)'),
+  ('DBS',              'Electrode channel: deep brain stimulation (intracranial)'),
+  ('AUDIO',            'Audio signal'                                        ),
+  ('PD',               'Photodiode'                                          ),
+  ('EYEGAZE',          'Eye Tracker gaze'                                    ),
+  ('PUPIL',            'Eye Tracker pupil diameter'                          ),
+  ('SYSCLOCK',         'System time showing elapsed time since trial started'),
+  ('ADC',              'Analog to Digital input'                             ),
+  ('DAC',              'Digital to Analog input'                             ),
+  ('HLU',              'Measure position of head and head coils'             ),
+  ('FITERR',           'Fit error signal from each head localization coil'   ),
+  ('OTHER',            'Any other type of channel'                           );
+
+
+-- Insert into physiological_modality
+INSERT INTO physiological_modality
+  (PhysiologicalModality)
+  VALUES
+  ('eeg'),
+  ('meg'),
+  ('ieeg');
+
+
+-- Insert into physiological_status_type
+INSERT INTO physiological_status_type
+  (ChannelStatus)
+  VALUES
+  ('good'),
+  ('bad');
+
+-- Insert into ImagingFileTypes
+INSERT INTO ImagingFileTypes
+  (type, description)
+  VALUES
+  ('set',  'EEGlab file format (EEG)'),
+  ('bdf',  'Biosemi file format (EEG)'),
+  ('vhdr', 'Brainvision file format (EEG)'),
+  ('vsm',  'BrainStorm file format (EEG)'),
+  ('edf',  'European data format (EEG)'),
+  ('cnt',  'Neuroscan CNT data format (EEG)');
+
+
+-- Insert into Config tables
+INSERT INTO ConfigSettings
+  (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber)
+  SELECT
+    'default_bids_vl',
+    'Default visit label to use when no visit label set in the BIDS dataset',
+    1,
+    0,
+    'text',
+    ID as parentID,
+    'Default visit label for BIDS dataset',
+    (SELECT MAX(OrderNumber) + 1 FROM ConfigSettings WHERE Parent=parentID)
+  FROM ConfigSettings
+  WHERE Name="imaging_pipeline";

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -16,6 +16,8 @@ CREATE TABLE `physiological_output_type` (
 
 
 -- Create a physiological_file table
+-- Note that the field InsertedByUser refers to the Linux User that ran the script
+-- and not a LORIS user
 CREATE TABLE `physiological_file` (
   `PhysiologicalFileID`       INT(10)    UNSIGNED  NOT NULL      AUTO_INCREMENT,
   `PhysiologicalModalityID`   INT(5)     UNSIGNED  DEFAULT NULL,

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -116,14 +116,14 @@ CREATE TABLE `physiological_channel` (
 -- Create physiololgical_electrode_type table
 CREATE TABLE `physiological_electrode_type` (
   `PhysiologicalElectrodeTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `ElectrodeType`                VARCHAR(50),
+  `ElectrodeType`                VARCHAR(50)     NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalElectrodeTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create physiological_electrode_material table
 CREATE TABLE `physiological_electrode_material` (
   `PhysiologicalElectrodeMaterialID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `ElectrodeMaterial`                VARCHAR(50),
+  `ElectrodeMaterial`                VARCHAR(50)     NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalElectrodeMaterialID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -204,7 +204,7 @@ INSERT INTO physiological_output_type
 
 -- Insert into physiological_channel_type
 INSERT INTO physiological_channel_type
-  (`ChannelType`, `ChannelDescription`)
+  (`ChannelTypeName`, `ChannelDescription`)
   VALUES
   ('EEG',              'ElectoEncephaloGram: EEG sensors'                    ),
   ('VEOG',             'Vertical ElectroOculoGram (eyes)'                    ),

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -33,10 +33,10 @@ CREATE TABLE `physiological_file` (
   CONSTRAINT `FK_ImagingFileTypes_type`
     FOREIGN KEY (`FileType`)
     REFERENCES `ImagingFileTypes` (`type`),
-  CONSTRAINT `FK_physiological_modality_PhysiologicalModalityID`
+  CONSTRAINT `FK_phys_modality_ModID`
     FOREIGN KEY (`PhysiologicalModalityID`)
     REFERENCES `physiological_modality` (`PhysiologicalModalityID`),
-  CONSTRAINT `FK_physiological_output_type_PhysiologicalOutputTypeID`
+  CONSTRAINT `FK_phys_output_type_TypeID`
     FOREIGN KEY (`PhysiologicalOutputTypeID`)
     REFERENCES `physiological_output_type` (`PhysiologicalOutputTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -52,11 +52,11 @@ CREATE TABLE `physiological_parameter_file` (
   `InsertTime`                   TIMESTAMP        NOT NULL  DEFAULT CURRENT_TIMESTAMP,
   `Value`                        VARCHAR(255),
   PRIMARY KEY (`PhysiologicalParameterFileID`),
-  CONSTRAINT `FK_physiological_file_PhysiologicalFileID`
+  CONSTRAINT `FK_phys_file_FileID`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE,
-  CONSTRAINT `FK_parameter_type_ParameterTypeID`
+  CONSTRAINT `FK_param_type_ParamTypeID`
     FOREIGN KEY (`ParameterTypeID`)
     REFERENCES `parameter_type` (`ParameterTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -101,14 +101,14 @@ CREATE TABLE `physiological_channel` (
   `Unit`                       VARCHAR(255)        DEFAULT NULL,
   `FilePath`                   VARCHAR(255)        DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalChannelID`),
-  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_2`
+  CONSTRAINT `FK_phys_file_FileID_2`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE,
-  CONSTRAINT `FK_physiological_channel_type_PhysiologicalChannelTypeID`
+  CONSTRAINT `FK_phys_channel_type_TypeID`
     FOREIGN KEY (`PhysiologicalChannelTypeID`)
     REFERENCES `physiological_channel_type` (`PhysiologicalChannelTypeID`),
-  CONSTRAINT `FK_physiological_status_type_PhysiologicalStatusTypeID`
+  CONSTRAINT `FK_phys_status_type_TypeID`
     FOREIGN KEY (`PhysiologicalStatusTypeID`)
     REFERENCES `physiological_status_type` (`PhysiologicalStatusTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -129,7 +129,7 @@ CREATE TABLE `physiological_electrode` (
   `Material`                 VARCHAR(50)      NOT NULL,
   `FilePath`                 VARCHAR(255)     DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalElectrodeID`),
-  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_3`
+  CONSTRAINT `FK_phys_file_FileID_3`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
@@ -153,7 +153,7 @@ CREATE TABLE `physiological_task_event` (
   `ResponseTime`             TIME             DEFAULT NULL,
   `FilePath`                 VARCHAR(255)     DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalTaskEventID`),
-  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_4`
+  CONSTRAINT `FK_phys_file_FileID_4`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
@@ -170,7 +170,7 @@ CREATE TABLE `physiological_archive` (
   `Blake2bHash`              VARCHAR(128)     NOT NULL,
   `FilePath`                 VARCHAR(255)     NOT NULL,
   PRIMARY KEY (`PhysiologicalArchiveID`),
-  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_5`
+  CONSTRAINT `FK_phys_file_FileID_5`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -1,0 +1,259 @@
+-- Create a physiological_modality table
+CREATE TABLE `physiological_modality` (
+  `PhysiologicalModalityID` TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `PhysiologicalModality`   VARCHAR(50)      NOT NULL,
+  PRIMARY KEY (`PhysiologicalModalityID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Create a physiological_output_type table
+CREATE TABLE `physiological_output_type` (
+  `PhysiologicalOutputTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `OutputType`                VARCHAR(20)     NOT NULL,
+  `OutputTypeDescription`     VARCHAR(255),
+  PRIMARY KEY (`PhysiologicalOutputTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Create a physiological_file table
+CREATE TABLE `physiological_file` (
+  `PhysiologicalFileID`       INT(10)    UNSIGNED  NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalModalityID`   TINYINT(3) UNSIGNED  DEFAULT NULL,
+  `Caveat`                    TINYINT(1) UNSIGNED  DEFAULT 0,
+  `PhysiologicalOutputTypeID` INT(5)     UNSIGNED  NOT NULL,
+  `SessionID`                 INT(10)    UNSIGNED  NOT NULL,
+  `InsertTime`                INT(10)    UNSIGNED  NOT NULL,
+  `FileType`                  VARCHAR(12)          DEFAULT NULL,
+  `AcquisitionTime`           VARCHAR(20)          DEFAULT NULL,
+  `InsertedByUser`            VARCHAR(50)          NOT NULL,
+  `File`                      VARCHAR(255)         NOT NULL,
+  PRIMARY KEY (`PhysiologicalFileID`),
+  CONSTRAINT `FK_session_ID`
+    FOREIGN KEY (`SessionID`)
+    REFERENCES `session` (`ID`),
+  CONSTRAINT `FK_ImagingFileTypes_type`
+    FOREIGN KEY (`FileType`)
+    REFERENCES `ImagingFileTypes` (`type`),
+  CONSTRAINT `FK_physiological_modality_PhysiologicalModalityID`
+    FOREIGN KEY (`PhysiologicalModalityID`)
+    REFERENCES `physiological_modality` (`PhysiologicalModalityID`),
+  CONSTRAINT `FK_physiological_output_type_PhysiologicalOutputTypeID`
+    FOREIGN KEY (`PhysiologicalOutputTypeID`)
+    REFERENCES `physiological_output_type` (`PhysiologicalOutputTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_parameter_file table that will store all JSON
+-- information that accompanies the BIDS physiological dataset
+CREATE TABLE `physiological_parameter_file` (
+  `PhysiologicalParameterFileID` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `PhysiologicalFileID`          INT(10) UNSIGNED NOT NULL,
+  `ParameterTypeID`              INT(10) UNSIGNED NOT NULL,
+  `InsertTime`                   INT(10) UNSIGNED NOT NULL,
+  `Value`                        VARCHAR(255),
+  PRIMARY KEY (`PhysiologicalParameterFileID`),
+  CONSTRAINT `FK_physiological_file_PhysiologicalFileID`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE,
+  CONSTRAINT `FK_parameter_type_ParameterTypeID`
+    FOREIGN KEY (`ParameterTypeID`)
+    REFERENCES `parameter_type` (`ParameterTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_status_type table
+CREATE TABLE `physiological_status_type` (
+  `PhysiologicalStatusTypeID` TINYINT(2) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ChannelStatus`             VARCHAR(10)         NOT NULL,
+  PRIMARY KEY (`PhysiologicalStatusTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_channel_type table
+CREATE TABLE `physiological_channel_type` (
+  `PhysiologicalChannelTypeID` TINYINT(3) UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `ChannelType`                VARCHAR(255)        NOT NULL,
+  `ChannelDescription`         VARCHAR(255)        DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalChannelTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_channel table that will store all information from
+CREATE TABLE `physiological_channel` (
+  `PhysiologicalChannelID`     INT(10) UNSIGNED    NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`        INT(10) UNSIGNED    NOT NULL,
+  `PhysiologicalChannelTypeID` TINYINT(3) UNSIGNED NOT NULL,
+  `PhysiologicalStatusTypeID`  TINYINT(2) UNSIGNED DEFAULT NULL,
+  `Name`                       VARCHAR(50)         NOT NULL,
+  `Description`                VARCHAR(255)        DEFAULT NULL,
+  `SamplingFrequency`          INT(6)              DEFAULT NULL,
+  `LowCutoff`                  DECIMAL(8,3)        DEFAULT NULL,
+  `HighCutoff`                 DECIMAL(8,3)        DEFAULT NULL,
+  `ManualFlag`                 DECIMAL(5,4)        DEFAULT NULL,
+  `Notch`                      INT(6)              DEFAULT NULL,
+  `StatusDescription`          VARCHAR(255)        DEFAULT NULL,
+  `Unit`                       VARCHAR(255)        DEFAULT NULL,
+  `File`                       VARCHAR(255)        DEFAULT NULL,
+  `SoftwareFilters`            VARCHAR(255)        DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalChannelID`),
+  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_2`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE,
+  CONSTRAINT `FK_physiological_channel_type_PhysiologicalChannelTypeID`
+    FOREIGN KEY (`PhysiologicalChannelTypeID`)
+    REFERENCES `physiological_channel_type` (`PhysiologicalChannelTypeID`),
+  CONSTRAINT `FK_physiological_status_type_PhysiologicalStatusTypeID`
+    FOREIGN KEY (`PhysiologicalStatusTypeID`)
+    REFERENCES `physiological_status_type` (`PhysiologicalStatusTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create a physiological_electrode table
+CREATE TABLE `physiological_electrode` (
+  `PhysiologicalElectrodeID` INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `Name`                     VARCHAR(50)      NOT NULL,
+  `X`                        DECIMAL(12,6)    NOT NULL,
+  `Y`                        DECIMAL(12,6)    NOT NULL,
+  `Z`                        DECIMAL(12,6)    NOT NULL,
+  `Type`                     VARCHAR(50)      NOT NULL,
+  `Material`                 VARCHAR(50)      NOT NULL,
+  `File`                     VARCHAR(255)     DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalElectrodeID`),
+  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_3`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create physiological_task_event table that will store all information
+-- regarding the task executed during the physiological recording
+CREATE TABLE `physiological_task_event` (
+  `PhysiologicalTaskEventID` INT(10) UNSIGNED NOT NULL       AUTO_INCREMENT,
+  `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `Onset`                    DECIMAL(11,6)    NOT NULL,
+  `Duration`                 DECIMAL(11,6)    NOT NULL,
+  `TrialType`                VARCHAR(255)     DEFAULT NULL,
+  `ResponseTime`             TIME             DEFAULT NULL,
+  `EventCode`                VARCHAR(255)     DEFAULT NULL,
+  `Sample`                   VARCHAR(255)     DEFAULT NULL,
+  `File`                     VARCHAR(255)     DEFAULT NULL,
+  PRIMARY KEY (`PhysiologicalTaskEventID`),
+  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_4`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+-- Create physiological_archive which will store archives of all the files for
+-- Front-end download
+CREATE TABLE `physiological_archive` (
+  `PhysiologicalArchiveID`   INT(10) UNSIGNED NOT NULL       AUTO_INCREMENT,
+  `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `InsertTime`               INT(10) UNSIGNED NOT NULL,
+  `Blake2bHash`              VARCHAR(128)     NOT NULL,
+  `File`                     VARCHAR(255)     NOT NULL,
+  PRIMARY KEY (`PhysiologicalArchiveID`),
+  CONSTRAINT `FK_physiological_file_PhysiologicalFileID_5`
+    FOREIGN KEY (`PhysiologicalFileID`)
+    REFERENCES `physiological_file` (`PhysiologicalFileID`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+-- Insert into physiological_output_type
+INSERT INTO physiological_output_type
+  (`OutputType`, `OutputTypeDescription`)
+  VALUES
+  ('raw',         'raw dataset'),
+  ('derivatives', 'derivative/processed dataset');
+
+-- Insert into physiological_channel_type
+INSERT INTO physiological_channel_type
+  (`ChannelType`, `ChannelDescription`)
+  VALUES
+  ('EEG',              'ElectoEncephaloGram: EEG sensors'                    ),
+  ('VEOG',             'Vertical ElectroOculoGram (eyes)'                    ),
+  ('HEOG',             'Horizontal ElectOculoGram'                           ),
+  ('EOG',              'Generic EOG channel, if HEOG or VEOG information not available'),
+  ('ECG',              'ElectroCardioGram (heart)'                           ),
+  ('EMG',              'ElectroMyoGram (muscle)'                             ),
+  ('TRIG',             'System Triggers'                                     ),
+  ('REF',              'Reference electrode'                                 ),
+  ('GRD',              'Ground electrode'                                    ),
+  ('MISC',             'Miscellaneous'                                       ),
+  ('MEGMAG',           'MEG magnetometer'                                    ),
+  ('MEGGRADAXIAL',     'MEG axial gradiometer'                               ),
+  ('MEGGRADPLANAR',    'MEG planar gradiometer'                              ),
+  ('MEGGREFMAG',       'MEG reference magnetometer'                          ),
+  ('MEGREFGRADAXIAL',  'MEG reference axial gradiometer'                     ),
+  ('MEGREFGRADPLANAR', 'MEG reference planar gradiometer'                    ),
+  ('MEGOTHER',         'Any other type of MEG sensor'                        ),
+  ('ECOG',             'Electrode channel: electrocortigogram (intracranial)'),
+  ('SEEG',             'Electrode channel: stereo-electroencephalogram (intracranial)'),
+  ('DBS',              'Electrode channel: deep brain stimulation (intracranial)'),
+  ('AUDIO',            'Audio signal'                                        ),
+  ('PD',               'Photodiode'                                          ),
+  ('EYEGAZE',          'Eye Tracker gaze'                                    ),
+  ('PUPIL',            'Eye Tracker pupil diameter'                          ),
+  ('SYSCLOCK',         'System time showing elapsed time since trial started'),
+  ('ADC',              'Analog to Digital input'                             ),
+  ('DAC',              'Digital to Analog input'                             ),
+  ('HLU',              'Measure position of head and head coils'             ),
+  ('FITERR',           'Fit error signal from each head localization coil'   ),
+  ('OTHER',            'Any other type of channel'                           );
+
+
+-- Insert into physiological_modality
+INSERT INTO physiological_modality
+  (PhysiologicalModality)
+  VALUES
+  ('eeg'),
+  ('meg'),
+  ('ieeg');
+
+
+-- Insert into physiological_status_type
+INSERT INTO physiological_status_type
+  (ChannelStatus)
+  VALUES
+  ('good'),
+  ('bad');
+
+-- Insert into ImagingFileTypes
+INSERT INTO ImagingFileTypes
+  (type, description)
+  VALUES
+  ('set',  'EEGlab file format (EEG)'),
+  ('bdf',  'Biosemi file format (EEG)'),
+  ('vhdr', 'Brainvision file format (EEG)'),
+  ('vsm',  'BrainStorm file format (EEG)'),
+  ('edf',  'European data format (EEG)'),
+  ('cnt',  'Neuroscan CNT data format (EEG)');
+
+
+-- Insert into Config tables
+INSERT INTO ConfigSettings
+  (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber)
+  SELECT
+    'default_bids_vl',
+    'Default visit label to use when no visit label set in the BIDS dataset',
+    1,
+    0,
+    'text',
+    ID as parentID,
+    'Default visit label for BIDS dataset',
+    (SELECT MAX(OrderNumber) + 1 FROM ConfigSettings WHERE Parent=parentID)
+  FROM ConfigSettings
+  WHERE Name="imaging_pipeline";

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -3,7 +3,7 @@ CREATE TABLE `physiological_modality` (
   `PhysiologicalModalityID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
   `PhysiologicalModality`   VARCHAR(50)         NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalModalityID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 -- Create a physiological_output_type table
@@ -12,7 +12,7 @@ CREATE TABLE `physiological_output_type` (
   `OutputTypeName`            VARCHAR(20)          NOT NULL UNIQUE,
   `OutputTypeDescription`     VARCHAR(255),
   PRIMARY KEY (`PhysiologicalOutputTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 -- Create a physiological_file table
@@ -39,7 +39,7 @@ CREATE TABLE `physiological_file` (
   CONSTRAINT `FK_physiological_output_type_PhysiologicalOutputTypeID`
     FOREIGN KEY (`PhysiologicalOutputTypeID`)
     REFERENCES `physiological_output_type` (`PhysiologicalOutputTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -59,7 +59,7 @@ CREATE TABLE `physiological_parameter_file` (
   CONSTRAINT `FK_parameter_type_ParameterTypeID`
     FOREIGN KEY (`ParameterTypeID`)
     REFERENCES `parameter_type` (`ParameterTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -68,7 +68,7 @@ CREATE TABLE `physiological_status_type` (
   `PhysiologicalStatusTypeID` INT(5)      UNSIGNED NOT NULL AUTO_INCREMENT,
   `ChannelStatus`             VARCHAR(10)          NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalStatusTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -78,7 +78,7 @@ CREATE TABLE `physiological_channel_type` (
   `ChannelTypeName`            VARCHAR(255)          NOT NULL      UNIQUE,
   `ChannelDescription`         VARCHAR(255)          DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalChannelTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -111,7 +111,7 @@ CREATE TABLE `physiological_channel` (
   CONSTRAINT `FK_physiological_status_type_PhysiologicalStatusTypeID`
     FOREIGN KEY (`PhysiologicalStatusTypeID`)
     REFERENCES `physiological_status_type` (`PhysiologicalStatusTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -124,6 +124,7 @@ CREATE TABLE `physiological_electrode` (
   `X`                        DECIMAL(12,6)    NOT NULL,
   `Y`                        DECIMAL(12,6)    NOT NULL,
   `Z`                        DECIMAL(12,6)    NOT NULL,
+  `Impedance`                INT(10)          DEFAULT NULL,
   `Type`                     VARCHAR(50)      NOT NULL,
   `Material`                 VARCHAR(50)      NOT NULL,
   `FilePath`                 VARCHAR(255)     DEFAULT NULL,
@@ -132,7 +133,7 @@ CREATE TABLE `physiological_electrode` (
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -145,16 +146,18 @@ CREATE TABLE `physiological_task_event` (
   `Onset`                    DECIMAL(11,6)    NOT NULL,
   `Duration`                 DECIMAL(11,6)    NOT NULL,
   `EventCode`                INT(10)          DEFAULT NULL,
+  `EventValue`               INT(10)          DEFAULT NULL,
+  `EventSample`              INT(10)          DEFAULT NULL,
+  `EventType`                VARCHAR(50)      DEFAULT NULL,
   `TrialType`                VARCHAR(255)     DEFAULT NULL,
   `ResponseTime`             TIME             DEFAULT NULL,
-  `Sample`                   VARCHAR(255)     DEFAULT NULL,
   `FilePath`                 VARCHAR(255)     DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalTaskEventID`),
   CONSTRAINT `FK_physiological_file_PhysiologicalFileID_4`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
@@ -171,7 +174,7 @@ CREATE TABLE `physiological_archive` (
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 -- Insert into physiological_output_type

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -1,15 +1,15 @@
 -- Create a physiological_modality table
 CREATE TABLE `physiological_modality` (
-  `PhysiologicalModalityID` TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `PhysiologicalModality`   VARCHAR(50)      NOT NULL,
+  `PhysiologicalModalityID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `PhysiologicalModality`   VARCHAR(50)         NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalModalityID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Create a physiological_output_type table
 CREATE TABLE `physiological_output_type` (
-  `PhysiologicalOutputTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `OutputType`                VARCHAR(20)     NOT NULL,
+  `PhysiologicalOutputTypeID` INT(5)      UNSIGNED NOT NULL AUTO_INCREMENT,
+  `OutputTypeName`            VARCHAR(20)          NOT NULL UNIQUE,
   `OutputTypeDescription`     VARCHAR(255),
   PRIMARY KEY (`PhysiologicalOutputTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -18,15 +18,14 @@ CREATE TABLE `physiological_output_type` (
 -- Create a physiological_file table
 CREATE TABLE `physiological_file` (
   `PhysiologicalFileID`       INT(10)    UNSIGNED  NOT NULL      AUTO_INCREMENT,
-  `PhysiologicalModalityID`   TINYINT(3) UNSIGNED  DEFAULT NULL,
-  `Caveat`                    TINYINT(1) UNSIGNED  DEFAULT 0,
+  `PhysiologicalModalityID`   INT(5)     UNSIGNED  DEFAULT NULL,
   `PhysiologicalOutputTypeID` INT(5)     UNSIGNED  NOT NULL,
   `SessionID`                 INT(10)    UNSIGNED  NOT NULL,
-  `InsertTime`                INT(10)    UNSIGNED  NOT NULL,
+  `InsertTime`                TIMESTAMP            NOT NULL      DEFAULT CURRENT_TIMESTAMP,
   `FileType`                  VARCHAR(12)          DEFAULT NULL,
-  `AcquisitionTime`           VARCHAR(20)          DEFAULT NULL,
+  `AcquisitionTime`           DATETIME             DEFAULT '1970-01-01 00:00:01',
   `InsertedByUser`            VARCHAR(50)          NOT NULL,
-  `File`                      VARCHAR(255)         NOT NULL,
+  `FilePath`                  VARCHAR(255)         NOT NULL,
   PRIMARY KEY (`PhysiologicalFileID`),
   CONSTRAINT `FK_session_ID`
     FOREIGN KEY (`SessionID`)
@@ -47,10 +46,10 @@ CREATE TABLE `physiological_file` (
 -- Create a physiological_parameter_file table that will store all JSON
 -- information that accompanies the BIDS physiological dataset
 CREATE TABLE `physiological_parameter_file` (
-  `PhysiologicalParameterFileID` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `PhysiologicalParameterFileID` INT(10) UNSIGNED NOT NULL  AUTO_INCREMENT,
   `PhysiologicalFileID`          INT(10) UNSIGNED NOT NULL,
   `ParameterTypeID`              INT(10) UNSIGNED NOT NULL,
-  `InsertTime`                   INT(10) UNSIGNED NOT NULL,
+  `InsertTime`                   TIMESTAMP        NOT NULL  DEFAULT CURRENT_TIMESTAMP,
   `Value`                        VARCHAR(255),
   PRIMARY KEY (`PhysiologicalParameterFileID`),
   CONSTRAINT `FK_physiological_file_PhysiologicalFileID`
@@ -66,8 +65,8 @@ CREATE TABLE `physiological_parameter_file` (
 
 -- Create a physiological_status_type table
 CREATE TABLE `physiological_status_type` (
-  `PhysiologicalStatusTypeID` TINYINT(2) UNSIGNED NOT NULL AUTO_INCREMENT,
-  `ChannelStatus`             VARCHAR(10)         NOT NULL,
+  `PhysiologicalStatusTypeID` INT(5)      UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ChannelStatus`             VARCHAR(10)          NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalStatusTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -75,9 +74,9 @@ CREATE TABLE `physiological_status_type` (
 
 -- Create a physiological_channel_type table
 CREATE TABLE `physiological_channel_type` (
-  `PhysiologicalChannelTypeID` TINYINT(3) UNSIGNED NOT NULL      AUTO_INCREMENT,
-  `ChannelType`                VARCHAR(255)        NOT NULL,
-  `ChannelDescription`         VARCHAR(255)        DEFAULT NULL,
+  `PhysiologicalChannelTypeID` INT(5)       UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `ChannelTypeName`            VARCHAR(255)          NOT NULL      UNIQUE,
+  `ChannelDescription`         VARCHAR(255)          DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalChannelTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -85,10 +84,11 @@ CREATE TABLE `physiological_channel_type` (
 
 -- Create a physiological_channel table that will store all information from
 CREATE TABLE `physiological_channel` (
-  `PhysiologicalChannelID`     INT(10) UNSIGNED    NOT NULL      AUTO_INCREMENT,
-  `PhysiologicalFileID`        INT(10) UNSIGNED    NOT NULL,
-  `PhysiologicalChannelTypeID` TINYINT(3) UNSIGNED NOT NULL,
-  `PhysiologicalStatusTypeID`  TINYINT(2) UNSIGNED DEFAULT NULL,
+  `PhysiologicalChannelID`     INT(10)    UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`        INT(10)    UNSIGNED NOT NULL,
+  `PhysiologicalChannelTypeID` INT(5)     UNSIGNED NOT NULL,
+  `PhysiologicalStatusTypeID`  INT(5)     UNSIGNED DEFAULT NULL,
+  `InsertTime`                 TIMESTAMP           NOT NULL      DEFAULT CURRENT_TIMESTAMP,
   `Name`                       VARCHAR(50)         NOT NULL,
   `Description`                VARCHAR(255)        DEFAULT NULL,
   `SamplingFrequency`          INT(6)              DEFAULT NULL,
@@ -96,10 +96,10 @@ CREATE TABLE `physiological_channel` (
   `HighCutoff`                 DECIMAL(8,3)        DEFAULT NULL,
   `ManualFlag`                 DECIMAL(5,4)        DEFAULT NULL,
   `Notch`                      INT(6)              DEFAULT NULL,
+  `Reference`                  VARCHAR(255)        DEFAULT NULL,
   `StatusDescription`          VARCHAR(255)        DEFAULT NULL,
   `Unit`                       VARCHAR(255)        DEFAULT NULL,
-  `File`                       VARCHAR(255)        DEFAULT NULL,
-  `SoftwareFilters`            VARCHAR(255)        DEFAULT NULL,
+  `FilePath`                   VARCHAR(255)        DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalChannelID`),
   CONSTRAINT `FK_physiological_file_PhysiologicalFileID_2`
     FOREIGN KEY (`PhysiologicalFileID`)
@@ -119,13 +119,14 @@ CREATE TABLE `physiological_channel` (
 CREATE TABLE `physiological_electrode` (
   `PhysiologicalElectrodeID` INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
   `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `InsertTime`               TIMESTAMP        NOT NULL      DEFAULT CURRENT_TIMESTAMP,
   `Name`                     VARCHAR(50)      NOT NULL,
   `X`                        DECIMAL(12,6)    NOT NULL,
   `Y`                        DECIMAL(12,6)    NOT NULL,
   `Z`                        DECIMAL(12,6)    NOT NULL,
   `Type`                     VARCHAR(50)      NOT NULL,
   `Material`                 VARCHAR(50)      NOT NULL,
-  `File`                     VARCHAR(255)     DEFAULT NULL,
+  `FilePath`                 VARCHAR(255)     DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalElectrodeID`),
   CONSTRAINT `FK_physiological_file_PhysiologicalFileID_3`
     FOREIGN KEY (`PhysiologicalFileID`)
@@ -138,15 +139,16 @@ CREATE TABLE `physiological_electrode` (
 -- Create physiological_task_event table that will store all information
 -- regarding the task executed during the physiological recording
 CREATE TABLE `physiological_task_event` (
-  `PhysiologicalTaskEventID` INT(10) UNSIGNED NOT NULL       AUTO_INCREMENT,
+  `PhysiologicalTaskEventID` INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
   `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
+  `InsertTime`               TIMESTAMP        NOT NULL      DEFAULT CURRENT_TIMESTAMP,
   `Onset`                    DECIMAL(11,6)    NOT NULL,
   `Duration`                 DECIMAL(11,6)    NOT NULL,
+  `EventCode`                INT(10)          DEFAULT NULL,
   `TrialType`                VARCHAR(255)     DEFAULT NULL,
   `ResponseTime`             TIME             DEFAULT NULL,
-  `EventCode`                VARCHAR(255)     DEFAULT NULL,
   `Sample`                   VARCHAR(255)     DEFAULT NULL,
-  `File`                     VARCHAR(255)     DEFAULT NULL,
+  `FilePath`                 VARCHAR(255)     DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalTaskEventID`),
   CONSTRAINT `FK_physiological_file_PhysiologicalFileID_4`
     FOREIGN KEY (`PhysiologicalFileID`)
@@ -159,11 +161,11 @@ CREATE TABLE `physiological_task_event` (
 -- Create physiological_archive which will store archives of all the files for
 -- Front-end download
 CREATE TABLE `physiological_archive` (
-  `PhysiologicalArchiveID`   INT(10) UNSIGNED NOT NULL       AUTO_INCREMENT,
+  `PhysiologicalArchiveID`   INT(10) UNSIGNED NOT NULL   AUTO_INCREMENT,
   `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
-  `InsertTime`               INT(10) UNSIGNED NOT NULL,
+  `InsertTime`               TIMESTAMP        NOT NULL   DEFAULT CURRENT_TIMESTAMP,
   `Blake2bHash`              VARCHAR(128)     NOT NULL,
-  `File`                     VARCHAR(255)     NOT NULL,
+  `FilePath`                 VARCHAR(255)     NOT NULL,
   PRIMARY KEY (`PhysiologicalArchiveID`),
   CONSTRAINT `FK_physiological_file_PhysiologicalFileID_5`
     FOREIGN KEY (`PhysiologicalFileID`)

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -179,7 +179,7 @@ CREATE TABLE `physiological_archive` (
 
 -- Insert into physiological_output_type
 INSERT INTO physiological_output_type
-  (`OutputType`, `OutputTypeDescription`)
+  (`OutputTypeName`, `OutputTypeDescription`)
   VALUES
   ('raw',         'raw dataset'),
   ('derivatives', 'derivative/processed dataset');

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -113,26 +113,44 @@ CREATE TABLE `physiological_channel` (
     REFERENCES `physiological_status_type` (`PhysiologicalStatusTypeID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+-- Create physiololgical_electrode_type table
+CREATE TABLE `physiological_electrode_type` (
+  `PhysiologicalElectrodeTypeID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ElectrodeType`                VARCHAR(50),
+  PRIMARY KEY (`PhysiologicalElectrodeTypeID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+-- Create physiological_electrode_material table
+CREATE TABLE `physiological_electrode_material` (
+  `PhysiologicalElectrodeMaterialID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `ElectrodeMaterial`                VARCHAR(50),
+  PRIMARY KEY (`PhysiologicalElectrodeMaterialID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create a physiological_electrode table
 CREATE TABLE `physiological_electrode` (
-  `PhysiologicalElectrodeID` INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
-  `PhysiologicalFileID`      INT(10) UNSIGNED NOT NULL,
-  `InsertTime`               TIMESTAMP        NOT NULL      DEFAULT CURRENT_TIMESTAMP,
-  `Name`                     VARCHAR(50)      NOT NULL,
-  `X`                        DECIMAL(12,6)    NOT NULL,
-  `Y`                        DECIMAL(12,6)    NOT NULL,
-  `Z`                        DECIMAL(12,6)    NOT NULL,
-  `Impedance`                INT(10)          DEFAULT NULL,
-  `Type`                     VARCHAR(50)      NOT NULL,
-  `Material`                 VARCHAR(50)      NOT NULL,
-  `FilePath`                 VARCHAR(255)     DEFAULT NULL,
+  `PhysiologicalElectrodeID`          INT(10) UNSIGNED NOT NULL      AUTO_INCREMENT,
+  `PhysiologicalFileID`               INT(10) UNSIGNED NOT NULL,
+  `PhysiologicalElectrodeTypeID`      INT(5)  UNSIGNED DEFAULT NULL,
+  `PhysiologicalElectrodeMaterialID`  INT(5)  UNSIGNED DEFAULT NULL,
+  `InsertTime`                        TIMESTAMP        NOT NULL      DEFAULT CURRENT_TIMESTAMP,
+  `Name`                              VARCHAR(50)      NOT NULL,
+  `X`                                 DECIMAL(12,6)    NOT NULL,
+  `Y`                                 DECIMAL(12,6)    NOT NULL,
+  `Z`                                 DECIMAL(12,6)    NOT NULL,
+  `Impedance`                         INT(10)          DEFAULT NULL,
+  `FilePath`                          VARCHAR(255)     DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalElectrodeID`),
   CONSTRAINT `FK_phys_file_FileID_3`
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
-    ON DELETE CASCADE
+    ON DELETE CASCADE,
+  CONSTRAINT `FK_phys_elec_type_ID`
+    FOREIGN KEY (`PhysiologicalElectrodeTypeID`)
+    REFERENCES `physiological_electrode_type` (`PhysiologicalElectrodeTypeID`),
+  CONSTRAINT `FK_phys_elec_material_ID`
+  FOREIGN KEY (`PhysiologicalElectrodeMaterialID`)
+  REFERENCES `physiological_electrode_material` (`PhysiologicalElectrodeMaterialID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/SQL/New_patches/2018-09-07_EEG_tables.sql
+++ b/SQL/New_patches/2018-09-07_EEG_tables.sql
@@ -3,7 +3,7 @@ CREATE TABLE `physiological_modality` (
   `PhysiologicalModalityID` INT(5) UNSIGNED NOT NULL AUTO_INCREMENT,
   `PhysiologicalModality`   VARCHAR(50)         NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalModalityID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Create a physiological_output_type table
@@ -12,7 +12,7 @@ CREATE TABLE `physiological_output_type` (
   `OutputTypeName`            VARCHAR(20)          NOT NULL UNIQUE,
   `OutputTypeDescription`     VARCHAR(255),
   PRIMARY KEY (`PhysiologicalOutputTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Create a physiological_file table
@@ -39,7 +39,7 @@ CREATE TABLE `physiological_file` (
   CONSTRAINT `FK_phys_output_type_TypeID`
     FOREIGN KEY (`PhysiologicalOutputTypeID`)
     REFERENCES `physiological_output_type` (`PhysiologicalOutputTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -59,7 +59,7 @@ CREATE TABLE `physiological_parameter_file` (
   CONSTRAINT `FK_param_type_ParamTypeID`
     FOREIGN KEY (`ParameterTypeID`)
     REFERENCES `parameter_type` (`ParameterTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -68,7 +68,7 @@ CREATE TABLE `physiological_status_type` (
   `PhysiologicalStatusTypeID` INT(5)      UNSIGNED NOT NULL AUTO_INCREMENT,
   `ChannelStatus`             VARCHAR(10)          NOT NULL UNIQUE,
   PRIMARY KEY (`PhysiologicalStatusTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -78,7 +78,7 @@ CREATE TABLE `physiological_channel_type` (
   `ChannelTypeName`            VARCHAR(255)          NOT NULL      UNIQUE,
   `ChannelDescription`         VARCHAR(255)          DEFAULT NULL,
   PRIMARY KEY (`PhysiologicalChannelTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -111,7 +111,7 @@ CREATE TABLE `physiological_channel` (
   CONSTRAINT `FK_phys_status_type_TypeID`
     FOREIGN KEY (`PhysiologicalStatusTypeID`)
     REFERENCES `physiological_status_type` (`PhysiologicalStatusTypeID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -133,7 +133,7 @@ CREATE TABLE `physiological_electrode` (
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -157,7 +157,7 @@ CREATE TABLE `physiological_task_event` (
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 
@@ -174,7 +174,7 @@ CREATE TABLE `physiological_archive` (
     FOREIGN KEY (`PhysiologicalFileID`)
     REFERENCES `physiological_file` (`PhysiologicalFileID`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- Insert into physiological_output_type


### PR DESCRIPTION
### Brief summary of changes

This PR includes the SQL patch to be run to create the EEG tables for the insertion scripts of the LORIS-MRI. Note that these tables will be used by the new Electrophysiology Browser module that will be in a separate PR.

This PR goes hand in hand with the following LORIS-MRI PR: https://github.com/aces/Loris-MRI/pull/337

For people that are visual, here is a screenshot summarizing the table structure for the EEG tables:

![overall tables](https://user-images.githubusercontent.com/1402456/46809313-307c8980-cd3c-11e8-9ad8-899c91e1730b.png)

### This resolves issue...

- [ ] Redmine? https://redmine.cbrain.mcgill.ca/issues/13603


### To test this change...

- Run the SQL patch and makes sure all statements work properly
- If you have an empty database, run the default schema with the new changes to make sure all statements work properly
- Feel free to make sure that the tables follow the LORIS SQL standard (crossing my fingers that I did not omit anything there!)