### PR TITLE
[data_release] Add permissions for upload and edit functionalities

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -109,7 +109,9 @@ INSERT INTO `permissions` VALUES
     (45,'issue_tracker_reporter', 'Can add a new issue, edit own issue, comment on all', 2),
     (46,'issue_tracker_developer', 'Can re-assign issues, mark issues as closed, comment on all, edit issues.', 2),
     (47,'imaging_browser_phantom_allsites', 'Can access only phantom data from all sites in Imaging Browser', 2),
-    (48,'imaging_browser_phantom_ownsite', 'Can access only phantom data from own site in Imaging Browser', 2);
+    (48,'imaging_browser_phantom_ownsite', 'Can access only phantom data from own site in Imaging Browser', 2),
+    (49,'data_release_upload', 'Data Release: Upload file', 2),
+    (50,'data_release_edit_permissions', 'Data Release: Give user permission to view files', 2);
 
 
 INSERT INTO `user_perm_rel` (userID, permID)

--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -111,7 +111,7 @@ INSERT INTO `permissions` VALUES
     (47,'imaging_browser_phantom_allsites', 'Can access only phantom data from all sites in Imaging Browser', 2),
     (48,'imaging_browser_phantom_ownsite', 'Can access only phantom data from own site in Imaging Browser', 2),
     (49,'data_release_upload', 'Data Release: Upload file', 2),
-    (50,'data_release_edit_permissions', 'Data Release: Give user permission to view files', 2);
+    (50,'data_release_edit_file_access', 'Data Release: Grant other users view-file permissions', 2);
 
 
 INSERT INTO `user_perm_rel` (userID, permID)

--- a/SQL/New_patches/2018-10-01-Add_data_release_permissions.sql
+++ b/SQL/New_patches/2018-10-01-Add_data_release_permissions.sql
@@ -1,0 +1,6 @@
+INSERT INTO permissions (code,description,categoryID) VALUES ('data_release_upload','Data Release: Upload file',2), ('data_release_edit_permissions','Data Release: Give user permission to view files',2);
+
+INSERT IGNORE INTO user_perm_rel 
+SELECT upr.userID, p.permID FROM user_perm_rel upr JOIN permissions p WHERE upr.permID=1 AND p.code IN ('data_release_upload', 'data_release_edit_permissions');
+
+

--- a/SQL/New_patches/2018-10-01-Add_data_release_permissions.sql
+++ b/SQL/New_patches/2018-10-01-Add_data_release_permissions.sql
@@ -1,4 +1,4 @@
-INSERT INTO permissions (code,description,categoryID) VALUES ('data_release_upload','Data Release: Upload file',2), ('data_release_edit_permissions','Data Release: Give user permission to view files',2);
+INSERT INTO permissions (code,description,categoryID) VALUES ('data_release_upload','Data Release: Upload file',2), ('data_release_edit_file_access','Data Release: Grant other users view-file permissions',2);
 
 INSERT IGNORE INTO user_perm_rel 
 SELECT upr.userID, p.permID FROM user_perm_rel upr JOIN permissions p WHERE upr.permID=1 AND p.code IN ('data_release_upload', 'data_release_edit_permissions');

--- a/modules/data_release/README.md
+++ b/modules/data_release/README.md
@@ -8,9 +8,50 @@ The Data Release Module can be used to easily distribute packaged data releases 
 - Differentiate releases using (optionally unique) versioning tag
 - Assign permissions for each release to any specific user
 
+## Intended users
+
+- Researchers and analysis teams
+- Data coordinator that manages access to and uploads data releases
+
+
+## Scope
+
+The module is used to manage, upload and download data releases of the study.
+- Different data releases can be differentiated using the version tag.
+- Data coordinators can upload data releases of the study via the front-end
+web interface.
+- For each data release, data coordinators can manage permissions of any
+  specific user.
+
+
+## Permissions
+
+- Only users with `data_release_upload` an superusers can upload anything, 
+no one else has upload permission.
+- Only users with `data_release_edit_permissions` and superusers can grant 
+permissions whether by "version" or specific "file_name".
+- Once a user is granted permission on any data release, they will be able
+  to see the data release and download it directly from the module.
+- Users permissions to view data releases are based on the file
+  level permissions in the `data_release_permissions` table. Granting by
+  version grants every file tied to the specified version.
+
+Note: At the moment, the only way to remove a user's permission to a specific
+      data release is via the backend, by manually deleting rows in the
+      `data_release_permissions` MySQL table.
+
+
+## Configurations
+
+- Data release uploads are stored under the
+  `modules/data_release/user_uploads directory`, which can easily be symlinked
+  to another location if necessary. Note that this directory needs to be
+  writable by your web server.
+
 ## Other notes:
 
-- Uploads are stored under the modules/data_release/user_uploads directory which can easily be symlinked to another location if necessary, but please create and make sure it is writable by your web server
-- Only superusers have permission to upload files and grant permissions
+- Uploads are stored under the modules/data_release/user_uploads directory which 
+can easily be symlinked to another location if necessary, but please create and 
+make sure it is writable by your web server
 - Remove permissions by deleting rows in the data_release_permissions table
 - Upload date will automatically be added during file upload

