### PR TITLE
[Examiner] Fix warnings caused by absent variable

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -402,11 +402,11 @@ class EditExaminer extends \NDB_Form
 
     /**
      * Grabs the certification instruments from the config and creates an array.
-     * The instrument id id the key, and the instrument label is the value.
+     * The instrument id is the key, and the instrument label is the value.
      *
      * @return array of instruments requiring certification
      */
-    function getCertificationInstruments()
+    function getCertificationInstruments(): array
     {
         $config = \NDB_Config::singleton();
         $DB     = \Database::singleton();
@@ -415,6 +415,9 @@ class EditExaminer extends \NDB_Form
         $certificationConfig      = $config->getSetting("Certification");
         $certificationInstruments = $certificationConfig['CertificationInstruments'];
 
+        if (!isset($certificationInstruments['test'])) {
+            return array();
+        }
         $certificationInstruments['test']
             = \Utility::toArray($certificationInstruments['test']);
         $instruments = array();

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -406,7 +406,7 @@ class EditExaminer extends \NDB_Form
      *
      * @return array of instruments requiring certification
      */
-    function getCertificationInstruments(): array
+    function getCertificationInstruments()
     {
         $config = \NDB_Config::singleton();
         $DB     = \Database::singleton();


### PR DESCRIPTION
### Brief summary of changes
Warnings were created when `$certificationInstruments['test']` was not set. I'm not sure what this does exactly but this code change handles the case when it's not there. 

Also fixed a typo ~~and added a return type to the function according to its PHP doc.~~

### To test this change...

- [ ] Go to the edit section of the examiner module. Notice the warnings! On my branch there are no warnings.
