### PR TITLE
[tool/Innodb converter] Change + to array_merge() to force reindexing

### DIFF
--- a/tools/single_use/Engine_Change_MyISAM_to_INNODB.php
+++ b/tools/single_use/Engine_Change_MyISAM_to_INNODB.php
@@ -58,7 +58,7 @@ $table_names = $DB->pselectCol(
 );
 
 // possible actions for script are schemaTables, all Tables or any table in the DB
-$actions    = array("allTables","schemaTables") + $table_names;
+$actions    = array_merge(array("allTables","schemaTables"),$table_names);
 // END INPUT
 
 


### PR DESCRIPTION
### Brief summary of changes
`array_merge()` re-indexes keys when creating the new merged array, the `+` operator prevent re-indexing. 

In this specific case, re-indexing is necessary because the `+` operator is truncating the array when the key is not unique across both arrays. if 2 keys collide, only the second value will be stored.

ie:
```
$a1 = array(
           1 => apple
           2 => orange
          )
$a2 = array(
           1 => godzilla
           3 => banana
          )
``` 

the output of `+`
```
array(
           1 => godzilla
           2 => orange
           3 => banana
          )
```
the output of `array_merge()`
```
array(
           1 => apple
           2 => orange
           3 => godzilla
           4 => banana
          )
```
