### PR TITLE
[Server Processes Manager] Prevent OS command injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,8 @@ before_script:
     - cd ..
     - mysql LorisTest -e "UPDATE Config SET Value='$(pwd)/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base')"
     - mysql LorisTest -e "UPDATE Config SET Value='http://localhost:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url')"
+    - mkdir -p data/loris/bin/mri
+    - mysql LorisTest -e "UPDATE Config SET Value='data/loris/bin/mri' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='MRICodePath')"
 
     # Set up the testing instrument environment
     - cp test/test_instrument/NDB_BVL_Instrument_testtest.class.inc project/instruments/NDB_BVL_Instrument_testtest.class.inc

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -139,7 +139,7 @@ class MriUploadServerProcess extends AbstractServerProcess
     {
         // Sanitize variables before using in exec statement.
         $env            = $this->_mriCodePath . '/' . self::ENVIRONMENT_BASENAME;
-        $env            = escapeshellarg($envFile);
+        $env            = escapeshellarg($env);
         $uploadScript   = $this->_mriCodePath . '/' . self::IMAGING_UPLOAD_FILE_PATH;
         $uploadScript   = escapeshellarg($uploadScript);
         $uploadId       = escapeshellarg($this->_mriUploadId);

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -105,6 +105,18 @@ class MriUploadServerProcess extends AbstractServerProcess
             throw $exception;
         }
 
+        // Check that paths exist before using.
+        if (!file_exists($this->_mriCodePath)) {
+            throw new \LorisException(
+                "Source code for imaging upload could not be found!"
+            );
+        }
+        if (!is_dir($this->_mriCodePath)) {
+            throw new \ConfigurationException(
+                "Value for MRI code path is not a directory!"
+            );
+        }
+
         $this->_mriUploadId    = $mriUploadId;
         $this->_sourceLocation = $sourceLocation;
 
@@ -130,17 +142,6 @@ class MriUploadServerProcess extends AbstractServerProcess
      */
     public function getShellCommand()
     {
-        // Check that paths exist before using.
-        if (!is_dir($this->_mriCodePath)) {
-            throw new \ConfigurationException(
-                "Value for MRI code path is not a directory!"
-            );
-        }
-        if (!file_exists($this->_mriCodePath)) {
-            throw new \LorisException(
-                "Source code for imaging upload could not be found!"
-            );
-        }
         // Sanitize variables before using in exec statement.
         $codePath       = escapeshellarg($this->_mriCodePath);
         $uploadId       = escapeshellarg($this->_mriUploadId);

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -138,11 +138,14 @@ class MriUploadServerProcess extends AbstractServerProcess
     public function getShellCommand()
     {
         // Sanitize variables before using in exec statement.
-        $codePath       = escapeshellarg($this->_mriCodePath);
+        $env = $this->_mriCodePath . '/' . self::ENVIRONMENT_BASENAME;
+        $env = escapeshellarg($envFile);
+        $uploadScript = $this->_mriCodePath . '/' . self::IMAGING_UPLOAD_FILE_PATH;
+        $uploadScript = escapeshellarg($uploadScript);
         $uploadId       = escapeshellarg($this->_mriUploadId);
         $sourceLocation = escapeshellarg($this->_sourceLocation);
-        return "source $codePath/" . self::ENVIRONMENT_BASENAME . " ;"
-               . " $codePath/" . self::IMAGING_UPLOAD_FILE_PATH
+        return "source $env;"
+               . " $uploadScript"
                . " -upload_id $uploadId"
                . " -profile prod $sourceLocation";
     }

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -142,8 +142,8 @@ class MriUploadServerProcess extends AbstractServerProcess
             );
         }
         // Sanitize variables before using in exec statement.
