### PR TITLE
[CouchDB] $port should be an int not a string

### DIFF
--- a/modules/dataquery/ajax/GetDoc.php
+++ b/modules/dataquery/ajax/GetDoc.php
@@ -26,7 +26,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/datadictionary.php
+++ b/modules/dataquery/ajax/datadictionary.php
@@ -25,7 +25,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/getAllSessions.php
+++ b/modules/dataquery/ajax/getAllSessions.php
@@ -24,7 +24,7 @@ $couchConfig    = $config->getSetting('CouchDB');
 $cdb            = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/queryContains.php
+++ b/modules/dataquery/ajax/queryContains.php
@@ -24,7 +24,7 @@ $couchConfig    = $config->getSetting('CouchDB');
 $cdb            = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/queryEqual.php
+++ b/modules/dataquery/ajax/queryEqual.php
@@ -24,7 +24,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/queryGreaterThanEqual.php
+++ b/modules/dataquery/ajax/queryGreaterThanEqual.php
@@ -25,7 +25,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/queryLessThanEqual.php
+++ b/modules/dataquery/ajax/queryLessThanEqual.php
@@ -24,7 +24,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/queryNotEqual.php
+++ b/modules/dataquery/ajax/queryNotEqual.php
@@ -24,7 +24,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/queryStartsWith.php
+++ b/modules/dataquery/ajax/queryStartsWith.php
@@ -24,7 +24,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/retrieveCategoryDocs.php
+++ b/modules/dataquery/ajax/retrieveCategoryDocs.php
@@ -25,7 +25,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/ajax/saveQuery.php
+++ b/modules/dataquery/ajax/saveQuery.php
@@ -27,7 +27,7 @@ $couchConfig = $config->getSetting('CouchDB');
 $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['dbName'],
     $couchConfig['hostname'],
-    $couchConfig['port'],
+    intval($couchConfig['port']),
     $couchConfig['admin'],
     $couchConfig['adminpass']
 );

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -54,7 +54,7 @@ class Dataquery extends \NDB_Form
         $couch       = \NDB_Factory::singleton()->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
-            $couchConfig['port'],
+            intval($couchConfig['port']),
             $couchConfig['admin'],
             $couchConfig['adminpass']
         );

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -199,14 +199,14 @@ class CouchDB
      *
      * @param string $database The couchDB database name
      * @param string $host     The couchDB host name
