### PR TITLE
Retored broken 'Acquisition ID' link on dicom archive details page.

### DIFF
--- a/modules/dicom_archive/.gitignore
+++ b/modules/dicom_archive/.gitignore
@@ -1,1 +1,2 @@
-js/*
+js/dicom_archive.js.map
+

--- a/modules/dicom_archive/js/view_details_link.js
+++ b/modules/dicom_archive/js/view_details_link.js
@@ -1,0 +1,53 @@
+$(document).ready(function() {
+    // Filters will only get applied on a POST, so
+    // on click we need to fake a form which posts
+    // to the mri_violations in order to get filters
+    $(".dicom_archive").click(function(e) {
+        e.preventDefault();
+        var form = $('<form />', {
+            "action" : loris.BaseURL + "/mri_violations/",
+            "method" : "post"
+        });
+        var values = {
+            "reset"       : "true",
+            "PatientName" : this.dataset.patientname,
+            "SeriesUID"   : this.dataset.seriesuid,
+            "filter"      : "Show Data"
+        };
+
+        $.each(values, function(name, value) {
+            $("<input />", {
+                type: 'hidden',
+                name: name,
+                value: value
+            }).appendTo(form);
+        });
+
+        form.appendTo('body').submit();
+    });
+
+    $(".dicom_archive_datasets").click(function(e) {
+        e.preventDefault();
+        var form = $('<form />', {
+            "action" : loris.BaseURL + "/mri_violations/",
+            "method" : "post"
+        });
+        var values = {
+            "reset"  : "true",
+            "PatientName"  : this.dataset.patientname,
+            "filter" : "Show Data"
+        };
+
+        $.each(values, function(name, value) {
+            $("<input />", {
+                type: 'hidden',
+                name: name,
+                value: value
+            }).appendTo(form);
+        });
+
+        form.appendTo('body').submit();
+    });
+
+});
+


### PR DESCRIPTION
### Brief summary of changes

Fixed the broken 'Acquisition ID' link on the DICOM archive details page. The link now redirects to the MRI violations module and shows the MRI violations for the patient name associated to the DICOM archive.

### This resolves issue...

- [ ] Github? #4549 

### To test this change...

1. Access the DICOM archive module and click on any archive to access its details.
2. Click on the link displayed  in the 'Acquisition ID' row and ensure that you are redirected to the MRI violations module, with the filter's patient name filled with the name of the patient who's associated with the archive.
