### PR TITLE
 [Core: Module] Handle 500 errors properly 

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -26,7 +26,7 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterface
 {
-    const GENERIC_500_ERROR = "We're sorry, LORIS has encountered an internal "
+    const GENERIC_500_ERROR   = "We're sorry, LORIS has encountered an internal "
         . "server error. Please contact your project administrator for more "
         . "information.";
     const CONFIGURATION_ERROR = "LORIS configuration settings are invalid or "
@@ -284,14 +284,14 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     )
                 )
             );
-        /* Catch more specific errors that may be thrown in the codebase.
-         * Without handling these exceptions explicitly, LORIS will display
-         * a 404 error and swallow the exception, hindering debugging efforts.
-         *
-         * NOTE The order of these catch statements matter and should go from
-         * most to least specific. Otherwise all Exceptions will be caught 
-         * as their more generic parent class which reduces precision.
-         */
+            /* Catch more specific errors that may be thrown in the codebase.
+            * Without handling these exceptions explicitly, LORIS will display
+            * a 404 error and swallow the exception, hindering debugging efforts.
+            *
+            * NOTE The order of these catch statements matter and should go from
+            * most to least specific. Otherwise all Exceptions will be caught
+            * as their more generic parent class which reduces precision.
+            */
         } catch (\DatabaseException $e) {
             error_log($e);
             return $this->responseStatus500(
@@ -328,11 +328,12 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
 
     /**
      * Return a properly-decorated response with status 500. Used to handle
-     * exceptions thrown within the codebase in a graceful way. 
+     * exceptions thrown within the codebase in a graceful way.
      *
      * @param ServerRequestInterface $request The request to process.
-     * @param \User $user The user to decorate the page with.
-     * @message string An error message explaining the 500 code to the user.
+     * @param \User                  $user    The user to decorate the page with.
+     * @param string                 $message An error message explaining the
+     *                                  500 code to the user.
      *
      * @return ResponseInterface A properly decorated 500 response.
      */

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -3,7 +3,7 @@
  * This file contains a class which encapsulates the concept of a "module"
  * in LORIS.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  Loris
@@ -271,7 +271,6 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                 );
             }
         } catch (\NotFound $e) {
-            error_log("IN the NotFound exception");
             return (new \LORIS\Middleware\PageDecorationMiddleware(
                 $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
             ))->process(
@@ -284,14 +283,10 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     )
                 )
             );
-            /* Catch more specific errors that may be thrown in the codebase.
-            * Without handling these exceptions explicitly, LORIS will display
-            * a 404 error and swallow the exception, hindering debugging efforts.
-            *
-            * NOTE The order of these catch statements matter and should go from
-            * most to least specific. Otherwise all Exceptions will be caught
-            * as their more generic parent class which reduces precision.
-            */
+            /* The order of these catch statements matter and should go from
+             * most to least specific. Otherwise all Exceptions will be caught
+             * as their more generic parent class which reduces precision.
+             */
         } catch (\DatabaseException $e) {
             error_log($e);
             return $this->responseStatus500(
@@ -301,7 +296,6 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
             );
         } catch (\ConfigurationException $e) {
             error_log($e);
-            error_log(self::CONFIGURATION_ERROR);
             return $this->responseStatus500(
                 $request,
                 $user,

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -26,6 +26,12 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterface
 {
+    const GENERIC_500_ERROR = "We're sorry, LORIS has encountered an internal "
+        . "server error. Please contact your project administrator for more "
+        . "information.";
+    const CONFIGURATION_ERROR = "LORIS configuration settings are invalid or "
+        . "missing and as a result execution cannot proceed. Please contact "
+        . "your project administrator and/or verify your LORIS configuration.";
     protected $name;
     protected $dir;
 
@@ -265,6 +271,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                 );
             }
         } catch (\NotFound $e) {
+            error_log("IN the NotFound exception");
             return (new \LORIS\Middleware\PageDecorationMiddleware(
                 $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
             ))->process(
@@ -277,8 +284,74 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     )
                 )
             );
+        /* Catch more specific errors that may be thrown in the codebase.
+         * Without handling these exceptions explicitly, LORIS will display
+         * a 404 error and swallow the exception, hindering debugging efforts.
+         *
+         * NOTE The order of these catch statements matter and should go from
+         * most to least specific. Otherwise all Exceptions will be caught 
+         * as their more generic parent class which reduces precision.
+         */
+        } catch (\DatabaseException $e) {
+            error_log($e);
+            return $this->responseStatus500(
+                $request,
+                $user,
+                self::GENERIC_500_ERROR
+            );
+        } catch (\ConfigurationException $e) {
+            error_log($e);
+            error_log(self::CONFIGURATION_ERROR);
+            return $this->responseStatus500(
+                $request,
+                $user,
+                self::CONFIGURATION_ERROR
+            );
+        } catch (\LorisException $e) {
+            error_log($e);
+            return $this->responseStatus500(
+                $request,
+                $user,
+                self::GENERIC_500_ERROR
+            );
+        } catch (\Exception $e) {
+            error_log($e);
+            return $this->responseStatus500(
+                $request,
+                $user,
+                self::GENERIC_500_ERROR
+            );
         }
 
         return $page->process($request, $page);
+    }
+
+    /**
+     * Return a properly-decorated response with status 500. Used to handle
+     * exceptions thrown within the codebase in a graceful way. 
+     *
+     * @param ServerRequestInterface $request The request to process.
+     * @param \User $user The user to decorate the page with.
+     * @message string An error message explaining the 500 code to the user.
+     *
+     * @return ResponseInterface A properly decorated 500 response.
+     */
+    function responseStatus500(
+        ServerRequestInterface $request,
+        \User $user,
+        string $message
+    ): ResponseInterface {
+        return (new \LORIS\Middleware\PageDecorationMiddleware(
+            $user
+        ))->process(
+            $request,
+            new \LORIS\Router\NoopResponder(
+                new \LORIS\Http\Error(
+                    $request,
+                    500,
+                    $message
+                )
+            )
+        );
     }
 }

--- a/smarty/templates/500.tpl
+++ b/smarty/templates/500.tpl
@@ -1,6 +1,4 @@
 <div class="container">
-{foreach from=$error_message item=message}
-    <h2>{$message}</h2>
-{/foreach}
+    <h3>{$message}</h3>
     <div><a href="{$baseurl}">Go to main page</a></div>
 </div>


### PR DESCRIPTION
### Brief summary of changes

Previously LORIS would crash and show a blank page on 500 errors OR mistakenly show a 404 page. 

This was because ~~the try-catch in Module only had a catch case for `NotFound` exceptions. Thus all exceptions were treated as 404 as a result even though it was wrong~~ of `reasons`.

On top of this, the actual exception message would be swallowed and would not appear in the error logs, making things very difficult to debug.

This PR fixes this issues and serves well-decorated 500 pages containing a message to the user. A special message is returned for ConfigurationExceptions as they reflect errors on the user's part rather than on LORIS's part. The exception information is also logged to assist with debugging.

### This resolves issue...
Should address numerous issues that have arisen in PRs https://github.com/aces/Loris/pull/3921 https://github.com/aces/Loris/pull/3881 https://github.com/aces/Loris/pull/4162, maybe more.

### To test this change...

- [ ] Throw an exception in the code anywhere. Instead of crashing you will either get a well-decorated generic 500 page or a page telling you that you have invalid Config settings.
