### PR TITLE
[acknowledgements] [FilteredDataTable] onChange handler for Maximum rows per page

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -467,7 +467,7 @@ class DataTable extends Component {
     let rowsPerPageDropdown = (
       <select
         className="input-sm perPage"
-        onChange={this.props.updatePageRows}
+        onChange={this.updatePageRows}
         value={this.state.page.rows}
       >
         <option>20</option>


### PR DESCRIPTION
### Brief summary of changes

Fixes the console react error for the FilteredDataTable Maximum rows to display for the table.

No longer will this error output:
`Warning: Failed prop type: You provided a valueprop to a form field without anonChangehandler. This will render a read-only field. If the field should be mutable usedefaultValue. Otherwise, set either onChangeorreadOnly.`

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4611

### To test this change...

- [x] Go to the acknowledgements module or any module that uses the FilteredDataTable 
