### PR TITLE
[Core: Module] Fix errors in 500-reponse logic

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -82,11 +82,11 @@ class Instrument_List extends \NDB_Menu_Filter
         $user      =& \User::singleton();
         $timePoint = $this->timePoint;
         if ($timePoint === null) {
-            throw new \LorisException("Page requires a timepoint to load");
+            throw new \NotFound("Page requires a timepoint to load");
         }
         $candidate = $this->candidate;
         if ($candidate === null) {
-            throw new \LorisException("Page requires a candidate to load");
+            throw new \NotFound("Page requires a candidate to load");
         }
 
         //These variable are only for checking the permissions.

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -33,7 +33,7 @@ class Module extends \Module
      * The instrument_list module falls back to the instrument_list page regardless
      * of what the page loaded was. This ensures that routes which use the CandID
      * (and not the word "instrument_list") are still able to be loaded and not
-     * 404 errors.
+     * give 404 errors.
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
      *
@@ -41,17 +41,20 @@ class Module extends \Module
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        try {
-            $resp = parent::handle($request);
-            // hasAccess from the parent returns a 403
-            if ($resp->getStatusCode() != 404) {
-                return $resp;
-            }
-        } catch (\LorisException $e) {
-            // Calling hasAccess from the loader would have failed with
-            // an exception saying it needs a timepoint/candidate if loading
-            // the instrument_list page, which we set below.
+        $resp = parent::handle($request);
+        // hasAccess from the parent returns a 403
+        if ($resp->getStatusCode() != 404) {
+            return $resp;
         }
+
+        /* If the response code above was a 404, it could have been caused by
+         * the \NotFound exception in instrument_list.class.inc. This means
+         * that the route used to access the module contained either a candID
+         * or a timepoint but not both.
+         * The code below extracts this information from the server so that the
+         * module can load properly even in cases like the above where
+         * "instrument_list" isn't actually in the URL path.
+         */
 
         // Falling back to instrument_list, ensure that the CandID
         // and SessionID are valid, and if so attach the models to

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -247,6 +247,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
         }
 
         try {
+            $user = $request->getAttribute("user") ?? new \LORIS\AnonymousUser();
             $page = $this->loadPage($pagename);
             // FIXME: Hack required for breadcrumbs. This should be removed,
             // but some tests depend on it.
@@ -258,7 +259,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
 
             if ($page->_hasAccess() !== true) {
                 return (new \LORIS\Middleware\PageDecorationMiddleware(
-                    $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
+                    $user
                 ))->process(
                     $request,
                     new \LORIS\Router\NoopResponder(
@@ -272,7 +273,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
             }
         } catch (\NotFound $e) {
             return (new \LORIS\Middleware\PageDecorationMiddleware(
-                $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
+                $user
             ))->process(
                 $request,
                 new \LORIS\Router\NoopResponder(


### PR DESCRIPTION
### Brief summary of changes

Instrument List crashes on `bugfix` because the `$user` variable was not properly set. A TypeError is thrown by `responseStatus500()` as a result.

This isn't clear from the code changes but this should fix errors like:
`Fatal error: Uncaught TypeError: Argument 2 passed to Module::responseStatus500() must be an instance of User, null given, called in /home/travis/build/aces/Loris/php/libraries/Module.class.inc on line 309 and defined in /home/travis/build/aces/Loris/php/libraries/Module.class.inc:334`
