### PR TITLE
[User_accouts] bugfix - can't create a new user

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1151,7 +1151,7 @@ class Edit_User extends \NDB_Form
             array('UID' => $this->identifier)
         );
 
-        if (!is_null($passwords['Password_hash'] ?? null)) {
+        if (!is_null($passwords)) {
             return !password_verify($newPassword, $passwords['Password_hash']);
         }
 

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1150,11 +1150,6 @@ class Edit_User extends \NDB_Form
             $passwordQuery,
             array('UID' => $this->identifier)
         );
-        if (is_null($passwords)) {
-            throw new \LorisException(
-                'No existing password found for user!'
-            );
-        }
 
         if (!is_null($passwords['Password_hash'] ?? null)) {
             return !password_verify($newPassword, $passwords['Password_hash']);


### PR DESCRIPTION
Remove the password check, new user the password always be null.

To test: create a new user.