### PR TITLE
[Core: Login] Add rate limiting/account lockout

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -319,7 +319,6 @@ class SinglePointLogin
         }
         /* Check whether a user's account is locked due to too many bad login
          * attempts before actually trying to authenticate their credentials.
-         * Doing so can help mititgate timing attacks against the server.
          */
         if ($this->accountLocked($_POST['username'])) {
             $this->_lastError = 'This account is currently suspended due '

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -325,10 +325,6 @@ class SinglePointLogin
             $this->_lastError = 'This account is currently suspended due '
                 . 'to too many bad login attempts.';
             $this->insertFailedDetail('Account locked', $setArray);
-            error_log(
-                "The acccount for $username is locked out. Potential "
-                . "brute force login attempt"
-            );
             return false;
         }
         // Validate passsword
@@ -473,10 +469,11 @@ class SinglePointLogin
         $longLockoutThreshold  = 15;
 
         // SQL code to run.
-        $query  = "SELECT COUNT(loginhistoryID)" .
+        $query  = "SELECT COUNT(loginhistoryID) " .
             "FROM user_login_history " .
             "WHERE userID = :username " .
             "AND Success = 'N' " .
+            "AND IP_address = :ip " .
             "AND Login_timestamp > ( " .
             "SELECT IF( MAX(Login_timestamp) > DATE_SUB(NOW(), ".
             "INTERVAL :timeWindowInMinutes MINUTE), " .
@@ -490,6 +487,7 @@ class SinglePointLogin
         $params = array(
                    'username'            => $username,
                    'timeWindowInMinutes' => $shortWindowInMinutes,
+                   'ip' => $_SERVER['REMOTE_ADDR'],
                   );
 
         $shortFailCount = $this->_getFailedLoginCount($query, $params);

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -469,11 +469,11 @@ class SinglePointLogin
         $longLockoutThreshold  = 15;
 
         // SQL code to run.
-        $query  = "SELECT COUNT(loginhistoryID) as loginattempts" .
+        $query  = "SELECT COUNT(loginhistoryID) as loginattempts " .
             "FROM user_login_history " .
             "WHERE userID = :username " .
-            "AND Success = 'N' " .
             "AND IP_address = :ip " .
+            "AND Success = 'N' " .
             "AND Login_timestamp > ( " .
             "SELECT IF( MAX(Login_timestamp) > DATE_SUB(NOW(), ".
             "INTERVAL :timeWindowInMinutes MINUTE), " .
@@ -484,6 +484,7 @@ class SinglePointLogin
             "WHERE userID = :username " .
             "AND Success = 'Y'" .
         ");";
+        error_log($_SERVER['REMOTE_ADDR']);
         $params = array(
                    'username'            => $username,
                    'timeWindowInMinutes' => $shortWindowInMinutes,

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -468,7 +468,7 @@ class SinglePointLogin
         $longWindowInMinutes  = 60;
 
         // SQL code to run.
-        $query = "SELECT COUNT(loginhistoryID) as loginattempts " .
+        $query  = "SELECT COUNT(loginhistoryID) as loginattempts " .
             "FROM user_login_history " .
             "WHERE userID = :username " .
             "AND IP_address = :ip " .

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -230,7 +230,8 @@ class SinglePointLogin
         $this->_username
             = isset($decodedArray['user'])
                 ? $decodedArray['user'] : 'Unknown';
-        return isset($decodedArray['user']);
+        return isset($decodedArray['user']) 
+            && !$this->accountLocked($decodedArray['user']);
     }
 
     /**
@@ -316,6 +317,16 @@ class SinglePointLogin
             $this->_lastError = "Incorrect username or password.";
             return false;
         }
+        /* Check whether a user's account is locked due to too many bad login
+         * attempts before actually trying to authenticate their credentials.
+         * Doing so can help mititgate timing attacks against the server.
+         */
+        if ($this->accountLocked($_POST['username'])){
+            $this->_lastError = 'This account is currently suspended due '
+                . 'to too many bad login attempts.';
+            $this->insertFailedDetail('Account locked', $setArray);
+            return false;
+        }
         // Validate passsword
         $oldhash = $row['Password_hash'];
         if (password_verify($password, $oldhash)) {
@@ -323,6 +334,34 @@ class SinglePointLogin
             if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {
                 $user = \User::factory($username);
                 $user->updatePassword($password);
+            }
+
+            if ($row['Active'] == 'N'
+                || $this->disabledDueToInactivity($username, 365)
+            ) {
+                $this->_lastError = "Your account has been deactivated."
+                    . " Please contact your project administrator to"
+                    . " reactivate this account.";
+                $this->insertFailedDetail(
+                    "user account not active",
+                    $setArray
+                );
+
+                return false;
+            }
+
+            // check if the account is longer active
+            $date       = new DateTime();
+            $currentDay = $date->getTimestamp();
+
+            if (($row['active_to'] != null)
+                && ($currentDay > strtotime($row['active_to']))
+            ) {
+                $this->_lastError = "Your account has expired."
+                    . " Please contact your project administrator to re-activate"
+                    . " this account.";
+                return false;
+
             }
 
             // Check whether the account is expired.
@@ -401,6 +440,63 @@ class SinglePointLogin
         return false;
     }
 
