### PR TITLE
[API] Adding json responses classes

### DIFF
--- a/modules/api/php/module.class.inc
+++ b/modules/api/php/module.class.inc
@@ -61,19 +61,9 @@ class Module extends \Module
             $pieces
         ) !== 1
         ) {
-            return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "application/json")
-                ->withStatus(400)
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            [
-                             'error' => "You must specify a version of the API "
-                                . "to use in the URL.",
-                            ]
-                        )
-                    )
-                );
+            return new \LORIS\Http\Response\BadRequest(
+                'You must specify a version of the API to use in the URL'
+            );
         };
 
         $version  = $pieces[1];
@@ -102,14 +92,7 @@ class Module extends \Module
             $handler = new \LORIS\Api\Endpoints\Projects();
             break;
         default:
-            return (new \LORIS\Http\Response())
-                    ->withStatus(404)
-                    ->withHeader('Content-Type', 'application/json')
-                    ->withBody(
-                        new \LORIS\Http\StringStream(
-                            json_encode(["error" => "not found"])
-                        )
-                    );
+            return new \LORIS\Http\Response\NotFound();
         }
 
         // This disregards the parent handler from the base module class,

--- a/src/Api/Endpoint.php
+++ b/src/Api/Endpoint.php
@@ -63,7 +63,7 @@ abstract class Endpoint implements RequestHandlerInterface
         $versions = $this->supportedVersions() ?? [];
         $version  = $request->getAttribute("LORIS-API-Version") ?? "unknown";
         if (!in_array($version, $versions)) {
-            return new \LORIS\Http\Response\BadRequest('unsupported version');
+            return new \LORIS\Http\Response\BadRequest('Unsupported version');
         }
 
         if ($handler instanceof \LORIS\Middleware\ETagCalculator) {

--- a/src/Api/Endpoint.php
+++ b/src/Api/Endpoint.php
@@ -62,32 +62,18 @@ abstract class Endpoint implements RequestHandlerInterface
     ): ResponseInterface {
         $methods = $this->allowedMethods();
         if (!in_array($request->getMethod(), $methods)) {
-            return (new \LORIS\Http\Response())
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array("error" => "Unsupported HTTP Method")
-                        )
-                    )
-                )->withHeader("Allow", join(",", $methods))
-                ->withStatus(405);
+            return new \LORIS\Http\Response\MethodNotAllowed(
+                $methods
+            );
         }
 
         $versions = $this->supportedVersions() ?? [];
         $version  = $request->getAttribute("LORIS-API-Version") ?? "unknown";
 
         if (!in_array($version, $versions)) {
-            return (new \LORIS\Http\Response())
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array("error" => "Unsupported LORIS API version")
-                        )
-                    )
-                )
-                ->withHeader("Allow", join(",", $methods))
-                ->withHeader("Content-Type", "application/json")
-                ->withStatus(400);
+            return new \LORIS\Http\Response\BadRequest(
+                'Unsupported LORIS API version'
+            );
         }
         if ($handler instanceof \LORIS\Middleware\ETagCalculator) {
             return (new \LORIS\Middleware\ETag())->process($request, $handler);

--- a/src/Api/Endpoint.php
+++ b/src/Api/Endpoint.php
@@ -60,24 +60,16 @@ abstract class Endpoint implements RequestHandlerInterface
         ServerRequestInterface $request,
         RequestHandlerInterface $handler
     ): ResponseInterface {
-        $methods = $this->allowedMethods();
-        if (!in_array($request->getMethod(), $methods)) {
-            return new \LORIS\Http\Response\MethodNotAllowed(
-                $methods
-            );
-        }
-
         $versions = $this->supportedVersions() ?? [];
         $version  = $request->getAttribute("LORIS-API-Version") ?? "unknown";
-
         if (!in_array($version, $versions)) {
-            return new \LORIS\Http\Response\BadRequest(
-                'Unsupported LORIS API version'
-            );
+            return new \LORIS\Http\Response\BadRequest('unsupported version');
         }
+
         if ($handler instanceof \LORIS\Middleware\ETagCalculator) {
             return (new \LORIS\Middleware\ETag())->process($request, $handler);
         }
+
         return $handler->handle($request);
     }
 }

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -88,7 +88,7 @@ class Login extends Endpoint
 
             if ($user === null || $password === null) {
                 return new \LORIS\Http\Response\BadRequest(
-                    'missing username or password'
+                    'Missing username or password'
                 );
             }
 
