### PR TITLE
Properly namespace php/installer and add to phan

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -43,8 +43,7 @@ return [
            which redeclare classes from php/libraries, in order
 		   to bootstrap the installer before the config/database
 		   is set up */
-		"php/libraries",
-		"php/exceptions",
+		"php",
 		"htdocs",
 		"modules",
         "src",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
         "psr-4": {
             "LORIS\\": "src/"
         },
-        "classmap": ["project/libraries", "php/libraries", "php/exceptions"]
+        "classmap": ["project/libraries", "php"]
     }
 }

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -53,6 +53,7 @@ require_once __DIR__ . "/../vendor/autoload.php";
 use \LORIS\Installer\Database as Database;
 
 $installer = new \LORIS\Installer\Installer();
+
 $factory = \NDB_Factory::singleton();
 $factory->setConfig(\LORIS\Installer\NDB_Config::singleton());
 

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -53,6 +53,8 @@ require_once __DIR__ . "/../vendor/autoload.php";
 use \LORIS\Installer\Database as Database;
 
 $installer = new \LORIS\Installer\Installer();
+$factory = \NDB_Factory::singleton();
+$factory->setConfig(\LORIS\Installer\NDB_Config::singleton());
 
 // Check the dependencies of this script.
 if ($installer->checkPreconditionsValid() === false) {
@@ -218,6 +220,7 @@ tplvar('use_existing_database');
 tplvar('use_existing_tables');
 tplvar('use_existing_configs');
 tplvar('lorismysql_already_created');
+
 $smarty = new Smarty_NeuroDB;
 $smarty->assign($tpl_data);
 $smarty->display('install.tpl');

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -41,7 +41,8 @@
 
 // the installer directory doesn't get autoloaded by composer, so we
 // need to manually require this.
-require_once __DIR__ . "/../php/installer/Installer.class.inc";
+require_once __DIR__ . "/../vendor/autoload.php";
+
 
 // Since LORIS isn't configured yet, these classes from the php/
 // directory won't work. We need stubs for the installer to use, and
@@ -49,11 +50,9 @@ require_once __DIR__ . "/../php/installer/Installer.class.inc";
 // autoload the ones that we can't use which try to access config.xml.
 // We don't need to implement all the functionality, just enough for
 // smarty to use when it gets autoloaded.
-require_once __DIR__ . "/../php/installer/Database.class.inc";
-require_once __DIR__ . "/../php/installer/NDB_Config.class.inc";
 use \LORIS\Installer\Database as Database;
 
-$installer = new Installer("../project");
+$installer = new \LORIS\Installer\Installer();
 
 // Check the dependencies of this script.
 if ($installer->checkPreconditionsValid() === false) {

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -113,7 +113,7 @@ class Database
     public static function canLogIn($host, $database, $username, $password)
     {
         try {
-            $test = new PDO(
+            $test = new \PDO(
                 "mysql:host={$host};dbname={$database};charset=UTF8",
                 $username,
                 $password

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -15,7 +15,6 @@
  */
 
 namespace LORIS\Installer;
-use \PDO;
 
 /**
  * The Installer Database class is like the LORIS database class, except it
@@ -62,7 +61,7 @@ class Database
     public function hasPrivilege($database, $table, $privilege)
     {
         $stmt    = $this->PDO->query("SHOW GRANTS");
-        $results = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $results = $stmt->fetchAll(\PDO::FETCH_COLUMN);
         $stmt->closeCursor();
         if ($database == '*') {
             $database = '\*';
@@ -120,7 +119,7 @@ class Database
                 $password
             );
             return true;
-        } catch (PDOException $ex) {
+        } catch (\PDOException $ex) {
             return false;
         } catch (\Exception $e) {
             return false;
@@ -153,13 +152,13 @@ class Database
         $host
     ) {
         try {
-            $this->PDO = new PDO(
+            $this->PDO = new \PDO(
                 "mysql:host=$host;charset=UTF8",
                 $username,
                 $password
             );
 
-            $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+            $this->PDO->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_WARNING);
 
             if (!$this->hasPrivilege("*", "*", "CREATE")) {
                 if ($this->databaseExists($database)) {
@@ -175,7 +174,7 @@ class Database
             $this->PDO->exec("CREATE DATABASE $database");
             $this->PDO->exec("USE $database");
             return true;
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             return false;
         }
     }
@@ -211,12 +210,12 @@ class Database
             return true;
         }
         try {
-            $this->PDO = new PDO(
+            $this->PDO = new \PDO(
                 "mysql:host=$host;charset=UTF8",
                 $username,
                 $password
             );
-            $this->PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+            $this->PDO->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_WARNING);
             if (!$this->databaseExists($database)) {
                 $this->lastErr = "Database `{$database}` does not exist; ".
                     "consider creating it first";
@@ -224,7 +223,7 @@ class Database
             }
             $this->PDO->exec("USE $database");
             return true;
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             error_log($e->getMessage());
             $this->lastErr = "Exceptional error connecting to the database "
             . $database . ".";
@@ -248,7 +247,7 @@ class Database
             }
             $this->PDO->query("SELECT 'x'");
             return true;
-        } catch(Exception $e) {
+        } catch(\Exception $e) {
             return false;
         }
     }
@@ -258,21 +257,10 @@ class Database
      *
      * @param string $query The SQL query to be prepared
      *
-     * @return PDOStatement of prepared statement
+     * @return \PDOStatement of prepared statement
      */
     public function prepare($query)
     {
         return $this->PDO->prepare($query);
-    }
-
-    /**
-     * Stub to prevent PHP from crashing if something autloads and tries
-     * to call pselect
-     *
-     * @return the empty array
-     */
-    public function pselect()
-    {
-        return array();
     }
 }

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -335,7 +335,7 @@ class Installer
         // what it is, as long as the server always uses the same one to
         // validate tokens. So we use the new user password code to generate a
         // really long password and use that as the key.
-        $this->_updateConfig($DB, "JWTKey", User::newPassword(64));
+        $this->_updateConfig($DB, "JWTKey", \User::newPassword(64));
     }
 
     /**

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -140,7 +140,7 @@ class Installer
         // Check that the PDO is able to connect to MySQL.
         try {
             // and check that the MySQL driver is available.
-            $drivers = PDO::getAvailableDrivers();
+            $drivers = \PDO::getAvailableDrivers();
             if (in_array("mysql", $drivers) == false) {
                 $this->_lastErr = "You do not appear to have MySQL support"
                 . " available in PHP. Aborting.\n"

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -12,8 +12,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-use \LORIS\Installer\Database as Database;
-
+namespace LORIS\Installer;
 /**
  * The Installer class handles all the logic used by the installdb.php
  * script under htdocs. It's put in a class for testability (even if there
@@ -148,7 +147,7 @@ class Installer
                 . " Please check your system dependencies and try again.";
                 return false;
             }
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->_lastErr = "You do not appear to have PDO support in your "
             . "version of PHP, which is required to access the database.";
             return false;
@@ -193,7 +192,7 @@ class Installer
                 $values['dbadminpassword'],
                 $values['dbhost']
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
             } else {
@@ -223,7 +222,7 @@ class Installer
                 $values['dbadminpassword'],
                 $values['dbhost']
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
             } else {
@@ -302,7 +301,7 @@ class Installer
                 $values['dbadminpassword'],
                 $values['dbhost']
             );
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
             } else {
@@ -346,7 +345,7 @@ class Installer
      * @param string   $setting The setting name to be updated.
      * @param string   $value   The value to set $setting to.
      *
-     * @return none
+     * @return void
      */
     private function _updateConfig($DB, $setting, $value)
     {
@@ -422,7 +421,7 @@ class Installer
         $connectHost = $DB->PDO->query(
             "SELECT host FROM `mysql`.`user`
 		WHERE CONCAT(user, '@', host)=CURRENT_USER"
-        )->fetch(PDO::FETCH_ASSOC);
+        )->fetch(\PDO::FETCH_ASSOC);
 
         if (!is_array($connectHost) || empty($connectHost['host'])) {
             // This should never happen. It would mean that the user
@@ -443,7 +442,7 @@ class Installer
              'q_host' => $connectHost,
             ]
         );
-        $results    = $userExistsQ->fetchAll(PDO::FETCH_ASSOC);
+        $results    = $userExistsQ->fetchAll(\PDO::FETCH_ASSOC);
         $userExists = false;
 
         $quotedUser = $DB->PDO->quote($values['lorismysqluser']) .

--- a/php/installer/NDB_Config.class.inc
+++ b/php/installer/NDB_Config.class.inc
@@ -36,9 +36,12 @@ class NDB_Config extends \NDB_Config
     /**
      * Returns a single NDB_Config object.
      *
+     * @param ?string $configFile Unused, for signature compatibility with
+     *                            \NDB_Config
+     *
      * @return NDB_Config
      */
-    public static function &singleton(?string $configFile=NULL) : \NDB_Config
+    public static function &singleton(?string $configFile=null) : \NDB_Config
     {
         static $cfg = null;
         if (is_null($cfg)) {

--- a/php/installer/NDB_Config.class.inc
+++ b/php/installer/NDB_Config.class.inc
@@ -58,7 +58,7 @@ class NDB_Config extends \NDB_Config
      *
      * @return mixed the setting value
      */
-    public function getSetting($setting)
+    public function getSetting(string $setting)
     {
         // the base path is used by smarty, so calculate it relative
         // to the current directory. Nothing else needs to be supported.

--- a/php/installer/NDB_Config.class.inc
+++ b/php/installer/NDB_Config.class.inc
@@ -31,14 +31,14 @@ namespace LORIS\Installer;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class NDB_Config
+class NDB_Config extends \NDB_Config
 {
     /**
      * Returns a single NDB_Config object.
      *
      * @return NDB_Config
      */
-    public static function singleton()
+    public static function &singleton(?string $configFile=NULL) : \NDB_Config
     {
         static $cfg = null;
         if (is_null($cfg)) {

--- a/php/installer/NDB_Config.class.inc
+++ b/php/installer/NDB_Config.class.inc
@@ -14,6 +14,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
+namespace LORIS\Installer;
 
 /**
  * This NDB_Config class is a stub that gets autoloaded by the LORIS installer.

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -68,14 +68,14 @@ class CandidateTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var \NDB_Config | PHPUnit_Framework_MockObject_MockObject
      */
     private $_configMock;
 
     /**
      * Test double for Database object
      *
-     * @var Database | PHPUnit_Framework_MockObject_MockObject
+     * @var \Database | PHPUnit_Framework_MockObject_MockObject
      */
     private $_dbMock;
 


### PR DESCRIPTION
Add a real namespace to php/installer and remove it as an
exception from phan.

There is no good reason to pretend that the classes are
the same, so this no longer does so.