### PR TITLE
[Core: Login] Log bad password attempts

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -387,15 +387,14 @@ class SinglePointLogin
 
             $DB->insert('user_login_history', $setArray);
             return true;
-        } else {
-            /* When the password is wrong, log this detail for rate-limiting 
-             * purposes.
-             */
-            $this->insertFailedDetail(
-                "Bad password",
-                $setArray
-            );
         }
+        /* When the password is wrong, log this detail for rate-limiting 
+         * purposes.
+         */
+        $this->insertFailedDetail(
+            "Bad password",
+            $setArray
+        );
 
         // Fail by default with a generic error message
         $this->_lastError = "Incorrect username or password.";

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -309,8 +309,8 @@ class SinglePointLogin
         $row   = $DB->pselectRow($query, array('username' => $username));
 
         if (intval($row['User_count'] ?? 0) !== 1) {
-            /* Display generic failure message to front-end so that an 
-             * attacker will have a harder time knowing the difference 
+            /* Display generic failure message to front-end so that an
+             * attacker will have a harder time knowing the difference
              * between a bad username and a bad password.
              */
             $this->_lastError = "Incorrect username or password.";

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -388,7 +388,7 @@ class SinglePointLogin
             $DB->insert('user_login_history', $setArray);
             return true;
         }
-        /* When the password is wrong, log this detail for rate-limiting 
+        /* When the password is wrong, log this detail for rate-limiting
          * purposes.
          */
         $this->insertFailedDetail(

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -316,17 +316,10 @@ class SinglePointLogin
             $this->_lastError = "Incorrect username or password.";
             return false;
         }
-        // validate passsword
+        // Validate passsword
         $oldhash = $row['Password_hash'];
-        if (!password_verify($password, $oldhash)) {
-            // Display generic failure message, as above.
-            $this->_lastError = "Incorrect username or password.";
-            $this->insertFailedDetail(
-                "Bad password",
-                $setArray
-            );
-            return false;
-        } else {
+        if (password_verify($password, $oldhash)) {
+            // Rehash according to latest standards if necessary.
             if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
                 $user = \User::factory($username);
                 $user->updatePassword($password);
@@ -345,7 +338,7 @@ class SinglePointLogin
                 return false;
             }
 
-            // check if the account is active
+            // Check if the account is active.
             if (($row['active_from'] != null)
                 && ($currentDay < strtotime($row['active_from']))
             ) {
@@ -356,6 +349,7 @@ class SinglePointLogin
                 return false;
             }
 
+            // Check whether account needs to be approved by an admin
             if ($row['Pending_approval'] == 'Y') {
                 $this->_lastError = "Your account has not yet been activated."
                     . " Please contact your project administrator to activate"
@@ -377,7 +371,7 @@ class SinglePointLogin
                 return false;
             }
 
-            // save the new password if the last password expired
+            // Save the new password if the last password expired
             if ($row['Expired']) {
                 $success = $this->save();
 
@@ -393,6 +387,14 @@ class SinglePointLogin
 
             $DB->insert('user_login_history', $setArray);
             return true;
+        } else {
+            /* When the password is wrong, log this detail for rate-limiting 
+             * purposes.
+             */
+            $this->insertFailedDetail(
+                "Bad password",
+                $setArray
+            );
         }
 
         // Fail by default with a generic error message

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -308,28 +308,30 @@ class SinglePointLogin
                   GROUP BY UserID";
         $row   = $DB->pselectRow($query, array('username' => $username));
 
-        if (($row['User_count'] ?? 0) == 1) {
-            // validate passsword
-            $oldhash = $row['Password_hash'];
-            if (password_verify($password, $oldhash)) {
-                if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
-                    $user =& User::factory($username);
-                    $user->updatePassword($password);
-                }
+        if (($row['User_count'] ?? 0) !== 1) {
+            /* Display generic failure message to front-end so that an 
+             * attacker will have a harder time knowing the difference 
+             * between a bad username and a bad password.
+             */
+            $this->_lastError = "Incorrect username or password.";
+            return false;
+        }
+        // validate passsword
+        $oldhash = $row['Password_hash'];
+        if (!password_verify($password, $oldhash)) {
+            // Display generic failure message, as above.
+            $this->_lastError = "Incorrect username or password.";
+            $this->insertFailedDetail(
+                "Bad password",
+                $setArray
+            );
+            return false;
+        }
 
-                if ($row['Active'] == 'N'
-                    || $this->disabledDueToInactivity($username, 365)
-                ) {
-                    $this->_lastError = "Your account has been deactivated."
-                        . " Please contact your project administrator to"
-                        . " reactivate this account.";
-                    $this->insertFailedDetail(
-                        "user account not active",
-                        $setArray
-                    );
-
-                    return false;
-                }
+        if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
+            $user =& User::factory($username);
+            $user->updatePassword($password);
+        }
 
                 // check if the account is longer active
                 $date       = new DateTime();
@@ -364,30 +366,45 @@ class SinglePointLogin
                     $this->insertFailedDetail("user account pending", $setArray);
                     return false;
                 }
