### PR TITLE
[TimePoint] Allow getApprovalStatus function to return null

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -490,9 +490,9 @@ class TimePoint
     /**
      * Return the approval status of this timepoint.
      *
-     * @return string 'In Progress', 'Pass' or 'Failure'
+     * @return string|null 'In Progress', 'Pass' or 'Failure'
      */
-    function getApprovalStatus(): string
+    function getApprovalStatus(): ?string
     {
         return $this->_timePointInfo["Approval"];
     }


### PR DESCRIPTION
### Brief summary of changes

This variable can be null in certain cases. The `sessions` table in MySQL which stores this value has a `NULL` value as the default, so it follows that this value can be `null` within PHP.

Resolves #4585 