### PR TITLE
[Instrument] Fix instrument typehinting

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1339,7 +1339,7 @@ class NDB_BVL_Instrument extends NDB_Page
      * @return boolean true if element should be required, false otherwise.
      */
     function XINRunRuleFunction(
-        string $controller,
+        ?string $controller,
         array $values,
         string $operator
     ): bool {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1248,7 +1248,7 @@ class NDB_BVL_Instrument extends NDB_Page
      *
      * **** DONT TOUCH THIS, EVER. ****
      *
-     * @param ?string $elname   The name of the element being validated
+     * @param string $elname   The name of the element being validated
      * @param array   $elements Array of values submitted on current page.
      * @param array   $rules    Array of rules that have been registered.
      *
@@ -1331,7 +1331,7 @@ class NDB_BVL_Instrument extends NDB_Page
     /**
      * Run a XIN rule on an individual element
      *
-     * @param string $controller The element which affects the validity of this
+     * @param ?string $controller The element which affects the validity of this
      *                           element
      * @param array  $values     Array of values which will invalidate the rule.
      * @param string $operator   The operator which is used to compare the rule.

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1248,9 +1248,9 @@ class NDB_BVL_Instrument extends NDB_Page
      *
      * **** DONT TOUCH THIS, EVER. ****
      *
-     * @param string $elname   The name of the element being validated
-     * @param array  $elements Array of values submitted on current page.
-     * @param array  $rules    Array of rules that have been registered.
+     * @param ?string $elname   The name of the element being validated
+     * @param array   $elements Array of values submitted on current page.
+     * @param array   $rules    Array of rules that have been registered.
      *
      * @return array of errors (fieldname => error message)
      */

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1249,8 +1249,8 @@ class NDB_BVL_Instrument extends NDB_Page
      * **** DONT TOUCH THIS, EVER. ****
      *
      * @param string $elname   The name of the element being validated
-     * @param array   $elements Array of values submitted on current page.
-     * @param array   $rules    Array of rules that have been registered.
+     * @param array  $elements Array of values submitted on current page.
+     * @param array  $rules    Array of rules that have been registered.
      *
      * @return array of errors (fieldname => error message)
      */
@@ -1333,8 +1333,8 @@ class NDB_BVL_Instrument extends NDB_Page
      *
      * @param ?string $controller The element which affects the validity of this
      *                           element
-     * @param array  $values     Array of values which will invalidate the rule.
-     * @param string $operator   The operator which is used to compare the rule.
+     * @param array   $values     Array of values which will invalidate the rule.
+     * @param string  $operator   The operator which is used to compare the rule.
      *
      * @return boolean true if element should be required, false otherwise.
      */


### PR DESCRIPTION
### Brief summary of changes
a null value should be allowed here for all the `field{@}=={@}NEVER_REQUIRED` cases of xin rules.

By default any field is required by xin rules. in order to make fields not required, a rule is added to them that translates into `this field is only required if this field is equal to NEVER_REQUIRED` this bypasses the mandatory nature of xin rules on instrument fields.

If if a field have NEVER REQUIRED on it then it will probably not be filled in and thus this value here is then null which should be okai. without this PR all instruments are broken