### PR TITLE
Fix error about htmlspecialchars expecting string but getting int

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -144,8 +144,7 @@ class TimePoint
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new LorisException(
-                'Failed to retrieve data for timepoint '
-                . htmlspecialchars($sessionID)
+                "Failed to retrieve data for timepoint $sessionID"
             );
         }
         // New feature, older databases might not have the table created,


### PR DESCRIPTION
This fixes a warning about htmlspecialchars expecting a string but receiving an int. It simply removes the call, since integers can't have special characters in them and the signature for the variable where $sessionID is defined is an int.