### PR TITLE
Cleanup duplicated data config paths

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -74,9 +74,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('paths', 'Specify directories where LORIS-related files are stored or created. Take care when editing these fields as changing them incorrectly can cause certain modules to lose functionality.', 1, 0, 'Paths', 2);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'imagePath', 'Path to images for display in Imaging Browser (e.g. /data/$project/data/) ', 1, 0, 'text', ID, 'Images', 9 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'base', 'The base filesystem path where LORIS is installed', 1, 0, 'text', ID, 'Base', 1 FROM ConfigSettings WHERE Name="paths";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'data', 'Path to main imaging data directory (e.g. /data/$project/data/) ', 1, 0, 'text', ID, 'Imaging data', 5 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'extLibs', 'Path to external libraries', 1, 0, 'text', ID, 'External libraries', 3 FROM ConfigSettings WHERE Name="paths";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'mincPath', 'Path to MINC files (e.g. /data/$project/data/)', 1, 0, 'text', ID, 'MINC files', 8 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'DownloadPath', 'Where files are downloaded', 1, 0, 'text', ID, 'Downloads', 4 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'log', 'Path to logs (relative path starting from /var/www/$projectname)', 1, 0, 'text', ID, 'Logs', 2 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MRICodePath', 'Path to directory where Loris-MRI (git) code is installed', 1, 0, 'text', ID, 'LORIS-MRI code', 6 FROM ConfigSettings WHERE Name="paths";
@@ -187,9 +185,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "YMd" FROM ConfigSettings WHERE 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="imagePath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "%LORISROOT%" FROM ConfigSettings WHERE Name="base";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="data";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/EXTERNAL/LIBRARY/" FROM ConfigSettings WHERE Name="extLibs";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="mincPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "%LORISROOT%" FROM ConfigSettings WHERE Name="DownloadPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "tools/logs/" FROM ConfigSettings WHERE Name="log";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/bin/mri/" FROM ConfigSettings WHERE Name="MRICodePath";
@@ -230,7 +226,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "Produced by LorisDB" FROM Confi
 INSERT INTO Config (ConfigID, Value) SELECT ID, "S3cret" FROM ConfigSettings WHERE Name="JWTKey";
 
 
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/DATA/location" FROM ConfigSettings cs WHERE cs.Name="Loris-MRI Data Directory";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings cs WHERE cs.Name="dataDirBasepath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "project" FROM ConfigSettings cs WHERE cs.Name="prefix";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "yourname\@example.com" FROM ConfigSettings cs WHERE cs.Name="mail_user";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/get_dicom_info.pl" FROM ConfigSettings cs WHERE cs.Name="get_dicom_info";

--- a/SQL/New_patches/2019-02-08_cleanup_duplicated_data_path_in_Config.sql
+++ b/SQL/New_patches/2019-02-08_cleanup_duplicated_data_path_in_Config.sql
@@ -1,0 +1,13 @@
+-- Remove entries for mincPath and data from the Config table
+DELETE
+FROM Config
+WHERE ConfigID IN (
+  SELECT ID
+  FROM ConfigSettings
+  WHERE Name IN ('mincPath', 'data')
+);
+
+-- Remove entries for mincPath and data from the ConfigSettings table
+DELETE
+FROM ConfigSettings
+WHERE Name IN ('mincPath', 'data');

