### PR TITLE
[candidate_parameters] PropTypes is not defined when clicking "edit candidate info" on major

### DIFF
--- a/modules/candidate_parameters/jsx/CandidateParameters.js
+++ b/modules/candidate_parameters/jsx/CandidateParameters.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import CandidateInfo from './CandidateInfo';
 import ProbandInfo from './ProbandInfo';
 import FamilyInfo from './FamilyInfo';

--- a/modules/candidate_parameters/jsx/ProbandInfo.js
+++ b/modules/candidate_parameters/jsx/ProbandInfo.js
@@ -1,10 +1,12 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Loader from 'Loader';
 /**
  * Proband Info Component.
  *
  * Renders the contents of the ProbandInfo tab, consisting of the FormElement component
  */
-class ProbandInfo extends React.Component {
+class ProbandInfo extends Component {
   constructor(props) {
     super(props);
 


### PR DESCRIPTION
### Brief summary of changes

Visit:
Candidate->Access Profile-> "Click on PSCID" of a Candidate Profile. Then click on the Edit Candidate Info button and your browser console will output these errors:
```
Uncaught ReferenceError: PropTypes is not defined ProbandInfo.js:328
Uncaught ReferenceError: PropTypes is not defined CandidateParameters.js:69
```

The change needed was to import PropTypes.

### To test this change...

- [x] See above 