@@ -102,7 +102,7 @@ class Login extends Endpoint
                     );
                 } else {
                     return new \LORIS\Http\Response\InternalServerError(
-                        'unacceptable JWT key'
+                        'Unacceptable JWT key'
                     );
                 }
             }

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -41,13 +41,11 @@ class Login extends Endpoint
     /**
      * Return which methods are supported by this endpoint.
      *
-     * Login can only be POSTed to
-     *
      * @return array supported HTTP methods
      */
     protected function allowedMethods() : array
     {
-        return ['POST'];
+        return array('POST');
     }
 
     /**
@@ -61,11 +59,11 @@ class Login extends Endpoint
      */
     protected function supportedVersions() : array
     {
-        return [
-                "v0.0.1",
-                "v0.0.2",
-                "v0.0.3-dev",
-               ];
+        return array(
+                'v0.0.1',
+                'v0.0.2',
+                'v0.0.3-dev',
+               );
     }
 
     /**
@@ -77,56 +75,49 @@ class Login extends Endpoint
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $requestdata = json_decode((string) $request->getBody(), true);
-        if (!isset($requestdata['username']) || !isset($requestdata['password'])) {
-            return (new \LORIS\Http\Response())
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array('error' => 'Missing username or password')
-                        )
-                    )
-                )
-                ->withStatus(400);
+        if (count($request->getAttribute('pathparts')) !== 1) {
+            return new \LORIS\Http\Response\NotFound();
         }
 
-        $user     = $requestdata['username'];
-        $password = $requestdata['password'];
+        switch ($request->getMethod()) {
+        case 'POST':
+            $requestdata = json_decode((string) $request->getBody(), true);
 
-        $login = $this->getLoginAuthenticator();
+            $user     = $requestdata['username'] ?? null;
+            $password = $requestdata['password'] ?? null;
 
-        if ($login->passwordAuthenticate($user, $password, false)) {
-            $token = $this->getEncodedToken($user);
-            if (!empty($token)) {
-                return (new \LORIS\Http\Response())
-                    ->withBody(
-                        new \LORIS\Http\StringStream(
-                            json_encode(array('token' => $token))
-                        )
-                    )
-                    ->withHeader("Content-Type", "application/json")
-                    ->withStatus(200);
-            } else {
-                return (new \LORIS\Http\Response())
-                    ->withBody(
-                        new \LORIS\Http\StringStream(
-                            json_encode(
-                                array('error' => 'Unacceptable JWT key')
-                            )
-                        )
-                    )
-                    ->withHeader("Content-Type", "application/json")
-                    ->withStatus(500);
+            if ($user === null || $password === null) {
+                return new \LORIS\Http\Response\BadRequest(
+                    'missing username or password'
+                );
             }
+
+            $login = $this->getLoginAuthenticator();
+
+            if ($login->passwordAuthenticate($user, $password, false)) {
+                $token = $this->getEncodedToken($user);
+                if (!empty($token)) {
+                    return new \LORIS\Http\Response\JsonResponse(
+                        array('token' => $token)
+                    );
+                } else {
+                    return new \LORIS\Http\Response\InternalServerError(
+                        'unacceptable JWT key'
+                    );
+                }
+            }
+
+            return new \LORIS\Http\Response\Unauthorized(
+                $login->_lastError
+            );
+        case 'OPTIONS':
+            return (new \LORIS\Http\Response())
+                ->withHeader('Allow', $this->allowedMethods());
+        default:
+            return new \LORIS\Http\Response\MethodNotAllowed(
+                $this->allowedMethods()
+            );
         }
-        return (new \LORIS\Http\Response())
-            ->withBody(
-                new \LORIS\Http\StringStream(
-                    json_encode(array("error" => $login->_lastError))
-                )
-            )
-            ->withHeader("Content-Type", "application/json")
-            ->withStatus(401);
     }
 
     /**

--- a/src/Http/Response/BadRequest.php
+++ b/src/Http/Response/BadRequest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 /**
- * File contains the PSR15 ResponseInterface implementation for
+ * File contains the PSR7 ResponseInterface implementation for
  * Bad Request responses.
  *
  * PHP Version 7

--- a/src/Http/Response/BadRequest.php
+++ b/src/Http/Response/BadRequest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Bad Request responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 400 Bad Request.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class BadRequest extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 400 Bad Request
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg = 'bad request')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 400);
+    }
+}
+

--- a/src/Http/Response/Conflict.php
+++ b/src/Http/Response/Conflict.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Conflict responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 409 Conflict.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Conflict extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 409 Conflict
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg = 'conflict')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 409);
+    }
+}
+

--- a/src/Http/Response/Forbidden.php
+++ b/src/Http/Response/Forbidden.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/**
+* File contains the PSR15 ResponseInterface implementation for
+* Forbidden responses.
+*
+* PHP Version 7
+*
+* @category PSR15
+* @package  Http
+* @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+* @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+* @link     https://www.github.com/aces/Loris/
+*/
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 403 Forbidden.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Forbidden extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 403 Forbidden
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg='forbidden')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 403);
+    }
+}
+

