### PR TITLE
[Examiner] Fix swal/modal closing

### DIFF
--- a/modules/examiner/jsx/examinerIndex.js
+++ b/modules/examiner/jsx/examinerIndex.js
@@ -104,6 +104,7 @@ class ExaminerIndex extends Component {
       if (resp.ok && resp.status === 200) {
         swal('Success!', 'Examiner added.', 'success').then((result) => {
           if (result.value) {
+            this.closeModal();
             this.fetchData();
           }
         });
@@ -157,7 +158,10 @@ class ExaminerIndex extends Component {
   }
 
   closeModal() {
-    this.setState({showModal: false});
+    this.setState({
+      formData: {},
+      showModal: false,
+    });
   }
 
   renderAddExaminerForm() {

--- a/modules/examiner/test/TestPlan.md
+++ b/modules/examiner/test/TestPlan.md
@@ -1,4 +1,4 @@
- Examiner module - Test Plan 
+# Examiner module - Test Plan 
 1. Access Examiner module page, ensure that it renders.
    [Automation Testing]
 2. Access Examiner module page with examiner view permission, ensure that it renders.

--- a/modules/examiner/test/TestPlan.md
+++ b/modules/examiner/test/TestPlan.md
@@ -1,11 +1,11 @@
-# Examiner module - Test Plan 
+ Examiner module - Test Plan 
 1. Access Examiner module page, ensure that it renders.
    [Automation Testing]
 2. Access Examiner module page with examiner view permission, ensure that it renders.
    [Automation Testing]
-3. Check "Show Data" button works well after inputting special option.
+3. Check that filtering of the data table works well after inputting selection into filter fields.
    [Automation Testing]
-4. Check "Clear Form" button works well.
+4. Check "Clear Filters" button works well.
    [Automation Testing]
 5. Test Add a new examiner.
    [Automation Testing]


### PR DESCRIPTION
### Brief summary of changes
- resets 'Add Examiner' form fields to empty on closing modal
- updates test plan