### PR TITLE
[Login] Fix issue where password reset emails were not sent

### DIFF
--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -65,7 +65,7 @@ class PasswordReset extends \NDB_Form
 
         // create the user object
         $username = $values['username'];
-        $user     =& \User::singleton($username);
+        $user     = \User::factory($username);
 
         $email = $user->getData('Email');
         // check that it is a valid user


### PR DESCRIPTION
### Brief summary of changes

This PR changes the module to use the `factory` function instead of the `singleton` function from the `User` class. Singleton is having issues as it returns an AnonymousUser instance when no logged-in session is active. This prevents the retrieval of the Email value for users attempting to reset their passwords.

This fix should solve the issue but the logic of this functionality should be reworked down the line.

### This resolves issue...

Resolves #4360 

### To test this change...

* Trigger a password reset email by using the "Forgot Password?" link on the front-page of LORIS. Make sure you can reset your password.
