### PR TITLE
[Meta] Prevent verbose "No syntax errors detected in..." from appearing in test output

### DIFF
--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -5,7 +5,7 @@ set -e
 # errors.
 for i in `ls php/libraries/*.class.inc modules/*/php/* modules/*/ajax/* htdocs/*.php htdocs/*/*.php`;
 do
-  php -l $i || exit $?;
+  php -l $i >/dev/null || exit $?;
 done
 
 # Run PHPCS on the entire libraries directory.


### PR DESCRIPTION
### Brief summary of changes

Make Travis/linting less verbose by hiding messages telling us everything is fine. Only STDOUT is affected so error messages will still appear.

#### To test
* Deliberately make a syntax error in a php file in LORIS. Run `make checkstatic` and it should fail and flag the syntax error
* Do the same on my branch. The same should happen but without output from `php -l` 