### PR TITLE
Update API summary header and qc too grep more info

### DIFF
--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -582,13 +582,22 @@ Returns file level QC information. It will return a JSON object of the form:
     },
     "QC" : "Pass|Fail",
     "Selected" : boolean,
-    "Caveats" : {
-      "Severity" : $severity,
-      "Header" : $header,
-      "Value" : $headerValue,
-      "ValidRange" : $headerValidRange,
-      "ValidRegex" : $headerValidRegex
-    }
+    "Caveats" : [
+        {
+            "Severity" : $severity,
+            "Header" : $header,
+            "Value" : $headerValue,
+            "ValidRange" : $headerValidRange,
+            "ValidRegex" : $headerValidRegex
+        },
+        {
+            "Severity" : $severity,
+            "Header" : $header,
+            "Value" : $headerValue,
+            "ValidRange" : $headerValidRange,
+            "ValidRegex" : $headerValidRegex
+        }
+    ]
 }
 ```
 

--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -581,7 +581,14 @@ Returns file level QC information. It will return a JSON object of the form:
         "File" : $Filename
     },
     "QC" : "Pass|Fail",
-    "Selected" : boolean
+    "Selected" : boolean,
+    "Caveats" : {
+      "Severity" : $severity,
+      "Header" : $header,
+      "Value" : $headerValue,
+      "ValidRange" : $headerValidRange,
+      "ValidRegex" : $headerValidRegex
+    }
 }
 ```
 
