### PR TITLE
[Cleanup] Remove many magic numbers from the codebase

### DIFF
--- a/php/libraries/SessionID.php
+++ b/php/libraries/SessionID.php
@@ -24,6 +24,7 @@
  */
 class SessionID extends ValidatableIdentifier
 {
+    protected const SESSIONID_MAX_LENGTH = 10;
     /**
      * Returns this identifier type
      *
@@ -36,7 +37,7 @@ class SessionID extends ValidatableIdentifier
 
     /**
      * Validate that the value of the SessionID is a positive integer that does
-     * not exceed 10 digits in length.
+     * not exceed a length defined by SESSIONID_MAX_LENGTH.
      * This does not check for uniqueness in the database or any other
      * state-related facts.
      *
@@ -50,7 +51,7 @@ class SessionID extends ValidatableIdentifier
     protected function validate(string $value): bool
     {
         return (intval($value) > 0)
-            && (strlen($value) <= 10)
+            && (strlen($value) <= SESSIONID_MAX_LENGTH)
             && (is_integer($value));
     }
 

--- a/php/libraries/SessionID.php
+++ b/php/libraries/SessionID.php
@@ -51,7 +51,7 @@ class SessionID extends ValidatableIdentifier
     protected function validate(string $value): bool
     {
         return (intval($value) > 0)
-            && (strlen($value) <= SESSIONID_MAX_LENGTH)
+            && (strlen($value) <= self::SESSIONID_MAX_LENGTH)
             && (is_integer($value));
     }
 

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -198,7 +198,7 @@ class Login extends Endpoint
     {
         // Note: this code adapted from User::isPasswordStrong
         $CharTypes = 0;
-        if (strlen($key) < MIN_JWT_KEY_LENGTH) {
+        if (strlen($key) < self::MIN_JWT_KEY_LENGTH) {
             return false;
         }
         // nothing but letters
@@ -213,7 +213,7 @@ class Login extends Endpoint
         $CharTypes += preg_match('/[0-9]+/', $key);
         $CharTypes += preg_match('/[A-Za-z]+/', $key);
         $CharTypes += preg_match('/[!\\\$\^@#%&\*\(\)]+/', $key);
-        if ($CharTypes < MIN_NUM_CHARSETS) {
+        if ($CharTypes < self::MIN_NUM_CHARSETS) {
             return false;
         }
 

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -7,7 +7,7 @@
  * @category API
  * @package  Loris
  * @author   Dave MacFarlane <dave.macfarlane@mcin.ca>
- * @license  Loris license
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
 namespace LORIS\Api\Endpoints;
@@ -22,11 +22,21 @@ use \LORIS\Api\Endpoint;
  * @category API
  * @package  Loris
  * @author   Dave MacFarlane <dave.macfarlane@mcin.ca>
- * @license  Loris license
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
 class Login extends Endpoint
 {
+    /* @var int A supplied JWT key must have at least this length or it will
+     * be rejected for being too weak.
+     */
+    protected const MIN_JWT_KEY_LENGTH = 20;
+    /* @var int The number of "character sets" that must be used in a password. 
+     * For example the characters 0-9, a-z, and miscellaneous symbols are all 
+     * different character sets. Used as a heuristic to determine password 
+     * complexity.
+     */
+    protected const MIN_NUM_CHARSETS = 3;
     /**
      * All users have access to the login endpoint to try and login.
      *
@@ -188,8 +198,7 @@ class Login extends Endpoint
     {
         // Note: this code adapted from User::isPasswordStrong
         $CharTypes = 0;
-        // less than 20 characters
-        if (strlen($key) < 20) {
+        if (strlen($key) < MIN_JWT_KEY_LENGTH) {
             return false;
         }
         // nothing but letters
@@ -204,7 +213,7 @@ class Login extends Endpoint
         $CharTypes += preg_match('/[0-9]+/', $key);
         $CharTypes += preg_match('/[A-Za-z]+/', $key);
         $CharTypes += preg_match('/[!\\\$\^@#%&\*\(\)]+/', $key);
-        if ($CharTypes < 3) {
+        if ($CharTypes < MIN_NUM_CHARSETS) {
             return false;
         }
 

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -34,6 +34,7 @@ class Login extends Endpoint
      * @var int 
      */
     protected const MIN_JWT_KEY_LENGTH = 20;
+
     /* 
      * The number of "character sets" that must be used in a password. 
      * For example the characters 0-9, a-z, and miscellaneous symbols are all 
@@ -43,6 +44,7 @@ class Login extends Endpoint
      * @var int
      */
     protected const MIN_COMPLEXITY_CHARSETS = 3;
+
     /**
      * All users have access to the login endpoint to try and login.
      *

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -27,16 +27,22 @@ use \LORIS\Api\Endpoint;
  */
 class Login extends Endpoint
 {
-    /* @var int A supplied JWT key must have at least this length or it will
+    /*
+     * A supplied JWT key must have at least this length or it will
      * be rejected for being too weak.
+     * 
+     * @var int 
      */
     protected const MIN_JWT_KEY_LENGTH = 20;
-    /* @var int The number of "character sets" that must be used in a password. 
+    /* 
+     * The number of "character sets" that must be used in a password. 
      * For example the characters 0-9, a-z, and miscellaneous symbols are all 
      * different character sets. Used as a heuristic to determine password 
      * complexity.
+     *
+     * @var int
      */
-    protected const MIN_NUM_CHARSETS = 3;
+    protected const MIN_COMPLEXITY_CHARSETS = 3;
     /**
      * All users have access to the login endpoint to try and login.
      *
@@ -213,7 +219,7 @@ class Login extends Endpoint
         $CharTypes += preg_match('/[0-9]+/', $key);
         $CharTypes += preg_match('/[A-Za-z]+/', $key);
         $CharTypes += preg_match('/[!\\\$\^@#%&\*\(\)]+/', $key);
-        if ($CharTypes < self::MIN_NUM_CHARSETS) {
+        if ($CharTypes < self::MIN_COMPLEXITY_CHARSETS) {
             return false;
         }
 

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -24,6 +24,11 @@ namespace LORIS\StudyEntities\Candidate;
  */
 class CandID extends ValidatableIdentifier
 {
+    /* @var int The minimum allowed value for valid CandIDs. Origin unclear but
+     * assists in avoiding issues with leading 0s in string repreentations of
+     * integers.
+     */
+    protected const MIN_CANDID_VALUE = 100000;
     /**
      * Returns this identifier type
      *
@@ -49,7 +54,7 @@ class CandID extends ValidatableIdentifier
     protected function validate(string $value): bool
     {
         return preg_match('/[0-9]{6}/', $value) === 1 &&
-            intval($value) >= 100000;
+            intval($value) >= MIN_CANDID_VALUE;
     }
 
     /**

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -39,6 +39,7 @@ class CandID extends ValidatableIdentifier
      * @var int
      */
     protected const LENGTH = 6;
+
     /**
      * Returns this identifier type
      *

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -54,7 +54,7 @@ class CandID extends ValidatableIdentifier
     protected function validate(string $value): bool
     {
         return preg_match('/[0-9]{6}/', $value) === 1 &&
-            intval($value) >= MIN_CANDID_VALUE;
+            intval($value) >= self::MIN_CANDID_VALUE;
     }
 
     /**

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -50,9 +50,9 @@ class CandID extends ValidatableIdentifier
     }
 
     /**
-     * Validate that the value of the CandID is a string of 6 numeric characters
-     * with decimal value greater than 100000. This does not check for uniqueness
-     * in the database or any other state related facts.
+     * Validate that the value of the CandID is a string of LENGTH numeric characters
+     * with integer value greater than 100000. This does not check for uniqueness
+     * in the database or any other state-related facts.
      *
      * This function is called by the contructor of ValidatableIdentifier
      * to ensure that no CandID exists if its value is not valid.
@@ -63,7 +63,7 @@ class CandID extends ValidatableIdentifier
      */
     protected function validate(string $value): bool
     {
-        $pattern = sprintf("/[0-9]{%s}", self::LENGTH);
+        $pattern = sprintf("/[0-9]{%s}/", self::LENGTH);
 
         return preg_match($pattern, $value) === 1 &&
             intval($value) >= self::MIN_VALUE;

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -24,11 +24,21 @@ namespace LORIS\StudyEntities\Candidate;
  */
 class CandID extends ValidatableIdentifier
 {
-    /* @var int The minimum allowed value for valid CandIDs. Origin unclear but
+    /* 
+     * The minimum allowed value for valid CandIDs. Origin unclear but
      * assists in avoiding issues with leading 0s in string repreentations of
      * integers.
+     *
+     * @var int
      */
-    protected const MIN_CANDID_VALUE = 100000;
+    protected const MIN_VALUE = 100000;
+
+    /*
+     * A valid CandID must have exactly this number of characters.
+     *
+     * @var int
+     */
+    protected const LENGTH = 6;
     /**
      * Returns this identifier type
      *
@@ -53,8 +63,10 @@ class CandID extends ValidatableIdentifier
      */
     protected function validate(string $value): bool
     {
-        return preg_match('/[0-9]{6}/', $value) === 1 &&
-            intval($value) >= self::MIN_CANDID_VALUE;
+        $pattern = sprintf("/[0-9]{%s}", self::LENGTH);
+
+        return preg_match($pattern, $value) === 1 &&
+            intval($value) >= self::MIN_VALUE;
     }
 
     /**

--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -40,12 +40,16 @@ require_once "generic_includes.php";
  * @license  Loris license
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
+const MIN_NUMBER_OF_ARGS = 4;
 
 // Possible script actions
 $actions = array('delete_candidate');
 
 //define the command line parameters
-if (count($argv) < 4 || $argv[1] == 'help' || !in_array($argv[1], $actions)) {
+if (count($argv) < MIN_NUMBER_OF_ARGS 
+    || $argv[1] == 'help' 
+    || !in_array($argv[1], $actions, true)
+) {
     showHelp();
 }
 

--- a/tools/delete_timepoint.php
+++ b/tools/delete_timepoint.php
@@ -13,19 +13,24 @@
  *
  * @category Main
  * @package  Loris
- * @author   Various <example@example.com>
- * @license  Loris license
+ * @author   Loris Team <loris-dev@bic.mni.mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once __DIR__ . "/generic_includes.php";
 
+/* @var int The minimum number of arguments required to run this script. */
+const MIN_NUMBER_OF_ARGS = 4;
 // Possible script actions
 $actions = array('delete_timepoint');
 
 //define the command line parameters
-if (count($argv) < 4 || $argv[1] == 'help' || !in_array($argv[1], $actions)) {
+if (count($argv) < MIN_NUMBER_OF_ARGS 
+    || $argv[1] == 'help' 
+    || !in_array($argv[1], $actions, true)
+) {
     showHelp();
 }
 

--- a/tools/delete_timepoint.php
+++ b/tools/delete_timepoint.php
@@ -21,7 +21,12 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once __DIR__ . "/generic_includes.php";
 
-/* @var int The minimum number of arguments required to run this script. */
+/* 
+ * The minimum number of arguments required to run this script.
+ *
+ * @var int 
+ */
+
 const MIN_NUMBER_OF_ARGS = 4;
 // Possible script actions
 $actions = array('delete_timepoint');

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -8,11 +8,12 @@
  *
  * PHP version 5
  *
- * @category Utility_Script
- * @package  Loris_Script 
+ * @category Main
+ * @package  Loris 
  * @author   Zia Mohaddes  <zia.mohades@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @license  Loris License
- * @link     https://github.com/aces/IBIS
+ * @link     https://github.com/aces/Loris
  */
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once "generic_includes.php";
@@ -24,9 +25,14 @@ require_once "Utility.class.inc";
 require_once "NDB_Client.class.inc";
 require_once "TimePoint.class.inc";
 
+/* @var int The minimum number of arguments required to run this script. */
+const MIN_NUMBER_OF_ARGS = 2;
+/* @var int The maximum number of arguments to run this script. */
+const MAX_NUMBER_OF_ARGS = 6;
+
 /// User prompt
  
-if ((count($argv)<2) || (count($argv)>6)) {
+if ((count($argv) < MIN_NUMBER_OF_ARGS) || (count($argv) > MAX_NUMBER_OF_ARGS)) {
 
     echo "Usage: php detect_conflicts.php -i [instrument] -t [timepoint]\n";
     echo "Example: php detect_conflicts.php -i bdi -t 3month \n\n";

--- a/tools/detect_conflicts.php
+++ b/tools/detect_conflicts.php
@@ -25,9 +25,18 @@ require_once "Utility.class.inc";
 require_once "NDB_Client.class.inc";
 require_once "TimePoint.class.inc";
 
-/* @var int The minimum number of arguments required to run this script. */
+/* 
+ * The minimum number of arguments required to run this script. 
+ *
+ * @var int 
+ */
 const MIN_NUMBER_OF_ARGS = 2;
-/* @var int The maximum number of arguments to run this script. */
+
+/*
+ * The maximum number of arguments to run this script. 
+ *
+ * @var int 
+ */
 const MAX_NUMBER_OF_ARGS = 6;
 
 /// User prompt

--- a/tools/detect_duplicated_commentids.php
+++ b/tools/detect_duplicated_commentids.php
@@ -26,8 +26,10 @@ require_once "NDB_Client.class.inc";
 
 /* @var int The minimum number of arguments required to run this script. */
 const MIN_NUMBER_OF_ARGS = 2;
+
 /* @var int The maximum number of arguments to run this script. */
 const MAX_NUMBER_OF_ARGS = 6;
+
 /* @var int The getCommentIDs function must return an array of at least this
  * size to be included in the csv output.
  */

--- a/tools/detect_duplicated_commentids.php
+++ b/tools/detect_duplicated_commentids.php
@@ -4,11 +4,12 @@
  *
  * PHP version 5
  *
- * @category Utility_Script
- * @package  Loris_Script 
+ * @category Main
+ * @package  Loris 
  * @author   Zia Mohaddes  <zia.mohades@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @license  Loris License
- * @link     https://github.com/aces/IBIS
+ * @link     https://github.com/aces/Loris
  */
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once "generic_includes.php";
@@ -19,22 +20,29 @@ require_once "Utility.class.inc";
 require_once "NDB_Client.class.inc";
 
 /**
- * *Todo:
+ * TODO:
  * 1) The option for removing the excluded_feedbacks should be added as well
  */
+
+/* @var int The minimum number of arguments required to run this script. */
+const MIN_NUMBER_OF_ARGS = 2;
+/* @var int The maximum number of arguments to run this script. */
+const MAX_NUMBER_OF_ARGS = 6;
+/* @var int The getCommentIDs function must return an array of at least this
+ * size to be included in the csv output.
+ */
+const MIN_SIZE_OF_COMMENTID_ARRAY = 2;
 
 /**
  * User prompt
  */
-if ((count($argv)<2) || (count($argv)>6)) {
 
-
+if ((count($argv) < MIN_NUMBER_OF_ARGS) || (count($argv) > MAX_NUMBER_OF_ARGS)) {
     echo "Usage: php detect_duplicated_commentids.php -i Instrument \n";
     echo "Example: php detect_duplicated_commentids.php bdi \n";
 
     echo "to run the script for all the instruments
             simply type -i all \n";
-
     die();
 }
 
@@ -117,7 +125,7 @@ foreach ($instruments as $instrument=>$full_name) {
                         $pscid, $subprojectid['subprojectid']
                         );
                         $size = sizeof($commentid);
-                        if ($size>=2) {
+                        if ($size >= MIN_SIZE_OF_COMMENTID_ARRAY) {
                             $commentids[] = $commentid;
                         }
                     }

--- a/tools/generate_project_statistics_csv.php
+++ b/tools/generate_project_statistics_csv.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * User: Stella
+ * @author Stella Lee
  * Date: 15-08-15
  *
  * Project Statistics - Updating Counts From Each LORIS
@@ -74,9 +74,13 @@ $queries = array(
 // Extracts data from each query and puts into $project_statistics array
 $project_statistics[$headers[0]] = $projectname;
 $i = 1;
+// @var int The number of remaining headers to check after the first header
+// has been manually added above. NOTE This comment not written by the author
+// of the script.
+$numHeaders = count($queries) - 1;
 
 foreach ($queries as $query) {
-    if ($i != 7) {
+    if ($i != $numHeaders) {
         foreach ($query as $j => $row) {
             foreach ($row as $k => $count) {
                 $project_statistics[$headers[$i]] = $count;
@@ -85,7 +89,7 @@ foreach ($queries as $query) {
             break;
         }
 
-    } elseif ($i == 7) {
+    } elseif ($i == $numHeaders) {
         $units_array = array('B' => 0.000000001, 'K' => 0.000001, 'M' => 0.001, 'G' => 1);
         $sum = 0.0;
 

--- a/tools/resetpassword.php
+++ b/tools/resetpassword.php
@@ -15,11 +15,12 @@
  */
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once "generic_includes.php";
+const MIN_NUMBER_OF_ARGS = 2;
 $args = $argv;
 if ($args[0] == 'php') {
 	$args = array_slice($argv, 1);
 }
-if (count($args) < 2) {
+if (count($args) < MIN_NUMBER_OF_ARGS) {
 	fwrite(STDERR, "Usage: resetpassword.php username\n");
 	fwrite(STDERR, "\nresetpassword.php will prompt for password on stdin\n");
 	exit(2);

--- a/tools/single_use/Engine_Change_MyISAM_to_INNODB.php
+++ b/tools/single_use/Engine_Change_MyISAM_to_INNODB.php
@@ -8,10 +8,13 @@
  * @category Main
  * @package  Loris
  * @author   Rida Abou-Haidar <rida.loris@gmail.com>
- * @license  Loris license
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 require_once __DIR__ . "/../generic_includes.php";
+
+/* @var int The exact number of arguments required to run this script. */
+const NUM_ARGS_REQUIRED = 3;
 
 $dbConfig = $config->getSetting("database");
 $adminDB  = Database::singleton(
@@ -36,7 +39,7 @@ This script includes foreign keycheck disabling and re-enabling.
 
 // define the command line parameters
 // expected commands all have 2 parameters
-if (count($argv) != 3 || $argv[1] == "help") {
+if (count($argv) != NUM_ARGS_REQUIRED || $argv[1] == "help") {
     showHelp();
 }
 


### PR DESCRIPTION
### Brief summary of changes

Replaced [magic numbers](https://en.wikipedia.org/wiki/Magic_number_%28programming%29#Unnamed_numerical_constants) in LORIS with documented constants where it was
easy to do so. These were flagged by the tool PHP Magic Number Detector.

Also updated some documentation and formatting.