+        if ($row['Active'] == 'N'
+            || $this->disabledDueToInactivity($username, 365)
+        ) {
+            $this->_lastError = "Your account has been deactivated."
+                . " Please contact your project administrator to"
+                . " reactivate this account.";
+            $this->insertFailedDetail(
+                "user account not active",
+                $setArray
+            );
 
-                // save the new password if the last password expired
-                if ($row['Expired']) {
-                    $success = $this->save();
+            return false;
+        }
 
-                    if ($success == false) {
-                        if ($redirect) {
-                            $this->showPasswordExpiryScreen();
-                        }
-                        return false;
-                    }
+        if ($row['Pending_approval'] == 'Y') {
+            $this->_lastError = "Your account has not yet been activated."
+                . " Please contact your project administrator to activate"
+                . " this account.";
+            $this->insertFailedDetail("user account pending", $setArray);
+            return false;
+        }
+
+        // save the new password if the last password expired
+        if ($row['Expired']) {
+            $success = $this->save();
+
+            if ($success == false) {
+                if ($redirect) {
+                    $this->showPasswordExpiryScreen();
                 }
-
-                // user is valid
-                $this->_username = $row['UserID'];
-
-                $DB->insert('user_login_history', $setArray);
-                return true;
+                return false;
             }
         }
 
-        // bad usename or password
-        $this->_lastError = "Incorrect email or password";
-        return false;
+        // user is valid
+        $this->_username = $row['UserID'];
+
+        $DB->insert('user_login_history', $setArray);
+        return true;
     }
 
     /**

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -308,7 +308,7 @@ class SinglePointLogin
                   GROUP BY UserID";
         $row   = $DB->pselectRow($query, array('username' => $username));
 
-        if (($row['User_count'] ?? 0) !== 1) {
+        if (intval($row['User_count'] ?? 0) !== 1) {
             /* Display generic failure message to front-end so that an 
              * attacker will have a harder time knowing the difference 
              * between a bad username and a bad password.

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -395,6 +395,8 @@ class SinglePointLogin
             return true;
         }
 
+        // Fail by default with a generic error message
+        $this->_lastError = "Incorrect username or password.";
         return false;
     }
 

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -237,7 +237,7 @@ class SinglePointLogin
      * Checks whether a given username and password are valid
      *
      * @param string $username The username to validate
-     * @param string $password The username to validate
+     * @param string $password The password to validate
      * @param bool   $redirect If this flag is true, this
      *                         function may instead print
      *                         out a login or password expiry

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -329,7 +329,7 @@ class SinglePointLogin
         }
 
         if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
-            $user =& User::factory($username);
+            $user = \User::factory($username);
             $user->updatePassword($password);
         }
 

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -245,7 +245,7 @@ class SinglePointLogin
      *                         If false, it won't provide any output
      *                         in those situation.
      *
-     * @return bool true if the username and password are valid
+     * @return bool False unless account is valid and password correct.
      * @access public
      */
     function passwordAuthenticate($username, $password, $redirect = true)
