### PR TITLE
 Refactor TimePoint::createNew

### DIFF
--- a/htdocs/api/v0.0.2/candidates/Visit.php
+++ b/htdocs/api/v0.0.2/candidates/Visit.php
@@ -196,7 +196,12 @@ class Visit extends \Loris\API\Candidates\Candidate
                 $this->safeExit(0);
             }
             // need to extract subprojectID
-            $this->createNew($this->CandID, $subprojectID, $this->VisitLabel, $centerID);
+            $this->createNew(
+                $this->CandID,
+                $subprojectID,
+                $this->VisitLabel,
+                $centerID
+            );
             $this->header("HTTP/1.1 201 Created");
         }
     }
@@ -211,6 +216,7 @@ class Visit extends \Loris\API\Candidates\Candidate
      * @param integer $subprojectID The subproject for the new visit
      * @param string  $VL           The visit label of the visit to
      *                              be created
+     * @param integer $CID          The CenterID for this timepoint
      *
      * @return void
      */

--- a/htdocs/api/v0.0.2/candidates/Visit.php
+++ b/htdocs/api/v0.0.2/candidates/Visit.php
@@ -196,7 +196,7 @@ class Visit extends \Loris\API\Candidates\Candidate
                 $this->safeExit(0);
             }
             // need to extract subprojectID
-            $this->createNew($this->CandID, $subprojectID, $this->VisitLabel);
+            $this->createNew($this->CandID, $subprojectID, $this->VisitLabel, $centerID);
             $this->header("HTTP/1.1 201 Created");
         }
     }
@@ -214,7 +214,7 @@ class Visit extends \Loris\API\Candidates\Candidate
      *
      * @return void
      */
-    function createNew($CandID, $subprojectID, $VL)
+    function createNew($CandID, $subprojectID, $VL, $CID)
     {
         try {
             \TimePoint::isValidVisitLabel($CandID, $subprojectID, $VL);
@@ -224,7 +224,10 @@ class Visit extends \Loris\API\Candidates\Candidate
             $this->safeExit(0);
         }
 
-        \TimePoint::createNew($CandID, $subprojectID, $VL);
+        $cand        = \Candidate::singleton($candID);
+        $sessionSite = \Site::singleton($CID);
+
+        \TimePoint::createNew($cand, $subprojectID, $VL, $sessionSite);
     }
 }
 

--- a/htdocs/api/v0.0.3-dev/candidates/Visit.php
+++ b/htdocs/api/v0.0.3-dev/candidates/Visit.php
@@ -258,7 +258,10 @@ class Visit extends \Loris\API\Candidates\Candidate
             $this->safeExit(0);
         }
 
-        \TimePoint::createNew($CandID, $subprojectID, $VL, $CID);
+        $cand        = \Candidate::singleton($candID);
+        $sessionSite = \Site::singleton($CID);
+
+        \TimePoint::createNew($cand, $subprojectID, $VL, $sessionSite);
     }
 }
 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -85,7 +85,7 @@ class Create_Timepoint extends \NDB_Form
             \Candidate::singleton($this->identifier),
             $values['subprojectID'],
             $values['visitLabel'] ?? null,
