### PR TITLE
[Core] Fix TypeError in Notifier

### DIFF
--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -86,16 +86,16 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     {
         foreach ($this->notified['email_text'] as $name=>$uid) {
             $notifierID = $this->notifier->getData('ID');
-            $fromEmail  = $this->notifier->getData('Email');
+            $senderEmail  = $this->notifier->getData('Email');
             $this->tpl_data['notified_user'] = $name;
-            $this->tpl_data['notifier_user'] = "$notifierID <$fromEmail>";
-            $toEmail = $this->getEmail($uid);
+            $this->tpl_data['notifier_user'] = "$notifierID <$senderEmail>";
+            $recipientEmail = $this->getEmail($uid);
 
             if ($notifierID === $uid) {
                 // TODO send confirmation email instead
             } else {
                 Email::send(
-                    $toEmail,
+                    $recipientEmail,
                     $this->template,
                     $this->tpl_data
                 );

--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -85,20 +85,21 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     private function _sendEmails(): void
     {
         foreach ($this->notified['email_text'] as $name=>$uid) {
+            $notifierID = $this->notifier->getData('ID');
+            $fromEmail  = $this->notifier->getData('Email');
             $this->tpl_data['notified_user'] = $name;
-            $this->tpl_data['notifier_user']
-                = $this->notifier['name'].' <'.$this->notifier['email'].'>';
-            $email =$this->getEmail($uid);
+            $this->tpl_data['notifier_user'] = "$notifierID <$fromEmail>";
+            $toEmail = $this->getEmail($uid);
 
-            if ($this->notifier['ID'] === $uid) {
+            if ($notifierID === $uid) {
                 // TODO send confirmation email instead
             } else {
                 Email::send(
-                    $email,
+                    $toEmail,
                     $this->template,
                     $this->tpl_data
                 );
-                $this->log($this->notifier['ID'], $uid, 'email_text');
+                $this->log($notifierID, $uid, 'email_text');
             }
         }
     }

--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -85,8 +85,8 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     private function _sendEmails(): void
     {
         foreach ($this->notified['email_text'] as $name=>$uid) {
-            $notifierID = $this->notifier->getData('ID');
-            $senderEmail  = $this->notifier->getData('Email');
+            $notifierID  = $this->notifier->getData('ID');
+            $senderEmail = $this->notifier->getData('Email');
             $this->tpl_data['notified_user'] = $name;
             $this->tpl_data['notifier_user'] = "$notifierID <$senderEmail>";
             $recipientEmail = $this->getEmail($uid);

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -51,7 +51,7 @@ abstract class NDB_Notifier_Abstract
     /**
      * Current logged in user issuing the notification.
      *
-     * @var array [ID,name,email]
+     * @var \User
      */
     protected $notifier;
 
@@ -129,7 +129,7 @@ abstract class NDB_Notifier_Abstract
         $this->module         = $module_name;
         $this->operation      = $operation_type;
         $this->notified       = $this->_get2DListToNotify();
-        $this->notifier       = $this->_getLoggedInUser();
+        $this->notifier       = \User::singleton();
         $this->_adminNotifier = $this->_getAdminUser();
         $this->tpl_data['study_logo'] = $config->getSetting('studylogo');
         $this->tpl_data['baseurl']    = $config->getSetting('url');
@@ -190,32 +190,17 @@ abstract class NDB_Notifier_Abstract
     }
 
     /**
-     * Gets information of logged in user and returns a name-email string combination
-     *
-     * @return string   string in the form `First Last <email@domain.com>`
-     */
-    private function _getLoggedInUser(): string
-    {
-        $user       = \User::singleton();
-        $info_array = array();
-        $info_array['ID']    = $user->getData('ID');
-        $info_array['name']  = $user->getFullname();
-        $info_array['email'] = $user->getData('Email');
-        return $info_array;
-    }
-
-    /**
      * Gets information of admin user and returns a name-email string combination
      *
-     * @return string   string in the form `First Last <email@domain.com>`
+     * @return array Containing UserID, Real_name, and Email of an admin user
      */
-    private function _getAdminUser(): string
+    private function _getAdminUser(): array
     {
         $result           = \Database::singleton()->pselectRow(
             "SELECT ID, Real_name, Email FROM users WHERE UserID='admin'",
             array()
         );
-        $info_array       =array();
+        $info_array       = array();
         $info_array['ID'] = $result['ID'];
         $info_array['name']  = $result['Real_name'];
         $info_array['email'] = $result['Email'];


### PR DESCRIPTION
### Brief summary of changes

A previous PR introduced a TypeError issue by using the PHPDoc return type as two functions' return type when the functions were not annotated properly. 

This PR removes one function altogether as it acted as a wrapper for \User which can be directly accessed. The other was changed to use the array type instead of the string type.