### PR TITLE
Fixed the 'no-warning-comments' ESLint warnings

### DIFF
--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -190,7 +190,7 @@ class ConsentStatus extends React.Component {
 
   render() {
     // If error occurs, return a message.
-    // XXX: Replace this with a UI component for 500 errors.
+    // Replace this with a UI component for 500 errors.
     if (this.state.error) {
       return <h3>An error occured while loading the page.</h3>;
     }

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -74,7 +74,7 @@ class DataDictIndex extends React.Component {
     this.setState({filter});
   }
 
-  // TODO: deprecate clearing filters via refs in future refactoring.
+  // Deprecate clearing filters via refs in future refactoring.
   /**
    * Reset the filter elements with textInput refs to empty values
    */

--- a/modules/help_editor/jsx/help_editor.js
+++ b/modules/help_editor/jsx/help_editor.js
@@ -25,7 +25,7 @@ class HelpEditor extends React.Component {
       data: {}
     };
 
-    // TODO: refs should be deprecated in future refactoring.
+    // Refs should be deprecated in future refactoring.
     /**
      * Set filter to the element's ref for filtering
      */
@@ -55,7 +55,7 @@ class HelpEditor extends React.Component {
       method: 'GET',
       dataType: 'json',
       success: data => {
-        // FIXME: Remove the following line of code as soon as hiddenHeaders is
+        // Remove the following line of code as soon as hiddenHeaders is
         // accepted as a prop by the StaticDataTable Component.
         loris.hiddenHeaders = data.hiddenHeaders || [];
         this.setState({
@@ -76,7 +76,7 @@ class HelpEditor extends React.Component {
     this.setState({filter});
   }
 
-  // TODO: Clearing filters via refs should be deprecated in future refactoring.
+  // Clearing filters via refs should be deprecated in future refactoring.
   /**
    * Reset the filter elements with textInput refs to empty values
    */

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -47,7 +47,7 @@ class ImagingUploader extends React.Component {
       method: "GET",
       dataType: 'json',
       success: data => {
-        // FIXME: Remove the following line of code, add ['PatientName'] to the
+        // Remove the following line of code, add ['PatientName'] to the
         // hiddenHeaders state and pass this.state.hiddenHeaders as a prop to
         // StaticDataTable as soon as hiddenHeaders is accepted as a prop by
         // the StaticDataTable Component.
@@ -70,7 +70,7 @@ class ImagingUploader extends React.Component {
     this.setState({filter});
   }
 
-  // TODO: deprecate clearing filters via refs in future refactoring.
+  // Deprecate clearing filters via refs in future refactoring.
   /**
    * Reset the filter elements with textInput refs to empty values
    */

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -192,7 +192,7 @@ class IssueForm extends React.Component {
             onUserInput={this.setFormData}
             ref="status"
             disabled={!hasEditPermission}
-            value={this.state.formData.status} // todo: edit this so the options are
+            value={this.state.formData.status} // edit this so the options are
                                                // different if the user doesn't have
                                                // permission
           />
@@ -361,7 +361,7 @@ class IssueForm extends React.Component {
    * @param {string} value - selected value for corresponding form element
    */
   setFormData(formElement, value) {
-    // todo: only give valid inputs for fields given previous input to other fields
+    // only give valid inputs for fields given previous input to other fields
     const formDataUpdate = this.state.formData;
     formDataUpdate[formElement] = value;
 

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -46,7 +46,7 @@ class MediaIndex extends React.Component {
       method: "GET",
       dataType: 'json',
       success: data => {
-        // FIXME: Remove the following line of code as soon as hiddenHeaders is
+        // Remove the following line of code as soon as hiddenHeaders is
         // accepted as a prop by the StaticDataTable Component.
         loris.hiddenHeaders = this.state.hiddenHeaders;
         this.setState({
@@ -67,7 +67,7 @@ class MediaIndex extends React.Component {
     this.setState({filter});
   }
 
-  // TODO: deprecate clearing filters via refs in future refactoring.
+  // Deprecate clearing filters via refs in future refactoring.
   /**
    * Reset the filter elements with textInput refs to empty values
    */


### PR DESCRIPTION
### Brief summary of changes
I made changes to some of the .js files so that when running "npm run lint:javascript" there would be less warning from eslint. 

### This resolves issue...

- [ ] Github? #4138 

### To test this change...

- [ ] Run "npm run lint:javascript"