+    /**
+     * Determines whether a user's account is locked due to too many failed 
+     * attempts.
+     *
+     * @param string username The user account to check.
+     *
+     * @return void
+     * @access public
+     */
+    function accountLocked(string $username): bool
+    {
+        /* A user is locked out if they have made X attempts in the last Y
+         * minutes or X' attempts in the last Y' minutes.
+         * The reason for using two time windows is to provide some flexibility:
+         * legitimate locked-out users to try again in a short time while also
+         * preventing attackers from simply trying another X login attempts 
+         * after Y minutes.
+         */
+
+        // These represent X and X' above, but with more helpful names.
+        $shortWindowInMinutes = 15;
+        $longWindowInMinutes = 60;
+        /* These represent Y and Y' above, but with more helpful names.
+         * These values represent the maximum umber of attempts a user may make
+         * to login before being locked out.
+         */
+        $shortLockoutThreshold = 10; 
+        $longLockoutThreshold = 15; 
+
+        $shortFailCount = $this->countFailedLogins(
+            $username,
+            $shortWindowInMinutes
+        );
+        $longFailCount = $this->countFailedLogins(
+            $username,
+            $longWindowInMinutes
+        );
+        return $shortFailCount > $shortLockoutThreshold
+            || $longFailCount > $longLockoutThreshold;
+    }
+
+    function countFailedLogins(string $username, int $timeWindow): int {
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->database();
+        $query = "SELECT COUNT(*) from user_login_history " .
+            "WHERE userID = :username " .
+            "AND Success = 'N' " .
+            "AND Login_timestamp < :queryTime;";
+        $row   = $db->pselectRow(
+            $query, 
+            array(
+                'username' => $username,
+                'queryTime' => strtotime("-$timeWindowInMinutes minutes"),
+            )
+        );
+        return intval($row[0] ?? 0);
+    }
     /**
      * Sets the session data (State object)
      *

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -483,7 +483,6 @@ class SinglePointLogin
             "WHERE userID = :username " .
             "AND Success = 'Y'" .
         ");";
-        error_log($_SERVER['REMOTE_ADDR']);
         $params = array(
                    'username'            => $username,
                    'timeWindowInMinutes' => $shortWindowInMinutes,

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -509,25 +509,6 @@ class SinglePointLogin
     }
 
     /**
-     * Gives the number of failed login attempts that occurred in within the
-     * time window specified in $params. Used to determine whether a user's
-     * login request should be denied as a security precaution.
-     *
-     * @param string $query  The DB query.
-     * @param array  $params Username and time window.
-     *
-     * @return int The number of failed login attempts that occurred during the
-     *              time window
-     */
-    private function _getFailedLoginCount(
-        string $query,
-        array $params
-    ): int {
-        $result = \Database::singleton()->pselect($query, $params);
-        return intval($result[0]["COUNT(loginhistoryID)"]);
-    }
-
-    /**
      * Sets the session data (State object)
      *
      * @return void

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -472,38 +472,8 @@ class SinglePointLogin
         $shortLockoutThreshold = 10;
         $longLockoutThreshold  = 15;
 
-        $shortFailCount = $this->countFailedLogins(
-            $username,
-            $shortWindowInMinutes
-        );
-        $longFailCount  = $this->countFailedLogins(
-            $username,
-            $longWindowInMinutes
-        );
-        return $shortFailCount > $shortLockoutThreshold
-            || $longFailCount > $longLockoutThreshold;
-    }
-
-    /**
-     * Gives the number of failed login attempts that occurred in the last
-     * $timeWindowInMinutes minutes. Used to determine whether a user's login
-     * request should be denied as a security precaution.
-     *
-     * @param string $username            The user account to check.
-     * @param int    $timeWindowInMinutes This value is subtracted from the
-     *                          current timestamp to find relevant failed
-     *                          login attempts. Only more recent failed
-     *                          attempts are considered relevant here.
-     *
-     * @return int The number of failed attempts in the time window.
-     */
-    function countFailedLogins(
-        string $username,
-        int $timeWindowInMinutes
-    ): int {
-        $factory = NDB_Factory::singleton();
-        $db      = $factory->database();
-        $query   = "SELECT COUNT(loginhistoryID)" .
+        // SQL code to run.
+        $query  = "SELECT COUNT(loginhistoryID)" .
             "FROM user_login_history " .
             "WHERE userID = :username " .
             "AND Success = 'N' " .
@@ -517,16 +487,39 @@ class SinglePointLogin
             "WHERE userID = :username " .
             "AND Success = 'Y'" .
         ");";
-        $result  = $db->pselect(
-            $query,
-            array(
-             "username"            => $username,
-             "timeWindowInMinutes" => $timeWindowInMinutes,
-            )
-        );
-        $failedLoginAttempts = intval($result[0]["COUNT(loginhistoryID)"]);
-        return $failedLoginAttempts;
+        $params = array(
+                   'username'            => $username,
+                   'timeWindowInMinutes' => $shortWindowInMinutes,
+                  );
+
+        $shortFailCount = $this->_getFailedLoginCount($query, $params);
+
+        $params['timeWindowInMinutes'] = $longWindowInMinutes;
+        $longFailCount = $this->_getFailedLoginCount($query, $params);
+
+        return $shortFailCount > $shortLockoutThreshold
+            || $longFailCount > $longLockoutThreshold;
     }
