### PR TITLE
[Core: Utility] Add log warning for deprecation

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -477,6 +477,11 @@ class Utility
      */
     static function toArray($var)
     {
+        error_log(
+            'Note: Utility::toArray() will be deprecated in LORIS ' .
+            'version 21.'
+        );
+
         if (is_array($var) && !array_key_exists(0, $var)) {
             $var = array($var);
         }


### PR DESCRIPTION
### Brief summary of changes

Requested by @ridz1208, this adds a log notice that toArray() in Utility [will be deprecated](https://github.com/aces/Loris/pull/4151) in the next release
