### PR TITLE
[Login] Fix type error when attempting to log in

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -321,7 +321,7 @@ class SinglePointLogin
             return false;
         }
         // Validate passsword
-        $oldhash = $row['Password_hash'];
+        $oldhash = $row['Password_hash'] ?? '';
         if (password_verify($password, $oldhash)) {
             // Rehash according to latest standards if necessary.
             if (password_needs_rehash($oldhash, PASSWORD_DEFAULT)) {


### PR DESCRIPTION
This fixes an error about password_verify getting a null but expecting
a string which could occur when attempting to login if Password_hash was
null.