### PR TITLE
fix syntax to drop foreign key in script

### DIFF
--- a/SQL/New_patches/2019-04-26-Delete_cascades_parameter_type_rel.sql
+++ b/SQL/New_patches/2019-04-26-Delete_cascades_parameter_type_rel.sql
@@ -1,5 +1,5 @@
-ALTER TABLE parameter_type_category_rel DROP CONSTRAINT `FK_parameter_type_category_rel_1`;
-ALTER TABLE parameter_type_category_rel DROP CONSTRAINT `FK_parameter_type_category_rel_2`;
+ALTER TABLE parameter_type_category_rel DROP FOREIGN KEY `FK_parameter_type_category_rel_1`;
+ALTER TABLE parameter_type_category_rel DROP FOREIGN KEY `FK_parameter_type_category_rel_2`;
 
 ALTER TABLE parameter_type_category_rel ADD CONSTRAINT `FK_parameter_type_category_rel_1` FOREIGN KEY (`ParameterTypeID`) REFERENCES `parameter_type` (`ParameterTypeID`) ON DELETE CASCADE;
 ALTER TABLE parameter_type_category_rel ADD CONSTRAINT `FK_parameter_type_category_rel_2` FOREIGN KEY (`ParameterTypeCategoryID`) REFERENCES `parameter_type_category` (`ParameterTypeCategoryID`) ON DELETE CASCADE;


### PR DESCRIPTION
### fix syntax error in SQL patch script



### This resolves issue https://github.com/aces/Loris/issues/4565


### To test this change...

run the New_patches/2019-04-26-Delete_cascades_parameter_type_rel.sql script on 20.0.0 database

