### PR TITLE
[Core] Add Response object implementation

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -190,7 +190,7 @@ class NDB_Form extends NDB_Page
             $this->save();
         }
 
-        return (new \Zend\Diactoros\Response())
+        return (new \LORIS\Http\Response())
             ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
     }
 }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -663,7 +663,7 @@ class NDB_Page implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $this->setup();
-        return (new \Zend\Diactoros\Response())
+        return (new \LORIS\Http\Response())
             ->withBody(new \LORIS\Http\StringStream($this->display()));
     }
 

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,0 +1,29 @@
+<?php
+/**
+* File contains the PSR15 ResponseInterface implementation that
+* can be constructed with the "new" keyword.
+*
+* PHP Version 7
+*
+* @category PSR15
+* @package  Http
+* @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+* @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+* @link     https://www.github.com/aces/Loris/
+*
+* @see https://www.php-fig.org/psr/psr-7/
+* @see https://www.php-fig.org/psr/psr-15/
+*/
+namespace LORIS\Http;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface to use
+ * in LORIS.
+ *
+ * It is intended to reduce our coupling to any particular PSR15 implementation.
+ */
+class Response 
+    extends \Zend\Diactoros\Response 
+    implements \Psr\Http\Message\ResponseInterface
+{
+}

--- a/src/Router/ModuleFileRouter.php
+++ b/src/Router/ModuleFileRouter.php
@@ -82,7 +82,7 @@ class ModuleFileRouter implements RequestHandlerInterface
         );
 
         if (is_file($fullpath)) {
-            $resp = (new \Zend\Diactoros\Response)
+            $resp = (new \LORIS\Http\Response)
                 ->withStatus(200)
                 ->withBody(new \Zend\Diactoros\Stream($fullpath));
             if ($this->contenttype != "") {


### PR DESCRIPTION
A couple places in our code are tightly coupled to the Zend Diactoros
Response object. This weaks the coupling by adding a class in between
which can be changed to another PSR15 implementation if desired. It
also solves the problem wherein I can never remember how to spell
"diactoros".