### PR TITLE
[Configuration] Path settings must be valid paths

### DIFF
--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -114,6 +114,8 @@ foreach ($_POST as $key => $value) {
                 'Config',
                 array('ConfigID' => $ConfigSettingsID)
             );
+        } else {
+            displayError(400, 'Invalid action');
         }
     }
     unset($pathIDs);

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -40,11 +40,8 @@ foreach ($_POST as $key => $value) {
         } else {
             // if no duplicate value then do updating
             if (noDuplicateInDropdown($key, $value)) {
-                error_log("About to check pathIDs for $key => $value");
                 if (in_array(intval($key), $pathIDs, true)) {
-                    error_log("$value is in pathIDs");
                     if (!validPath($value)) {
-                        error_log("$value is invalid!");
                         $err = 'Directory `'
                             . htmlspecialchars($value, ENT_QUOTES)
                             . '` is invalid';
@@ -68,16 +65,14 @@ foreach ($_POST as $key => $value) {
                 if (countDuplicate($keySplit[1], $value) == '0') {
                     $DB->update(
                         'Config',
+                        array('Value' => $value),
                         array(
-                            'Value'    => $value
-                        ),
-                        array(
-                         'ConfigID' => $keySplit[1]
+                         'ConfigID' => $keySplit[1],
                         )
                     );
                 } else {
-                        header("HTTP/1.1 303 Duplicate value");
-                        exit();
+                    header("HTTP/1.1 303 Duplicate value");
+                    exit();
                 }
                 if (in_array(intval($keySplit[1]), $pathIDs, true)) {
                     if (!validPath($value)) {
@@ -98,8 +93,8 @@ foreach ($_POST as $key => $value) {
             }
         } elseif ($valueSplit[0] == 'remove') {
             $DB->update(
-                'Config', 
-                array('Value' => null), 
+                'Config',
+                array('Value' => null),
                 array('ID' => $valueSplit[1])
             );
         }

--- a/modules/configuration/js/configuration_helper.js
+++ b/modules/configuration/js/configuration_helper.js
@@ -72,7 +72,8 @@ $(function () {
 
         var form = $(this).serialize();
 
-        //validate(form);
+        // Clear previous feedback
+        $('.submit-area > label').remove();
 
         $.ajax({
             type: 'post',
@@ -84,8 +85,9 @@ $(function () {
                 $('input[type="reset"]').attr('disabled','disabled');
             },
             error: function(xhr, desc, err) {
-                var html = "<label>One or more fields with multiple-entry option has duplicate values</label>";
-                $(html).hide().appendTo('.submit-area').fadeIn(500).delay(1000).fadeOut(500)
+                console.log('Test');
+                var html = "<label>" + xhr.responseText + "</label>";
+                $(html).hide().appendTo('.submit-area').fadeIn(500).delay(1000)
                 $('input[type="reset"]').attr('disabled','disabled')
             }
         });

--- a/modules/configuration/js/configuration_helper.js
+++ b/modules/configuration/js/configuration_helper.js
@@ -85,7 +85,6 @@ $(function () {
                 $('input[type="reset"]').attr('disabled','disabled');
             },
             error: function(xhr, desc, err) {
-                console.log('Test');
                 var html = "<label>" + xhr.responseText + "</label>";
                 $(html).hide().appendTo('.submit-area').fadeIn(500).delay(1000)
                 $('input[type="reset"]').attr('disabled','disabled')


### PR DESCRIPTION
### Brief summary of changes

I was recently able to develop an exploit where I could upload and execute scripts via manipulating config path settings. This PR ensures that these settings actually correspond to existing paths on the system before changing their values in the database.

### To Test
* Try changing one of the Configuration settings under `Paths` to an invalid path. You'll get a `400` error.