### PR TITLE
[Imaging Uploader] Use Utility::getMaxUploadSize() instead of ini_get

### DIFF
--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -121,7 +121,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         if (empty($_FILES) && empty($_POST)
             && ($_SERVER['REQUEST_METHOD']=='POST')
         ) { //catch file overload error...
-            $upload_max_size = ini_get('upload_max_filesize');
+            $upload_max_size = \Utility::getMaxUploadSize();
             $error_message   = "Please make sure files are not larger than " .
                                 $upload_max_size;
             http_response_code(400);


### PR DESCRIPTION
### Brief summary of changes
Makes error message consistent with upload size limit that's displayed on the front-end in the case where `post_max_size != upload_max_filesize`

### To test this change...

- [ ] Try uploading a file greater in size than the limit displayed in the upload form. Error message should specify that the file size cannot be larger than the limit displayed on the upload form
