### PR TITLE
Fixed MRI uploader with auto-launch turned on that was not working.

### DIFF
--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -58,6 +58,20 @@ class MriUploadServerProcess extends AbstractServerProcess
     private $_mriCodePath;
 
     /**
+     * Path of the environment file (relative to $_mriCodePath).
+     *
+     * @var string
+     */
+    private $_environmentFile;
+
+    /**
+     * Path of the prod file (relative to $_mriCodePath/dicom-archive/.loris-mri).
+     *
+     * @var string
+     */
+    private $_prodFile;
+
+    /**
      * Builds a new MriUploadServerProcess
      *
      * @param int    $mriUploadId    MRI upload ID
@@ -126,16 +140,17 @@ class MriUploadServerProcess extends AbstractServerProcess
     public function getShellCommand()
     {
         // Sanitize variables before using in exec statement.
-        $env            = $this->_mriCodePath . '/' . self::ENVIRONMENT_BASENAME;
+        $env            = $this->_mriCodePath . '/' . $this->_environmentFile;
         $env            = escapeshellarg($env);
         $uploadScript   = $this->_mriCodePath . '/' . self::IMAGING_UPLOAD_FILE_PATH;
         $uploadScript   = escapeshellarg($uploadScript);
         $uploadId       = escapeshellarg($this->_mriUploadId);
         $sourceLocation = escapeshellarg($this->_sourceLocation);
+        $prodFile       = escapeshellarg($this->_prodFile);
         return "source $env ;"
                . " $uploadScript"
                . " -upload_id $uploadId"
-               . " -profile prod $sourceLocation";
+               . " -profile $prodFile $sourceLocation";
     }
 
     /**


### PR DESCRIPTION
### Brief summary of changes

As the tile says, when auto-launch was turned on, the MRI uploader always failed to automatically execute the MRI pipeline. This bug was introduced in 20.2. This fix should consequently be propagated to that branch also.

### This resolves issue...

- [x] Github? Resolves #4401 

### To test this change...

- [x]  Make sure that auto-launch is set to true in the Config module and upload a valid scan.
- [x]  Verify that the MRI pipeline is started automatically when the scan is successfully uploaded.

"Priority High", as instructed by @ridz1208 