### PR TITLE
[Instrument] Use table attribute over testname

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2051,7 +2051,7 @@ class NDB_BVL_Instrument extends NDB_Page
         $CommentID = $this->getCommentID();
 
         $dates = $db->pselectRow(
-            "SELECT i.Date_taken, c.DoB FROM $this->testName i
+            "SELECT i.Date_taken, c.DoB FROM $this->table i
             JOIN flag f USING (CommentID)
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
@@ -2081,7 +2081,7 @@ class NDB_BVL_Instrument extends NDB_Page
         $CommentID = $this->getCommentID();
 
         $pscid = $db->pselectOne(
-            "SELECT c.PSCID FROM $this->testName i
+            "SELECT c.PSCID FROM $this->table i
             JOIN flag f USING (CommentID)
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
@@ -2251,7 +2251,7 @@ class NDB_BVL_Instrument extends NDB_Page
         );
 
         $Responses = $DB->pselectRow(
-            "SELECT * FROM " . $this->testName . " WHERE CommentID=:CID",
+            "SELECT * FROM " . $this->table . " WHERE CommentID=:CID",
             array('CID' => $this->getCommentID())
         );
 


### PR DESCRIPTION
### Brief summary of changes
This follows the same idea as #3989 , instruments should refer to the table attribute rather than assuming the table is the same as test name


### This resolves issue...
Saving instruments that don't have identical table & test names

### To test this change...

- [ ] create a duplicate instrument of an existing one, change the test name attribute and class name. load it onto your front end and try saving

