### PR TITLE
Add new phan rule PhanTypeArraySuspicious

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -30,7 +30,6 @@ return [
 		"PhanTypeMismatchReturn",
 		"PhanTypeMismatchProperty",
 		"PhanNonClassMethodCall",
-		"PhanTypeArraySuspicious",
         "PhanTypeSuspiciousStringExpression",
 	],
 	"analyzed_file_extensions" => ["php", "inc"],

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -127,7 +127,9 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
             );
     }
 
-    $CommentTpl['name'] = $comment_array['name'];
+    if (is_array($comment_array)) {
+        $CommentTpl['name'] = $comment_array['name'];
+    }
 
     // get the list of predefined comments for the current type
     $predefined_comments = $comments->getAllPredefinedComments($comment_type_id);

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -162,6 +162,7 @@ class Create_Timepoint extends \NDB_Form
             \Utility::associativeToNumericArray($visitLabelSettings)
             as $visitLabel
         ) {
+            $visitLabel = \Utility::asArray($visitLabel);
             if ($visitLabel['@']['subprojectID'] == $this->subprojectID) {
                 if (isset($visitLabel['generation'])
                     && $visitLabel['generation'] !== 'sequence'

--- a/modules/data_integrity_flag/php/data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/data_integrity_flag.class.inc
@@ -68,8 +68,8 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
      */
     function _insertDataFlag($req)
     {
-        $user =& \User::singleton();
-        $db   =& \Database::singleton();
+        $user = \User::singleton();
+        $db   = \Database::singleton();
 
         if (!isset($req['instrument'])
             || !isset($req['visitLabel'])
@@ -79,6 +79,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
         ) {
             return "Error";
         }
+        $req = \Utility::asArray($req);
 
         $db->update(
             'data_integrity_flag',

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -318,7 +318,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      *
      * @param string  $elname     The element to be validate
      * @param array   $elements   array of values from current page.
-     * @param boolean $registered Array of all rules which have been
+     * @param array $registered Array of all rules which have been
      *                            registered.
      *
      * @return boolean true if the element passes, false if it fails a rule.
@@ -326,7 +326,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
     function DINRunElementRules(
         string $elname,
         array $elements,
-        bool $registered
+        array $registered
     ): bool {
         foreach ($registered['rules'] AS $rule) {
             //Loop through the assigned rules (which is the array of formatted

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -316,9 +316,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      * Run registered rules for $elname. Only used for instrument builder
      * instruments.
      *
-     * @param string  $elname     The element to be validate
-     * @param array   $elements   array of values from current page.
-     * @param array $registered Array of all rules which have been
+     * @param string $elname     The element to be validate
+     * @param array  $elements   array of values from current page.
+     * @param array  $registered Array of all rules which have been registered.
      *                            registered.
      *
      * @return boolean true if the element passes, false if it fails a rule.


### PR DESCRIPTION
This rule checks whether something is being treated like an array when it isn't necessarily an array. For LORIS that occurs where we are using `mixed` or `object` PHPDocs. This PR mostly uses the `asArray` function in Utility to make it clear that we are interested in arrays. 