### PR TITLE
[Core/Instrument] added function loadInstanceDataFromArray

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2048,6 +2048,31 @@ class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
+     * Gets specified fields of data from an instrument out of the database and
+     * returns it as an array.
+     *
+     * @param NDB_BVL_Instrument $instrumentInstance The object whose data is
+     *                                               to be retrieved.
+     * @param array $fieldsArray Contains the fields of interest
+     *
+     * @return array containing the data for the fields specified in $fieldsArray
+     */
+    static function loadInstanceDataFromArray($instrumentInstance, $fieldsArray)
+    {
+        // Load instance data
+        $instanceData = NDB_BVL_Instrument::loadInstanceData($instrumentInstance);
+
+        // Filter results
+        $filteredData = array();
+        foreach ($fieldsArray as $key) {
+            if (array_key_exists($key, $instanceData)) {
+                $filteredData[$key] = $instanceData[$key];
+            }
+        }
+        return $filteredData;
+    }
+
+    /**
      * Calculates the candidate's age at the time of this instrument.
      * If Date_taken was based in, it will calculate the age as of
      * the date passed as a parameter (this is used, for instance, in

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2053,7 +2053,7 @@ class NDB_BVL_Instrument extends NDB_Page
      *
      * @param NDB_BVL_Instrument $instrumentInstance The object whose data is
      *                                               to be retrieved.
-     * @param array $fieldsArray Contains the fields of interest
+     * @param array              $fieldsArray        Contains the fields of interest
      *
      * @return array containing the data for the fields specified in $fieldsArray
      */


### PR DESCRIPTION
### Brief summary of changes
Added a new function that filters the instance data and returns only columns specified in the array that is passed. This can be useful in the case where we only want a subset of the data for an instrument as opposed to the full table. 

### To test this change...
- [ ] Open any instrument and test by passing to the function:  (a) The instrument instance, (b) An array of fields you want to select. 
            `$this->loadInstanceDataFromArray($this, $arrayofFields)`
- [ ] Print the results or replace a query

