### PR TITLE
[deps] min phan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "phpunit/dbunit": "3.0.*",
         "facebook/webdriver" : "dev-master",
         "phpmd/phpmd": "^2.6",
-        "phan/phan": "0.12.x"
+        "phan/phan": ">=0.12.0"
     },
     "scripts": {
       "pre-install-cmd": "mkdir -p project/libraries"


### PR DESCRIPTION
Anyone know if this will break something? I think as our systems are getting newer, we're no longer installing low versions of ast which phan 0.12.x requires...also isn't phan 0.12.x a bit old?