### PR TITLE
[JSX] Add new FilterableDataTable component

### DIFF
--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -1,0 +1,36 @@
+import React, {Component} from 'react';
+
+import DynamicDataTable from 'jsx/DynamicDataTable';
+import FilterForm from 'jsx/FilterForm';
+
+class FilterableDataTable extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+        'filters': {},
+    };
+    this.updateFilter = this.updateFilter.bind(this);
+  }
+
+  updateFilter(filter) {
+      this.setState({'filters': filter});
+  }
+  render() {
+      return (<div>
+          <FilterForm
+            name={this.props.name + '_filter'}
+            id={this.props.name + '_filter_form'}
+            ref={this.props.name + 'Filter'}
+            columns={3}
+            formElements={this.props.FilterForm}
+            onUpdate={this.updateFilter}
+          />
+          <DynamicDataTable {...this.props}
+            Filter={this.state.filters}
+          />
+          </div>
+      );
+  }
+}
+
+export default FilterableDataTable;


### PR DESCRIPTION
This adds a new FilterableDataTable component in order to make it easier to
create tables which have filters that dynamically restrict the content.

The filterable datatable component is like a DynamicDataTable, except it also
creates a filter based on a object passed to it as a prop. The data in the table
and the filters are dynamically linked.

This is intended to make the reactification of menu filters both easier and more consistent across LORIS.