+
+    /**
+     * Gives the number of failed login attempts that occurred in within the
+     * time window specified in $params. Used to determine whether a user's
+     * login request should be denied as a security precaution.
+     *
+     * @param string $query  The DB query.
+     * @param array  $params Username and time window.
+     *
+     * @return int The number of failed login attempts that occurred during the
+     *              time window
+     */
+    private function _getFailedLoginCount(
+        string $query,
+        array $params
+    ): int {
+        $result = \Database::singleton()->pselect($query, $params);
+        return intval($result[0]["COUNT(loginhistoryID)"]);
+    }
+
     /**
      * Sets the session data (State object)
      *

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -321,7 +321,7 @@ class SinglePointLogin
          * attempts before actually trying to authenticate their credentials.
          * Doing so can help mititgate timing attacks against the server.
          */
-        if ($this->accountLocked($_POST['username'])){
+        if ($this->accountLocked($_POST['username'])) {
             $this->_lastError = 'This account is currently suspended due '
                 . 'to too many bad login attempts.';
             $this->insertFailedDetail('Account locked', $setArray);

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -469,7 +469,7 @@ class SinglePointLogin
         $longLockoutThreshold  = 15;
 
         // SQL code to run.
-        $query  = "SELECT COUNT(loginhistoryID) " .
+        $query  = "SELECT COUNT(loginhistoryID) as loginattempts" .
             "FROM user_login_history " .
             "WHERE userID = :username " .
             "AND Success = 'N' " .
@@ -490,10 +490,19 @@ class SinglePointLogin
                    'ip'                  => $_SERVER['REMOTE_ADDR'],
                   );
 
-        $shortFailCount = $this->_getFailedLoginCount($query, $params);
+        // Query DB for login attempts.
+        $database  = \NDB_Factory::singleton()->database();
+        $statement = $database->prepare($query);
+
+        $shortFailCount = intval(
+            $database->execute($statement, $params)[0]['loginattempts']
+        );
 
         $params['timeWindowInMinutes'] = $longWindowInMinutes;
-        $longFailCount = $this->_getFailedLoginCount($query, $params);
+
+        $longFailCount = intval(
+            $database->execute($statement, $params)[0]['loginattempts']
+        );
 
         return $shortFailCount > $shortLockoutThreshold
             || $longFailCount > $longLockoutThreshold;

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -487,7 +487,7 @@ class SinglePointLogin
         $params = array(
                    'username'            => $username,
                    'timeWindowInMinutes' => $shortWindowInMinutes,
-                   'ip' => $_SERVER['REMOTE_ADDR'],
+                   'ip'                  => $_SERVER['REMOTE_ADDR'],
                   );
 
         $shortFailCount = $this->_getFailedLoginCount($query, $params);

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -503,12 +503,13 @@ class SinglePointLogin
     ): int {
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();
-        $query = "SELECT COUNT(loginhistoryID)" .
+        $query   = "SELECT COUNT(loginhistoryID)" .
             "FROM user_login_history " .
             "WHERE userID = :username " .
             "AND Success = 'N' " .
             "AND Login_timestamp > ( " .
-                "SELECT IF( MAX(Login_timestamp) > DATE_SUB(NOW(),  INTERVAL :timeWindowInMinutes MINUTE), " .
+            "SELECT IF( MAX(Login_timestamp) > DATE_SUB(NOW(), ".
+            "INTERVAL :timeWindowInMinutes MINUTE), " .
                 "MAX(Login_timestamp), DATE_SUB(NOW(), " .
                 "INTERVAL :timeWindowInMinutes MINUTE) " .
             ") " .
@@ -516,10 +517,11 @@ class SinglePointLogin
             "WHERE userID = :username " .
             "AND Success = 'Y'" .
         ");";
-        $result = $db->pselect($query, 
+        $result  = $db->pselect(
+            $query,
             array(
-            "username" => $username,
-            "timeWindowInMinutes" => $timeWindowInMinutes
+             "username"            => $username,
+             "timeWindowInMinutes" => $timeWindowInMinutes,
             )
         );
         $failedLoginAttempts = intval($result[0]["COUNT(loginhistoryID)"]);

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -503,37 +503,27 @@ class SinglePointLogin
     ): int {
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();
-        $query   = "SELECT Login_timestamp from user_login_history " .
+        $query = "SELECT COUNT(loginhistoryID)" .
+            "FROM user_login_history " .
             "WHERE userID = :username " .
-            "AND Success = 'N' ";
-        $results = $db->pselect(
-            $query,
-            array('username' => $username)
+            "AND Success = 'N' " .
+            "AND Login_timestamp > ( " .
+                "SELECT IF( MAX(Login_timestamp) > DATE_SUB(NOW(),  INTERVAL :timeWindowInMinutes MINUTE), " .
+                "MAX(Login_timestamp), DATE_SUB(NOW(), " .
+                "INTERVAL :timeWindowInMinutes MINUTE) " .
+            ") " .
+            "FROM user_login_history " .
+            "WHERE userID = :username " .
+            "AND Success = 'Y'" .
+        ");";
+        $result = $db->pselect($query, 
+            array(
+            "username" => $username,
+            "timeWindowInMinutes" => $timeWindowInMinutes
+            )
         );
-        /* Iterate over bad login attempts to find those logged between now
-         * and $timeWindowInMinutes minutes ago.
-         */
-        $badLoginsInsideTimeWindow = 0;
-        foreach ($results as $row) {
-            $attemptTime = date_create($row['Login_timestamp']);
-            // Create a date object for $timeWindowInMinutes minutes ago.
-            $now           = date_create();
-            $timeThreshold = date_sub(
-                $now,
-                date_interval_create_from_date_string(
-                    "$timeWindowInMinutes minutes"
-                )
-            );
-            /* If a failed login attempt is made with a timestamp that is more
-             * recent than the time threshold, then it is considered in the
-             * decision to lockout a user. Timestamps older than this are
-             * considered too distant for concern.
-             */
-            if ($attemptTime > $timeThreshold) {
-                $badLoginsInsideTimeWindow++;
-            }
-        }
-        return $badLoginsInsideTimeWindow;
+        $failedLoginAttempts = intval($result[0]["COUNT(loginhistoryID)"]);
+        return $failedLoginAttempts;
     }
     /**
      * Sets the session data (State object)

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -458,15 +458,15 @@ class SinglePointLogin
          * after Y minutes.
          */
 
-        // These represent X and X' above, but with more helpful names.
-        $shortWindowInMinutes = 15;
-        $longWindowInMinutes  = 60;
-        /* These represent Y and Y' above, but with more helpful names.
+        /* These represent X and X' above, but with more helpful names.
          * These values represent the maximum number of attempts a user may make
          * to login before being locked out.
          */
         $shortLockoutThreshold = 10;
         $longLockoutThreshold  = 15;
+        // These represent Y and Y' above, but with more helpful names.
+        $shortWindowInMinutes = 15;
+        $longWindowInMinutes  = 60;
 
         // SQL code to run.
         $query = "SELECT COUNT(loginhistoryID) as loginattempts " .

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -469,7 +469,7 @@ class SinglePointLogin
         $longLockoutThreshold  = 15;
 
         // SQL code to run.
-        $query  = "SELECT COUNT(loginhistoryID) as loginattempts " .
+        $query = "SELECT COUNT(loginhistoryID) as loginattempts " .
             "FROM user_login_history " .
             "WHERE userID = :username " .
             "AND IP_address = :ip " .

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -347,6 +347,14 @@ class SinglePointLogin
                     $setArray
                 );
 
+=======
+            if ($this->accountLocked($username)){
+                $this->_lastError = 'This account is currently suspended due '
+                    . 'to too many bad login attempts.';
+                error_log("The acccount for $username is locked out. Potential "
+                    . "brute force login attempt"
+                );
+>>>>>>> a59b9289e... Add rate-limting mechanism for log ins.
                 return false;
             }
 
@@ -481,21 +489,45 @@ class SinglePointLogin
             || $longFailCount > $longLockoutThreshold;
     }
 