--- a/modules/data_release/README.md
+++ b/modules/data_release/README.md
@@ -28,7 +28,7 @@ web interface.
 
 - Only users with `data_release_upload` an superusers can upload anything, 
 no one else has upload permission.
-- Only users with `data_release_edit_permissions` and superusers can grant 
+- Only users with `data_release_edit_file_access` and superusers can grant 
 permissions whether by "version" or specific "file_name".
 - Once a user is granted permission on any data release, they will be able
   to see the data release and download it directly from the module.

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -66,12 +66,12 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         $DB->run("TRUNCATE data_release_permissions");
         foreach ($_POST as $key => $value) {
             if (strpos($key, 'permissions') !== false) {
-                $parsed_user   = str_replace(
+                $parsed_user = str_replace(
                     "_",
                     "%",
                     str_replace("permissions_", "", $key)
                 );
-                $userid = $DB->pselectOne(
+                $userid      = $DB->pselectOne(
                     "SELECT ID FROM users WHERE UserID LIKE :userid",
                     array('userid' => $parsed_user)
                 );

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -53,7 +53,6 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
             );
         }
     }
-    // Currently all the *Success=true don't do anything, maybe some visual feedback can be incorporated at some point.
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
 } elseif ($_POST['action'] == 'managepermissions'
     && $user->hasPermission('superuser')
@@ -93,13 +92,11 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         }
         $DB->_PDO->commit();
         header("HTTP/1.1 303 See Other");
