### PR TITLE
[Instrument] Fix PHP Warning

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2115,7 +2115,7 @@ class NDB_BVL_Instrument extends NDB_Page
             switch ($row['COLUMN_NAME']) {
             case 'CommentID':
             case 'UserID':
-                continue;
+                continue 2;
             case 'Data_entry_completion_status':
                 $values[$row['COLUMN_NAME']] = 'Incomplete';
                 break;


### PR DESCRIPTION
### Brief summary of changes
this line was generating the notice:
`PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /var/www/loris/php/libraries/NDB_BVL_Instrument.class.inc on line 2118`
on version 7.3

i don't think this really fixes anything. from looking at the code, it seems that using a continue or a break would result in the same behavior. i decided to go with `continue 2` since that seems to be closer with what the original author had in mind and it's what my PHP version condescendingly told me to use.

for more info: http://php.net/manual/en/control-structures.continue.php
### This resolves issue...
this just prevents the Warning from coming up. Warning will occur when running any script which uses `generic_includes.php` on PHP 7.3 (or so i'm guessing since this is the first i've ever encountered this warning)

### To test this change...

- [ ] run a script which uses `generic_includes.php`
