### PR TITLE
[React/jsx] Render action buttons when data table is empty

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -340,7 +340,7 @@ div.navbar div.container div.navbar-brand {
     color: #064785;
     background-color: #E4EBF2;
     border-color: #E4EBF2;
-    margin: 0px 14px;
+    margin: 0 14px;
 }
 
 /*

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -340,6 +340,7 @@ div.navbar div.container div.navbar-brand {
     color: #064785;
     background-color: #E4EBF2;
     border-color: #E4EBF2;
+    margin: 0px 14px;
 }
 
 /*

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -369,8 +369,17 @@ class DataTable extends Component {
   render() {
     if (this.props.data === null || this.props.data.length === 0) {
       return (
-        <div className='alert alert-info no-result-found-panel'>
-          <strong>No result found.</strong>
+        <div>
+          <div className="row">
+            <div className="col-xs-12">
+              <div className="pull-right" style={{marginRight: '10px'}}>
+                {this.renderActions()}
+              </div>
+            </div>
+          </div>
+          <div className='alert alert-info no-result-found-panel'>
+            <strong>No result found.</strong>
+          </div>
         </div>
       );
     }
@@ -521,25 +530,25 @@ class DataTable extends Component {
       <div className="table-header">
         <div className="row">
           <div className="col-xs-12">
-          <div>
-            {rows.length} rows displayed of {filteredRows}.
-            (Maximum rows per page: {RowsPerPageDropdown})
-          </div>
-          <div className="pull-right" style={{marginTop: '-43px'}}>
-            {this.renderActions()}
-            <button
-              className="btn btn-primary"
-              onClick={this.downloadCSV.bind(null, csvData)}
-            >
-              Download Table as CSV
-            </button>
-            <PaginationLinks
-              Total={filteredRows}
-              onChangePage={this.changePage}
-              RowsPerPage={rowsPerPage}
-              Active={this.state.PageNumber}
-            />
-          </div>
+            <div>
+              {rows.length} rows displayed of {filteredRows}.
+              (Maximum rows per page: {RowsPerPageDropdown})
+            </div>
+            <div className="pull-right" style={{marginTop: '-43px'}}>
+              {this.renderActions()}
+              <button
+                className="btn btn-primary"
+                onClick={this.downloadCSV.bind(null, csvData)}
+              >
+                Download Table as CSV
+              </button>
+              <PaginationLinks
+                Total={filteredRows}
+                onChangePage={this.changePage}
+                RowsPerPage={rowsPerPage}
+                Active={this.state.PageNumber}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Brief summary of changes
At the moment, if the data table is empty, the action buttons aren't rendered. This PR renders action buttons, i.e. to add an entry to the table, when no result found.

before: 
![55336947-c8496d80-546b-11e9-81a5-01663b035302](https://user-images.githubusercontent.com/17415878/55355946-a36aef80-5497-11e9-9c17-dfbacf5ac5c3.png)

after:
<img width="1249" alt="Screenshot 2019-04-01 16 03 23" src="https://user-images.githubusercontent.com/17415878/55356009-d01f0700-5497-11e9-8143-2cc882bbf574.png">

## To test:

1. choose newly reactified module with action buttons e.g. 'examiner'. manipulate the data so that the data table is empty. you will see that there is no way to add an examiner.
2. on this branch, you can add an entry to the empty table.