-        // Currently all the *Success=true don't do anything, maybe some visual feedback can be incorporated at some point.
         header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
     } catch (Exception $e) {
         $DB->_PDO->rollback();
         error_log("ERROR: Did not update Data Release permissions.");
         header("HTTP/1.1 500 Internal Server Error");
-        // Currently all the *Success=true don't do anything, maybe some visual feedback can be incorporated at some point.
         header("Location: {$baseURL}/data_release/?addpermissionSuccess=false");
     }
 } else {

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -56,6 +56,11 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
 } elseif ($_POST['action'] == 'managepermissions'
     && $user->hasPermission('superuser')
 ) {
+    // 1) so with checkboxes it's not straightforward to figure out
+    //    which permissions were either set or unset during the save,
+    //    hence the TRUNCATE at the beginning
+    // 2) put it in a transaction to make sure it succeeds or not at all
+    // 3) some special characters become "_" so we wildcard match the username
     try {
         $DB->_PDO->beginTransaction();
         $DB->run("TRUNCATE data_release_permissions");

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -3,6 +3,8 @@
 /**
  * Add permissions through Ajax, how crazy.
  *
+ * @todo use the 'addpermissionSuccess' flag for front-end enhancements
+ *
  * PHP Version 7
  *
  *  @category Loris

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -14,23 +14,67 @@
 
 $DB =& Database::singleton();
 
+$factory  = NDB_Factory::singleton();
+$settings = $factory->settings();
+$baseURL = $settings->getBaseURL();
+
 if ($_POST['action'] == 'addpermission') {
-    $userid          = $_POST['userid'];
-    $data_release_id = $_POST['data_release_id'];
-    $success         = $DB->insert(
-        'data_release_permissions',
-        array(
-         'userid'          => $userid,
-         'data_release_id' => $data_release_id,
-        )
-    );
+    if (!empty($_POST['data_release_id']) && empty($_POST['data_release_version'])) {
+        $userid          = $_POST['userid'];
+        $data_release_id = $_POST['data_release_id'];
+        $success         = $DB->insert(
+            'data_release_permissions',
+            array(
+             'userid'          => $userid,
+             'data_release_id' => $data_release_id,
+            )
+        );
+    } elseif (empty($_POST['data_release_id']) && !empty($_POST['data_release_version'])) {
+        $userid               = $_POST['userid'];
+        $data_release_version = $_POST['data_release_version'];
 
-    $factory  = NDB_Factory::singleton();
-    $settings = $factory->settings();
+        $IDs      = $DB->pselect(
+            "SELECT id FROM data_release WHERE "
+            . "version=:data_release_version",
+            array(
+             'data_release_version' => $data_release_version,
+            )
+        );
 
-    $baseURL = $settings->getBaseURL();
+        foreach ($IDs as $ID) {
+            $success         = $DB->insert(
+             'data_release_permissions',
+             array(
+              'userid'          => $userid,
+              'data_release_id' => $ID['id'],
+             )
+            );
+        }
+    }
 
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
+} elseif ($_POST['action'] == 'managepermissions') {
+    try {
+        $DB->_PDO->beginTransaction();
+        $DB->run("TRUNCATE data_release_permissions");
+        foreach ($_POST as $key => $value) {
+            if (strpos($key, 'permissions') !== false) {
+                $user = str_replace("_" , "%", str_replace("permissions_", "", $key));
+                $userid = $DB->pselectOne("SELECT ID FROM users WHERE UserID LIKE :userid", array('userid' => $user));
+                foreach ($value as $k => $v) {
+                    $data_release_ids = $DB->pselect("SELECT id FROM data_release WHERE version=:version", array('version' => $v));
+                    foreach ($data_release_ids as $data_release_id) {
+                        $success = $DB->run("INSERT IGNORE INTO data_release_permissions VALUES ($userid, {$data_release_id['id']})");
+                    }
+                }
+            }
+        }
+        $DB->_PDO->commit();
+        header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
+    } catch (Exception $e) {
+        $DB->_PDO->rollback();
+        header("Location: {$baseURL}/data_release/?addpermissionSuccess=false");
+    }
 } else {
     header("HTTP/1.1 400 Bad Request");
     echo "There was an error adding permissions";

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -12,8 +12,8 @@
  *  @link     https://github.com/aces/Loris
  */
 
-$user     = User::singleton();
-$factory  = NDB_Factory::singleton();
+$user     = \User::singleton();
+$factory  = \NDB_Factory::singleton();
 $settings = $factory->settings();
 $baseURL  = $settings->getBaseURL();
 $DB       = $factory->database();

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -20,7 +20,8 @@ $settings = $factory->settings();
 $baseURL  = $settings->getBaseURL();
 $DB       = $factory->database();
 
-if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
+if ($_POST['action'] == 'addpermission'
+    && $user->hasPermission('data_release_edit_file_access')) {
     if (!empty($_POST['data_release_id']) && empty($_POST['data_release_version'])) {
         $userid          = $_POST['userid'];
         $data_release_id = $_POST['data_release_id'];
@@ -55,7 +56,7 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
     }
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
 } elseif ($_POST['action'] == 'managepermissions'
-    && $user->hasPermission('superuser')
+    && $user->hasPermission('data_release_edit_file_access')
 ) {
     // 1) so with checkboxes it's not straightforward to figure out
     //    which permissions were either set or unset during the save,

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -66,14 +66,14 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         $DB->run("TRUNCATE data_release_permissions");
         foreach ($_POST as $key => $value) {
             if (strpos($key, 'permissions') !== false) {
-                $user   = str_replace(
+                $parsed_user   = str_replace(
                     "_",
                     "%",
                     str_replace("permissions_", "", $key)
                 );
                 $userid = $DB->pselectOne(
                     "SELECT ID FROM users WHERE UserID LIKE :userid",
-                    array('userid' => $user)
+                    array('userid' => $parsed_user)
                 );
                 foreach ($value as $k => $v) {
                     $data_release_ids = $DB->pselect(

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -90,9 +90,12 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
             }
         }
         $DB->_PDO->commit();
+        header("HTTP/1.1 303 See Other");
         header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
     } catch (Exception $e) {
         $DB->_PDO->rollback();
+        error_log("ERROR: Did not update Data Release permissions.");
+        header("HTTP/1.1 500 Internal Server Error");
         header("Location: {$baseURL}/data_release/?addpermissionSuccess=false");
     }
 } else {

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -12,12 +12,11 @@
  *  @link     https://github.com/aces/Loris
  */
 
-$DB =& Database::singleton();
-
 $user     = User::singleton();
 $factory  = NDB_Factory::singleton();
 $settings = $factory->settings();
 $baseURL  = $settings->getBaseURL();
+$DB       = $factory->database();
 
 if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
     if (!empty($_POST['data_release_id']) && empty($_POST['data_release_version'])) {

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -35,7 +35,7 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         $userid = $_POST['userid'];
         $data_release_version = $_POST['data_release_version'];
 
-        $IDs = $DB->pselect(
+        $IDs = $DB->pselectCol(
             "SELECT id FROM data_release WHERE "
             . "version=:data_release_version",
             array('data_release_version' => $data_release_version)

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -30,11 +30,13 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
              'data_release_id' => $data_release_id,
             )
         );
-    } elseif (empty($_POST['data_release_id']) && !empty($_POST['data_release_version'])) {
+    } elseif (empty($_POST['data_release_id'])
+        && !empty($_POST['data_release_version'])
+    ) {
         $userid               = $_POST['userid'];
         $data_release_version = $_POST['data_release_version'];
 
-        $IDs      = $DB->pselect(
+        $IDs = $DB->pselect(
             "SELECT id FROM data_release WHERE "
             . "version=:data_release_version",
             array(
@@ -43,29 +45,42 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         );
 
         foreach ($IDs as $ID) {
-            $success         = $DB->insert(
-             'data_release_permissions',
-             array(
-              'userid'          => $userid,
-              'data_release_id' => $ID['id'],
-             )
+            $success = $DB->insert(
+                'data_release_permissions',
+                array(
+                 'userid'          => $userid,
+                 'data_release_id' => $ID['id'],
+                )
             );
         }
     }
 
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
-} elseif ($_POST['action'] == 'managepermissions' && $user->hasPermission('superuser')) {
+} elseif ($_POST['action'] == 'managepermissions'
+    && $user->hasPermission('superuser')
+) {
     try {
         $DB->_PDO->beginTransaction();
         $DB->run("TRUNCATE data_release_permissions");
         foreach ($_POST as $key => $value) {
             if (strpos($key, 'permissions') !== false) {
-                $user = str_replace("_" , "%", str_replace("permissions_", "", $key));
-                $userid = $DB->pselectOne("SELECT ID FROM users WHERE UserID LIKE :userid", array('userid' => $user));
+                $user   = str_replace(
+                    "_", "%", str_replace("permissions_", "", $key)
+                );
+                $userid = $DB->pselectOne(
+                    "SELECT ID FROM users WHERE UserID LIKE :userid",
+                    array('userid' => $user)
+                );
                 foreach ($value as $k => $v) {
-                    $data_release_ids = $DB->pselect("SELECT id FROM data_release WHERE version=:version", array('version' => $v));
+                    $data_release_ids = $DB->pselect(
+                        "SELECT id FROM data_release WHERE version=:version",
+                        array('version' => $v)
+                    );
                     foreach ($data_release_ids as $data_release_id) {
-                        $success = $DB->run("INSERT IGNORE INTO data_release_permissions VALUES ($userid, {$data_release_id['id']})");
+                        $success = $DB->run(
+                            "INSERT IGNORE INTO data_release_permissions VALUES "
+                            . "($userid, {$data_release_id['id']})"
+                        );
                     }
                 }
             }

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -3,7 +3,7 @@
 /**
  * Add permissions through Ajax, how crazy.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  *  @category Loris
  *  @package  Data_Release
@@ -14,11 +14,12 @@
 
 $DB =& Database::singleton();
 
+$user     = User::singleton();
 $factory  = NDB_Factory::singleton();
 $settings = $factory->settings();
-$baseURL = $settings->getBaseURL();
+$baseURL  = $settings->getBaseURL();
 
-if ($_POST['action'] == 'addpermission') {
+if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
     if (!empty($_POST['data_release_id']) && empty($_POST['data_release_version'])) {
         $userid          = $_POST['userid'];
         $data_release_id = $_POST['data_release_id'];
@@ -53,7 +54,7 @@ if ($_POST['action'] == 'addpermission') {
     }
 
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
-} elseif ($_POST['action'] == 'managepermissions') {
+} elseif ($_POST['action'] == 'managepermissions' && $user->hasPermission('superuser')) {
     try {
         $DB->_PDO->beginTransaction();
         $DB->run("TRUNCATE data_release_permissions");

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -33,15 +33,13 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
     } elseif (empty($_POST['data_release_id'])
         && !empty($_POST['data_release_version'])
     ) {
-        $userid               = $_POST['userid'];
+        $userid = $_POST['userid'];
         $data_release_version = $_POST['data_release_version'];
 
         $IDs = $DB->pselect(
             "SELECT id FROM data_release WHERE "
             . "version=:data_release_version",
-            array(
-             'data_release_version' => $data_release_version,
-            )
+            array('data_release_version' => $data_release_version)
         );
 
         foreach ($IDs as $ID) {
@@ -65,7 +63,9 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         foreach ($_POST as $key => $value) {
             if (strpos($key, 'permissions') !== false) {
                 $user   = str_replace(
-                    "_", "%", str_replace("permissions_", "", $key)
+                    "_",
+                    "%",
+                    str_replace("permissions_", "", $key)
                 );
                 $userid = $DB->pselectOne(
                     "SELECT ID FROM users WHERE UserID LIKE :userid",

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -3,9 +3,9 @@
 /**
  * Add permissions through Ajax, how crazy.
  *
- * @todo use the 'addpermissionSuccess' flag for front-end enhancements
- *
  * PHP Version 7
+ *
+ *  @todo use the 'addpermissionSuccess' flag for front-end enhancements
  *
  *  @category Loris
  *  @package  Data_Release

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -53,7 +53,7 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
             );
         }
     }
-
+    // Currently all the *Success=true don't do anything, maybe some visual feedback can be incorporated at some point.
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
 } elseif ($_POST['action'] == 'managepermissions'
     && $user->hasPermission('superuser')
@@ -93,11 +93,13 @@ if ($_POST['action'] == 'addpermission' && $user->hasPermission('superuser')) {
         }
         $DB->_PDO->commit();
         header("HTTP/1.1 303 See Other");
+        // Currently all the *Success=true don't do anything, maybe some visual feedback can be incorporated at some point.
         header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
     } catch (Exception $e) {
         $DB->_PDO->rollback();
         error_log("ERROR: Did not update Data Release permissions.");
         header("HTTP/1.1 500 Internal Server Error");
+        // Currently all the *Success=true don't do anything, maybe some visual feedback can be incorporated at some point.
         header("Location: {$baseURL}/data_release/?addpermissionSuccess=false");
     }
 } else {

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -12,10 +12,12 @@
   *  @link     https://github.com/aces/Loris
   */
 
-$DB   =& Database::singleton();
-$user =& User::singleton();
+$DB   = \Database::singleton();
+$user = \User::singleton();
 
-if ($_POST['action'] == 'upload') {
+if ($_POST['action'] == 'upload'
+    && $user->hasPermission("data_release_upload")
+) {
     $fileName    = $_FILES["file"]["name"];
     $version     = $_POST['version'];
     $upload_date = date('Y-m-d');

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -3,7 +3,7 @@
 /**
  * Controls access to data release files.
  *
- * PHP Version 7
+ * PHP Version 5
  *
  *  @category Loris
  *  @package  Data_Release
@@ -52,11 +52,8 @@ if (empty($permission)) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }
-
-// Output file in downloadable format
-header('Content-Description: File Transfer');
-header("Content-Transfer-Encoding: Binary");
-header("Content-disposition: attachment; filename=\"" . basename($FullPath) . "\"");
-readfile($FullPath);
+$fp = fopen($FullPath, 'r');
+fpassthru($fp);
+fclose($fp);
 
 ?>

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -3,7 +3,7 @@
 /**
  * Controls access to data release files.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  *  @category Loris
  *  @package  Data_Release
@@ -52,8 +52,11 @@ if (empty($permission)) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }
-$fp = fopen($FullPath, 'r');
-fpassthru($fp);
-fclose($fp);
+
+// Output file in downloadable format
+header('Content-Description: File Transfer');
+header("Content-Transfer-Encoding: Binary");
+header("Content-disposition: attachment; filename=\"" . basename($FullPath) . "\"");
+readfile($FullPath);
 
 ?>

--- a/modules/data_release/help/data_release.md
+++ b/modules/data_release/help/data_release.md
@@ -1,3 +1,3 @@
 # Data Release
 
-The Data Release Module can be used to easily distribute packaged data releases of your study. Use the "Upload File" button to upload your file and tag it with a version based on your own version convention. Grant access to any of your users using the "Add Permission" button. These buttons will be visible only if you have the "superuser" permission.
+The Data Release Module can be used to easily distribute packaged data releases of your study. Use the "Upload File" button to upload your file and tag it with a version based on your own version convention. Grant access to any of your users using the "Add Permission" button. These buttons will be visible only if you have the proper permissions.

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -68,17 +68,14 @@ class Data_Release extends \NDB_Menu_Filter
                                'upload_date' => 'upload_date',
                               );
 
-        $userCanUpload = $user->hasPermission("data_release_upload");
-        $userCanEdit   = $user->hasPermission("data_release_edit_permissions");
+        $userUpload = $user->hasPermission("data_release_upload");
+        $userEditAccess = $user->hasPermission("data_release_edit_file_access");
 
-        $results = $DB->pselect(
+        $userids = $DB->pselectColWithIndexKey(
             "SELECT ID, UserID FROM users",
-            array()
+            array(),
+            "ID"
         );
-        $userids = array();
-        foreach ($results as $row) {
-            $userids[$row['ID']] =$row['UserID'];
-        }
 
         $results          = $DB->pselect(
             "SELECT id, file_name, version FROM data_release",
@@ -92,12 +89,14 @@ class Data_Release extends \NDB_Menu_Filter
         }
 
         $results = $DB->pselect(
-            "SELECT DISTINCT users.UserID, version FROM users"
-             . " LEFT JOIN data_release_permissions"
-             . " ON (users.ID=data_release_permissions.userid)"
-             . " LEFT JOIN data_release"
-             . " ON (data_release_permissions.data_release_id=data_release.id)"
-             . " ORDER BY users.UserID, version",
+            "SELECT 
+                DISTINCT users.UserID, 
+                version 
+             FROM users u
+                LEFT JOIN data_release_permissions drp ON (u.ID=drp.userid) 
+                LEFT JOIN data_release dr ON (drp.data_release_id=dr.id)
+             ORDER BY users.UserID, 
+                version",
             array()
         );
         foreach ($results as $row) {
@@ -108,8 +107,8 @@ class Data_Release extends \NDB_Menu_Filter
             $manage_permissions[$row['UserID']] = $version;
         }
 
-        $this->tpl_data['usercanupload']    = $userCanUpload;
-        $this->tpl_data['usercanedit']      = $userCanEdit;
+        $this->tpl_data['user_upload']    = $userUpload;
+        $this->tpl_data['user_edit_access']      = $userEditAccess;
         $this->tpl_data['userids']          = $userids;
         $this->tpl_data['data_release_ids'] = $data_release_ids;
         $this->tpl_data['data_release_versions'] = $data_release_versions;

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -95,12 +95,17 @@ class Data_Release extends \NDB_Menu_Filter
         $data_release_ids = array();
         $data_release_versions = array();
         foreach ($results as $row) {
-            $data_release_ids[$row['id']] =$row['file_name'];
-            $data_release_versions[$row['version']] =$row['version'];
+            $data_release_ids[$row['id']] = $row['file_name'];
+            $data_release_versions[$row['version']] = $row['version'];
         }
 
         $results = $DB->pselect(
-            "SELECT DISTINCT users.UserID, version FROM users LEFT JOIN data_release_permissions ON (users.ID=data_release_permissions.userid) LEFT JOIN data_release ON (data_release_permissions.data_release_id=data_release.id) ORDER BY users.UserID, version",
+            "SELECT DISTINCT users.UserID, version FROM users
+             LEFT JOIN data_release_permissions
+             ON (users.ID=data_release_permissions.userid)
+             LEFT JOIN data_release
+             ON (data_release_permissions.data_release_id=data_release.id)
+             ORDER BY users.UserID, version",
             array()
         );
         foreach ($results as $row) {
@@ -111,11 +116,11 @@ class Data_Release extends \NDB_Menu_Filter
             $manage_permissions[$row['UserID']] = $version;
         }
 
-        $this->tpl_data['superuser']        = $superuser;
-        $this->tpl_data['userids']          = $userids;
-        $this->tpl_data['data_release_ids'] = $data_release_ids;
+        $this->tpl_data['superuser']             = $superuser;
+        $this->tpl_data['userids']               = $userids;
+        $this->tpl_data['data_release_ids']      = $data_release_ids;
         $this->tpl_data['data_release_versions'] = $data_release_versions;
-        $this->tpl_data['manage_permissions'] = $manage_permissions;
+        $this->tpl_data['manage_permissions']    = $manage_permissions;
 
         return true;
     }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -100,7 +100,7 @@ class Data_Release extends \NDB_Menu_Filter
         }
 
         $results = $DB->pselect(
-            "SELECT DISTINCT users.UserID, version FROM users LEFT JOIN data_release_permissions ON (users.ID=data_release_permissions.userid) LEFT JOIN data_release ON (data_release_permissions.data_release_id=data_release.id) ORDER BY data_release_permissions.UserID",
+            "SELECT DISTINCT users.UserID, version FROM users LEFT JOIN data_release_permissions ON (users.ID=data_release_permissions.userid) LEFT JOIN data_release ON (data_release_permissions.data_release_id=data_release.id) ORDER BY users.UserID, version",
             array()
         );
         foreach ($results as $row) {

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -116,9 +116,9 @@ class Data_Release extends \NDB_Menu_Filter
             $manage_permissions[$row['UserID']] = $version;
         }
 
-        $this->tpl_data['superuser']             = $superuser;
-        $this->tpl_data['userids']               = $userids;
-        $this->tpl_data['data_release_ids']      = $data_release_ids;
+        $this->tpl_data['superuser']        = $superuser;
+        $this->tpl_data['userids']          = $userids;
+        $this->tpl_data['data_release_ids'] = $data_release_ids;
         $this->tpl_data['data_release_versions'] = $data_release_versions;
         $this->tpl_data['manage_permissions']    = $manage_permissions;
 

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -68,16 +68,8 @@ class Data_Release extends \NDB_Menu_Filter
                                'upload_date' => 'upload_date',
                               );
 
-        $user_ID   = $DB->pselectOne(
-            "SELECT ID FROM users WHERE userid=:UserID",
-            array('UserID' => $user->getUsername())
-        );
-        $superuser = $DB->pselectOne(
-            "SELECT true FROM users WHERE ID IN "
-            . "(SELECT userid FROM user_perm_rel WHERE "
-            . "permid=1 AND userid=:UserID)",
-            array('UserID' => $user_ID)
-        );
+        $userCanUpload = $user->hasPermission("data_release_upload");
+        $userCanEdit= $user->hasPermission("data_release_edit_permissions");
 
         $results = $DB->pselect(
             "SELECT ID, UserID FROM users",
@@ -116,7 +108,8 @@ class Data_Release extends \NDB_Menu_Filter
             $manage_permissions[$row['UserID']] = $version;
         }
 
-        $this->tpl_data['superuser']        = $superuser;
+        $this->tpl_data['usercanupload']    = $userCanUpload;
+        $this->tpl_data['usercanedit']      = $userCanEdit;
         $this->tpl_data['userids']          = $userids;
         $this->tpl_data['data_release_ids'] = $data_release_ids;
         $this->tpl_data['data_release_versions'] = $data_release_versions;

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -89,17 +89,33 @@ class Data_Release extends \NDB_Menu_Filter
         }
 
         $results          = $DB->pselect(
-            "SELECT id, file_name FROM data_release",
+            "SELECT id, file_name, version FROM data_release",
             array()
         );
         $data_release_ids = array();
+        $data_release_versions = array();
         foreach ($results as $row) {
             $data_release_ids[$row['id']] =$row['file_name'];
+            $data_release_versions[$row['version']] =$row['version'];
+        }
+
+        $results = $DB->pselect(
+            "SELECT DISTINCT users.UserID, version FROM users LEFT JOIN data_release_permissions ON (users.ID=data_release_permissions.userid) LEFT JOIN data_release ON (data_release_permissions.data_release_id=data_release.id) ORDER BY data_release_permissions.UserID",
+            array()
+        );
+        foreach ($results as $row) {
+            if (!isset($manage_permissions[$row['UserID']])) {
+                $version = array();
+            }
+                $version[] = $row['version'];
+                $manage_permissions[$row['UserID']] = $version;
         }
 
         $this->tpl_data['superuser']        = $superuser;
         $this->tpl_data['userids']          = $userids;
         $this->tpl_data['data_release_ids'] = $data_release_ids;
+        $this->tpl_data['data_release_versions'] = $data_release_versions;
+        $this->tpl_data['manage_permissions'] = $manage_permissions;
 
         return true;
     }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -95,17 +95,17 @@ class Data_Release extends \NDB_Menu_Filter
         $data_release_ids = array();
         $data_release_versions = array();
         foreach ($results as $row) {
-            $data_release_ids[$row['id']] = $row['file_name'];
+            $data_release_ids[$row['id']]           = $row['file_name'];
             $data_release_versions[$row['version']] = $row['version'];
         }
 
         $results = $DB->pselect(
-            "SELECT DISTINCT users.UserID, version FROM users
-             LEFT JOIN data_release_permissions
-             ON (users.ID=data_release_permissions.userid)
-             LEFT JOIN data_release
-             ON (data_release_permissions.data_release_id=data_release.id)
-             ORDER BY users.UserID, version",
+            "SELECT DISTINCT users.UserID, version FROM users"
+             . " LEFT JOIN data_release_permissions"
+             . " ON (users.ID=data_release_permissions.userid)"
+             . " LEFT JOIN data_release"
+             . " ON (data_release_permissions.data_release_id=data_release.id)"
+             . " ORDER BY users.UserID, version",
             array()
         );
         foreach ($results as $row) {

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -2,7 +2,7 @@
 /**
  * This file handles the Data Release for LORIS
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category LORIS
  * @package  Main
@@ -107,8 +107,8 @@ class Data_Release extends \NDB_Menu_Filter
             if (!isset($manage_permissions[$row['UserID']])) {
                 $version = array();
             }
-                $version[] = $row['version'];
-                $manage_permissions[$row['UserID']] = $version;
+            $version[] = $row['version'];
+            $manage_permissions[$row['UserID']] = $version;
         }
 
         $this->tpl_data['superuser']        = $superuser;

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -69,7 +69,7 @@ class Data_Release extends \NDB_Menu_Filter
                               );
 
         $userCanUpload = $user->hasPermission("data_release_upload");
-        $userCanEdit= $user->hasPermission("data_release_edit_permissions");
+        $userCanEdit   = $user->hasPermission("data_release_edit_permissions");
 
         $results = $DB->pselect(
             "SELECT ID, UserID FROM users",

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -72,11 +72,77 @@
                                 </select>
                             </div>
                         </div>
+                        <div class="col-xs-12 form-group">
+                            <label class="col-xs-4" for="data_release_id">Data Release Version</label>
+                            <div class="col-xs-8">
+                                <select name="data_release_version" id = "data_release_version" class = "form-fields form-control input-sm">
+                                <option value=""> </option>
+                                    {foreach from = $data_release_versions item=val key=k}
+                                        <option value={$k}>{$val}</option>
+                                    {/foreach}
+                                </select>
+                            </div>
+                        </div>
                         <input type="hidden" name = "action" id = "action" value = "addpermission">
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button class="btn btn-primary" id = "uploadButton" role="button" aria-disabled="false">Add Permission</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<button type="button" name = "managepermissions" class = "btn btn-sm btn-primary" data-toggle="modal" data-target="#managePermissionsModal">Manage Permissions</button>
+
+<div class="modal fade" id="managePermissionsModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                <h3 class="modal-title" id="myModalLabel">Manage Permissions</h3>
+            </div>
+            <form name = "uploadForm" id = "uploadForm" method = "POST" enctype="multipart/form-data" action="{$baseurl}/data_release/ajax/AddPermission.php">
+                <div class="modal-body">
+                    <div class="row">
+                        <table  class="table table-hover table-primary table-bordered dynamictable" border="0" width="100%">
+                            <thead>
+                                <tr class="info">
+                                    <th>Users</th>
+                                    <th>Permissions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {foreach from = $manage_permissions key=k item=elem}
+                                <tr>
+                                    <td>
+                                        {$k}
+                                        <!--<input type="hidden" name="{$k}" value="{$k}" readonly>{$k}</input>-->
+                                    </td>
+                                    <td>
+                                    {foreach from = $data_release_versions item=vv key=kk}
+                                        {foreach from = $elem key=key item=value}
+                                           {if in_array($vv, $elem)}
+                                               <input type='checkbox' name='permissions_{$k}[]' value='{$vv}' checked>{$vv}</input>
+                                           {else}
+                                               <input type='checkbox' name='permissions_{$k}[]' value='{$vv}'>{$vv}</input>
+                                           {/if}
+                                           {break} 
+                                        {/foreach}
+                                    {/foreach}
+
+                                    </td>
+                                </tr>
+                                {/foreach}
+                            </tbody>                        
+                        </table>
+                        <input type="hidden" name = "action" id = "action" value = "managepermissions">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-primary" id = "uploadButton" role="button" aria-disabled="false">Manage Permissions</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 </div>
             </form>

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -47,7 +47,7 @@
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                 <h3 class="modal-title" id="myModalLabel">Add Permission</h3>
             </div>
-            <form name = "uploadForm" id = "uploadForm" method = "POST" enctype="multipart/form-data" action="{$baseurl}/data_release/ajax/AddPermission.php">
+            <form name = "uploadForm" id = "addForm" method = "POST" enctype="multipart/form-data" action="{$baseurl}/data_release/ajax/AddPermission.php">
                 <div class="modal-body">
                     <div class="row">
                         <div class="col-xs-12 form-group">
@@ -104,7 +104,7 @@
                 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
                 <h3 class="modal-title" id="myModalLabel">Manage Permissions</h3>
             </div>
-            <form name = "uploadForm" id = "uploadForm" method = "POST" enctype="multipart/form-data" action="{$baseurl}/data_release/ajax/AddPermission.php">
+            <form name = "uploadForm" id = "manageForm" method = "POST" enctype="multipart/form-data" action="{$baseurl}/data_release/ajax/AddPermission.php">
                 <div class="modal-body">
                     <div class="row">
                         <table  class="table table-hover table-primary table-bordered dynamictable" border="0" width="100%">

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -1,4 +1,4 @@
-{if $superuser}
+{if $usecanupload}
 
 <button type="button" name = "upload" class = "btn btn-sm btn-primary" data-toggle="modal" data-target="#fileUploadModal">Upload File</button>
 
@@ -36,8 +36,8 @@
         </div>
     </div>
 </div>
-
-
+{/if}
+{if $usecanedit}
 <button type="button" name = "permission" class = "btn btn-sm btn-primary" data-toggle="modal" data-target="#permissionModal">Add Permission</button>
 
 <div class="modal fade" id="permissionModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -87,7 +87,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-primary" id = "uploadButton" role="button" aria-disabled="false">Add Permission</button>
+                    <button class="btn btn-primary" id = "addButton" role="button" aria-disabled="false">Add Permission</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 </div>
             </form>
@@ -142,7 +142,7 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-primary" id = "uploadButton" role="button" aria-disabled="false">Manage Permissions</button>
+                    <button class="btn btn-primary" id = "manageButton" role="button" aria-disabled="false">Manage Permissions</button>
                     <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 </div>
             </form>

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -1,5 +1,4 @@
-{if $usecanupload}
-
+{if $user_upload}
 <button type="button" name = "upload" class = "btn btn-sm btn-primary" data-toggle="modal" data-target="#fileUploadModal">Upload File</button>
 
 <div class="modal fade" id="fileUploadModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
@@ -37,7 +36,7 @@
     </div>
 </div>
 {/if}
-{if $usecanedit}
+{if $user_edit_access}
 <button type="button" name = "permission" class = "btn btn-sm btn-primary" data-toggle="modal" data-target="#permissionModal">Add Permission</button>
 
 <div class="modal fade" id="permissionModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -24,7 +24,7 @@
                                 <input type="text" size = "27" name="version" id="version" class="ui-corner-all form-fields form-control input-sm" />
                             </div>
                         </div>
-                        <input type="hidden" name = "action" id = "action" value = "upload">
+                        <input type="hidden" name = "action" id = "uploadaction" value = "upload">
                         <input type="hidden" id="MAX_FILE_SIZE" name="MAX_FILE_SIZE" value="100000000" />
                     </div>
                 </div>
@@ -83,7 +83,7 @@
                                 </select>
                             </div>
                         </div>
-                        <input type="hidden" name = "action" id = "action" value = "addpermission">
+                        <input type="hidden" name = "action" id = "addaction" value = "addpermission">
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -138,7 +138,7 @@
                                 {/foreach}
                             </tbody>                        
                         </table>
-                        <input type="hidden" name = "action" id = "action" value = "managepermissions">
+                        <input type="hidden" name = "action" id = "manageaction" value = "managepermissions">
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/modules/data_release/test/data_release_test_plan.md
+++ b/modules/data_release/test/data_release_test_plan.md
@@ -1,30 +1,42 @@
 # Data Release Module Test Plan 
 
+Make sure that regular users can see the data release module without the 
+'Upload File' and 'Add Permission' buttons at the top
+
+
+## Upload File
+1. Give the user the `data_release_upload` *(Data Release: Upload file)* permission. 
+ Make sure the user can upload new files to the module
+ 
+2. As the 'superuser', click on the 'Upload File' button to upload a file 
+ and make sure the uploaded file is available in the list of files
+ 
 ## Permissions
 
-1. Make sure that regular users can see the data release module without the 
-'Upload File' and 'Add Permission' buttons at the top
-2. Make sure that only the 'superuser' can see the 'Upload File' and 'Add 
-Permission' buttons at the top of the module, as well as the list of already 
-uploaded files
-3. As the 'superuser', execute the following:
- > - Click on the 'Add Permission' button
- > - Select another 'User ID' (that you have access to and is not a 
- 'superuser') 
- > - Select a 'Data Release ID' (ideally a file that the 'User ID' has no 
+1. Give the user the `data_release_edit_permissions` *(Data Release: Give user 
+permission to view files)* permission
+
+2. Click on the 'Add Permission' button
+
+3. Select another 'User ID' (that you have access to and is not a 
+ 'superuser')
+ 
+4. Select a 'Data Release ID' (ideally a file that the 'User ID' has no 
  access to yet) (note that at least one file needs to be uploaded in the 
  module to be able to set permissions to access a file, otherwise, the drop 
  down for 'Data Release ID' will remain empty)
- > - Make sure that this 'User ID' can now see the file now that the 
+ 
+5. Make sure that this 'User ID' can now see the file now that the 
  permission was added for him/her
+
+## Superuser
+
+Make sure that a 'superuser' can see the 'Upload File' and 'Add 
+Permission' buttons at the top of the module, as well as the list of already 
+uploaded files
+
+## Sort table
  
- ## Upload File
- 
- 4. As the 'superuser', click on the 'Upload File' button to upload a file 
- and make sure the uploaded file is available in the list of files
- 
- ## Sort table
- 
- 5. Make sure that clicking on the table headers will sort the data present 
- in the data release table according to that column.
+Make sure that clicking on the table headers will sort the data present 
+ in the data release table according to that column\
 


### PR DESCRIPTION
### Brief summary of changes
Currently in order to be able to upload and/or edit the access to files in the data release module one needs to have the `superuser` permission. Given that this permission gives access to so many other things, this PR separates these functionalities from `superuser` and adds 2 new permissions `data_release_upload` and `data_release_edit_permissions`.

### To test this change...

- [ ] source SQL patch
- [ ] follow the newly modified test plan
- [ ] make sure documentation was properly updated everywhere
