### PR TITLE
[MediaUpload] Restrict file upload to candidate who has visited user's site

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -212,7 +212,7 @@ function getUploadFields()
         $candquery    .= " WHERE FIND_IN_SET(s.CenterID, :cid) ORDER BY PSCID";
         $qparam['cid'] = implode(",", $user->getCenterIDs());
     } else {
-        $candquery    .= " ORDER BY PSCID";
+        $candquery .= " ORDER BY PSCID";
     }
     $candidates = $db->pselect(
         $candquery,


### PR DESCRIPTION
### Brief summary of changes

Users may only upload files to a candidate for a visit label at a site that the user belongs to.

This PR:
- replaces #3697, which I will be closing. this PR should include all important changes from the old PR
- cleans up #3697 by removing unnecessary changes
- removes $candIdList query and variable because it's not ever used

**Note: Media module should be refactored to have a real LORIS endpoint i.e. remove ajax. this is out of the scope of this PR. changes made here should only be sufficient to address the permission issue.**

### This resolves issue...
- [x] Redmine? https://redmine.cbrain.mcgill.ca/issues/11681

### To test this change...
1. On superuser/all sites account, go to Media module 'Upload' tab. 'PSCID' select element should have all candidates.
2. On non-superuser account,
- assign a set of (not all) sites
- uncheck `Across all sites access candidate profiles`
- check both `Media files` permissions. 'PSCID' select element should only have candidates that have a visit label at a site the user belongs to.