### PR TITLE
[Core]  Populate Instruments in Alphabetic Order

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -540,7 +540,7 @@ class Utility
         $Factory       = NDB_Factory::singleton();
         $DB            = $Factory->Database();
         $instruments_q = $DB->pselect(
-            "SELECT Test_name,Full_name FROM test_names",
+            "SELECT Test_name,Full_name FROM test_names ORDER BY Full_name",
             array()
         );
         $instruments   = array();
@@ -595,7 +595,8 @@ class Utility
         $DB            =& Database::singleton();
         $instruments   = array();
         $instruments_q = $DB->pselect(
-            "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true",
+            "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true 
+             ORDER BY Full_name",
             array()
         );
         foreach ($instruments_q as $key) {


### PR DESCRIPTION
### Brief Summary of Changes
This PR makes the Instruments in the Instrument dropdown in alphabetic order.
 
### To test this change...

- Any place where Utility::getDirectInstruments() or Utility::getAllInstruments() is called
(eg: Data Dictionary Instrument Dropdown, Survey Accounts Instrument Dropdown etc)


