### PR TITLE
[user_accounts] my_preferences fix when ['perm'] is undefined

### DIFF
--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -333,13 +333,15 @@ class My_Preferences extends \NDB_Form
 
                 // Check for permissions
                 $display =true;
-                foreach ($services['perm'] as $k=>$permission) {
-                    if (!$user->hasPermission($permission)) {
-                        $display =false;
-                        break;
+                if (isset($services['perm'])) {
+                    foreach ($services['perm'] as $k => $permission) {
+                        if (!$user->hasPermission($permission)) {
+                            $display = false;
+                            break;
+                        }
                     }
+                    unset($services['perm']);
                 }
-                unset($services['perm']);
 
                 foreach ($services as $service=>$avail) {
                     if ($avail==='Y' && $display) {


### PR DESCRIPTION
### Brief summary of changes

The user_accounts module has the $services['perm'] inside my_preferences.class.inc and where it could be undefined & polluting the logs with Notice: Undefined index: perm. I wrote an isset check for the bugfix.

### To test this change...

- [x] Visit http://(your_loris)/user_accounts/my_preferences/