--- a/src/Http/Response/InternalServerError.php
+++ b/src/Http/Response/InternalServerError.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Internal Server Error responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 500 Internal Server Error.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class InternalServerError extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 500 Internal Server Error
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg = 'internal server error')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 500);
+    }
+}
+

--- a/src/Http/Response/JsonResponse.php
+++ b/src/Http/Response/JsonResponse.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Json response
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for Json repsonse.
+ *
+ * It is intended to reduce our coupling to any particular PSR15 implementation.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class JsonResponse
+    extends \Zend\Diactoros\Response\JsonResponse
+    implements \Psr\Http\Message\ResponseInterface
+{
+}
+

--- a/src/Http/Response/MethodNotAllowed.php
+++ b/src/Http/Response/MethodNotAllowed.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Method Not Allowed responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 405 Method Not Allowed.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class MethodNotAllowed extends JsonResponse
+{
+    /**
+     * The server MUST generate an Allow header field in a 405 response
+     * containing a list of the target resource's currently supported methods.
+     *
+     * @param array  $allowedmethods The list of supported methods
+     * @param string $msg            The error message
+     *
+     * @see RFC 7231, section 6.5.5: 405 Method Not Allowed
+     */
+    public function __construct(
+        array $allowedmethods,
+        string $msg='method not allowed'
+    ) {
+        $body    = array('error' => $msg);
+        $headers = array('Allow' => $allowedmethods);
+        parent::__construct($body, 405, $headers);
+    }
+}
+

--- a/src/Http/Response/NotFound.php
+++ b/src/Http/Response/NotFound.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Not Found responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 404 Not Found.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NotFound extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 404 Not Found
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg = 'not found')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 404);
+    }
+}
+

--- a/src/Http/Response/NotImplemented.php
+++ b/src/Http/Response/NotImplemented.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Not Implemented responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 501 Not Implemented.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NotImplemented extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 501 Not Implemented
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg = 'not implemented')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 501);
+    }
+}
+

--- a/src/Http/Response/NotModified.php
+++ b/src/Http/Response/NotModified.php
@@ -34,13 +34,11 @@ class NotModified extends JsonResponse
      * Create a Json response specific to 404 Not Found
      *
      * @param string $etag The endpoint etag
-     * @param string $msg  The error message
      */
