### PR TITLE
[Core: Database] Add type check to HTMLEscapeArray

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -315,7 +315,7 @@ class Database
         $retVal = array();
         foreach ($set as $key => $val) {
             // Only call htmlspecialchars on strings, or else an error occurs.
-            $retVal[$key] = is_string($val)? htmlspecialchars($val) : $val;
+            $retVal[$key] = is_string($val) ? htmlspecialchars($val) : $val;
         }
         return $retVal;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -297,30 +297,25 @@ class Database
     }
 
     /**
-     * Escapes the HTML from an array that is about to be inserted into the database
+     * Escape the HTML from an array that is about to be inserted into the
+     * database.
+     * NOTE this only provide safety when elements are inserted into the
+     * "innerHTML" of an element; if a value is instead injected
+     * into attribute such as 'name', 'value', 'class', etc.
+     * then Javascript injection is still possible.
+     *
+     * This function alone goes not guarantee safety.
      *
      * @param array $set The array to be inserted as a new row
      *
-     * @return A copy of $set with the HTML characters escaped
+     * @return array A copy of $set with the HTML characters escaped
      */
     private function _HTMLEscapeArray($set)
     {
         $retVal = array();
         foreach ($set as $key => $val) {
             // Only call htmlspecialchars on strings, or else an error occurs.
-            if (is_string($val)) {
-                /* Escape HTML characters when present. NOTE that this will
-                 * only provide safety when elements are inserted into the
-                 * "innerHTML" of an element; if a value is instead injected
-                 * into attribute such as 'name', 'value', 'class', etc.
-                 * then Javascript injection is still possible.
-                 *
-                 * This function alone goes not guarantee safety.
-                 */
-                $retVal[$key] = htmlspecialchars($val);
-            } else {
-                $retVal[$key] = $val;
-            }
+            $retVal[$key] = is_string($val)? htmlspecialchars($val) : $val;
         }
         return $retVal;
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -309,19 +309,15 @@ class Database
         foreach ($set as $key => $val) {
             // Only call htmlspecialchars on strings, or else an error occurs.
             if (is_string($val)) {
-                if ($val === 'Unrated') {
-                    $retVal[$key] = '';
-                } else {
-                    /* Escape HTML characters when present. NOTE that this will
-                     * only provide safety when elements are inserted into the
-                     * "innerHTML" of an element; if a value is instead injected
-                     * into attribute such as 'name', 'value', 'class', etc.
-                     * then Javascript injection is still possible.
-                     *
-                     * This function alone goes not guarantee safety.
-                     */
-                    $retVal[$key] = htmlspecialchars($val);
-                }
+                /* Escape HTML characters when present. NOTE that this will
+                 * only provide safety when elements are inserted into the
+                 * "innerHTML" of an element; if a value is instead injected
+                 * into attribute such as 'name', 'value', 'class', etc.
+                 * then Javascript injection is still possible.
+                 *
+                 * This function alone goes not guarantee safety.
+                 */
+                $retVal[$key] = htmlspecialchars($val);
             } else {
                 $retVal[$key] = $val;
             }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -304,7 +304,7 @@ class Database
      * into attribute such as 'name', 'value', 'class', etc.
      * then Javascript injection is still possible.
      *
-     * This function alone goes not guarantee safety.
+     * This function alone does not guarantee safety.
      *
      * @param array $set The array to be inserted as a new row
      *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -314,6 +314,14 @@ class Database
     {
         $retVal = array();
         foreach ($set as $key => $val) {
+            /* FIXME this check is only here because of a quirk of the
+             * imaging browser. The module should be refactored and this check
+             * removed.
+             */
+            if ($val === 'Unrated') {
+                $retVal[$key] = '';
+                continue;
+            }
             // Only call htmlspecialchars on strings, or else an error occurs.
             $retVal[$key] = is_string($val) ? htmlspecialchars($val) : $val;
         }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -307,10 +307,23 @@ class Database
     {
         $retVal = array();
         foreach ($set as $key => $val) {
-            if ($val === 'Unrated') {
-                $retVal[$key] = '';
+            // Only call htmlspecialchars on strings, or else an error occurs.
+            if (is_string($val)) {
+                if ($val === 'Unrated') {
+                    $retVal[$key] = '';
+                } else {
+                    /* Escape HTML characters when present. NOTE that this will
+                     * only provide safety when elements are inserted into the
+                     * "innerHTML" of an element; if a value is instead injected
+                     * into attribute such as 'name', 'value', 'class', etc.
+                     * then Javascript injection is still possible.
+                     *
+                     * This function alone goes not guarantee safety.
+                     */
+                    $retVal[$key] = htmlspecialchars($val);
+                }
             } else {
-                $retVal[$key] = is_null($val) ? null : htmlspecialchars($val);
+                $retVal[$key] = $val;
             }
         }
         return $retVal;


### PR DESCRIPTION
### Brief summary of changes

In [the process](https://github.com/aces/Loris/pull/3878) of adding return types and type declarations to the
Database class, the LORIS integration tests failed when an int value was
passed to htmlspecialchars.

This PR checks that inputs to that function are of string type before
passing them as arguments.
A comment is added to this function to let developers know that
htmlspecialchars as called in the DB is not a magic bullet to preventing
JS injection.

### To test this change...

Functionality should remain the same.
