### PR TITLE
Fix Api Warning

### DIFF
--- a/htdocs/api/v0.0.3-dev/APIBase.php
+++ b/htdocs/api/v0.0.3-dev/APIBase.php
@@ -127,9 +127,6 @@ abstract class APIBase
      */
     function handleETag()
     {
-        session_destroy();
-        session_cache_limiter('private');
-        session_start(array('cookie_httponly' => true));
         $ETag = $this->calculateETag();
 
         $this->header("ETag: $ETag");

--- a/htdocs/api/v0.0.3-dev/APIBase.php
+++ b/htdocs/api/v0.0.3-dev/APIBase.php
@@ -127,7 +127,9 @@ abstract class APIBase
      */
     function handleETag()
     {
+        session_destroy();
         session_cache_limiter('private');
+        session_start(array('cookie_httponly' => true));
         $ETag = $this->calculateETag();
 
         $this->header("ETag: $ETag");

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -139,6 +139,11 @@ class NDB_Client
             $sessionOptions['cookie_samesite'] = true;
         }
 
+        // API Detect
+        if (strpos($_SERVER['REDIRECT_URL'], '/api/v0.0.3-dev/') !== false) {
+            session_cache_limiter('private');
+        }
+
         session_start($sessionOptions);
         // if exiting, destroy the php session
         if (isset($_REQUEST['logout']) && $_REQUEST['logout']) {


### PR DESCRIPTION
### Brief summary of changes

**Solved by:**
The new change is making the session_cache_limiter be called before session_start

**Fixes:**
The LORIS API displays a warning when calling the localhost/api/v0.0.3-dev/candidates

The warning:
Warning: session_cache_limiter(): Cannot change cache limiter when session is active in /Users/alizee/Development/GitHub/McGill/Loris/htdocs/api/v0.0.3-dev/APIBase.php on line 130

```
Call Stack
--

1 | 0.0013 | 399280 | {main}( ) | .../Candidates.php:0
2 | 0.0019 | 412376 | Loris\API\Candidates->__construct( ) | .../Candidates.php:258
3 | 0.0019 | 412376 | Loris\API\Candidates->__construct( ) | .../Candidates.php:44
4 | 0.0073 | 599368 | Loris\API\Candidates->handleRequest( ) | .../APIBase.php:87
5 | 0.0073 | 599368 | Loris\API\Candidates->handleETag( ) | .../APIBase.php:103
6 | 0.0073 | 599368 | session_cache_limiter ( ) | .../APIBase.php:130
```

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4576 

### To test this change...

- [x]  Test the API such as: localhost/api/v0.0.3-dev/candidates