### PR TITLE
Make getFullName and getSubtestList abstract

### DIFF
--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -12,7 +12,6 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-namespace LORIS;
 
 /**
  * The LegacyInstrumentTrait provides implementations of

--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file contains the a trait to provide legacy behaviour
+ * (database lookup) for abstract functions getFullNames and
+ * getSubtestList.
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Behavioural
+ * @author   Loris team <info-loris.mni@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+namespace LORIS;
+
+/**
+ * The LegacyInstrumentTrait provides implementations of
+ * abstract functions in NDB_BVL_Instrument which previously
+ * had implementations provided. It can be used as a mixin
+ * for existing instruments as a stop-gap until the existing
+ * instruments are updated.
+ *
+ * @category Main
+ * @package  Behavioural
+ * @author   Loris team <info-loris.mni@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+trait LegacyInstrumentTrait
+{
+    /**
+     * Return the full, human readable name for the
+     * current instrument.
+     *
+     * @return string the full name of the instrument
+     */
+    public function getFullName(): string
+    {
+        $db = \Database::singleton();
+
+        $success = $db->pselectOne(
+            "SELECT Full_name FROM test_names WHERE Test_name=:TN",
+            array('TN' => $this->testName)
+        );
+        return $success;
+    }
+
+    /**
+     * Returns a list of subtests of the current instrument.
+     * The returned array should be a list of rows where each
+     * row has a key for "Name" (the subpage name) and "Description"
+     * (the human readable name)
+     *
+     * @return array
+     */
+    function getSubtestList(): array
+    {
+        // get a database connection
+        $db = \Database::singleton();
+
+        $query = "SELECT Subtest_name AS Name, Description
+            FROM instrument_subtests
+            WHERE Test_name=:TN
+                ORDER BY Order_number";
+
+        $results = $db->pselect($query, array('TN' => $this->testName));
+
+        return $results;
+    }
+}

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -22,7 +22,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-class NDB_BVL_Instrument extends NDB_Page
+abstract class NDB_BVL_Instrument extends NDB_Page
 {
 
     /**
@@ -966,21 +966,12 @@ class NDB_BVL_Instrument extends NDB_Page
 
 
     /**
-     * Looks up the full name for the current instrument
+     * Return the full, human readable name for the
+     * current instrument.
      *
      * @return string the full name of the instrument
      */
-    function getFullName(): string
-    {
-        $db = \Database::singleton();
-
-        $success = $db->pselectOne(
-            "SELECT Full_name FROM test_names WHERE Test_name=:TN",
-            array('TN' => $this->testName)
-        );
-        return $success;
-    }
-
+    abstract public function getFullName(): string;
 
     /**
      * Gets the current object instance CommentID
@@ -1030,25 +1021,14 @@ class NDB_BVL_Instrument extends NDB_Page
 
 
     /**
-     * Gets a list of subtests of the current instrument
+     * Returns a list of subtests of the current instrument.
+     * The returned array should be a list of rows where each
+     * row has a key for "Name" (the subpage name) and "Description"
+     * (the human readable name)
      *
      * @return array
      */
-    function getSubtestList(): array
-    {
-        // get a database connection
-        $db = \Database::singleton();
-
-        $query = "SELECT Subtest_name AS Name, Description
-            FROM instrument_subtests
-            WHERE Test_name=:TN
-                ORDER BY Order_number";
-
-        $results = $db->pselect($query, array('TN' => $this->testName));
-
-        return $results;
-    }
-
+    abstract function getSubtestList(): array;
 
     /**
      * Marks an element in the quickform object as being required (for

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1338,15 +1338,15 @@ class NDB_BVL_Instrument extends NDB_Page
     /**
      * Run a XIN rule on an individual element
      *
-     * @param string $controller The element which affects the validity of this
+     * @param ?string $controller The element which affects the validity of this
      *                           element
-     * @param array  $values     Array of values which will invalidate the rule.
-     * @param string $operator   The operator which is used to compare the rule.
+     * @param array   $values     Array of values which will invalidate the rule.
+     * @param string  $operator   The operator which is used to compare the rule.
      *
      * @return boolean true if element should be required, false otherwise.
      */
     function XINRunRuleFunction(
-        string $controller,
+        ?string $controller,
         array $values,
         string $operator
     ): bool {

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -23,6 +23,12 @@ namespace Loris\Behavioural;
  */
 class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 {
+    /**
+     * FIXME: LINST instruments should parse the full name
+     * and the subtest names from the linst file, not select
+     * them from the database.
+     */
+    use \LORIS\LegacyInstrumentTrait;
 
     var $InstrumentType = 'LINST';
 
@@ -97,45 +103,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
         $this->addRule('Examiner', 'Examiner is required', 'required');
     }
-
-    /**
-     * Looks up the full name for the current instrument
-     * TODO: Update this to parse from LINST file
-     *
-     * @return string the full name of the instrument
-     */
-    function getFullName(): string
-    {
-        $db =& Database::singleton();
-
-        $success = $db->pselectOne(
-            "SELECT Full_name FROM test_names WHERE Test_name=:TN",
-            array('TN' => $this->testName)
-        );
-        return $success;
-    }
-
-    /**
-     * Gets a list of subtests of the current instrument
-     * TODO: Update this to parse from LINST file
-     *
-     * @return array
-     */
-    function getSubtestList(): array
-    {
-        // get a database connection
-        $db =& \Database::singleton();
-
-        $query = "SELECT Subtest_name AS Name, Description
-            FROM instrument_subtests
-            WHERE Test_name=:TN
-                ORDER BY Order_number";
-
-        $results = $db->pselect($query, array('TN' => $this->testName));
-
-        return $results;
-    }
-
 
     /**
      * This runs the XIN rules on all the elements on the current page to ensure

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -28,7 +28,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      * and the subtest names from the linst file, not select
      * them from the database.
      */
-    use \LORIS\LegacyInstrumentTrait;
+    use \LegacyInstrumentTrait;
 
     var $InstrumentType = 'LINST';
 

--- a/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
+++ b/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
@@ -17,7 +17,7 @@
  */
 class NDB_BVL_Instrument_testtest extends NDB_BVL_Instrument
 {
-    use \LORIS\LegacyInstrumentTrait;
+    use \LegacyInstrumentTrait;
 
     /**
      * Sets up basic data, such as the LorisForm object, and so on.

--- a/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
+++ b/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
@@ -17,6 +17,7 @@
  */
 class NDB_BVL_Instrument_testtest extends NDB_BVL_Instrument
 {
+    use \LORIS\LegacyInstrumentTrait;
 
     /**
      * Sets up basic data, such as the LorisForm object, and so on.

--- a/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
@@ -42,7 +42,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $this->Client->makeCommandLine();
         $this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
-        $this->i = $this->getMockForAbstractClass(\NDB_BVL_Instrument::class)->setMethods(array("getFullName"))->getMock();
+        $this->i = $this->getMockBuilder(\NDB_BVL_Instrument::class)->disableOriginalConstructor()->setMethods(array("getFullName", "getSubtestList"))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->method('getSubtestList')->willReturn(array());
         $this->i->form = $this->QuickForm;
@@ -365,7 +365,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
     }
 
     function testPageGroup() {
-        $this->i = $this->getMockForAbstractClass(\NDB_BVL_Instrument::class)->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
+        $this->i = $this->getMockBuilder(\NDB_BVL_Instrument::class)->disableOriginalConstructor()->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->method('getSubtestList')->willReturn(
             array(

--- a/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_ToJSON_Test.php
@@ -42,8 +42,9 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $this->Client->makeCommandLine();
         $this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
-        $this->i = $this->getMockBuilder("\NDB_BVL_Instrument")->disableOriginalConstructor()->setMethods(array("getFullName"))->getMock();
+        $this->i = $this->getMockForAbstractClass(\NDB_BVL_Instrument::class)->setMethods(array("getFullName"))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
+        $this->i->method('getSubtestList')->willReturn(array());
         $this->i->form = $this->QuickForm;
         $this->i->testName = "Test";
     }
@@ -364,7 +365,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
     }
 
     function testPageGroup() {
-        $this->i = $this->getMockBuilder("\NDB_BVL_Instrument")->disableOriginalConstructor()->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
+        $this->i = $this->getMockForAbstractClass(\NDB_BVL_Instrument::class)->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->method('getSubtestList')->willReturn(
             array(


### PR DESCRIPTION
The NDB_BVL_Instrument class has two functions 
which select from the database to get metadata
about the instrument: getFullName and getSubtestList.

Neither of these are pieces of metadata that should
be coming from the database, since they're information
about the instrument itself, not data.

This makes the functions abstract, forcing instruments
to implement the functions themselves and return appropriate
values.

A trait is provided to provide the legacy behaviour for
existing instruments.

Fixes #4405.