### PR TITLE
[SQL] Add 'path' and 'web_path' data types to ConfigSettings

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -17,7 +17,7 @@ CREATE TABLE `ConfigSettings` (
     `Description` varchar(255) DEFAULT NULL,
     `Visible` tinyint(1) DEFAULT '0',
     `AllowMultiple` tinyint(1) DEFAULT '0',
-    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type', 'lookup_center') DEFAULT NULL,
+    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type', 'lookup_center', 'path', 'web_path') DEFAULT NULL,
     `Parent` int(11) DEFAULT NULL,
     `Label` varchar(255) DEFAULT NULL,
     `OrderNumber` int(11) DEFAULT NULL,

--- a/SQL/New_patches/2018-11-13_add_path_to_config_enum.sql
+++ b/SQL/New_patches/2018-11-13_add_path_to_config_enum.sql
@@ -4,5 +4,5 @@
 -- will be validated when configured from the front-end and will throw errors
 -- if not reachable by the server.
 ALTER TABLE ConfigSettings MODIFY COLUMN DataType enum('text','boolean','email','instrument','textarea','scan_type','lookup_center','path','web_path');
-UPDATE ConfigSettings SET DataType='web_path' where Name IN ('imagePath', 'base', 'data', 'extLibs', 'mincPath', 'DownloadPath', 'IncomingPath', 'MRICodePath', 'MRIUploadIncomingPath', 'GenomicDataPath', 'mediaPath');
-UPDATE ConfigSettings SET DataType='path' WHERE Name='log';
+UPDATE ConfigSettings SET DataType='web_path' where Name IN ('imagePath', 'base', 'data', 'extLibs', 'mincPath', 'DownloadPath', 'IncomingPath', 'MRICodePath', 'MRIUploadIncomingPath', 'GenomicDataPath', 'mediaPath', 'dataDirBasepath');
+UPDATE ConfigSettings SET DataType='path' WHERE Name IN ('log', 'MRICodePath', 'tarchiveLibraryDir', 'get_dicom_info', 'niak_path');

--- a/SQL/New_patches/2018-11-13_add_path_to_config_enum.sql
+++ b/SQL/New_patches/2018-11-13_add_path_to_config_enum.sql
@@ -1,0 +1,8 @@
+-- Add 'path' and 'web_path' to DataType enum. The first should represent an 
+-- arbitrary path used in LORIS. 'web_path' should represent a full path
+-- that is reachable by the web-server i.e. Apache. Paths of type 'web_path'
+-- will be validated when configured from the front-end and will throw errors
+-- if not reachable by the server.
+ALTER TABLE ConfigSettings MODIFY COLUMN DataType enum('text','boolean','email','instrument','textarea','scan_type','lookup_center','path','web_path');
+UPDATE ConfigSettings SET DataType='web_path' where Parent=24;
+UPDATE ConfigSettings SET DataType='path' WHERE Name='log';

--- a/SQL/New_patches/2018-11-13_add_path_to_config_enum.sql
+++ b/SQL/New_patches/2018-11-13_add_path_to_config_enum.sql
@@ -4,5 +4,5 @@
 -- will be validated when configured from the front-end and will throw errors
 -- if not reachable by the server.
 ALTER TABLE ConfigSettings MODIFY COLUMN DataType enum('text','boolean','email','instrument','textarea','scan_type','lookup_center','path','web_path');
-UPDATE ConfigSettings SET DataType='web_path' where Parent=24;
+UPDATE ConfigSettings SET DataType='web_path' where Name IN ('imagePath', 'base', 'data', 'extLibs', 'mincPath', 'DownloadPath', 'IncomingPath', 'MRICodePath', 'MRIUploadIncomingPath', 'GenomicDataPath', 'mediaPath');
 UPDATE ConfigSettings SET DataType='path' WHERE Name='log';


### PR DESCRIPTION
### Brief summary of changes

To fix a [bug](https://github.com/aces/Loris/pull/4023 ) in the configuration module @driusan suggested that these data types be added in the back-end. This way when their values are being changed we know what should be validated as a full apache-reachable path on the filesystem.
