### PR TITLE
Candidate::getCandidateSex() must be of the type string, null returned in Loris/php/libraries/Candidate.class.inc on line 499 Call Stack

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -492,9 +492,10 @@ class Candidate
     /**
      * Return the candidate's sex
      *
-     * @return string Male|Female String describing the sex
+     * @return string|null Male|Female String describing the sex
+     *                     and null if scanner
      */
-    function getCandidateSex(): string
+    function getCandidateSex(): ?string
     {
         return $this->candidateInfo["Sex"];
     }


### PR DESCRIPTION
### Brief summary of changes

Solved by adding null as return type in case of scanner.

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4620

### To test this change...

- [x] Call the API /candidates/$candID when candID is a scanner 