### PR TITLE
Add document describing new routing

### DIFF
--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -1,0 +1,25 @@
+# Routing
+
+Since LORIS 20.0, LORIS has included a router and middleware based
+on (PSR15)[https://www.php-fig.org/psr/psr-15/] This has a number
+of benefits over the custom scripts in the htdocs directory used
+by previous LORIS releases such as reducing the dependency on Apache,
+removing the dependency on mod_rewrite, and making it possible for
+Modules to declare their own custom routes with complex path
+components or use the same access checking mechanisms as the rest
+of LORIS automatically.
+
+The AjaxHelper.php and associated module/*/ajax/*.php scripts are
+being deprecated as a result.
+
+In the new architecture, modules should implement an endpoint which
+handles the ServerRequestInterface passed to it in a RESTful manor.
+An example of how to do this is https://github.com/aces/Loris/pull/3977,
+which removes the "validateIDs.php" ajax script from the candidate_list
+module and replaces it with a validateIDs candidate_list/validateIDs
+endpoint.
+
+The exact release that will remove the AjaxHelper.php is undefined
+because of the number of existing modules that need to be updated,
+but it should not be depended on for any new development.
+

--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -5,11 +5,11 @@ on (PSR15)[https://www.php-fig.org/psr/psr-15/] This has a number
 of benefits over the custom scripts in the htdocs directory used
 by previous LORIS releases such as reducing the dependency on Apache,
 removing the dependency on mod_rewrite, and making it possible for
-Modules to declare their own custom routes with complex path
+modules to declare their own custom routes with complex path
 components or use the same access checking mechanisms as the rest
 of LORIS automatically.
 
-The AjaxHelper.php and associated module/*/ajax/*.php scripts are
+The AjaxHelper.php and associated `module/*/ajax/*.php` scripts are
 being deprecated as a result.
 
 In the new architecture, modules should implement an endpoint which

--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -13,7 +13,7 @@ The AjaxHelper.php and associated `module/*/ajax/*.php` scripts are
 being deprecated as a result.
 
 In the new architecture, modules should implement an endpoint which
-handles the ServerRequestInterface passed to it in a RESTful manor.
+handles the ServerRequestInterface passed to it in a RESTful manner.
 An example of how to do this is https://github.com/aces/Loris/pull/3977,
 which removes the "validateIDs.php" ajax script from the candidate_list
 module and replaces it with a validateIDs candidate_list/validateIDs

--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -18,6 +18,10 @@
  */
 
 
+// This error log should be uncommented once a reasonable number of modules have been updated to
+// give some urgency to people who are still using ajax/ directories. For now, it would generate
+// too much noise in the logs.
+// error_log("The AjaxHelper.php script is deprecated and will be removed in a future LORIS release. See docs/Routing.md for details.")
 // Load config file and ensure paths are correct
 set_include_path(
     get_include_path() . ":" .

--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -18,10 +18,14 @@
  */
 
 
-// This error log should be uncommented once a reasonable number of modules have been updated to
-// give some urgency to people who are still using ajax/ directories. For now, it would generate
-// too much noise in the logs.
-// error_log("The AjaxHelper.php script is deprecated and will be removed in a future LORIS release. See docs/Routing.md for details.")
+// This error log should be uncommented once a reasonable number of
+// modules have been updated to give some urgency to people who are
+// still using ajax/ directories. For now, it would generate too much
+// noise in the logs.
+// error_log(
+// "The AjaxHelper.php script is deprecated and will be removed"
+// . " in a future LORIS release. See docs/Routing.md for details."
+// );
 // Load config file and ensure paths are correct
 set_include_path(
     get_include_path() . ":" .


### PR DESCRIPTION
This adds a document to the docs directory explicitly telling developers not to depend on the `module/*/ajax` directory and puts in place a (commented out, until more modules are updated) deprecation warnings in AjaxHelper.php.

The document explains why the deprecation is happening and points to an example PR of how to update an ajax script to the new architecture. It can be updated to be more helpful as people have more experience doing so or find common patterns, but for now this is better than nothing.