### PR TITLE
[Core: Utility] Add code comment on calculateAge()

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -35,6 +35,10 @@ class Utility
     /**
      * Computes an age in years:months:days (assumes 30 days per months)
      *
+     * NOTE This function assumes 1 month = 30 days. Although this is not really
+     * accurate, it should not be changed as it impacts the reproducibility of
+     * the analysis of data in LORIS.
+     *
      * @param string $dob      date of birth (or first date), formatted YYYY-MM-DD
      * @param string $testdate date of testing (or second date), formatted YYYY-MM-DD
      *


### PR DESCRIPTION
### Brief summary of changes

Pursuant to the conversation in #4131, this functionality of LORIS should be documented in the code. 

Whether to use 30 day months or more accurate date calculations will be discussed in an upcoming LORIS meeting. If it's decided that LORIS should use 30 day months, this PR should be merged. Otherwise #4131 should be re-opened and merged.

Adding Blocked and Discussion Required until we know the right approach to take based on the needs of researchers.
