### PR TITLE
[Core: TimePoint] Make return value of getBVLQCType() nullable

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -565,9 +565,9 @@ class TimePoint
     /**
      * Returns BVLQC exclusion type
      *
-     * @return string
+     * @return string|null
      */
-    function getBVLQCType(): string
+    function getBVLQCType(): ?string
     {
         return $this->_timePointInfo['BVLQCType'];
     }


### PR DESCRIPTION
### Brief summary of changes

#4049 introduced strict typing into TimePoint. While on my sandbox I found a case where getBVLQCType() needs to return null or else LORIS will crash with a TypeError.