### PR TITLE
Update Phan to newest version

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -31,6 +31,10 @@ return [
 		"PhanTypeMismatchProperty",
 		"PhanNonClassMethodCall",
 		"PhanTypeArraySuspicious",
+        "PhanTypeExpectedObjectPropAccess",
+        "PhanTypeSuspiciousStringExpression",
+        "PhanContinueTargetingSwitch",
+        "PhanTypeVoidAssignment"
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -31,10 +31,8 @@ return [
 		"PhanTypeMismatchProperty",
 		"PhanNonClassMethodCall",
 		"PhanTypeArraySuspicious",
-        "PhanTypeExpectedObjectPropAccess",
         "PhanTypeSuspiciousStringExpression",
         "PhanContinueTargetingSwitch",
-        "PhanTypeVoidAssignment"
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "phpunit/dbunit": "3.0.*",
         "facebook/webdriver" : "dev-master",
         "phpmd/phpmd": "^2.6",
-        "phan/phan": ">1.0"
+        "phan/phan": ">1.2.2"
     },
     "scripts": {
       "pre-install-cmd": "mkdir -p project/libraries"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad4e36e20b5c15038e240770a5535c83",
+    "content-hash": "d750c428c31880d67ce7984cabab6aff",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -862,16 +862,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.1.0",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08"
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/c919dc6c62e221fc6406f861ea13433c0aa24f08",
-                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
                 "shasum": ""
             },
             "require": {
@@ -902,7 +902,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-04-11T15:42:36+00:00"
+            "time": "2019-01-28T20:25:53+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1001,16 +1001,16 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.0.1",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "29f1d8c2c17f8c04f9768d382b72aeeb0715ebb8"
+                "reference": "241c470695366e7b83672be04ea0e64d8085a551"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/29f1d8c2c17f8c04f9768d382b72aeeb0715ebb8",
-                "reference": "29f1d8c2c17f8c04f9768d382b72aeeb0715ebb8",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/241c470695366e7b83672be04ea0e64d8085a551",
+                "reference": "241c470695366e7b83672be04ea0e64d8085a551",
                 "shasum": ""
             },
             "require": {
@@ -1038,20 +1038,20 @@
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
-            "time": "2017-10-28T21:26:16+00:00"
+            "time": "2018-09-10T08:58:41+00:00"
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.13",
+            "version": "v0.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Microsoft/tolerant-php-parser.git",
-                "reference": "89ade271e639e0612deeccb0555f13c2224ecf84"
+                "reference": "b662587eb797685a98239d1d52d25168a03fdfb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/89ade271e639e0612deeccb0555f13c2224ecf84",
-                "reference": "89ade271e639e0612deeccb0555f13c2224ecf84",
+                "url": "https://api.github.com/repos/Microsoft/tolerant-php-parser/zipball/b662587eb797685a98239d1d52d25168a03fdfb2",
+                "reference": "b662587eb797685a98239d1d52d25168a03fdfb2",
                 "shasum": ""
             },
             "require": {
@@ -1079,7 +1079,7 @@
                 }
             ],
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
-            "time": "2018-08-07T04:52:21+00:00"
+            "time": "2018-12-29T00:31:32+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1210,24 +1210,25 @@
         },
         {
             "name": "phan/phan",
-            "version": "1.0.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "47cd6776f746962a1d2ec986bf6fb90d95b2ce7d"
+                "reference": "532c43562af1206f68b504a89cc71737063b3972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/47cd6776f746962a1d2ec986bf6fb90d95b2ce7d",
-                "reference": "47cd6776f746962a1d2ec986bf6fb90d95b2ce7d",
+                "url": "https://api.github.com/repos/phan/phan/zipball/532c43562af1206f68b504a89cc71737063b3972",
+                "reference": "532c43562af1206f68b504a89cc71737063b3972",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^1.4",
-                "composer/xdebug-handler": "^1.1",
-                "ext-ast": "^0.1.5",
-                "felixfbecker/advanced-json-rpc": "^3.0",
-                "microsoft/tolerant-php-parser": "0.0.13",
+                "composer/xdebug-handler": "^1.3",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "microsoft/tolerant-php-parser": "0.0.16",
                 "php": "^7.0.0",
                 "sabre/event": "^5.0",
                 "symfony/console": "^2.3|^3.0|~4.0"
@@ -1236,7 +1237,8 @@
                 "phpunit/phpunit": "^6.3.0"
             },
             "suggest": {
-                "ext-tokenizer": "Needed for non-AST support and file/line-based suppressions"
+                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). php-ast ^0.1.5|^1.0.0 is needed.",
+                "ext-tokenizer": "Needed for non-AST support and file/line-based suppressions."
             },
             "bin": [
                 "phan",
@@ -1270,7 +1272,7 @@
                 "php",
                 "static"
             ],
-            "time": "2018-08-27T01:28:15+00:00"
+            "time": "2019-02-10T23:34:07+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -228,7 +228,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         // An exit code of 0 is a success and 1 means failure
         if ($status) {
             error_log(
-                "The installation of $instrument->table.sql failed. "
+                "The installation of $instrument.sql failed. "
                 . "Either: the instrument table exists (but is not in the "
                 . "test_names table), or "
                 . "LORIS could not connect to the database using the "

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -71,7 +71,7 @@ class PasswordReset extends \NDB_Form
                   $password = \User::newPassword();
                   // reset the password in the database
                   // expire password so user must change it upon login
-                  $success = $user->updatePassword($password, '1999-01-01');
+                  $user->updatePassword($password, '1999-01-01');
                 if ($success === false) {
                      error_log("Could not update password for $username");
                     return;

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -58,27 +58,6 @@ class FeedbackMRI
     }
 
     /**
-     * Clears all predefined comments from the object
-     * (used prior to re-setting the list of predefined comments)
-     *
-     * @return bool true if operation succeeded
-     */
-    function clearPredefinedComments()
-    {
-        // start the query
-        $query = "DELETE FROM feedback_mri_comments WHERE ".$this->_buildWhere();
-
-        // limit to predefined comments
-        $query .= "AND PredefinedCommentID IS NOT NULL";
-
-        // run the query
-        $success = mysql_query($query);
-
-        // return success
-        return $success;
-    }
-
-    /**
      * Clears all comments from the object
      *
      * @return bool

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1080,7 +1080,7 @@ class NDB_BVL_Instrument extends NDB_Page
             ) {
 
                 if (array_key_exists("Y", $formDateValue)) {
-                    $yearString = $formDateValue[Y];
+                    $yearString = $formDateValue['Y'];
                 } else {
                     $yearString = "0001";
                 }


### PR DESCRIPTION
### Brief summary of changes

Our previous version of Phan was 1.0.1 and the current is 1.2.3 so I figured it was time to update. Since this is a dev-only tool updating shouldn't have any adverse effects on projects. 

Since new features have been introduced I have added the new rules to our list of ignored rules. They can be tracked and amended using https://github.com/aces/Loris/projects/14.

The PR also deletes a function in FeedbackMRI.class.inc that was [previously removed](https://github.com/aces/Loris/pull/4264/files#r248417342) and mistakenly re-added to the codebase.