### PR TITLE
[SQL] Add instrument hash for Z-JSON instruments

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -225,16 +225,32 @@ CREATE TABLE `test_subgroups` (
 
 INSERT INTO test_subgroups (Subgroup_name) VALUES ('Instruments'),('Imaging');
 
+CREATE TABLE `instrument_schema` (
+  `InstrumentSchemaID` int(10) unsigned NOT NULL auto_increment,
+  `PreviousVersion` int(10) unsigned default NULL,
+  `UsersID` int(10) unsigned NOT NULL,
+  `SchemaHash` char(64) NOT NULL,
+  `DateUpdated` datetime NOT NULL DEFAULT NOW(),
+  `SchemaURI` TEXT NOT NULL,
+  `SchemaJSON` TEXT NOT NULL,
+  CONSTRAINT `PK_instrument_schema` PRIMARY KEY (`InstrumentSchemaID`),
+  CONSTRAINT `UK_instrument_schema_SchemaHash` UNIQUE KEY (`SchemaHash`),
+  CONSTRAINT `FK_instrument_Schema_PreviousVersion` FOREIGN KEY (`PreviousVersion`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `FK_instrument_schema_UsersID` FOREIGN KEY (`UsersID`) REFERENCES `users` (`ID`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE `test_names` (
   `ID` int(10) unsigned NOT NULL auto_increment,
   `Test_name` varchar(255) default NULL,
   `Full_name` varchar(255) default NULL,
   `Sub_group` int(11) unsigned default NULL,
+  `InstrumentSchemaID` int(10) unsigned default NULL,
   `IsDirectEntry` boolean default NULL,
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Test_name` (`Test_name`),
   KEY `FK_test_names_1` (`Sub_group`),
-  CONSTRAINT `FK_test_names_1` FOREIGN KEY (`Sub_group`) REFERENCES `test_subgroups` (`ID`)
+  CONSTRAINT `FK_test_names_1` FOREIGN KEY (`Sub_group`) REFERENCES `test_subgroups` (`ID`),
+  CONSTRAINT `FK_test_names_InstrumentSchemaID` FOREIGN KEY (`InstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `instrument_subtests` (
@@ -262,6 +278,7 @@ CREATE TABLE `flag` (
   `UserID` varchar(255) default NULL,
   `Testdate` timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
   `Data` TEXT default NULL,
+  `InstrumentSchemaID` int(10) unsigned default NULL,
   PRIMARY KEY  (`CommentID`),
   KEY `Status` (`Flag_status`),
   KEY `flag_ID` (`ID`),
@@ -273,7 +290,8 @@ CREATE TABLE `flag` (
   KEY `flag_Administration` (`Administration`),
   KEY `flag_UserID` (`UserID`),
   CONSTRAINT `FK_flag_1` FOREIGN KEY (`SessionID`) REFERENCES `session` (`ID`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_flag_2` FOREIGN KEY (`Test_name`) REFERENCES `test_names` (`Test_name`)
+  CONSTRAINT `FK_flag_2` FOREIGN KEY (`Test_name`) REFERENCES `test_names` (`Test_name`),
+  CONSTRAINT `FK_flag_InstrumentSchemaID` FOREIGN KEY (`InstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `history` (

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -244,13 +244,13 @@ CREATE TABLE `test_names` (
   `Test_name` varchar(255) default NULL,
   `Full_name` varchar(255) default NULL,
   `Sub_group` int(11) unsigned default NULL,
-  `InstrumentSchemaID` int(10) unsigned default NULL,
+  `LatestInstrumentSchemaID` int(10) unsigned UNIQUE default NULL,
   `IsDirectEntry` boolean default NULL,
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Test_name` (`Test_name`),
   KEY `FK_test_names_1` (`Sub_group`),
   CONSTRAINT `FK_test_names_1` FOREIGN KEY (`Sub_group`) REFERENCES `test_subgroups` (`ID`),
-  CONSTRAINT `FK_test_names_InstrumentSchemaID` FOREIGN KEY (`InstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT
+  CONSTRAINT `FK_test_names_LatestInstrumentSchemaID` FOREIGN KEY (`LatestInstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `instrument_subtests` (

--- a/SQL/9999-99-99-drop_tables.sql
+++ b/SQL/9999-99-99-drop_tables.sql
@@ -156,6 +156,7 @@ DROP TABLE IF EXISTS `test_battery`;
 DROP TABLE IF EXISTS `flag`;
 DROP TABLE IF EXISTS `instrument_subtests`;
 DROP TABLE IF EXISTS `test_names`;
+DROP TABLE IF EXISTS `instrument_schema`;
 DROP TABLE IF EXISTS `test_subgroups`;
 DROP TABLE IF EXISTS `session_status`;
 DROP TABLE IF EXISTS `session`;

--- a/SQL/New_patches/2019-03-20_add_instrument_hash.sql
+++ b/SQL/New_patches/2019-03-20_add_instrument_hash.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `instrument_schema` (
+  `InstrumentSchemaID` int(10) unsigned NOT NULL auto_increment,
+  `PreviousVersion` int(10) unsigned default NULL,
+  `UsersID` int(10) unsigned NOT NULL,
+  `SchemaHash` char(64) NOT NULL,
+  `DateUpdated` datetime NOT NULL DEFAULT NOW(),
+  `SchemaURI` TEXT NOT NULL,
+  `SchemaJSON` TEXT NOT NULL,
+  CONSTRAINT `PK_instrument_schema` PRIMARY KEY (`InstrumentSchemaID`),
+  CONSTRAINT `UK_instrument_schema_SchemaHash` UNIQUE KEY (`SchemaHash`),
+  CONSTRAINT `FK_instrument_Schema_PreviousVersion` FOREIGN KEY (`PreviousVersion`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `FK_instrument_schema_UsersID` FOREIGN KEY (`UsersID`) REFERENCES `users` (`ID`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `test_names`
+  ADD COLUMN `InstrumentSchemaID` int(10) unsigned default NULL after Sub_group,
+  ADD CONSTRAINT `FK_test_names_InstrumentSchemaID` FOREIGN KEY (`InstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE `flag`
+  ADD COLUMN `InstrumentSchemaID` int(10) unsigned default NULL after Data,
+  ADD CONSTRAINT `FK_flag_InstrumentSchemaID` FOREIGN KEY (`InstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT;

--- a/SQL/New_patches/2019-03-20_add_instrument_hash.sql
+++ b/SQL/New_patches/2019-03-20_add_instrument_hash.sql
@@ -13,8 +13,8 @@ CREATE TABLE `instrument_schema` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 ALTER TABLE `test_names`
-  ADD COLUMN `InstrumentSchemaID` int(10) unsigned default NULL after Sub_group,
-  ADD CONSTRAINT `FK_test_names_InstrumentSchemaID` FOREIGN KEY (`InstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+  ADD COLUMN `LatestInstrumentSchemaID` int(10) unsigned UNIQUE default NULL after Sub_group,
+  ADD CONSTRAINT `FK_test_names_LatestInstrumentSchemaID` FOREIGN KEY (`LatestInstrumentSchemaID`) REFERENCES `instrument_schema` (`InstrumentSchemaID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
 
 ALTER TABLE `flag`
   ADD COLUMN `InstrumentSchemaID` int(10) unsigned default NULL after Data,


### PR DESCRIPTION
### Brief summary of changes

![Instruments Tables (3)](https://user-images.githubusercontent.com/17415878/54781450-b0175a00-4bf2-11e9-8bd3-283cf9dd1b3b.jpeg)

`TestJsonID` will be a hash generated by the content in `JsonData` using SHA 256 (32-byte). Having a unique hash allows for version tracking and data integrity. If the JsonData is modified in the back end, an error will throw when being rendered on the front-end if hash and content don't match

`instrument_subtests` should be dropped later as Z-JSON contains page information.