### PR TITLE
[Core: NDB Page and Children] Add return types to function signatures

### DIFF
--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -66,7 +66,7 @@ class NDB_Menu extends NDB_Page
      *
      * @return object The new object of $menu type
      */
-    static function &factory($menu, $mode)
+    static function &factory(string $menu, string $mode): object
     {
         // get the name of the class
         if (class_exists("NDB_Menu_$menu")) {
@@ -114,7 +114,7 @@ class NDB_Menu extends NDB_Page
      * @return string
      * @access public
      */
-    function display()
+    function display(): string
     {
         if ($this->skipTemplate) {
             return "";

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -1,8 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This class features the code for the Menu Filter.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Behavioural
  * @package  Main
@@ -134,10 +134,10 @@ class NDB_Menu_Filter extends NDB_Menu
     /**
      * Calls other member functions to do all the work necessary to create the menu
      *
-     * @return void
+     * @return bool True
      * @access public
      */
-    function setup(): void
+    public function setup(): bool
     {
         parent::setup();
 
@@ -173,7 +173,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access public
      */
-    function registerDefaultFilter(): void
+    public function registerDefaultFilter(): void
     {
         $this->form->applyFilter('__ALL__', 'trim');
     }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -137,7 +137,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access public
      */
-    function setup()
+    function setup(): void
     {
         parent::setup();
 
@@ -173,7 +173,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access public
      */
-    function registerDefaultFilter()
+    function registerDefaultFilter(): void
     {
         $this->form->applyFilter('__ALL__', 'trim');
     }
@@ -192,7 +192,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access private
      */
-    function _setupVariables()
+    function _setupVariables(): void
     {
     }
 
@@ -202,7 +202,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return void
      */
-    function _resetFilters()
+    function _resetFilters(): void
     {
         $_SESSION['State']->setProperty('filter', null);
         $_SESSION['State']->setProperty('keyword', null);
@@ -216,16 +216,16 @@ class NDB_Menu_Filter extends NDB_Menu
      * set.
      *
      * @param array $values An array of the form
-     *                             [FormFieldName => Value,
-     *                             FormFieldName2 => Value2,
-     *                             ...
-     *                             ]
+     *                      [FormFieldName => Value,
+     *                      FormFieldName2 => Value2,
+     *                      ...
+     *                      ]
      *                      to retrieve the values from.
      *
      * @return array of filters in the same form as the $values parameter
      *         that can be saved for future use.
      */
-    function _setFilters($values)
+    function _setFilters(array $values): array
     {
         $newFormFilters = array();
 
@@ -257,15 +257,15 @@ class NDB_Menu_Filter extends NDB_Menu
      * it into the current filter.
      *
      * @param array $order An array of the form
-     *                      [
-     *                          'field' => Form Field Name
-     *                          'fieldOrder' => "ASC|DESC"
-     *                      ]
+     *                     [
+     *                     'field' => Form Field Name
+     *                     'fieldOrder' => "ASC|DESC"
+     *                     ]
      *
      * @return void (modifies both $_SESSION and $this->filter as
      *         a side-effect.)
      */
-    function _setFilterSortOrder($order)
+    function _setFilterSortOrder(array $order): void
     {
         // Get the existing filter. It's already been saved into
         // the session previously in $this->_setupFilters.
@@ -290,7 +290,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return void (but side-effect modifies $this->searchKey)
      */
-    function _setSearchKeyword($keyword)
+    function _setSearchKeyword(string $keyword): void
     {
         $this->searchKey = array('keyword' => $keyword);
     }
@@ -311,7 +311,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return void
      */
-    function _setupFilters()
+    function _setupFilters(): void
     {
         // 1. Reset filters
         if (isset($_REQUEST['reset'])) {
@@ -384,7 +384,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access private
      */
-    function _build()
+    function _build(): void
     {
         // show selection form table
         $success = $this->_setFilterForm();
@@ -406,16 +406,16 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access private
      */
-    function _setFilterForm()
+    function _setFilterForm(): void
     {
         return true;
     }
     /**
-    * Gets the base query
-    *
-    * @return string ($query)
-    */
-    function _getBaseQuery()
+     * Gets the base query
+     *
+     * @return string ($query)
+     */
+    function _getBaseQuery(): string
     {
         $query = "SELECT ";
         if (is_array($this->columns) && count($this->columns) > 0) {
@@ -428,16 +428,19 @@ class NDB_Menu_Filter extends NDB_Menu
 
     }
     /**
-    * Adds filters
-    *
-    * @param string $prepared_key filter key
-    * @param string $field        filter field
-    * @param string $val          filter value
-    *
-    * @return string ($query)
-    */
-    function _addValidFilters($prepared_key, $field, $val)
-    {
+     * Adds filters
+     *
+     * @param string $prepared_key filter key
+     * @param string $field        filter field
+     * @param string $val          filter value
+     *
+     * @return string ($query)
+     */
+    function _addValidFilters(
+        string $prepared_key,
+        string $field,
+        string $val
+    ): string {
         $query = '';
         if ((!empty($val) || $val === '0') && $field != 'order') {
 
@@ -466,7 +469,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return array
      * @access private
      */
-    function _getList()
+    function _getList(): array
     {
         // create DB object
         $DB =& Database::singleton();
@@ -512,7 +515,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *               for the SQL query and 'params' which contains the
      *               parameters to use bind for a prepared query.
      */
-    function _getBaseFilter()
+    function _getBaseFilter(): array
     {
         $qparams     = array();
         $WhereClause = '';
@@ -591,7 +594,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return integer The number of pages that the query returns
      */
-    function _getNumberPages($query)
+    function _getNumberPages(string $query): int
     {
         $wheredetails = $this->_getBaseFilter();
         $db           = Database::singleton();
@@ -610,7 +613,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access private
      */
-    function _setDataTable()
+    function _setDataTable(): void
     {
         // create instance of config object
         $config =& NDB_Config::singleton();
@@ -669,7 +672,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return void
      * @access private
      */
-    function _setDataTableRows($count)
+    function _setDataTableRows(int $count): void
     {
         // print out
         $x = 0;
@@ -697,7 +700,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return string
      * @access public
      */
-    function display()
+    function display(): string
     {
         switch($this->format) {
         case 'json':
@@ -735,7 +738,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return string  csv formated string
      */
-    function getCSVData()
+    function getCSVData(): string
     {
         $list['data']    = $this->_getFullList();
         $list['headers'] = $this->headers;
@@ -753,7 +756,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return array
      */
-    function toArray()
+    function toArray(): array
     {
         $data = $this->_getFullList();
 
@@ -782,7 +785,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return string a json encoded string of the headers and data from this table
      */
-    function toJSON()
+    function toJSON(): string
     {
         return json_encode($this->toArray());
     }
@@ -792,7 +795,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @return array
      * @access private
      */
-    function _getFullList()
+    function _getFullList(): array
     {
         // create DB object
         $factory = NDB_Factory::singleton();
@@ -832,7 +835,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return array of filters that are set
      */
-    function _getFilterValues()
+    function _getFilterValues(): array
     {
         $FilterValues = array();
         foreach (array_keys($this->formToFilter) as $formName) {
@@ -851,7 +854,7 @@ class NDB_Menu_Filter extends NDB_Menu
      *
      * @return array of javascript files to be sourced
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
         $factory = NDB_Factory::singleton();
         $depends = parent::getJSDependencies();

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -1,9 +1,9 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This class over-rides the NDB_Menu_Filter class by including the functionality
  * of saving/processing the form.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Behavioural
  * @package  Main
@@ -40,7 +40,7 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
      * @return void
      * @access public
      */
-    function save()
+    function save(): void
     {
         if (!isset($_REQUEST['filter'])
             && isset($_REQUEST['fire_away'])
@@ -58,12 +58,12 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
      * Preprocesses the array of values to be saved into the database
      *
      * @param array $values the array of values ready to be passed to
-                             a Database::replace call as the set array
+                   a Database::replace call as the set array
      *
      * @return void
      * @access private
      */
-    function _save($values)
+    function _save(array $values): void
     {
         unset(
             $values['test_name'],
@@ -90,7 +90,7 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
      *
      * @return bool true if successful
      */
-    function _process($values)
+    function _process(array $values): bool
     {
         return true;
     }

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file contains the NDB_Page base class. This file should
  * contain ALL of the references to HTML_QuickForm (or any library
  * used to render HTML.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  Main
@@ -118,7 +118,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function setTemplateVar($name, $value)
+    function setTemplateVar(string $name, string $value): void
     {
         $this->tpl_data[$name] = htmlspecialchars($value);
     }
@@ -128,7 +128,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return array Mapping of variable names to template value.
      */
-    function getTemplateData()
+    function getTemplateData(): array
     {
         return $this->tpl_data;
     }
@@ -143,7 +143,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addFile($name, $label, $options=array())
+    function addFile(string $name, string $label, array $options=array()): void
     {
         $this->form->addElement(
             'file',
@@ -160,7 +160,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addHeader($header)
+    function addHeader(string $header): void
     {
         $this->form->addElement('header', null, $header);
     }
@@ -177,7 +177,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addSelect($name, $label, $options, $optional=array())
+    function addSelect(string $name, string $label, array $options, array $optional=array()): void
     {
         $optional = array_merge(
             array('class' => 'form-control input-sm'),
@@ -193,7 +193,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addLabel($label)
+    function addLabel(string $label): void
     {
         $this->form->addElement('static', null, $label);
     }
@@ -206,7 +206,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addScoreColumn($name, $label)
+    function addScoreColumn(string $name, string $label): void
     {
         $this->form->addElement('static', $name, $label);
     }
@@ -222,7 +222,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addBasicText($field, $label, $options=array())
+    function addBasicText(string $field, string $label, array $options=array()): void
     {
         $options = array_merge(array('class' => 'form-control input-sm'), $options);
         $this->form->addElement('text', $field, $label, $options);
@@ -239,10 +239,10 @@ class NDB_Page implements RequestHandlerInterface
      * @return void
      */
     function addBasicTextArea(
-        $field,
-        $label,
-        $specifications=array()
-    ) {
+        string $field,
+        string $label,
+        array $specifications=array()
+    ): void {
         $specifications = array_merge(
             array('class' => 'form-control input-sm'),
             $specifications
@@ -262,14 +262,14 @@ class NDB_Page implements RequestHandlerInterface
      * @return void
      */
     function addBasicDate(
-        $field,
-        $label,
-        $options=array(),
-        $attr=array(
-               'class' => 'form-control input-sm',
-               'style' => 'max-width:33%; display:inline-block;',
-              )
-    ) {
+        string $field,
+        string $label,
+        array $options=array(),
+        array $attr=array(
+                     'class' => 'form-control input-sm',
+                     'style' => 'max-width:33%; display:inline-block;',
+                    )
+    ): void {
         $this->form->addElement('date', $field, $label, $options, $attr);
     }
 
@@ -285,7 +285,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addCheckbox($name, $label, $options, $optional=array())
+    function addCheckbox(string $name, string $label, array $options, array $optional=array()): void
     {
         $optional = array_merge(
             array('class' => 'form-control input-sm'),
@@ -308,7 +308,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addRadio($name, $groupLabel, $radios, $options=array())
+    function addRadio(string $name, string $groupLabel, array $radios, array $options=array()): void
     {
         foreach ($radios as $radElement) {
             $tempOptions = array_merge(
@@ -331,14 +331,17 @@ class NDB_Page implements RequestHandlerInterface
      * Adds a hidden element to the current page. Note if the hidden element
      * needs a value it should be added to the defaults.
      *
-     * @param string $name       The name of the hidden element to add
-     * @param array  $value      The value of the hidden element to add
-     * @param array  $attributes Additional html attributes for element
+     * @param string     $name       The name of the hidden element to add
+     * @param array|null $value      The value of the hidden element to add
+     * @param array      $attributes Additional html attributes for element
      *
      * @return void
      */
-    function addHidden($name, $value=null, $attributes=array())
-    {
+    function addHidden(
+        string $name,
+        ?array $value=null,
+        array $attributes=array()
+    ): void {
         $this->form->addElement('hidden', $name, $value, $attributes);
     }
 
@@ -354,13 +357,13 @@ class NDB_Page implements RequestHandlerInterface
      * @return void
      */
     function addTextAreaGroup(
-        $field,
-        $label,
-        $not_answered_options=array(
-                               ''             => '',
-                               'not_answered' => 'Not Answered',
-                              )
-    ) {
+        string $field,
+        string $label,
+        array $not_answered_options=array(
+                                     ''             => '',
+                                     'not_answered' => 'Not Answered',
+                                    )
+    ): void {
         $group   = array();
         $group[] = $this->createTextArea($field, '');
         $group[] = $this->createSelect(
@@ -384,10 +387,10 @@ class NDB_Page implements RequestHandlerInterface
      * @return void
      */
     function addPassword(
-        $field,
-        $label=null,
-        $attr=array('class' => 'form-control input-sm')
-    ) {
+        string $field,
+        string $label=null,
+        array $attr=array('class' => 'form-control input-sm')
+    ): void {
         $this->form->addElement('password', $field, $label, $attr);
     }
 
@@ -401,7 +404,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addRule($element, $message, $type, $format=null)
+    function addRule(string $element, string $message, string $type, string $format=null): void
     {
         $this->form->addRule($element, $message, $type, $format);
     }
@@ -417,7 +420,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addGroupRule($group, $arg1, $type='', $format=null)
+    function addGroupRule(string $group, $arg1, $type='', $format=null): void
     {
         $this->form->addGroupRule($group, $arg1, $type);
     }
@@ -434,7 +437,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addGroup($elements, $name, $label, $separator, $appendName=null)
+    function addGroup(array $elements, string $name, string $label, string $separator, string $appendName=null): void
     {
         $this->form->addGroup($elements, $name, $label, $separator, $appendName);
     }
@@ -450,11 +453,11 @@ class NDB_Page implements RequestHandlerInterface
      * @return array representing select element
      */
     function createSelect(
-        $field,
-        $label,
-        $options=null,
-        $attr=array('class' => 'form-control input-sm')
-    ) {
+        string $field,
+        string $label,
+        array $options=null,
+        array $attr=array('class' => 'form-control input-sm')
+    ): array {
         return $this->form->createElement("select", $field, $label, $options, $attr);
     }
 
@@ -466,8 +469,8 @@ class NDB_Page implements RequestHandlerInterface
      * @return array representing label element
      */
     function createLabel(
-        $labelString
-    ) {
+        string $labelString
+    ): array {
         return $this->form->createElement(
             "static",
             null,
@@ -478,30 +481,33 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates a QuickForm text element but does not add it to the form
      *
-     * @param string $field   The field name for this text element
-     * @param string $label   The label to attach to the element
-     * @param array  $attribs Extra HTML attributes to add to the element
+     * @param string      $field   The field name for this text element
+     * @param string|null $label   The label to attach to the element
+     * @param array       $attribs Extra HTML attributes to add to the element
      *
      * @return array representing text element
      */
     function createText(
-        $field,
-        $label=null,
-        $attribs=array()
-    ) {
-        $attr =array_merge($attribs, array('class' => 'form-control input-sm'));
+        string $field,
+        ?string $label=null,
+        array $attribs=array()
+    ): array {
+        $attr = array_merge(
+            $attribs,
+            array('class' => 'form-control input-sm')
+        );
         return $this->form->createElement("text", $field, $label, $attr);
     }
 
     /**
      * Creates a QuickForm TextArea element but does not add it to the form.
      *
-     * @param string $field The field name for the TextArea
-     * @param string $label The label to attach to this TextArea
+     * @param string      $field The field name for the TextArea
+     * @param string|null $label The label to attach to this TextArea
      *
      * @return array representing textarea element
      */
-    function createTextArea($field, $label=null)
+    function createTextArea(string $field, ?string $label=null): array
     {
         return $this->form->createElement(
             "textarea",
@@ -514,23 +520,23 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates a QuickForm date element but does not add it to the form.
      *
-     * @param string $field       The fieldname for this date field
-     * @param string $label       The label to attach to this date
-     * @param array  $dateOptions List of options to pass to QuickForm
-     * @param array  $attr        List of HTML attributes to add to the date
-     *                            group.
+     * @param string     $field       The fieldname for this date field
+     * @param string     $label       The label to attach to this date
+     * @param array|null $dateOptions List of options to pass to QuickForm
+     * @param array      $attr        List of HTML attributes to add to the date
+     *                                group.
      *
      * @return array representing date element
      */
     function createDate(
-        $field,
-        $label,
-        $dateOptions=null,
-        $attr=array(
-               'class' => 'form-control input-sm',
-               'style' => 'max-width:33%; display:inline-block;',
-              )
-    ) {
+        string $field,
+        string $label,
+        ?array $dateOptions=null,
+        array $attr=array(
+                     'class' => 'form-control input-sm',
+                     'style' => 'max-width:33%; display:inline-block;',
+                    )
+    ): array {
         return $this->form->createElement(
             "date",
             $field,
@@ -543,15 +549,19 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates an HTML checkbox but does not add it to the form.
      *
-     * @param string $field   The fieldname for this checkbox
-     * @param string $label   The label to attach to this checkbox
-     * @param string $options Options to pass to HTML_QuickForm
-     * @param string $closer  ?????
+     * @param string      $field   The fieldname for this checkbox
+     * @param string      $label   The label to attach to this checkbox
+     * @param string|null $options Options to pass to HTML_QuickForm
+     * @param string      $closer  ?????
      *
      * @return array representing checkbox
      */
-    function createCheckbox($field, $label, $options=null, $closer='</label>')
-    {
+    function createCheckbox(
+        string $field,
+        string $label,
+        ?string $options=null,
+        string $closer='</label>'
+    ): array {
         return $this->form->createElement(
             "advcheckbox",
             $field,
@@ -564,14 +574,17 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates an HTML radio button but does not add it to the form.
      *
-     * @param string $field   The fieldname for this radio button
-     * @param string $label   The label to attach to this radio button
-     * @param string $options Options to pass to LorisForm
+     * @param string      $field   The fieldname for this radio button
+     * @param string      $label   The label to attach to this radio button
+     * @param string|null $options Options to pass to LorisForm
      *
      * @return array representing radio button
      */
-    function createRadio($field, $label, $options=null)
-    {
+    function createRadio(
+        string $field,
+        string $label,
+        ?string $options=null
+    ): array {
         return $this->form->createElement(
             "radio",
             $field,
@@ -584,17 +597,17 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates a password form element but does not add it to the page
      *
-     * @param string $field The fieldname for the password box
-     * @param string $label The label to attach to the form element
-     * @param array  $attr  List of HTML attributes to add to the element
+     * @param string      $field The fieldname for the password box
+     * @param string|null $label The label to attach to the form element
+     * @param array       $attr  List of HTML attributes to add to the element
      *
      * @return array representing form element
      */
     function createPassword(
-        $field,
-        $label=null,
-        $attr=array('class' => 'form-control input-sm')
-    ) {
+        string $field,
+        ?string $label=null,
+        array $attr=array('class' => 'form-control input-sm')
+    ): array {
         return $this->form->createElement('password', $field, $label, $attr);
     }
 
@@ -672,7 +685,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return string of the content to be inserted into the template
      */
-    function display()
+    function display(): string
     {
         if ($this->skipTemplate) {
             return "";
@@ -716,7 +729,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return array
      */
-    function _getDefaults()
+    function _getDefaults(): array
     {
         return $this->defaults;
     }
@@ -728,7 +741,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return array The defaults
      */
-    function _setDefaults($defaults = array())
+    function _setDefaults(array $defaults = array()): array
     {
         $this->defaults = $defaults;
         $this->form->setDefaults($defaults);
@@ -742,7 +755,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return array of strings with URLs to retrieve JS resources
      */
-    function getJSDependencies()
+    function getJSDependencies(): array
     {
         $factory = NDB_Factory::singleton();
         $config  = $factory->config();
@@ -791,7 +804,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return array of strings with URLs to retrieve CSS resources
      */
-    function getCSSDependencies()
+    function getCSSDependencies(): array
     {
         $factory = NDB_Factory::singleton();
         $config  = $factory->config();
@@ -814,7 +827,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void (but may have side-effects)
      */
-    function setup()
+    function setup(): void
     {
     }
 


### PR DESCRIPTION
See #3878 for background.

This PR covers NDB Page and its child classes. They must be updated together because their function signatures all need to match.