### PR TITLE
[phan] Add two rules that created no errors

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -19,8 +19,6 @@ return [
         "PhanTypeExpectedObjectPropAccessButGotNull",
         "PhanTypeInvalidDimOffset",
         "PhanTypeMismatchDimAssignment",
-		"PhanRedefineClass",
-		"PhanRedefinedExtendedClass",
 		"PhanUndeclaredMethod",
 		"PhanUndeclaredVariable",
 		"PhanUndeclaredVariableDim",


### PR DESCRIPTION
This enables the PhanRedefineClass and PhanRedefinedExtendedClass rules,
which cause no errors but were still being ignored.