### PR TITLE
[Core: BVL_Feedback] Fix error that makes LORIS crash when accessing candidate info on `major` branch

### DIFF
--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -74,7 +74,7 @@ class BVL_Feedback_Panel
 
         $this->tpl_data['candID'] = $candidateID;
 
-        $candidateObject         = Candidate::singleton($candidateID);
+        $candidateObject         = Candidate::singleton(intval($candidateID)));
         $this->tpl_data['pscid'] = $candidateObject->getPSCID();
 
         $this->tpl_data['sessionID'] = $feedbackProfile["SessionID"] ?? null;

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -74,7 +74,7 @@ class BVL_Feedback_Panel
 
         $this->tpl_data['candID'] = $candidateID;
 
-        $candidateObject         = Candidate::singleton(intval($candidateID)));
+        $candidateObject         = Candidate::singleton(intval($candidateID));
         $this->tpl_data['pscid'] = $candidateObject->getPSCID();
 
         $this->tpl_data['sessionID'] = $feedbackProfile["SessionID"] ?? null;

--- a/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
+++ b/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
@@ -74,7 +74,7 @@ class NDB_BVL_Instrument_testtest extends NDB_BVL_Instrument
       $this->addCheckbox('testCheckbox', 'Check this checkbox default value is 1', array('value' => '1'));
       $this->form->addElement("text", 'testText', "text_input", array("class" => "encrypt required"));
       $yesNo = array(null=>"", 'yes'=>"Yes", 'no'=>"No");
-      $group[] =& $this->form->createElement("select","consent", "", $yesNo);
+      $group[] = $this->form->createElement("select","consent", "", $yesNo);
       $this->XINRegisterRule("consent", array("code{@}=={@}"), "Required.", "consent_group");
       $this->form->addGroup($group, "consent_group", "Test selecting 'Yes' from the dropdown menu.", null, false);
       unset($group);


### PR DESCRIPTION
### Brief summary of changes

Merging #4124 caused some errors to appear in Travis and make it crash. This will make every PR to major fail and also means that no candidate info can be accessed.

This PR should fix those errors. For an example see this report: https://travis-ci.org/aces/Loris/jobs/462997840
