### PR TITLE
fix api call for argument 3 needs to be string

### DIFF
--- a/htdocs/api/v0.0.3-dev/candidates/InstrumentData.php
+++ b/htdocs/api/v0.0.3-dev/candidates/InstrumentData.php
@@ -95,7 +95,7 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
             $this->Instrument = \NDB_BVL_Instrument::factory(
                 $Instrument,
                 $CommentID,
-                null,
+                '',
                 true
             );
         } catch(\Exception $e) {

--- a/src/Api/Endpoints/Project/Instruments.php
+++ b/src/Api/Endpoints/Project/Instruments.php
@@ -102,8 +102,8 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
         try {
             $instrument = \NDB_BVL_Instrument::factory(
                 $instrumentname,
-                null,
-                null,
+                '',
+                '',
                 true
             );
         } catch (\Exception $e) {


### PR DESCRIPTION
### Brief summary of changes

Fixed by supplying string for 3rd argument of the NDB_BVL_Instrument::factor

Second commit fixes:
`TypeError: Argument 2 passed to NDB_BVL_Instrument::factory() must be of the type string, null given, called in /Users/alizee/Development/GitHub/McGill/Loris/src/Api/Endpoints/Project/Instruments.php on line 107 in /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/NDB_BVL_Instrument.class.inc on line 173`

when api: `localhost/api/v0.0.3-dev/projects/Rye/instruments/bmi` is called.

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4624

### To test this change...

- [x] Make API call such as: `localhost/api/v0.0.3-dev/candidates/300020/V1/instruments/bmi`
