### PR TITLE
[SinglePointLogin] fix passwordAuthenticate accessing $_POST superglobal

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -320,7 +320,7 @@ class SinglePointLogin
         /* Check whether a user's account is locked due to too many bad login
          * attempts before actually trying to authenticate their credentials.
          */
-        if ($this->accountLocked($_POST['username'])) {
+        if ($this->accountLocked($username)) {
             $this->_lastError = 'This account is currently suspended due '
                 . 'to too many bad login attempts.';
             $this->insertFailedDetail('Account locked', $setArray);


### PR DESCRIPTION
This remove the $_POST['username'] in favor of $username variable passed to the function as a parameter.

It fixes `PHP Fatal error:  Uncaught TypeError: Argument 1 passed to SinglePointLogin::accountLocked() must be of the type string, null given` occurring because the API consumes 'application/json' content-type and $_POST is populated only; 
> [...] when using application/x-www-form-urlencoded or multipart/form-data as the HTTP Content-Type in the request.
http://php.net/manual/en/reserved.variables.post.php


