### PR TITLE
[new_profile] Notice: Undefined index: ProjectID 

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -74,7 +74,7 @@ class New_Profile extends \NDB_Form
             $values['edc1'] ?? null,
             $values['sex'],
             $values['PSCID'] ?? null,
-            intval($values['ProjectID']) ?? null
+            isset($values['ProjectID']) ? intval($values['ProjectID']) : null
         );
         /* Update front-end data. Use passed PSCID when present, otherwise
          * retrieve it from the newly-created candidate.


### PR DESCRIPTION
### Brief summary of changes

I found a bug in major when creating a new profile. 

The previous code would throw an error:
Notice: Undefined index: ProjectID in /Users/alizee/Development/GitHub/McGill/Loris/modules/new_profile/php/new_profile.class.inc on line 77

Turns out the ProjectID was being made "0" when it's set as null because the intval returns 0 (when given null). New line of code fixes this bug. 

### This resolves issue...

- [ ] Redmine? #

- [ ] Github? #

### To test this change...

- [x] Test on VM and make a new profile.
