### PR TITLE
[Core: Utility, Menu Filter] Move functions from Utility to Menu Filter because they're not used elsewhere

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -513,7 +513,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // add filters to query
         if (is_array($this->filter) && count($this->filter) > 0) {
             foreach ($this->filter as $field => $val) {
-                $prepared_key = Utility::getCleanString($field);
+                $prepared_key = $this->getCleanString($field);
                 $query_piece  = $this->_addValidFilters($prepared_key, $field, $val);
                 if (!empty($query_piece)) {
                     $WhereClause .= $query_piece;
@@ -557,7 +557,7 @@ class NDB_Menu_Filter extends NDB_Menu
             $first = true;
             foreach ($this->having as $key => $val) {
                 if ($val !== '' and $val != null) {
-                    $prepared_key = Utility::getCleanString($key);
+                    $prepared_key = $this->getCleanString($key);
                     if ($first == false) {
                         $WhereClause .= ' AND ';
                     } else {
@@ -735,6 +735,26 @@ class NDB_Menu_Filter extends NDB_Menu
         $list['headers'] = $this->headers;
 
         return Utility::arrayToCSV($list);
+    }
+
+    /**
+     * Cleans a string to make it safe for variables and such
+     *
+     * @param string $string the string to clean
+     *
+     * @return string The string cleaned up enough to be used as a
+     *                variable name
+     */
+    function getCleanString(string $string): string
+    {
+        $string = trim($string);
+        $string = str_replace('  ', ' ', $string);
+        $string = str_replace(' ', '_', $string);
+        $string = str_replace("'", '', $string);
+        $string = str_replace('"', '', $string);
+        $string = preg_replace('/[^A-Za-z0-9_\/-]*/', '', $string);
+        $string = strtolower($string);
+        return $string;
     }
 
     /**

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -734,7 +734,7 @@ class NDB_Menu_Filter extends NDB_Menu
         $list['data']    = $this->_getFullList();
         $list['headers'] = $this->headers;
 
-        return Utility::arrayToCSV($list);
+        return $this->arrayToCSV($list);
     }
 
     /**
@@ -755,6 +755,30 @@ class NDB_Menu_Filter extends NDB_Menu
         $string = preg_replace('/[^A-Za-z0-9_\/-]*/', '', $string);
         $string = strtolower($string);
         return $string;
+    }
+
+    /**
+    * Coverts array into CSV string
+    *
+    * @param array $array the array to be converted
+    *
+    * @return string CSV string of data
+    */
+    function arrayToCSV(array $array): string
+    {
+        $fp = fopen("php://temp", 'w+');
+
+        fputcsv($fp, $array['headers']);
+        foreach ($array['data'] as $item) {
+            fputcsv($fp, $item);
+        }
+
+        // Read what we have written.
+        rewind($fp);
+        $csv_string = stream_get_contents($fp);
+
+        fclose($fp);
+        return $csv_string;
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -949,30 +949,6 @@ class Utility
     }
 
     /**
-    * Coverts array into CSV string
-    *
-    * @param array $array the array to be converted
-    *
-    * @return string CSV string of data
-    */
-    static function arrayToCSV(array $array): string
-    {
-        $fp = fopen("php://temp", 'w+');
-
-        fputcsv($fp, $array['headers']);
-        foreach ($array['data'] as $item) {
-            fputcsv($fp, $item);
-        }
-
-        // Read what we have written.
-        rewind($fp);
-        $csv_string = stream_get_contents($fp);
-
-        fclose($fp);
-        return $csv_string;
-    }
-
-    /**
      * QuickForm rule to check that a date is valid.
      * This is used by create timepoint and start timepoint pages,
      * so it probably shouldn't be in the instrument class.

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -284,26 +284,6 @@ class Utility
     }
 
     /**
-     * Cleans a string to make it safe for variables and such
-     *
-     * @param string $string the string to clean
-     *
-     * @return string The string cleaned up enough to be used as a
-     *                variable name
-     */
-    static function getCleanString(string $string): string
-    {
-        $string = trim($string);
-        $string = str_replace('  ', ' ', $string);
-        $string = str_replace(' ', '_', $string);
-        $string = str_replace("'", '', $string);
-        $string = str_replace('"', '', $string);
-        $string = preg_replace('/[^A-Za-z0-9_\/-]*/', '', $string);
-        $string = strtolower($string);
-        return $string;
-    }
-
-    /**
      * Transforms a config structure (such as in PSCID) into a
      * Perl-compatible regex expression for validation
      *


### PR DESCRIPTION
### Brief summary of changes

`arrayToCsv` and `getCleanString` are only used by `NDB_Menu_Filter` and so they should go there instead of `Utility`.

This PR is based on #4118 as that PR removes the only occurrence of `getCleanString()` that occurs elsewhere.