### PR TITLE
[instrument_list] Replace header table with HTML header element

### DIFF
--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -1,6 +1,5 @@
 <!-- table title -->
-<br />
-<table border="0" valign="bottom" width="100%"><td class="controlPanelSection"><strong>Behavioral Battery of Instruments</strong></td></table>
+<h3>Behavioral Battery of Instruments</h3>
 
 <!-- table with list of instruments and links to open them -->
 <table class="table table-hover table-bordered dynamictable" cellpadding="2">


### PR DESCRIPTION
This replaces the 100% width single cell table with embedded formatting
tags with a normal `<h3>` element in the instrument_list page for the
"Behavioural Battery of Instruments" header.

This is slightly prettier in the front end, and makes reading the HTML
significantly less soul crushing.