--- a/htdocs/api/v0.0.2/candidates/visits/images/Image.php
+++ b/htdocs/api/v0.0.2/candidates/visits/images/Image.php
@@ -168,7 +168,7 @@ class Image extends \Loris\API\Candidates\Candidate\Visit
     {
         $factory = \NDB_Factory::singleton();
         $config  = $factory->Config();
-        return $config->getSetting("mincPath");
+        return $config->getSetting("imagePath");
     }
 
     /**

--- a/htdocs/api/v0.0.3-dev/candidates/visits/images/Image.php
+++ b/htdocs/api/v0.0.3-dev/candidates/visits/images/Image.php
@@ -168,7 +168,7 @@ class Image extends \Loris\API\Candidates\Candidate\Visit
     {
         $factory = \NDB_Factory::singleton();
         $config  = $factory->Config();
-        return $config->getSetting("mincPath");
+        return $config->getSetting("imagePath");
     }
 
     /**

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -39,14 +39,12 @@ $pipeline = $config->getSetting('imaging_pipeline');
 
 $imagePath    = $paths['imagePath'];
 $DownloadPath = $paths['DownloadPath'];
-$mincPath     = $paths['mincPath'];
 $tarchivePath = $pipeline['tarchiveLibraryDir'];
 // Basic config validation
 if (!validConfigPaths(
     array(
      $imagePath,
      $DownloadPath,
-     $mincPath,
      $tarchivePath,
     )
 )) {
@@ -90,17 +88,17 @@ if (strpos($FileBase, "DCM_") === 0) {
 $DownloadFilename = '';
 switch($FileExt) {
 case 'mnc':
-    $FullPath         = $mincPath . '/' . $File;
+    $FullPath         = $imagePath . '/' . $File;
     $MimeType         = "application/x-minc";
     $DownloadFilename = basename($File);
     break;
 case 'nii':
-    $FullPath         = $mincPath . '/' . $File;
+    $FullPath         = $imagePath . '/' . $File;
     $MimeType         = "application/x-nifti";
     $DownloadFilename = basename($File);
     break;
 case 'nii.gz':
-    $FullPath         = $mincPath . '/' . $File;
+    $FullPath         = $imagePath . '/' . $File;
     $MimeType         = "application/x-nifti-gz";
     $DownloadFilename = basename($File);
     break;
@@ -190,9 +188,8 @@ function validConfigPaths(array $paths): bool
     foreach ($paths as $p) {
         if (empty($p)) {
             throw new \LorisException(
-                'Config paths are not initialized. Please ensure that valid ' .
-                'paths are set for imagePath, downloadPath, mincPath and ' .
-                'tarchiveLibraryDir'
+                'Config paths are not initialized. Please ensure that valid paths ' .
+                'are set for imagePath, downloadPath and tarchiveLibraryDir'
             );
             return false;
         }
@@ -200,7 +197,7 @@ function validConfigPaths(array $paths): bool
             throw new \LorisException(
                 'Config path invalid. Paths cannot be set to root, i.e., `/`' .
                 ' Please verify your path settings for imagePath, ' .
-                'downloadPath, mincPath and tarchiveLibraryDir.'
+                'downloadPath and tarchiveLibraryDir.'
             );
             return false;
         }
@@ -226,8 +223,8 @@ function validDownloadPath($path): bool
     }
     // Make sure that the user isn't trying to break out of the $path by
     // using a relative filename.
-    // No need to check for '/' since all downloads are relative to $imagePath,
-    // $DownloadPath or $mincPath
+    // No need to check for '/' since all downloads are relative to $imagePath or
+    // $DownloadPath
     if (strpos($path, "..") !== false) {
         error_log(
             'ERROR: Invalid filename. Contains path traversal characters'

--- a/modules/brainbrowser/ajax/image.php
+++ b/modules/brainbrowser/ajax/image.php
@@ -84,7 +84,7 @@ function getFileLocation()
 {
     $config     = & NDB_Config::singleton();
     $paths      = $config->getSetting('paths');
-    $image_path = $paths['mincPath'];
+    $image_path = $paths['imagePath'];
     return $image_path;
 }
 

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -324,7 +324,6 @@ class Installer
 
         $this->_updateConfig($DB, "imagePath", $datadir);
         $this->_updateConfig($DB, "data", $datadir);
-        $this->_updateConfig($DB, "mincPath", $datadir);
         $this->_updateConfig($DB, "MRICodePath", $datadir);
 
         // Update the host based and URL based on the location that


### PR DESCRIPTION
### Brief summary of changes

This PR cleans up all the different paths that are referring to the same path (a.k.a. `/data/%PROJECT%/data/`. This gets rid of the Config settings `mincPath` and `data` and updates the code accordingly.

The code changes on the LORIS-MRI front can be found in https://github.com/aces/Loris-MRI/pull/399

### This resolves issue...

- [x] Github #4197 and LORIS-MRI https://github.com/aces/Loris-MRI/issues/367

### To test this change...

- [ ] run the SQL patch
- [ ] make sure the imaging modules work properly and are able to see the images
- [ ] test the API v0.0.2 and v0.0.3-dev to make sure the images can be found and read

### Caveat for existing projects

Make sure that your Config setting `dataDirBasepath` and `imagePath` are configured to the proper data path (typically `/data/%PROJECT%/data`). Note that `dataDirBasepath` is the path used by the LORIS-MRI pipelines and `imagePath` is the path where the imaging data can be read by the web server.
