### PR TITLE
[Testing] Add PhanTypeMismatchDefault rule to checks

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -31,7 +31,6 @@ return [
 		"PhanUndeclaredTypeParameter",
 		"PhanUndeclaredConstant",
 		"PhanTypeMismatchForeach",
-		"PhanTypeMismatchDefault",
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchArgumentInternal",
 		"PhanTypeMismatchReturn",

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -396,7 +396,7 @@ class File_Upload
     * @return boolean true
     * @see    File_Upload::processFiles()
     */
-    function setFileHandler($fieldName, $className, $methods="")
+    function setFileHandler($fieldName, $className, $methods=array())
     {
         $default_methods =array(
                            "verify" => "isValid",

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -772,19 +772,18 @@ class NDB_BVL_Feedback
      *
      * @param integer $feedbackID Thread ID being updated
      * @param string  $comment    The comment to update the thread to
-     * @param integer $type       The typeID to update Feedback_type to
+     * @param ?integer $type       The typeID to update Feedback_type to
      * @param string  $public     Y or N to update thread's public status to
      * @param string  $status     Status of the thread (options from
      *                            feedback_bvl_thread.Status)
      * @param string  $fieldname  The optional fieldname that the thread is in
      *                            reference to.
-     *
-     * @return void
+     c@return void
      */
     function updateThread(
         $feedbackID,
         $comment,
-        $type='',
+        $type=null,
         $public='',
         $status='',
         $fieldname =''

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -770,15 +770,16 @@ class NDB_BVL_Feedback
      * Creates a new thread entry and (if allowed) updates the selected
      * thread's type/status/public
      *
-     * @param integer $feedbackID Thread ID being updated
-     * @param string  $comment    The comment to update the thread to
+     * @param integer  $feedbackID Thread ID being updated
+     * @param string   $comment    The comment to update the thread to
      * @param ?integer $type       The typeID to update Feedback_type to
-     * @param string  $public     Y or N to update thread's public status to
-     * @param string  $status     Status of the thread (options from
+     * @param string   $public     Y or N to update thread's public status to
+     * @param string   $status     Status of the thread (options from
      *                            feedback_bvl_thread.Status)
-     * @param string  $fieldname  The optional fieldname that the thread is in
+     * @param string   $fieldname  The optional fieldname that the thread is in
      *                            reference to.
-     c@return void
+     *
+     * @return void
      */
     function updateThread(
         $feedbackID,


### PR DESCRIPTION
This is a pretty straightforward rule that doesn't cause problems to include in LORIS. 

It's a good idea to progressively introduce more checks to phan to make our code cleaner. 

The issues with Feedback_MRI are addressed by #4264. Until then I'll keep the blocked label on.