### PR TITLE
[API] TypeError: Argument 2 passed to NDB_BVL_Instrument::factory() must be of the type string, null given, called in Loris/src/Api/Endpoints/Project/Instruments.php on line 107 in Loris/php/libraries/NDB_BVL_Instrument.class.inc on line 173

### DIFF
--- a/src/Api/Endpoints/Project/Instruments.php
+++ b/src/Api/Endpoints/Project/Instruments.php
@@ -102,8 +102,8 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
         try {
             $instrument = \NDB_BVL_Instrument::factory(
                 $instrumentname,
-                null,
-                null,
+                '',
+                '',
                 true
             );
         } catch (\Exception $e) {


### PR DESCRIPTION
### Brief summary of changes

Fixes the error by supplying strings and not null.

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4616

### To test this change...

- [x] Make the API call: `localhost/api/v0.0.3-dev/projects/Pumpernickel/instruments/radiology_review`
