### PR TITLE
[Do not merge] Project permissions

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -253,7 +253,7 @@ CREATE TABLE `user_project_rel` (
   KEY `FK_user_project_rel_2` (`ProjectID`),
   CONSTRAINT `FK_user_project_rel_2` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `FK_user_project_rel_1` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO user_project_rel (UserID, ProjectID) SELECT 1, ProjectID FROM Project;
 

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -246,6 +246,17 @@ CREATE TABLE `users` (
 INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expiry)
 VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N','2016-03-30');
 
+CREATE TABLE `user_project_rel` (
+  `UserID` int(10) unsigned NOT NULL,
+  `ProjectID` int(2) NOT NULL,
+  PRIMARY KEY  (`UserID`,`ProjectID`),
+  KEY `FK_user_project_rel_2` (`ProjectID`),
+  CONSTRAINT `FK_user_project_rel_2` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_user_project_rel_1` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO user_project_rel (UserID, ProjectID) SELECT 1, ProjectID FROM Project;
+
 CREATE TABLE `user_psc_rel` (
   `UserID` int(10) unsigned NOT NULL,
   `CenterID` integer unsigned NOT NULL,

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -69,6 +69,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ImagingUploaderAutoLaunch', "Allows running the ImagingUpload pre-processing scripts", 1, 0, 'boolean', ID, 'ImagingUploader Auto Launch',23 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'citation_policy', 'Citation Policy for Acknowledgements module', 1, 0, 'textarea', ID, 'Citation Policy', 24 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'CSPAdditionalHeaders', 'Extensions to the Content-security policy allow only for self-hosted content', 1, 0, 'text', ID, 'Content-Security Extensions', 25 FROM ConfigSettings WHERE Name="study";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'useProjectPermissions', "Enable project level permissions", 1, 0, 'boolean', ID, 'Use project-level permissions', 26 FROM ConfigSettings WHERE Name="study";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('paths', 'Specify directories where LORIS-related files are stored or created. Take care when editing these fields as changing them incorrectly can cause certain modules to lose functionality.', 1, 0, 'Paths', 2);
@@ -181,6 +182,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name
 INSERT INTO Config (ConfigID, Value) SELECT ID, "Modify this to your project's citation policy" FROM ConfigSettings WHERE Name="citation_policy";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "" FROM ConfigSettings WHERE Name="CSPAdditionalHeaders";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "YMd" FROM ConfigSettings WHERE Name="dobFormat";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "false" FROM ConfigSettings WHERE Name="useProjectPermissions";
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="imagePath";
@@ -250,3 +252,4 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/issue_tracker" FROM ConfigSett
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'prod' FROM ConfigSettings cs WHERE cs.Name="mriConfigFile";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'environment' FROM ConfigSettings cs WHERE cs.Name="EnvironmentFile";
+

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -252,4 +252,3 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/issue_tracker" FROM ConfigSett
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings cs WHERE cs.Name="ComputeDeepQC";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'prod' FROM ConfigSettings cs WHERE cs.Name="mriConfigFile";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'environment' FROM ConfigSettings cs WHERE cs.Name="EnvironmentFile";
-

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -259,6 +259,7 @@ class Edit_User extends \NDB_Form
         if ($values['Password_hash'] == '' && !$this->isCreatingNewUser()) {
             unset($values['Password_hash']);
         }
+
         // multi-site UPDATE
         $uid           = $user->getData('ID');
         $us_curr_sites = $values['CenterIDs'];
@@ -276,6 +277,23 @@ class Edit_User extends \NDB_Form
         }
         unset($values['CenterIDs']);
         // END multi-site UPDATE
+
+        // multi-project UPDATE
+        $us_curr_projects = $values['ProjectIDs'];
+        if (!$this->isCreatingNewUser()) {
+            $DB->delete('user_project_rel', array("UserID" => $uid));
+            foreach ($us_curr_projects as $project) {
+                $DB->insert(
+                    'user_project_rel',
+                    array(
+                     "UserID"    => $uid,
+                     "ProjectID" => $project,
+                    )
+                );
+            }
+        }
+        unset($values['ProjectIDs']);
+        // END multi-project UPDATE
 
         // EXAMINER UPDATE
         if ($editor->hasPermission('examiner_multisite')) {
@@ -713,6 +731,14 @@ class Edit_User extends \NDB_Form
             'CenterIDs',
             'Sites',
             $siteOptions,
+            array('multiple' => 'multiple')
+        );
+
+        $projArr = $editor->getData('Projects');
+        $this->addSelect(
+            'ProjectIDs',
+            'Projects',
+            $projArr,
             array('multiple' => 'multiple')
         );
 

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -290,6 +290,15 @@
         {/if}
     </div>
     {/if}
+    <div class="row form-group form-inline">
+        <label class="col-sm-2">
+            {$form.ProjectIDs.label}
+        </label>
+        <div class="col-sm-10">
+            {$form.ProjectIDs.html}
+        </div>
+    </div>
+
     {if $form.errors.sites_group}
     <div class="row form-group form-inline has-error">
     {else}

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -352,7 +352,7 @@ class User extends UserPermissions
      *
      * @return array
      */
-    function getProjectIds()
+    function getProjectIds(): array
     {
         return $this->userInfo['ProjectIDs'];
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -110,10 +110,29 @@ class User extends UserPermissions
                                                   );
             }
         }
+
+        // Get user projects
+        $project_rows = $DB->pselect(
+            "SELECT p.Name, p.ProjectID from user_project_rel upr
+             LEFT JOIN Project p on (p.ProjectID=upr.ProjectID)
+             WHERE (upr.UserID=:UserID)",
+            array(
+             "UserID" => $row['ID'],
+            )
+        );
+        $projects     = array();
+        $project_IDs  = array();
+        foreach ($project_rows as $project_row) {
+            $projects[$project_row['ProjectID']] = $project_row['Name'];
+            $project_ID[] = $project_row['ProjectID'];
+        }
+
         // store user data in object property
-        $row['examiner']  = $examiner_info;
-        $row['CenterIDs'] = $user_cid;
-        $obj->userInfo    = $row;
+        $row['examiner']   = $examiner_info;
+        $row['CenterIDs']  = $user_cid;
+        $row['Projects']   = $projects;
+        $row['ProjectIDs'] = $project_IDs; 
+        $obj->userInfo     = $row;
         return $obj;
     }
 
@@ -316,6 +335,26 @@ class User extends UserPermissions
         unset($site_list['pending']);
         natcasesort($site_list);
         return $site_list;
+    }
+
+    /**
+     * Get the user's projects
+     *
+     * @return array
+     */
+    function getProjects()
+    {
+        return $this->userInfo['Projects'];
+    }
+
+    /**
+     * Get the user's project ids
+     *
+     * @return array
+     */
+    function getProjectIds()
+    {
+        return $this->userInfo['ProjectIDs'];
     }
 
     /**
@@ -529,6 +568,22 @@ class User extends UserPermissions
         );
 
         $this->update($updateArray);
+    }
+
+    /**
+     * Checks if a user has access to a project
+     *
+     * @param int $projectID The project's unique ID
+     *
+     * @return bool
+     */
+    public function hasAccessToProject(int $projectID) : bool
+    {
+        return in_array(
+            $projectID,
+            $this->getProjectIds(),
+            true
+        );
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -342,7 +342,7 @@ class User extends UserPermissions
      *
      * @return array
      */
-    function getProjects()
+    function getProjects(): array
     {
         return $this->userInfo['Projects'];
     }


### PR DESCRIPTION
### Brief summary of changes

- [x] `user_project_rel` table (Discuss: do we want a 'default' project? otherwise can remove https://github.com/aces/Loris/blob/32786ce8cfbe553188988e273eafd450c4ae0a10/SQL/0000-00-00-schema.sql#L258)
- [x] new Config option "Use Project Permissions" 
- [x] un-reactified(?) modifications to User Accounts module to administer project access per user (multiselect element just like Site selector)
- [ ] php/libraries/Project.class.inc customizations to be be discussed - functions added to Project class are only to support Dashboard's recruitment counts
- [ ] example of a module using the permission e.g. candidate list.   CAP implemented user-project permission checks in each module to filter data

Many projects can be assigned to one user. 

( To do: )
- [ ] Add SQL patch  --> depends on outstanding question:  Should all users automatically get access to all existing projects?  That way no users lose access to data, but the onus would be on the admin to **remove** user access to projects they should not access.  
The conservative alternative is: don't assign any users to any projects, and make the admin manually **add** user access to projects (infeasible? could take a while.)  
Also -- Will/should there be a default Project (ProjectID=1) in every LORIS 
- [ ] Ensure Release Notes tells all admins to Manually assign Each users to Projects via User Accounts ASAP.  Big Caveat because this will lock all users out of all data without admin's manual intervention. 

(Table originally created by @jacobpenny for CAP project, and modelled on Mouna's `user_psc_rel` table)