### PR TITLE
[phan] Remove redeclaration of PHP internal getallheaders function

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -36,7 +36,6 @@ return [
 		"PhanNonClassMethodCall",
 		"PhanTypeVoidAssignment",
 		"PhanTypeArraySuspicious",
-        "PhanRedefineFunctionInternal",
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -148,38 +148,6 @@ class SinglePointLogin
         // Reset passwordExpired flag
         $this->_passwordExpired = false;
 
-        if (!function_exists('getallheaders')) {
-            /**
-             * In case unable to detect getallheaders function
-             *
-             * @return array headers
-             */
-            function getallheaders(): array
-            {
-                $headers = '';
-                foreach ($_SERVER as $name => $value) {
-                    if (substr($name, 0, 5) == 'HTTP_') {
-                        $headers[str_replace(
-                            ' ',
-                            '-',
-                            ucwords(
-                                strtolower(
-                                    str_replace(
-                                        '_',
-                                        ' ',
-                                        substr(
-                                            $name,
-                                            5
-                                        )
-                                    )
-                                )
-                            )
-                        )] = $value;
-                    }
-                }
-                return $headers;
-            }
-        }
         // First try JWT authentication, which is cheaper and
         // doesn't involve database calls
         $headers    = getallheaders();


### PR DESCRIPTION
This removes the intentional redeclaration of the PHP getallheaders
function in SinglePointLogin.

It was previously required because getallheaders() only existed under
Apache. According to the PHP documentation (http://php.net/manual/en/function.getallheaders.php)
it became available under the CLI server in PHP 5.5.7, so it should
no longer be required for Travis or development purposes under
supported versions of PHP.