### PR TITLE
Adding the image_type to the mri_protocol when identifying for imaging protocol

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -708,6 +708,7 @@ CREATE TABLE `mri_protocol` (
   `ystep_range` varchar(255) default NULL,
   `zstep_range` varchar(255) default NULL,
   `time_range` varchar(255) default NULL,
+  `image_type` varchar(255) default NULL,
   `series_description_regex` varchar(255) default NULL,
   PRIMARY KEY  (`ID`),
   KEY `FK_mri_protocol_1` (`ScannerID`),
@@ -832,6 +833,7 @@ CREATE TABLE `mri_protocol_violated_scans` (
   `zstep_range` varchar(255) DEFAULT NULL,
   `time_range` varchar(255)  DEFAULT NULL,
   `SeriesUID` varchar(64) DEFAULT NULL,
+  `image_type` varchar(255) default NULL,
   PRIMARY KEY (`ID`),
   KEY `TarchiveID` (`TarchiveID`),
   CONSTRAINT `FK_mri_violated_1` FOREIGN KEY (`TarchiveID`) REFERENCES `tarchive` (`TarchiveID`)

--- a/SQL/New_patches/2019-04-04_add_image_type_to_mri_protocol.sql
+++ b/SQL/New_patches/2019-04-04_add_image_type_to_mri_protocol.sql
@@ -1,0 +1,8 @@
+-- Add an image_type column to be used for scan identification 
+-- in the mri_protocol and mri_protocol_violated_scans tables
+
+ALTER TABLE mri_protocol 
+  ADD COLUMN `image_type` varchar(255) default NULL;
+
+ALTER TABLE mri_protocol_violated_scans
+  ADD COLUMN `image_type` varchar(255) default NULL;


### PR DESCRIPTION
### Brief summary of changes

This PR contains the SQL patches to run to add the `image_type` check in the `mri_protocol` and `mri_protocol_violated_scans`. 

This `image_type` header field is a key variable as this is the only MINC header that allows to differentiate between a fieldmap phase difference from a fieldmap magnitude file which have different purposes when it comes to analyses and the insertion pipeline should be able to recognize one from the other. This is also the case for MP2RAGE modalities and other modern imaging modalities, hence the need to add that field in the mri_protocol table.

Example:
- image_type for fieldmap phase difference image: `ORIGINAL\\PRIMARY\\P\\ND` (P for phase)
- image_type for fieldmap magnitude image: `ORIGINAL\\PRIMARY\\M\\ND` (M for magnitude)

Note that because of the multiple `\` in that field, in order to insert the correct value, each `\` needs to be escaped. Example: 
`INSERT INTO mri_protocol SET image_type='ORIGINAL\\\\PRIMARY\\\\P\\\\ND', ...`

This PR is linked to the following LORIS-MRI PR: https://github.com/aces/Loris-MRI/pull/416

### This resolves issue...

- no issue reported but this script was particularly useful when inserting more modern imaging modalities into LORIS so making it available to the community :)

### To test this change...

- [ ] test that the SQL patch runs properly

