### PR TITLE
[timepoint_list] Breadcrumb link fix for Candidate profile

### DIFF
--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -309,8 +309,6 @@ class Timepoint_List extends \NDB_Menu
         $candid = $this->tpl_data['candID'];
         $pscid  = $this->tpl_data['PSCID'];
 
-        $link = ltrim($_SERVER['REQUEST_URI'], '/');
-
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
                 'Access Profile',
@@ -318,7 +316,7 @@ class Timepoint_List extends \NDB_Menu
             ),
             new \LORIS\Breadcrumb(
                 "Candidate Profile $candid / $pscid",
-                "/$candid"
+                "$candid"
             )
         );
     }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -316,7 +316,7 @@ class Timepoint_List extends \NDB_Menu
             ),
             new \LORIS\Breadcrumb(
                 "Candidate Profile $candid / $pscid",
-                "$candid"
+                $this->candID
             )
         );
     }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -316,7 +316,7 @@ class Timepoint_List extends \NDB_Menu
             ),
             new \LORIS\Breadcrumb(
                 "Candidate Profile $candid / $pscid",
-                $this->candID
+                "/$candid"
             )
         );
     }

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -108,7 +108,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             switch (count($components)) {
             case 1:
                 $request = $request
-                    ->withAttribute("baseurl", $baseurl->__toString())
+                    ->withAttribute("baseurl", rtrim($baseurl->__toString(), '/'))
                     ->withAttribute("CandID", $components[0]);
                 $module  = \Module::factory("timepoint_list");
                 $mr      = new ModuleRouter($module, $this->moduledir);


### PR DESCRIPTION
### Brief summary of changes

Fixes the breadcrumb containing an extra forward slash. Ex. http://localhost//162517/

### To test this change...

- [x] Click on candidate and then click on the Candidate Profile breadcrumb.

https://github.com/aces/Loris/issues/4723