### PR TITLE
[Imaging Browser] Simplify permission checking

### DIFF
--- a/modules/imaging_browser/ajax/setSortedRows.php
+++ b/modules/imaging_browser/ajax/setSortedRows.php
@@ -17,9 +17,9 @@
  */
 $canAccess = \User::singleton()->hasAnyPermission(
     array(
-        'imaging_browser_view_allsites',
-        'imaging_browser_phantom_allsites',
-        'imaging_browser_phantom_ownsite'
+     'imaging_browser_view_allsites',
+     'imaging_browser_phantom_allsites',
+     'imaging_browser_phantom_ownsite',
     )
 )
 || ($user->hasStudySite()

--- a/modules/imaging_browser/ajax/setSortedRows.php
+++ b/modules/imaging_browser/ajax/setSortedRows.php
@@ -12,16 +12,20 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-// Get LORIS user issuing the request
-$user =& User::singleton();
-if (!($user->hasPermission('imaging_browser_view_allsites')
-    || ($user->hasStudySite()
-    && $user->hasPermission('imaging_browser_view_site'))
-    || $user->hasPermission('imaging_browser_phantom_allsites')
-    || $user->hasPermission('imaging_browser_phantom_ownsite'))
-) {
+/* User has access if they have an 'all site' permission or if they are
+ * part of a study site and are permitted to view their own site.
+ */
+$canAccess = \User::singleton()->hasAnyPermission(
+    'imaging_browser_view_allsites',
+    'imaging_browser_phantom_allsites',
+    'imaging_browser_phantom_ownsite'
+)
+|| ($user->hasStudySite()
+&& $user->hasPermission('imaging_browser_view_site'));
+
+if (!$canAccess) {
     header("HTTP/1.1 403 Forbidden");
-    exit;
+    return;
 }
 
 if (!empty($_POST['sortedIDs'])) {
@@ -34,4 +38,4 @@ if (!empty($_POST['sortedIDs'])) {
         );
 }
 
-exit;
+return;

--- a/modules/imaging_browser/ajax/setSortedRows.php
+++ b/modules/imaging_browser/ajax/setSortedRows.php
@@ -16,9 +16,11 @@
  * part of a study site and are permitted to view their own site.
  */
 $canAccess = \User::singleton()->hasAnyPermission(
-    'imaging_browser_view_allsites',
-    'imaging_browser_phantom_allsites',
-    'imaging_browser_phantom_ownsite'
+    array(
+        'imaging_browser_view_allsites',
+        'imaging_browser_phantom_allsites',
+        'imaging_browser_phantom_ownsite'
+    )
 )
 || ($user->hasStudySite()
 && $user->hasPermission('imaging_browser_view_site'));

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -42,9 +42,9 @@ class Imaging_Browser extends \NDB_Menu_Filter
          */
         return $user->hasAnyPermission(
             array(
-                'imaging_browser_view_allsites',
-                'imaging_browser_phantom_allsites',
-                'imaging_browser_phantom_ownsite'
+             'imaging_browser_view_allsites',
+             'imaging_browser_phantom_allsites',
+             'imaging_browser_phantom_ownsite',
             )
         )
         || (

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -37,12 +37,17 @@ class Imaging_Browser extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        return ($user->hasPermission('imaging_browser_view_allsites')
-               || ($user->hasStudySite()
-                   && $user->hasPermission('imaging_browser_view_site')
-                  )
-               || $user->hasPermission('imaging_browser_phantom_allsites')
-               || $user->hasPermission('imaging_browser_phantom_ownsite')
+        /* User has access if they have an 'all site' permission or if they are
+        * part of a study site and are permitted to view their own site.
+         */
+        return $user->hasAnyPermission(
+            'imaging_browser_view_allsites',
+            'imaging_browser_phantom_allsites',
+            'imaging_browser_phantom_ownsite'
+        )
+        || (
+            $user->hasStudySite()
+            && $user->hasPermission('imaging_browser_view_site')
         );
     }
 

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -41,9 +41,11 @@ class Imaging_Browser extends \NDB_Menu_Filter
         * part of a study site and are permitted to view their own site.
          */
         return $user->hasAnyPermission(
-            'imaging_browser_view_allsites',
-            'imaging_browser_phantom_allsites',
-            'imaging_browser_phantom_ownsite'
+            array(
+                'imaging_browser_view_allsites',
+                'imaging_browser_phantom_allsites',
+                'imaging_browser_phantom_ownsite'
+            )
         )
         || (
             $user->hasStudySite()

--- a/modules/imaging_browser/php/mrinavigation.class.inc
+++ b/modules/imaging_browser/php/mrinavigation.class.inc
@@ -13,7 +13,7 @@
 */
 namespace LORIS\imaging_browser;
 /**
- * MRINavigatoin class
+ * MRINavigation class
  *
  * This class provides the management of sessions
  * to navigate to the previous and/or next session.

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -51,8 +51,6 @@ class ViewSession extends \NDB_Form
         /* User has access if they have an 'all site' permission or if they are
         * part of a study site and are permitted to view their own site.
          */
-        $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
-
         return $user->hasAnyPermission(
             array(
                 'imaging_browser_view_allsites',
@@ -60,11 +58,9 @@ class ViewSession extends \NDB_Form
                 'imaging_browser_phantom_ownsite'
             )
         )
-        || (
-            in_array(
-                $timePoint->getData('CenterID'),
-                $user->getData('CenterIDs')
-            ) && $user->hasPermission('imaging_browser_view_site')
+        || $user->hasCenterPermission(
+            'imaging_browser_view_site',
+            \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
         );
     }
 

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -53,9 +53,9 @@ class ViewSession extends \NDB_Form
          */
         return $user->hasAnyPermission(
             array(
-                'imaging_browser_view_allsites',
-                'imaging_browser_phantom_allsites',
-                'imaging_browser_phantom_ownsite'
+             'imaging_browser_view_allsites',
+             'imaging_browser_phantom_allsites',
+             'imaging_browser_phantom_ownsite',
             )
         )
         || $user->hasCenterPermission(

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -48,18 +48,21 @@ class ViewSession extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        // allow only to view own site data
+        /* User has access if they have an 'all site' permission or if they are
+        * part of a study site and are permitted to view their own site.
+         */
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
 
-        return ($user->hasPermission('imaging_browser_view_allsites')
-                || ((in_array(
-                    $timePoint->getData('CenterID'),
-                    $user->getData('CenterIDs')
-                ))
-                     && $user->hasPermission('imaging_browser_view_site')
-                   )
-                || $user->hasPermission('imaging_browser_phantom_allsites')
-                || $user->hasPermission('imaging_browser_phantom_ownsite')
+        return $user->hasAnyPermission(
+            'imaging_browser_view_allsites',
+            'imaging_browser_phantom_allsites',
+            'imaging_browser_phantom_ownsite'
+        )
+        || (
+            in_array(
+                $timePoint->getData('CenterID'),
+                $user->getData('CenterIDs')
+            ) && $user->hasPermission('imaging_browser_view_site')
         );
     }
 
@@ -70,9 +73,7 @@ class ViewSession extends \NDB_Form
      */
     function _hasQCPerm()
     {
-        $user =& \User::singleton();
-
-        return $user->hasPermission('imaging_browser_qc');
+        return \User::singleton()->hasPermission('imaging_browser_qc');
     }
 
     /**

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -54,9 +54,11 @@ class ViewSession extends \NDB_Form
         $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
 
         return $user->hasAnyPermission(
-            'imaging_browser_view_allsites',
-            'imaging_browser_phantom_allsites',
-            'imaging_browser_phantom_ownsite'
+            array(
+                'imaging_browser_view_allsites',
+                'imaging_browser_phantom_allsites',
+                'imaging_browser_phantom_ownsite'
+            )
         )
         || (
             in_array(


### PR DESCRIPTION
### Brief summary of changes
The permissions string for imaging browser is pretty wacky. This PR takes advantage of a [new function](#3966 ) added on the major branch to hopefully make the permissions a little more readable.

### To test this change...

- [ ] The module should function as before.
