### PR TITLE
[phan] Fix error about continue targetting switch

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -32,7 +32,6 @@ return [
 		"PhanNonClassMethodCall",
 		"PhanTypeArraySuspicious",
         "PhanTypeSuspiciousStringExpression",
-        "PhanContinueTargetingSwitch",
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -481,28 +481,27 @@ class Instrument_Manager extends \NDB_Menu_Filter
             }
             switch($type) {
             case 'page':
-                continue;
             case 'table':
             case 'title':
-                continue; // Should these two do something special?
+                break;
             case 'selectmultiple': // fallthrough, both selectmultiple and text
                 // require varchar to save
             case 'text':
                 $error = $this->checkType($instname, $name, 'varchar');
                 if ($error == null) {
-                    continue;
+                    break;
                 }
                 return $error;
             case 'textarea':
                 $error = $this->checkType($instname, $name, 'text');
                 if ($error == null) {
-                    continue;
+                    break;
                 }
                 return $error;
             case 'date':
                 $error = $this->checkType($instname, $name, 'date');
                 if ($error == null) {
-                    continue;
+                    break;
                 }
                 return $error;
             case 'select':


### PR DESCRIPTION
Fix errors in instrument manager about a continue statement inside
of a switch statement. These are changed to a break, since that's
how the continue behaves in that context anyways. "continue 2" or
"break" are equivalent in this context, since the switch in question
is at the end of a loop, so breaking out of the switch will already
continue to the next iteration.