### PR TITLE
[candidate_list] fixed undefined project_options on Major

### DIFF
--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -135,6 +135,7 @@ class Candidate_List extends \NDB_Menu_Filter
 
         // get the list of projects
         $list_of_projects = \Utility::getProjectList();
+        $project_options  = array();
         foreach ($list_of_projects as $id => $name) {
             $project_options[$name] = $name;
         }


### PR DESCRIPTION
### Brief summary of changes

On a fresh install of LORIS candidate_list will not load and displays the error: 
```
Notice: Undefined variable: project_options in 
Loris/modules/candidate_list/php/candidate_list.class.inc on line 158
```
This PR fixes the issue by initializing the project_options outside the loop.

### To test this change...

- [x] Checkout PR and test on fresh install of LORIS.