### PR TITLE
[CSS] .btn class CSS misaligned

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -449,7 +449,7 @@ div.navbar div.container div.navbar-brand {
 
 .btn {
     font-size: 14px;
-    margin: 10px 5px;
+    margin: 10px 5px 10px 0;
 }
 
 .btn-default {

--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -449,7 +449,7 @@ div.navbar div.container div.navbar-brand {
 
 .btn {
     font-size: 14px;
-    margin: 10px 5px 10px 0;
+    margin-right: 5px;
 }
 
 .btn-default {


### PR DESCRIPTION
any buttton using the .btn class is misaligned to the right. this PR is a quick fix for 21.0 before we revamp all of LORIS's css into flexbox anyways