-    function countFailedLogins(string $username, int $timeWindow): int {
+    function countFailedLogins(
+        string $username, 
+        int $timeWindowInMinutes
+    ): int {
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();
-        $query = "SELECT COUNT(*) from user_login_history " .
+        $query = "SELECT Login_timestamp from user_login_history " .
             "WHERE userID = :username " .
-            "AND Success = 'N' " .
-            "AND Login_timestamp < :queryTime;";
-        $row   = $db->pselectRow(
+            "AND Success = 'N' ";
+        $results   = $db->pselect(
             $query, 
             array(
-                'username' => $username,
-                'queryTime' => strtotime("-$timeWindowInMinutes minutes"),
+                'username' => $username
             )
         );
-        return intval($row[0] ?? 0);
+        /* Iterate over bad login attempts to find those logged between now
+         * and $timeWindowInMinutes minutes ago.
+         */
+        $badLoginsInsideTimeWindow = 0;
+        foreach ($results as $row) {
+            $attemptTime = date_create($row['Login_timestamp']);
+            // Create a date object for $timeWindowInMinutes minutes ago.
+            $now = date_create();
+            $timeThreshold = date_sub(
+                $now,
+                date_interval_create_from_date_string(
+                    "$timeWindowInMinutes minutes"
+                )
+            );
+            /* If a failed login attempt is made with a timestamp that is more
+             * recent than the time threshold, then it is considered in the 
+             * decision to lockout a user. Timestamps older than this are 
+             * considered too distant for concern.
+             */
+            if ($attemptTime > $timeThreshold) {
+                $badLoginsInsideTimeWindow++;
+            }
+        }
+        return $badLoginsInsideTimeWindow;
     }
     /**
      * Sets the session data (State object)

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -350,7 +350,7 @@ class SinglePointLogin
                 return false;
             }
 
-            // check if the account is longer active
+            // check if the account is no longer active
             $date       = new DateTime();
             $currentDay = $date->getTimestamp();
 
@@ -462,7 +462,7 @@ class SinglePointLogin
         $shortWindowInMinutes = 15;
         $longWindowInMinutes  = 60;
         /* These represent Y and Y' above, but with more helpful names.
-         * These values represent the maximum umber of attempts a user may make
+         * These values represent the maximum number of attempts a user may make
          * to login before being locked out.
          */
         $shortLockoutThreshold = 10;

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -230,7 +230,7 @@ class SinglePointLogin
         $this->_username
             = isset($decodedArray['user'])
                 ? $decodedArray['user'] : 'Unknown';
-        return isset($decodedArray['user']) 
+        return isset($decodedArray['user'])
             && !$this->accountLocked($decodedArray['user']);
     }
 
@@ -325,6 +325,10 @@ class SinglePointLogin
             $this->_lastError = 'This account is currently suspended due '
                 . 'to too many bad login attempts.';
             $this->insertFailedDetail('Account locked', $setArray);
+            error_log(
+                "The acccount for $username is locked out. Potential "
+                . "brute force login attempt"
+            );
             return false;
         }
         // Validate passsword
