### PR TITLE
[JS] Replace arrray with array throughout javascript files

### DIFF
--- a/modules/acknowledgements/jsx/columnFormatter.js
+++ b/modules/acknowledgements/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of headers for the table
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of headers for the table
  * @return {*} a formated table cell for a given column
  */
 function formatAcknowledgementsColumn(column, cell, rowData, rowHeaders) {

--- a/modules/candidate_list/jsx/columnFormatter.js
+++ b/modules/candidate_list/jsx/columnFormatter.js
@@ -4,7 +4,7 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
+ * @param {array} rowData - array of cell contents for a specific row
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData) {

--- a/modules/conflict_resolver/jsx/resolved_conflicts_columnFormatter.js
+++ b/modules/conflict_resolver/jsx/resolved_conflicts_columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/conflict_resolver/jsx/unresolved_columnFormatter.js
+++ b/modules/conflict_resolver/jsx/unresolved_columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/data_integrity_flag/jsx/columnFormatter.js
+++ b/modules/data_integrity_flag/jsx/columnFormatter.js
@@ -4,8 +4,8 @@ loris.hiddenHeaders = [];
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/datadict/jsx/columnFormatter.js
+++ b/modules/datadict/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatDataDictColumn(column, cell, rowData, rowHeaders) {

--- a/modules/dicom_archive/jsx/columnFormatter.js
+++ b/modules/dicom_archive/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/examiner/jsx/columnFormatter.js
+++ b/modules/examiner/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/genomic_browser/jsx/profileColumnFormatter.js
+++ b/modules/genomic_browser/jsx/profileColumnFormatter.js
@@ -2,8 +2,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/help_editor/jsx/columnFormatter.js
+++ b/modules/help_editor/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/imaging_browser/jsx/columnFormatter.js
+++ b/modules/imaging_browser/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/imaging_uploader/jsx/columnFormatter.js
+++ b/modules/imaging_uploader/jsx/columnFormatter.js
@@ -6,8 +6,8 @@ loris.hiddenHeaders = ['PatientName'];
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/issue_tracker/jsx/columnFormatter.js
+++ b/modules/issue_tracker/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/media/jsx/columnFormatter.js
+++ b/modules/media/jsx/columnFormatter.js
@@ -2,8 +2,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/mri_violations/jsx/columnFormatter.js
+++ b/modules/mri_violations/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/mri_violations/jsx/columnFormatterUnresolved.js
+++ b/modules/mri_violations/jsx/columnFormatterUnresolved.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/mri_violations/jsx/mri_protocol_check_violations_columnFormatter.js
+++ b/modules/mri_violations/jsx/mri_protocol_check_violations_columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/mri_violations/jsx/mri_protocol_violations_columnFormatter.js
+++ b/modules/mri_violations/jsx/mri_protocol_violations_columnFormatter.js
@@ -2,8 +2,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/server_processes_manager/jsx/columnFormatter.js
+++ b/modules/server_processes_manager/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData) {

--- a/modules/survey_accounts/jsx/columnFormatter.js
+++ b/modules/survey_accounts/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {

--- a/modules/user_accounts/jsx/columnFormatter.js
+++ b/modules/user_accounts/jsx/columnFormatter.js
@@ -4,8 +4,8 @@
  * Modify behaviour of specified column cells in the Data Table component
  * @param {string} column - column name
  * @param {string} cell - cell content
- * @param {arrray} rowData - array of cell contents for a specific row
- * @param {arrray} rowHeaders - array of table headers (column names)
+ * @param {array} rowData - array of cell contents for a specific row
+ * @param {array} rowHeaders - array of table headers (column names)
  * @return {*} a formated table cell for a given column
  */
 function formatColumn(column, cell, rowData, rowHeaders) {


### PR DESCRIPTION
This replaces the typo "arrray" with the real word "array" in various javascript files.

I don't know what the origin of this typo is, but I'm tired of pointing it out in every javascript PR that bases it on something else.

(Sent to major to avoid conflicts in compiled javascript files)