### PR TITLE
[Data Release] Fixing PHP logic for adding permissions via versions

### DIFF
--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -40,7 +40,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'addpermission'
         $userid = $_POST['userid'];
         $data_release_version = $_POST['data_release_version'];
 
-        $data_release_version = 'Unversioned' ? '' : $data_release_version;
+        $data_release_version = $data_release_version == 'Unversioned' ? '' : $data_release_version;
 
         $IDs = $DB->pselectCol(
             "SELECT id 

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -38,9 +38,7 @@ if (isset($_POST['action']) && $_POST['action'] == 'addpermission'
         && !empty($_POST['data_release_version'])
     ) {
         $userid = $_POST['userid'];
-        $data_release_version = $_POST['data_release_version'];
-
-        $data_release_version = $data_release_version == 'Unversioned' ? '' : $data_release_version;
+        $data_release_version = $_POST['data_release_version'] == 'Unversioned' ? '' : $_POST['data_release_version'];
 
         $IDs = $DB->pselectCol(
             "SELECT id 

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -38,7 +38,8 @@ if (isset($_POST['action']) && $_POST['action'] == 'addpermission'
         && !empty($_POST['data_release_version'])
     ) {
         $userid = $_POST['userid'];
-        $data_release_version = $_POST['data_release_version'] == 'Unversioned' ? '' : $_POST['data_release_version'];
+        $data_release_version = $_POST['data_release_version'] == 'Unversioned'
+                                ? '' : $_POST['data_release_version'];
 
         $IDs = $DB->pselectCol(
             "SELECT id 


### PR DESCRIPTION
### Brief summary of changes

Bad logic in PHP code for adding permissions via the version in Data Release

### This resolves issue...

- [x] Github? #4539

### To test this change...

- [ ] Specify the version when adding permissions to a specific user in the Data Release 

