### PR TITLE
[DICOM archive] Ensure that settings necessary for anonymization exist

### DIFF
--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -14,7 +14,6 @@
  * @link       https://www.github.com/aces/Loris-Trunk/
  */
 namespace LORIS\dicom_archive;
-use \Psr\Http\Server\RequestHandlerInterface;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -14,8 +14,6 @@
  * @link       https://www.github.com/aces/Loris-Trunk/
  */
 namespace LORIS\dicom_archive;
-use \Psr\Http\Message\ServerRequestInterface;
-use \Psr\Http\Message\ResponseInterface;
 
 /**
  * Provides the PHP code for the menu filter for the dicom archive
@@ -98,66 +96,6 @@ class Dicom_Archive extends \NDB_Menu_Filter
         $this->addBasicText('archiveLocation', 'Archive Location');
         $this->addBasicText('seriesuid', 'Series UID');
     }
-
-
-    /**
-     * Handle a PSR7 Request for the dicom_archive endpoint. Also calls a
-     * validation function to ensure necessary configuration settings exist.
-     *
-     * @param ServerRequestInterface $request The PSR15 Request being handled
-     *
-     * @return ResponseInterface The PSR15 response for the page.
-     */
-    public function handle(ServerRequestInterface $request) : ResponseInterface
-    {
-        try {
-            $this->validateConfig();
-        } catch (\ConfigurationException $e) {
-            error_log($e);
-            return (new \Zend\Diactoros\Response())
-                ->withStatus(500, 'Forbidden')
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        'Required configuration settings for DICOM ' .
-                        'anonymization are missing. Cannot continue.'
-                    )
-                );
-        }
-        return parent::handle($request);
-    }
-
-    /**
-     * Checks that the required configuration settings are properly set. Throws
-     * a ConfigurationException if not.
-     *
-     * @return void
-     *
-     * @throws \ConfigurationException
-     */
-    function validateConfig(): void
-    {
-        /* Ensure that all required configuraton settings are properly set
-         * before continuing.
-         */
-        $config        = \NDB_Config::singleton()->getSetting("imaging_modules");
-        $configOptions = array(
-                          'patientNameRegex',
-                          'LegoPhantomRegex',
-                          'LivingPhantomRegex',
-                          'patientIDRegex',
-                         );
-        $configError   = 'Configuration settings missing for DICOM anonymization. ' .
-            'Please ensure that the following settings are configured to ' .
-            'be valid regular expressions: ';
-        foreach ($configOptions as $option) {
-            if (!isset($config[$option])) {
-                throw new \ConfigurationException(
-                    $configError . implode(', ', $configOptions)
-                );
-            }
-        }
-    }
-
 
     /**
      * Converts the results of this menu filter to a JSON format to be retrieved

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -4,7 +4,7 @@
  * This class features the code for the menu portion
  * of the Loris dicom archive.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category   Behavioural
  * @package    Main
@@ -14,6 +14,9 @@
  * @link       https://www.github.com/aces/Loris-Trunk/
  */
 namespace LORIS\dicom_archive;
