### PR TITLE
[Config / DICOM Archive / Imaging]Change default phantom regex config

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -204,10 +204,10 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "http://localhost/" FROM ConfigS
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun." FROM ConfigSettings WHERE Name="projectDescription";
 
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/./" FROM ConfigSettings WHERE Name="patientIDRegex";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/./i" FROM ConfigSettings WHERE Name="patientNameRegex";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/phantom/i" FROM ConfigSettings WHERE Name="LegoPhantomRegex";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/phantom/i" FROM ConfigSettings WHERE Name="LivingPhantomRegex";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "." FROM ConfigSettings WHERE Name="patientIDRegex";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "." FROM ConfigSettings WHERE Name="patientNameRegex";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "(?i)phantom" FROM ConfigSettings WHERE Name="LegoPhantomRegex";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "(?i)phantom" FROM ConfigSettings WHERE Name="LivingPhantomRegex";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="showTransferStatus";
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=44;
 INSERT INTO Config (ConfigID, Value) SELECT cs.ID, GROUP_CONCAT(mst.Scan_Type) FROM ConfigSettings cs JOIN mri_scan_type mst WHERE cs.Name="tblScanTypes" AND mst.ID=45;

--- a/SQL/New_patches/2018-10-05_change_regex_config.sql
+++ b/SQL/New_patches/2018-10-05_change_regex_config.sql
@@ -1,19 +1,47 @@
+-- Convert all Perl regex that contain the case-insensitive modifier 'i'
 UPDATE Config
-SET Value = "."
+SET Value=CONCAT('(?i)', SUBSTRING(Value FROM 2 FOR LENGTH(Value)-3))
 WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='patientIDRegex')
-AND Value='/./i';
+AND Value LIKE '/%/i';
 
+-- Removes the leading and trailing forward slashes from every regex that do not contain any modifier
 UPDATE Config
-SET Value = "."
+SET Value=SUBSTRING(Value FROM 2 FOR LENGTH(Value)-2)
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='patientIDRegex')
+AND Value LIKE '/%/';
+
+-- Convert all Perl regex that contain the case-insensitive modifier 'i'
+UPDATE Config
+SET Value=CONCAT('(?i)', SUBSTRING(Value FROM 2 FOR LENGTH(Value)-3))
 WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='patientNameRegex')
-AND Value='/./i';
+AND Value LIKE '/%/i';
 
+-- Removes the leading and trailing forward slashes from every regex that do not contain any modifier
 UPDATE Config
-SET Value = "(?i)phantom"
+SET Value=SUBSTRING(Value FROM 2 FOR LENGTH(Value)-2)
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='patientNameRegex')
+AND Value LIKE '/%/';
+
+-- Convert all Perl regex that contain the case-insensitive modifier 'i'
+UPDATE Config
+SET Value=CONCAT('(?i)', SUBSTRING(Value FROM 2 FOR LENGTH(Value)-3))
 WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='LegoPhantomRegex')
-AND Value='/phantom/i';
+AND Value LIKE '/%/i';
 
+-- Removes the leading and trailing forward slashes from every regex that do not contain any modifier
 UPDATE Config
-SET Value = "(?i)phantom"
+SET Value=SUBSTRING(Value FROM 2 FOR LENGTH(Value)-2)
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='LegoPhantomRegex')
+AND Value LIKE '/%/';
+
+-- Convert all Perl regex that contain the case-insensitive modifier 'i'
+UPDATE Config
+SET Value=CONCAT('(?i)', SUBSTRING(Value FROM 2 FOR LENGTH(Value)-3))
 WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='LivingPhantomRegex')
-AND Value='/phantom/i';
+AND Value LIKE '/%/i';
+
+-- Removes the leading and trailing forward slashes from every regex that do not contain any modifier
+UPDATE Config
+SET Value=SUBSTRING(Value FROM 2 FOR LENGTH(Value)-2)
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='LivingPhantomRegex')
+AND Value LIKE '/%/';

