### PR TITLE
[Statistics] Add a hint for project filter testing under Behavioural Statistics.

### DIFF
--- a/modules/statistics/test/TestPlan.md
+++ b/modules/statistics/test/TestPlan.md
@@ -13,7 +13,7 @@
    - check to see if the % Male is being calculated properly by looking at the data that's in the table.
 
 ### Behavioural Statistics
-1. Click on the Behavioural Statistics tab. Try using the project filter Data Entry Statistics table. Does it work? Does it change what appears in both the top table and bottom table?
+1. Click on the Behavioural Statistics tab. Try using the project filter Data Entry Statistics table (The `use projects` option need to set to `yes` under Loris configration). Does it work? Does it change what appears in both the top table and bottom table?
 2. For both tables:
    - check that the % Completion makes sense in relation to the values in the table.
    - check that the data in the table matches what is stored in the database.

--- a/modules/statistics/test/TestPlan.md
+++ b/modules/statistics/test/TestPlan.md
@@ -13,7 +13,7 @@
    - check to see if the % Male is being calculated properly by looking at the data that's in the table.
 
 ### Behavioural Statistics
-1. Click on the Behavioural Statistics tab. Try using the project filter Data Entry Statistics table (The `use projects` option need to set to `yes` under Loris configration). Does it work? Does it change what appears in both the top table and bottom table?
+1. Click on the Behavioural Statistics tab. Try using the project filter Data Entry Statistics table (The `use projects` option need to be set to `yes` under Loris configration). Does it work? Does it change what appears in both the top table and bottom table?
 2. For both tables:
    - check that the % Completion makes sense in relation to the values in the table.
    - check that the data in the table matches what is stored in the database.


### PR DESCRIPTION
### Brief summary of changes
Add a sentence to hint the tester to set `use porjects` option to yes for the testing of the project filter for the Data Entry Statistics table under Behavioural Statistics.

### This resolves issue...

- [ ] Github?  Resolves #4550

### To test this change...

- [ ] Review modules/statistics/test/TestPlan.md, under No.1 under Behavioural Statistics, check the hint.