### PR TITLE
[webpack] simplification of the project webpack file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 node_modules/*
 modules/*/js/*.js
 htdocs/js/components/*
+project/*
 
 # Ignore until ESLint is run
 modules/dataquery/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,6 @@
 node_modules/*
 modules/*/js/*.js
 htdocs/js/components/*
-project/*
 
 # Ignore until ESLint is run
 modules/dataquery/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -126,7 +126,7 @@ const config = [{
 // Support project overrides
 if (fs.existsSync('./project/webpack-project.config.js')) {
   const projConfig = require('./project/webpack-project.config.js');
-  config.push(projConfig);
+  config[0].entry = Object.assign(config[0].entry, projConfig);
 }
 
 module.exports = config;


### PR DESCRIPTION
### Brief summary of changes
This is necessary to keep supporting projects adding their own modules to webpack from the `webpack-project.config.js`

this functionality was added in https://github.com/aces/Loris/pull/3006

Everything was simplified here the only requirement is to create a `webpack-project.config.js` with the following content

```
const entry = {
    './project/modules/candidate_parameters/js/index.js': './project/modules/candidate_parameters/jsx/index.js',
    './project/modules/media/js/mediaIndex.js': './project/modules/media/jsx/mediaIndex.js',
};

module.exports = entry;
```

This will simply concatenate the lines to the `webpack.config.js` loris file and all the jsx files will be then transpiled.

Also, added the `project/*` to the ignore list for eslint since project files do not need to be linted.

### Testing
- simply override a module with JSX files
- make changes in the overridden JSX
- without this PR, the changes would never take effect because the JSX files in the overridden module are never compiled
- with this PR and the properly configured  `webpack-project.config.js` file. the changes will be transpiled into JS