-     * @param string $port     The couchDB port number
+     * @param int    $port     The couchDB port number
      * @param string $user     The couchDB user name
      * @param string $password The couchDB password
      */
     private function __construct(
         string $database = '',
         string $host = '',
-        string $port = '',
+        int $port = null,
         string $user = '',
         string $password = ''
     ) {
@@ -260,7 +260,7 @@ class CouchDB
 
                 $database = $couchConfig['dbName'];
                 $host     = $couchConfig['hostname'];
-                $port     = $couchConfig['port'];
+                $port     = intval($couchConfig['port']);
                 $user     = $couchConfig['admin'];
                 $password = $couchConfig['adminpass'];
                 error_log(
@@ -281,7 +281,7 @@ class CouchDB
                 $couchConfig = $config->getSetting("CouchDB");
 
                 $host     = $couchConfig['hostname'];
-                $port     = $couchConfig['port'];
+                $port     = intval($couchConfig['port']);
                 $user     = $couchConfig['admin'];
                 $password = $couchConfig['adminpass'];
                 error_log(

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -206,7 +206,7 @@ class CouchDB
     private function __construct(
         string $database = '',
         string $host = '',
-        int   $port = 5984,
+        int    $port = 5984,
         string $user = '',
         string $password = ''
     ) {

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -199,14 +199,14 @@ class CouchDB
      *
      * @param string $database The couchDB database name
      * @param string $host     The couchDB host name
-     * @param ?int   $port     The couchDB port number
+     * @param int    $port     The couchDB port number
      * @param string $user     The couchDB user name
      * @param string $password The couchDB password
      */
     private function __construct(
         string $database = '',
         string $host = '',
-        ?int   $port = null,
+        int   $port = 5984,
         string $user = '',
         string $password = ''
     ) {

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -199,14 +199,14 @@ class CouchDB
      *
      * @param string $database The couchDB database name
      * @param string $host     The couchDB host name
-     * @param int    $port     The couchDB port number
+     * @param ?int   $port     The couchDB port number
      * @param string $user     The couchDB user name
      * @param string $password The couchDB password
      */
     private function __construct(
         string $database = '',
         string $host = '',
-        int $port = null,
+        ?int   $port = null,
         string $user = '',
         string $password = ''
     ) {

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -256,7 +256,7 @@ class NDB_Factory
 
             $database = $couchConfig['dbName'];
             $host     = $couchConfig['hostname'];
-            $port     = $couchConfig['port'];
+            $port     = intval($couchConfig['port']);
             $user     = $couchConfig['admin'];
             $password = $couchConfig['adminpass'];
             error_log(
@@ -277,7 +277,7 @@ class NDB_Factory
             $couchConfig = $config->getSetting("CouchDB");
 
             $host     = $couchConfig['hostname'];
-            $port     = $couchConfig['port'];
+            $port     = intval($couchConfig['port']);
             $user     = $couchConfig['admin'];
             $password = $couchConfig['adminpass'];
             error_log(

--- a/tools/CouchDB_Confirm_Integrity.php
+++ b/tools/CouchDB_Confirm_Integrity.php
@@ -55,7 +55,7 @@ class CouchDBIntegrityChecker
         $this->CouchDB = $factory->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
-            $couchConfig['port'],
+            intval($couchConfig['port']),
             $couchConfig['admin'],
             $couchConfig['adminpass']
         );
@@ -102,11 +102,11 @@ class CouchDBIntegrityChecker
             } else if (!empty($sqlDB) && $sqlDB['Active'] != 'Y') {
                 $numActive = $this->SQLDB->execute(
                     $activeExists, array(
-                    'PID' => $pscid, 
+                    'PID' => $pscid,
                     'VL' => $vl)
                 );
 
-                if (!array_key_exists('count', $numActive[0]) 
+                if (!array_key_exists('count', $numActive[0])
                     || $numActive[0]['count'] == '0'
                 ) {
                     print "PSCID $pscid VL $vl is cancelled and has no active "

--- a/tools/CouchDB_Import_Demographics.php
+++ b/tools/CouchDB_Import_Demographics.php
@@ -87,7 +87,7 @@ class CouchDBDemographicsImporter {
         ),
         'Config' => array(
             'GroupString'  => 'How to arrange data: ',
-            'GroupOptions' => 
+            'GroupOptions' =>
                 array('Cross-sectional', 'Longitudinal')
         )
     );
@@ -100,7 +100,7 @@ class CouchDBDemographicsImporter {
         $this->CouchDB = $factory->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
-            $couchConfig['port'],
+            intval($couchConfig['port']),
             $couchConfig['admin'],
             $couchConfig['adminpass']
         );

--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -19,7 +19,7 @@ class CouchDBInstrumentImporter
         $this->CouchDB = $factory->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
-            $couchConfig['port'],
+            intval($couchConfig['port']),
             $couchConfig['admin'],
             $couchConfig['adminpass']
         );

--- a/tools/CouchDB_Import_RadiologicalReview.php
+++ b/tools/CouchDB_Import_RadiologicalReview.php
@@ -12,31 +12,31 @@ class CouchDBRadiologicalReviewImporter {
         'FinalReview_Radiologist' => array(
             'Description' => 'Radiologist/Reviewer doing the final review',
             'Type' => 'varchar(255)'
-        ),  
+        ),
         'FinalReview_Done' => array(
             'Description' => 'Final review done',
             'Type' => "enum('No','Yes')"
-        ),  
+        ),
         'FinalReview_Results' => array(
             'Description' => 'Results of the final radiology review',
             'Type' => "enum('normal','abnormal','atypical','not_answered')"
-        ),  
+        ),
         'FinalReview_ExclusionaryStatus' => array(
             'Description' => 'Final review exclusionary status',
             'Type' => "enum('exclusionary','non_exclusionary','not_answered')"
-        ),  
+        ),
         'FinalReview_SAS' => array(
             'Description' => 'Final review subarachnoid space',
             'Type' => "enum('None', 'Minimal', 'Mild', 'Moderate', 'Marker')"
-        ),  
+        ),
         'FinalReview_PVS' => array(
             'Description' => 'Final review perivascular space',
             'Type' => "enum('None', 'Minimal', 'Mild', 'Moderate', 'Marker')",
-        ),  
+        ),
         'FinalReview_Comment' => array(
             'Description' => 'Current stage of visit',
             'Type' => 'text'
-        ),  
+        ),
         'FinalReview_Finalized' =>  array(
             'Description' => 'Final review finalized',
             'Type' => "enum('No','Yes')",
@@ -44,27 +44,27 @@ class CouchDBRadiologicalReviewImporter {
         'ExtraReview_Radiologist' => array(
             'Description' => 'Radiologist/Reviewer doing the extra review',
             'Type' => 'varchar(255)'
-        ),  
+        ),
         'ExtraReview_Done' => array(
             'Description' => 'Extra review done',
             'Type' => "enum('No','Yes')"
-        ),  
+        ),
         'ExtraReview_Results' => array(
             'Description' => 'Results of the extra radiology review',
             'Type' => "enum('normal','abnormal','atypical','not_answered')"
-        ),  
+        ),
         'ExtraReview_ExclusionaryStatus' => array(
             'Description' => 'Extra review exclusionary status',
             'Type' => "enum('exclusionary','non_exclusionary','not_answered')"
-        ),  
+        ),
         'ExtraReview_SAS' => array(
             'Description' => 'Extra review subarachnoid space',
             'Type' => "enum('None', 'Minimal', 'Mild', 'Moderate', 'Marker')"
-        ),  
+        ),
         'ExtraReview_PVS' => array(
             'Description' => 'Extra review perivascular space',
             'Type' => "enum('None', 'Minimal', 'Mild', 'Moderate', 'Marker')",
-        ),  
+        ),
         'ExtraReview_Comment' => array(
             'Description' => 'Current stage of visit',
             'Type' => "enum('Not Started','Screening','Visit','Approval','Subject','Recycling Bin')"
@@ -87,7 +87,7 @@ class CouchDBRadiologicalReviewImporter {
         $this->CouchDB = $factory->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
-            $couchConfig['port'],
+            intval($couchConfig['port']),
             $couchConfig['admin'],
             $couchConfig['adminpass']
         );
@@ -98,7 +98,7 @@ class CouchDBRadiologicalReviewImporter {
         // Update CouchDB data dictionary
         $this->CouchDB->replaceDoc('DataDictionary:FinalRadiologicalReview',
             array('Meta' => array('DataDict' => true),
-                  'DataDictionary' => array('FinalRadiologicalReview' => $this->Dictionary) 
+                  'DataDictionary' => array('FinalRadiologicalReview' => $this->Dictionary)
             )
         );
 
@@ -156,7 +156,7 @@ class CouchDBRadiologicalReviewImporter {
             LEFT JOIN candidate c ON (c.CandID=s.CandID)
             LEFT JOIN examiners eFinal ON (eFinal.ExaminerID=frr.Final_Examiner)
             LEFT JOIN examiners eExtra ON (eExtra.ExaminerID=frr.Final_Examiner2)", array());
-        
+
         // Adding the data to CouchDB documents
         foreach($finalradiologicalreview as $review) {
             $identifier = array($review['PSCID'], $review['Visit_label']);

--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -35,7 +35,7 @@ class CouchDBMRIImporter
         $this->CouchDB = $factory->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
-            $couchConfig['port'],
+            intval($couchConfig['port']),
             $couchConfig['admin'],
             $couchConfig['adminpass']
         );
@@ -216,7 +216,7 @@ class CouchDBMRIImporter
      * @return scannerID
      */
      function _getScannerID($FileID){
- 
+
          $scannerID = $this->SQLDB->pselectOne("SELECT ScannerID FROM files ".
              "WHERE FileID =:FileID",
              array(
@@ -225,7 +225,7 @@ class CouchDBMRIImporter
          );
          return $scannerID;
      }
- 
+
     /**
      * Gets a rejected parameter according to its type
      *


### PR DESCRIPTION
### Brief summary of changes

The $port should be an int but $couchConfig returns a string. I added the intval function when using the $couchConfig function to retrieve the port from config.xml. I also updated the comment for the constructor to reflect an int for $port and not a string.
