### PR TITLE
[Core: User] getSiteNames now returns array instead of a string

### DIFF
--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -37,7 +37,7 @@ class Dashboard extends \NDB_Form
         $DB     = \Database::singleton();
         $user   = \User::singleton();
         $config = \NDB_Config::singleton();
-        $site   = explode(';', $user->getSiteNames());
+        $site   = $user->getSiteNames();
 
         $userID     = $user->getUsername();
         $last_login = $DB->pselectOne(

--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -30,8 +30,8 @@ class AnonymousUser extends \User
      *
      * @return string The empty string
      */
-    public function getSiteNames() : string
+    public function getSiteNames() : array
     {
-        return "";
+        return array();
     }
 }

--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -28,7 +28,7 @@ class AnonymousUser extends \User
     /**
      * An anonymous user is not a member of any site.
      *
-     * @return string The empty string
+     * @return array The empty string
      */
     public function getSiteNames() : array
     {

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -39,13 +39,6 @@ class NDB_Config
     var $_settings = array();
 
     /**
-     * The merged array of study and site-specific settings
-     *
-     * @access private
-     */
-    var $_siteSettings = array();
-
-    /**
      * An optional override for the location of the config file.
      * (default is ../project/config.xml)
      *

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -239,43 +239,6 @@ class NDB_Config
     }
 
     /**
-     * Attempts to determine the site of the user currently logged in and uses
-     * that to get site specific settings and override study defaults,
-     * building the _siteSettings property
-     *
-     * @return void (but modifies $this->siteSettings)
-     */
-    function mergeSettings()
-    {
-        // make sure this is a web client
-        if (!class_exists("User") || !isset($_SESSION['State'])) {
-            return;
-        }
-
-        // make sure a user has logged in
-        $username = $_SESSION['State']->getUsername();
-        if (empty($username)) {
-            $this->_siteSettings =& $this->_settings;
-        } else {
-            $user     =& User::singleton($username);
-            $siteName = Utility::getCleanString($user->getSiteNames());
-            if (isset($this->_settings['sites'][$siteName])
-                && is_array($this->_settings['sites'][$siteName])
-            ) {
-                $this->_siteSettings          = $this->_settings;
-                $this->_siteSettings['study']
-                    = Utility::arrayMergeRecursiveOverwriting(
-                        $this->_settings['study'],
-                        $this->_settings['sites'][$siteName]
-                    );
-                unset($this->_siteSettings['sites']);
-            } else {
-                $this->_siteSettings =& $this->_settings;
-            }
-        }
-    }
-
-    /**
      * Gets a setting from the database config tables
      *
      * @param string  $name The name of the config setting to get
@@ -390,32 +353,15 @@ class NDB_Config
      */
     function getSettingFromXML($name)
     {
-        if (class_exists("User") && isset($_SESSION['State'])) {
-            if (empty($this->_siteSettings)) {
-                // merge site and study settings
-                $this->mergeSettings();
-            }
-
-            // look at the merged site settings
-            $settingsArray =& $this->_siteSettings;
-        } else {
-            // by default, look at the raw settings
-            $settingsArray =& $this->_settings;
-        }
-
         // loop over the settings, and find the node
-        foreach ($settingsArray AS $key=>$value) {
+        foreach ($this->_settings as $key => $value) {
             // see if they want the top level node
             if ($key == $name) {
                 return $value;
             }
 
             // Look inside the top level node
-            // is_array is called before the isset check. This is done to
-            // fix an undesirable feature of isset: it would sometimes
-            // return true is $value was not an array (see isset PHP doc)
-            // in PHP <= 5.3. This behavior was changed for PHP > 5.3.
-            if (is_array($value) && isset($value[$name])) {
+            if (isset($value[$name])) {
                 return $value[$name];
             }
         }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -255,14 +255,17 @@ class User extends UserPermissions
     }
 
     /**
-     * Get the user's sites' names, concatenated with
-     * a semi-colon if the User is at more than one site
+     * Returns an array of sites a user belongs to.
      *
-     * @return string
+     * @return array
      */
-    function getSiteNames()
+    function getSiteNames(): array
     {
-        return $this->userInfo['Sites'];
+        /* The original query to fetch userInfo in the factory() function CONCAT
+         * CONCATs the site names together in a string using semi-colons.
+         * Therefore this string must be split and returned as an array.
+         */
+        return explode(';', $this->userInfo['Sites']);
     }
 
     /**


### PR DESCRIPTION
### Brief summary of changes

The old function returned a string concatenated with semi-colons which is confusing and wasn't well documented. Now the function returns an array as you'd expect. I updated the calling code.

In updating the calling code I found that the function `mergeSettings()` in `NDB_Config` probably was never working correctly with multisites. `Utility::getCleanString()` would just remove the semicolons in the siteNames array, e.g. `dcc;ottawa;montreal;rome` --> `dccottawamontrealrome`. 

I don't think this was ever a valid array key which means the whole function is essentially pointless. The git blame shows that this `getCleanString` call hasn't been updated in 11 years so it's likely something we can remove.

If Travis doesn't complain I think this change should be safe.

### This resolves issue...

- [ ] Github? https://github.com/aces/Loris/pull/4027#discussion_r233911632

### To test this change...

Everything should work the same.