### PR TITLE
[Core: Client] Add SameSite flag to session cookie to prevent CSRF

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -132,40 +132,20 @@ class NDB_Client
             . $config_additions
         );
         // start php session
+        $sessionOptions = array('cookie_httponly' => true);
+        // TODO remove this if statement when 7.3 is the minimum required LORIS
+        // version. All session from then onward should have Same Site enabled.
         if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
-            session_start(
-                array(
-                 'cookie_httponly' => true,
-                 'cookie_samesite' => true,
-                )
-            );
-        } else {
-            // TODO Remove this branch when 7.3 is the minimum required
-            // version for LORIS.
-            session_start(
-                array('cookie_httponly' => true)
-            );
-        }
+            $sessionOptions['cookie_samesite'] = true;
+        } 
 
+        session_start($sessionOptions);
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {
             session_destroy();
             header("HTTP/1.1 303 See Other");
             header("Location: /");
-            if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
-                session_start(
-                    array(
-                     'cookie_httponly' => true,
-                     'cookie_samesite' => true,
-                    )
-                );
-            } else {
-                // TODO Remove this branch when 7.3 is the minimum required
-                // version for LORIS.
-                session_start(
-                    array('cookie_httponly' => true)
-                );
-            }
+            session_start($sessionOptions);
         }
 
         /**

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -134,8 +134,8 @@ class NDB_Client
         // start php session
         session_start(
             array(
-                'cookie_httponly' => true,
-                'cookie_samesite' => true,
+             'cookie_httponly' => true,
+             'cookie_samesite' => true,
             )
         );
 
@@ -146,8 +146,8 @@ class NDB_Client
             header("Location: /");
             session_start(
                 array(
-                    'cookie_httponly' => true,
-                    'cookie_samesite' => true,
+                 'cookie_httponly' => true,
+                 'cookie_samesite' => true,
                 )
             );
         }

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -166,12 +166,6 @@ class NDB_Client
                     array('cookie_httponly' => true)
                 );
             }
-            session_start(
-                array(
-                 'cookie_httponly' => true,
-                 'cookie_samesite' => true,
-                )
-            );
         }
 
         /**

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -133,7 +133,10 @@ class NDB_Client
         );
         // start php session
         session_start(
-            ['cookie_httponly' => true]
+            array(
+                'cookie_httponly' => true,
+                'cookie_samesite' => true,
+            )
         );
 
         // if exiting, destroy the php session
@@ -142,7 +145,10 @@ class NDB_Client
             header("HTTP/1.1 303 See Other");
             header("Location: /");
             session_start(
-                ['cookie_httponly' => true]
+                array(
+                    'cookie_httponly' => true,
+                    'cookie_samesite' => true,
+                )
             );
         }
 

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -132,18 +132,40 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        session_start(
-            array(
-             'cookie_httponly' => true,
-             'cookie_samesite' => true,
-            )
-        );
+        if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
+            session_start(
+                array(
+                 'cookie_httponly' => true,
+                 'cookie_samesite' => true,
+                )
+            );
+        } else {
+            // TODO Remove this branch when 7.3 is the minimum required
+            // version for LORIS.
+            session_start(
+                array('cookie_httponly' => true)
+            );
+        }
 
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {
             session_destroy();
             header("HTTP/1.1 303 See Other");
             header("Location: /");
+            if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
+                session_start(
+                    array(
+                     'cookie_httponly' => true,
+                     'cookie_samesite' => true,
+                    )
+                );
+            } else {
+                // TODO Remove this branch when 7.3 is the minimum required
+                // version for LORIS.
+                session_start(
+                    array('cookie_httponly' => true)
+                );
+            }
             session_start(
                 array(
                  'cookie_httponly' => true,

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -137,7 +137,7 @@ class NDB_Client
         // version. All session from then onward should have Same Site enabled.
         if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
             $sessionOptions['cookie_samesite'] = true;
-        } 
+        }
 
         session_start($sessionOptions);
         // if exiting, destroy the php session


### PR DESCRIPTION
### Brief summary of changes

As of PHP 7.3 we can now use the SameSite flag on the session cookie to totally prevent CSRF attacks. This approach will be taken instead of ad-hoc implementation.

This PR will be marked as `Blocked` until we require 7.3 as the minimum PHP version. Travis is expected to fail for the 7.2 environment.

### This resolves issue...

- [x] Github? #3869 
