### PR TITLE
[unittest] remove skip test

### DIFF
--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -5,50 +5,13 @@
         colors="true">
     <testsuites>
         <testsuite name='LorisUnitTests'>
-            <directory>./unittests/</directory>
+          <directory>./unittests/</directory>
         </testsuite>
 
         <testsuite name='LorisCoreIntegrationTests'>
-            <directory>./integrationtests/</directory>
         </testsuite>
 
         <testsuite name='LorisModuleIntegrationTests'>
-            <directory>../modules/acknowledgements/test/</directory>
-            <directory>../modules/brainbrowser/test/</directory>
-            <directory>../modules/candidate_list/test/</directory>
-            <directory>../modules/candidate_parameters/test/</directory>
-            <directory>../modules/configuration/test/</directory>
-            <directory>../modules/conflict_resolver/test/</directory>
-            <directory>../modules/create_timepoint/test/</directory>
-            <directory>../modules/dashboard/test/</directory>
-            <directory>../modules/data_integrity_flag/test/</directory>
-            <directory>../modules/data_team_helper/test/</directory>
-            <directory>../modules/datadict/test/</directory>
-            <directory>../modules/dicom_archive/test/</directory>
-            <directory>../modules/document_repository/test/</directory>
-            <directory>../modules/examiner/test/</directory>
-            <directory>../modules/genomic_browser/test/</directory>
-            <directory>../modules/help_editor/test/</directory>
-            <directory>../modules/imaging_browser/test/</directory>
-            <directory>../modules/imaging_uploader/test/</directory>
-            <directory>../modules/instrument_builder/test/</directory>
-            <directory>../modules/instrument_list/test/</directory>
-            <directory>../modules/instrument_manager/test/</directory>
-            <directory>../modules/mri_upload/test/</directory>
-            <directory>../modules/mri_violations/test/</directory>
-            <directory>../modules/new_profile/test/</directory>
-            <directory>../modules/next_stage/test/</directory>
-            <directory>../modules/statistics/test/</directory>
-            <directory>../modules/survey_accounts/test/</directory>
-            <directory>../modules/timepoint_flag/test/</directory>
-            <directory>../modules/timepoint_list/test/</directory>
-            <directory>../modules/training/test/</directory>
-            <directory>../modules/user_accounts/test/</directory>
-            <directory>../modules/media/test/</directory>
-            <directory>../modules/issue_tracker/test/</directory>
-            <directory>../modules/server_processes_manager/test/</directory>
-            <directory>../test/test_instrument/</directory>
-            <directory>../modules/bvl_feedback/test/</directory>
         </testsuite>
 
     </testsuites>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -5,13 +5,50 @@
         colors="true">
     <testsuites>
         <testsuite name='LorisUnitTests'>
-          <directory>./unittests/</directory>
+            <directory>./unittests/</directory>
         </testsuite>
 
         <testsuite name='LorisCoreIntegrationTests'>
+            <directory>./integrationtests/</directory>
         </testsuite>
 
         <testsuite name='LorisModuleIntegrationTests'>
+            <directory>../modules/acknowledgements/test/</directory>
+            <directory>../modules/brainbrowser/test/</directory>
+            <directory>../modules/candidate_list/test/</directory>
+            <directory>../modules/candidate_parameters/test/</directory>
+            <directory>../modules/configuration/test/</directory>
+            <directory>../modules/conflict_resolver/test/</directory>
+            <directory>../modules/create_timepoint/test/</directory>
+            <directory>../modules/dashboard/test/</directory>
+            <directory>../modules/data_integrity_flag/test/</directory>
+            <directory>../modules/data_team_helper/test/</directory>
+            <directory>../modules/datadict/test/</directory>
+            <directory>../modules/dicom_archive/test/</directory>
+            <directory>../modules/document_repository/test/</directory>
+            <directory>../modules/examiner/test/</directory>
+            <directory>../modules/genomic_browser/test/</directory>
+            <directory>../modules/help_editor/test/</directory>
+            <directory>../modules/imaging_browser/test/</directory>
+            <directory>../modules/imaging_uploader/test/</directory>
+            <directory>../modules/instrument_builder/test/</directory>
+            <directory>../modules/instrument_list/test/</directory>
+            <directory>../modules/instrument_manager/test/</directory>
+            <directory>../modules/mri_upload/test/</directory>
+            <directory>../modules/mri_violations/test/</directory>
+            <directory>../modules/new_profile/test/</directory>
+            <directory>../modules/next_stage/test/</directory>
+            <directory>../modules/statistics/test/</directory>
+            <directory>../modules/survey_accounts/test/</directory>
+            <directory>../modules/timepoint_flag/test/</directory>
+            <directory>../modules/timepoint_list/test/</directory>
+            <directory>../modules/training/test/</directory>
+            <directory>../modules/user_accounts/test/</directory>
+            <directory>../modules/media/test/</directory>
+            <directory>../modules/issue_tracker/test/</directory>
+            <directory>../modules/server_processes_manager/test/</directory>
+            <directory>../test/test_instrument/</directory>
+            <directory>../modules/bvl_feedback/test/</directory>
         </testsuite>
 
     </testsuites>

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -588,7 +588,6 @@ class CandidateTest extends TestCase
 
         $this->_configMock->method('getSetting')
             ->will($this->returnValueMap($this->_configMap));
