### PR TITLE
[Smarty] Add noopener and noreferrer to external links

### DIFF
--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -478,7 +478,7 @@
                     Powered by LORIS &copy; {$currentyear}. All rights reserved.
                 </div>
       		<div align="center" colspan="1">
-                    Created by <a href="http://mcin-cnim.ca/" target="_blank" rel="noopener noreferrer">
+                    Created by <a href="http://mcin-cnim.ca/" target="_blank">
                          MCIN
                     </a>
                 </div>

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -466,7 +466,7 @@
                         </li>
                         {foreach from=$links item=link}
                                 <li>
-                                    <a href="{$link.url}" target="{$link.windowName}">
+                                    <a href="{$link.url}" target="{$link.windowName}" rel="noopener noreferrer">
                                         {$link.label}
                                     </a>
                                     |
@@ -478,7 +478,7 @@
                     Powered by LORIS &copy; {$currentyear}. All rights reserved.
                 </div>
       		<div align="center" colspan="1">
-                    Created by <a href="http://mcin-cnim.ca/" target="_blank">
+                    Created by <a href="http://mcin-cnim.ca/" target="_blank" rel="noopener noreferrer">
                          MCIN
                     </a>
                 </div>

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -46,13 +46,13 @@
   </section>
 
   <footer class="footer">
-    Powered by <a href="http://www.loris.ca/" target="_blank" rel="noopener noreferrer">LORIS</a>
+    Powered by <a href="http://www.loris.ca/" target="_blank">LORIS</a>
     | GPL-3.0 &copy; {$currentyear} <br/>
     Developed at
     <a href="http://www.mni.mcgill.ca" target="_blank">
       Montreal Neurological Institute and Hospital
     </a>
-    by <a href="http://mcin-cnim.ca" target="_blank" rel="noopener noreferrer">MCIN</a>
+    by <a href="http://mcin-cnim.ca" target="_blank">MCIN</a>
   </footer>
   <script src="{$baseurl}/js/modernizr/modernizr.min.js"/>
   <script>

--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -33,7 +33,7 @@
           {$study_title}
         </div>
         <div class="github-logo">
-          <a href="https://github.com/aces/Loris" target="_blank">
+          <a href="https://github.com/aces/Loris" target="_blank" rel="noopener noreferrer">
             <img src="{$baseurl}/images/GitHub-Mark-Light-64px.png" alt="Github"/>
           </a>
         </div>
@@ -46,13 +46,13 @@
   </section>
 
   <footer class="footer">
-    Powered by <a href="http://www.loris.ca/" target="_blank">LORIS</a>
+    Powered by <a href="http://www.loris.ca/" target="_blank" rel="noopener noreferrer">LORIS</a>
     | GPL-3.0 &copy; {$currentyear} <br/>
     Developed at
     <a href="http://www.mni.mcgill.ca" target="_blank">
       Montreal Neurological Institute and Hospital
     </a>
-    by <a href="http://mcin-cnim.ca" target="_blank">MCIN</a>
+    by <a href="http://mcin-cnim.ca" target="_blank" rel="noopener noreferrer">MCIN</a>
   </footer>
   <script src="{$baseurl}/js/modernizr/modernizr.min.js"/>
   <script>


### PR DESCRIPTION
### Brief summary of changes
Without [noopener](https://mathiasbynens.github.io/rel-noopener/), an external page that is opened and is malicious or compromised gains control over the `window` of the opening page's DOM. 
Basically it allows a website partial control over the tab that a user navigated from.

Noreferrer is a workaround for the same for browsers that do not support noopener. It also scrubs the Referer header which is a tiny privacy boost.

Also checkout https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

### To test this change...

- [ ] Make sure external links still work, such as the study links in the footer.
