### PR TITLE
Fix api redirects and bugs

### DIFF
--- a/htdocs/api/v0.0.2/.htaccess
+++ b/htdocs/api/v0.0.2/.htaccess
@@ -14,7 +14,7 @@ RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/candidates(/*)$ projects/Project.php?
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php?Project=$1&Instruments=true&PrintProjectJSON=true&InstrumentDetails=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
-RewriteRule ^projects(/*)$ Projects.php?PrintProjects=true [L]
+RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.2/projects/ [QSA,END]
 
 # Candidates API rewrite rules
 

--- a/htdocs/api/v0.0.2/.htaccess
+++ b/htdocs/api/v0.0.2/.htaccess
@@ -38,3 +38,6 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/header
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/headers/full$ candidates/visits/images/headers/Full.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintHeadersFull=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/headers/(.*)$ candidates/visits/images/headers/Specific.php?CandID=$1&VisitLabel=$2&Filename=$3&Header=$4&PrintSpecificHeader=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)$ candidates/visits/images/Image.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageData=true [L]
+
+# New module enpoints
+RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.2/login/ [QSA,END]

--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -15,7 +15,7 @@ RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/images(/*)$ projects/Images.php?project_name=$1 [QSA,L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
-RewriteRule ^projects(/*)$ Projects.php?PrintProjects=true [L]
+RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.3-dev/projects/ [QSA,END]
 
 # Candidates API rewrite rules
 

--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -43,3 +43,6 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)$ cand
 ## DICOMs API related URLs
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/dicoms$ candidates/visits/Dicoms.php?CandID=$1&VisitLabel=$2&PrintDicoms=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/dicoms/([a-zA-Z0-9_.-]+)$ candidates/visits/dicoms/Dicom.php?CandID=$1&VisitLabel=$2&Tarname=$3&PrintDicomData=true [L]
+
+# New module enpoints
+RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.3-dev/login/ [QSA,END]

--- a/modules/api/php/apiendpoint.class.inc
+++ b/modules/api/php/apiendpoint.class.inc
@@ -67,7 +67,9 @@ abstract class APIEndpoint extends \NDB_Page
             return (new \LORIS\Http\Response())
                 ->withBody(
                     new \LORIS\Http\StringStream(
-                        json_encode("error", "Unsupported HTTP Method")
+                        json_encode(
+                            array("error" => "Unsupported HTTP Method")
+                        )
                     )
                 )->withHeader("Allow", join(",", $methods))
                 ->withStatus(405);
@@ -81,7 +83,7 @@ abstract class APIEndpoint extends \NDB_Page
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode(
-                            array("error" => "Unsupported LORIS API version.")
+                            array("error" => "Unsupported LORIS API version")
                         )
                     )
                 )

--- a/modules/api/php/projects.class.inc
+++ b/modules/api/php/projects.class.inc
@@ -89,9 +89,9 @@ class Projects extends APIEndpoint implements \LORIS\Middleware\ETagCalculator
         case "projects":
         case "projects/":
             $projects = $this->_getProjectList();
-            return (new \LORIS\HTTP\Response())
+            return (new \LORIS\Http\Response())
                 ->withHeader("Content-Type", "application/json")
-                ->withBody(new \LORIS\HTTP\StringStream(json_encode($projects)));
+                ->withBody(new \LORIS\Http\StringStream(json_encode($projects)));
         // FIXME: Delegate to other endpoints under /projects/ for other paths.
         default:
             return (new \LORIS\Http\Response())


### PR DESCRIPTION
### Brief summary of changes

Now redirect `/login` and `/projects` to the `module/api` endpoints


### This resolves issue...

- [x] It was impossible to get an api token on a loris instance runing on apache
- [x] The module/api/projects class could not find `\LORIS\HTTP\Response` class du to capitalisation of `TTP`.
- [x] The login enpoint error for Unsuported method was throing an error du to json_encode expecting an array but receiving two strings.

### To test this change...
send a the following curl request:
```
curl -k https://<your-vm-hostname>/api/v0.0.3-dev/login -d '{"username": "your-username", "password": "your-password"}'
#put the string token from the response in a token variable
curl -k -H "Authorization: Bearer $token" https://<your-vm-hostname>/api/v0.0.3-dev/projects/
curl -k -H "Authorization: Bearer $token" https://<your-vm-hostname>/api/v0.0.2/projects/
```
Note that the `-k` option is used only if your vm ssl certificat is not up to date.

# If this sentence shows up it means I didn't read the instructions! Not!
