### PR TITLE
[Instrument_builder] Fix page min-height for list

### DIFF
--- a/htdocs/main.css
+++ b/htdocs/main.css
@@ -31,7 +31,7 @@ html, body {
 }
 
 #page {
-    min-height: 100%;
+    min-height: 100vh;
     position: relative;
     padding-top: 50px;
 }


### PR DESCRIPTION
### Brief summary of changes

Fixes page cutoff on instrument builder and any other page where there's not enough content to make the page bigger than the screen.

### This resolves issue...

- As reported by Yang Ding

### To test this change...

- [ ] Test on Firefox
