### PR TITLE
[Core] Add pwned passwords API to prevent common passwords and password reuse

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -69,6 +69,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ImagingUploaderAutoLaunch', "Allows running the ImagingUpload pre-processing scripts", 1, 0, 'boolean', ID, 'ImagingUploader Auto Launch',23 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'citation_policy', 'Citation Policy for Acknowledgements module', 1, 0, 'textarea', ID, 'Citation Policy', 24 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'CSPAdditionalHeaders', 'Extensions to the Content-security policy allow only for self-hosted content', 1, 0, 'text', ID, 'Content-Security Extensions', 25 FROM ConfigSettings WHERE Name="study";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'usePwnedPasswordsAPI', 'Whether to query the Have I Been Pwned password API on password changes to prevent the usage of common and breached passwords', 1, 0, 'boolean', ID, 'Enable "Pwned Password" check', 26 FROM ConfigSettings WHERE Name="study";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('paths', 'Specify directories where LORIS-related files are stored or created. Take care when editing these fields as changing them incorrectly can cause certain modules to lose functionality.', 1, 0, 'Paths', 2);
@@ -261,3 +262,4 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, 'flair' FROM ConfigSettings WHER
 INSERT INTO Config (ConfigID, Value) SELECT ID, 't1'    FROM ConfigSettings WHERE Name="modalities_to_deface";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 't2'    FROM ConfigSettings WHERE Name="modalities_to_deface";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'pd'    FROM ConfigSettings WHERE Name="modalities_to_deface";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 'true'  FROM ConfigSettings WHERE Name="usePwnedPasswordsAPI";

--- a/SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql
+++ b/SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql
@@ -1,0 +1,31 @@
+-- Adds the option to toggle the usage of the Pwned Passwords
+-- API (https://haveibeenpwned.com/API/v2#PwnedPasswords) in a project. This
+-- should be enabled by default to allow for a higher level of security. This
+-- setting is added to allow projects to disable the API check in case of
+-- networking issues.
+INSERT INTO ConfigSettings
+  (
+    Name,
+    Description,
+    Visible,
+    AllowMultiple,
+    DataType,
+    Parent,
+    Label,
+    OrderNumber
+  )
+  SELECT
+    'usePwnedPasswordsAPI',
+    'Whether to query the Have I Been Pwned password API on password changes to prevent the usage of common and breached passwords',
+    1,
+    0,
+    'boolean',
+    ID,
+    'Enable "Pwned Password" check',
+    22
+  FROM
+    ConfigSettings
+  WHERE
+    Name="study";
+
+INSERT INTO Config (ConfigID, Value) SELECT ID, 'true' FROM ConfigSettings WHERE Name="usePwnedPasswordsAPI";

--- a/SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql
+++ b/SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql
@@ -1,6 +1,6 @@
 -- Adds the option to toggle the usage of the Pwned Passwords
 -- API (https://haveibeenpwned.com/API/v2#PwnedPasswords) in a project. This
--- is be enabled by default to allow for a higher level of security. This
+-- is enabled by default to allow for a higher level of security. This
 -- setting is added to allow projects to disable the API check in case of
 -- networking issues.
 INSERT INTO ConfigSettings

--- a/SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql
+++ b/SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql
@@ -1,6 +1,6 @@
 -- Adds the option to toggle the usage of the Pwned Passwords
 -- API (https://haveibeenpwned.com/API/v2#PwnedPasswords) in a project. This
--- should be enabled by default to allow for a higher level of security. This
+-- is be enabled by default to allow for a higher level of security. This
 -- setting is added to allow projects to disable the API check in case of
 -- networking issues.
 INSERT INTO ConfigSettings

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -92,10 +92,10 @@ class PasswordExpiry extends \NDB_Form
             // from SinglePointLogin. As a result, the usual way of displaying errors
             // by returning them in an array with the key of the element with the
             // problem doesn't work.
-            $this->tpl_data['error_message'] = 'Can not use an empty password';
+            $this->tpl_data['error_message'] = 'Cannot use an empty password';
 
             // But we'll pretend it does anyways, so that validation still fails.
-            return array('password' => 'Can not use an empty password');
+            return array('password' => 'Cannot use an empty password');
         }
 
         $this->_user = \User::factory($this->_username);
@@ -123,6 +123,12 @@ class PasswordExpiry extends \NDB_Form
             $this->tpl_data['error_message'] = 'The password is weak, or'
                 . ' the passwords do not match';
             return array('password' => 'Weak password.');
+        }
+        // Check if password is present in existing data breaches.
+        if (\User::pwnedPassword($_POST['password'])) {
+            $this->tpl_data['error_message'] = 'The password you chose is too common. Please '
+                . 'choose a more unique password.';
+            return array('password' => 'Password pwned.');
         }
 
         return true;

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -126,8 +126,8 @@ class PasswordExpiry extends \NDB_Form
         }
         // Check if password is present in existing data breaches.
         if (\User::pwnedPassword($_POST['password'])) {
-            $this->tpl_data['error_message'] = 'The password you chose is too common. Please '
-                . 'choose a more unique password.';
+            $this->tpl_data['error_message'] = 'The password you chose is ' .
+                'too common. Please choose a more unique password.';
             return array('password' => 'Password pwned.');
         }
 

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1030,6 +1030,10 @@ class Edit_User extends \NDB_Form
                         . 'are identical: please choose another one';
                 }
             }
