### PR TITLE
[Core: Utility] Remove asArray function

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -295,7 +295,7 @@ class NDB_BVL_Instrument extends NDB_Page
             foreach ($instrumentPermissions["instrument"] as $instrument) {
                 if ($instrument["Test_name"] == $this->testName) {
                     $instrumentListed = true;
-                    $instrumentPerms  = Utility::asArray($instrument["permission"]);
+                    $instrumentPerms  = Utility::toArray($instrument["permission"]);
                 }
             }
 

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -71,7 +71,7 @@ class NDB_Config
 
             if (!empty($config->_settings['include'])) {
                 // Load all includes found in the config
-                $includes = Utility::asArray($config->_settings['include']);
+                $includes = Utility::toArray($config->_settings['include']);
                 foreach ($includes as $path) {
                     $config->load($config->configFilePath($path));
                 }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -492,25 +492,6 @@ class Utility
     }
 
     /**
-     * Ensures that $var is a collection elements, not just a single element
-     * Not the same as toArray, apparently.
-     * Note: This function should be used for tags without attributes
-     *
-     * @param mixed $var The variable to be converted to an array.
-     *
-     * @return  array If $var is an array, var, otherwise an array containing $var
-     * @cleanup This should be removed and all uses converted to toArray
-     *          (or vice versa, but toArray seems to be more common in the code)
-     */
-    static function asArray($var): array
-    {
-        if (!is_array($var)) {
-            return array($var);
-        }
-        return $var;
-    }
-
-    /**
      * Replace the empty string with null in specified field
      * in an array passed in as an argument. This undoes the
      * damage that Smarty causes by making nulls in a dropdown

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -244,7 +244,7 @@ function getExcludedInstruments()
 
     $ex_instruments =array();
     foreach ($excluded_instruments as $instruments) {
-        foreach (Utility::asArray($instruments) as $instrument) {
+        foreach (Utility::toArray($instruments) as $instrument) {
             $ex_instruments[$instrument] = $instrument;
         }
 


### PR DESCRIPTION
### Brief summary of changes

`asArray()` had a cleanup tag about deleting it and replacing its calling code with toArray instead since the functions are basically equivalent.