+use \Psr\Http\Server\RequestHandlerInterface;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 /**
  * Provides the PHP code for the menu filter for the dicom archive
@@ -99,6 +102,65 @@ class Dicom_Archive extends \NDB_Menu_Filter
 
 
     /**
+     * Handle a PSR7 Request for the dicom_archive endpoint. Also calls a
+     * validation function to ensure necessary configuration settings exist.
+     *
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface The PSR15 response for the page.
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        try {
+            $this->validateConfig();
+        } catch (\ConfigurationException $e) {
+            error_log($e);
+            return (new \Zend\Diactoros\Response())
+                ->withStatus(500, 'Forbidden')
+                ->withBody(
+                    new \LORIS\Http\StringStream(
+                        'Required configuration settings for DICOM ' .
+                        'anonymization are missing. Cannot continue.'
+                    )
+                );
+        }
+        return parent::handle($request);
+    }
+
+    /**
+     * Checks that the required configuration settings are properly set. Throws
+     * a ConfigurationException if not.
+     *
+     * @return void
+     *
+     * @throws \ConfigurationException
+     */
+    function validateConfig(): void
+    {
+        /* Ensure that all required configuraton settings are properly set
+         * before continuing.
+         */
+        $config        = \NDB_Config::singleton()->getSetting("imaging_modules");
+        $configOptions = array(
+                          'patientNameRegex',
+                          'LegoPhantomRegex',
+                          'LivingPhantomRegex',
+                          'patientIDRegex',
+                         );
+        $configError   = 'Configuration settings missing for DICOM anonymization. ' .
+            'Please ensure that the following settings are configured to ' .
+            'be valid regular expressions: ';
+        foreach ($configOptions as $option) {
+            if (!isset($config[$option])) {
+                throw new \ConfigurationException(
+                    $configError . implode(', ', $configOptions)
+                );
+            }
+        }
+    }
+
+
+    /**
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
@@ -106,6 +168,9 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function toJSON()
     {
+        /* Ensure that the server is well configured to prevent displaying
+         * data that is not properly anonmyized.
+         */
         $table = (new \LORIS\Data\Table())
             ->withDataFrom($this->getDataProvisioner());
         $arr   = array_map(

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -105,9 +105,6 @@ class Dicom_Archive extends \NDB_Menu_Filter
      */
     function toJSON()
     {
-        /* Ensure that the server is well configured to prevent displaying
-         * data that is not properly anonmyized.
-         */
         $table = (new \LORIS\Data\Table())
             ->withDataFrom($this->getDataProvisioner());
         $arr   = array_map(

--- a/modules/dicom_archive/php/module.class.inc
+++ b/modules/dicom_archive/php/module.class.inc
@@ -13,6 +13,8 @@
  * @link       https://www.github.com/aces/Loris-Trunk/
  */
 namespace LORIS\dicom_archive;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 /**
  * Class module implements the basic LORIS module functionality
@@ -26,4 +28,67 @@ namespace LORIS\dicom_archive;
  */
 class Module extends \Module
 {
+    /**
+     * Handle a PSR7 Request for the dicom_archive endpoint. Also calls a
+     * validation function to ensure necessary configuration settings exist.
+     *
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface The PSR15 response for the page.
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        try {
+            $this->validateConfig();
+        } catch (\ConfigurationException $e) {
+            error_log($e);
+            return (new \LORIS\Middleware\PageDecorationMiddleware(
+                $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
+            ))->process(
+                $request,
+                new \LORIS\Router\NoopResponder(
+                    new \LORIS\Http\Error(
+                        $request,
+                        500,
+                        'Required configuration settings for DICOM ' .
+                        'anonymization are missing. Cannot continue.'
+                    )
+                )
+            );
+        }
+        return parent::handle($request);
+    }
+
+    /**
+     * Checks that the required configuration settings are properly set. Throws
+     * a ConfigurationException if not.
+     *
+     * @return void
+     *
+     * @throws \ConfigurationException
+     */
+    function validateConfig(): void
+    {
+        /* Ensure that all required configuraton settings are properly set
+         * before continuing.
+         */
+        $config        = \NDB_Config::singleton()->getSetting("imaging_modules");
+        $configOptions = array(
+                          'patientNameRegex',
+                          'LegoPhantomRegex',
+                          'LivingPhantomRegex',
+                          'patientIDRegex',
+                         );
+        $configError   = 'Configuration settings missing for DICOM anonymization. ' .
+            'Please ensure that the following settings are configured to ' .
+            'be valid regular expressions: ';
+        foreach ($configOptions as $option) {
+            if (!isset($config[$option])) {
+                throw new \ConfigurationException(
+                    $configError . implode(', ', $configOptions)
+                );
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
### Brief summary of changes

While hunting down a PHP Warning I discovered that `dicomarchiveanonymizer.class.inc` does not do any validation on the config settings it uses. This results in empty values being sent to `preg_match` with possible consequences where DICOMs are not properly anonymized. I did not actually discover a case where this is true but my dummy imaging data is very limited.

This PR adds some validation to `dicom_archive.class.inc`. It will now refuse to show DICOM data when the regex config values are not properly configured. 

### This resolves issue...

Should eliminate warnings like
`
PHP Warning:  preg_match(): Empty regular expression in /var/www/loris/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc on line 62, referer: https://jsaigle-dev.loris.ca/dicom_archive/
`

### To test this change...

- [ ] On another branch, go to DICOM archive and check your error logs. See if you get the above warning.
* If so, check out my branch and you should see a new error message on the front-end as well as a ConfigurationException in the logs. 
   * Now change the Regex ConfigSettings (see source code) to valid regular expressions.
    * Navigate back to DICOM archive and ensure the page loads normally
* If you do not get a warning, delete one of the Regex Config Settings and follow the steps above.