+            if (\User::pwnedPassword($values['Password_hash'])) {
+                $errors['Password_Group'] = 'The password you chose is too '
+                    . 'common. Please choose a more unique password.';
+            }
         }
 
         // if password is generated then the email user button should be clicked

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -444,7 +444,6 @@ class My_Preferences extends \NDB_Form
             if (\User::pwnedPassword($values['Password_hash'])) {
                 $errors['Password_hash'] = 'The password you chose is too '
                     . 'common. Please choose a more unique password.';
-                return $errors;
             }
         }
 

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -417,11 +417,6 @@ class My_Preferences extends \NDB_Form
         // if password is user-defined, and user wants to change password
         if (!empty($values['Password_hash'])) {
 
-            if (\User::pwnedPassword($values['Password_hash'])) {
-                $errors['Password_hash'] = 'The password you chose is too common. Please '
-                    . 'choose a more unique password.';
-                return $errors;
-            }
             // check password strength
             $isPasswordStrong = \User::isPasswordStrong(
                 $values['Password_hash'],
@@ -447,8 +442,8 @@ class My_Preferences extends \NDB_Form
                 }
             }
             if (\User::pwnedPassword($values['Password_hash'])) {
-                $errors['Password_hash'] = 'The password you chose is too common. Please '
-                    . 'choose a more unique password.';
+                $errors['Password_hash'] = 'The password you chose is too '
+                    . 'common. Please choose a more unique password.';
                 return $errors;
             }
         }

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -416,6 +416,12 @@ class My_Preferences extends \NDB_Form
 
         // if password is user-defined, and user wants to change password
         if (!empty($values['Password_hash'])) {
+
+            if (\User::pwnedPassword($values['Password_hash'])) {
+                $errors['Password_hash'] = 'The password you chose is too common. Please '
+                    . 'choose a more unique password.';
+                return $errors;
+            }
             // check password strength
             $isPasswordStrong = \User::isPasswordStrong(
                 $values['Password_hash'],
@@ -439,6 +445,11 @@ class My_Preferences extends \NDB_Form
                     $errors['Password_hash'] = 'New and old passwords '
                         . 'are identical: please choose another one';
                 }
+            }
+            if (\User::pwnedPassword($values['Password_hash'])) {
+                $errors['Password_hash'] = 'The password you chose is too common. Please '
+                    . 'choose a more unique password.';
+                return $errors;
             }
         }
 

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -121,15 +121,18 @@ class SinglePointLogin
         ) {
             $this->_lastError = 'The password is weak, or'
                . ' the passwords do not match';
+            return false;
         }
 
         if (password_verify($_POST['password'], $data['Password_hash'])) {
             $this->_lastError = 'You cannot keep the same password';
-        }
-
-        // if errors
-        if (!empty($this->_lastError)) {
             return false;
+        }
+        // Check if password is present in existing data breaches.
+        if ($user->pwnedPassword($_POST['password'])) {
+            $this->_lastError = 'The password you chose is too common. Please '
+                . 'choose a more unique password.';
+                return false;
         }
 
         // Reset passwordExpired flag

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -531,6 +531,47 @@ class User extends UserPermissions
         $this->update($updateArray);
     }
 
