### PR TITLE
[jsx/Form] DateElement other browsers fix

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -980,6 +980,30 @@ class DateElement extends Component {
     this.props.onUserInput(this.props.name, e.target.value);
   }
 
+  componentDidMount() {
+    // Support Browsers not using type date.
+    if ($('[type="date"]').prop('type') !== 'date') {
+      let inputs = document.getElementsByTagName('input');
+      for (let i=0; i<inputs.length; i++) {
+        if ((inputs[i].outerHTML).includes('type="date"')) {
+          $(inputs[i]).datepicker({
+            dateFormat: 'yy-mm-dd',
+            minDate: new Date(
+              parseInt(this.props.minYear),
+              1,
+              1
+            ),
+            maxDate: new Date(
+              parseInt(this.props.maxYear),
+              12,
+              31
+            ),
+          });
+        }
+      }
+    }
+  }
+
   render() {
     let disabled = this.props.disabled ? 'disabled' : null;
     let required = this.props.required ? 'required' : null;


### PR DESCRIPTION
### Brief summary of changes

I added some code making the "DateElement" mimic all the other browsers. Although LORIS doesn't support Safari, I use the browser and it's not much to get it showing a calendar with Jquery and which is already a dependency of LORIS. I'm not sure if we're going to remove Jquery in the future or not but in the meantime this code could make it so a calendar is shown on all browsers that don't support input type=date. Anyway I'm alright if this change doesn't get included.

### To test this change...

- [x] Visit new profile on Safari and click on the date input field. 