### PR TITLE
Fix INSERT ... WHERE EXIST

### DIFF
--- a/SQL/New_patches/2019-05-03-deprecate_useprojects.sql
+++ b/SQL/New_patches/2019-05-03-deprecate_useprojects.sql
@@ -6,10 +6,10 @@ SELECT 'loris'
 WHERE NOT EXISTS (SELECT * FROM Project);
 
 -- associate all subprojects to the loris project by default if project table was empty
-INSERT INTO project_rel (ProjectID,SubprojectID)
-SELECT ProjectID, SubprojectID 
-FROM Project JOIN subproject 
-WHERE Project.Name='loris';
+INSERT IGNORE INTO Project (ProjectID, Name)
+  (SELECT * FROM
+     (SELECT min(ProjectID), 'loris' FROM Project AS q1)
+  AS q2);
 
 -- if the loris project was added, set all candidates to that default project
 UPDATE candidate SET ProjectID=(SELECT ProjectID FROM Project WHERE Name='loris') WHERE ProjectID IS NULL AND Entity_type='Human';

--- a/SQL/New_patches/2019-05-03-deprecate_useprojects.sql
+++ b/SQL/New_patches/2019-05-03-deprecate_useprojects.sql
@@ -1,15 +1,16 @@
 DELETE cs, c FROM ConfigSettings cs JOIN Config c ON c.ConfigID=cs.ID WHERE cs.Name='useProjects';
 
 -- if Project table is empty, add default 'loris' project
-INSERT INTO Project (Name)
-SELECT 'loris'
-WHERE NOT EXISTS (SELECT * FROM Project);
-
--- associate all subprojects to the loris project by default if project table was empty
 INSERT IGNORE INTO Project (ProjectID, Name)
   (SELECT * FROM
      (SELECT min(ProjectID), 'loris' FROM Project AS q1)
   AS q2);
+
+-- associate all subprojects to the loris project by default if project table was empty
+INSERT INTO project_rel (ProjectID,SubprojectID)
+SELECT ProjectID, SubprojectID 
+FROM Project JOIN subproject 
+WHERE Project.Name='loris';
 
 -- if the loris project was added, set all candidates to that default project
 UPDATE candidate SET ProjectID=(SELECT ProjectID FROM Project WHERE Name='loris') WHERE ProjectID IS NULL AND Entity_type='Human';

--- a/SQL/New_patches/2019-05-03-deprecate_useprojects.sql
+++ b/SQL/New_patches/2019-05-03-deprecate_useprojects.sql
@@ -1,10 +1,9 @@
 DELETE cs, c FROM ConfigSettings cs JOIN Config c ON c.ConfigID=cs.ID WHERE cs.Name='useProjects';
 
 -- if Project table is empty, add default 'loris' project
-INSERT IGNORE INTO Project (ProjectID, Name)
-  (SELECT * FROM
-     (SELECT min(ProjectID), 'loris' FROM Project AS q1)
-  AS q2);
+INSERT INTO Project (Name)
+(SELECT 'loris' FROM DUAL
+WHERE NOT EXISTS (SELECT * FROM Project));
 
 -- associate all subprojects to the loris project by default if project table was empty
 INSERT INTO project_rel (ProjectID,SubprojectID)


### PR DESCRIPTION
### Brief summary of changes
select from DUAL table as  we can't use WHERE clause in a SELECT without FROM table

### This resolves issue...
Resolves https://github.com/aces/Loris/issues/4595


### To test this change...

run the SQL/New_patches/2019-05-03-deprecate_useprojects.sql script on a version 20 database

