### PR TITLE
[Main] Sanitize Timepoint error message

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -127,8 +127,7 @@ if (!empty($TestName)) {
         try {
             $timePoint = TimePoint::singleton($_REQUEST['sessionID']);
         } catch (Exception $e) {
-            $tpl_data['error_message'][]
-                = "TimePoint Error (".$_REQUEST['sessionID']."): ".$e->getMessage();
+            $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
         }
     }
 
@@ -153,10 +152,7 @@ if (!empty($TestName)) {
             }
             $tpl_data['timePoint'] = $timePoint->getData();
         } catch(Exception $e) {
-            $tpl_data['error_message'][]
-                = htmlspecialchars(
-                    "TimePoint Error (".$_REQUEST['sessionID']."): ".$e->getMessage()
-                );
+            $tpl_data['error_message'][] = htmlspecialchars($e->getMessage());
         }
     }
 }


### PR DESCRIPTION
### Brief summary of changes
Reflected XSS was possible by providing a javascript payload into the sessionID GET parameter.

This PR adds escaping to the error message in way that is consistent elsewhere in the file.
