### PR TITLE
[Instruments] Revert intval of CommentID because CommentID is not an int

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -41,7 +41,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             ? intval($_REQUEST['candID'])
             : '';
         $this->tpl_data['sessionID'] = intval($_REQUEST['sessionID']);
-        $this->tpl_data['commentID'] = intval($_REQUEST['commentID']);
+        $this->tpl_data['commentID'] = $_REQUEST['commentID'];
         $this->tpl_data['test_name'] = $_REQUEST['test_name'];
         $this->tpl_data['subtest']   = $_REQUEST['subtest'] ?? '';
 


### PR DESCRIPTION
### Brief summary of changes
CommentID is an alpha-numerical string. Removing the intval here allows me to correctly access an instrument's subtest pages. 

### To test this change...

- [ ] On major, try to access an instrument's second page. The link is broken
- [ ] On this branch, it's fixed
