### PR TITLE
[create timepoint] Fix error in logic when projects are enabled

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -116,7 +116,7 @@ class Create_Timepoint extends \NDB_Form
         if ($config->getSetting('useProjects') === 'true') {
             // If projects enabled, loop through and add valid subprojects only
             $subprojList = $candidate->getValidSubprojects();
-            if (empty($allSubprojects)) {
+            if (empty($subprojList)) {
                 $this->form->errors['subprojectID'] = "No subprojects have been 
                 defined for the project this candidate is affiliated with. 
                 If you are an administrator, please use the Configuration module to 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -104,13 +104,24 @@ class Create_Timepoint extends \NDB_Form
 
         $candidate =& \Candidate::singleton($this->identifier);
         // List of all subprojects from config file
-        $allSubprojects  = \Utility::getSubprojectList();
+        $allSubprojects = \Utility::getSubprojectList();
+        if (empty($allSubprojects)) {
+            $this->form->errors['subprojectID'] = "No subprojects have been defined 
+            for this study. If you are an administrator, please use the 
+            Configuration module to add new subprojects.";
+        }
         $sp_labelOptions = array(null => '');
         $subprojList     = null;
         //List of valid subprojects for a given project
         if ($config->getSetting('useProjects') === 'true') {
             // If projects enabled, loop through and add valid subprojects only
             $subprojList = $candidate->getValidSubprojects();
+            if (empty($allSubprojects)) {
+                $this->form->errors['subprojectID'] = "No subprojects have been 
+                defined for the project this candidate is affiliated with. 
+                If you are an administrator, please use the Configuration module to 
+                add new subprojects and associate them with projects.";
+            }
             foreach ($allSubprojects as $subprojectID => $title) {
                 if (in_array($subprojectID, $subprojList)) {
                     $sp_labelOptions[$subprojectID] = $title;

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -103,26 +103,22 @@ class Create_Timepoint extends \NDB_Form
         $this->addHidden('candID', $this->identifier);
 
         $candidate   =& \Candidate::singleton($this->identifier);
+        // List of all subprojects from config file
+        $allSubprojects  = \Utility::getSubprojectList();
+        $sp_labelOptions = array(null => '');
         $subprojList = null;
         //List of valid subprojects for a given project
         if ($config->getSetting('useProjects') === 'true') {
+            // If projects enabled, loop through and add valid subprojects only
             $subprojList = $candidate->getValidSubprojects();
-        }
-        // List of all subprojects from config file
-
-        // Loop through the subprojects to get an id out and to create
-        // the subproject drop down.
-        $allSubprojects  = \Utility::getSubprojectList();
-        $sp_labelOptions = array(null => '');
-
-        foreach ($allSubprojects as $subprojectID => $title) {
-            if (! empty($subprojList)) {
+            foreach ($allSubprojects as $subprojectID => $title) {
                 if (in_array($subprojectID, $subprojList)) {
                     $sp_labelOptions[$subprojectID] = $title;
                 }
-            } else {
-                $sp_labelOptions[$subprojectID] = $title;
             }
+        } else {
+            // If projects disabled, add all subprojects
+            $sp_labelOptions += $allSubprojects;
         }
 
         $attributes = array(

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -102,11 +102,11 @@ class Create_Timepoint extends \NDB_Form
 
         $this->addHidden('candID', $this->identifier);
 
-        $candidate   =& \Candidate::singleton($this->identifier);
+        $candidate =& \Candidate::singleton($this->identifier);
         // List of all subprojects from config file
         $allSubprojects  = \Utility::getSubprojectList();
         $sp_labelOptions = array(null => '');
-        $subprojList = null;
+        $subprojList     = null;
         //List of valid subprojects for a given project
         if ($config->getSetting('useProjects') === 'true') {
             // If projects enabled, loop through and add valid subprojects only


### PR DESCRIPTION
### Brief summary of changes
Shifting calls a bit to rectify fault in logic. If projects are disabled all subrojects should be displayed by default when creating a timepoint (this was and still is working). When projects are enabled and the `project_rel` has data for all projects only the designated subprojects should be displayed in the dropdown when creating a timepoint (this was and still is working). When projects are enabled but the `project_rel` table IS NOT populated, no options should be displayed when creating a timepoint; this PR fixes that, before this PR the dropdown would default to all subprojects.

### To test this change...
- empty `project_rel` table
- enable `useProjects`
- go to create_timepoint
- the dropdown should be empty