### PR TITLE
[Testing] Prevent phan from checking htdocs/api since this is being refactored into a module

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -57,6 +57,7 @@ return [
 	],
 	"exclude_analysis_directory_list" => [
 		"vendor",
+		"htdocs/api/",
 	],
     'autoload_internal_extension_signatures' => [
         // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,


### PR DESCRIPTION
My various PRs to increase phan's strictness (https://github.com/aces/Loris/projects/14) require `htdocs/api` changes. However @xlecours is converting this code to be module-based so conflicts are likely to arise. 

This PR suspends checking `htdocs/api/` with Phan as per @driusan's suggestion to deal with these conflicts.