### PR TITLE
[Core] Remove checkDate() function from Utility

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -239,10 +239,6 @@ class New_Profile extends \NDB_Form
         if ($config->getSetting('useEDC') == "true") {
             if (empty($values['edc1'])) {
                 $errors['edc1'] = 'Expected Date of Confinement field is required';
-            } else if (strlen(implode($values['edc1'])) > 2
-                && !\Utility::_checkDate($values['edc1'])
-            ) {
-                $errors['edc1'] = 'EDC is not a valid date';
             }
 
             if (empty($values['edc2'])) {
@@ -250,7 +246,7 @@ class New_Profile extends \NDB_Form
             }
 
             if ($values['edc1'] != $values['edc2']) {
-                $errors['edc1'] = 'Estimated Due date fields must match.';
+                $errors['edc1'] = 'Estimated due date fields must match.';
             }
         }
 

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -239,8 +239,6 @@ class Next_Stage extends \NDB_Form
         // check date pairs
         if (empty($values['date1'])) {
             $errors['date1'] .= "Date is required. \n";
-        } elseif (!\Utility::_checkDate($values['date1'])) {
-            $errors['date1'] .= "Date is not a valid date. \n";
         }
 
         if ($values['date1'] != $values['date2']) {

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -870,35 +870,6 @@ class Utility
     }
 
     /**
-     * QuickForm rule to check that a date is valid.
-     * This is used by create timepoint and start timepoint pages,
-     * so it probably shouldn't be in the instrument class.
-     *
-     * @param string $dateElement The date element in QuickForm array format.
-     *
-     * @return True if the date is invalid, false if it's valid.
-     */
-    static function _checkDate(string $dateElement): bool
-    {
-        if (empty($dateElement['M'])
-            && empty($dateElement['d'])
-            && empty($dateElement['Y'])
-        ) {
-            // if all three elements are empty, return true b/c it'll
-            // save the NULL in date field
-            return true;
-        } elseif (empty($dateElement['M'])
-            || empty($dateElement['d'])
-            || empty($dateElement['Y'])
-        ) {
-            // otherwise, if any of the three elements are empty, return
-            // false b/c date entry has been attempted
-            return false;
-        }
-        return checkdate($dateElement['M'], $dateElement['d'], $dateElement['Y']);
-    }
-
-    /**
      * Effectively resolve '..' characters in a file path
      *
      * @param string $path A potentially-relative filepath to be resolved


### PR DESCRIPTION
### Brief summary of changes

Remove the `_checkDate()` function from Utility and delete instances of calling code.

#### Justification
* The function was declared to accept only strings and generated no bugs -- therefore it was never used in the `array` context
* The `empty()` checks at the beginning of the function always return true on a string input, therefore the function would always short circuit and not validate dates properly
* The calling code pass strings, never arrays in "QuickForm array format"
* The calling code in `next_stage` and `new_profile` are generated using JavaScript date picker elements and so there should never be an occasion where a date is manually entered by a user and require this kind of validation.