### PR TITLE
[data_release] Fix access for admin

### DIFF
--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -44,13 +44,13 @@ class Data_Release extends \NDB_Menu_Filter
                           'version',
                           'upload_date',
                          );
-        $this->query   = " FROM data_release dr JOIN"
-                               . " data_release_permissions drp"
-                               . " ON (dr.id=drp.data_release_id)";
+        $this->query   = " FROM data_release dr";
 
         if (!$user->hasPermission("superuser")) {
-            $this->query .= " JOIN users u ON (u.ID=drp.userid)"
-            . " WHERE u.UserID="
+            $this->query .= " JOIN data_release_permissions drp 
+            ON (dr.id=drp.data_release_id) 
+            JOIN users u ON (u.ID=drp.userid) 
+            WHERE u.UserID="
             . $DB->quote($user->getUsername());
         }
 

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -39,17 +39,21 @@ class Data_Release extends \NDB_Menu_Filter
         $DB      = $Factory->Database();
 
         // set the class variables
-        $this->columns      = array(
-                               'file_name',
-                               'version',
-                               'upload_date',
-                              );
-        $this->query        = " FROM data_release dr JOIN"
+        $this->columns = array(
+                          'file_name',
+                          'version',
+                          'upload_date',
+                         );
+        $this->query   = " FROM data_release dr JOIN"
                                . " data_release_permissions drp"
-                               . " ON (dr.id=drp.data_release_id)"
-                               . " JOIN users u ON (u.ID=drp.userid)"
-                               . " WHERE u.UserID="
-                               . $DB->quote($user->getUsername());
+                               . " ON (dr.id=drp.data_release_id)";
+
+        if (!$user->hasPermission("superuser")) {
+            $this->query .= " JOIN users u ON (u.ID=drp.userid)"
+            . " WHERE u.UserID="
+            . $DB->quote($user->getUsername());
+        }
+
         $this->group_by     = '';
         $this->order_by     = 'upload_date';
         $this->headers      = array(


### PR DESCRIPTION
### Brief summary of changes
The data_release test plan mentions that `2. Make sure that only the 'superuser' can ... as well as the list of already uploaded files` which makes sens but is not currently the case. this PR changes the query slightly to make sure the Admin user can see all the files and only regular users have a limited subsection.

### to test
- [ ] as a regular user make sure you can only see the files you have access to.
- [ ] as an admin make sure you can see all the files 