### PR TITLE
[Server Processes Manager] Fix LORIS crashing when mriCodePath is invalid

### DIFF
--- a/modules/server_processes_manager/php/module.class.inc
+++ b/modules/server_processes_manager/php/module.class.inc
@@ -26,6 +26,8 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Module extends \Module
 {
+    const ERR_MSG_CONFIG_MISSING = 'Required configuration settings for Server '
+        . 'Processes Manager are missing. Cannot continue.';
     /**
      * Handle a PSR7 Request for the serverprocessesmanager endpoint. Also calls a
      * validation function to ensure necessary configuration settings exist.
@@ -48,8 +50,7 @@ class Module extends \Module
                     new \LORIS\Http\Error(
                         $request,
                         500,
-                        'Required configuration settings for Server Processes ' .
-                        'Manager are missing. Cannot continue.'
+                        self::ERR_MSG_CONFIG_MISSING
                     )
                 )
             );

--- a/modules/server_processes_manager/php/module.class.inc
+++ b/modules/server_processes_manager/php/module.class.inc
@@ -39,7 +39,7 @@ class Module extends \Module
         try {
             $this->validateConfig();
         } catch (\ConfigurationException $e) {
-            error_log($e);
+            error_log($e->getMessage());
             return (new \LORIS\Middleware\PageDecorationMiddleware(
                 $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
             ))->process(

--- a/modules/server_processes_manager/php/module.class.inc
+++ b/modules/server_processes_manager/php/module.class.inc
@@ -1,9 +1,9 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This serves as a hint to LORIS that this module is a real module.
  * It does nothing but implement the module class in the module's namespace.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category LORIS_Module
  * @package  Server
@@ -12,6 +12,8 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 namespace LORIS\server_processes_manager;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
 
 /**
  * Class module implements the basic LORIS module functionality
@@ -24,4 +26,55 @@ namespace LORIS\server_processes_manager;
  */
 class Module extends \Module
 {
+    /**
+     * Handle a PSR7 Request for the serverprocessesmanager endpoint. Also calls a
+     * validation function to ensure necessary configuration settings exist.
+     *
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface The PSR15 response for the page.
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        try {
+            $this->validateConfig();
+        } catch (\ConfigurationException $e) {
+            error_log($e);
+            return (new \LORIS\Middleware\PageDecorationMiddleware(
+                $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
+            ))->process(
+                $request,
+                new \LORIS\Router\NoopResponder(
+                    new \LORIS\Http\Error(
+                        $request,
+                        500,
+                        'Required configuration settings for Server Processes ' .
+                        'Manager are missing. Cannot continue.'
+                    )
+                )
+            );
+        }
+        return parent::handle($request);
+    }
+
+    /**
+     * Checks that the required configuration settings are properly set. Throws
+     * a ConfigurationException if not.
+     *
+     * @return void
+     *
+     * @throws \ConfigurationException
+     */
+    function validateConfig(): void
+    {
+        /* Ensure that all required configuraton settings are properly set
+         * before continuing.
+         */
+        $path = \NDB_Config::singleton()->getSetting("mriCodePath");
+        if (empty($path) || !is_readable($path)) {
+            throw new \ConfigurationException(
+                'Config setting mriCodePath is missing or unreadable.'
+            );
+        }
+    }
 }

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -55,6 +55,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testLoadsWithoutPermissionRead()
     {
+        $this->setupConfigSetting('mriCodePath', '/etc/');
         $this->setupPermissions(array(""));
         $this->safeGet($this->url . "/server_processes_manager/");
         $bodyText = $this->webDriver->findElement(

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -27,6 +27,14 @@ require_once __DIR__ .
  */
 class Server_Processes_ManagerTest extends LorisIntegrationTest
 {
+    /* Set mriCodePath to a valid, readable path. The integration tests
+     * don't actually interact with the LORIS-MRI libraries so /etc/ works
+     * as a dummy value since Travis should always have this directory.
+     *
+     * @var string
+     */
+    const MRI_CODE_PATH = '/etc/';
+
     /**
      * UI elements and locations
      * breadcrumb - ''
@@ -48,6 +56,24 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             'End Time'                 => '#dynamictable > thead > tr',
            );
     /**
+     * Tests that the page does not load if config setting mriCodePath has
+     * not been set.
+     *
+     * @return void
+     */
+    function testDoesNotLoadWithoutMRICodePath()
+    {
+        $this->setupConfigSetting('mriCodePath', null);
+        $this->setupPermissions(array("server_processes_manager"));
+        $this->safeGet($this->url . "/server_processes_manager/");
+        $bodyText = $this->webDriver->findElement(
+            WebDriverBy::cssSelector("body")
+        )->getText();
+        $this->assertContains('Cannot continue', $bodyText);
+        $this->resetPermissions();
+    }
+
+    /**
      * Tests that the page does not load if the user does not have correct
      * permissions
      *
@@ -55,7 +81,8 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testLoadsWithoutPermissionRead()
     {
-        $this->setupConfigSetting('mriCodePath', '/etc/');
+        // This function sets mriCodePath for all future functions
+        $this->setupConfigSetting('mriCodePath', self::MRI_CODE_PATH);
         $this->setupPermissions(array(""));
         $this->safeGet($this->url . "/server_processes_manager/");
         $bodyText = $this->webDriver->findElement(
@@ -80,6 +107,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         $this->assertNotContains("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
+
     /**
       * Testing UI elements when page loads
       *


### PR DESCRIPTION
### Brief summary of changes

Fixes a white-screen-of-death when `mriCodePath` is not set and the user tries to go to Server Processes Manager

Also adds a new integration test to check for this case.

### To test this change...

- [x] Delete the `mriCodePath` setting in the Congifuration module
- [x] On `major`, Server Processes Manager will crash
- [x] On my branch you will get an error message instead