### PR TITLE
[Imaging Uploader] Prevent duplicate insertions

### DIFF
--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -382,7 +382,9 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             array('ul' => "%$file_name")
         );
 
-        if (!$updateFile && !empty($id)) {
+        $uploadPath = $config->getSetting('MRIUploadIncomingPath') . $file_name;
+
+        if (!$updateFile && !empty($id) && file_exists($uploadPath)) {
             array_push(
                 $errors['mri_file'],
                 "This file has already been uploaded! Please refresh your browser."

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -369,6 +369,25 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                 " .tgz, .tar.gz or .zip."
             );
         }
+        ///////////////////////////////////////////////////////////////////////
+        //////// Make sure there's no existing identical entry ////////////////
+        //////// for "new" scans //////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////
+        $updateFile = $args['values']['overwrite'] ? true : false;
+        $id       = $db->pselectOne(
+            "SELECT 
+                IF (InsertionComplete=0 AND 
+                (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID 
+                FROM mri_upload WHERE UploadLocation LIKE :ul",
+            array('ul' => "%$file_name")
+        );
+
+        if (!$updateFile && !empty($id)) {
+            array_push(
+              $errors['mri_file'],
+                "This file has already been uploaded! Please refresh your browser."
+            );
+        }
         // Loops through associative array of error messages
         // If there are error messages, array is passed to front end
         // If there are no error messages but the file name is wrong,

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -387,7 +387,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         if (!$updateFile && !empty($id) && file_exists($uploadPath)) {
             array_push(
                 $errors['mri_file'],
-                "This file has already been uploaded! Please refresh your browser."
+                "This file has already been uploaded."
             );
         }
         // Loops through associative array of error messages

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -374,7 +374,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         //////// for "new" scans //////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////
         $updateFile = $args['values']['overwrite'] ? true : false;
-        $id       = $db->pselectOne(
+        $id         = $db->pselectOne(
             "SELECT 
                 IF (InsertionComplete=0 AND 
                 (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID 
@@ -384,7 +384,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
 
         if (!$updateFile && !empty($id)) {
             array_push(
-              $errors['mri_file'],
+                $errors['mri_file'],
                 "This file has already been uploaded! Please refresh your browser."
             );
         }


### PR DESCRIPTION
### Brief summary of changes
Imaging Uploader only checks if a file already exists on the front end. This makes it possible to insert duplicate scans which happens surprisingly often on CCNA. This change adds a backend check for an existing mri_upload entry that is not being intentionally overwritten / updated.


### This resolves issue...
mri_upload duplicates

### To test this change...
Open the Imaging Uploader Upload tab in two browser tabs. Fill out both simultaneously for the same scan, then submit one after the other. The first submission should go through and the other should throw an error.
