### PR TITLE
Fixed Type Check for hasCenter Method - HACKTOBERFEST 2018 🎃

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -532,12 +532,12 @@ class User extends UserPermissions
      *
      * @return bool
      */
-    public function hasCenter($center_id)
+    public function hasCenter(int $center_id)
     {
         return in_array(
             $center_id,
             $this->getCenterIDs(),
-            true
+            false
         );
     }
     /**


### PR DESCRIPTION
### Previously on User...
The `hasCenter` method enforces strict type checking, however in the function doc it explicitly says that it expects an `int`. This `int` is then forced to be compared with a `string` provided by the `getCenterIDs` method. Therefore, if an `int` is passed to the function, the result will necessarily be false.

### This Week on FINAL HACKTOBERFEST PR:
I changed the `in_array` check to *not* be strict. This allows a check across `ints` and `strings`.
If this is not an ideal fix, I suggest forcing the function to receive a `string` as a parameter, or to change the types of the values of the array that results from the `getCenterIDs` method.
