### PR TITLE
[Phan] Add PhanTypeMismatchDimAssignment to static analysis rules

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -18,7 +18,6 @@ return [
 	"suppress_issue_types" => [
         "PhanTypeExpectedObjectPropAccessButGotNull",
         "PhanTypeInvalidDimOffset",
-        "PhanTypeMismatchDimAssignment",
 		"PhanUndeclaredMethod",
 		"PhanUndeclaredVariable",
 		"PhanUndeclaredVariableDim",

--- a/modules/dataquery/ajax/saveQuery.php
+++ b/modules/dataquery/ajax/saveQuery.php
@@ -72,6 +72,7 @@ $cond   = $_REQUEST['Filters'];
 $baseDocument['Conditions'] = $cond;
 $baseDocument['Fields']     = $fields;
 
+$query = array();
 if ($_REQUEST['OverwriteQuery'] === "true") {
     unset($baseDocument['_id']);
     $cdb->replaceDoc($qid, $baseDocument);

--- a/modules/imaging_browser/php/mrinavigation.class.inc
+++ b/modules/imaging_browser/php/mrinavigation.class.inc
@@ -27,6 +27,9 @@ namespace LORIS\imaging_browser;
 
 class MRINavigation
 {
+
+    var $urlParams = array();
+
     /**
     *  Gets the session
     *

--- a/modules/imaging_browser/php/mrinavigation.class.inc
+++ b/modules/imaging_browser/php/mrinavigation.class.inc
@@ -28,7 +28,7 @@ namespace LORIS\imaging_browser;
 class MRINavigation
 {
 
-    var $urlParams = array();
+    public $urlParams = array();
 
     /**
     *  Gets the session

--- a/modules/issue_tracker/php/issue_tracker_controlpanel.class.inc
+++ b/modules/issue_tracker/php/issue_tracker_controlpanel.class.inc
@@ -116,7 +116,7 @@ class Issue_Tracker_ControlPanel
 class IssueNavigation
 {
 
-    var $urlParams = array();
+    public $urlParams = array();
 
     /**
     *  Gets the session

--- a/modules/issue_tracker/php/issue_tracker_controlpanel.class.inc
+++ b/modules/issue_tracker/php/issue_tracker_controlpanel.class.inc
@@ -115,12 +115,15 @@ class Issue_Tracker_ControlPanel
 
 class IssueNavigation
 {
+
+    var $urlParams = array();
+
     /**
     *  Gets the session
     *
     * @param int $issueID sessionID
     *
-    * @return null
+    * @return void
     */
     function __construct($issueID = null)
     {


### PR DESCRIPTION
### Brief summary of changes

Add another phan rule to our checks. This rule makes sure that when array elements are accessed that they have the right type (e.g. numeric arrays should have numeric keys).