### PR TITLE
[Candidate List] Enabled Advanced Filter Toggle Via Query Params

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -17,6 +17,13 @@ class Filter extends Component {
     this.renderFilterFields = this.renderFilterFields.bind(this);
   }
 
+  componentDidMount() {
+    const queryParams = new URLSearchParams(location.search);
+    const filter = JSON.parse(JSON.stringify(this.props.filter));
+    queryParams.forEach((value, name) => filter[name]= {value});
+    this.props.updateFilter(filter);
+  }
+
   /**
    * Sets filter object to reflect values of input fields.
    *
@@ -36,6 +43,11 @@ class Filter extends Component {
         exactMatch: exactMatch,
       };
     }
+
+    const queryParams = Object.keys(filter)
+                          .map((name) => name+'='+filter[name].value)
+                          .join('&');
+    history.replaceState(filter, '', `?${queryParams}`);
 
     this.props.updateFilter(filter);
   }

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -17,13 +17,6 @@ class Filter extends Component {
     this.renderFilterFields = this.renderFilterFields.bind(this);
   }
 
-  componentDidMount() {
-    const queryParams = new URLSearchParams(location.search);
-    const filter = JSON.parse(JSON.stringify(this.props.filter));
-    queryParams.forEach((value, name) => filter[name]= {value});
-    this.props.updateFilter(filter);
-  }
-
   /**
    * Sets filter object to reflect values of input fields.
    *
@@ -43,11 +36,6 @@ class Filter extends Component {
         exactMatch: exactMatch,
       };
     }
-
-    const queryParams = Object.keys(filter)
-                          .map((name) => name+'='+filter[name].value)
-                          .join('&');
-    history.replaceState(filter, '', `?${queryParams}`);
 
     this.props.updateFilter(filter);
   }

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -24,7 +24,6 @@ class CandidateListIndex extends Component {
       error: false,
       isLoaded: false,
       hideFilter: true,
-      buttonLabel: 'Show Advanced Filters',
       show: {profileForm: false},
     };
 
@@ -48,6 +47,11 @@ class CandidateListIndex extends Component {
   componentDidMount() {
     this.fetchData()
       .then(() => this.setState({isLoaded: true}));
+
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.has('hide')) {
+      this.setState({hideFilter: JSON.parse(searchParams.get('hide'))});
+    }
   }
 
   /**
@@ -70,8 +74,12 @@ class CandidateListIndex extends Component {
   // Basic/Advanced toggle
   toggleFilters() {
     const hideFilter = !this.state.hideFilter;
-    const buttonLabel = hideFilter ? 'Show Advanced Filters' : 'Hide Advanced Filters';
-    this.setState({hideFilter, buttonLabel});
+    this.setState({hideFilter});
+
+    // Updates query params to reflect advance filter toggle.
+    const searchParams = new URLSearchParams(location.search);
+    searchParams.set('hide', hideFilter);
+    history.replaceState(history.state, '', `?${searchParams.toString()}`);
   };
 
   /**
@@ -317,7 +325,7 @@ class CandidateListIndex extends Component {
     // FIXME: move toggle button in the filter component next to the clear button
     const actions = [
       {
-        label: this.state.buttonLabel,
+        label: this.state.hideFilter ? 'Show Advanced Filters' : 'Hide Advanced Filters',
         action: this.toggleFilters,
         name: 'advanced',
       },


### PR DESCRIPTION
## Summary
Toggling the 'Show Advanced Filter' Button will append a query param to the URL that will propagate the state of the toggled filter when the loading the page with that URL.

## Issue
#4540

## Testing
1. Go to Candidate List module.
2. Press the 'Show Advanced Filter' Button.
3. Make sure a query param in the url is added called `hide` with value `false`
4. Refresh the page.
5. Make sure the advanced filters are still revealed.
6. Repeat steps 2-5 except by pressing the `Hide Advanced Filter` Button.
