### PR TITLE
[Install.sh/Typo] Updated Ubuntu version number to include later versions

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -196,7 +196,7 @@ echo "Ubuntu distribution detected."
     # for CentOS, the log directory is called httpd
     logdirectory=/var/log/apache2
     while true; do
-        read -p "Would you like to automatically create/install apache config files? (Works for Ubuntu 14.04 default Apache installations) [yn] " yn
+        read -p "Would you like to automatically create/install apache config files? (Works for Ubuntu 14.04 or later default Apache installations) [yn] " yn
         echo $yn | tee -a $LOGFILE > /dev/null
         case $yn in
             [Yy]* )


### PR DESCRIPTION
### Brief summary of changes

In [install.sh](https://github.com/aces/Loris/blob/minor/tools/install.sh), line number 199 updated the Ubuntu version number from "14.04" to "14.04 or later",  to include later versions of Ubuntu.

### This resolves issue...

- [ ] Github? #4460

### To test this change...

- [ ] Pull it and try to run the new install.sh on Ubuntu 16.04 and 18.04 to see if it works.
- [ ] Referring to [install steps](https://github.com/aces/Loris/wiki/Installing-Loris-in-Depth) in the "Running the Install Script" section-step 5. Make sure [line 199](https://github.com/aces/Loris/blob/minor/tools/install.sh) says this: "Would you like to automatically create/install apache config files? (Works for Ubuntu 14.04 or later default Apache installations)".