### PR TITLE
[Core:NDB_Config] fix parameter type

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -163,7 +163,7 @@ class NDB_Config
         if (count($children) > 0) {
             foreach ($children as $child) {
                 $name      = $child->getName();
-                $tagExists = isset($retVal[$name]);
+                $tagExists = isset($retVal[$name]) && is_array($retVal[$name]);
                 if ($tagExists) {
                     if (!self::isNumericArray($retVal[$name])) {
                         // The tag is duplicated in the XML, so it should
@@ -230,12 +230,12 @@ class NDB_Config
      * are 0, 1, ..., n - 1.
      * If an empty array is passed as $arr, this function will return true.
      *
-     * @param mixed $arr The array or string to be checked for numeric keys.
+     * @param  array $arr The array to be checked for numeric keys.
      *
      * @return boolean True if the given parameter is an array with
      *                 numeric keys, false otherwise.
      */
-    static function isNumericArray($arr): bool
+    static function isNumericArray(array $arr): bool
     {
         if ($arr === array()) {
             return true;

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -230,7 +230,7 @@ class NDB_Config
      * are 0, 1, ..., n - 1.
      * If an empty array is passed as $arr, this function will return true.
      *
-     * @param  array $arr The array to be checked for numeric keys.
+     * @param array $arr The array to be checked for numeric keys.
      *
      * @return boolean True if the given parameter is an array with
      *                 numeric keys, false otherwise.

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -230,7 +230,7 @@ class NDB_Config
      * are 0, 1, ..., n - 1.
      * If an empty array is passed as $arr, this function will return true.
      *
-     * @param mix $arr The array to be checked for numeric keys.
+     * @param mixed $arr The array or string to be checked for numeric keys.
      *
      * @return boolean True if the given parameter is an array with
      *                 numeric keys, false otherwise.

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -164,7 +164,6 @@ class NDB_Config
             foreach ($children as $child) {
                 $name      = $child->getName();
                 $tagExists = isset($retVal[$name]);
-
                 if ($tagExists) {
                     if (!self::isNumericArray($retVal[$name])) {
                         // The tag is duplicated in the XML, so it should
@@ -231,12 +230,12 @@ class NDB_Config
      * are 0, 1, ..., n - 1.
      * If an empty array is passed as $arr, this function will return true.
      *
-     * @param array $arr The array to be checked for numeric keys.
+     * @param mix $arr The array to be checked for numeric keys.
      *
      * @return boolean True if the given parameter is an array with
      *                 numeric keys, false otherwise.
      */
-    static function isNumericArray(array $arr): bool
+    static function isNumericArray($arr): bool
     {
         if ($arr === array()) {
             return true;


### PR DESCRIPTION
### Brief summary of changes
Fix Loris can't load on local VM with a specific config setting. 
This function can't handle a string.

PHP Fatal error:  Uncaught TypeError: Argument 1 passed to NDB_Config::isNumericArray() must be of the type array, string given


### To test this change...
test loading your Loris on this branch without issue.