-            $site,
+            $site
         );
 
         $this->tpl_data['success'] = true;

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -69,11 +69,23 @@ class Create_Timepoint extends \NDB_Form
      */
     function _process($values)
     {
+        // convert site entered to a \Site object
+        $user = \User::singleton();
+
+        $user_list_of_sites = $user->getCenterIDs();
+        $num_sites          = count($user_list_of_sites);
+        if ($num_sites == 1) {
+            $site = \Site::singleton($user_list_of_sites[0]);
+        } else if ($num_sites > 1) {
+            $site = \Site::singleton(intval($values['psc']));
+        }
+
+        assert(isset($site) && $site !== null);
         \TimePoint::createNew(
-            $this->identifier,
+            \Candidate::singleton($this->identifier),
             $values['subprojectID'],
-            $values['visitLabel'],
-            $values['psc']
+            $values['visitLabel'] ?? null,
+            $site,
         );
 
         $this->tpl_data['success'] = true;
@@ -228,9 +240,12 @@ class Create_Timepoint extends \NDB_Form
 
         // validate site entered
         $site = $val['psc'] ?? '';
-        $user_list_of_sites = $user->getData('CenterIDs');
+        $user_list_of_sites = $user->getStudySites();
         $num_sites          = count($user_list_of_sites);
-        if ($num_sites > 1 && (empty($site) || !$user->hasCenter($site))) {
+        if ($num_sites == 0) {
+            $errors['psc']
+                = "You must be affiliated with a site to create a timepoint.";
+        } else if ($num_sites > 1 && (empty($site) || !$user->hasCenter($site))) {
             $errors['psc'] = "Site must be selected from the available dropdown.";
         }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -621,6 +621,29 @@ class Candidate
     }
 
     /**
+     * Returns the next visit number that should be created for this
+     * candidate.
+     *
+     * @return int The next visit number
+     */
+    public function getNextVisitNo() : int
+    {
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->database();
+
+        $query  = "SELECT MAX(s.VisitNo)+1
+                    FROM candidate AS c
+                        LEFT JOIN session AS s USING (CandID)
+                    WHERE c.CandID=:CaID AND s.Active='Y' AND c.Active='Y'";
+        $result = $db->pselectOne($query, array('CaID' => $this->getCandID()));
+
+        if ($result === null) {
+            return 1;
+        }
+        return intval($result);
+    }
+
+    /**
      * Returns list of consents and their respective statuses for this candidate
      *
      * @return array List of consents and their associated values for this candidate

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -188,21 +188,22 @@ class TimePoint
     /**
      * Registers a new timepoint into the session table
      *
-     * @param integer     $candID         6 digit CandID having a timepoint created.
+     * @param \Candidate  $candidate      The Candidate to create this timepoint for
      * @param integer     $SubprojectID   The subprojectID of the new timepoint
      * @param string|null $nextVisitLabel The visit label of the timepoint
-     *                                    being created
-     * @param string|null $psc            The centre of the timepoint
+     *                                    being created. If null, consecutive V1, V2,
+     *                                    etc will be created.
+     * @param \Site       $psc            The centre of the timepoint
      *
      * @throws DatabaseException
      *
      * @return void
      */
     static function createNew(
-        int $candID,
+        \Candidate $candidate,
         int $SubprojectID,
-        ?string $nextVisitLabel = null,
-        ?string $psc = null
+        ?string $nextVisitLabel,
+        \Site $psc
     ): void {
 
         // insert into session set CandID=$candID,
@@ -211,21 +212,6 @@ class TimePoint
         // specified here!
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();
-
-        // select the candidate data
-        $query = "SELECT c.RegistrationCenterID,
-                         IFNULL(max(s.VisitNo)+1, 1) AS nextVisitNo
-                    FROM candidate AS c
-                        LEFT OUTER JOIN session AS s USING (CandID)
-                    WHERE c.CandID=:CaID AND (s.Active='Y' OR s.Active is null)
-                    GROUP BY c.CandID";
-        $row   = $db->pselectRow($query, array('CaID' => $candID));
-        if (is_null($row)) {
-            throw new \LorisException(
-                "No candidate information exists for Candidate $candID. "
-                . "TimePoint cannot be created."
-            );
-        }
 
         // if this is a web hit (thus state exists)
         if (isset($_SESSION) && is_object($_SESSION['State'])) {
@@ -239,19 +225,19 @@ class TimePoint
         // generate today's date for the Date registered field
         $today = date("Y-m-d");
 
+        $visitNo = $candidate->getNextVisitNo();
         // setup the insert data array
-        $VisitLabel = $nextVisitLabel == null
-            ? 'V' . $row['nextVisitNo']
-            : $nextVisitLabel;
-        $centerID   = $psc == null
-        ? $row['CenterID']
-        : $psc;
+        $VisitLabel = $nextVisitLabel;
+        if ($VisitLabel === null) {
+            $VisitLabel = "V$visitNo";
+        }
+
         $insertData = array(
-                       'CandID'          => $candID,
+                       'CandID'          => $candidate->getCandID(),
                        'SubprojectID'    => $SubprojectID,
-                       'VisitNo'         => $row['nextVisitNo'],
+                       'VisitNo'         => $visitNo,
                        'Visit_label'     => $VisitLabel,
-                       'CenterID'        => $centerID,
+                       'CenterID'        => $psc->getCenterID(),
                        'Current_stage'   => 'Not Started',
                        'Submitted'       => 'N',
                        'registeredBy'    => $userID,

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -193,7 +193,7 @@ class TimePoint
      * @param string|null $nextVisitLabel The visit label of the timepoint
      *                                    being created. If null, consecutive V1, V2,
      *                                    etc will be created.
-     * @param \Site       $psc            The centre of the timepoint
+     * @param \Site       $psc            The center of the timepoint
      *
      * @throws DatabaseException
      *


### PR DESCRIPTION
This refactors the TimePoint::createNew function so that it:

1. Uses classes instead of integers/strings for its parameters
2. Does not directly access data from SQL
3. Requires the site to be passed explicitly.

It also fixes a bug where V0.0.2 of the API was not passing the CenterID to 
createNew and verifies that a user has at least one site before allowing them
to create timepoints in create_timepoint.

Fixes #4414.