### PR TITLE
[Instrument List] Prevent TypeErrors from crashing instrument list

### DIFF
--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -96,7 +96,7 @@ class Module extends \Module
                 new \LORIS\Router\NoopResponder(
                     new \LORIS\Http\Error(
                         $request,
-                        500,
+                        404,
                         $message
                     )
                 )

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -63,26 +63,46 @@ class Module extends \Module
 
         $gets = $request->getQueryParams();
 
-        $attribute = $request->getAttribute("CandID");
-        if ($attribute !== null) {
-            $candidate = \Candidate::singleton($attribute);
-        } else {
-            $candidate = \Candidate::singleton($gets['candID'] ?? '');
-        }
-        $request = $request->withAttribute("Candidate", $candidate);
+        try {
+            $attribute = $request->getAttribute("CandID");
+            if ($attribute !== null) {
+                $candidate = \Candidate::singleton(intval($attribute));
+            } else {
+                $candidate = \Candidate::singleton(intval($gets['candID']) ?? -1);
+            }
+            $request = $request->withAttribute("Candidate", $candidate);
 
-        $attribute = $request->getAttribute("timePoint");
-        if ($attribute === null) {
-            $request = $request->withAttribute(
-                "timePoint",
-                \TimePoint::singleton($gets['sessionID'])
+            $attribute = $request->getAttribute("timePoint");
+            if ($attribute === null) {
+                $request = $request->withAttribute(
+                    "timePoint",
+                    \TimePoint::singleton(intval($gets['sessionID']))
+                );
+            }
+
+            // We need to set the internal page properties for hasAccess to succeed.
+            $page->setCandidate($candidate);
+            $page->setTimePoint($request->getAttribute("timePoint"));
+
+        } catch (\LorisException $e) {
+            $user    = $request->getAttribute("user") ?? new \LORIS\AnonymousUser();
+            $message = 'Could not find candidate information for candidate '
+                . htmlspecialchars($gets['candID']) . ' and session '
+                . htmlspecialchars($gets['sessionID']) . '.';
+            return (new \LORIS\Middleware\PageDecorationMiddleware(
+                $user
+            ))->process(
+                $request,
+                new \LORIS\Router\NoopResponder(
+                    new \LORIS\Http\Error(
+                        $request,
+                        500,
+                        $message
+                    )
+                )
             );
+
         }
-
-        // We need to set the internal page properties for hasAccess to succeed.
-        $page->setCandidate($candidate);
-        $page->setTimePoint($request->getAttribute("timePoint"));
-
         return $page->process($request, $page);
 
     }

--- a/smarty/templates/404.tpl
+++ b/smarty/templates/404.tpl
@@ -1,5 +1,5 @@
 <div class="container">
-    <h2>404: Page not found.</h2>
+    <h2>404: Not Found</h2>
     <h3>{$message}</h3>
     <a href="{$baseurl}">Go to main page</a></div>
 </div>


### PR DESCRIPTION
### Brief summary of changes

When bad input is given to instrument list, LORIS will crash and the back-end will throw either a LorisException or TypeError depending on the type of input.

This PR handles these cases as a 500 response and displays an error to the user instead of crashing.

### To test this change...

- [ ] Go to instrument list and change one of the values to a negative number or to a string. LORIS will crash
- [ ] Do the same on my branch and you'll instead see an error message.
