### PR TITLE
[JSX] Fixed Bug That Revealed Hidden Headers

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -356,8 +356,8 @@ class StaticDataTable extends Component {
     ];
 
     for (let i = 0; i < this.props.Headers.length; i += 1) {
-      if (typeof this.props.hiddenHeaders === 'undefined' ||
-        this.props.hiddenHeaders.indexOf(this.props.Headers[i]) === -1) {
+      if (typeof loris.hiddenHeaders === 'undefined' ||
+        loris.hiddenHeaders.indexOf(this.props.Headers[i]) === -1) {
         let colIndex = i + 1;
         if (this.props.Headers[i] === this.props.freezeColumn) {
           headers.push(


### PR DESCRIPTION
## Summary
Made a slight change so that Hidden Headers remain hidden in non-reactified modules.

## Issues
#4634

## Testing
1. Go to a non-reactified module (e.g. MRI Violations, etc.) and make sure there are no extra columns at the end of the datatable with empty rows.
2. Test another non-reactified module.
