### PR TITLE
[libraries/Project.class.inc] Allow null type hinting for setID

### DIFF
--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -158,7 +158,7 @@ class Project
     /**
      * Set this project's id
      *
-     * @param integer $projectId This project's id
+     * @param int|null $projectId This project's id
      *
      * @return void
      */

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -25,8 +25,8 @@ class Project
 {
     private static $_instances = array();
 
-    private $_projectId;
-    private $_projectName;
+    protected $_projectId;
+    protected $_projectName;
     private $_recruitmentTarget;
 
     /**
@@ -158,11 +158,11 @@ class Project
     /**
      * Set this project's id
      *
-     * @param int|null $projectId This project's id
+     * @param integer $projectId This project's id
      *
      * @return void
      */
-    public function setId(int $projectId = null): void
+    public function setId(int $projectId): void
     {
         $this->_projectId = $projectId;
     }

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -162,7 +162,7 @@ class Project
      *
      * @return void
      */
-    public function setId(int $projectId): void
+    public function setId(int $projectId = null): void
     {
         $this->_projectId = $projectId;
     }

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -25,8 +25,8 @@ class Project
 {
     private static $_instances = array();
 
-    protected $_projectId;
-    protected $_projectName;
+    private $_projectId;
+    private $_projectName;
     private $_recruitmentTarget;
 
     /**
@@ -150,7 +150,7 @@ class Project
      *
      * @return integer This project's id
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->_projectId;
     }

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -150,7 +150,7 @@ class Project
      *
      * @return integer This project's id
      */
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->_projectId;
     }
@@ -158,11 +158,11 @@ class Project
     /**
      * Set this project's id
      *
-     * @param integer $projectId This project's id
+     * @param integer|null $projectId This project's id
      *
      * @return void
      */
-    public function setId(int $projectId): void
+    public function setId(int $projectId = null): void
     {
         $this->_projectId = $projectId;
     }

--- a/php/libraries/ProjectDefault.class.inc
+++ b/php/libraries/ProjectDefault.class.inc
@@ -30,8 +30,8 @@ class ProjectDefault extends Project
      */
     private function __construct()
     {
-        $this->setId(null);
-        $this->setName('loris');
+        $this->_projectId = null;
+        $this->_projectName = 'loris';
     }
 
     /**

--- a/php/libraries/ProjectDefault.class.inc
+++ b/php/libraries/ProjectDefault.class.inc
@@ -30,7 +30,7 @@ class ProjectDefault extends Project
      */
     private function __construct()
     {
-        $this->_projectId = null;
+        $this->_projectId = 1;
         $this->_projectName = 'loris';
     }
 

--- a/php/libraries/ProjectDefault.class.inc
+++ b/php/libraries/ProjectDefault.class.inc
@@ -30,8 +30,8 @@ class ProjectDefault extends Project
      */
     private function __construct()
     {
-        $this->_projectId = 1;
-        $this->_projectName = 'loris';
+        $this->setId(null);
+        $this->setName('loris');
     }
 
     /**


### PR DESCRIPTION
### Brief summary of changes

The php/libraries/ProjectDefault.class.inc will set the projectId to null in the constructor. The type hinting was not allowing it to be null and expecting an Int. So I added the ability for it to be assigned null.
