### PR TITLE
[survey_accounts] Fixing unable to proceed/complete survey issue

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -149,14 +149,14 @@ class DirectDataEntryMainPage
         if ($currentPage === null) {
             return 1;
         }
+        $nextPage = $currentPage+1;
         return intval(
             \Database::singleton()->pselectOne(
                 "SELECT Order_number FROM instrument_subtests
-                WHERE Test_name=:TN AND Order_number > :PN 
-                ORDER BY Order_number",
+                WHERE Test_name=:TN AND Order_number=:PN",
                 array(
                  'TN' => $this->TestName,
-                 'PN' => $currentPage,
+                 'PN' => $nextPage,
                 )
             )
         );
@@ -191,12 +191,13 @@ class DirectDataEntryMainPage
                 array('TN' => $this->TestName)
             );
         }
+        $prevPage = $currentPage-1;
         return $DB->pselectOne(
             "SELECT Order_number FROM instrument_subtests 
-            WHERE Test_name=:TN AND Order_number < :PN ORDER BY Order_number DESC",
+            WHERE Test_name=:TN AND Order_number=:PN",
             array(
              'TN' => $this->TestName,
-             'PN' => $currentPage,
+             'PN' => $prevPage,
             )
         );
     }


### PR DESCRIPTION
### Brief summary of changes
Unable to proceed after the main page of the survey as it was throwing error
`Attempt to use pselectRow on a query that returns multiple rows` This PR fixes the issue.

### This resolves issue...

- [ ] Github # [4534](https://github.com/aces/Loris/issues/4534)

### To test this change...

- [ ] Try to fill out a survey.

