### PR TITLE
Add create-project script

### DIFF
--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Creates a stub LORIS project directory at the location passed as the first argument
+for d in data libraries instruments templates tables_sql modules; do
+    mkdir -p "${1}/${d}"
+done
+

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -139,8 +139,9 @@ if [ -f ../project/config.xml ]; then
 fi
 
 # Create some subdirectories, if needed.
-mkdir -p ../project ../project/data ../project/libraries ../project/instruments ../project/templates ../project/tables_sql ../project/modules ../smarty/templates_c
+create-project.sh ../project
 
+mkdir -p ../smarty/templates_c
 # Setting 770 permissions for templates_c
 chmod 770 ../smarty/templates_c
 


### PR DESCRIPTION
This extracts the create-project.sh script from PR #1965

I've removed the bits about smarty, since they don't belong in the
project directory.

I'm sending this to major even though it's relatively minor because it's step 1 of trying to bring the debian packaging PR up to date.

To test this: try the install.sh script and ensure it still installs LORIS correctly.