### PR TITLE
[install] Fixed checkbox formatting in installdb.php frontend

### DIFF
--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -174,33 +174,27 @@
             </fieldset>
             <fieldset>
                 <legend>Options</legend>
-            <div>
-                <div class="col-md-9">
-                    <label for="use_existing_database">Use existing database:</label>
-                </div>
-                <div class="col-md-9">
-                    <input type="checkbox" id="use_existing_database" name="use_existing_database" value="on" {($use_existing_database == 'on') ? 'checked' : ''}/>
-                                        Check this if the database already exists but does not have Loris installed yet
-                </div>
+            <div class="col-md-12">
+                <label for="use_existing_database">Use existing database:</label>
             </div>
-            <div>
-                <div class="col-md-10">
-                    <label for="use_existing_tables">Use existing tables:</label>
-                </div>
-                <div class="col-md-10">
-                    <input type="checkbox" id="use_existing_tables" name="use_existing_tables" value="on" {($use_existing_tables == 'on') ? 'checked' : ''}/>
-                                        Check this if you already installed Loris at the specified database
-                </div>
+            <div class="col-md-12">
+                <input type="checkbox" id="use_existing_database" name="use_existing_database" value="on" {($use_existing_database == 'on') ? 'checked' : ''}/>
+                                    Check this if the database already exists but does not have Loris installed yet
             </div>
-            <div>
-                <div class="col-md-10">
-                    <label for="use_existing_configs">Use existing configs:</label>
-                </div>
-                <div class="col-md-10">
-                    <input type="checkbox" id="use_existing_configs" name="use_existing_configs" value="on" {($do_not_update_config == 'on') ? 'checked' : ''}/>
-                                        Check this if you don't want to update the configuration.
-                                    <em>(You really should update the configuration if possible, though)</em>
-                </div>
+            <div class="col-md-12">
+                <label for="use_existing_tables">Use existing tables:</label>
+            </div>
+            <div class="col-md-12">
+                <input type="checkbox" id="use_existing_tables" name="use_existing_tables" value="on" {($use_existing_tables == 'on') ? 'checked' : ''}/>
+                                    Check this if you already installed Loris at the specified database
+            </div>
+            <div class="col-md-12">
+                <label for="use_existing_configs">Use existing configs:</label>
+            </div>
+            <div class="col-md-12">
+                <input type="checkbox" id="use_existing_configs" name="use_existing_configs" value="on" {($do_not_update_config == 'on') ? 'checked' : ''}/>
+                                    Check this if you don't want to update the configuration.
+                                <em>(You really should update the configuration if possible, though)</em>
             </div>
             </fieldset>
             <input type="hidden" name="formname" value="validaterootaccount" />

--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -1,4 +1,4 @@
-<html>
+html>
     <head>
     {* installdb.php is in the root directory, so we know these relative
        links should work. Load in the base LORIS bootstrap CSS
@@ -175,7 +175,7 @@
             <fieldset>
                 <legend>Options</legend>
             <div>
-                <div class="col-md-2">
+                <div class="col-md-9">
                     <label for="use_existing_database">Use existing database:</label>
                 </div>
                 <div class="col-md-9">
@@ -184,7 +184,7 @@
                 </div>
             </div>
             <div>
-                <div class="col-md-2">
+                <div class="col-md-10">
                     <label for="use_existing_tables">Use existing tables:</label>
                 </div>
                 <div class="col-md-10">
@@ -193,7 +193,7 @@
                 </div>
             </div>
             <div>
-                <div class="col-md-2">
+                <div class="col-md-10">
                     <label for="use_existing_configs">Use existing configs:</label>
                 </div>
                 <div class="col-md-10">

--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -1,4 +1,4 @@
-html>
+<html>
     <head>
     {* installdb.php is in the root directory, so we know these relative
        links should work. Load in the base LORIS bootstrap CSS


### PR DESCRIPTION
### Brief summary of changes
I made changes to the [Loris/smarty/templates/install.tpl](https://github.com/aces/Loris/blob/minor/smarty/templates/install.tpl) file to fix the formatting of the checkboxes in the loris-url/installdb.php frontend.

Here is the original formatting:
<img width="1127" alt="Screen Shot 2019-05-17 at 12 12 26 PM" src="https://user-images.githubusercontent.com/35467361/57942619-f231e480-789f-11e9-9262-17d4ac15a850.png">

And the fixed formatting:
<img width="790" alt="Screen Shot 2019-05-17 at 12 32 57 PM" src="https://user-images.githubusercontent.com/35467361/57942628-f8c05c00-789f-11e9-904c-e6dbb819b2b2.png">

### This resolves issue...
- [ ] Github #4647 

### To test this change...

Since Loris is already installed, you will need to move the config.xml file out of the project folder so that when you check out <loris-url>/installdb.php, it does not say "Loris already installed".

1. Move config.xml from loris/project to another folder (ex. just the loris folder)
2. Put loris-url/installdb.php in browser (ex. for me, it is alivadas-dev.loris.ca/installdb.php)
3. Check that the changes were made.