-        $codePath = escapeshellarg($this->_mriCodePath);
-        $uploadId = escapeshellarg($this->_mriUploadId);
+        $codePath       = escapeshellarg($this->_mriCodePath);
+        $uploadId       = escapeshellarg($this->_mriUploadId);
         $sourceLocation = escapeshellarg($this->_sourceLocation);
         return "source $codePath/" . self::ENVIRONMENT_BASENAME . " ;"
                . " $codePath/" . self::IMAGING_UPLOAD_FILE_PATH

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -138,10 +138,10 @@ class MriUploadServerProcess extends AbstractServerProcess
     public function getShellCommand()
     {
         // Sanitize variables before using in exec statement.
-        $env = $this->_mriCodePath . '/' . self::ENVIRONMENT_BASENAME;
-        $env = escapeshellarg($envFile);
-        $uploadScript = $this->_mriCodePath . '/' . self::IMAGING_UPLOAD_FILE_PATH;
-        $uploadScript = escapeshellarg($uploadScript);
+        $env            = $this->_mriCodePath . '/' . self::ENVIRONMENT_BASENAME;
+        $env            = escapeshellarg($envFile);
+        $uploadScript   = $this->_mriCodePath . '/' . self::IMAGING_UPLOAD_FILE_PATH;
+        $uploadScript   = escapeshellarg($uploadScript);
         $uploadId       = escapeshellarg($this->_mriUploadId);
         $sourceLocation = escapeshellarg($this->_sourceLocation);
         return "source $env;"

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -144,7 +144,7 @@ class MriUploadServerProcess extends AbstractServerProcess
         $uploadScript   = escapeshellarg($uploadScript);
         $uploadId       = escapeshellarg($this->_mriUploadId);
         $sourceLocation = escapeshellarg($this->_sourceLocation);
-        return "source $env;"
+        return "source $env ;"
                . " $uploadScript"
                . " -upload_id $uploadId"
                . " -profile prod $sourceLocation";

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -130,10 +130,25 @@ class MriUploadServerProcess extends AbstractServerProcess
      */
     public function getShellCommand()
     {
-        return "source {$this->_mriCodePath}/" . self::ENVIRONMENT_BASENAME . " ; "
-               . "{$this->_mriCodePath}/" . self::IMAGING_UPLOAD_FILE_PATH
-               . " -upload_id "    . escapeshellarg($this->_mriUploadId)
-               . " -profile prod " . escapeshellarg($this->_sourceLocation);
+        // Check that paths exist before using.
+        if (!is_dir($this->_mriCodePath)) {
+            throw new \ConfigurationException(
+                "Value for MRI code path is not a directory!"
+            );
+        }
+        if (!file_exists($this->_mriCodePath)) {
+            throw new \LorisException(
+                "Source code for imaging upload could not be found!"
+            );
+        }
+        // Sanitize variables before using in exec statement.
+        $codePath = escapeshellarg($this->_mriCodePath);
+        $uploadId = escapeshellarg($this->_mriUploadId);
+        $sourceLocation = escapeshellarg($this->_sourceLocation);
+        return "source $codePath/" . self::ENVIRONMENT_BASENAME . " ;"
+               . " $codePath/" . self::IMAGING_UPLOAD_FILE_PATH
+               . " -upload_id $uploadId"
+               . " -profile prod $sourceLocation";
     }
 
     /**

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -106,11 +106,6 @@ class MriUploadServerProcess extends AbstractServerProcess
         }
 
         // Check that paths exist before using.
-        if (!file_exists($this->_mriCodePath)) {
-            throw new \LorisException(
-                "Source code for imaging upload could not be found!"
-            );
-        }
         if (!is_dir($this->_mriCodePath)) {
             throw new \ConfigurationException(
                 "Value for MRI code path is not a directory!"


### PR DESCRIPTION
### Brief summary of changes

The arguments being used in getShellCommand() are user-supplied and need to be checked. This PR validates and sanitizes the values that are eventually sent to the dangerous `exec` function.

A proof-of-concept exploit is available upon request.

### To test this change...

- [ ] Serves processes manager should work the same before and after.

Come see me for information if you want to see or learn about the exploit.