-
         $this->assertEquals(
             1,
             Candidate::validatePSCID('AAA0012', 'AAA'),
@@ -609,17 +608,14 @@ class CandidateTest extends TestCase
      */
     public function testCreateNew()
     {
-        $this->markTestIncomplete("Test not implemented!");
+       $mock = $this->getMockBuilder('Candidate')
+                     ->setMethods(array('createNew'))
+                     ->getMock();
+       $mock->expects($this->once())
+            ->method('createNew')
+            ->will($this->returnValue(12345));
         
-        $this->_dbMock->expects($this->once())
-            ->method('pselectRow')
-            ->willReturn(array('CandID' => 969664));
-        $this->_candidate = new Candidate("1","1988-08-08","M");
-$mock = $this->getMockBuilder('Candidate')
-    ->setMethods(array('handleValue'))
-    ->getMock();
-
-
+       $this->assertEquals('12345',$mock::createNew(1,"1980-01-01",null,"M"));
 
     }
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -179,10 +179,10 @@ class CandidateTest extends TestCase
     {
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
-            ->willReturn(false);
+            ->willReturn(null);
         
         $this->expectException('LorisException');
-        $this->_candidate->select('invalid value');
+        $this->_candidate->select(88888);
 
     }
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -181,7 +181,7 @@ class CandidateTest extends TestCase
             ->method('pselectRow')
             ->willReturn(false);
         
-        $this->expectedException('LorisException');
+        $this->expectException('LorisException');
         $this->_candidate->select('invalid value');
 
     }

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -177,12 +177,11 @@ class CandidateTest extends TestCase
      */
     public function testsSelectFailsWhenInvalidCandidateIdPassed()
     {
-        $this->markTestSkipped("setExpectedException has been deprecated! ");
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')
             ->willReturn(false);
         
-        $this->setExpectedException('LorisException');
+        $this->expectedException('LorisException');
         $this->_candidate->select('invalid value');
 
     }

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -610,6 +610,17 @@ class CandidateTest extends TestCase
     public function testCreateNew()
     {
         $this->markTestIncomplete("Test not implemented!");
+        
+        $this->_dbMock->expects($this->once())
+            ->method('pselectRow')
+            ->willReturn(array('CandID' => 969664));
+        $this->_candidate = new Candidate("1","1988-08-08","M");
+$mock = $this->getMockBuilder('Candidate')
+    ->setMethods(array('handleValue'))
+    ->getMock();
+
+
+
     }
 
     /**

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -608,15 +608,7 @@ class CandidateTest extends TestCase
      */
     public function testCreateNew()
     {
-       $mock = $this->getMockBuilder('Candidate')
-                     ->setMethods(array('createNew'))
-                     ->getMock();
-       $mock->expects($this->once())
-            ->method('createNew')
-            ->will($this->returnValue(12345));
-        
-       $this->assertEquals('12345',$mock::createNew(1,"1980-01-01",null,"M"));
-
+        $this->markTestIncomplete("Test not implemented!");
     }
 
     /**

--- a/test/unittests/SettingsTest.php
+++ b/test/unittests/SettingsTest.php
@@ -220,11 +220,10 @@ class SettingsTest extends TestCase
      */
     public function testExceptionThrownWhenNoPasswordInConfig()
     {
-        $this->markTestSkipped("setExpectedException has been deprecated!");
         unset($this->_databaseConfigValues['password']);
         $this->_setUpConfigDatabaseTestDouble();
 
-        $this->setExpectedException('ConfigurationException');
+        $this->expectException('ConfigurationException');
         $this->_settings->dbPassword();
     }
 


### PR DESCRIPTION
### Brief summary of changes
Removing skip test in Candidate Test.
It fixes the" setExpectedException has been deprecated!"
