### PR TITLE
[Core: User] Fixed Type Check for hasCenter Method - HACKTOBERFEST 2018 🎃

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -76,7 +76,7 @@ class User extends UserPermissions
         );
         $user_cid            = array();
         foreach ($user_centerID_query as $key=>$val) {
-            $user_cid[$key] =$val['CenterID'];
+            $user_cid[$key] = intval($val['CenterID']) //Cast values to int;
         }
 
         // Get examiner information
@@ -532,7 +532,7 @@ class User extends UserPermissions
      *
      * @return bool
      */
-    public function hasCenter($center_id)
+    public function hasCenter(int $center_id) : bool
     {
         return in_array(
             $center_id,
@@ -540,6 +540,7 @@ class User extends UserPermissions
             true
         );
     }
+
     /**
      * Determines if the user has a permission
      * for a center

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -76,7 +76,8 @@ class User extends UserPermissions
         );
         $user_cid            = array();
         foreach ($user_centerID_query as $key=>$val) {
-            $user_cid[$key] = intval($val['CenterID']) //Cast values to int;
+            // Convert string representation of ID to int
+            $user_cid[$key] = intval($val['CenterID']);
         }
 
         // Get examiner information


### PR DESCRIPTION
### Previously on User...
The `hasCenter` method enforces strict type checking, however in the function doc it explicitly says that it expects an `int`. This `int` is then forced to be compared with a `string` provided by the `getCenterIDs` method. Therefore, if an `int` is passed to the function, the result will necessarily be false.

### This Week on FINAL HACKTOBERFEST PR:
I cast the value being stored in the CenterIDs array to ints. This allows a strict comparison between the values passed to `hasCenterID` and the `getCenterIDs` array.
