### PR TITLE
[Core: Client] Prevent PHP Notice "A session had already been started - ignoring"

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -133,9 +133,11 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        session_start(
-            ['cookie_httponly' => true]
-        );
+        if (!isset($_SESSION)) {
+            session_start(
+                ['cookie_httponly' => true]
+            );
+        }
 
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {


### PR DESCRIPTION
### Brief summary of changes
Prevent PHP Notice "A session had already been started - ignoring" by wrapping `session_start()` with an `isset()` check

### To test this change...

- [ ] Go to imaging_uploader and click some table rows. PHP Notices will appear in the logs
- [ ] They won't appear on this branch