### PR TITLE
[JSX] Fixed Datatable Pagination Bugs

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -21,6 +21,7 @@ class DataTable extends Component {
       },
     };
 
+    this.changePage = this.changePage.bind(this);
     this.setSortColumn = this.setSortColumn.bind(this);
     this.updateSortColumn = this.updateSortColumn.bind(this);
     this.toggleSortOrder = this.toggleSortOrder.bind(this);
@@ -28,9 +29,15 @@ class DataTable extends Component {
     this.updatePageRows = this.updatePageRows.bind(this);
     this.downloadCSV = this.downloadCSV.bind(this);
     this.countFilteredRows = this.countFilteredRows.bind(this);
-    this.getSortedRows = this.getSortedRows.bind(this);//
+    this.getSortedRows = this.getSortedRows.bind(this);
     this.hasFilterKeyword = this.hasFilterKeyword.bind(this);
     this.renderActions = this.renderActions.bind(this);
+  }
+
+  changePage(i) {
+    const page = this.state.page;
+    page.number = i;
+    this.setState({page});
   }
 
   setSortColumn(column) {
@@ -467,7 +474,7 @@ class DataTable extends Component {
     let rowsPerPageDropdown = (
       <select
         className="input-sm perPage"
-        onChange={this.props.updatePageRows}
+        onChange={this.updatePageRows}
         value={this.state.page.rows}
       >
         <option>20</option>
@@ -522,7 +529,7 @@ class DataTable extends Component {
                 Total={filteredRows}
                 onChangePage={this.changePage}
                 RowsPerPage={rowsPerPage}
-                Active={this.state.PageNumber}
+                Active={this.state.page.number}
               />
             </div>
           </div>
@@ -564,7 +571,7 @@ class DataTable extends Component {
                 Total={filteredRows}
                 onChangePage={this.changePage}
                 RowsPerPage={rowsPerPage}
-                Active={this.state.PageNumber}
+                Active={this.state.page.number}
               />
             </div>
           </div>

--- a/jsx/PaginationLinks.js
+++ b/jsx/PaginationLinks.js
@@ -13,6 +13,12 @@ class PaginationLinks extends Component {
     this.changePage = this.changePage.bind(this);
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.Total < prevProps.Total) {
+      this.props.onChangePage(1);
+    }
+  }
+
   changePage(i) {
     return function(evt) {
       // Don't jump to the top of the page


### PR DESCRIPTION
## Summary
This PR Kills 2 bugs with one stone.
1. Pagination works again.
2. When the user is not on the first page of the datatable and alters the number of rows in the datatable via the filter such that the new number of rows is less than the previous number of rows, the user is returned to the first page of the datatable.

## Issues
1. #4626
2. #3948

## Testing
1. Go to your favourite reactified module.
2. Make sure pagination works.
3. Change one of the filter values
4. Make sure that you are returned to the first page of the datatable.
5. Repeat steps 1-4 for another reactified module.