### PR TITLE
[Login: Request Account] Fixing 500 Error that arises due to email discrepancy 

### DIFF
--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -160,7 +160,7 @@ class RequestAccount extends \NDB_Form
 
         // check email address' uniqueness
         $result = $DB->pselectOne(
-            "SELECT COUNT(*) FROM users WHERE Email = :VEmail",
+            "SELECT COUNT(*) FROM users WHERE Email OR UserID=:VEmail",
             array('VEmail' => $from)
         );
 

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -160,7 +160,7 @@ class RequestAccount extends \NDB_Form
 
         // check email address' uniqueness
         $result = $DB->pselectOne(
-            "SELECT COUNT(*) FROM users WHERE Email OR UserID=:VEmail",
+            "SELECT COUNT(*) FROM users WHERE Email:VEmail OR UserID=:VEmail",
             array('VEmail' => $from)
         );
 

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -160,7 +160,7 @@ class RequestAccount extends \NDB_Form
 
         // check email address' uniqueness
         $result = $DB->pselectOne(
-            "SELECT COUNT(*) FROM users WHERE Email:VEmail OR UserID=:VEmail",
+            "SELECT COUNT(*) FROM users WHERE Email=:VEmail OR UserID=:VEmail",
             array('VEmail' => $from)
         );
 


### PR DESCRIPTION
### Brief summary of changes
Hey y'all! 

Charlie and I came across a weird use case that results in a 500 error on the request account page. 
Normally, if the email provided is not unique, a success message is still supposed to be displayed for security reasons. 
However, the current code only checks if the email exists under the 'Email' column in users table. In the case where the UserID and Email are different (as in, 2 different email addresses), this leads to a database duplication error. This PR addresses that problem by checking whether the email provided exists in either of the columns mentioned. 

### To test this change...

- [ ] Duplicate the error by heading to the 'User Accounts' page and changing the email associated with your account. If you are reluctant to do so, you can also run this query and find accounts that already have the email discrepancy.
`SELECT Email, UserID FROM users WHERE Email <> UserID;`
- [ ] First test when not on this branch. Request a new account using the email from column `UserID`. You should get a HTTP 500 error.
- [ ] Now checkout this branch and try requesting account again. You should be redirected to "thank you" message.

