### PR TITLE
[API] Adding /projects/$projectname

### DIFF
--- a/htdocs/api/v0.0.1/.htaccess
+++ b/htdocs/api/v0.0.1/.htaccess
@@ -7,18 +7,20 @@ Options -Indexes
 RewriteCond %{ENV:REDIRECT_STATUS} 200
 RewriteRule ^ - [L]
 
-RewriteRule ^login Login.php?PrintLogin=true [L]
+# Login
+RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.2/login/ [QSA,END]
+
 # Projects API rewrite rules
+RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.1/projects/ [QSA,END]
+RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ /index.php?lorispath=api/v0.0.1/projects/$1 [QSA,END]
+
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments/([a-zA-Z0-9_.]+)$ projects/InstrumentForm.php?Instrument=$2&PrintInstrumentForm=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/visits(/*)$ projects/Project.php?Project=$1&Visits=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/candidates(/*)$ projects/Project.php?Project=$1&Candidates=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php?Project=$1&Instruments=true&PrintProjectJSON=true&InstrumentDetails=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
-RewriteRule ^projects(/*)$ Projects.php?PrintProjects=true [L]
-
 # Candidates API rewrite rules
-
 RewriteRule ^candidates(/*)$ Candidates.php?PrintCandidates=true [L]
 RewriteRule ^candidates/([0-9]+)(/*)$ candidates/Candidate.php?CandID=$1&PrintCandidate=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)(/*)$ candidates/Visit.php?CandID=$1&VisitLabel=$2&PrintVisit=true [L]

--- a/htdocs/api/v0.0.1/.htaccess
+++ b/htdocs/api/v0.0.1/.htaccess
@@ -8,7 +8,7 @@ RewriteCond %{ENV:REDIRECT_STATUS} 200
 RewriteRule ^ - [L]
 
 # Login
-RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.2/login/ [QSA,END]
+RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.1/login/ [QSA,END]
 
 # Projects API rewrite rules
 RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.1/projects/ [QSA,END]
@@ -18,7 +18,6 @@ RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments/([a-zA-Z0-9_.]+)$ project
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/visits(/*)$ projects/Project.php?Project=$1&Visits=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/candidates(/*)$ projects/Project.php?Project=$1&Candidates=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php?Project=$1&Instruments=true&PrintProjectJSON=true&InstrumentDetails=true [L]
-RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
 # Candidates API rewrite rules
 RewriteRule ^candidates(/*)$ Candidates.php?PrintCandidates=true [L]

--- a/htdocs/api/v0.0.2/.htaccess
+++ b/htdocs/api/v0.0.2/.htaccess
@@ -8,13 +8,15 @@ RewriteCond %{ENV:REDIRECT_STATUS} 200
 RewriteRule ^ - [L]
 
 # Projects API rewrite rules
+RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.2/projects/ [QSA,END]
+RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ /index.php?lorispath=api/v0.0.2/projects/$1 [QSA,END]
+
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments/([a-zA-Z0-9_.]+)$ projects/InstrumentForm.php?Instrument=$2&PrintInstrumentForm=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/visits(/*)$ projects/Project.php?Project=$1&Visits=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/candidates(/*)$ projects/Project.php?Project=$1&Candidates=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php?Project=$1&Instruments=true&PrintProjectJSON=true&InstrumentDetails=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
-RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.2/projects/ [QSA,END]
 
 # Candidates API rewrite rules
 

--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -7,15 +7,19 @@ Options -Indexes
 RewriteCond %{ENV:REDIRECT_STATUS} 200
 RewriteRule ^ - [L]
 
+# Login
+RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.2/login/ [QSA,END]
+
 # Projects API rewrite rules
+RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.3-dev/projects/ [QSA,END]
+RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ /index.php?lorispath=api/v0.0.2/projects/$1 [QSA,END]
+
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments/([a-zA-Z0-9_.]+)$ projects/InstrumentForm.php?Instrument=$2&PrintInstrumentForm=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/visits(/*)$ projects/Project.php?Project=$1&Visits=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/candidates(/*)$ projects/Project.php?Project=$1&Candidates=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php?Project=$1&Instruments=true&PrintProjectJSON=true&InstrumentDetails=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/images(/*)$ projects/Images.php?project_name=$1 [QSA,L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
-
-RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.3-dev/projects/ [QSA,END]
 
 # Candidates API rewrite rules
 
@@ -44,5 +48,3 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)$ cand
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/dicoms$ candidates/visits/Dicoms.php?CandID=$1&VisitLabel=$2&PrintDicoms=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/dicoms/([a-zA-Z0-9_.-]+)$ candidates/visits/dicoms/Dicom.php?CandID=$1&VisitLabel=$2&Tarname=$3&PrintDicomData=true [L]
 
-# New module enpoints
-RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.3-dev/login/ [QSA,END]

--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -8,7 +8,7 @@ RewriteCond %{ENV:REDIRECT_STATUS} 200
 RewriteRule ^ - [L]
 
 # Login
-RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.2/login/ [QSA,END]
+RewriteRule ^login[/]?$ /index.php?lorispath=api/v0.0.3-dev/login/ [QSA,END]
 
 # Projects API rewrite rules
 RewriteRule ^projects/$ /index.php?lorispath=api/v0.0.3-dev/projects/ [QSA,END]
@@ -19,7 +19,6 @@ RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/visits(/*)$ projects/Project.php?Proj
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/candidates(/*)$ projects/Project.php?Project=$1&Candidates=true&PrintProjectJSON=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/instruments(/*)$ projects/Project.php?Project=$1&Instruments=true&PrintProjectJSON=true&InstrumentDetails=true [L]
 RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)/images(/*)$ projects/Images.php?project_name=$1 [QSA,L]
-RewriteRule ^projects/([a-zA-Z0-9_\w\s.]+)(/*)$ projects/Project.php?Project=$1&Instruments=true&Visits=true&Candidates=true&PrintProjectJSON=true [L]
 
 # Candidates API rewrite rules
 

--- a/modules/api/php/login.class.inc
+++ b/modules/api/php/login.class.inc
@@ -14,7 +14,7 @@ namespace LORIS\api;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
-
+use \LORIS\Api\Endpoint;
 
 /**
  * A class for handling the api/v????/login endpoint.
@@ -25,7 +25,7 @@ use \Psr\Http\Message\ResponseInterface;
  * @license  Loris license
  * @link     https://github.com/aces/Loris
  */
-class Login extends APIEndpoint
+class Login extends Endpoint
 {
     /**
      * All users have access to the login endpoint to try and login.

--- a/modules/api/php/module.class.inc
+++ b/modules/api/php/module.class.inc
@@ -98,7 +98,8 @@ class Module extends \Module
         // Strip the version and add it to a request attribute, then let the default
         // module handler kick in to delegate to the appropriate page.
         $newurl = $request->getURI()->withPath($endpoint);
-        // split the url into parts to form a queue for the endpoints to delegate
+        // Split the url into parts to form a queue for the endpoints to delegate
+        // the request to subendpoints
         $pathparts  = explode('/', $newurl->getPath());
         $newrequest = $request
             ->withURI($newurl)

--- a/modules/api/php/module.class.inc
+++ b/modules/api/php/module.class.inc
@@ -97,10 +97,13 @@ class Module extends \Module
 
         // Strip the version and add it to a request attribute, then let the default
         // module handler kick in to delegate to the appropriate page.
-        $newurl     = $request->getURI()->withPath($endpoint);
+        $newurl = $request->getURI()->withPath($endpoint);
+        // split the url into parts to form a queue for the endpoints to delegate
+        $pathparts  = explode('/', $newurl->getPath());
         $newrequest = $request
             ->withURI($newurl)
-            ->withAttribute("LORIS-API-Version", $version);
+            ->withAttribute("LORIS-API-Version", $version)
+            ->withAttribute('pathparts', $pathparts);
 
         $parentresp = parent::handle($newrequest);
         switch ($parentresp->getStatusCode()) {

--- a/modules/api/php/projects.class.inc
+++ b/modules/api/php/projects.class.inc
@@ -14,8 +14,7 @@ namespace LORIS\api;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
-
-
+use \LORIS\Api\Endpoint;
 /**
  * A class for handling the api/v????/projects endpoint.
  *
@@ -25,7 +24,7 @@ use \Psr\Http\Message\ResponseInterface;
  * @license  Loris license
  * @link     https://github.com/aces/Loris
  */
-class Projects extends APIEndpoint implements \LORIS\Middleware\ETagCalculator
+class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
 {
     public $skipTemplate = true;
 
@@ -85,15 +84,9 @@ class Projects extends APIEndpoint implements \LORIS\Middleware\ETagCalculator
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         // FIXME: Validate permissions.
-        switch ($request->getURI()->getPath()) {
-        case "projects":
-        case "projects/":
-            $projects = $this->_getProjectList();
-            return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "application/json")
-                ->withBody(new \LORIS\Http\StringStream(json_encode($projects)));
-        // FIXME: Delegate to other endpoints under /projects/ for other paths.
-        default:
+        $pathparts = $request->getAttribute('pathparts');
+
+        if ($pathparts[0] != 'projects') {
             return (new \LORIS\Http\Response())
             ->withBody(
                 new \LORIS\Http\StringStream(
@@ -101,6 +94,24 @@ class Projects extends APIEndpoint implements \LORIS\Middleware\ETagCalculator
                 )
             )->withStatus(404);
         }
+
+        if (count($pathparts) === 1) {
+            $projects = $this->_getProjectList();
+            return (new \LORIS\Http\Response())
+                ->withHeader("Content-Type", "application/json")
+                ->withBody(
+                    new \LORIS\Http\StringStream(
+                        json_encode($projects)
+                    )
+                );
+        }
+
+        // Delegate to project specific endpoint.
+        $endpoint = new \LORIS\Api\Endpoints\Projects\Project();
+        array_shift($pathparts);
+        $request = $request->withAttribute('pathparts', $pathparts);
+
+        return $endpoint->process($request, $endpoint);
     }
 
     /**

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -70,7 +70,7 @@ class Project
                 );
 
                 if (empty($projectData)) {
-                    throw new \LorisException("No project named: $projectName");
+                    throw new \NotFound("No project named: $projectName");
                 }
 
                 $project = new Project();

--- a/src/Api/Endpoint.php
+++ b/src/Api/Endpoint.php
@@ -11,7 +11,7 @@
  * @license  Loris license
  * @link     https://github.com/aces/Loris
  */
-namespace LORIS\api;
+namespace LORIS\Api;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Server\RequestHandlerInterface;
@@ -27,7 +27,7 @@ use \Psr\Http\Message\ResponseInterface;
  * @license  Loris license
  * @link     https://github.com/aces/Loris
  */
-abstract class APIEndpoint extends \NDB_Page
+abstract class Endpoint implements RequestHandlerInterface
 {
     public $skipTemplate = true;
 

--- a/src/Api/Endpoints/Projects/Project.php
+++ b/src/Api/Endpoints/Projects/Project.php
@@ -17,7 +17,7 @@ use \Psr\Http\Message\ResponseInterface;
 use \LORIS\Api\Endpoint;
 
 /**
- * A class for handling the api/v????/projects/$projectname endpoint.
+ * A class for handling the /projects/$projectname endpoint.
  *
  * @category API
  * @package  Loris
@@ -30,8 +30,8 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
     public $skipTemplate = true;
 
     /**
-     * A cache of the results of the projects/ endpoint, so that it doesn't
-     * need to be recalculated for the ETag and handler
+     * A cache of the results of the projects/$projectname endpoint, so that
+     * it doesn't need to be recalculated for the ETag and handler
      */
     protected $responseCache = array();
 
@@ -86,14 +86,16 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         // FIXME: Validate project based permissions.
-        $pathparts = $request->getAttribute('pathparts');
+
+        $pathparts   = $request->getAttribute('pathparts');
+        $projectname = $pathparts[0];
 
         $this->project = \NDB_Factory::singleton()
-            ->project($pathparts[0]);
+            ->project($projectname);
 
         if (count($pathparts) > 1) {
             switch($pathparts[1]) {
-                // FIXME: delegate to other handlers
+            // FIXME: delegate to other handlers
             case 'candidates':
             case 'images':
             case 'instruments':
@@ -109,7 +111,7 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
             ->withHeader("Content-Type", "application/json")
             ->withBody(
                 new \LORIS\Http\StringStream(
-                    json_encode($this->_getProject($pathparts[0]))
+                    json_encode($this->_getProject($projectname))
                 )
             );
     }

--- a/src/Api/Endpoints/Projects/Project.php
+++ b/src/Api/Endpoints/Projects/Project.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * This implements the Project page class under Projects
+ *
+ * PHP Version 7
+ *
+ * @category API
+ * @package  Loris
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  Loris license
+ * @link     https://github.com/aces/Loris
+ */
+namespace LORIS\Api\Endpoints\Projects;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \LORIS\Api\Endpoint;
+
+/**
+ * A class for handling the api/v????/projects/$projectname endpoint.
+ *
+ * @category API
+ * @package  Loris
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  Loris license
+ * @link     https://github.com/aces/Loris
+ */
+class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
+{
+    public $skipTemplate = true;
+
+    /**
+     * A cache of the results of the projects/ endpoint, so that it doesn't
+     * need to be recalculated for the ETag and handler
+     */
+    protected $responseCache = array();
+
+    /**
+     * All users have access to the login endpoint to try and login.
+     *
+     * @return boolean true if access is permitted
+     */
+    function _hasAccess()
+    {
+        $user = \User::singleton();
+        return !($user instanceof \LORIS\AnonymousUser);
+    }
+
+    /**
+     * Return which methods are supported by this endpoint.
+     *
+     * Projects can only be retrieved, not created.
+     *
+     * @return array supported HTTP methods
+     */
+    protected function allowedMethods() : array
+    {
+        return ['GET'];
+    }
+
+    /**
+     * Versions of the LORIS API which are supported by this
+     * endpoint.
+     *
+     * Projects has existed since v0.0.1 of the API and has not
+     * changed since.
+     *
+     * @return array a list of supported API versions.
+     */
+    protected function supportedVersions() : array
+    {
+        return [
+                "v0.0.1",
+                "v0.0.2",
+                "v0.0.3-dev",
+               ];
+    }
+
+    /**
+     * Handles a request that starts with /projects/$projectname
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface The outgoing PSR7 response
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        // FIXME: Validate project based permissions.
+        $pathparts = $request->getAttribute('pathparts');
+
+        $this->project = \NDB_Factory::singleton()
+            ->project($pathparts[0]);
+
+        if (count($pathparts) > 1) {
+            switch($pathparts[1]) {
+                // FIXME: delegate to other handlers
+            case 'candidates':
+            case 'images':
+            case 'instruments':
+            case 'visits':
+                break;
+            default:
+                return (new \LORIS\Http\Response())
+                        ->withStatus(404);
+            }
+        }
+
+        return (new \LORIS\Http\Response())
+            ->withHeader("Content-Type", "application/json")
+            ->withBody(
+                new \LORIS\Http\StringStream(
+                    json_encode($this->_getProject($pathparts[0]))
+                )
+            );
+    }
+
+    /**
+     * Returns an array of projects for this LORIS instance
+     * a format that can be JSON encoded to confirm to the
+     * API.
+     *
+     * @param string $name The project name
+     *
+     * @return array That endpoint representation of a project
+     */
+    private function _getProject(string $name) : array
+    {
+        if (!isset($this->responseCache[$name])) {
+
+            $project = \NDB_Factory::singleton()->project($name);
+
+            $meta = array('Project' => $name);
+
+            $visits = array_keys(
+                \Utility::getExistingVisitLabels(
+                    $project->getId()
+                )
+            );
+
+            $instruments = array_keys(
+                \Utility::getAllInstruments()
+            );
+
+            $candids = $project->getCandidateIds();
+
+            $responsebody['Meta']        = $meta;
+            $responsebody['Visits']      = $visits;
+            $responsebody['Instruments'] = $instruments;
+            $responsebody['Candidates']  = $candids;
+
+            $this->responseCache[$name] = $responsebody;
+        }
+
+        return $this->responseCache[$name];
+    }
+
+    /**
+     * Implements the ETagCalculator interface
+     *
+     * @param ServerRequestInterface $request The PSR7 incoming request.
+     *
+     * @return string etag summarizing value of this request.
+     */
+    public function ETag(ServerRequestInterface $request) : string
+    {
+        $projectname = $request->getAttribute('pathparts')[0];
+        return md5(json_encode($this->_getProject($projectname), true));
+    }
+}

--- a/src/Middleware/ETag.php
+++ b/src/Middleware/ETag.php
@@ -36,7 +36,7 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
 
     /**
      * Process processes an incoming request by delegating to $handler,
-     * and adds an HTTP Content-Length header to the response if possible.
+     * and adds an HTTP ETag header to the response if possible.
      *
      * @param ServerRequestInterface  $request The incoming PSR7 request.
      * @param RequestHandlerInterface $handler The PSR15 handler to delegate
@@ -54,21 +54,28 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
             return $handler->handle($request);
         }
 
-        $clientETag = $request->getHeaderLine("If-None-Match") ?? false;
-        if ($clientETag  && $handler->ETag($request) === $clientETag) {
-            if ($handler->ETag($request) == $clientETag) {
+        $clientETag   = $request->getHeaderLine("If-None-Match") ?? false;
+        $endpointETag = $handler->ETag($request);
+        if ($clientETag  && $endpointETag === $clientETag) {
+            if ($endpointETag == $clientETag) {
                 // It matches, so just return a 304 Not modified instead of
                 // doing any work.
-                return (new \LORIS\Http\Response())->withStatus(304);
+                return (new \LORIS\Http\Response())
+                    ->withStatus(304)
+                    ->withHeader('ETag', $endpointETag);
             }
         }
-    
+
         // It either doesn't match or the client didn't send an ETag. In either
         // case, we calculate one and add it to the response header after calling
         // the handler.
-        return $handler->handle($request)->withHeader(
-            "ETag",
-            $handler->ETag($request)
-        );
+        $response = $handler->handle($request);
+        if (empty($response->getHeaderLine('Etag'))) {
+            $response = $response->withHeader(
+                "ETag",
+                $handler->ETag($request)
+            );
+        }
+        return $response;
     }
 }


### PR DESCRIPTION
- Adding `/projects/$projectname` endpoint in the api module
- Moving endpoints in PSR-4 autoloading scope
- Adding logic in ETag middleware to not overwrite ETag header

### To test this change...
HTTP/1.1 GET api/v0.0.1/projects/`$projectname` 
HTTP/1.1 GET api/v0.0.2/projects/`$projectname` 
HTTP/1.1 GET api/v0.0.3-dev/projects/`$projectname` 

The response should match the specification found @ https://github.com/aces/Loris/blob/minor/docs/API/LorisRESTAPI_v0.0.3.md#21-single-project
