### PR TITLE
Patient name should be prepended to the name of a downloaded DICOM archive

### DIFF
--- a/modules/dicom_archive/jsx/dicom_archive.js
+++ b/modules/dicom_archive/jsx/dicom_archive.js
@@ -64,7 +64,8 @@ class DicomArchive extends Component {
     let result = <td>{cell}</td>;
     switch (column) {
       case 'Archive Location': {
-        const downloadURL = '/mri/jiv/get_file.php?file=' + cell;
+        const downloadURL = '/mri/jiv/get_file.php?file=' + cell
+            + '&patientName=' + row['Patient Name'];
         result =
           <td>
             <a href={downloadURL}>


### PR DESCRIPTION

### Brief summary of changes

In the DICOM archive module, when downloading an archive, the patient name should be prepended to the archive file name to facilitate identification. 

### This resolves issue...

- [ ] Github? #4556

### To test this change...

Access the DICOM archive module and download any archive. Check that the downloaded file name starts with the patient name.
