### PR TITLE
[ImagingUploader] Revert file upload element name

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -385,7 +385,7 @@ class UploadForm extends Component {
               value={this.state.formData.visitLabel}
             />
             <FileElement
-              name='mri_file'
+              name='mriFile'
               label='File to Upload'
               onUserInput={this.onFormChange}
               required={true}

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -386,7 +386,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
 
         if (!$updateFile && !empty($id) && file_exists($uploadPath)) {
             array_push(
-                $errors['mri_file'],
+                $errors['mriFile'],
                 "This file has already been uploaded."
             );
         }


### PR DESCRIPTION
### Brief summary of changes

Somehow the name got changed and now there's a bug. I'm changing back the name to match the prop key

To test:
- on major, in 'Imaging Uploader' module, under 'Upload' tab, try to add a file to upload. the file element field stays empty and you can't click submit.
- on this branch, there are no issues