### PR TITLE
[Candidate, TimePoint] Refactor setData() to accept only array as argument

### DIFF
--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -105,7 +105,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         ) {
             $this->setData(
                 array(
-                    $currentStage => $_REQUEST['setStageUpdate']
+                 $currentStage => $_REQUEST['setStageUpdate'],
                 )
             );
             return;
@@ -173,7 +173,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             // Send to DCC - set Submitted to Y
             $this->setData(
                 array(
-                    'Submitted' => $_REQUEST['setSubmitted']
+                 'Submitted' => $_REQUEST['setSubmitted'],
                 )
             );
             // move to next stage (approval or the bin)
@@ -237,7 +237,7 @@ class Instrument_List_ControlPanel extends \TimePoint
 
             $this->setData(
                 array(
-                    'Submitted' => $_REQUEST['setSubmitted']
+                 'Submitted' => $_REQUEST['setSubmitted'],
                 )
             );
 
@@ -297,15 +297,13 @@ class Instrument_List_ControlPanel extends \TimePoint
         ) {
             $this->setData(
                 array(
-                    'BVLQCStatus' => $_REQUEST['setBVLQCStatus']
+                 'BVLQCStatus' => $_REQUEST['setBVLQCStatus'],
                 )
             );
             return;
         } else {
             $this->setData(
-                array(
-                    'BVLQCStatus' => null
-                )
+                array('BVLQCStatus' => null)
             );
             return;
         }
@@ -314,15 +312,13 @@ class Instrument_List_ControlPanel extends \TimePoint
         ) {
             $this->setData(
                 array(
-                    'BVLQCType' => $_REQUEST['setBVLQCType']
+                 'BVLQCType' => $_REQUEST['setBVLQCType'],
                 )
             );
             return;
         } else {
             $this->setData(
-                array(
-                    'BVLQCType' => null
-                )
+                array('BVLQCType' => null)
             );
             return;
         }

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -103,7 +103,11 @@ class Instrument_List_ControlPanel extends \TimePoint
             && in_array($_REQUEST['setStageUpdate'], $this->_statusOptions)
             && in_array($currentStage, $this->_dynamicStageOptions)
         ) {
-            $this->setData($currentStage, $_REQUEST['setStageUpdate']);
+            $this->setData(
+                array(
+                    $currentStage => $_REQUEST['setStageUpdate']
+                )
+            );
             return;
         }
 
@@ -167,7 +171,11 @@ class Instrument_List_ControlPanel extends \TimePoint
             }
 
             // Send to DCC - set Submitted to Y
