### PR TITLE
[src/Middleware] AnonymousPageDecorationMiddleware.php Post response bugfix

### DIFF
--- a/src/Middleware/AnonymousPageDecorationMiddleware.php
+++ b/src/Middleware/AnonymousPageDecorationMiddleware.php
@@ -52,7 +52,18 @@ class AnonymousPageDecorationMiddleware implements MiddlewareInterface {
             );
         }
 
+        // Handle needs to be called before form action, because handle potentially
+        // calls setup which modifies the $page->FormAction value (ie in the imaging
+        // browser)
         $undecorated = $handler->handle($request);
+        $contenttype = $undecorated->getHeaderLine("Content-Type");
+        if ($contenttype != "" && strpos($contenttype, "text/html") === false) {
+            // FIXME: This should explicitly check for text/html instead of implicitly treating
+            // no content type as text/html, but most of our code doesn't add an appropriate
+            // content type right now, so we default to assuming HTML.
+            return $undecorated;
+        }
+
         // Finally, the actual content and render it..
         $tpl_data += array(
             'jsfiles'   => $this->JSFiles,


### PR DESCRIPTION
### Brief summary of changes

Yesterday I was having issues with attempting to receive a JSON object from the server (after a post request from the client). The client was receiving data from the server but html content was included as well. Making my JSON object not be a JSON object and the javascript error would fail inside the fetch function.

One of my PRs is working on making the login form react. Well it turns out this bug only happens when the user isn't logged in. This bugfix is needed for when the user is not logged in and for the server to respond to a post request with data that's correctly formatted (such as a JSON object).

Note: I made a PR for both major & bugfix branch because I'm in the processing of making the login react on major.

### This resolves issue...

- [ ] Redmine? #

- [ ] Github? #

### To test this change...

- [x] Trust me it fixes the problem above. Otherwise make a post request without being logged in and attempt to receive a json response from the server. You would be debugging for days without this fix!
