### PR TITLE
[Imaging Browser] Fix a bug in imaging browser view session page for projects without EDC

### DIFF
--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -703,9 +703,7 @@ class ViewSession extends \NDB_Form
         $candidate            =& \Candidate::singleton($timePoint->getCandID());
         $subjectData['pscid'] = $candidate->getPSCID();
         $subjectData['dob']   = $candidate->getCandidateDoB();
-        if ($tpl_data['useEDC'] === 'true') {
-            $subjectData['edc'] = $candidate->getCandidateEDC();
-        }
+        $subjectData['edc']   = $candidate->getCandidateEDC();
         $subjectData['gender'] = $candidate->getCandidateGender();
 
         // This doesn't work.

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -703,7 +703,9 @@ class ViewSession extends \NDB_Form
         $candidate            =& \Candidate::singleton($timePoint->getCandID());
         $subjectData['pscid'] = $candidate->getPSCID();
         $subjectData['dob']   = $candidate->getCandidateDoB();
-        $subjectData['edc']   = $candidate->getCandidateEDC();
+        if ($tpl_data['useEDC'] === 'true') {
+            $subjectData['edc'] = $candidate->getCandidateEDC();
+        }
         $subjectData['gender'] = $candidate->getCandidateGender();
 
         // This doesn't work.

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -486,9 +486,9 @@ class Candidate
      * Returns the expect date of confinement (due date)
      * of this candidate.
      *
-     * @return string The DoB in YYYY-MM-DD format
+     * @return string|null The DoB in YYYY-MM-DD format
      */
-    function getCandidateEDC(): string
+    function getCandidateEDC(): ?string
     {
         return $this->candidateInfo["EDC"];
     }


### PR DESCRIPTION
### Brief summary of changes

The view session page is currently broken on major for projects not using EDC. This PR fixes the bug so that projects not using EDC can still load the view session page of the imaging browser module.

### This resolves issue...

- [x] Github? #4184 

### To test this change...

- [ ] make sure that your datasets does not include EDC (Config set to no and EDC=NULL in the candidate table for the candidate you are testing). Test the major branch and notice you get a 500 error
- [ ] pull the code from this branch and notice you can load the view session page.
- [ ] also test on a candidate with an EDC to make sure it works as well
