### PR TITLE
[Core, NDB_BVL_Battery] Use instrument table attribute over test name when inserting new entries / CommentIDs

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -191,8 +191,11 @@ class NDB_BVL_Battery
         // generate a commentID
         $commentID = $this->_createCommentID($testName);
 
+        // instantiate instrument object to get table name attribute
+        $obj = NDB_BVL_Instrument::factory($testName, '', '');
+
         // insert into the test table
-        $success = $DB->insert($testName, array('CommentID' => $commentID));
+        $success = $DB->insert($obj->table, array('CommentID' => $commentID));
 
         // insert into the flag table
         $success = $DB->insert(
@@ -209,7 +212,7 @@ class NDB_BVL_Battery
         $ddeCommentID = 'DDE_'.$commentID;
 
         // insert the dde into the test table
-        $success = $DB->insert($testName, array('CommentID' => $ddeCommentID));
+        $success = $DB->insert($obj->table, array('CommentID' => $ddeCommentID));
 
         // insert the dde into the flag table
         $success = $DB->insert(


### PR DESCRIPTION
### Brief summary of changes
Instruments set a `table` attribute that detail the name of the table where the instrument's data is stored
The battery library should use this rather than `$testName` when inserting new rows

### This resolves issue...
This is needed for a CCNA feature

### To test this change...

- [ ] create a new dummy instrument. set table name to be an existing table / instrument in the `setup` method. make sure a new row is inserted into that table when you run `assign_missing_instruments`
