### PR TITLE
[Core] Add hasAllPermissions and hasAnyPermission to facilitate privilege-checking

### DIFF
--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -39,8 +39,8 @@ class Examiner extends \NDB_Menu_Filter_Form
     {
         return $user->hasAnyPermission(
             array(
-                'examiner_view', 
-                'examiner_multisite',
+             'examiner_view',
+             'examiner_multisite',
             )
         );
     }

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -37,8 +37,7 @@ class Examiner extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('examiner_view')
-            || $user->hasPermission('examiner_multisite');
+        return $user->hasPermission('examiner_view', 'examiner_multisite');
     }
 
     /**

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -37,7 +37,12 @@ class Examiner extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('examiner_view', 'examiner_multisite');
+        return $user->hasAnyPermission(
+            array(
+                'examiner_view', 
+                'examiner_multisite',
+            )
+        );
     }
 
     /**

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -113,7 +113,7 @@ class UserPermissions
      *
      * @return bool If the user has a permission.
      */
-    function hasPermission($code): bool
+    function hasPermission(string $code): bool
     {
         /* True if user superuser permission is set and user has it OR all
          * permissions are true.
@@ -130,7 +130,7 @@ class UserPermissions
      *
      * @return bool The setting of permission code $permission
      */
-    function permissionTrueAndValid(string $code)
+    function permissionTrueAndValid(string $code): bool
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
@@ -148,7 +148,7 @@ class UserPermissions
      */
     function hasAllPermissions(array $permissions): bool
     {
-        if (!count($permissions)) {
+        if (count($permissions) === 0) {
             throw new LorisException(
                 "Cannot call hasAllPermissions with an empty array!"
             );
@@ -170,7 +170,7 @@ class UserPermissions
      */
     function hasAnyPermission(array $permissions): bool
     {
-        if (!count($permissions)) {
+        if (count($permissions) === 0) {
             throw new LorisException(
                 "Cannot call hasAnyPermission with an empty array!"
             );

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -109,7 +109,7 @@ class UserPermissions
      * Determines if the user has the permission to access a specific module
      * or page.
      *
-     * @param string $code     The permission code
+     * @param string $code The permission code
      *
      * @return bool If the user has a permission.
      */
@@ -142,12 +142,17 @@ class UserPermissions
      * Used to test whether a user has ALL of an array of specified permissions.
      * Returns false on the first permission that the user doesn't have.
      *
-     * @param array $permissions Array of permissions codes.
+     * @param string[] $permissions Array of permissions codes.
      *
      * @return bool Whether the user has all the permissions in $permissions.
      */
     function hasAllPermissions(array $permissions): bool
     {
+        if (!count($permissions)) {
+            throw new LorisException(
+                "Cannot call hasAllPermissions with an empty array!"
+            );
+        }
         foreach ($permissions as $p) {
             if (!$this->permissionTrueAndValid($p)) {
                 return false;
@@ -158,14 +163,18 @@ class UserPermissions
 
     /**
      * Used to test whether a user has ANY of an array of specified permissions.
-     * Returns true on the first permission that the user has.
      *
-     * @param array $permissions Array of permissions codes.
+     * @param string[] $permissions Array of permissions codes.
      *
      * @return bool Whether the user has any of the permissions in $permissions.
      */
     function hasAnyPermission(array $permissions): bool
     {
+        if (!count($permissions)) {
+            throw new LorisException(
+                "Cannot call hasAnyPermission with an empty array!"
+            );
+        }
         foreach ($permissions as $p) {
             if ($this->permissionTrueAndValid($p)) {
                 return true;

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -115,8 +115,8 @@ class UserPermissions
      */
     public function hasPermission(string $code): bool
     {
-        return $this->permissionTrueAndValid('superuser')
-            || $this->permissionTrueAndValid($code);
+        return $this->_permissionTrueAndValid('superuser')
+            || $this->_permissionTrueAndValid($code);
     }
 
     /**
@@ -127,7 +127,7 @@ class UserPermissions
      *
      * @return bool The setting of permission code $permission
      */
-    protected function permissionTrueAndValid(string $code): bool
+    private function _permissionTrueAndValid(string $code): bool
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
@@ -151,7 +151,7 @@ class UserPermissions
             );
         }
         foreach ($permissions as $p) {
-            if (!$this->permissionTrueAndValid($p)) {
+            if (!$this->_permissionTrueAndValid($p)) {
                 return false;
             }
         }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -126,7 +126,7 @@ class UserPermissions
          */
         return $this->permissions['superuser'] ?? false
             || $hasSinglePermission
-            || hasPermissions(array_merge(array($code), $codes));
+            || $this->hasPermissions(array_merge(array($code), $codes));
     }
 
     /**
@@ -171,7 +171,6 @@ class UserPermissions
      */
     function getPermissions()
     {
-        var_dump($this->permissions);
         return $this->permissions;
     }
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -115,13 +115,8 @@ class UserPermissions
      */
     public function hasPermission(string $code): bool
     {
-        if (get_class() === 'UserPermissions') {
-            return $this->_permissionTrueAndValid['superuser']
-                || $this->_permissionTrueAndValid($code);
-        } else if (get_class() === 'User') {
-            return parent::_permissionTrueAndValid['superuser']
-                || parent::_permissionTrueAndValid($code);
-        }
+        return $this->permissionTrueAndValid('superuser')
+            || $this->permissionTrueAndValid($code);
     }
 
     /**
@@ -132,7 +127,7 @@ class UserPermissions
      *
      * @return bool The setting of permission code $permission
      */
-    private function _permissionTrueAndValid(string $code): bool
+    protected function permissionTrueAndValid(string $code): bool
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
@@ -156,7 +151,7 @@ class UserPermissions
             );
         }
         foreach ($permissions as $p) {
-            if (!$this->_permissionTrueAndValid($p)) {
+            if (!$this->permissionTrueAndValid($p)) {
                 return false;
             }
         }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -110,23 +110,16 @@ class UserPermissions
      * or page.
      *
      * @param string $code     The permission code
-     * @param string ...$codes Optional additional permission codes
      *
-     * @return bool
+     * @return bool If the user has a permission.
      */
-    function hasPermission($code, ...$codes): bool
+    function hasPermission($code): bool
     {
-        /* True if $code is the only parameter passed and it is a valid
-         * permission code possessed by the user.
-         */
-        $hasSinglePermission = $this->permissionTrueAndValid($code)
-            && count($codes) === 0;
         /* True if user superuser permission is set and user has it OR all
          * permissions are true.
          */
         return $this->permissions['superuser'] ?? false
-            || $hasSinglePermission
-            || $this->hasPermissions(array_merge(array($code), $codes));
+            || $this->permissionTrueAndValid($code);
     }
 
     /**
@@ -146,14 +139,14 @@ class UserPermissions
     }
 
     /**
-     * Used to test whether a user has all of an array of specified permissions.
+     * Used to test whether a user has ALL of an array of specified permissions.
      * Returns false on the first permission that the user doesn't have.
      *
      * @param array $permissions Array of permissions codes.
      *
      * @return bool Whether the user has all the permissions in $permissions.
      */
-    function hasPermissions(array $permissions): bool
+    function hasAllPermissions(array $permissions): bool
     {
         foreach ($permissions as $p) {
             if (!$this->permissionTrueAndValid($p)) {
@@ -161,6 +154,24 @@ class UserPermissions
             }
         }
         return true;
+    }
+
+    /**
+     * Used to test whether a user has ANY of an array of specified permissions.
+     * Returns true on the first permission that the user has.
+     *
+     * @param array $permissions Array of permissions codes.
+     *
+     * @return bool Whether the user has any of the permissions in $permissions.
+     */
+    function hasAnyPermission(array $permissions): bool
+    {
+        foreach ($permissions as $p) {
+            if ($this->permissionTrueAndValid($p)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -106,29 +106,62 @@ class UserPermissions
 
 
     /**
-     * Determines if the user has a permission
+     * Determines if the user has the permission to access a specific module
+     * or page.
      *
-     * @param string $code The permission code
+     * @param string $code     The permission code
+     * @param string ...$codes Optional additional permission codes
      *
      * @return bool
      */
-    function hasPermission($code)
+    function hasPermission($code, ...$codes): bool
+    {
+        /* True if $code is the only parameter passed and it is a valid
+         * permission code possessed by the user.
+         */
+        $hasSinglePermission = $this->permissionTrueAndValid($code)
+            && count($codes) === 0;
+        /* True if user superuser permission is set and user has it OR all
+         * permissions are true.
+         */
+        return $this->permissions['superuser'] ?? false
+            || $hasSinglePermission
+            || hasPermissions(array_merge(array($code), $codes));
+    }
+
+    /**
+     * Check if a given permission code is present in a user's list of
+     * permissions. Also validates that the permission code is real.
+     *
+     * @param string $code Permission code to test.
+     *
+     * @return bool The setting of permission code $permission
+     */
+    function permissionTrueAndValid(string $code)
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
         }
-        if ($this->permissions[$code] === true) {
-            return true;
-        }
-
-        if (isset($this->permissions['superuser'])
-            && $this->permissions['superuser'] == true
-        ) {
-            return true;
-        }
-        return false;
+        return $this->permissions[$code];
     }
 
+    /**
+     * Used to test whether a user has all of an array of specified permissions.
+     * Returns false on the first permission that the user doesn't have.
+     *
+     * @param array $permissions Array of permissions codes.
+     *
+     * @return bool Whether the user has all the permissions in $permissions.
+     */
+    function hasPermissions(array $permissions): bool
+    {
+        foreach ($permissions as $p) {
+            if (!$this->permissionTrueAndValid($p)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /**
      * Returns the permissions array
@@ -138,6 +171,7 @@ class UserPermissions
      */
     function getPermissions()
     {
+        var_dump($this->permissions);
         return $this->permissions;
     }
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -113,7 +113,7 @@ class UserPermissions
      *
      * @return bool If the user has a permission.
      */
-    public function hasPermission(string $code): bool
+    public function hasPermission($code): bool
     {
         /* True if user superuser permission is set and user has it OR all
          * permissions are true.
@@ -130,7 +130,7 @@ class UserPermissions
      *
      * @return bool The setting of permission code $permission
      */
-    private function _permissionTrueAndValid(string $code): bool
+    private function _permissionTrueAndValid($code): bool
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -113,12 +113,9 @@ class UserPermissions
      *
      * @return bool If the user has a permission.
      */
-    public function hasPermission($code): bool
+    public function hasPermission(string $code): bool
     {
-        /* True if user superuser permission is set and user has it OR all
-         * permissions are true.
-         */
-        return $this->permissions['superuser'] ?? false
+        return $this->_permissionTrueAndValid['superuser']
             || $this->_permissionTrueAndValid($code);
     }
 
@@ -130,12 +127,12 @@ class UserPermissions
      *
      * @return bool The setting of permission code $permission
      */
-    private function _permissionTrueAndValid($code): bool
+    private function _permissionTrueAndValid(string $code): bool
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
         }
-        return $this->permissions[$code];
+        return intval($this->permissions[$code]) === 1;
     }
 
     /**

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -113,13 +113,13 @@ class UserPermissions
      *
      * @return bool If the user has a permission.
      */
-    function hasPermission(string $code): bool
+    public function hasPermission(string $code): bool
     {
         /* True if user superuser permission is set and user has it OR all
          * permissions are true.
          */
         return $this->permissions['superuser'] ?? false
-            || $this->permissionTrueAndValid($code);
+            || $this->_permissionTrueAndValid($code);
     }
 
     /**
@@ -130,7 +130,7 @@ class UserPermissions
      *
      * @return bool The setting of permission code $permission
      */
-    function permissionTrueAndValid(string $code): bool
+    private function _permissionTrueAndValid(string $code): bool
     {
         if (!isset($this->permissions[$code])) {
             throw new ConfigurationException("Invalid permission code $code");
@@ -146,7 +146,7 @@ class UserPermissions
      *
      * @return bool Whether the user has all the permissions in $permissions.
      */
-    function hasAllPermissions(array $permissions): bool
+    public function hasAllPermissions(array $permissions): bool
     {
         if (count($permissions) === 0) {
             throw new LorisException(
@@ -154,7 +154,7 @@ class UserPermissions
             );
         }
         foreach ($permissions as $p) {
-            if (!$this->permissionTrueAndValid($p)) {
+            if (!$this->_permissionTrueAndValid($p)) {
                 return false;
             }
         }
@@ -168,7 +168,7 @@ class UserPermissions
      *
      * @return bool Whether the user has any of the permissions in $permissions.
      */
-    function hasAnyPermission(array $permissions): bool
+    public function hasAnyPermission(array $permissions): bool
     {
         if (count($permissions) === 0) {
             throw new LorisException(
@@ -176,7 +176,7 @@ class UserPermissions
             );
         }
         foreach ($permissions as $p) {
-            if ($this->permissionTrueAndValid($p)) {
+            if ($this->_permissionTrueAndValid($p)) {
                 return true;
             }
         }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -115,8 +115,13 @@ class UserPermissions
      */
     public function hasPermission(string $code): bool
     {
-        return $this->_permissionTrueAndValid['superuser']
-            || $this->_permissionTrueAndValid($code);
+        if (get_class() === 'UserPermissions') {
+            return $this->_permissionTrueAndValid['superuser']
+                || $this->_permissionTrueAndValid($code);
+        } else if (get_class() === 'User') {
+            return parent::_permissionTrueAndValid['superuser']
+                || parent::_permissionTrueAndValid($code);
+        }
     }
 
     /**


### PR DESCRIPTION
### Brief summary of changes

Now we can do

```php
return $user->hasAllPermissions(array('permission1', 'permission2', ...));
```
or
```php
return $user->hasAnyPermission(array('permission1', 'permission2', ...));
```


instead of 

```php
return $user->hasPermission('examiner_view')
            || $user->hasPermission('examiner_multisite')
            || ....;
```

Which will help to make it easier to review permissions.

### To test this change...

- [ ] Go to examiner and make sure the permissions still work as expected.
