### PR TITLE
Adding "imaging non minc file insertion" to the types of notification

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -902,7 +902,8 @@ INSERT INTO `notification_types` (Type,private,Description) VALUES
     ('tarchive loader',1,'calls specific Insertion Scripts'),
     ('tarchive validation',1,'Validation of the dicoms After uploading'),
     ('mri upload runner',1,'Validation of DICOMS before uploading'),
-    ('mri upload processing class',1,'Validation and execution of DicomTar.pl and TarchiveLoader');
+    ('mri upload processing class',1,'Validation and execution of DicomTar.pl and TarchiveLoader'),
+    ('imaging non minc file insertion', 1, 'Insertion of non-minc files into the mri-table');
 
 CREATE TABLE `notification_spool` (
   `NotificationID` int(11) NOT NULL auto_increment,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -898,12 +898,12 @@ INSERT INTO `notification_types` (Type,private,Description) VALUES
     ('hardcopy request',0,'Hardcopy requests'),
     ('visual bvl qc',0,'Timepoints selected for visual QC'),
     ('mri qc status',0,'MRI QC Status change'),
-    ('minc insertion',1,'Insertion of the mincs into the mri-table'),
+    ('minc insertion',1,'Insertion of a MINC file into the MRI tables (files/parameter_file)'),
     ('tarchive loader',1,'calls specific Insertion Scripts'),
     ('tarchive validation',1,'Validation of the dicoms After uploading'),
     ('mri upload runner',1,'Validation of DICOMS before uploading'),
     ('mri upload processing class',1,'Validation and execution of DicomTar.pl and TarchiveLoader'),
-    ('imaging non minc file insertion', 1, 'Insertion of non-minc files into the mri-table');
+    ('imaging non minc file insertion', 1, 'Insertion of a non-MINC file into the MRI tables (files/parameter_file)');
 
 CREATE TABLE `notification_spool` (
   `NotificationID` int(11) NOT NULL auto_increment,

--- a/SQL/New_patches/2018-11-23_insert_imaging_non_minc_file_insertion_in_notification_types.sql
+++ b/SQL/New_patches/2018-11-23_insert_imaging_non_minc_file_insertion_in_notification_types.sql
@@ -1,0 +1,4 @@
+INSERT INTO notification_types
+  (Type, private, Description)
+  VALUES
+  ('imaging non minc file insertion', 1, 'Insertion of non-minc files into the mri-table');

--- a/SQL/New_patches/2018-11-23_insert_imaging_non_minc_file_insertion_in_notification_types.sql
+++ b/SQL/New_patches/2018-11-23_insert_imaging_non_minc_file_insertion_in_notification_types.sql
@@ -1,4 +1,8 @@
 INSERT INTO notification_types
   (Type, private, Description)
   VALUES
-  ('imaging non minc file insertion', 1, 'Insertion of non-minc files into the mri-table');
+  ('imaging non minc file insertion', 1, 'Insertion of a non-MINC file into the MRI tables (files/parameter_file)');
+
+UPDATE notification_types
+  SET Description = 'Insertion of a MINC file into the MRI tables (files/parameter_file)'
+  WHERE Type = 'minc insertion';


### PR DESCRIPTION
### Brief summary of changes

This PR accompanies the LORIS-MRI PR to insert non MINC files into the database (https://github.com/aces/Loris-MRI/pull/271). In order for the notification for this new script to save in the notification table, we have to add one row to the `notification_types` table.

### This resolves issue...

- [x] Redmine https://redmine.cbrain.mcgill.ca/issues/10557

- [x] Goes with Github LORIS-MRI PR https://github.com/aces/Loris-MRI/pull/271

