### PR TITLE
[JSX] StaticDataTable - Replaced loris.hiddenHeaders with this.props.hiddenheaders

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -357,8 +357,8 @@ class StaticDataTable extends Component {
     ];
 
     for (let i = 0; i < this.props.Headers.length; i += 1) {
-      if (typeof loris.hiddenHeaders === 'undefined' ||
-        loris.hiddenHeaders.indexOf(this.props.Headers[i]) === -1) {
+      if (typeof this.props.hiddenHeaders === 'undefined' ||
+        this.props.hiddenHeaders.indexOf(this.props.Headers[i]) === -1) {
         let colIndex = i + 1;
         if (this.props.Headers[i] === this.props.freezeColumn) {
           headers.push(


### PR DESCRIPTION
### Summary of changes

The loris.hiddenHeaders variable has been replaced by this.props.hiddenHeaders. This is to allow the formatColumns function in reactified modules to live in the main index file for that module. States should be passed down as props, and not saved as global variables; hence the change.

The merging of this PR will allow those that reference this PR to be unblocked.