### PR TITLE
[Media] Fix call for count() on strings. Use strlen() instead

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -135,7 +135,7 @@ function uploadFile()
         ]
     );
 
-    if (!isset($sessionID) || count($sessionID) < 1) {
+    if (!isset($sessionID) || strlen($sessionID) < 1) {
         showMediaError(
             "Error! A session does not exist for candidate '$pscid'' " .
             "and visit label '$visit'."


### PR DESCRIPTION
`$sessionID` is a string value so `count()` causes a PHP Warning.