### PR TITLE
[Media] Allow access to the module when a user has only 'media_write'

### DIFF
--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -15,6 +15,8 @@
  */
 
 $user =& User::singleton();
+//NOTE Should this be 'media_read' instead? It seems that downloading files
+//should be a read permission, not write.
 if (!$user->hasPermission('media_write')) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -51,8 +51,7 @@ class Media extends \NDB_Menu_Filter
         // Set permission to access user-hidden files, currently based on superuser
         $this->hasHidePermission = $user->hasPermission("superuser");
 
-        return $this->hasPermission('media_read') ||  $this->hasWritePermission;
-            || $user->hasPermission('media_write');
+        return $this->hasPermission('media_read') || $this->hasWritePermission;
     }
 
     /**

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -51,7 +51,7 @@ class Media extends \NDB_Menu_Filter
         // Set permission to access user-hidden files, currently based on superuser
         $this->hasHidePermission = $user->hasPermission("superuser");
 
-        return $user->hasPermission('media_read')
+        return $this->hasPermission('media_read') ||  $this->hasWritePermission;
             || $user->hasPermission('media_write');
     }
 

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -51,7 +51,8 @@ class Media extends \NDB_Menu_Filter
         // Set permission to access user-hidden files, currently based on superuser
         $this->hasHidePermission = $user->hasPermission("superuser");
 
-        return $user->hasPermission('media_read');
+        return $user->hasPermission('media_read')
+            || $user->hasPermission('media_write');
     }
 
     /**

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -51,7 +51,7 @@ class Media extends \NDB_Menu_Filter
         // Set permission to access user-hidden files, currently based on superuser
         $this->hasHidePermission = $user->hasPermission("superuser");
 
-        return $this->hasPermission('media_read') || $this->hasWritePermission;
+        return $user->hasPermission('media_read') || $this->hasWritePermission;
     }
 
     /**


### PR DESCRIPTION
### Brief summary of changes
Previously when a user had the media_write permission but not the media_read permission they could not access the module. Although this is probably a misconfiguration, it makes sense that if someone can upload files that they should also be able to browse them.

Also added a note about whether FileDownload should be a read permission or a write permission.

### To test this change...

- [ ] Give a user the `media_write` permission but not `media_read`. You should be able to view the module.
