### PR TITLE
[Docs] Specify Apache 2.4 required in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
 # Prerequisites for Installation
 
  * Apache **2.4** or higher
- * MySQL 5.7
+ * MySQL >= 5.7 (or MariaDB >= 10.3) 
  * PHP <b>7.2</b> or higher
  * [Composer](https://getcomposer.org/)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
  * Apache **2.4** or higher
  * MySQL 5.7
  * PHP <b>7.2</b> or higher
- * Package manager (for LINUX distributions)
 
 <b>Important:</b>
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
 
 # Prerequisites for Installation
 
- * LINUX (supported on Ubuntu 14+ and [CentOS 6.5](https://github.com/aces/Loris/blob/master/README.CentOS6.md))
+ * LINUX (supported on Ubuntu 14+ and [CentOS 7](https://github.com/aces/Loris/blob/master/README.CentOS6.md))
  * Apache **2.4** or higher
  * MySQL 5.7
  * PHP <b>7.2</b> or higher

--- a/README.md
+++ b/README.md
@@ -24,15 +24,12 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
 
 # Prerequisites for Installation
 
- * LINUX (supported on Ubuntu 14+ and [CentOS 7](https://github.com/aces/Loris/blob/master/README.CentOS6.md))
  * Apache **2.4** or higher
  * MySQL 5.7
  * PHP <b>7.2</b> or higher
  * Package manager (for LINUX distributions)
- * Composer : should be run with --no-dev option
 
 <b>Important:</b>
- * If you are upgrading your LORIS, you'll also want to upgrade to both PHP 7.2 and MySQL 5.7.
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 LORIS (Longitudinal Online Research and Imaging System) is a web-based data and project management software for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
 <hr>
-NEW <b>⇾  Try LORIS on Heroku</b> before installing it on your system<br>
+<b>⇾  Try LORIS on Heroku</b> before installing it on your system<br>
 Test out the project management and clinical data management side of LORIS (complete Imaging features not yet available)<br>
 Deploy and log in with username <i>admin</i> and the password that's set up during deployment via ClearDB.
 
@@ -25,7 +25,7 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
 # Prerequisites for Installation
 
  * LINUX (supported on Ubuntu 14+ and [CentOS 6.5](https://github.com/aces/Loris/blob/master/README.CentOS6.md))
- * Apache2
+ * Apache **2.4**
  * MySQL 5.7 
  * PHP <b>7.2</b>  
  * Package manager (for LINUX distributions)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
 # Prerequisites for Installation
 
  * LINUX (supported on Ubuntu 14+ and [CentOS 6.5](https://github.com/aces/Loris/blob/master/README.CentOS6.md))
- * Apache **2.4**
- * MySQL 5.7 
- * PHP <b>7.2</b>  
+ * Apache **2.4** or higher
+ * MySQL 5.7
+ * PHP <b>7.2</b> or higher
  * Package manager (for LINUX distributions)
  * Composer : should be run with --no-dev option
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/S
  * Apache **2.4** or higher
  * MySQL 5.7
  * PHP <b>7.2</b> or higher
+ * [Composer](https://getcomposer.org/)
 
-<b>Important:</b>
+<b>Note:</b>
  * Composer should be run with --no-dev option unless you are an active LORIS developer. 
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.


### PR DESCRIPTION
### Brief summary of changes

Specifiy that Apache 2.4 is required.

Heroku deploy is no longer "new" so that is removed.


### This addresses issue...

- [x] Github? #3972 
