### PR TITLE
[new_profile] Prevent duplication when button is clicked repetitively

### DIFF
--- a/modules/new_profile/templates/form_new_profile.tpl
+++ b/modules/new_profile/templates/form_new_profile.tpl
@@ -69,7 +69,7 @@
     {/if}
 
 	<div class="form-group col-sm-12">
-		<div class="col-sm-12"><input class="btn btn-primary col-sm-offset-2 col-sm-2" name="fire_away" value="Create" type="submit" /></div>
+		<div class="col-sm-12"><input class="btn btn-primary col-sm-offset-2 col-sm-2" name="fire_away" value="Create" type="submit" onClick="this.form.submit(); this.disabled=true;"/></div>
 	</div>
 </table>
 {$form.hidden}


### PR DESCRIPTION
### Brief summary of changes
Added safeguard for disabling button after first click while the request is being processed in the backend. this was copied from the `next_stage` change done a while back (see related PR)

https://github.com/aces/Loris/pull/2358 


### This resolves issue...
Issue reported by collaborators at the CRU

### To test this change...

- [ ] before checking out the branch, try creating a candidate, fill out all the information on the form and click multiple times consecutively on the submission button. `n` new candidates will be created
- [ ] after checking out this branch. as soon as you click the first time the button should be disabled and no additional candidates created