@@ -326,77 +326,76 @@ class SinglePointLogin
                 $setArray
             );
             return false;
-        }
+        } else {
+            if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
+                $user = \User::factory($username);
+                $user->updatePassword($password);
+            }
 
-        if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
-            $user = \User::factory($username);
-            $user->updatePassword($password);
-        }
+            // Check whether the account is expired.
+            $date       = new DateTime();
+            $currentDay = $date->getTimestamp();
 
-        // check if the account is longer active
-        $date       = new DateTime();
-        $currentDay = $date->getTimestamp();
-
-        if (($row['active_to'] != null)
-            && ($currentDay > strtotime($row['active_to']))
-        ) {
-            $this->_lastError = "Your account has expired."
-                . " Please contact your project administrator to re-activate"
-                . " this account.";
-            return false;
-
-        }
-
-        // check if the account is active
-        if (($row['active_from'] != null)
-            && ($currentDay < strtotime($row['active_from']))
-        ) {
-            $this->_lastError = "Your account is not active yet."
-                ." According to our records it will be active from 
-        {$row['active_from']}"
-        . " Please contact your project administrator";
-            return false;
-
-        }
-
-        if ($row['Pending_approval'] == 'Y') {
-            $this->_lastError = "Your account has not yet been activated."
-                . " Please contact your project administrator to activate"
-                . " this account.";
-            $this->insertFailedDetail("user account pending", $setArray);
-            return false;
-        }
-        if ($row['Active'] == 'N'
-            || $this->disabledDueToInactivity($username, 365)
-        ) {
-            $this->_lastError = "Your account has been deactivated."
-                . " Please contact your project administrator to"
-                . " reactivate this account.";
-            $this->insertFailedDetail(
-                "user account not active",
-                $setArray
-            );
-
-            return false;
-        }
-
-        // save the new password if the last password expired
-        if ($row['Expired']) {
-            $success = $this->save();
-
-            if ($success == false) {
-                if ($redirect) {
-                    $this->showPasswordExpiryScreen();
-                }
+            if (($row['active_to'] != null)
+                && ($currentDay > strtotime($row['active_to']))
+            ) {
+                $this->_lastError = "Your account has expired."
+                    . " Please contact your project administrator to re-activate"
+                    . " this account.";
                 return false;
             }
+
+            // check if the account is active
+            if (($row['active_from'] != null)
+                && ($currentDay < strtotime($row['active_from']))
+            ) {
+                $this->_lastError = "Your account is not active yet."
+                    ." According to our records it will be active from 
+            {$row['active_from']}"
+                . " Please contact your project administrator";
+                return false;
+            }
+
+            if ($row['Pending_approval'] == 'Y') {
+                $this->_lastError = "Your account has not yet been activated."
+                    . " Please contact your project administrator to activate"
+                    . " this account.";
+                $this->insertFailedDetail("user account pending", $setArray);
+                return false;
+            }
+            if ($row['Active'] == 'N'
+                || $this->disabledDueToInactivity($username, 365)
+            ) {
+                $this->_lastError = "Your account has been deactivated."
+                    . " Please contact your project administrator to"
+                    . " reactivate this account.";
+                $this->insertFailedDetail(
+                    "user account not active",
+                    $setArray
+                );
+
+                return false;
+            }
+
+            // save the new password if the last password expired
+            if ($row['Expired']) {
+                $success = $this->save();
+
+                if ($success == false) {
+                    if ($redirect) {
+                        $this->showPasswordExpiryScreen();
+                    }
+                    return false;
+                }
+            }
+            // Allow a user to login if none of the previous cases have occurred
+            $this->_username = $row['UserID'];
+
+            $DB->insert('user_login_history', $setArray);
+            return true;
         }
 
-        // user is valid
-        $this->_username = $row['UserID'];
-
-        $DB->insert('user_login_history', $setArray);
-        return true;
+        return false;
     }
 
     /**

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -333,39 +333,39 @@ class SinglePointLogin
             $user->updatePassword($password);
         }
 
-                // check if the account is longer active
-                $date       = new DateTime();
-                $currentDay = $date->getTimestamp();
+        // check if the account is longer active
+        $date       = new DateTime();
+        $currentDay = $date->getTimestamp();
 
-                if (($row['active_to'] != null)
-                    && ($currentDay > strtotime($row['active_to']))
-                ) {
-                    $this->_lastError = "Your account has expired."
-                        . " Please contact your project administrator to re-activate"
-                        . " this account.";
-                    return false;
+        if (($row['active_to'] != null)
+            && ($currentDay > strtotime($row['active_to']))
+        ) {
+            $this->_lastError = "Your account has expired."
+                . " Please contact your project administrator to re-activate"
+                . " this account.";
+            return false;
 
-                }
+        }
 
-                // check if the account is active
-                if (($row['active_from'] != null)
-                    && ($currentDay < strtotime($row['active_from']))
-                ) {
-                    $this->_lastError = "Your account is not active yet."
-                        ." According to our records it will be active from 
-			{$row['active_from']}"
-                        . " Please contact your project administrator";
-                    return false;
+        // check if the account is active
+        if (($row['active_from'] != null)
+            && ($currentDay < strtotime($row['active_from']))
+        ) {
+            $this->_lastError = "Your account is not active yet."
+                ." According to our records it will be active from 
+        {$row['active_from']}"
+        . " Please contact your project administrator";
+            return false;
 
-                }
+        }
 
-                if ($row['Pending_approval'] == 'Y') {
-                    $this->_lastError = "Your account has not yet been activated."
-                        . " Please contact your project administrator to activate"
-                        . " this account.";
-                    $this->insertFailedDetail("user account pending", $setArray);
-                    return false;
-                }
+        if ($row['Pending_approval'] == 'Y') {
+            $this->_lastError = "Your account has not yet been activated."
+                . " Please contact your project administrator to activate"
+                . " this account.";
+            $this->insertFailedDetail("user account pending", $setArray);
+            return false;
+        }
         if ($row['Active'] == 'N'
             || $this->disabledDueToInactivity($username, 365)
         ) {
@@ -377,14 +377,6 @@ class SinglePointLogin
                 $setArray
             );
 
-            return false;
-        }
-
-        if ($row['Pending_approval'] == 'Y') {
-            $this->_lastError = "Your account has not yet been activated."
-                . " Please contact your project administrator to activate"
-                . " this account.";
-            $this->insertFailedDetail("user account pending", $setArray);
             return false;
         }
 

--- a/test/integrationtests/Login_Test.php
+++ b/test/integrationtests/Login_Test.php
@@ -23,7 +23,7 @@ class LorisLoginTest extends LorisIntegrationTest
        $login->click();
 
        $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))->getText();
-       $this->assertContains("Incorrect email or password", $bodyText);
+       $this->assertContains("Incorrect username or password", $bodyText);
     }
 
     function testLoginSuccess()


### PR DESCRIPTION
_Note: It's best to add `?w=1` to the URL when reviewing the code as there are many spacing changes._

----

### Brief summary of changes

Adds a log entry when a user enters the wrong password. I imagine that this was intended to be included by the original author but was left out for some reason. 

Also did happy path refactoring in this function to make it more clear. The important line is [this](https://github.com/aces/Loris/compare/bugfix...johnsaigle:180911-LogBadPasswords?expand=1#diff-2c13360f65cfe03fa685449b9074176eR321).

Finally, changed the front-end error message to say "Invalid username" instead of "Invalid email" and updated the integration tests accordingly.

### To test this change...

- [ ] Keep an eye on the `user_login_history` table.
- [ ] On your branch, try to login with a bad password. Nothing should change
- [ ] Do the same on my branch. A new line should appear stating that a bad password was used.