### PR TITLE
[Statistics] Fix type error causing "breakdown by participant" link to give 500 error

### DIFF
--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -53,7 +53,7 @@ class Statistics_Site extends \NDB_Menu
         if (!empty($_REQUEST['CenterID'])) {
             $hasCenterPermission = $user->hasCenterPermission(
                 'data_entry',
-                intval($centerID)
+                intval($_REQUEST['CenterID'])
             );
         }
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -43,15 +43,19 @@ class Statistics_Site extends \NDB_Menu
         //TODO: Create a permission specific to statistics
         $hasAccessToAllProfiles = $user->hasAllPermissions(
             array(
-                'access_all_profiles',
-                'data_entry'
+             'access_all_profiles',
+             'data_entry',
             )
         );
         // If a CenterID is passed in the request, check if the user has the
         // data_entry permission at the site/center specified by CenterID.
-        $hasCenterPermission = !empty($_REQUEST['CenterID'] ?? '') ?
-            $user->hasCenterPermission('data_entry', intval($centerID))
-            : false;
+        $hasCenterPermission = false;
+        if (!empty($_REQUEST['CenterID'] ?? '')) {
+            $hasCenterPermission = $user->hasCenterPermission(
+                'data_entry',
+                intval($centerID)
+            );
+        }
 
         return $hasAccessToAllProfiles || $hasCenterPermission;
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -50,7 +50,7 @@ class Statistics_Site extends \NDB_Menu
         // If a CenterID is passed in the request, check if the user has the
         // data_entry permission at the site/center specified by CenterID.
         $hasCenterPermission = false;
-        if (!empty($_REQUEST['CenterID'] ?? '')) {
+        if (!empty($_REQUEST['CenterID'])) {
             $hasCenterPermission = $user->hasCenterPermission(
                 'data_entry',
                 intval($centerID)

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -40,12 +40,20 @@ class Statistics_Site extends \NDB_Menu
      */
     function _hasAccess(\User $user) : bool
     {
-        $centerID = htmlspecialchars($_REQUEST['CenterID']);
         //TODO: Create a permission specific to statistics
-        $accessAllProfiles = $user->hasPermission('access_all_profiles') &&
-            $user->hasPermission('data_entry');
-        return $user->hasCenterPermission('data_entry', $centerID) ||
-            $accessAllProfiles;
+        $hasAccessToAllProfiles = $user->hasAllPermissions(
+            array(
+                'access_all_profiles',
+                'data_entry'
+            )
+        );
+        // If a CenterID is passed in the request, check if the user has the
+        // data_entry permission at the site/center specified by CenterID.
+        $hasCenterPermission = !empty($_REQUEST['CenterID'] ?? '') ?
+            $user->hasCenterPermission('data_entry', intval($centerID))
+            : false;
+
+        return $hasAccessToAllProfiles || $hasCenterPermission;
 
     }
 


### PR DESCRIPTION
### Brief summary of changes

The `$centerID` variable was being passed as a string when it should've been an int. This caused a TypeError to be thrown.

Resolves https://github.com/aces/Loris/issues/4555