### PR TITLE
[Core: User, My Preferences] Eliminate type juggling in password expiration functionality

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -456,9 +456,10 @@ class Edit_User extends \NDB_Form
         // prepend two random characters
         if (isset($set['Password_hash'])) {
             // Update CouchDB. Must do before password is salted/hashed.
-            $expiry = isset($values['Password_expiry'])
-                ? $values['Password_expiry'] : null;
-            $user->updatePassword($set['Password_hash'], $expiry);
+            $user->updatePassword(
+                $set['Password_hash'],
+                $values['Password_expiry'] ?? ''
+            );
         }
         // update the user permissions if applicable
         // If the user is editing his/her own account, skip the part where

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -194,9 +194,10 @@ class My_Preferences extends \NDB_Form
         // prepend two random characters
         if (isset($set['Password_hash'])) {
             // Update CouchDB. Must do before password is salted/hashed.
-            $expiry = isset($values['Password_expiry'])
-                ? $values['Password_expiry'] : null;
-            $user->updatePassword($set['Password_hash'], $expiry);
+            $user->updatePassword(
+                $set['Password_hash'],
+                $values['Password_expiry'] ?? ''
+            );
         }
 
         // send the user an email

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -507,12 +507,12 @@ class User extends UserPermissions
      *
      * @return void
      */
-    function updatePassword($password, $expiry = null)
+    function updatePassword(string $password, string $expiry = '')
     {
-        if (is_null($expiry)) {
+        if ($expiry === '') {
             $expiry = date(
                 'Y-m-d',
-                mktime(0, 0, 0, date('n') + 6, date('j'), date('Y'))
+                strtotime('+6 months')
             );
         }
 


### PR DESCRIPTION
### Brief summary of changes
After toggling the "Strict types" flag in the User class in another PR Travis gave the error `TypeError: mktime() expects parameter 5 to be integer, string given`.

This PR uses `strtotime()` to generate a password expiry date instead of `mktime()`. This way we don't have to juggle types. It also has the benefit of being more readable.

This function also standardizes the `$expiry` variable to be a string everywhere instead of a nullable string.


### Related
- [ ] Github? #4027

### To test this change...

- [ ] Make sure you can still change your password via My Preferences AND via Edit User.