-            $this->setData('Submitted', $_REQUEST['setSubmitted']);
+            $this->setData(
+                array(
+                    'Submitted' => $_REQUEST['setSubmitted']
+                )
+            );
             // move to next stage (approval or the bin)
             if ($currentStatus == 'Pass') {
                 $nextStage = 'Approval';
@@ -227,7 +235,11 @@ class Instrument_List_ControlPanel extends \TimePoint
         // un-submit to dcc
         if ($condition1 && $condition2 && $condition3 && $condition4) {
 
-                $this->setData('Submitted', $_REQUEST['setSubmitted']);
+            $this->setData(
+                array(
+                    'Submitted' => $_REQUEST['setSubmitted']
+                )
+            );
 
                 // revert from approval (or the bin)
             if ($currentStage == 'Approval') {
@@ -283,19 +295,35 @@ class Instrument_List_ControlPanel extends \TimePoint
         if (!empty($_REQUEST['setBVLQCStatus'])
             && $user->hasPermission('bvl_feedback')
         ) {
-            $this->setData('BVLQCStatus', $_REQUEST['setBVLQCStatus']);
+            $this->setData(
+                array(
+                    'BVLQCStatus' => $_REQUEST['setBVLQCStatus']
+                )
+            );
             return;
         } else {
-            $this->setData('BVLQCStatus', null);
+            $this->setData(
+                array(
+                    'BVLQCStatus' => null
+                )
+            );
             return;
         }
         if (!empty($_REQUEST['setBVLQCType'])
             && $user->hasPermission('bvl_feedback')
         ) {
-            $this->setData('BVLQCType', $_REQUEST['setBVLQCType']);
+            $this->setData(
+                array(
+                    'BVLQCType' => $_REQUEST['setBVLQCType']
+                )
+            );
             return;
         } else {
-            $this->setData('BVLQCType', null);
+            $this->setData(
+                array(
+                    'BVLQCType' => null
+                )
+            );
             return;
         }
     }

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -70,7 +70,7 @@ class New_Profile extends \NDB_Form
         if ($config->getSetting('useProjects') == "true") {
             $candidate->setData(
                 array(
-                    'ProjectID' => $values['ProjectID']
+                 'ProjectID' => $values['ProjectID'],
                 )
             );
 

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -63,41 +63,29 @@ class New_Profile extends \NDB_Form
         $centerIDs = \User::singleton()->getData('CenterIDs');
         if (count($centerIDs) > 1 || !isset($values['psc'])) {
             $values['psc'] = $centerIDs[0];
-
-            // get the candidate
-            $candidate =& \Candidate::singleton($candID);
-
-            if ($config->getSetting('useProjects') == "true") {
-                $candidate->setData(
-                    array(
-                        'ProjectID' => $values['ProjectID'],
-                    )
-                );
-
-            }
-
-            /* Create the candidate and retrive its ID.
-             * Use form values when present, otherwise default to null.
-             */
-            $candID = \Candidate::createNew(
-                $values['psc'],
-                $values['dob1'],
-                $values['edc1'] ?? null,
-                $values['gender'],
-                $values['PSCID'] ?? null,
-                intval($values['ProjectID']) ?? null
-            );
-            /* Update front-end data. Use passed PSCID when present, otherwise
-             * retrieve it from the newly-created candidate.
-             */
-            $this->tpl_data['candID']  = $candID;
-            $this->tpl_data['PSCID']   = $values['PSCID']
-                ?? \Candidate::singleton($candID)->getPSCID();
-            $this->tpl_data['success'] = true;
-
-            // freeze it, just in case
-            $this->form->freeze();
         }
+
+        /* Create the candidate and retrive its ID.
+         * Use form values when present, otherwise default to null.
+         */
+        $candID = \Candidate::createNew(
+            $values['psc'],
+            $values['dob1'],
+            $values['edc1'] ?? null,
+            $values['gender'],
+            $values['PSCID'] ?? null,
+            intval($values['ProjectID']) ?? null
+        );
+        /* Update front-end data. Use passed PSCID when present, otherwise
+         * retrieve it from the newly-created candidate.
+         */
+        $this->tpl_data['candID']  = $candID;
+        $this->tpl_data['PSCID']   = $values['PSCID']
+            ?? \Candidate::singleton($candID)->getPSCID();
+        $this->tpl_data['success'] = true;
+
+        // freeze it, just in case
+        $this->form->freeze();
     }
 
     /**

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -63,6 +63,17 @@ class New_Profile extends \NDB_Form
         $centerIDs = \User::singleton()->getData('CenterIDs');
         if (count($centerIDs) > 1 || !isset($values['psc'])) {
             $values['psc'] = $centerIDs[0];
+
+        // get the candidate
+        $candidate =& \Candidate::singleton($candID);
+
+        if ($config->getSetting('useProjects') == "true") {
+            $candidate->setData(
+                array(
+                    'ProjectID' => $values['ProjectID']
+                )
+            );
+
         }
 
         /* Create the candidate and retrive its ID.

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -64,39 +64,40 @@ class New_Profile extends \NDB_Form
         if (count($centerIDs) > 1 || !isset($values['psc'])) {
             $values['psc'] = $centerIDs[0];
 
-        // get the candidate
-        $candidate =& \Candidate::singleton($candID);
+            // get the candidate
+            $candidate =& \Candidate::singleton($candID);
 
-        if ($config->getSetting('useProjects') == "true") {
-            $candidate->setData(
-                array(
-                 'ProjectID' => $values['ProjectID'],
-                )
+            if ($config->getSetting('useProjects') == "true") {
+                $candidate->setData(
+                    array(
+                        'ProjectID' => $values['ProjectID'],
+                    )
+                );
+
+            }
+
+            /* Create the candidate and retrive its ID.
+             * Use form values when present, otherwise default to null.
+             */
+            $candID = \Candidate::createNew(
+                $values['psc'],
+                $values['dob1'],
+                $values['edc1'] ?? null,
+                $values['gender'],
+                $values['PSCID'] ?? null,
+                intval($values['ProjectID']) ?? null
             );
+            /* Update front-end data. Use passed PSCID when present, otherwise
+             * retrieve it from the newly-created candidate.
+             */
+            $this->tpl_data['candID']  = $candID;
+            $this->tpl_data['PSCID']   = $values['PSCID']
+                ?? \Candidate::singleton($candID)->getPSCID();
+            $this->tpl_data['success'] = true;
 
+            // freeze it, just in case
+            $this->form->freeze();
         }
-
-        /* Create the candidate and retrive its ID.
-         * Use form values when present, otherwise default to null.
-         */
-        $candID = \Candidate::createNew(
-            $values['psc'],
-            $values['dob1'],
-            $values['edc1'] ?? null,
-            $values['gender'],
-            $values['PSCID'] ?? null,
-            intval($values['ProjectID']) ?? null
-        );
-        /* Update front-end data. Use passed PSCID when present, otherwise
-         * retrieve it from the newly-created candidate.
-         */
-        $this->tpl_data['candID']  = $candID;
-        $this->tpl_data['PSCID']   = $values['PSCID']
-            ?? \Candidate::singleton($candID)->getPSCID();
-        $this->tpl_data['success'] = true;
-
-        // freeze it, just in case
-        $this->form->freeze();
     }
 
     /**

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -79,16 +79,28 @@ class Next_Stage extends \NDB_Form
         $timePoint->startStage($newStage);
 
         // set the date for the new stage
-        $timePoint->setData("Date_".$newStage, $values['date1']);
+        $timePoint->setData(
+            array(
+                "Date_".$newStage => $values['date1']
+            )
+        );
 
         // set SubprojectID if applicable
         if (isset($values['SubprojectID'])) {
-            $timePoint->setData('SubprojectID', $values['SubprojectID']);
+            $timePoint->setData(
+                array(
+                    'SubprojectID' => $values['SubprojectID']
+                )
+            );
         }
 
         // set scan done if applicable
         if (isset($values['scan_done'])) {
-            $timePoint->setData('Scan_done', $values['scan_done']);
+            $timePoint->setData(
+                array(
+                    'Scan_done' => $values['scan_done']
+                )
+            );
         }
 
         // create a new battery object && new battery

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -81,7 +81,7 @@ class Next_Stage extends \NDB_Form
         // set the date for the new stage
         $timePoint->setData(
             array(
-                "Date_".$newStage => $values['date1']
+             "Date_".$newStage => $values['date1'],
             )
         );
 
@@ -89,7 +89,7 @@ class Next_Stage extends \NDB_Form
         if (isset($values['SubprojectID'])) {
             $timePoint->setData(
                 array(
-                    'SubprojectID' => $values['SubprojectID']
+                 'SubprojectID' => $values['SubprojectID'],
                 )
             );
         }
@@ -98,7 +98,7 @@ class Next_Stage extends \NDB_Form
         if (isset($values['scan_done'])) {
             $timePoint->setData(
                 array(
-                    'Scan_done' => $values['scan_done']
+                 'Scan_done' => $values['scan_done'],
                 )
             );
         }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -376,33 +376,35 @@ class Candidate
      * Sets some data about the candidate and saves it into the
      * database.
      *
-     * @param mixed $var   Either a key-value pair passed as an array or just
-     *                          a key.
-     * @param mixed $value The value to be set to when $var is a string key.
+     * @param array $newData Key-value pair(s) of the field(s) to change and the
+     *                              new value(s).
      *
-     * @return true on success
+     * @return bool true
+     *
      * @throws DatabaseException
      * @note   This function is sometimes called as a key-value array and other
      * times with two separate key arguments. This should be refactored
      * to enforce one standard way of calling the function.
      */
