### PR TITLE
[Core: Utility] Fix type error in toArray

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -427,7 +427,7 @@ class Utility
      *
      * @param mixed $var The variable to be converted to an array.
      *
-     * @return array|string If $var is an array, $var, 
+     * @return array|string If $var is an array, $var,
      *                          otherwise an array containing $var
      */
     static function toArray($var)

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -427,9 +427,10 @@ class Utility
      *
      * @param mixed $var The variable to be converted to an array.
      *
-     * @return array If $var is an array, var, otherwise an array containing $var
+     * @return array|string If $var is an array, $var, 
+     *                          otherwise an array containing $var
      */
-    static function toArray($var): array
+    static function toArray($var)
     {
         if (is_array($var) && !array_key_exists(0, $var)) {
             $var = array($var);


### PR DESCRIPTION
### Brief summary of changes

#4151 should be merged but this is causing problems until then.

### This resolves issue...

` PHP Fatal error:  Uncaught TypeError: Return value of Utility::toArray() must be of the type array, string returned in /var/www/loris/php/libraries/Utility.class.inc:437`

