### PR TITLE
[libraries/TimePoint.class.inc] change return type to array from string

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -597,9 +597,9 @@ class TimePoint
     /**
      * Returns the list of BVLQC exclusion statuses
      *
-     * @return string
+     * @return array
      */
-    function getBVLQCExclusionStatusList(): string
+    function getBVLQCExclusionStatusList(): array
     {
         return $this->bvlQcExclusionStatuses;
     }


### PR DESCRIPTION
### Brief summary of changes

The return type for the function getBVLQCExclusionStatusList should be an array. 