### PR TITLE
[JS/Config] Remove unnecessary eslint config from htdocs directory

### DIFF
--- a/htdocs/js/.eslintrc.json
+++ b/htdocs/js/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "parserOptions": {
-    "sourceType": "script"
-  }
-}


### PR DESCRIPTION
This removes an .eslint file that was in the htdocs directory for
some unknown reason.

It doesn't touch the main eslint file in the root directory.

(lintian was complaining about it while trying to build a debian package,
but besides that I don't know why it's there overriding the default.)