-    public function setData($var, $value = null): bool
+    public function setData(array $newData): bool
     {
-        if (!is_array($var)) {
-            $setData = array($var => $value);
-        } else {
-            $setData = $var;
+        /* $newData should be in the form: array($key => $value). Count should
+         * equal 1 if this is the case.
+         */
+        if (empty($newData)) {
+            throw new LorisException(
+                'Candidate::setData() cannot be called with an empty array!'
+            );
+            return false;
         }
+        $this->candidateInfo = array_merge($this->candidateInfo, $newData);
 
-        $this->candidateInfo = array_merge($this->candidateInfo, $setData);
-
-        $factory = NDB_Factory::singleton();
-        $db      = $factory->database();
-
-        $db->update(
+        \Database::singleton()->update(
             'candidate',
-            $setData,
-            array('CandID' => $this->getData('CandID'))
+            $newData,
+            array(
+             'CandID' => $this->getData('CandID'),
+            )
         );
         return true;
     }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -397,7 +397,7 @@ class Candidate
         }
         $this->candidateInfo = array_merge($this->candidateInfo, $newData);
 
-        \Database::singleton()->update(
+        \NDB_Factory::singleton()->database()->update(
             'candidate',
             $newData,
             array(

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -379,12 +379,10 @@ class Candidate
      * @param array $newData Key-value pair(s) of the field(s) to change and the
      *                              new value(s).
      *
-     * @return bool true
+     * @return bool
      *
      * @throws DatabaseException
-     * @note   This function is sometimes called as a key-value array and other
-     * times with two separate key arguments. This should be refactored
-     * to enforce one standard way of calling the function.
+     * @throws LorisException
      */
     public function setData(array $newData): bool
     {

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -352,9 +352,10 @@ class TimePoint
      * @param array $newData Key-value pair(s) of the field(s) to change and its
      *                              new value(s).
      *
-     * @return bool true
+     * @return bool
      *
      * @throws DatabaseException
+     * @throws LorisException
      */
     public function setData(array $newData): bool
     {
@@ -375,6 +376,7 @@ class TimePoint
              'ID' => $this->getData('SessionID'),
             )
         );
+        return true;
     }
 
     /**

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -343,29 +343,39 @@ class TimePoint
 
     /**
      * Sets a piece of data for this timepoint and saves it to the session table.
+     * $newData should be in the form: array($key => $value).
      *
      * This should usually not be used directly but instead use one of the set*
      * methods below. However, there are cases where it may be easier to directly
      * use setData.
      *
-     * @param string      $var   The variable to set for this timepoint.
-     * @param string|null $value The value to set $var to.
+     * @param array $newData Key-value pair(s) of the field(s) to change and its
+     *                              new value(s).
      *
-     * @return void (side-effect modifies session table.)
+     * @return bool true
+     *
+     * @throws DatabaseException
      */
-    function setData($var, ?string $value = null): void
+    public function setData(array $newData): bool
     {
-        if (!is_array($var)) {
-            $setData = array($var => $value);
-        } else {
-            $setData = $var;
+        /* $newData should be in the form: array($key => $value). Count should
+         * equal 1 if this is the case.
+         */
+        if (empty($newData)) {
+            throw new LorisException(
+                'TimePoint::setData() cannot be called with an empty array!'
+            );
+            return false;
         }
+        $this->candidateInfo = array_merge($this->candidateInfo, $newData);
 
-        //$this->_timePointInfo = array_merge($this->_timePointInfo, $setData);
-
-        $db =& Database::singleton();
-        $db->update('session', $setData, array('ID' => $this->getData('SessionID')));
-        $this->select(intval($this->getData('SessionID')));
+        \Database::singleton()->update(
+            'session',
+            $newData,
+            array(
+             'ID' => $this->getData('SessionID'),
+            )
+        );
     }
 
     /**

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -367,7 +367,6 @@ class TimePoint
             );
             return false;
         }
-        $this->candidateInfo = array_merge($this->candidateInfo, $newData);
 
         \Database::singleton()->update(
             'session',

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -235,7 +235,13 @@ class CandidateTest extends TestCase
                 array('CandID' => $this->_candidateInfo['CandID'])
             );
 
-        $this->assertTrue($this->_candidate->setData('RegisteredBy', 'TestUser'));
+        $this->assertTrue(
+            $this->_candidate->setData(
+                array(
+                    'RegisteredBy' => 'TestUser'
+                )
+            )
+        );
         $this->assertEquals(
             $data['RegisteredBy'],
             $this->_candidate->getData('RegisteredBy')


### PR DESCRIPTION
### Brief summary of changes

Previously the setData() function in both of these classes accepted arrays or two separate strings. This prevents being able to use return types in these classes.

These functions were refactored to accept key-value arrays as they are occasionally called with multiple values to update. Calling functions are changed to use this new method of passing arguments.

### Related

* #4049 
* #4047 

### To test this change...

- [ ] Modify data in for Candidates and TimePoints. Everything should work as before.
