### PR TITLE
[data_release] Saving a duplicate permission will cause an error. 

### DIFF
--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -14,7 +14,7 @@
 
 $factory  = \NDB_Factory::singleton();
 $settings = $factory->settings();
-$DB = $factory->database();
+$DB       = $factory->database();
 if ($_POST['action'] == 'addpermission') {
     $userid          = $_POST['userid'];
     $data_release_id = $_POST['data_release_id'];
@@ -29,9 +29,9 @@ if ($_POST['action'] == 'addpermission') {
             )
         );
 
-        $baseURL  = $settings->getBaseURL();
+        $baseURL = $settings->getBaseURL();
         if ($result != '1') {
-            $success  = $DB->insert(
+            $success = $DB->insert(
                 'data_release_permissions',
                 array(
                  'userid'          => $userid,
@@ -53,7 +53,8 @@ if ($_POST['action'] == 'addpermission') {
             );
 
             header(
-                "Location:{$baseURL}/data_release/?addpermissionSuccess=false&user={$username}&file={$file}"
+                "Location:{$baseURL}/data_release/".
+                "?addpermissionSuccess=false&user={$username}&file={$file}"
             );
         }
 

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -12,39 +12,49 @@
  *  @link     https://github.com/aces/Loris
  */
 
-$DB =& Database::singleton();
+$DB = \Database::singleton();
 if ($_POST['action'] == 'addpermission') {
     $userid          = $_POST['userid'];
     $data_release_id = $_POST['data_release_id'];
 
         $result = $DB->pselectOne(
-            "SELECT COUNT(*) FROM data_release_permissions WHERE userid = :userid and data_release_id = :data_release_id",
-            array('userid' => $data_release_id,'data_release_id' => $data_release_id)
+            "SELECT COUNT(*) FROM data_release_permissions
+             WHERE userid = :userid and
+             data_release_id = :data_release_id",
+            array(
+             'userid'          => $data_release_id,
+             'data_release_id' => $data_release_id,
+            )
         );
 
-    $factory  = NDB_Factory::singleton();
-    $settings = $factory->settings();
-    $baseURL = $settings->getBaseURL();
-    if ($result != '1'){
-    $success         = $DB->insert(
-        'data_release_permissions',
-        array(
-         'userid'          => $userid,
-         'data_release_id' => $data_release_id,
-        )
-    );
-    $factory  = NDB_Factory::singleton();
-    $settings = $factory->settings();
+        $factory  = \NDB_Factory::singleton();
+        $settings = $factory->settings();
+        $baseURL  = $settings->getBaseURL();
+        if ($result != '1') {
+            $success  = $DB->insert(
+                'data_release_permissions',
+                array(
+                 'userid'          => $userid,
+                 'data_release_id' => $data_release_id,
+                )
+            );
+            $factory  = NDB_Factory::singleton();
+            $settings = $factory->settings();
 
-    header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
-    } else {
-    // return username and file with permisson.
+            header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
+        } else {
+            // return username and file with permisson.
             $file = $DB->pselectOne(
-            "SELECT file_name FROM data_release WHERE id = :data_release_id",
-            array('data_release_id' => $data_release_id)
-        );
-    header("Location: {$baseURL}/data_release/?addpermissionSuccess=false&user=&file={$file}");
-    }
+                "SELECT file_name FROM data_release WHERE id = :data_release_id",
+                array('data_release_id' => $data_release_id)
+            );
+            header(
+                "
+            Location:
+            {$baseURL}/data_release/?addpermissionSuccess=false&user=&file={$file}
+            "
+            );
+        }
 
 
 } else {

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -12,7 +12,9 @@
  *  @link     https://github.com/aces/Loris
  */
 
-$DB = \Database::singleton();
+$factory  = \NDB_Factory::singleton();
+$settings = $factory->settings();
+$DB = $factory->database();
 if ($_POST['action'] == 'addpermission') {
     $userid          = $_POST['userid'];
     $data_release_id = $_POST['data_release_id'];
@@ -22,13 +24,11 @@ if ($_POST['action'] == 'addpermission') {
              WHERE userid = :userid and
              data_release_id = :data_release_id",
             array(
-             'userid'          => $data_release_id,
+             'userid'          => $userid,
              'data_release_id' => $data_release_id,
             )
         );
 
-        $factory  = \NDB_Factory::singleton();
-        $settings = $factory->settings();
         $baseURL  = $settings->getBaseURL();
         if ($result != '1') {
             $success  = $DB->insert(
@@ -38,8 +38,6 @@ if ($_POST['action'] == 'addpermission') {
                  'data_release_id' => $data_release_id,
                 )
             );
-            $factory  = NDB_Factory::singleton();
-            $settings = $factory->settings();
 
             header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
         } else {
@@ -48,11 +46,14 @@ if ($_POST['action'] == 'addpermission') {
                 "SELECT file_name FROM data_release WHERE id = :data_release_id",
                 array('data_release_id' => $data_release_id)
             );
+            //add username
+            $username = $DB->pselectOne(
+                "SELECT userid FROM users WHERE id = :id",
+                array('id' => $userid)
+            );
+
             header(
-                "
-            Location:
-            {$baseURL}/data_release/?addpermissionSuccess=false&user=&file={$file}
-            "
+                "Location:{$baseURL}/data_release/?addpermissionSuccess=false&user={$username}&file={$file}"
             );
         }
 

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -13,10 +13,19 @@
  */
 
 $DB =& Database::singleton();
-
 if ($_POST['action'] == 'addpermission') {
     $userid          = $_POST['userid'];
     $data_release_id = $_POST['data_release_id'];
+
+        $result = $DB->pselectOne(
+            "SELECT COUNT(*) FROM data_release_permissions WHERE userid = :userid and data_release_id = :data_release_id",
+            array('userid' => $data_release_id,'data_release_id' => $data_release_id)
+        );
+
+    $factory  = NDB_Factory::singleton();
+    $settings = $factory->settings();
+    $baseURL = $settings->getBaseURL();
+    if ($result != '1'){
     $success         = $DB->insert(
         'data_release_permissions',
         array(
@@ -24,13 +33,20 @@ if ($_POST['action'] == 'addpermission') {
          'data_release_id' => $data_release_id,
         )
     );
-
     $factory  = NDB_Factory::singleton();
     $settings = $factory->settings();
 
-    $baseURL = $settings->getBaseURL();
-
     header("Location: {$baseURL}/data_release/?addpermissionSuccess=true");
+    } else {
+    // return username and file with permisson.
+            $file = $DB->pselectOne(
+            "SELECT file_name FROM data_release WHERE id = :data_release_id",
+            array('data_release_id' => $data_release_id)
+        );
+    header("Location: {$baseURL}/data_release/?addpermissionSuccess=false&user=&file={$file}");
+    }
+
+
 } else {
     header("HTTP/1.1 400 Bad Request");
     echo "There was an error adding permissions";

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -104,9 +104,12 @@ class Data_Release extends \NDB_Menu_Filter
         $this->tpl_data['superuser']        = $superuser;
         $this->tpl_data['userids']          = $userids;
         $this->tpl_data['data_release_ids'] = $data_release_ids;
-        if (isset($_GET['addpermissionSuccess']) && $_GET['addpermissionSuccess'] == "false") {
-        $this->tpl_data['err']          = "This user already has the permisson for ".$_GET['file'].".";
-        // todo add username
+        if (isset($_GET['addpermissionSuccess'])
+            && $_GET['addpermissionSuccess'] == "false"
+        ) {
+            $this->tpl_data['err'] = "This user already has the permisson for "
+                                     .$_GET['file'].".";
+            // todo add username
         }
 
     }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -107,7 +107,7 @@ class Data_Release extends \NDB_Menu_Filter
         if (isset($_GET['addpermissionSuccess'])
             && $_GET['addpermissionSuccess'] == "false"
         ) {
-            $this->tpl_data['err'] = "This user already has the permisson for "
+            $this->tpl_data['err'] = $_GET['user']." already has the permisson for "
                                      .$_GET['file'].".";
         }
 

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -107,8 +107,10 @@ class Data_Release extends \NDB_Menu_Filter
         if (isset($_GET['addpermissionSuccess'])
             && $_GET['addpermissionSuccess'] == "false"
         ) {
-            $this->tpl_data['err'] = $_GET['user']." already has the permisson for "
-                                     .$_GET['file'].".";
+            $user = strip_tags(trim($_GET['user']));
+            $file = strip_tags(trim($_GET['file']));
+            $this->tpl_data['err'] = $user." already has the permisson for "
+                                     .$file.".";
         }
 
     }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -109,7 +109,6 @@ class Data_Release extends \NDB_Menu_Filter
         ) {
             $this->tpl_data['err'] = "This user already has the permisson for "
                                      .$_GET['file'].".";
-            // todo add username
         }
 
     }

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -104,6 +104,10 @@ class Data_Release extends \NDB_Menu_Filter
         $this->tpl_data['superuser']        = $superuser;
         $this->tpl_data['userids']          = $userids;
         $this->tpl_data['data_release_ids'] = $data_release_ids;
+        if (isset($_GET['addpermissionSuccess']) && $_GET['addpermissionSuccess'] == "false") {
+        $this->tpl_data['err']          = "This user already has the permisson for ".$_GET['file'].".";
+        // todo add username
+        }
 
     }
 

--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -1,3 +1,6 @@
+{if $err}
+  <label class="error col-sm-12">{$err}</label>
+{/if}
 {if $superuser}
 
 <button type="button" name = "upload" class = "btn btn-sm btn-primary" data-toggle="modal" data-target="#fileUploadModal">Upload File</button>
@@ -54,7 +57,6 @@
                             <label class="col-xs-4" for="userid">User ID</label>
                             <div class="col-xs-8">
                                 <select name="userid" id = "userid" class = "form-fields form-control input-sm">
-                                <option value=""> </option>
                                     {foreach from = $userids item=val key=k}
                                         <option value={$k}>{$val}</option>
                                     {/foreach}
@@ -65,7 +67,6 @@
                             <label class="col-xs-4" for="data_release_id">Data Release ID</label>
                             <div class="col-xs-8">
                                 <select name="data_release_id" id = "data_release_id" class = "form-fields form-control input-sm">
-                                <option value=""> </option>
                                     {foreach from = $data_release_ids item=val key=k}
                                         <option value={$k}>{$val}</option>
                                     {/foreach}


### PR DESCRIPTION
### Brief summary of changes
Saving a duplicate permission will cause an error in data_release.
Do a database check first, then insert an error message on the front_end.

### This resolves issue...
Can't save a duplicate permission and cause an error.

### To test this change...
Add a permission twice.


