### PR TITLE
[Core] Add "npm install" to make's "dev" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ all:
 
 dev:
 	composer install
+	npm install
 	npm run compile
 	git describe --tags --always > VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all:
 	composer install --no-dev
+	npm install
 	npm run compile
 	git describe --tags --always > VERSION
 


### PR DESCRIPTION
### Brief summary of changes

When `make`ing a dev environment it makes sense to install the node modules you need. Let me know if there's a reason not to do this.
