### PR TITLE
[candidate_list] Fix path to scan 

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -98,16 +98,11 @@ class CandidateListIndex extends Component {
       }
     }
     if (column === 'Scan Done' && cell === 'Y') {
+      let url = this.props.baseURL + '/imaging_browser/?PSCID=' + row['PSCID'];
       return (
         <td className="scanDoneLink">
-          <a href="#"
-            onClick={loris.loadFilteredMenuClickHandler('imaging_browser/',
-            {pscid: row['PSCID']})}
-          >
-            {cell}
-          </a>
-        </td>
-    );
+          <a href={url}>{cell}</a></td>
+      );
     }
     return <td>{cell}</td>;
   }


### PR DESCRIPTION
### Brief summary of changes
Fixes path to scan done in candidate list. 


### This resolves issue...
This PR + @HenriRabalais 's PR #4590 resolve the issue #4533 

### To test this change...

- [ ] Click on link in `Scan Done` column. Link should redirect to `baseURL + /imaging_browser/?PSCID=%pscid%`
- [ ] With changes from #4590 the form should filter on load.

