### PR TITLE
[Core] Fix PHP Warning

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -145,12 +145,14 @@ class NDB_Menu_Filter extends NDB_Menu
         $success = $this->_setupVariables();
 
         // set the headers if necessary
-        if (!is_array($this->headers) || count($this->headers) == 0) {
-            foreach ($this->columns as $value) {
-                if (preg_match('/[0-9A-Za-z_]+$/', $value, $match)) {
-                    $this->headers[] = $match[0];
-                }
-            }
+        if (!is_array($this->headers) || 
+            count($this->headers) == 0 &&
+             is_array($this->columns)) {
+               foreach ($this->columns as $value) {
+                  if (preg_match('/[0-9A-Za-z_]+$/', $value, $match)) {
+                      $this->headers[] = $match[0];
+                  }
+               }
         }
 
         // start the filter form

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -145,14 +145,15 @@ class NDB_Menu_Filter extends NDB_Menu
         $success = $this->_setupVariables();
 
         // set the headers if necessary
-        if (!is_array($this->headers) || 
-            count($this->headers) == 0 &&
-             is_array($this->columns)) {
-               foreach ($this->columns as $value) {
-                  if (preg_match('/[0-9A-Za-z_]+$/', $value, $match)) {
-                      $this->headers[] = $match[0];
-                  }
-               }
+        if (!is_array($this->headers)
+            || count($this->headers) == 0
+            && is_array($this->columns)
+        ) {
+            foreach ($this->columns as $value) {
+                if (preg_match('/[0-9A-Za-z_]+$/', $value, $match)) {
+                    $this->headers[] = $match[0];
+                }
+            }
         }
 
         // start the filter form

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -145,8 +145,8 @@ class NDB_Menu_Filter extends NDB_Menu
         $success = $this->_setupVariables();
 
         // set the headers if necessary
-        if (!is_array($this->headers)
-            || count($this->headers) == 0
+        if ((!is_array($this->headers)
+            || count($this->headers) == 0)
             && is_array($this->columns)
         ) {
             foreach ($this->columns as $value) {

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -147,7 +147,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // set the headers if necessary
         if ((!is_array($this->headers)
             || count($this->headers) == 0)
-            && is_array($this->columns)
+            && is_iterable($this->columns)
         ) {
             foreach ($this->columns as $value) {
                 if (preg_match('/[0-9A-Za-z_]+$/', $value, $match)) {


### PR DESCRIPTION
This PR adds an is_array check for foreach() .

Warning: Invalid argument supplied for foreach() in /app/php/libraries/NDB_Menu_Filter.class.inc on line 149

Warning: Cannot modify header information - headers already sent by (output started at /app/php/libraries/NDB_Menu_Filter.class.inc:149) in /app/htdocs/index.php on line 53

Warning: Cannot modify header information - headers already sent by (output started at /app/php/libraries/NDB_Menu_Filter.class.inc:149) in /app/htdocs/index.php on line 59

