### PR TITLE
[composer] ext-json is missing in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "psr/http-message": "~1.0",
         "psr/http-server-handler" : "*",
         "psr/http-server-middleware" : "*",
-        "zendframework/zend-diactoros": "^1.6"
+        "zendframework/zend-diactoros": "^1.6",
+        "ext-json": "*"
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : "2.5.*",


### PR DESCRIPTION
### Brief summary of changes

I added the ext-json to composer.json and so the "ext-json is missing in composer.json" warning is not shown. The extension is used with JavaScript Object Notation and specifically when we use json_encode in Loris. I'm not sure if it's necessary because the method does work already without needing to require the extension in composer but it does get rid of the warning in my IDE that is setup to watch composer.json.