+    function pwnedPassword(string $password): bool
+    {
+        // TODO Use the HttpClient in LORIS core to cURL more simply.
+        
+        /* The pwned passwords API searches a range of password hashes to 
+         * protect the actual SHA1 hash from being revealed.
+         * More here: <https://haveibeenpwned.com/API/v2#PwnedPasswords>
+         */
+        $hash = sha1($password);
+        $hashPrefix = substr(sha1($password), 0, 5);
+        $url = "https://api.pwnedpasswords.com/range/$hashPrefix";
+
+        /* Build curl */
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+
+        // get response
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        $hashSuffixes = explode("\n", $response);
+        /* The response will be one long string consisting of suffixes matching
+         * our hash prefix, followed by a colon and the number of times the 
+         * password has occurred in data breaches.
+         * Here we iterate over all of the suffixes and check whether the prefix
+         * and the whole suffix line together contain $hash as a substring at 
+         * the beginning of the line (instead of preprocessing by removing
+         * the colon and count from the end of the $suffix line.
+         * Check the above link if you want more info.
+         */
+        foreach ($hashSuffixes as $suffix) {
+            $line = strtolower($hashPrefix . $suffix);
+            if ($hash == substr($line, 0, strlen($hash))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Determines if the user has a center
      *

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -546,6 +546,10 @@ class User extends UserPermissions
         /* The pwned passwords API searches a range of password hashes to
          * protect the actual SHA1 hash from being revealed.
          * More here: <https://haveibeenpwned.com/API/v2#PwnedPasswords>
+         *
+         * NOTE your webserver will need to be configured to allow going 
+         * connections to the link below. If you encounter errors please
+         * verify your firewall settings.
          */
         $hash       = sha1($password);
         $hashPrefix = substr(sha1($password), 0, 5);
@@ -559,6 +563,15 @@ class User extends UserPermissions
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
         $response = curl_exec($ch);
+        // In case request fials for any reason
+        if (curl_error($ch)) {
+            error_log("ERROR: Problem connecting to pwned passwords API: "
+                . curl_error($ch));
+            /* Don't prevent password change if there is a cURL error. Using
+             * this API is nice but not critical to functioning.
+             */
+            return false;
+        }
         curl_close($ch);
 
         $hashSuffixes = explode("\n", $response);

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -566,11 +566,10 @@ class User extends UserPermissions
         $hashPrefix = substr(sha1($password), 0, 5);
         // $url        = "https://api.pwnedpasswords.com/range/$hashPrefix";
 
-        $client   = Client::createWithConfig(
-            array('base_uri' => 'https://api.pwnedpasswords.com')
+        $client   = new Client('https://api.pwnedpasswords.com');
+        $response = $client->sendRequest(
+            new Request('GET', "/range/$hashPrefix")
         );
-        $request  = new Request('GET', "/range/$hashPrefix");
-        $response = $client->sendRequest($request);
 
         /* We don't want password changes to fail in case there is a
          * networking issue while making the request. If the API can't be

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -562,7 +562,6 @@ class User extends UserPermissions
         );
         $request  = new Request('GET', "/range/$hashPrefix");
         $response = $adapter->sendRequest($request);
-        print_r($response);
 
         /* We don't want password changes to fail in case there is a
          * networking issue while making the request. If the API can't be

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -11,8 +11,8 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
-use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
-use GuzzleHttp\Psr7\Request;
+use \LORIS\Http\Client;
+use \LORIS\Http\Request;
 /**
  * User class. This deals with any User management except permissions,
  * which is contained in the UserPermissions base class.
@@ -566,11 +566,11 @@ class User extends UserPermissions
         $hashPrefix = substr(sha1($password), 0, 5);
         // $url        = "https://api.pwnedpasswords.com/range/$hashPrefix";
 
-        $adapter  = GuzzleAdapter::createWithConfig(
+        $client   = Client::createWithConfig(
             array('base_uri' => 'https://api.pwnedpasswords.com')
         );
         $request  = new Request('GET', "/range/$hashPrefix");
-        $response = $adapter->sendRequest($request);
+        $response = $client->sendRequest($request);
 
         /* We don't want password changes to fail in case there is a
          * networking issue while making the request. If the API can't be
@@ -579,7 +579,7 @@ class User extends UserPermissions
         if (!$response->getStatusCode() === 200) {
             return false;
         }
-        $hashSuffixes = explode("\n", $response->getBody());
+        $hashSuffixes = explode("\n", $response->getBody()->getContents());
         /* The response will be one long string consisting of suffixes matching
          * our hash prefix, followed by a colon and the number of times the
          * password has occurred in data breaches.

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -543,8 +543,6 @@ class User extends UserPermissions
      */
     function pwnedPassword(string $password): bool
     {
-        // TODO Use the HttpClient in LORIS core to cURL more simply.
-
         /* The pwned passwords API searches a range of password hashes to
          * protect the actual SHA1 hash from being revealed.
          * More here: <https://haveibeenpwned.com/API/v2#PwnedPasswords>

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -547,7 +547,7 @@ class User extends UserPermissions
          * protect the actual SHA1 hash from being revealed.
          * More here: <https://haveibeenpwned.com/API/v2#PwnedPasswords>
          *
-         * NOTE your webserver will need to be configured to allow going 
+         * NOTE your webserver will need to be configured to allow going
          * connections to the link below. If you encounter errors please
          * verify your firewall settings.
          */
@@ -565,8 +565,10 @@ class User extends UserPermissions
         $response = curl_exec($ch);
         // In case request fials for any reason
         if (curl_error($ch)) {
-            error_log("ERROR: Problem connecting to pwned passwords API: "
-                . curl_error($ch));
+            error_log(
+                "ERROR: Problem connecting to pwned passwords API: "
+                . curl_error($ch)
+            );
             /* Don't prevent password change if there is a cURL error. Using
              * this API is nice but not critical to functioning.
              */

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -550,7 +550,6 @@ class User extends UserPermissions
             'usePwnedPasswordsAPI'
         )
         ) {
-            error_log('Setting disabled!');
             return false;
         }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -543,6 +543,17 @@ class User extends UserPermissions
      */
     function pwnedPassword(string $password): bool
     {
+
+        // If the project is configured to disable the Pwned Password check,
+        // always return false (meanning that the password has not been pwned).
+        if ('true' !== \NDB_Factory::singleton()->config()->getSetting(
+            'usePwnedPasswordsAPI'
+        )
+        ) {
+            error_log('Setting disabled!');
+            return false;
+        }
+
         /* The pwned passwords API searches a range of password hashes to
          * protect the actual SHA1 hash from being revealed.
          * More here: <https://haveibeenpwned.com/API/v2#PwnedPasswords>

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -531,17 +531,25 @@ class User extends UserPermissions
         $this->update($updateArray);
     }
 
+    /**
+     * Use the Pwned Passwords API to determine whether a user is trying
+     * to use a password that has been revealed in public data breaches.
+     *
+     * @param string $password The password to check for pwnage.
+     *
+     * @return bool Whether the password is known to be pwned.
+     */
     function pwnedPassword(string $password): bool
     {
         // TODO Use the HttpClient in LORIS core to cURL more simply.
-        
-        /* The pwned passwords API searches a range of password hashes to 
+
+        /* The pwned passwords API searches a range of password hashes to
          * protect the actual SHA1 hash from being revealed.
          * More here: <https://haveibeenpwned.com/API/v2#PwnedPasswords>
          */
-        $hash = sha1($password);
+        $hash       = sha1($password);
         $hashPrefix = substr(sha1($password), 0, 5);
-        $url = "https://api.pwnedpasswords.com/range/$hashPrefix";
+        $url        = "https://api.pwnedpasswords.com/range/$hashPrefix";
 
         /* Build curl */
         $ch = curl_init();
@@ -555,10 +563,10 @@ class User extends UserPermissions
 
         $hashSuffixes = explode("\n", $response);
         /* The response will be one long string consisting of suffixes matching
-         * our hash prefix, followed by a colon and the number of times the 
+         * our hash prefix, followed by a colon and the number of times the
          * password has occurred in data breaches.
          * Here we iterate over all of the suffixes and check whether the prefix
-         * and the whole suffix line together contain $hash as a substring at 
+         * and the whole suffix line together contain $hash as a substring at
          * the beginning of the line (instead of preprocessing by removing
          * the colon and count from the end of the $suffix line.
          * Check the above link if you want more info.

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -11,6 +11,8 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
+use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
+use GuzzleHttp\Psr7\Request;
 /**
  * User class. This deals with any User management except permissions,
  * which is contained in the UserPermissions base class.
@@ -553,30 +555,23 @@ class User extends UserPermissions
          */
         $hash       = sha1($password);
         $hashPrefix = substr(sha1($password), 0, 5);
-        $url        = "https://api.pwnedpasswords.com/range/$hashPrefix";
+        // $url        = "https://api.pwnedpasswords.com/range/$hashPrefix";
 
-        /* Build curl */
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $url);
+        $adapter  = GuzzleAdapter::createWithConfig(
+            array('base_uri' => 'https://api.pwnedpasswords.com')
+        );
+        $request  = new Request('GET', "/range/$hashPrefix");
+        $response = $adapter->sendRequest($request);
+        print_r($response);
 
-        // get response
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
-        $response = curl_exec($ch);
-        // In case request fials for any reason
-        if (curl_error($ch)) {
-            error_log(
-                "ERROR: Problem connecting to pwned passwords API: "
-                . curl_error($ch)
-            );
-            /* Don't prevent password change if there is a cURL error. Using
-             * this API is nice but not critical to functioning.
-             */
+        /* We don't want password changes to fail in case there is a
+         * networking issue while making the request. If the API can't be
+         * reached for any reason, we will skip the pwned password check.
+         */
+        if (!$response->getStatusCode() === 200) {
             return false;
         }
-        curl_close($ch);
-
-        $hashSuffixes = explode("\n", $response);
+        $hashSuffixes = explode("\n", $response->getBody());
         /* The response will be one long string consisting of suffixes matching
          * our hash prefix, followed by a colon and the number of times the
          * password has occurred in data breaches.
@@ -584,7 +579,7 @@ class User extends UserPermissions
          * and the whole suffix line together contain $hash as a substring at
          * the beginning of the line (instead of preprocessing by removing
          * the colon and count from the end of the $suffix line.
-         * Check the above link if you want more info.
+         * Check the API documentation linked above if you want more info.
          */
         foreach ($hashSuffixes as $suffix) {
             $line = strtolower($hashPrefix . $suffix);

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -585,8 +585,7 @@ class User extends UserPermissions
          * password has occurred in data breaches.
          * Here we iterate over all of the suffixes and check whether the prefix
          * and the whole suffix line together contain $hash as a substring at
-         * the beginning of the line (instead of preprocessing by removing
-         * the colon and count from the end of the $suffix line.
+         * the beginning of the line.
          * Check the API documentation linked above if you want more info.
          */
         foreach ($hashSuffixes as $suffix) {

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+/**
+* File contains the PSR18 HTTP Client implementation that
+* can be constructed with the "new" keyword.
+*
+* PHP Version 7
+*
+* @category PSR18
+* @package  Http
+* @author   John Saigle <john.saigle@mcin.ca>
+* @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+* @link     https://www.github.com/aces/Loris/
+*
+* @see https://www.php-fig.org/psr/psr-18/
+*/
+namespace LORIS\Http;
+
+use \Http\Adapter\Guzzle6\Client as GuzzleClient;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR18 ResponseInterface to use
+ * in LORIS.
+ *
+ * It is intended to reduce our coupling to any particular PSR18 implementation.
+ */
+class Client 
+{
+
+    /**
+     * Private to prevent from creating this object on its own since it's just
+     * a wrapper for Guzzle at this time.
+     */
+    private function __construct() {
+    }
+
+    /**
+     * Guzzle's Client class is final and so cannot be extended directly. This
+     * function acts as a wrapper for this function and serves as a workaround.
+     */
+    public static function createWithConfig(array $config): GuzzleClient {
+        return \Http\Adapter\Guzzle6\Client::createWithConfig($config);
+    }
+}

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -16,28 +16,39 @@
 namespace LORIS\Http;
 
 use \Http\Adapter\Guzzle6\Client as GuzzleClient;
+use \Psr\Http\Client\ClientInterface;
+use \Psr\Http\Message\RequestInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 /**
- * A LORIS Http Response is an implementation of the PSR18 ResponseInterface to use
+ * A LORIS Http Client is an implementation of the PSR18 ClientInterface to use
  * in LORIS.
  *
  * It is intended to reduce our coupling to any particular PSR18 implementation.
  */
-class Client 
+class Client implements ClientInterface
 {
-
-    /**
-     * Private to prevent from creating this object on its own since it's just
-     * a wrapper for Guzzle at this time.
-     */
-    private function __construct() {
-    }
-
+    private $client;
     /**
      * Guzzle's Client class is final and so cannot be extended directly. This
      * function acts as a wrapper for this function and serves as a workaround.
+     *
+     * @param string $uri The base uri targeted for requests.
+     *
+     * @return void
      */
-    public static function createWithConfig(array $config): GuzzleClient {
-        return \Http\Adapter\Guzzle6\Client::createWithConfig($config);
+    public function __construct(string $uri) {
+        $this->client = GuzzleClient::createWithConfig(
+            array(
+                'base_uri' => $uri
+            )
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function sendRequest(RequestInterface $request): ResponseInterface {
+        return $this->client->sendRequest($request);
     }
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,13 +1,13 @@
 <?php
 /**
-* File contains the PSR15 ResponseInterface implementation that
+* File contains the PSR15 RequestInterface implementation that
 * can be constructed with the "new" keyword.
 *
 * PHP Version 7
 *
 * @category PSR15
 * @package  Http
-* @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+* @author   John Saigle <john.saigle@mcin.ca>
 * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
 * @link     https://www.github.com/aces/Loris/
 *
@@ -17,13 +17,13 @@
 namespace LORIS\Http;
 
 /**
- * A LORIS Http Response is an implementation of the PSR15 ResponseInterface to
- * use in LORIS.
+ * A LORIS Http Request is an implementation of the PSR15 RequestInterface to use
+ * in LORIS.
  *
  * It is intended to reduce our coupling to any particular PSR15 implementation.
  */
-class Response 
-    extends \Zend\Diactoros\Response 
-    implements \Psr\Http\Message\ResponseInterface
+class Request 
+    extends \GuzzleHttp\Psr7\Request
+    implements \Psr\Http\Message\RequestInterface
 {
 }


### PR DESCRIPTION
### Brief summary of changes

Add the [pwned passwords API](https://haveibeenpwned.com/API/v2#PwnedPasswords) into the LORIS password logic. This is part of a refactoring effort to modernize the way LORIS does passwords.

In particular, this API prevents users from creating passwords that are known to be present in previous data leaks. After a password breach, hackers compose large lists of the password and try them in brute force attacks against the sites. 

After this PR users will be prevented from creating a password like `Spring2016!` which is a bad password even though it passes the (current) LORIS password strength requirements.

### Related to

#3314, #3949, #3950 

### To test this change...

- [ ] Checkout my branch.
- [ ] Run the new patch on your DB: `SQL/New_patches/2019-01-28_Add_Pwned_Password_ConfigSetting.sql`
- [ ] On your VM go to the Configuration menu and enable the "Use Pwned Password" check
- [ ] Try changing your password to `Spring2016!`. You should get an error message. 

As @zaliqarosli pointed out, curl is required so if you get an error do 
`sudo apt-get install php7.2-curl; sudo service apache2 restart`
