### PR TITLE
[User] Make pwnedPassword function static

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -541,7 +541,7 @@ class User extends UserPermissions
      *
      * @return bool Whether the password is known to be pwned.
      */
-    function pwnedPassword(string $password): bool
+    static function pwnedPassword(string $password): bool
     {
 
         // If the project is configured to disable the Pwned Password check,


### PR DESCRIPTION
### Brief summary of changes

This function is called statically during the change password procedure but it was not explicitly declared to be static. This generates a PHP Warning in recent versions.

Resolves #4503 