### PR TITLE
[Core: Module] Make debugging more verbose

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -77,7 +77,9 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     . ".class.inc";
                     if (!file_exists($fpath)) {
                         throw new \LorisException(
-                            "Could not resolve $fpath to a LORIS module."
+                            "Could not resolve $fpath to a LORIS module. " .
+                            "Note that PHP filenames within modules must be " .
+                            "entirely lowercase."
                         );
                     }
                     include $fpath;

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -77,9 +77,8 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     . ".class.inc";
                     if (!file_exists($fpath)) {
                         throw new \NotFound(
-                            "Could not resolve $fpath to a LORIS module. " .
-                            "Note that PHP filenames within modules must be " .
-                            "entirely lowercase."
+                            "Could not load module `$name`: file `$fpath` " .
+                            "does not exist"
                         );
                     }
                     include $fpath;

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -76,7 +76,9 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     . strtolower(substr($class, strlen("LORIS\\$name\\")))
                     . ".class.inc";
                     if (!file_exists($fpath)) {
-                        throw new \NotFound($name);
+                        throw new \LorisException(
+                            "Could not resolve $fpath to a LORIS module."
+                        );
                     }
                     include $fpath;
                 }

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -76,7 +76,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     . strtolower(substr($class, strlen("LORIS\\$name\\")))
                     . ".class.inc";
                     if (!file_exists($fpath)) {
-                        throw new \LorisException(
+                        throw new \NotFound(
                             "Could not resolve $fpath to a LORIS module. " .
                             "Note that PHP filenames within modules must be " .
                             "entirely lowercase."


### PR DESCRIPTION
### Brief summary of changes

While working on #3881 I kept running into a problem where I would have a bug but all the error log would display was something like 
```
PHP Fatal error:  Uncaught NotFound: media in /var/www/loris/php/libraries/Module.class.inc:81
```
and a generic stack trace. As a result normal PHP errors got swallowed up by the NotFound exception making it very hard to determine what was actually going wrong.

This change logs the entire path that the Module class tries to resolve and also explains what's happening behind the scenes.