### PR TITLE
[Core: Instrument class] Added function that gets the subprojectID

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1429,7 +1429,7 @@ class NDB_BVL_Instrument extends NDB_Page
      *
      * @return int for the subprojectID
      */
-    function getSubprojectID()
+    function getSubprojectID(): ?int
     {
         $sessionID = $this->getSessionID();
         if (!empty($sessionID)) {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1427,7 +1427,7 @@ class NDB_BVL_Instrument extends NDB_Page
     /**
      * Gets the subprojectID for the timepoint to which this instrument pertains
      *
-     * @return int for the subprojectID
+     * @return int|null The subprojectID
      */
     function getSubprojectID(): ?int
     {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1433,7 +1433,7 @@ class NDB_BVL_Instrument extends NDB_Page
     {
         $sessionID = $this->getSessionID();
         if (!empty($sessionID)) {
-            $timepoint = \Timepoint::singleton($sessionID);
+            $timepoint    = \Timepoint::singleton($sessionID);
             $subprojectID = $timepoint->getSubprojectID();
             return $subprojectID;
         }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1424,6 +1424,22 @@ class NDB_BVL_Instrument extends NDB_Page
         return '';
     }
 
+    /**
+     * Gets the subprojectID for the timepoint to which this instrument pertains
+     *
+     * @return int for the subprojectID
+     */
+    function getSubprojectID()
+    {
+        $sessionID = $this->getSessionID();
+        if (!empty($sessionID)) {
+            $timepoint = \Timepoint::singleton($sessionID);
+            $subprojectID = $timepoint->getSubprojectID();
+            return $subprojectID;
+        }
+        return null;
+    }
+
 
     /**
      * Determines what the data entry status flag should be set to


### PR DESCRIPTION
### Brief summary of changes
Rida has requested that this function (used frequently in CCNA) be added to the LORIS repo. Perhaps some other projects may find it useful to have a function that returns the subprojectID. 

In CCNA we use this function particularly in cases where more than one version of an instrument exists for different cohorts. In cases where the versions differ subtly (different drop down options, or an additional question), rather than re-coding the instrument, we use if-blocks to determine what the user will see / what will be displayed depending on the current candidate's subprojectID.

### To test this change...

1. Make a call to the function from any instrument: `$subprojectID = $this->getSubprojectID();`
2. Display the subprojectID: `print_r($subprojectID);`
3. Access the instrument from different candidate profiles and see if the subprojectID matches the current timepoint.

