### PR TITLE
[API] Fix type error when passing JSON data to StringStream

### DIFF
--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -82,7 +82,9 @@ class Login extends Endpoint
             return (new \LORIS\Http\Response())
                 ->withBody(
                     new \LORIS\Http\StringStream(
-                        '{ "error" : Missing username or password" }'
+                        json_encode(
+                            array('error' => 'Missing username or password')
+                        )
                     )
                 )
                 ->withStatus(400);
@@ -99,7 +101,7 @@ class Login extends Endpoint
                 return (new \LORIS\Http\Response())
                     ->withBody(
                         new \LORIS\Http\StringStream(
-                            json_encode(['token' => $token])
+                            json_encode(array('token' => $token))
                         )
                     )
                     ->withHeader("Content-Type", "application/json")
@@ -108,7 +110,9 @@ class Login extends Endpoint
                 return (new \LORIS\Http\Response())
                     ->withBody(
                         new \LORIS\Http\StringStream(
-                            ['error' => 'Unacceptable JWT key']
+                            json_encode(
+                                array('error' => 'Unacceptable JWT key')
+                            )
                         )
                     )
                     ->withHeader("Content-Type", "application/json")


### PR DESCRIPTION
### Brief summary of changes

There was an instance where an array was passed to StringStream causing a TypeError. This PR normalizes the way JSON data is passed to the StringStream class.
