### PR TITLE
[CORE-Candidate] adding check to ensure no PSCID or ExternalID end with zero values

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -968,47 +968,47 @@ class Candidate
         return $option_array;
     }
 
-}
+    /**
+     * Ensure that generated IDs do not end with 0
+     * replace every consecutive digit pattern ending with 000 by 001
+     * or string ending with an alpha char followed by a 0
+     * e.g.: abc000 -> abc001
+     *       abc000r4 -> abc001r4
+     *       abc123d0 -> abc123d1
+     *
+     * @param string $string the string to correct
+     *
+     * @return string the string with offending 0 replaced by 1
+     */
+    function zeroSupress(string $string): string
+    {
+        $matches  = array();
+        $replaces = array();
+        $pattern  = "|0{3,}|";
 
-/**
- * Ensure that generated IDs do not end with 0
- * replace every consecutive digit pattern ending with 000 by 001
- * or string ending with an alpha char followed by a 0
- * e.g.: abc000 -> abc001
- *       abc000r4 -> abc001r4
- *       abc123d0 -> abc123d1
- *
- * @param string $string the string to correct
- *
- * @return string the string with offending 0 replaced by 1
- */
-function zeroSupress(string $string): string
-{
-    $matches  = array();
-    $replaces = array();
-    $pattern  = "|0{3,}|";
+        // find occurence of at least 3 consecutive 0
+        preg_match_all($pattern, $string, $matches);
+        $matches  = $matches[0];
+        $replaces = array();
+        foreach ($matches as $match) {
+            $replaces[] = str_pad("1", strlen($match), "0", STR_PAD_LEFT);
+        }
 
-    // find occurence of at least 3 consecutive 0
-    preg_match_all($pattern, $string, $matches);
-    $matches  = $matches[0];
-    $replaces = array();
-    foreach ($matches as $match) {
-        $replaces[] = str_pad("1", strlen($match), "0", STR_PAD_LEFT);
+        //replace the last 0 by 1
+        $pos = 0;
+        $len = 0;
+
+        for ($i = 0; $i < sizeof($matches); $i++) {
+            $pos    = strpos($string, $matches[$i], $pos+$len);
+            $len    = strlen($matches[$i]);
+            $string = substr_replace($string, $replaces[$i], $pos, $len);
+        }
+
+        // if string end with [a-z]0 replace by [a-z]1
+        $string = preg_replace("/(.*)([a-z])(0)$/i", '${1}${2}1', $string);
+
+        return $string;
     }
 
-    //replace the last 0 by 1
-    $pos = 0;
-    $len = 0;
-
-    for ($i = 0; $i < sizeof($matches); $i++) {
-        $pos    = strpos($string, $matches[$i], $pos+$len);
-        $len    = strlen($matches[$i]);
-        $string = substr_replace($string, $replaces[$i], $pos, $len);
-    }
-
-    // if string end with [a-z]0 replace by [a-z]1
-    $string = preg_replace("/(.*)([a-z])(0)$/i", '${1}${2}1', $string);
-
-    return $string;
 }
 ?>

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -725,6 +725,9 @@ class Candidate
                 );
             }
 
+            // ensure that no candidate as number <pattern>0000
+            $pscid = zeroSuppress($pscid);
+
             // check if the pscid is used
         } while (
             $db->pselectOne(
@@ -767,6 +770,9 @@ class Candidate
                     $ExternalIDArrays
                 );
             }
+
+            // ensure that no externalID as number <pattern>0000
+            $externalID = zeroSuppress($externalID);
 
             // check if the external ID is used
         } while (
@@ -962,5 +968,47 @@ class Candidate
         return $option_array;
     }
 
+}
+
+/**
+ * Ensure that generated IDs do not end with 0
+ * replace every consecutive digit pattern ending with 000 by 001
+ * or string ending with an alpha char followed by a 0
+ * e.g.: abc000 -> abc001
+ *       abc000r4 -> abc001r4
+ *       abc123d0 -> abc123d1
+ *
+ * @param string $string the string to correct
+ *
+ * @return string the string with offending 0 replaced by 1
+ */
+function zeroSupress(string $string): string
+{
+    $matches  = array();
+    $replaces = array();
+    $pattern  = "|0{3,}|";
+
+    // find occurence of at least 3 consecutive 0
+    preg_match_all($pattern, $string, $matches);
+    $matches  = $matches[0];
+    $replaces = array();
+    foreach ($matches as $match) {
+        $replaces[] = str_pad("1", strlen($match), "0", STR_PAD_LEFT);
+    }
+
+    //replace the last 0 by 1
+    $pos = 0;
+    $len = 0;
+
+    for ($i = 0; $i < sizeof($matches); $i++) {
+        $pos    = strpos($string, $matches[$i], $pos+$len);
+        $len    = strlen($matches[$i]);
+        $string = substr_replace($string, $replaces[$i], $pos, $len);
+    }
+
+    // if string end with [a-z]0 replace by [a-z]1
+    $string = preg_replace("/(.*)([a-z])(0)$/i", '${1}${2}1', $string);
+
+    return $string;
 }
 ?>


### PR DESCRIPTION
this replace all digits parts ending with 3 consecutive 0s by 001
or end with [a-z]0 by [a-z]1

### Brief summary of changes

after generating the tentative psicid (externalID), call a function to check if the string contain parts that equate to '0' value and replace them with a '1' value

side effect, there can be no more pscid in the for of 'abc1000' as it would be replaced 'abc1001'.

created this to support complicated pscid as at least one organization as IDs in the form of
xyz0001.1
xyz0001.a1

### This resolves issue...
issue identified by a group where the first candidate was 'xyz0000'

### To test this change...

- send string containing multiple consecutive '0's in it to the function and check that the last one is replaced by '1'