@@ -668,7 +675,7 @@ will return a JSON object of the form:
     "Description" : {
         "SeriesName" : "",
         "SeriesDescription"  : ""
-    }
+    },
     "Dimensions" : {
         "XSpace" : {
             "Length" : "",
@@ -686,6 +693,13 @@ will return a JSON object of the form:
             "Length" : "",
             "StepSize" : ""
         }
+    },
+    "ScannerInfo" : {
+      "Manufacturer" : $scannerManufacturer,
+      "Model" : $scannerModel,
+      "SoftwareVersion" : $scannerSoftwareVersion,
+      "SerialNumber" : $scannerSerialNumber,
+      "FieldStrength" : $scannerFieldStrength
     }
 }
 ```

--- a/htdocs/api/v0.0.2/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/qc/QC.php
@@ -64,9 +64,13 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $factory    = \NDB_Factory::singleton();
         $DB         = $factory->Database();
         $QCStatus   = $DB->pselectRow(
-            "SELECT QCStatus, Selected FROM files f
-                LEFT JOIN files_qcstatus fqc ON (f.FileID=fqc.FileID)
-                WHERE f.File LIKE CONCAT('%', :FName)",
+            "SELECT QCStatus, Selected 
+             FROM files_qcstatus
+             WHERE FileID in ( 
+                SELECT FileID
+                FROM files
+                WHERE File LIKE CONCAT('%', :FName)
+            )",
             array('FName' => $this->Filename)
         );
         $this->JSON = [

--- a/htdocs/api/v0.0.2/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/qc/QC.php
@@ -64,12 +64,8 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $factory    = \NDB_Factory::singleton();
         $DB         = $factory->Database();
         $QCStatus   = $DB->pselectRow(
-            "SELECT QCStatus, 
-                pf.Value as Selected FROM files f
+            "SELECT QCStatus, Selected FROM files f
                 LEFT JOIN files_qcstatus fqc ON (f.FileID=fqc.FileID)
-                LEFT JOIN parameter_file pf ON (f.FileID=pf.FileID)
-                LEFT JOIN parameter_type pt 
-                    ON (pf.ParameterTypeID=pt.ParameterTypeID AND pt.Name='Selected')
                 WHERE f.File LIKE CONCAT('%', :FName)",
             array('FName' => $this->Filename)
         );

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
@@ -86,6 +86,13 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                        "Length"   => $this->getHeader("time:length"),
                        "StepSize" => $this->getHeader("time:step"),
                       ];
+
+        $Manufacturer    = $this->getHeader("study:manufacturer");
+        $Model           = $this->getHeader("study:device_model");
+        $SoftwareVersion = $this->getHeader("study:software_version");
+        $SerialNumber    = $this->getHeader("study:serial_no");
+        $FieldStrength   = $this->getHeader("study:field_value");
+
         $this->JSON = [
                        'Meta'        => [
                                          'CandID'   => $this->CandID,
@@ -108,7 +115,13 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                                          "ZSpace"        => $ZSpace,
                                          "TimeDimension" => $TimeD,
                                         ],
-
+                       'ScannerInfo' => [
+                                         "Manufacturer"    => $Manufacturer,
+                                         "Model"           => $Model,
+                                         "SoftwareVersion" => $SoftwareVersion,
+                                         "SerialNumber"    => $SerialNumber,
+                                         "FieldStrength"   => $FieldStrength,
+                                        ],
                       ];
     }
 

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
@@ -70,22 +70,22 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $SeriesName        =  $this->getHeader("acquisition:protocol");
         $SeriesDescription = $this->getHeader("acquisition:series_description");
 
-        $XSpace     = [
-                       "Length"   => $this->getHeader("xspace:length"),
-                       "StepSize" => $this->getHeader("xspace:step"),
-                      ];
-        $YSpace     = [
-                       "Length"   => $this->getHeader("yspace:length"),
-                       "StepSize" => $this->getHeader("yspace:step"),
-                      ];
-        $ZSpace     = [
-                       "Length"   => $this->getHeader("zspace:length"),
-                       "StepSize" => $this->getHeader("zspace:step"),
-                      ];
-        $TimeD      = [
-                       "Length"   => $this->getHeader("time:length"),
-                       "StepSize" => $this->getHeader("time:step"),
-                      ];
+        $XSpace = [
+                   "Length"   => $this->getHeader("xspace:length"),
+                   "StepSize" => $this->getHeader("xspace:step"),
+                  ];
+        $YSpace = [
+                   "Length"   => $this->getHeader("yspace:length"),
+                   "StepSize" => $this->getHeader("yspace:step"),
+                  ];
+        $ZSpace = [
+                   "Length"   => $this->getHeader("zspace:length"),
+                   "StepSize" => $this->getHeader("zspace:step"),
+                  ];
+        $TimeD  = [
+                   "Length"   => $this->getHeader("time:length"),
+                   "StepSize" => $this->getHeader("time:step"),
+                  ];
 
         $manufacturer    = $this->getHeader("study:manufacturer");
         $model           = $this->getHeader("study:device_model");

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
@@ -62,27 +62,27 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
      */
     public function handleGET()
     {
-        $TE = $this->getHeader('acquisition:echo_time');
-        $TR = $this->getHeader('acquisition:repetition_time');
-        $TI = $this->getHeader('acquisition:inversion_time');
-        $ST = $this->getHeader('acquisition:slice_thickness');
+        $te = $this->getHeader('acquisition:echo_time');
+        $tr = $this->getHeader('acquisition:repetition_time');
+        $ti = $this->getHeader('acquisition:inversion_time');
+        $st = $this->getHeader('acquisition:slice_thickness');
 
-        $SeriesName        =  $this->getHeader("acquisition:protocol");
-        $SeriesDescription = $this->getHeader("acquisition:series_description");
+        $seriesName        =  $this->getHeader("acquisition:protocol");
+        $seriesDescription = $this->getHeader("acquisition:series_description");
 
-        $XSpace = [
+        $xspace = [
                    "Length"   => $this->getHeader("xspace:length"),
                    "StepSize" => $this->getHeader("xspace:step"),
                   ];
-        $YSpace = [
+        $yspace = [
                    "Length"   => $this->getHeader("yspace:length"),
                    "StepSize" => $this->getHeader("yspace:step"),
                   ];
-        $ZSpace = [
+        $zspace = [
                    "Length"   => $this->getHeader("zspace:length"),
                    "StepSize" => $this->getHeader("zspace:step"),
                   ];
-        $TimeD  = [
+        $timeD  = [
                    "Length"   => $this->getHeader("time:length"),
                    "StepSize" => $this->getHeader("time:step"),
                   ];
@@ -100,20 +100,20 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                                          'Filename' => $this->Filename,
                                         ],
                        'Physical'    => [
-                                         "TE"             => $TE,
-                                         "TR"             => $TR,
-                                         "TI"             => $TI,
-                                         "SliceThickness" => $ST,
+                                         "TE"             => $te,
+                                         "TR"             => $tr,
+                                         "TI"             => $ti,
+                                         "SliceThickness" => $st,
                                         ],
                        'Description' => [
-                                         "SeriesName"        => $SeriesName,
-                                         "SeriesDescription" => $SeriesDescription,
+                                         "SeriesName"        => $seriesName,
+                                         "SeriesDescription" => $seriesDescription,
                                         ],
                        'Dimensions'  => [
-                                         "XSpace"        => $XSpace,
-                                         "YSpace"        => $YSpace,
-                                         "ZSpace"        => $ZSpace,
-                                         "TimeDimension" => $TimeD,
+                                         "XSpace"        => $xspace,
+                                         "YSpace"        => $yspace,
+                                         "ZSpace"        => $zspace,
+                                         "TimeDimension" => $timeD,
                                         ],
                        'ScannerInfo' => [
                                          "Manufacturer"    => $manufacturer,

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
@@ -87,11 +87,11 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                        "StepSize" => $this->getHeader("time:step"),
                       ];
 
-        $Manufacturer    = $this->getHeader("study:manufacturer");
-        $Model           = $this->getHeader("study:device_model");
-        $SoftwareVersion = $this->getHeader("study:software_version");
-        $SerialNumber    = $this->getHeader("study:serial_no");
-        $FieldStrength   = $this->getHeader("study:field_value");
+        $manufacturer    = $this->getHeader("study:manufacturer");
+        $model           = $this->getHeader("study:device_model");
+        $softwareVersion = $this->getHeader("study:software_version");
+        $serialNumber    = $this->getHeader("study:serial_no");
+        $fieldStrength   = $this->getHeader("study:field_value");
 
         $this->JSON = [
                        'Meta'        => [
@@ -116,11 +116,11 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                                          "TimeDimension" => $TimeD,
                                         ],
                        'ScannerInfo' => [
-                                         "Manufacturer"    => $Manufacturer,
-                                         "Model"           => $Model,
-                                         "SoftwareVersion" => $SoftwareVersion,
-                                         "SerialNumber"    => $SerialNumber,
-                                         "FieldStrength"   => $FieldStrength,
+                                         "Manufacturer"    => $manufacturer,
+                                         "Model"           => $model,
+                                         "SoftwareVersion" => $softwareVersion,
+                                         "SerialNumber"    => $serialNumber,
+                                         "FieldStrength"   => $fieldStrength,
                                         ],
                       ];
     }

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/headers/Headers.php
@@ -70,22 +70,22 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $seriesName        =  $this->getHeader("acquisition:protocol");
         $seriesDescription = $this->getHeader("acquisition:series_description");
 
-        $xspace = [
+        $xspace = array(
                    "Length"   => $this->getHeader("xspace:length"),
                    "StepSize" => $this->getHeader("xspace:step"),
-                  ];
-        $yspace = [
+                  );
+        $yspace = array(
                    "Length"   => $this->getHeader("yspace:length"),
                    "StepSize" => $this->getHeader("yspace:step"),
-                  ];
-        $zspace = [
+                  );
+        $zspace = array(
                    "Length"   => $this->getHeader("zspace:length"),
                    "StepSize" => $this->getHeader("zspace:step"),
-                  ];
-        $timeD  = [
+                  );
+        $timeD  = array(
                    "Length"   => $this->getHeader("time:length"),
                    "StepSize" => $this->getHeader("time:step"),
-                  ];
+                  );
 
         $manufacturer    = $this->getHeader("study:manufacturer");
         $model           = $this->getHeader("study:device_model");
@@ -93,36 +93,36 @@ class Headers extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $serialNumber    = $this->getHeader("study:serial_no");
         $fieldStrength   = $this->getHeader("study:field_value");
 
-        $this->JSON = [
-                       'Meta'        => [
+        $this->JSON = array(
+                       'Meta'        => array(
                                          'CandID'   => $this->CandID,
                                          'Visit'    => $this->VisitLabel,
                                          'Filename' => $this->Filename,
-                                        ],
-                       'Physical'    => [
+                                        ),
+                       'Physical'    => array(
                                          "TE"             => $te,
                                          "TR"             => $tr,
                                          "TI"             => $ti,
                                          "SliceThickness" => $st,
-                                        ],
-                       'Description' => [
+                                        ),
+                       'Description' => array(
                                          "SeriesName"        => $seriesName,
                                          "SeriesDescription" => $seriesDescription,
-                                        ],
-                       'Dimensions'  => [
+                                        ),
+                       'Dimensions'  => array(
                                          "XSpace"        => $xspace,
                                          "YSpace"        => $yspace,
                                          "ZSpace"        => $zspace,
                                          "TimeDimension" => $timeD,
-                                        ],
-                       'ScannerInfo' => [
+                                        ),
+                       'ScannerInfo' => array(
                                          "Manufacturer"    => $manufacturer,
                                          "Model"           => $model,
                                          "SoftwareVersion" => $softwareVersion,
                                          "SerialNumber"    => $serialNumber,
                                          "FieldStrength"   => $fieldStrength,
-                                        ],
-                      ];
+                                        ),
+                      );
     }
 
     /**

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
@@ -69,7 +69,7 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                 WHERE f.File LIKE CONCAT('%', :FName)",
             array('FName' => $this->Filename)
         );
-        $Caveats = $this->getImageCaveats();
+        $Caveats    = $this->getImageCaveats();
         $this->JSON = [
                        'Meta'     => [
                                       'CandID' => $this->CandID,

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
@@ -89,7 +89,7 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
     /**
      * Gets the list of Caveats for the file.
      *
-     * @return an array with list of caveats for the file
+     * @return array A list of caveats for the file
      */
     function getImageCaveats(): array
     {

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
@@ -64,12 +64,16 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
         $factory    = \NDB_Factory::singleton();
         $DB         = $factory->Database();
         $QCStatus   = $DB->pselectRow(
-            "SELECT QCStatus, Selected FROM files f
-                LEFT JOIN files_qcstatus fqc ON (f.FileID=fqc.FileID)
-                WHERE f.File LIKE CONCAT('%', :FName)",
+            "SELECT QCStatus, Selected 
+             FROM files_qcstatus
+             WHERE FileID in (
+                SELECT FileID
+                FROM files
+                WHERE File LIKE CONCAT('%', :FName)
+            )",
             array('FName' => $this->Filename)
         );
-        $Caveats    = $this->getImageCaveats();
+        $caveats    = $this->getImageCaveats();
         $this->JSON = [
                        'Meta'     => [
                                       'CandID' => $this->CandID,
@@ -78,7 +82,7 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
                                      ],
                        'QC'       => $QCStatus['QCStatus'],
                        'Selected' => $QCStatus['Selected'],
-                       'Caveats'  => $Caveats,
+                       'Caveats'  => $caveats,
                       ];
     }
 

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/qc/QC.php
@@ -74,16 +74,16 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
             array('FName' => $this->Filename)
         );
         $caveats    = $this->getImageCaveats();
-        $this->JSON = [
-                       'Meta'     => [
+        $this->JSON = array(
+                       'Meta'     => array(
                                       'CandID' => $this->CandID,
                                       'Visit'  => $this->VisitLabel,
                                       'File'   => $this->Filename,
-                                     ],
+                                     ),
                        'QC'       => $QCStatus['QCStatus'],
                        'Selected' => $QCStatus['Selected'],
                        'Caveats'  => $caveats,
-                      ];
+                      );
     }
 
     /**
@@ -91,7 +91,7 @@ class QC extends \Loris\API\Candidates\Candidate\Visit\Imaging\Image
      *
      * @return an array with list of caveats for the file
      */
-    function getImageCaveats()
+    function getImageCaveats(): array
     {
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->Database();


### PR DESCRIPTION
### Brief summary of changes

**Updates to the API v.0.0.3 on the imaging side:**
- Addition of scanner information to the summary header of the API for a given filename (manufacturer, model, software version, serial number)
- Addition of the image Caveat flag with the reason for the Caveat flag in the file qc page of the API

**Fix to API v0.0.2 on the imaging side:**
- The selected were not queried at the right place. The selected has been part of the files_qcstatus for several LORIS releases so updated the API queries so we can grep the Selected flag (before it returned some hash, now it returns True or False)

### This resolves issue...

Did not take the time to create an issue for that. Needed for the phantom VM so I figured I would issue a PR to the LORIS repo at the same time :).

### To test this change...

You need imaging data to test this

- [ ] test $API/candidates/$CandID/$VisitLabel/images/$filename/headers (should see ScannerInfo now in addition to everything else that was already in the JSON)
- [ ] test $API/candidates/$CandID/$VisitLabel/images/$filename/qc (make sure the selected value is properly displayed with this PR and that Caveats is added to the JSON)

# If this sentence shows up it means I didn't read the instructions!

Yes I read it ;)