### PR TITLE
[Utility] Add isPositiveInteger function (+ unit tests)

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -963,7 +963,7 @@ class Utility
      *
      * @return bool Whether $value is a positive int.
      */
-    public static function isPositiveInteger($value): bool
+    public static function valueIsPositiveInteger($value): bool
     {
 
         // Reject arrays and objects

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -952,5 +952,28 @@ class Utility
         }
         return implode('', $pieces);
     }
+
+     /**
+     * Takes an argument and determine whether it is a positive integer
+     * i.e. > 0.
+     *
+     * @param mixed $value The value to check. Intentionally not type hinted as
+     * this function is meant to assist in cases where the type is unknown, e.g.
+     * when a parameter is sent via a form.
+     */
+    public static function isPositiveInteger($value): bool {
+        // First clause checks that only digits are present
+        // Second clause ensures a positive value
+        // We can't use intval() alone because it has odd behaviour when given
+        // arrays and objects.
+        // @link https://secure.php.net/manual/en/function.intval.php
+        
+        // Reject arrays and objects
+        if (!is_scalar($value)) {
+            return false;
+        }
+
+        return ctype_digit(strval($value)) && intval($value) > 0;
+    }
 }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -963,8 +963,9 @@ class Utility
      *
      * @return bool Whether $value is a positive int.
      */
-    public static function isPositiveInteger($value): bool {
-        
+    public static function isPositiveInteger($value): bool
+    {
+
         // Reject arrays and objects
         if (!is_scalar($value)) {
             return false;

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -960,19 +960,18 @@ class Utility
      * @param mixed $value The value to check. Intentionally not type hinted as
      * this function is meant to assist in cases where the type is unknown, e.g.
      * when a parameter is sent via a form.
+     *
+     * @return bool Whether $value is a positive int.
      */
     public static function isPositiveInteger($value): bool {
-        // First clause checks that only digits are present
-        // Second clause ensures a positive value
-        // We can't use intval() alone because it has odd behaviour when given
-        // arrays and objects.
-        // @link https://secure.php.net/manual/en/function.intval.php
         
         // Reject arrays and objects
         if (!is_scalar($value)) {
             return false;
         }
 
+        // First clause checks that only digits are present
+        // Second clause ensures a positive value
         return ctype_digit(strval($value)) && intval($value) > 0;
     }
 }

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -825,7 +825,7 @@ class UtilityTest extends TestCase
 =======
 >>>>>>> 81d586a44... Fix file and class doc
     /*
-     * dataProvider for function testIsPositiveIntegerReturnsFalse
+     * dataProvider for function testValueIsPositiveIntegerReturnsFalse
      */
     public function notPositiveIntegerValues(): array
     {
@@ -844,7 +844,7 @@ class UtilityTest extends TestCase
     }
 
     /*
-     * dataProvider for function testIsPositiveIntegerReturnsTrue
+     * dataProvider for function testValueIsPositiveIntegerReturnsTrue
      */
     public function positiveIntegerValues(): array
     {
@@ -858,16 +858,16 @@ class UtilityTest extends TestCase
     /**
      * @dataProvider notPositiveIntegerValues
      */
-    public function testIsPositiveIntegerReturnsFalse($notInt): void
+    public function testValueIsPositiveIntegerReturnsFalse($notInt): void
     {
-        $this->assertFalse(\Utility::isPositiveInteger($notInt));
+        $this->assertFalse(\Utility::valueIsPositiveInteger($notInt));
     }
 
     /**
      * @dataProvider positiveIntegerValues
      */
-    public function testIsPositiveIntegerReturnsTrue($int): void
+    public function testValueIsPositiveIntegerReturnsTrue($int): void
     {
-        $this->assertTrue(\Utility::isPositiveInteger($int));
+        $this->assertTrue(\Utility::valueIsPositiveInteger($int));
     }
 }

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -820,10 +820,7 @@ class UtilityTest extends TestCase
     }
 }
 
-=======
 
-=======
->>>>>>> 81d586a44... Fix file and class doc
     /*
      * dataProvider for function testValueIsPositiveIntegerReturnsFalse
      */

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -1,26 +1,18 @@
 <?php declare(strict_types=1);
 /**
- * Utility class tests
+ * Unit tests for Utility class.
  *
  * PHP Version 7
  *
  * @category Tests
  * @package  Test
  * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
+ *           John Saigle <john.saigle@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
 require_once __DIR__ . '/../../php/libraries/Utility.class.inc';
 use PHPUnit\Framework\TestCase;
-/**
- * Unit test for Utility class
- *
- * @category Tests
- * @package  Main
- * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris/
- */
 class UtilityTest extends TestCase
 {
     /**
@@ -830,6 +822,8 @@ class UtilityTest extends TestCase
 
 =======
 
+=======
+>>>>>>> 81d586a44... Fix file and class doc
     /*
      * dataProvider for function testIsPositiveIntegerReturnsFalse
      */
@@ -876,5 +870,4 @@ class UtilityTest extends TestCase
     {
         $this->assertTrue(\Utility::isPositiveInteger($int));
     }
-
 }

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Utility class tests
  *

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -828,3 +828,53 @@ class UtilityTest extends TestCase
     }
 }
 
+=======
+
+    /*
+     * dataProvider for function testIsPositiveIntegerReturnsFalse
+     */
+    public function notPositiveIntegerValues(): array
+    {
+        return array(
+                [-1],
+                [0],
+                [3.14],
+                ['abcdefg'],
+                ['-1'],
+                ['-98.6'],
+                ['0'],
+                [array()],
+                [array(1)],
+                [new stdClass()]
+               );
+    }
+
+    /*
+     * dataProvider for function testIsPositiveIntegerReturnsTrue
+     */
+    public function positiveIntegerValues(): array
+    {
+        return array(
+                [1],
+                [100],
+                ['1000'],
+               );
+    }
+
+    /**
+     * @dataProvider notPositiveIntegerValues
+     */
+    public function testIsPositiveIntegerReturnsFalse($notInt): void
+    {
+        $this->assertFalse(\Utility::isPositiveInteger($notInt));
+    }
+
+    /**
+     * @dataProvider positiveIntegerValues
+     */
+    public function testIsPositiveIntegerReturnsTrue($int): void
+    {
+        $this->assertTrue(\Utility::isPositiveInteger($int));
+    }
+
+}

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -579,7 +579,7 @@ class UtilityTest extends TestCase
 
         $this->assertEquals(
             array('VL1' => 'VL1'),
-            Utility::getExistingVisitLabels('1')
+            Utility::getExistingVisitLabels(1)
         );
     }
 
@@ -818,8 +818,6 @@ class UtilityTest extends TestCase
             Utility::getSourcefields('instrument1', '1', 'name')
         );
     }
-}
-
 
     /*
      * dataProvider for function testValueIsPositiveIntegerReturnsFalse

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -834,6 +834,7 @@ class UtilityTest extends TestCase
                 ['0'],
                 [array()],
                 [array(1)],
+                [null],
                 [new stdClass()]
                );
     }


### PR DESCRIPTION
### Brief summary of changes

When checking data coming from e.g. the database or a form, there are some weird subtleties with using `intval()`. It'll return `0` on an input of `null` which makes it hard to differentiate between inputs that are `null` and `0` and those that are unset. It also has non-intuitive behaviour for array and object inputs, see: https://secure.php.net/manual/en/function.intval.php

This PR adds a simple function to check whether a given value is a positive integer as well as unit tests to prove that it works.