### PR TITLE
DICOM archive details does not work when more than one upload is associated to the archive.

### DIFF
--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -25,7 +25,10 @@ namespace LORIS\dicom_archive;
  */
 class ViewDetails extends \NDB_Form
 {
-   var $tarchiveID;
+    /**
+     * ID of the tarchive for which the details should be displayed.
+     */
+    var $tarchiveID;
 
     /**
      * Keeps array of protocols from mri_protocol
@@ -55,8 +58,8 @@ class ViewDetails extends \NDB_Form
 
         $user = \User::singleton();
         if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess($user))) {
-            $this->tarchiveID = $_REQUEST['tarchiveID'];
-            $this->tpl_data['archive']        = $this->_getTarchiveData(
+            $this->tarchiveID          = $_REQUEST['tarchiveID'];
+            $this->tpl_data['archive'] = $this->_getTarchiveData(
                 $this->tarchiveID,
                 'tarchive',
                 'LastUpdate'
@@ -169,13 +172,15 @@ class ViewDetails extends \NDB_Form
             $dicomArchiveSettings['patientIDRegex']
         );
 
-        $query = "SELECT IsPhantom "
-               . "FROM mri_upload m "
-               . "JOIN tarchive t USING(TarchiveID) "
-               . "WHERE t.TarchiveID =:tid "
-               . "AND t.archivelocation LIKE CONCAT("
-               .     "'%', substring_index(m.decompressedlocation, '/', -1),  '.tar'"
-               . ")";
+        $query     = "SELECT IsPhantom "
+                   . "FROM mri_upload m "
+                   . "JOIN tarchive t USING(TarchiveID) "
+                   . "WHERE t.TarchiveID =:tid "
+                   . "AND t.archivelocation LIKE CONCAT("
+                   .     "'%', "
+                   .     "substring_index(m.decompressedlocation, '/', -1), "
+                   .     " '.tar'"
+                   . ")";
         $isPhantom = $db->pselectRow(
             $query,
             array('tid' => $this->tpl_data['archive']['TarchiveID'])

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -28,7 +28,7 @@ class ViewDetails extends \NDB_Form
     /**
      * ID of the tarchive for which the details should be displayed.
      */
-    var $tarchiveID;
+    public $tarchiveID;
 
     /**
      * Keeps array of protocols from mri_protocol

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -25,6 +25,8 @@ namespace LORIS\dicom_archive;
  */
 class ViewDetails extends \NDB_Form
 {
+   var $tarchiveID;
+
     /**
      * Keeps array of protocols from mri_protocol
      */
@@ -53,19 +55,19 @@ class ViewDetails extends \NDB_Form
 
         $user = \User::singleton();
         if ((!empty($_REQUEST['tarchiveID'])) && ($this->_hasAccess($user))) {
-            $tarchiveID = $_REQUEST['tarchiveID'];
+            $this->tarchiveID = $_REQUEST['tarchiveID'];
             $this->tpl_data['archive']        = $this->_getTarchiveData(
-                $tarchiveID,
+                $this->tarchiveID,
                 'tarchive',
                 'LastUpdate'
             );
             $this->tpl_data['archive_series'] = $this->_getTarchiveData(
-                $tarchiveID,
+                $this->tarchiveID,
                 'tarchive_series',
                 'TarchiveSeriesID'
             );
             $this->tpl_data['archive_files']  = $this->_getTarchiveData(
-                $tarchiveID,
+                $this->tarchiveID,
                 'tarchive_files',
                 'TarchiveFileID'
             );
@@ -167,9 +169,16 @@ class ViewDetails extends \NDB_Form
             $dicomArchiveSettings['patientIDRegex']
         );
 
+        $query = "SELECT IsPhantom "
+               . "FROM mri_upload m "
+               . "JOIN tarchive t USING(TarchiveID) "
+               . "WHERE t.TarchiveID =:tid "
+               . "AND t.archivelocation LIKE CONCAT("
+               .     "'%', substring_index(m.decompressedlocation, '/', -1),  '.tar'"
+               . ")";
         $isPhantom = $db->pselectRow(
-            "SELECT IsPhantom FROM mri_upload WHERE SessionID=:sid",
-            array('sid' => $this->tpl_data['archive']['SessionID'])
+            $query,
+            array('tid' => $this->tpl_data['archive']['TarchiveID'])
         )['IsPhantom'] ?? null;
 
         if ($isPhantom === 'Y') {


### PR DESCRIPTION

### Brief summary of changes

When more than one MRI upload is associated to a given archive, its details cannot be displayed in the DICOM archive: an HTTP 500 error is generated (a `pselectRow` statement returns more than one row).

This PR also fixes the breadcrumbs on the DICOM archive details page: clicking on the 'details' breadcrumb if your are already on the DICOM archive details page takes you to a DICOM archive details page where all the lines in the displayed table are empty.

### This resolves issue...

- [ ] Github? #4553

### To test this change...

Access the DICOM archive and try to view the details of an archive associated to multiple MRI uploads. On the test VM, one such archive has TarchiveID=2.
