### PR TITLE
[publication] help dialog info

### DIFF
--- a/modules/publication/help/publication.md
+++ b/modules/publication/help/publication.md
@@ -1,48 +1,16 @@
 # Publication
 
-The publication module allows users to propose research projects based on LORIS 
-data, upload publication media, and allows study PIs to review the project 
+Publication is intended for users to propose specific research projects
+and for PIs to review them. When proposing a project, PIs may also specify 
+other users to help with editing and maintaining their project proposals.
+
+
+Navigate to the "__Propose a Project__" tab for proposing research projects based on the data required. You may upload publication media, and allows study PIs to review the project 
 proposals.
 
-## Intended Users
-
-Publication module is intended for users to propose specific research projects
-and for PIs to review them. When proposing a project, PIs may also specify 
-other LORIS users to help with editing and maintaining their project proposals.
-
-## Scope
-
-The publication module is intended to view and manage research project proposals.
-Users who are proposing a project are able to specify which specific variables of 
-interest that are relevant to their research. However, gathering and releasing this 
+Specify which specific variables of 
+interest that are relevant to the research. Gathering and releasing this 
 data remains within the scope of the DQT and Data Release modules respectively.
-Realizing and implementing the proposals are also outside the scope; this module 
-is intended solely for tracking the status and metadata of the proposals, as well as 
+
+Remember the Publication module is intended solely for tracking the status and metadata of the proposals, as well as 
 storing the resulting publication media.
-
-
-## Permissions
-
-There are three main permissions for the publication module:
-
-- `publication_view`: grants the user access to viewing the module and pending 
-or approved project proposals, as well as downloading publication media which may 
-be included in the proposals.
-- `publication_propose`: grants the user access to proposing their research projects
-and uploading relevant publication media.
-- `publication_approve`: grants the user access to reviewing (accepting or rejecting)
-project proposals.
-
-## Configurations
-
-- `publication_uploads`: This configuration determines the directory where file uploads
- get stored. By default, this directory will be `/data/publication_uploads/` but
-  it is not automatically created.
-- `publication_delections`: Only users that are affiliated with the proposal can delete.
-
-## Interactions with LORIS
-
-The publication module creates foreign key relations between its primary `publication` 
- table, the `parameter_type` table, the `test_names` table, and the `users` table.
- There is also a link to the Data Dictionary in the project proposal / editing view
- in order to assist in finding variables of interest.

--- a/modules/publication/help/publication.md
+++ b/modules/publication/help/publication.md
@@ -2,15 +2,10 @@
 
 Publication is intended for users to propose specific research projects
 and for PIs to review them. When proposing a project, PIs may also specify 
-other users to help with editing and maintaining their project proposals.
+other users for help with editing and maintaining their project proposals. Only users that are affiliated with the proposal can delete publications.
 
 
-Navigate to the "__Propose a Project__" tab for proposing research projects based on the data required. You may upload publication media, and allows study PIs to review the project 
-proposals.
 
-Specify which specific variables of 
-interest that are relevant to the research. Gathering and releasing this 
-data remains within the scope of the DQT and Data Release modules respectively.
+Navigate to the "__Propose a Project__" tab for proposing research projects based on the data required. You may upload publication media which may then be reviewed by study PIs.
 
-Remember the Publication module is intended solely for tracking the status and metadata of the proposals, as well as 
-storing the resulting publication media. Only users that are affiliated with the proposal can delete publications.
+You should specify which specific variables of interest are relevant to your research so that the reviewers can determine if they should grant access to the data.

--- a/modules/publication/help/publication.md
+++ b/modules/publication/help/publication.md
@@ -38,6 +38,7 @@ project proposals.
 - `publication_uploads`: This configuration determines the directory where file uploads
  get stored. By default, this directory will be `/data/publication_uploads/` but
   it is not automatically created.
+- `publication_delections`: Only users that are affiliated with the proposal can delete.
 
 ## Interactions with LORIS
 

--- a/modules/publication/help/publication.md
+++ b/modules/publication/help/publication.md
@@ -1,0 +1,47 @@
+# Publication
+
+The publication module allows users to propose research projects based on LORIS 
+data, upload publication media, and allows study PIs to review the project 
+proposals.
+
+## Intended Users
+
+Publication module is intended for users to propose specific research projects
+and for PIs to review them. When proposing a project, PIs may also specify 
+other LORIS users to help with editing and maintaining their project proposals.
+
+## Scope
+
+The publication module is intended to view and manage research project proposals.
+Users who are proposing a project are able to specify which specific variables of 
+interest that are relevant to their research. However, gathering and releasing this 
+data remains within the scope of the DQT and Data Release modules respectively.
+Realizing and implementing the proposals are also outside the scope; this module 
+is intended solely for tracking the status and metadata of the proposals, as well as 
+storing the resulting publication media.
+
+
+## Permissions
+
+There are three main permissions for the publication module:
+
+- `publication_view`: grants the user access to viewing the module and pending 
+or approved project proposals, as well as downloading publication media which may 
+be included in the proposals.
+- `publication_propose`: grants the user access to proposing their research projects
+and uploading relevant publication media.
+- `publication_approve`: grants the user access to reviewing (accepting or rejecting)
+project proposals.
+
+## Configurations
+
+- `publication_uploads`: This configuration determines the directory where file uploads
+ get stored. By default, this directory will be `/data/publication_uploads/` but
+  it is not automatically created.
+
+## Interactions with LORIS
+
+The publication module creates foreign key relations between its primary `publication` 
+ table, the `parameter_type` table, the `test_names` table, and the `users` table.
+ There is also a link to the Data Dictionary in the project proposal / editing view
+ in order to assist in finding variables of interest.

--- a/modules/publication/help/publication.md
+++ b/modules/publication/help/publication.md
@@ -13,4 +13,4 @@ interest that are relevant to the research. Gathering and releasing this
 data remains within the scope of the DQT and Data Release modules respectively.
 
 Remember the Publication module is intended solely for tracking the status and metadata of the proposals, as well as 
-storing the resulting publication media.
+storing the resulting publication media. Only users that are affiliated with the proposal can delete publications.


### PR DESCRIPTION
### Brief summary of changes

Added Readme.md to be the help info for the module because it describes the module. 

### This resolves issue...

- [ ] Redmine? #

- [x] Github? Resolves #4593

### To test this change...

- [x] go to publication module, click the ? 