### PR TITLE
[login] Fix login Error log notice for examiner/radiologist

### DIFF
--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -170,9 +170,11 @@ class RequestAccount extends \NDB_Form
                 )
             );
 
-            if ($_REQUEST['examiner'] == 'on') {
+            if (isset($_REQUEST['examiner']) && $_REQUEST['examiner'] == 'on') {
                 $rad = 0;
-                if ($_REQUEST['radiologist'] == 'on') {
+                if (isset($_REQUEST['radiologist'])
+                    && $_REQUEST['radiologist'] == 'on'
+                ) {
                     $rad = 1;
                 }
                 //insert in DB as inactive until account approved

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -169,12 +169,13 @@ class RequestAccount extends \NDB_Form
                  'CenterID' => $site,
                 )
             );
+            
+            $examinerCheck = $_REQUEST['examiner'] ?? 'off';
+            $radiologistCheck = $_REQUEST['radiologist'] ?? 'off';
 
-            if (isset($_REQUEST['examiner']) && $_REQUEST['examiner'] == 'on') {
+            if ($examinerCheck == 'on') {
                 $rad = 0;
-                if (isset($_REQUEST['radiologist'])
-                    && $_REQUEST['radiologist'] == 'on'
-                ) {
+                if ($radiologistCheck == 'on') {
                     $rad = 1;
                 }
                 //insert in DB as inactive until account approved

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -169,8 +169,8 @@ class RequestAccount extends \NDB_Form
                  'CenterID' => $site,
                 )
             );
-            
-            $examinerCheck = $_REQUEST['examiner'] ?? 'off';
+
+            $examinerCheck    = $_REQUEST['examiner'] ?? 'off';
             $radiologistCheck = $_REQUEST['radiologist'] ?? 'off';
 
             if ($examinerCheck == 'on') {


### PR DESCRIPTION
### Brief summary of changes
Checkboxes are not submitted when they are not checked and thus they are not set in the `$_REQUEST` array(). added `isset()` checks to avoid warnings


### This resolves issue...

- [ ] Github? #4502

### To test this change...

- [ ] check if notices are generated when boxes are checked/uncheccked and the form is submitted

