### PR TITLE
[Testing] Add PhanTypeMismatchForeach rule to static analysis

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -28,7 +28,7 @@ return [
         "PhanTypeArraySuspiciousNullable",
 		"PhanUndeclaredClassMethod",
 		"PhanUndeclaredConstant",
-		"PhanTypeMismatchForeach",
+		"PhanTypeMismatchDefault",
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchArgumentInternal",
 		"PhanTypeMismatchReturn",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -28,7 +28,6 @@ return [
         "PhanTypeArraySuspiciousNullable",
 		"PhanUndeclaredClassMethod",
 		"PhanUndeclaredConstant",
-		"PhanTypeMismatchDefault",
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchArgumentInternal",
 		"PhanTypeMismatchReturn",

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -47,8 +47,6 @@ if ($_POST['fire_away']) {
     $comments->setPredefinedComments($_POST['savecomments']['predefined']);
 
     // save all textual comments but only if there is an entry [sebas]
-    // The foreach below is operating on an array even though phan doesn't
-    // think so.
     foreach (\Utility::asArray($_POST['savecomments']['text'])
         as $comment_type_id => $comment_message
     ) {

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -49,8 +49,7 @@ if ($_POST['fire_away']) {
     // save all textual comments but only if there is an entry [sebas]
     // The foreach below is operating on an array even though phan doesn't
     // think so.
-    /* @phan-suppress-next-line PhanTypeMismatchForeach */
-    foreach ($_POST['savecomments']['text']
+    foreach (\Utility::asArray($_POST['savecomments']['text'])
         as $comment_type_id => $comment_message
     ) {
         if (trim($comment_message)) {

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -47,6 +47,9 @@ if ($_POST['fire_away']) {
     $comments->setPredefinedComments($_POST['savecomments']['predefined']);
 
     // save all textual comments but only if there is an entry [sebas]
+    // The foreach below is operating on an array even though phan doesn't
+    // think so.
+    /* @phan-suppress-next-line PhanTypeMismatchForeach */
     foreach ($_POST['savecomments']['text']
         as $comment_type_id => $comment_message
     ) {

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -218,7 +218,7 @@ class Document_Repository extends \NDB_Menu_Filter
     /**
      * ParseTree function
      *
-     * @param string $treeToParse the value of treeToParse
+     * @param array $treeToParse the value of treeToParse
      *
      * @return array
      */

--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -220,7 +220,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
       * This function could test UI elemnts in each Tabs.
       *
       * @param string $url this is for the url which needs to be tested.
-      * @param array $ui  UI elements in each Tabs.
+      * @param array  $ui  UI elements in each Tabs.
       *
       * @return void
       */

--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -220,7 +220,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
       * This function could test UI elemnts in each Tabs.
       *
       * @param string $url this is for the url which needs to be tested.
-      * @param string $ui  UI elements in each Tabs.
+      * @param array $ui  UI elements in each Tabs.
       *
       * @return void
       */

--- a/modules/imaging_uploader/test/imaging_uploaderTest.php
+++ b/modules/imaging_uploader/test/imaging_uploaderTest.php
@@ -216,7 +216,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
       * This function could test UI elements in each Tabs.
       *
       * @param string $url this is for the url which needs to be tested.
-      * @param array $uis UI elements in each Tabs.
+      * @param array  $uis UI elements in each Tabs.
       *
       * @return void
       */

--- a/modules/imaging_uploader/test/imaging_uploaderTest.php
+++ b/modules/imaging_uploader/test/imaging_uploaderTest.php
@@ -216,7 +216,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
       * This function could test UI elements in each Tabs.
       *
       * @param string $url this is for the url which needs to be tested.
-      * @param string $uis UI elements in each Tabs.
+      * @param array $uis UI elements in each Tabs.
       *
       * @return void
       */

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -40,7 +40,7 @@ class Stats_Behavioural extends \NDB_Form
      * InCenter function
      *
      * @param string $centerID the value of centerID
-     * @param string $Centers  the value of centers
+     * @param array $Centers  the value of centers
      *
      * @return bool
      */

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -40,7 +40,7 @@ class Stats_Behavioural extends \NDB_Form
      * InCenter function
      *
      * @param string $centerID the value of centerID
-     * @param array $Centers  the value of centers
+     * @param array  $Centers  the value of centers
      *
      * @return bool
      */

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -47,7 +47,7 @@ class Stats_Demographic extends \NDB_Form
      * InCenter function
      *
      * @param string $centerID the value of centerID
-     * @param string $centers  the value of Centers
+     * @param array $centers  the value of Centers
      *
      * @return bool
      */
@@ -70,8 +70,8 @@ class Stats_Demographic extends \NDB_Form
      * @param string $dropdownName     the value of dropdownName
      * @param string $dropdownOpt      the value of dropdownOpt
      * @param string $dropdownSelected the value of dropdownSelected
-     * @param string $centers          the value of centers
-     * @param string $data             the value of data
+     * @param array $centers          the value of centers
+     * @param array $data             the value of data
      * @param string $subsection       the value of subsection=''
      * @param string $disclamer        the value of disclamer=''
      * @param string $projectID        the value of projectID is null

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -47,7 +47,7 @@ class Stats_Demographic extends \NDB_Form
      * InCenter function
      *
      * @param string $centerID the value of centerID
-     * @param array $centers  the value of Centers
+     * @param array  $centers  the value of Centers
      *
      * @return bool
      */
@@ -70,8 +70,8 @@ class Stats_Demographic extends \NDB_Form
      * @param string $dropdownName     the value of dropdownName
      * @param string $dropdownOpt      the value of dropdownOpt
      * @param string $dropdownSelected the value of dropdownSelected
-     * @param array $centers          the value of centers
-     * @param array $data             the value of data
+     * @param array  $centers          the value of centers
+     * @param array  $data             the value of data
      * @param string $subsection       the value of subsection=''
      * @param string $disclamer        the value of disclamer=''
      * @param string $projectID        the value of projectID is null

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -41,7 +41,7 @@ class Stats_MRI extends \NDB_Form
      * InCenter function
      *
      * @param string $centerID the value of centerID
-     * @param array $Centers  the value of centers
+     * @param array  $Centers  the value of centers
      *
      * @return bool
      */
@@ -66,7 +66,7 @@ class Stats_MRI extends \NDB_Form
      * @param string $dropdown_opt      the value of dropdown_opt
      * @param string $dropdown_selected the value of dropdown_selected
      * @param array  $centers           the value of centers
-     * @param array $data              the value of data
+     * @param array  $data              the value of data
      * @param string $Subsection        the value of Subsection=''
      * @param string $disclamer         the value of disclamer=''
      * @param string $projectID         the value of projectID is null

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -41,7 +41,7 @@ class Stats_MRI extends \NDB_Form
      * InCenter function
      *
      * @param string $centerID the value of centerID
-     * @param string $Centers  the value of centers
+     * @param array $Centers  the value of centers
      *
      * @return bool
      */
@@ -65,8 +65,8 @@ class Stats_MRI extends \NDB_Form
      * @param string $dropdown_name     the value of dropdown_name
      * @param string $dropdown_opt      the value of dropdown_opt
      * @param string $dropdown_selected the value of dropdown_selected
-     * @param string $centers           the value of centers
-     * @param string $data              the value of data
+     * @param array  $centers           the value of centers
+     * @param array $data              the value of data
      * @param string $Subsection        the value of Subsection=''
      * @param string $disclamer         the value of disclamer=''
      * @param string $projectID         the value of projectID is null


### PR DESCRIPTION
This rule makes sure that when you pass a variable to foreach that the variable is expected to be something iterable. We had a few cases where parameters that were declared to be strings were actually arrays.