-    public function __construct(string $etag, string $msg = 'not modified')
+    public function __construct(string $etag)
     {
-        $body    = array('error' => $msg);
         $headers = array('ETag' => $etag);
-        parent::__construct($body, 304, $headers);
+        parent::__construct(null, 304, $headers);
     }
 }
 

--- a/src/Http/Response/NotModified.php
+++ b/src/Http/Response/NotModified.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Not Modified responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 304 Not Modified.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NotModified extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 404 Not Found
+     *
+     * @param string $etag The endpoint etag
+     * @param string $msg  The error message
+     */
+    public function __construct(string $etag, string $msg = 'not modified')
+    {
+        $body    = array('error' => $msg);
+        $headers = array('ETag' => $etag);
+        parent::__construct($body, 304, $headers);
+    }
+}
+

--- a/src/Http/Response/Unauthorized.php
+++ b/src/Http/Response/Unauthorized.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * File contains the PSR15 ResponseInterface implementation for
+ * Unauthorized responses.
+ *
+ * PHP Version 7
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ *
+ * @see https://www.php-fig.org/psr/psr-7/
+ * @see https://www.php-fig.org/psr/psr-15/
+ */
+namespace LORIS\Http\Response;
+
+use \LORIS\Http\Response\JsonResponse;
+
+/**
+ * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
+ * to use in LORIS specific for 401 Unauthorized.
+ *
+ * @category PSR15
+ * @package  Http
+ * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class Unauthorized extends JsonResponse
+{
+    /**
+     * Create a Json response specific to 401 Unauthorized
+     *
+     * @param string $msg The error message
+     */
+    public function __construct(string $msg = 'unauthorized')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 401);
+    }
+}
+

--- a/src/Middleware/ETag.php
+++ b/src/Middleware/ETag.php
@@ -61,9 +61,9 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
             if ($clientETag == $endpointETag) {
                 // It matches, so just return a 304 Not modified instead of
                 // doing any work.
-                return (new \LORIS\Http\Response())
-                    ->withStatus(304)
-                    ->withHeader('ETag', $endpointETag);
+                return new \LORIS\Http\Response\NotModified(
+                    $endpointETag
+                );
             }
         }
 

--- a/src/Middleware/ETag.php
+++ b/src/Middleware/ETag.php
@@ -54,10 +54,11 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
             return $handler->handle($request);
         }
 
-        $clientETag   = $request->getHeaderLine("If-None-Match") ?? false;
-        $endpointETag = $handler->ETag($request);
-        if ($clientETag  && $endpointETag === $clientETag) {
-            if ($endpointETag == $clientETag) {
+        $clientETag = $request->getHeaderLine("If-None-Match");
+        if ($clientETag !== '') {
+            // If-None-Match header provided
+            $endpointETag = $handler->ETag($request);
+            if ($clientETag == $endpointETag) {
                 // It matches, so just return a 304 Not modified instead of
                 // doing any work.
                 return (new \LORIS\Http\Response())
@@ -70,12 +71,20 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
         // case, we calculate one and add it to the response header after calling
         // the handler.
         $response = $handler->handle($request);
+
+        if ($response->getStatusCode() >= 400) {
+            // In case of client or server error, do not calculate ETag
+            return $response;
+        }
+
         if (empty($response->getHeaderLine('Etag'))) {
+            // If a sub-endpoint already added a Etag, do not calculate ETag
             $response = $response->withHeader(
                 "ETag",
                 $handler->ETag($request)
             );
         }
+
         return $response;
     }
 }


### PR DESCRIPTION
This brings current development from https://github.com/aces/Loris/pull/4244 to minor so it can be share/use earlier then when the other PR will be merged.

### Brief summary of changes
- Allow to generate PSR-7 responses in one line instead of repeating the same 7 lines each time.
- Login endpoint now use the new response classes
- Etag are added only if the header do not exists. (This resolves issue where etag from subendpoints were overwritten by parents endpoint.)

Todo:
- [ ] ~~unit tests --> https://github.com/xlecours/Loris/pull/5 (discussion required)~~ will be sent in an other PR