### PR TITLE
[Core: Utility] Deprecate Utility::toArray()

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -154,7 +154,7 @@ class Create_Timepoint extends \NDB_Form
         $visitLabelSettings = $config->getSetting('visitLabel');
         $visitLabelAdded    = false;
 
-        foreach (\Utility::toArray($visitLabelSettings) as $visitLabel) {
+        foreach (\Utility::associativeToNumericArray($visitLabelSettings) as $visitLabel) {
             if ($visitLabel['@']['subprojectID'] == $this->subprojectID) {
                 if (isset($visitLabel['generation'])
                     && $visitLabel['generation'] !== 'sequence'
@@ -165,7 +165,7 @@ class Create_Timepoint extends \NDB_Form
                     );
                 }
                 $labelOptions[''] = null;
-                $items            = \Utility::toArray(
+                $items            = \Utility::associativeToNumericArray(
                     $visitLabel['labelSet']['item']
                 );
                 foreach ($items as $item) {

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -154,7 +154,10 @@ class Create_Timepoint extends \NDB_Form
         $visitLabelSettings = $config->getSetting('visitLabel');
         $visitLabelAdded    = false;
 
-        foreach (\Utility::associativeToNumericArray($visitLabelSettings) as $visitLabel) {
+        foreach (
+            \Utility::associativeToNumericArray($visitLabelSettings)
+            as $visitLabel
+        ) {
             if ($visitLabel['@']['subprojectID'] == $this->subprojectID) {
                 if (isset($visitLabel['generation'])
                     && $visitLabel['generation'] !== 'sequence'

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -418,7 +418,7 @@ class EditExaminer extends \NDB_Form
             return array();
         }
         $certificationInstruments['test']
-            = \Utility::toArray($certificationInstruments['test']);
+            = \Utility::associativeToNumericArray($certificationInstruments['test']);
         $instruments = array();
 
         foreach ($certificationInstruments['test'] as $certificationInstrument) {

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -120,7 +120,7 @@ class Training extends \NDB_Form
 
         if (isset($certificationInstruments['test'])) {
             $certificationInstruments['test']
-                = \Utility::toArray($certificationInstruments['test']);
+                = \Utility::associativeToNumericArray($certificationInstruments['test']);
             foreach ($certificationInstruments['test'] as $certificationInstrument) {
                 $test_key = $certificationInstrument['@']['value'];
                 $testID   = $DB->pselectOne(

--- a/modules/training/php/training.class.inc
+++ b/modules/training/php/training.class.inc
@@ -120,8 +120,12 @@ class Training extends \NDB_Form
 
         if (isset($certificationInstruments['test'])) {
             $certificationInstruments['test']
-                = \Utility::associativeToNumericArray($certificationInstruments['test']);
-            foreach ($certificationInstruments['test'] as $certificationInstrument) {
+                = \Utility::associativeToNumericArray(
+                    $certificationInstruments['test']
+                );
+            foreach (
+                $certificationInstruments['test'] as $certificationInstrument
+            ) {
                 $test_key = $certificationInstrument['@']['value'];
                 $testID   = $DB->pselectOne(
                     "SELECT ID

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -849,7 +849,7 @@ class NDB_BVL_Instrument extends NDB_Page
 
         if ($CertificationEnabled) {
             foreach (
-                Utility::toArray($CertificationConfig['CertificationProjects'])
+                Utility::associativeToNumericArray($CertificationConfig['CertificationProjects'])
                 as $value
             ) {
                 if (is_array($value['CertificationProject'])) {
@@ -860,10 +860,10 @@ class NDB_BVL_Instrument extends NDB_Page
                 }
             }
             foreach (
-                Utility::toArray($CertificationConfig['CertificationInstruments'])
+                Utility::associativeToNumericArray($CertificationConfig['CertificationInstruments'])
                 as $instrument
             ) {
-                foreach (Utility::toArray($instrument['test']) as $test) {
+                foreach (Utility::associativeToNumericArray($instrument['test']) as $test) {
                     $CertificationInstruments[] = $test['@']['value'];
                 }
             }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -849,7 +849,9 @@ class NDB_BVL_Instrument extends NDB_Page
 
         if ($CertificationEnabled) {
             foreach (
-                Utility::associativeToNumericArray($CertificationConfig['CertificationProjects'])
+                Utility::associativeToNumericArray(
+                    $CertificationConfig['CertificationProjects']
+                )
                 as $value
             ) {
                 if (is_array($value['CertificationProject'])) {
@@ -860,10 +862,15 @@ class NDB_BVL_Instrument extends NDB_Page
                 }
             }
             foreach (
-                Utility::associativeToNumericArray($CertificationConfig['CertificationInstruments'])
+                Utility::associativeToNumericArray(
+                    $CertificationConfig['CertificationInstruments']
+                )
                 as $instrument
             ) {
-                foreach (Utility::associativeToNumericArray($instrument['test']) as $test) {
+                foreach (
+                    Utility::associativeToNumericArray($instrument['test'])
+                    as $test
+                ) {
                     $CertificationInstruments[] = $test['@']['value'];
                 }
             }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -288,9 +288,9 @@ class TimePoint
         $config =& \NDB_Config::singleton();
         $visitLabelSettings = $config->getSetting('visitLabel');
         $isValid            = false;
-        foreach (\Utility::toArray($visitLabelSettings) as $visitLabelSetting) {
+        foreach (\Utility::associativeToNumericArray($visitLabelSettings) as $visitLabelSetting) {
             if ($visitLabelSetting['@']['subprojectID'] == $subprojectID) {
-                $items = \Utility::toArray(
+                $items = \Utility::associativeToNumericArray(
                     $visitLabelSetting['labelSet']['item']
                 );
                 foreach ($items as $item) {

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -288,7 +288,8 @@ class TimePoint
         $config =& \NDB_Config::singleton();
         $visitLabelSettings = $config->getSetting('visitLabel');
         $isValid            = false;
-        foreach (\Utility::associativeToNumericArray($visitLabelSettings) as $visitLabelSetting) {
+        foreach (\Utility::associativeToNumericArray($visitLabelSettings)
+            as $visitLabelSetting) {
             if ($visitLabelSetting['@']['subprojectID'] == $subprojectID) {
                 $items = \Utility::associativeToNumericArray(
                     $visitLabelSetting['labelSet']['item']

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -422,16 +422,16 @@ class Utility
      * original functioning of toArray which was not type-safe. It is
      * primarily used for extracting configuration settings.
      *
-     * @param array $array An asssociative array.
+     * @param array $associative_array An asssociative array.
      *
      * @return array The new numeric array, or $array if it was already numeric.
      */
-    static function associativeToNumericArray(array $array): array
+    static function associativeToNumericArray(array $associative_array): array
     {
-        if (!array_key_exists(0, $array)) {
-            return array($var);
+        if (!array_key_exists(0, $associative_array)) {
+            return array($associative_array);
         }
-        return $array;
+        return $associative_array;
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -417,6 +417,24 @@ class Utility
     }
 
     /**
+     * Converts an associative array to a numeric array consisting of the 
+     * argument's value as its first and only element. This is adapted from the
+     * original functioning of toArray which was not type-safe. It is 
+     * primarily used for extracting configuration settings.
+     *
+     * @param $array An asssociative array.
+     *
+     * @return array The new numeric array, or $array if it was already numeric.
+     */
+    static function associativeToNumericArray(array $array): array
+    {
+        if (!array_key_exists(0, $array)) {
+            return array($var);
+        }
+        return $array;
+    }
+
+    /**
      * Ensures that $var is a collection of $var elements, not just a
      * single element. This is useful for using config->getSetting for an element
      * that may be in the config multiple times or may be in the config file a
@@ -429,24 +447,23 @@ class Utility
      *
      * @return array If $var is an array, var, otherwise an array containing $var
      */
-    static function toArray($var): array
+    static function toArray(array $array): array
     {
-        if (is_array($var) && !array_key_exists(0, $var)) {
-            $var = array($var);
-        }
-        return $var;
+        throw new DeprecatedException(
+            'Utility::toArray() is deprecated and should not be used. ' .
+            'Instead use Utility::associativeToNumericArray() for converting ' .
+            'arrays. Scalar values cannot be passed to this function.'
+        );
     }
 
     /**
-     * Ensures that $var is a collection elements, not just a single element
-     * Not the same as toArray, apparently.
+     * Takes a scalar value and returns an array containing that value as its
+     * only element.
      * Note: This function should be used for tags without attributes
      *
      * @param mixed $var The variable to be converted to an array.
      *
-     * @return  array If $var is an array, var, otherwise an array containing $var
-     * @cleanup This should be removed and all uses converted to toArray
-     *          (or vice versa, but toArray seems to be more common in the code)
+     * @return array If $var is an array, var, otherwise an array containing $var
      */
     static function asArray($var): array
     {

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -417,12 +417,12 @@ class Utility
     }
 
     /**
-     * Converts an associative array to a numeric array consisting of the 
+     * Converts an associative array to a numeric array consisting of the
      * argument's value as its first and only element. This is adapted from the
-     * original functioning of toArray which was not type-safe. It is 
+     * original functioning of toArray which was not type-safe. It is
      * primarily used for extracting configuration settings.
      *
-     * @param $array An asssociative array.
+     * @param array $array An asssociative array.
      *
      * @return array The new numeric array, or $array if it was already numeric.
      */

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -449,11 +449,19 @@ class Utility
      */
     static function toArray($var)
     {
-        throw new DeprecatedException(
-            'Utility::toArray() is deprecated and should not be used. ' .
-            'Instead use Utility::associativeToNumericArray() for converting ' .
-            'arrays. Scalar values cannot be passed to this function.'
-        );
+        // TODO Uncomment the exception code below after LORIS 21 is released.
+        //throw new DeprecatedException(
+        //    'Utility::toArray() is deprecated and should not be used. ' .
+        //    'Instead use Utility::associativeToNumericArray() for converting ' .
+        //    'arrays. Scalar values cannot be passed to this function.'
+        //);
+        error_log('Utility::toArray() will be deprecated in LORIS ' .
+            'version 21. Please use Utility::associativeToNumericArray() ' .
+            'instead.');
+        if (is_array($var) && !array_key_exists(0, $var)) {
+            $var = array($var);
+        }
+        return $var;
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -447,7 +447,7 @@ class Utility
      *
      * @return array If $var is an array, var, otherwise an array containing $var
      */
-    static function toArray(array $array): array
+    static function toArray($var)
     {
         throw new DeprecatedException(
             'Utility::toArray() is deprecated and should not be used. ' .

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -455,9 +455,11 @@ class Utility
         //    'Instead use Utility::associativeToNumericArray() for converting ' .
         //    'arrays. Scalar values cannot be passed to this function.'
         //);
-        error_log('Utility::toArray() will be deprecated in LORIS ' .
+        error_log(
+            'Utility::toArray() will be deprecated in LORIS ' .
             'version 21. Please use Utility::associativeToNumericArray() ' .
-            'instead.');
+            'instead.'
+        );
         if (is_array($var) && !array_key_exists(0, $var)) {
             $var = array($var);
         }

--- a/tools/populate_visit_windows.php
+++ b/tools/populate_visit_windows.php
@@ -81,8 +81,8 @@ class VisitWindowPopulator
     {
         // Can't use Utility::getVisits() because that uses the Visit_Window table..
         $vls = $this->Config->getSetting("visitLabel");
-        foreach (Utility::toArray($vls) as $visits) {
-            foreach (Utility::toArray($visits['labelSet']['item']) as $item) {
+        foreach (Utility::associativeToNumericArray($vls) as $visits) {
+            foreach (Utility::associativeToNumericArray($visits['labelSet']['item']) as $item) {
                 $visit = $item['@']['value'];
                 if (!empty($visit)) {
                     $this->insertIfMissing($visit);

--- a/tools/single_use/Normalize_Consent_Data.php
+++ b/tools/single_use/Normalize_Consent_Data.php
@@ -37,7 +37,7 @@ $useConsent = $consentConfig['useConsent'];
 $consents = $consentConfig['Consent'];
 
 // Format array of consents
-foreach(\Utility::toArray($consents) as $consent) {
+foreach(\Utility::associativeToNumericArray($consents) as $consent) {
     $consentName = $consent['name'];
     $consentLabel = $consent['label'];
     $consentList[$consentName] = $consentLabel;


### PR DESCRIPTION
### Brief summary of changes
 Following #4133 `toArray()` is being deprecated in favour of the more precise function `associativeToNumericArray()`. This function does the same thing as toArray() but only accepts and returns arrays. 

This change reduces confusion between toArray and asArray as well as allows us to be more precise with the way we're using types.

The calling code has been updated to use the new function and the old function will throw a deprecation exception in the next release.


### Related

- [ ] Github? #4133 #3878 #4046 

### To test this change...

- [ ] Try running the tools scripts and make sure they don't do anything weird.