@@ -347,14 +351,6 @@ class SinglePointLogin
                     $setArray
                 );
 
-=======
-            if ($this->accountLocked($username)){
-                $this->_lastError = 'This account is currently suspended due '
-                    . 'to too many bad login attempts.';
-                error_log("The acccount for $username is locked out. Potential "
-                    . "brute force login attempt"
-                );
->>>>>>> a59b9289e... Add rate-limting mechanism for log ins.
                 return false;
             }
 
@@ -449,13 +445,12 @@ class SinglePointLogin
     }
 
     /**
-     * Determines whether a user's account is locked due to too many failed 
+     * Determines whether a user's account is locked due to too many failed
      * attempts.
      *
-     * @param string username The user account to check.
+     * @param string $username The user account to check.
      *
-     * @return void
-     * @access public
+     * @return bool
      */
     function accountLocked(string $username): bool
     {
@@ -463,25 +458,25 @@ class SinglePointLogin
          * minutes or X' attempts in the last Y' minutes.
          * The reason for using two time windows is to provide some flexibility:
          * legitimate locked-out users to try again in a short time while also
-         * preventing attackers from simply trying another X login attempts 
+         * preventing attackers from simply trying another X login attempts
          * after Y minutes.
          */
 
         // These represent X and X' above, but with more helpful names.
         $shortWindowInMinutes = 15;
-        $longWindowInMinutes = 60;
+        $longWindowInMinutes  = 60;
         /* These represent Y and Y' above, but with more helpful names.
          * These values represent the maximum umber of attempts a user may make
          * to login before being locked out.
          */
-        $shortLockoutThreshold = 10; 
-        $longLockoutThreshold = 15; 
+        $shortLockoutThreshold = 10;
+        $longLockoutThreshold  = 15;
 
         $shortFailCount = $this->countFailedLogins(
             $username,
             $shortWindowInMinutes
         );
-        $longFailCount = $this->countFailedLogins(
+        $longFailCount  = $this->countFailedLogins(
             $username,
             $longWindowInMinutes
         );
@@ -489,20 +484,31 @@ class SinglePointLogin
             || $longFailCount > $longLockoutThreshold;
     }
 
+    /**
+     * Gives the number of failed login attempts that occurred in the last
+     * $timeWindowInMinutes minutes. Used to determine whether a user's login
+     * request should be denied as a security precaution.
+     *
+     * @param string $username            The user account to check.
+     * @param int    $timeWindowInMinutes This value is subtracted from the
+     *                          current timestamp to find relevant failed
+     *                          login attempts. Only more recent failed
+     *                          attempts are considered relevant here.
+     *
+     * @return int The number of failed attempts in the time window.
+     */
     function countFailedLogins(
-        string $username, 
+        string $username,
         int $timeWindowInMinutes
     ): int {
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();
-        $query = "SELECT Login_timestamp from user_login_history " .
+        $query   = "SELECT Login_timestamp from user_login_history " .
             "WHERE userID = :username " .
             "AND Success = 'N' ";
-        $results   = $db->pselect(
-            $query, 
-            array(
-                'username' => $username
-            )
+        $results = $db->pselect(
+            $query,
+            array('username' => $username)
         );
         /* Iterate over bad login attempts to find those logged between now
          * and $timeWindowInMinutes minutes ago.
@@ -511,7 +517,7 @@ class SinglePointLogin
         foreach ($results as $row) {
             $attemptTime = date_create($row['Login_timestamp']);
             // Create a date object for $timeWindowInMinutes minutes ago.
-            $now = date_create();
+            $now           = date_create();
             $timeThreshold = date_sub(
                 $now,
                 date_interval_create_from_date_string(
@@ -519,8 +525,8 @@ class SinglePointLogin
                 )
             );
             /* If a failed login attempt is made with a timestamp that is more
-             * recent than the time threshold, then it is considered in the 
-             * decision to lockout a user. Timestamps older than this are 
+             * recent than the time threshold, then it is considered in the
+             * decision to lockout a user. Timestamps older than this are
              * considered too distant for concern.
              */
             if ($attemptTime > $timeThreshold) {


### PR DESCRIPTION
### Brief summary of changes

Make it so that many bad passwords attempts result in a message telling the user they'll need to wait before trying to login again. This helps protect us in the case where an attacker would try many many logins to try to break in to LORIS.

More detailed explanations exist in the comments to the code.

Addresses rate limiting mentioned in #3314 

### To test this change...

**Note** until [[Core: Login] Log login attempts using bad passwords](#3949) is merged, the below won't work because we don't actually log bad passwords attempts right now...

- [x] Check out the branch and try to log in 10 times with a bad password. A message will appear  
