### PR TITLE
[Statistics] Fix breakdown stats issue when visits were not populated

### DIFF
--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -157,11 +157,7 @@ class Stats_Demographic extends \NDB_Form
     function setup()
     {
         parent::setup();
-        //FIXME visits is never initialized properly though it is used in
-        //functions below. This declaration was added to satisfy phan but work
-        //should be done to properly populate this value. Until then there is
-        //the possibility of errors arising in the demographic stats.
-        $visits = array();
+        $visits = \Utility::getExistingVisitLabels();
         $db     = \Database::singleton();
         //This boolean is for optional use by project if the demographics table
         // queries any information from the mri_parameter_form table


### PR DESCRIPTION
### Brief summary of changes

This addresses a FIXME issue where $visits wasn't populated. They are now populated via Utility.

### This resolves issue...

- [ ] Github? Resolves #4546 

### Test instructions

On `21.0-release`
1. Go to the statistics module click on the Demo Statistics tab
2. The "Breakdown of Registered Candidates" table should be empty/filled with 0s.

On this branch 
3. The table should now contain some numbers