### PR TITLE
[user_accounts] fix permissions for viewing / certifying examiners from user accounts edit page

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -278,7 +278,7 @@ class Edit_User extends \NDB_Form
         // END multi-site UPDATE
 
         // EXAMINER UPDATE
-        if ($editor->hasPermission('examiner_multisite')) {
+        if ($this->showExaminerFields($editor)) {
             // get all fields that are related to examiners
             $ex_curr_sites  = array();
             $ex_prev_sites  = array();
@@ -716,10 +716,16 @@ class Edit_User extends \NDB_Form
             array('multiple' => 'multiple')
         );
 
-        if ($editor->hasPermission('examiner_multisite')) {
+        // Should be able to view examiner fields in the following cases:
+        // (1) Editor has 'examiner_multisite' permission.
+        // (2) Editor has 'examiner_view' permission
+        //      AND  either:
+        //          i) The user is from same site as editor,
+        //         OR
+        //          ii) The editor is creating a new user.
+        if ($this->showExaminerFields($editor)) {
             //get site aliases
-            $DB      =& \Database::singleton();
-            $aliases = $DB->pselect("SELECT CenterID, Alias FROM psc ", array());
+            $aliases = $this->getEditorSiteAliases($editor);
 
             foreach ($aliases as $row) {
                 $groupA[] = $this->createCheckbox(
@@ -1087,7 +1093,7 @@ class Edit_User extends \NDB_Form
         //======================================
         //        Validate Examiner Status
         //======================================
-        if ($editor->hasPermission('examiner_multisite')) {
+        if ($this->showExaminerFields($editor)) {
             $matched = false;
             foreach ($values as $k => $v) {
                 if (preg_match("/^ex_[0-9]+$/", $k)) {
@@ -1216,6 +1222,70 @@ class Edit_User extends \NDB_Form
             list(,$description) = each($permission[0]);
         }
         return $permission;
+    }
+
+    /**
+     * This function returns a boolean representing whether or not
+     * to display examiner fields to a user that is editing an account.
+     * Examiner fields SHOULD be displayed in the following cases:
+     *      (1) Editor has 'examiner_multisite' permission
+     *          (which allows to add / certify examiners across all sites).
+     *      (2) Editor has 'examiner_view' permission
+     *          (which allows them to add / certify examiner at their own site)
+     *              AND  either:
+     *                  i) The user is from same site as editor,
+     *                      OR
+     *                  ii) The editor is creating a new user.
+     *
+     * @param \User $editor User editing the form
+     *
+     * @return bool  - whether or not to display examiner fields
+     */
+    function showExaminerFields($editor)
+    {
+        $siteMatch = false;
+        if (!$this->isCreatingNewUser()) {
+            $user        = \User::factory($this->identifier);
+            $userSites   = $user->getCenterIDs();
+            $editorSites = $editor->getCenterIDs();
+            foreach ($userSites as $site) {
+                if (in_array($site, $editorSites)) {
+                    $siteMatch = true;
+                }
+            }
+        }
+        return $editor->hasPermission('examiner_multisite')
+            || ($editor->hasPermission('examiner_view') &&
+                ($this->isCreatingNewUser() || $siteMatch));
+    }
+
+    /**
+     * Returns an array of site aliases that the editor is affiliated with.
+     *
+     * @param \User $editor User editing the form
+     *
+     * @return array - array of aliases
+     *
+     * @throws \DatabaseException
+     */
+    function getEditorSiteAliases($editor)
+    {
+        $DB      =& \Database::singleton();
+        $aliases = array();
+        if ($editor->hasPermission('examiner_multisite')) {
+            $aliases = $DB->pselect(
+                "SELECT CenterID, Alias FROM psc",
+                array()
+            );
+        } elseif ($editor->hasPermission('examiner_view')) {
+            $aliases = $DB->pselect(
+                "SELECT p.CenterID, Alias FROM psc p
+                JOIN user_psc_rel u ON (p.CenterID=u.CenterID)
+                WHERE UserID=:uid",
+                array("uid" => $editor->getId())
+            );
+        }
+        return $aliases;
     }
 
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -278,7 +278,7 @@ class Edit_User extends \NDB_Form
         // END multi-site UPDATE
 
         // EXAMINER UPDATE
-        if ($this->showExaminerFields($editor)) {
+        if ($this->isViewableExaminerFields($editor)) {
             // get all fields that are related to examiners
             $ex_curr_sites  = array();
             $ex_prev_sites  = array();
@@ -723,7 +723,7 @@ class Edit_User extends \NDB_Form
         //          i) The user is from same site as editor,
         //         OR
         //          ii) The editor is creating a new user.
-        if ($this->showExaminerFields($editor)) {
+        if ($this->isViewableExaminerFields($editor)) {
             //get site aliases
             $aliases = $this->getEditorSiteAliases($editor);
 
@@ -1093,7 +1093,7 @@ class Edit_User extends \NDB_Form
         //======================================
         //        Validate Examiner Status
         //======================================
-        if ($this->showExaminerFields($editor)) {
+        if ($this->isViewableExaminerFields($editor)) {
             $matched = false;
             foreach ($values as $k => $v) {
                 if (preg_match("/^ex_[0-9]+$/", $k)) {
@@ -1241,7 +1241,7 @@ class Edit_User extends \NDB_Form
      *
      * @return bool  - whether or not to display examiner fields
      */
-    function showExaminerFields($editor)
+    function isViewableExaminerFields($editor)
     {
         $siteMatch = false;
         if (!$this->isCreatingNewUser()) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1241,7 +1241,7 @@ class Edit_User extends \NDB_Form
      *
      * @return bool  - whether or not to display examiner fields
      */
-    function isViewableExaminerFields($editor)
+    function isViewableExaminerFields($editor) : bool
     {
         $siteMatch = false;
         if (!$this->isCreatingNewUser()) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1251,6 +1251,7 @@ class Edit_User extends \NDB_Form
             foreach ($userSites as $site) {
                 if (in_array($site, $editorSites)) {
                     $siteMatch = true;
+                    break;
                 }
             }
         }

--- a/modules/user_accounts/test/TestPlan.md
+++ b/modules/user_accounts/test/TestPlan.md
@@ -51,38 +51,38 @@ When creating or editing a user: (subtest: edit_user)
 18. Check that setting the radiologist to Yes/No changes the values for X for all sites
 19. Check that by removing the "examiner_view" and "examiner_multisite" permission, the user(editor) cannot modify X's Examiner Status.
 20. Check that by removing the "examiner_multisite" permission, the user(editor) can only modify X's Examiner Status if the editor and user X are affiliated with a common site.
-20. Setting the Pending Approval for user X prevents user X from logging in until his/her account is approved.
-21. Setting the Active=”No” for user X prevents user X from logging in until his/her account is active again.
-22. Check that modifications made to the basic user infos are displayed when the user table is reloaded.
-23. When editing an existing user: Check that Reset button restores previous settings (does not wipe all settings, or
+21. Setting the Pending Approval for user X prevents user X from logging in until his/her account is approved.
+22. Setting the Active=”No” for user X prevents user X from logging in until his/her account is active again.
+23. Check that modifications made to the basic user infos are displayed when the user table is reloaded.
+24. When editing an existing user: Check that Reset button restores previous settings (does not wipe all settings, or
     retain any changes).
-24. When editing an existing user: Check that Back button takes you to the User Account page and does not save any
+25. When editing an existing user: Check that Back button takes you to the User Account page and does not save any
     changes. 
-25. When editing an existing user: Clicking on the 'User Account' breadcrumb takes you to the User Account page
+26. When editing an existing user: Clicking on the 'User Account' breadcrumb takes you to the User Account page
     without saving any changes to the user profile.
     
 ### Testing permissions:
 *Log in as a simple user (non-admin) and ensure the following. Define `editee` as the user being edited and `editor` as the logged in user making the changes.*
 
-26. Editor can only see and manipulate permissions for editee if and only if editor has the permissions in question
-27. When page is saved with any set of selected permissions, on reload all selected permissions are kept and all unselected permissions are removed.
-28. If editee has permissions that editor does not have, said permissions are not impacted by manipulating the editee's visible permissions (requires admin user login in a side window to be able to view all permissions for editee as editor will only be able to view permissions they own)
-29. See security testing below
+27. Editor can only see and manipulate permissions for editee if and only if editor has the permissions in question
+28. When page is saved with any set of selected permissions, on reload all selected permissions are kept and all unselected permissions are removed.
+29. If editee has permissions that editor does not have, said permissions are not impacted by manipulating the editee's visible permissions (requires admin user login in a side window to be able to view all permissions for editee as editor will only be able to view permissions they own)
+30. See security testing below
 
 ##### Security testing:
- - Try manipulating the POST request from the browser to add a permission to the editee. Make sure that the editee gets the permission if it is within the set of permissions of the editor Make sure the editee does not get the permission if it is not within the set of permissions of the editor. [See this PR](https://github.com/aces/Loris/pull/3818#issuecomment-408882440) for more details.
+31. Try manipulating the POST request from the browser to add a permission to the editee. Make sure that the editee gets the permission if it is within the set of permissions of the editor Make sure the editee does not get the permission if it is not within the set of permissions of the editor. [See this PR](https://github.com/aces/Loris/pull/3818#issuecomment-408882440) for more details.
 
 On the My Preferences page:
 ==========================
 
-30. Check that all users (even those with NO permissions) have access to the My Preferences page.
-31. Change the user’s password.  Check that the password rules are enforced.
-32. Check that if password and confirmed password do not match you get an error.
-33. Check that saving fails if any field is left blank (except password).
-34. Check that if you do not enter an email address that is syntactically valid you get an error.
-35. Modify any field on the page and save, and go to the User Account page. Check that the modifications are
+32. Check that all users (even those with NO permissions) have access to the My Preferences page.
+33. Change the user’s password.  Check that the password rules are enforced.
+34. Check that if password and confirmed password do not match you get an error.
+35. Check that saving fails if any field is left blank (except password).
+36. Check that if you do not enter an email address that is syntactically valid you get an error.
+37. Modify any field on the page and save, and go to the User Account page. Check that the modifications are
     displayed when looking at the modified user account.  
-36. Verify that all notification checkboxes match what the project has enabled in the `notification_modules_services_rel`. See WIKI for more details https://github.com/aces/Loris/wiki/Notification-system.
-37. Verify that checkboxes available respect the permission restrictions set in the `notification_modules_perm_rel`. See WIKI for more details https://github.com/aces/Loris/wiki/Notification-system.
-38. Verify that the notifications are sent when the trigger event occurs. (NB the user triggering the event will not get the email, only other registered users are notified)
-39. Clicking on the 'User Account' breadcrumb takes you to the User Account page without saving any changes. If you do not have access to the user account module, the system should tell you so.
+38. Verify that all notification checkboxes match what the project has enabled in the `notification_modules_services_rel`. See WIKI for more details https://github.com/aces/Loris/wiki/Notification-system.
+39. Verify that checkboxes available respect the permission restrictions set in the `notification_modules_perm_rel`. See WIKI for more details https://github.com/aces/Loris/wiki/Notification-system.
+40. Verify that the notifications are sent when the trigger event occurs. (NB the user triggering the event will not get the email, only other registered users are notified)
+41. Clicking on the 'User Account' breadcrumb takes you to the User Account page without saving any changes. If you do not have access to the user account module, the system should tell you so.

--- a/modules/user_accounts/test/TestPlan.md
+++ b/modules/user_accounts/test/TestPlan.md
@@ -49,7 +49,8 @@ When creating or editing a user: (subtest: edit_user)
 16. Check that selecting sites for the "Examiner At:" Section and saving, adds user X to the Examiner list (and in examiners table).
 17. Check that de-selecting sites from the "Examiner At:" section and saving, does NOT delete X from the Examiner table but rather sets them as inactive for that site.
 18. Check that setting the radiologist to Yes/No changes the values for X for all sites
-19. Check that by removing the "examiner_multisite" permission, the user(editor) can not modify X's Examiner Status.
+19. Check that by removing the "examiner_view" and "examiner_multisite" permission, the user(editor) cannot modify X's Examiner Status.
+20. Check that by removing the "examiner_multisite" permission, the user(editor) can only modify X's Examiner Status if the editor and user X are affiliated with a common site.
 20. Setting the Pending Approval for user X prevents user X from logging in until his/her account is approved.
 21. Setting the Active=”No” for user X prevents user X from logging in until his/her account is active again.
 22. Check that modifications made to the basic user infos are displayed when the user table is reloaded.


### PR DESCRIPTION
### Brief summary of changes
Examiner status fields in user_accounts edit form were only show for users with `examiner_multisite` permission. 
This PR makes it so users with `examiner_view` permissions can view / certify users from their own site.

Recap on the permissions:
`examiner_multisite`: add / certify examiners across all sites
`examiner_view` : add / certify examiner at users' own site

### This resolves issue...
- [ ] Github? #4523 

### To test this change...

- [ ] Play around with different permissions and site affiliations. 
- [ ] When you have `examiner_multisite` you should see all fields related to examiner and all center aliases displayed. 
- [ ] When you have `examiner_view` you should ONLY see the examiner fields and center aliases that you are affiliated with IF: 1) you share a site with the user you are editing, 2) you are creating a new user.
