### PR TITLE
Update SweetAlert2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "sweetalert2": "^7.28.4"
+    "sweetalert2": "^7.29.2"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",


### PR DESCRIPTION
This updates the version of SWAL2 to the most recent
version in order to ensure we have the fix in
https://github.com/sweetalert2/sweetalert2/pull/1305
applied.

SweetAlert2 had a dependency on https://github.com/dominictarr/event-stream/issues/116. This updates the version in package.json to one which has the dependency removed.

(The bitcoin stealing code doesn't affect LORIS since our npm package description is not "A Secure Bitcoin Wallet", but it's still best to remove it.)