--- a/SQL/New_patches/2018-10-05_change_regex_config.sql
+++ b/SQL/New_patches/2018-10-05_change_regex_config.sql
@@ -1,0 +1,19 @@
+UPDATE Config
+SET Value = "."
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='patientIDRegex')
+AND Value='/./i';
+
+UPDATE Config
+SET Value = "."
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='patientNameRegex')
+AND Value='/./i';
+
+UPDATE Config
+SET Value = "(?i)phantom"
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='LegoPhantomRegex')
+AND Value='/phantom/i';
+
+UPDATE Config
+SET Value = "(?i)phantom"
+WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='LivingPhantomRegex')
+AND Value='/phantom/i';

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -53,9 +53,18 @@ class DICOMArchiveAnonymizer implements Mapper
         $newrow = json_decode($resource->toJSON(), true);
         $cid    = $resource->getCenterID();
 
-        if (!preg_match("/{$config['patientNameRegex']}/", $newrow['Patient Name'])
-            && !preg_match("/{$config['LegoPhantomRegex']}/", $newrow['Patient Name'])
-            && !preg_match("/{$config['LivingPhantomRegex']}/", $newrow['Patient Name'])
+        if (!preg_match(
+            "/{$config['patientNameRegex']}/",
+                $newrow['Patient Name']
+            )
+            && !preg_match(
+                "/{$config['LegoPhantomRegex']}/",
+                $newrow['Patient Name']
+            )
+            && !preg_match(
+                "/{$config['LivingPhantomRegex']}/",
+                $newrow['Patient Name']
+            )
         ) {
             $newrow['Patient Name'] = 'INVALID - HIDDEN';
         }

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -53,22 +53,43 @@ class DICOMArchiveAnonymizer implements Mapper
         $newrow = json_decode($resource->toJSON(), true);
         $cid    = $resource->getCenterID();
 
+        // escape any forward slashes
+        $pNameRegex      = preg_replace(
+            '/\//',
+            '\/',
+            $config['patientNameRegex']
+        );
+        $legoPhanRegex   = preg_replace(
+            '/\//',
+            '\/',
+            $config['LegoPhantomRegex']
+        );
+        $livingPhanRegex = preg_replace(
+            '/\//',
+            '\/',
+            $config['LivingPhantomRegex']
+        );
+        $pIDRegex        = preg_replace(
+            '/\//',
+            '\/',
+            $config['patientIDRegex']
+        );
         if (!preg_match(
-            "/{$config['patientNameRegex']}/",
+            "/$pNameRegex/",
             $newrow['Patient Name']
         )
             && !preg_match(
-                "/{$config['LegoPhantomRegex']}/",
+                "/$legoPhanRegex/",
                 $newrow['Patient Name']
             )
             && !preg_match(
-                "/{$config['LivingPhantomRegex']}/",
+                "/$livingPhanRegex/",
                 $newrow['Patient Name']
             )
         ) {
             $newrow['Patient Name'] = 'INVALID - HIDDEN';
         }
-        if (!preg_match("/{$config['patientIDRegex']}/", $newrow['Patient ID'])) {
+        if (!preg_match("/$pIDRegex/", $newrow['Patient ID'])) {
             $newrow['Patient ID'] = 'INVALID - HIDDEN';
         }
         return new DICOMArchiveRow($newrow, $cid);

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -53,13 +53,13 @@ class DICOMArchiveAnonymizer implements Mapper
         $newrow = json_decode($resource->toJSON(), true);
         $cid    = $resource->getCenterID();
 
-        if (!preg_match($config['patientNameRegex'], $newrow['Patient Name'])
-            && !preg_match($config['LegoPhantomRegex'], $newrow['Patient Name'])
-            && !preg_match($config['LivingPhantomRegex'], $newrow['Patient Name'])
+        if (!preg_match("/{$config['patientNameRegex']}/", $newrow['Patient Name'])
+            && !preg_match("/{$config['LegoPhantomRegex']}/", $newrow['Patient Name'])
+            && !preg_match("/{$config['LivingPhantomRegex']}/", $newrow['Patient Name'])
         ) {
             $newrow['Patient Name'] = 'INVALID - HIDDEN';
         }
-        if (!preg_match($config['patientIDRegex'], $newrow['Patient ID'])) {
+        if (!preg_match("/{$config['patientIDRegex']}/", $newrow['Patient ID'])) {
             $newrow['Patient ID'] = 'INVALID - HIDDEN';
         }
         return new DICOMArchiveRow($newrow, $cid);

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -55,8 +55,8 @@ class DICOMArchiveAnonymizer implements Mapper
 
         if (!preg_match(
             "/{$config['patientNameRegex']}/",
-                $newrow['Patient Name']
-            )
+            $newrow['Patient Name']
+        )
             && !preg_match(
                 "/{$config['LegoPhantomRegex']}/",
                 $newrow['Patient Name']

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -149,13 +149,13 @@ class ViewDetails extends \NDB_Form
         $dicomArchiveSettings = $config->getSetting('imaging_modules');
 
         if ((preg_match(
-            $dicomArchiveSettings['patientNameRegex'],
+            "/{$dicomArchiveSettings['patientNameRegex']}/",
             $this->tpl_data['archive']['PatientName']
         )) || (preg_match(
-            $dicomArchiveSettings['LegoPhantomRegex'],
+            "/{$dicomArchiveSettings['LegoPhantomRegex']}/",
             $this->tpl_data['archive']['PatientName']
         )) || (preg_match(
-            $dicomArchiveSettings['LivingPhantomRegex'],
+            "/{$dicomArchiveSettings['LivingPhantomRegex']}/",
             $this->tpl_data['archive']['PatientName']
         ))) {
             $this->tpl_data['archive']['patientNameValid'] = 1;
@@ -165,7 +165,7 @@ class ViewDetails extends \NDB_Form
         }
 
         if (preg_match(
-            $dicomArchiveSettings['patientIDRegex'],
+            "/{$dicomArchiveSettings['patientIDRegex']}/",
             $this->tpl_data['archive']['PatientID']
         )) {
             $this->tpl_data['archive']['patientIDValid'] = 1;

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -148,14 +148,36 @@ class ViewDetails extends \NDB_Form
         $config =& \NDB_Config::singleton();
         $dicomArchiveSettings = $config->getSetting('imaging_modules');
 
+        // escape any forward slashes
+        $pNameRegex      = preg_replace(
+            '/\//',
+            '\/',
+            $dicomArchiveSettings['patientNameRegex']
+        );
+        $legoPhanRegex   = preg_replace(
+            '/\//',
+            '\/',
+            $dicomArchiveSettings['LegoPhantomRegex']
+        );
+        $livingPhanRegex = preg_replace(
+            '/\//',
+            '\/',
+            $dicomArchiveSettings['LivingPhantomRegex']
+        );
+        $pIDRegex        = preg_replace(
+            '/\//',
+            '\/',
+            $dicomArchiveSettings['patientIDRegex']
+        );
+
         if ((preg_match(
-            "/{$dicomArchiveSettings['patientNameRegex']}/",
+            "/$pNameRegex/",
             $this->tpl_data['archive']['PatientName']
         )) || (preg_match(
-            "/{$dicomArchiveSettings['LegoPhantomRegex']}/",
+            "/$legoPhanRegex/",
             $this->tpl_data['archive']['PatientName']
         )) || (preg_match(
-            "/{$dicomArchiveSettings['LivingPhantomRegex']}/",
+            "/$livingPhanRegex/",
             $this->tpl_data['archive']['PatientName']
         ))) {
             $this->tpl_data['archive']['patientNameValid'] = 1;
@@ -165,7 +187,7 @@ class ViewDetails extends \NDB_Form
         }
 
         if (preg_match(
-            "/{$dicomArchiveSettings['patientIDRegex']}/",
+            "/$pIDRegex/",
             $this->tpl_data['archive']['PatientID']
         )) {
             $this->tpl_data['archive']['patientIDValid'] = 1;

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -146,6 +146,7 @@ class ViewDetails extends \NDB_Form
     function _validateNamesIds()
     {
         $config =& \NDB_Config::singleton();
+        $db     = \Database::singleton();
         $dicomArchiveSettings = $config->getSetting('imaging_modules');
 
         // escape any forward slashes
@@ -170,20 +171,42 @@ class ViewDetails extends \NDB_Form
             $dicomArchiveSettings['patientIDRegex']
         );
 
-        if ((preg_match(
-            "/$pNameRegex/",
-            $this->tpl_data['archive']['PatientName']
-        )) || (preg_match(
-            "/$legoPhanRegex/",
-            $this->tpl_data['archive']['PatientName']
-        )) || (preg_match(
-            "/$livingPhanRegex/",
-            $this->tpl_data['archive']['PatientName']
-        ))) {
-            $this->tpl_data['archive']['patientNameValid'] = 1;
+        $isPhantom = $db->pselectRow(
+            "SELECT IsPhantom FROM mri_upload WHERE SessionID=:sid",
+            array('sid' => $this->tpl_data['archive']['SessionID'])
+        )['IsPhantom'] ?? null;
+
+        if ($isPhantom === 'Y') {
+             $isValid = preg_match(
+                    "/$legoPhanRegex/",
+                    $this->tpl_data['archive']['PatientName']
+                ) || preg_match(
+                     "/$livingPhanRegex/",
+                     $this->tpl_data['archive']['PatientName']
+                 );
+        } else if ($isPhantom === 'N') {
+            $isValid = preg_match(
+                "/$pNameRegex/",
+                $this->tpl_data['archive']['PatientName']
+            );
         } else {
-            $this->tpl_data['archive']['patientNameValid'] = 0;
-            $this->tpl_data['archive']['PatientName']      = "INVALID - HIDDEN";
+            // if scan was uploaded via non-imaging uploader method
+            // run patient name through all regex validations
+            $isValid = (preg_match(
+                    "/$pNameRegex/",
+                    $this->tpl_data['archive']['PatientName']
+                )) || (preg_match(
+                    "/$legoPhanRegex/",
+                    $this->tpl_data['archive']['PatientName']
+                )) || (preg_match(
+                    "/$livingPhanRegex/",
+                    $this->tpl_data['archive']['PatientName']
+                ));
+        }
+
+        $this->tpl_data['archive']['patientNameValid'] = $isValid ? 1 : 0;
+        if (!$isValid) {
+            $this->tpl_data['archive']['PatientName'] = "INVALID - HIDDEN";
         }
 
         if (preg_match(

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -178,12 +178,12 @@ class ViewDetails extends \NDB_Form
 
         if ($isPhantom === 'Y') {
              $isValid = preg_match(
-                    "/$legoPhanRegex/",
-                    $this->tpl_data['archive']['PatientName']
-                ) || preg_match(
-                     "/$livingPhanRegex/",
-                     $this->tpl_data['archive']['PatientName']
-                 );
+                 "/$legoPhanRegex/",
+                 $this->tpl_data['archive']['PatientName']
+             ) || preg_match(
+                 "/$livingPhanRegex/",
+                 $this->tpl_data['archive']['PatientName']
+             );
         } else if ($isPhantom === 'N') {
             $isValid = preg_match(
                 "/$pNameRegex/",
@@ -193,15 +193,15 @@ class ViewDetails extends \NDB_Form
             // if scan was uploaded via non-imaging uploader method
             // run patient name through all regex validations
             $isValid = (preg_match(
-                    "/$pNameRegex/",
-                    $this->tpl_data['archive']['PatientName']
-                )) || (preg_match(
-                    "/$legoPhanRegex/",
-                    $this->tpl_data['archive']['PatientName']
-                )) || (preg_match(
-                    "/$livingPhanRegex/",
-                    $this->tpl_data['archive']['PatientName']
-                ));
+                "/$pNameRegex/",
+                $this->tpl_data['archive']['PatientName']
+            )) || (preg_match(
+                "/$legoPhanRegex/",
+                $this->tpl_data['archive']['PatientName']
+            )) || (preg_match(
+                "/$livingPhanRegex/",
+                $this->tpl_data['archive']['PatientName']
+            ));
         }
 
         $this->tpl_data['archive']['patientNameValid'] = $isValid ? 1 : 0;


### PR DESCRIPTION
### Brief summary of changes
This PR changes the default regex configurations to not contain forward slashes and replaces them with equivalent expressions. 


### This resolves issue...
LORIS-MRI would like to start using the configuration options made available in the Config module,
however the current default values are incompatible with Perl

### To test this change...

- [ ] If your dev environment uses the default regex values in Config, just run the patch. Then click some of the `View Details` links in Imaging Uploader to be taken to DICOM Archive and ensure that the PatientName & PatientID fields are still viewable for different types of scans (both patients and lego / living phantoms)

- [ ] If your dev environment has custom regexs for these options, your project may have to create an equivalent regex without using forward slashes