### PR TITLE
[Core] Add babel-core as a dependency on minor branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "babel-core": "^6.26.3",
     "sweetalert2": "^7.28.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### Brief summary of changes

Should fix errors like `ERROR in Cannot find module 'babel-core'` when compiling React files on the `minor` branch. 

Issuing this to `minor` because I think we'll probably have a minor release soon and so this will bubble up into future bugfix releases.
