### PR TITLE
Make session CenterID and Visit_label not nullable

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -302,9 +302,9 @@ CREATE TABLE `candidate` (
 CREATE TABLE `session` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `CandID` int(6) NOT NULL DEFAULT '0',
-  `CenterID` integer unsigned DEFAULT NULL,
+  `CenterID` integer unsigned NOT NULL,
   `VisitNo` smallint(5) unsigned DEFAULT NULL,
-  `Visit_label` varchar(255) DEFAULT NULL,
+  `Visit_label` varchar(255) NOT NULL,
   `SubprojectID` int(11) DEFAULT NULL,
   `Submitted` enum('Y','N') DEFAULT NULL,
   `Current_stage` enum('Not Started','Screening','Visit','Approval','Subject','Recycling Bin') DEFAULT NULL,

--- a/SQL/New_patches/2019-03-20-session-notnull.sql
+++ b/SQL/New_patches/2019-03-20-session-notnull.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `session` 
+CHANGE COLUMN `CenterID` `CenterID` INTEGER UNSIGNED NOT NULL,
+CHANGE COLUMN `Visit_label` `Visit_label` varchar(255) NOT NULL;


### PR DESCRIPTION
These should always be populated, so this updates the schema
to enforce that they can not be null.
