### PR TITLE
[Core/Timepoint] bug fix to update timepoint object when setting new data

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -369,6 +369,8 @@ class TimePoint
              'ID' => $this->getData('SessionID'),
             )
         );
+        // this select updates the timepoint object
+        $this->select(intval($this->getData('SessionID')));
         return true;
     }
 


### PR DESCRIPTION
### This resolves issue...
- [ ] Github #4563 

A brief summary of the issue: Test battery was not being populated when starting new visit stage. 
After some digging, it turned out that the issue was being caused by new session data only being updated in the database and not in the timepoint instance itself. 

### Brief summary of changes
This PR edits the `setData` function of the TimePoint class. When setting data for a timepoint, we should be updating the singleton instance to include the new data. 

Please refer to[ this PR](https://github.com/aces/Loris/commit/0eb134a33a2eb076177adb7865c79344b99767a9#diff-3331857654de63c280eeedba8a7fca9cL368) where this line seems to have been omitted 

### To test this change...

- [ ] Attempt creating a new timepoint and starting the next stage. See if the visit is populated with proper battery.