### PR TITLE
[Instrument] permissions should check for string

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -287,7 +287,7 @@ class NDB_BVL_Instrument extends NDB_Page
         )) {
             //instrument permissions not used...
             return true; //default
-        } else if ($instrumentPermissions['useInstrumentPermissions'] == false) {
+        } else if ($instrumentPermissions['useInstrumentPermissions'] == 'false') {
             //instrument permissions not used...
             return true; //default
         } else { //check if user has instrument's permissions


### PR DESCRIPTION
### Brief summary of changes
The current `true/false` switch is in `config.xml` the code is supposed to `return true;` if it's set to false however that does not happen because the code is checking for a boolean false instead of the string which is queried.

### To test this change...

- [ ] simply dump the value and see the type that is returned from the config.xml

