### PR TITLE
[Imaging Browser] Exclude DDE instruments from imaging browser instruments query

### DIFF
--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -77,7 +77,8 @@ class Imaging_Session_ControlPanel
             $qresult = $DB->pselectRow(
                 "SELECT f.CommentID, tn.Full_name FROM flag f
             JOIN test_names tn ON f.Test_name = tn.Test_name 
-            WHERE f.Test_name = :tname AND f.SessionID = :v_sessions_id",
+            WHERE f.Test_name = :tname AND f.SessionID = :v_sessions_id
+            AND f.CommentID NOT LIKE 'DDE_%'",
                 array(
                  'tname'         => $v,
                  'v_sessions_id' => $this->sessionID,


### PR DESCRIPTION
### Brief summary of changes
This query was throwing exceptions due to there being entries for both initial and double data entry using `pselectRow`
Fixed by excluding DDE entries


### This resolves issue...
#4068 

### To test this change...

- [x] make sure you have an instrument configured to be linked to in imaging browser, which is also enabled for DDE. should break when trying to access view_session of imaging_browser. check out my branch and you should be able to access it without getting an internal server error
