### PR TITLE
[Documentation] Fixed the link to codingstandards.md in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ do before contributing is probably sign up for the [LORIS developers'
 mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev).
 
 Your next step before issuing a pull request is to review our
-[Coding Standards](./docs/CodingStandards). If you are doing
+[Coding Standards](https://github.com/aces/Loris/blob/minor/docs/CodingStandards.md). If you are doing
 front-end development you should also check out our [React
 guidelines](./LORIS_react.README.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ do before contributing is probably sign up for the [LORIS developers'
 mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev).
 
 Your next step before issuing a pull request is to review our
-[Coding Standards](https://github.com/aces/Loris/blob/minor/docs/CodingStandards.md). If you are doing
+[Coding Standards](./docs/CodingStandards.md). If you are doing
 front-end development you should also check out our [React
 guidelines](./LORIS_react.README.md).
 


### PR DESCRIPTION
This pull request fixes the broken link to [CodingStandards.md](https://github.com/aces/Loris/blob/minor/docs/CodingStandards.md) in [CONTRIBUTING.MD](https://github.com/aces/Loris/blob/minor/CONTRIBUTING.md).

This resolves issue Github #4361 

### To test this change...

- In the main LORIS top level directory open [Contributing.md](https://github.com/aces/Loris/blob/fixdocumentation/CONTRIBUTING.md), and click on the Coding Standards link in the second paragraph and make sure it opens to the correct file.
