### PR TITLE
[Core] Declare strict types in Breadcrumb classes

### DIFF
--- a/php/libraries/Breadcrumb.class.inc
+++ b/php/libraries/Breadcrumb.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file defines a Breadcrumb element.
  *

--- a/php/libraries/BreadcrumbTrail.class.inc
+++ b/php/libraries/BreadcrumbTrail.class.inc
@@ -1,7 +1,7 @@
-<?php
+<?php declare(strict_types=1);
 /**
- * This file represent a BreadcrumbTrail object that can be print as a string
- * that containt all its breadcrumbs.
+ * This file represents a BreadcrumbTrail object that can be printed as a string
+ * that contains all its breadcrumbs.
  *
  * PHP Version 7
  *


### PR DESCRIPTION
### Brief summary of changes
These settings will create a Fatal error if types are used incorrectly in these classes