### PR TITLE
Brainbrowser not working after fixing paths in violation tables

### DIFF
--- a/modules/brainbrowser/ajax/image.php
+++ b/modules/brainbrowser/ajax/image.php
@@ -37,17 +37,7 @@ if (strpos($_REQUEST['file_id'], 'l') !== false) {
 
     if (!empty($query)) {
         $image_file = $DB->pselectOne($query, array('LogID' => $id));
-        $file       = implode('/', array_slice(explode('/', $image_file), -2));
-
-        if (strpos($image_file, 'assembly') !== false) {
-            if (strpos($image_file, 'assembly') === 0) {
-                $image_path = getFileLocation() . $image_file;
-            } else {
-                $image_path = $image_file;
-            }
-        } else {
-            $image_path = getFileLocation() . "trashbin/" . $file;
-        }
+        $image_path = getFileLocation() . $image_file;
     }
 } else {
     $query      = "select File from files where FileID = :FileID";


### PR DESCRIPTION
### Brief summary of changes

The paths stored in the 3 violation tables (`MRICandidateErrors`, `mri_violations_log` and `mri_protocol_violated_scans`) were wrong and a tool script has been provided on the [LORIS-MRI](https://github.com/aces/Loris-MRI/pull/403) side to correct the paths to the MINC files so that they are valid paths.

Due to the bad paths being present in those tables, brainbrowser was hacked on the LORIS side to be able to display the images. Now that the paths are corrected, this hack can be removed which also simplifies the code.

This PR goes with https://github.com/aces/Loris-MRI/pull/403 on the LORIS-MRI side where more details can be found regarding the bad paths stored in the violation tables.

### This resolves issue...

- [x] Github https://github.com/aces/Loris-MRI/issues/401

### Caveat for existing projects

Make sure to run the tool script called `cleanup_paths_of_violation_tables.pl` on the LORIS-MRI side in order to update the MINC location in the violation tables.

### To test this change...

- [ ] make sure to run the tool provided on the LORIS-MRI side to update the violation tables and then try clicking on an image link in the MRI violation module to see if the image gets displayed
