### PR TITLE
[JS] Convert console.log from a javascript error to a warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,7 @@
     "new-cap": ["error", {
       "capIsNewExceptions": ["DynamicTable"]
     }],
-    "no-console": ["error", {
+    "no-console": ["warn", {
       "allow": ["info", "warn", "error"]
     }]
   },


### PR DESCRIPTION
Having console.log be a javascript error encourages developers to
just use console.error (which is allowed) as a work-around while
trying to do development. Forgetting to remove the console.error
leaves us in the same state (or perhaps slightly worse) than having
the console.log would have in the first place.

This converts usage of console.log from a compilation error to a warning,
so that it can still be used for development.

We should be catching any forgotten logs in code review anyways.
