### PR TITLE
[Meta] Fix Travis failure on major

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -123,8 +123,8 @@ class Installer
     {
         // Check PHP version is supported.
         if (PHP_MAJOR_VERSION < 7) {
-            $this->_lastErr = "PHP version 7 or higher is required to run "
-            . "LORIS. $PHP_RELEASE_VERSION is not supported.";
+            $this->_lastErr = 'PHP version 7 or higher is required to run '
+            . 'LORIS. ' . PHP_RELEASE_VERSION . ' is not supported.';
             return false;
         }
 


### PR DESCRIPTION
### Brief summary of changes

#4273 was just merged and flags an issue in the Installer.class.inc. Since this was merged to major, every major build will fail until this PR goes through. Not sure why it wasn't caught in the original PR.

Discovered in PR #4374 which fails with this message:
> php/installer/Installer.class.inc:127 PhanUndeclaredVariable Variable $PHP_RELEASE_VERSION is undeclared
