### PR TITLE
[statistics] fix imaging tab loading when Scan_Done is not in mri_parameter_form

### DIFF
--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -70,6 +70,7 @@ class Stats_MRI extends \NDB_Form
      * @param string  $Subsection        the value of Subsection=''
      * @param string  $disclamer         the value of disclamer=''
      * @param ?string $projectID         the value of projectID is null
+     * @param bool    $scanDoneExists    does the column exist in the databse
      *
      * @return string
      */
@@ -84,128 +85,122 @@ class Stats_MRI extends \NDB_Form
         array $data,
         $Subsection="",
         $disclamer='',
-        $projectID=null
+        $projectID=null,
+        $scanDoneExists = true
     ): string {
 
         $tpl_data = array();
-        $smarty = new \Smarty_neurodb("statistics");
         // Sanitize test name if present. Otherwise use empty string.
-        $tpl_data['test_name'] = isset($_REQUEST['test_name'])
+        $tpl_data['test_name']  = isset($_REQUEST['test_name'])
             ? htmlspecialchars($_REQUEST['test_name'])
             : '';
         $tpl_data['Subsection'] = $Subsection;
-        $tpl_data['DropdownName'] = $dropdown_name;
-        $tpl_data['DropdownOptions'] = $dropdown_opt;
+        $tpl_data['Visits']     = $visits;
+        $smarty = new \Smarty_neurodb("statistics");
+        $tpl_data['SectionHeader'] = $sectionHeader;
+        $tpl_data['TableHeader']   = $tableHeader;
+        $tpl_data['Disclamer']     = $disclamer;
+        $tpl_data['Subcategories'] = $subcats;
+        $tpl_var = \Utility::getSubprojectsForProject($projectID);
+        $tpl_data['Subprojects']      = $tpl_var;
+        $tpl_data['DropdownName']     = $dropdown_name;
+        $tpl_data['DropdownOptions']  = $dropdown_opt;
         $tpl_data['DropdownSelected'] = $dropdown_selected;
+        $tpl_data['Centers']          = $centers;
+        foreach ($data as $row) {
+            $subproj = $row['SubprojectID'];
+            $vl      = $row['VLabel'];
+            $subcat  = $row['Subcat'];
+            $center  = $row['CenterID'];
 
-        // if the data array is empty, means the scan_done does not exist for that
-        // scan type
-        if (!empty($data)) {
-            $tpl_data['scan_done_exists'] = true;
-            $tpl_data['Visits'] = $visits;
-            $tpl_data['SectionHeader'] = $sectionHeader;
-            $tpl_data['TableHeader'] = $tableHeader;
-            $tpl_data['Disclamer'] = $disclamer;
-            $tpl_data['Subcategories'] = $subcats;
-            $tpl_var = \Utility::getSubprojectsForProject($projectID);
-            $tpl_data['Subprojects'] = $tpl_var;
-            $tpl_data['Centers'] = $centers;
-            foreach ($data as $row) {
-                $subproj = $row['SubprojectID'];
-                $vl = $row['VLabel'];
-                $subcat = $row['Subcat'];
-                $center = $row['CenterID'];
-
-                /* Calculate the totals for each element of the stats table. Each
-                 * node of this nested array contains a key-value array consisting
-                 * of the subcategories as they keys and the totals as values.
-                 * There is one additional key, 'total'.
-                 * E.g.
-                 *      array(
-                 *          'total' = x;
-                 *          $subcategory1 = y;
-                 *          $subcategory2 = z;
-                 *          ...
-                 *      )
+            /* Calculate the totals for each element of the stats table. Each
+             * node of this nested array contains a key-value array consisting
+             * of the subcategories as they keys and the totals as values.
+             * There is one additional key, 'total'.
+             * E.g.
+             *      array(
+             *          'total' = x;
+             *          $subcategory1 = y;
+             *          $subcategory2 = z;
+             *          ...
+             *      )
+             */
+            if (in_array($vl, $visits)
+                && in_array($subcat, $subcats)
+                && $this->_inCenter($center, $centers)
+            ) {
+                $C = 'C' . $center;
+                /* This array contains all the $subcategories as keys as well
+                * as 'total'. All values are 0.
+                */
+                $blankStatsArray = $this->initializeStatsArray($subcats);
+                /* Initialize values for all of the endpoints using the array
+                 * just created. This step is done to prevent undefined index
+                 * notices from appearing in the PHP logs for uninitialzed keys.
                  */
-                if (in_array($vl, $visits)
-                    && in_array($subcat, $subcats)
-                    && $this->_inCenter($center, $centers)
-                ) {
-                    $C = 'C' . $center;
-                    /* This array contains all the $subcategories as keys as well
-                    * as 'total'. All values are 0.
-                    */
-                    $blankStatsArray = $this->initializeStatsArray($subcats);
-                    /* Initialize values for all of the endpoints using the array
-                     * just created. This step is done to prevent undefined index
-                     * notices from appearing in the PHP logs for uninitialzed keys.
-                     */
 
-                    // Data
-                    if (!isset($tpl_data['data'])) {
-                        $tpl_data['data'] = $blankStatsArray;
-                    }
-                    // Data => Visit_Label
-                    if (!isset($tpl_data['data'][$vl])) {
-                        $tpl_data['data'][$vl] = $blankStatsArray;
-                    }
-                    // Data => Subproject
-                    if (!isset($tpl_data['data'][$subproj])) {
-                        $tpl_data['data'][$subproj] = $blankStatsArray;
-                    }
-                    // Data => Subproject => Visit_label
-                    if (!isset($tpl_data['data'][$subproj][$vl])) {
-                        $tpl_data['data'][$subproj][$vl] = $blankStatsArray;
-                    }
-                    // Data => Subproject => Center
-                    if (!isset($tpl_data['data'][$subproj][$C])) {
-                        $tpl_data['data'][$subproj][$C] = $blankStatsArray;
-                    }
-                    // Data => Subproject => Center => Visit_Label
-                    if (!isset($tpl_data['data'][$subproj][$C][$vl])) {
-                        $tpl_data['data'][$subproj][$C][$vl] = $blankStatsArray;
-                    }
-                    // Data => Center
-                    if (!isset($tpl_data['data'][$C])) {
-                        $tpl_data['data'][$C] = $blankStatsArray;
-                    }
-                    // Data => Center => Visit_Label
-                    if (!isset($tpl_data['data'][$C][$vl])) {
-                        $tpl_data['data'][$C][$vl] = $blankStatsArray;
-                    }
-
-                    // Update the $subcat and total values for each element.
-                    // Data
-                    $tpl_data['data'][$subcat] += $row['val'];
-                    $tpl_data['data']['total'] += $row['val'];
-                    // Data => Visit_Label
-                    $tpl_data['data'][$vl][$subcat] += $row['val'];
-                    $tpl_data['data'][$vl]['total'] += $row['val'];
-                    // Data => Subproject
-                    $tpl_data['data'][$subproj][$subcat] += $row['val'];
-                    $tpl_data['data'][$subproj]['total'] += $row['val'];
-                    // Data => Subproject => Visit_Label
-                    $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
-                    $tpl_data['data'][$subproj][$vl]['total'] += $row['val'];
-                    // Data => Subproject => Center
-                    $tpl_data['data'][$subproj][$C][$subcat] += $row['val'];
-                    $tpl_data['data'][$subproj][$C]['total'] += $row['val'];
-                    // Data => Subproject => Center => Visit_Label
-                    $tpl_data['data'][$subproj][$C][$vl][$subcat] = $row['val'];
-                    $tpl_data['data'][$subproj][$C][$vl]['total'] += $row['val'];
-                    // Data => Center
-                    $tpl_data['data'][$C][$subcat] += $row['val'];
-                    $tpl_data['data'][$C]['total'] += $row['val'];
-                    // Data => Center => Visit_Label
-                    $tpl_data['data'][$C][$vl][$subcat] += $row['val'];
-                    $tpl_data['data'][$C][$vl]['total'] += $row['val'];
+                // Data
+                if (!isset($tpl_data['data'])) {
+                    $tpl_data['data'] = $blankStatsArray;
                 }
+                // Data => Visit_Label
+                if (!isset($tpl_data['data'][$vl])) {
+                    $tpl_data['data'][$vl] = $blankStatsArray;
+                }
+                // Data => Subproject
+                if (!isset($tpl_data['data'][$subproj])) {
+                    $tpl_data['data'][$subproj] = $blankStatsArray;
+                }
+                // Data => Subproject => Visit_label
+                if (!isset($tpl_data['data'][$subproj][$vl])) {
+                    $tpl_data['data'][$subproj][$vl] = $blankStatsArray;
+                }
+                // Data => Subproject => Center
+                if (!isset($tpl_data['data'][$subproj][$C])) {
+                    $tpl_data['data'][$subproj][$C] = $blankStatsArray;
+                }
+                // Data => Subproject => Center => Visit_Label
+                if (!isset($tpl_data['data'][$subproj][$C][$vl])) {
+                    $tpl_data['data'][$subproj][$C][$vl] = $blankStatsArray;
+                }
+                // Data => Center
+                if (!isset($tpl_data['data'][$C])) {
+                    $tpl_data['data'][$C] = $blankStatsArray;
+                }
+                // Data => Center => Visit_Label
+                if (!isset($tpl_data['data'][$C][$vl])) {
+                    $tpl_data['data'][$C][$vl] = $blankStatsArray;
+                }
+
+                // Update the $subcat and total values for each element.
+                // Data
+                $tpl_data['data'][$subcat] += $row['val'];
+                $tpl_data['data']['total'] += $row['val'];
+                // Data => Visit_Label
+                $tpl_data['data'][$vl][$subcat] += $row['val'];
+                $tpl_data['data'][$vl]['total'] += $row['val'];
+                // Data => Subproject
+                $tpl_data['data'][$subproj][$subcat] += $row['val'];
+                $tpl_data['data'][$subproj]['total'] += $row['val'];
+                // Data => Subproject => Visit_Label
+                $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
+                $tpl_data['data'][$subproj][$vl]['total'] += $row['val'];
+                // Data => Subproject => Center
+                $tpl_data['data'][$subproj][$C][$subcat] += $row['val'];
+                $tpl_data['data'][$subproj][$C]['total'] += $row['val'];
+                // Data => Subproject => Center => Visit_Label
+                $tpl_data['data'][$subproj][$C][$vl][$subcat]  = $row['val'];
+                $tpl_data['data'][$subproj][$C][$vl]['total'] += $row['val'];
+                // Data => Center
+                $tpl_data['data'][$C][$subcat] += $row['val'];
+                $tpl_data['data'][$C]['total'] += $row['val'];
+                // Data => Center => Visit_Label
+                $tpl_data['data'][$C][$vl][$subcat] += $row['val'];
+                $tpl_data['data'][$C][$vl]['total'] += $row['val'];
             }
-        } else {
-            $tpl_data['scan_done_exists'] = false;
         }
 
+        $tpl_data['scan_done_exists'] = $scanDoneExists;
         $smarty->assign($tpl_data);
         $html = $smarty->fetch("table_statistics.tpl");
         return $html;
@@ -345,8 +340,8 @@ class Stats_MRI extends \NDB_Form
         }
 
         $MRI_Type_Field = $MRI_Type . "_Scan_Done";
-        $MRIHeader = "$MRI_Type Breakdown";
-        $CaseStatement = "
+        $MRIHeader      = "$MRI_Type Breakdown";
+        $CaseStatement  = "
                           CASE($MRI_Type_Field)
                           WHEN 'Partial' THEN 'Partial Run'
                           WHEN 'No' THEN 'No Scan'
@@ -355,9 +350,11 @@ class Stats_MRI extends \NDB_Form
 
         // Check if the mri_parameter_form contains the necessary columns before
         // running the query
-        $result = array();
+        $result         = array();
+        $scanDoneExists = false;
         if ($DB->columnExists('mri_parameter_form', $MRI_Type . "_Scan_Done")) {
-            $result = $DB->pselect(
+            $scanDoneExists = true;
+            $result         = $DB->pselect(
                 "SELECT s.SubprojectID,
                     s.CenterID,
                     s.Visit_label as VLabel,
@@ -368,6 +365,7 @@ class Stats_MRI extends \NDB_Form
                     JOIN session s ON (f.SessionID=s.ID)
                     JOIN candidate c ON (c.CandID=s.CandID)
                 WHERE s.Current_stage <> 'Recycling Bin'
+                    AND f.Administration <> 'None'
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND f.CommentID NOT LIKE 'DDE%'
@@ -395,7 +393,8 @@ class Stats_MRI extends \NDB_Form
             $result,
             "mri",
             "",
-            $currentProject
+            $currentProject,
+            $scanDoneExists
         );
         //END BIGTABLE
 

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -88,115 +88,124 @@ class Stats_MRI extends \NDB_Form
     ): string {
 
         $tpl_data = array();
+        $smarty = new \Smarty_neurodb("statistics");
         // Sanitize test name if present. Otherwise use empty string.
-        $tpl_data['test_name']  = isset($_REQUEST['test_name'])
+        $tpl_data['test_name'] = isset($_REQUEST['test_name'])
             ? htmlspecialchars($_REQUEST['test_name'])
             : '';
         $tpl_data['Subsection'] = $Subsection;
-        $tpl_data['Visits']     = $visits;
-        $smarty = new \Smarty_neurodb("statistics");
-        $tpl_data['SectionHeader'] = $sectionHeader;
-        $tpl_data['TableHeader']   = $tableHeader;
-        $tpl_data['Disclamer']     = $disclamer;
-        $tpl_data['Subcategories'] = $subcats;
-        $tpl_var = \Utility::getSubprojectsForProject($projectID);
-        $tpl_data['Subprojects']      = $tpl_var;
-        $tpl_data['DropdownName']     = $dropdown_name;
-        $tpl_data['DropdownOptions']  = $dropdown_opt;
+        $tpl_data['DropdownName'] = $dropdown_name;
+        $tpl_data['DropdownOptions'] = $dropdown_opt;
         $tpl_data['DropdownSelected'] = $dropdown_selected;
-        $tpl_data['Centers']          = $centers;
-        foreach ($data as $row) {
-            $subproj = $row['SubprojectID'];
-            $vl      = $row['VLabel'];
-            $subcat  = $row['Subcat'];
-            $center  = $row['CenterID'];
 
-            /* Calculate the totals for each element of the stats table. Each
-             * node of this nested array contains a key-value array consisting
-             * of the subcategories as they keys and the totals as values.
-             * There is one additional key, 'total'.
-             * E.g.
-             *      array(
-             *          'total' = x;
-             *          $subcategory1 = y;
-             *          $subcategory2 = z;
-             *          ...
-             *      )
-             */
-            if (in_array($vl, $visits)
-                && in_array($subcat, $subcats)
-                && $this->_inCenter($center, $centers)
-            ) {
-                $C = 'C' . $center;
-                /* This array contains all the $subcategories as keys as well
-                * as 'total'. All values are 0.
-                */
-                $blankStatsArray = $this->initializeStatsArray($subcats);
-                /* Initialize values for all of the endpoints using the array
-                 * just created. This step is done to prevent undefined index
-                 * notices from appearing in the PHP logs for uninitialzed keys.
+        // if the data array is empty, means the scan_done does not exist for that
+        // scan type
+        if (!empty($data)) {
+            $tpl_data['scan_done_exists'] = true;
+            $tpl_data['Visits'] = $visits;
+            $tpl_data['SectionHeader'] = $sectionHeader;
+            $tpl_data['TableHeader'] = $tableHeader;
+            $tpl_data['Disclamer'] = $disclamer;
+            $tpl_data['Subcategories'] = $subcats;
+            $tpl_var = \Utility::getSubprojectsForProject($projectID);
+            $tpl_data['Subprojects'] = $tpl_var;
+            $tpl_data['Centers'] = $centers;
+            foreach ($data as $row) {
+                $subproj = $row['SubprojectID'];
+                $vl = $row['VLabel'];
+                $subcat = $row['Subcat'];
+                $center = $row['CenterID'];
+
+                /* Calculate the totals for each element of the stats table. Each
+                 * node of this nested array contains a key-value array consisting
+                 * of the subcategories as they keys and the totals as values.
+                 * There is one additional key, 'total'.
+                 * E.g.
+                 *      array(
+                 *          'total' = x;
+                 *          $subcategory1 = y;
+                 *          $subcategory2 = z;
+                 *          ...
+                 *      )
                  */
+                if (in_array($vl, $visits)
+                    && in_array($subcat, $subcats)
+                    && $this->_inCenter($center, $centers)
+                ) {
+                    $C = 'C' . $center;
+                    /* This array contains all the $subcategories as keys as well
+                    * as 'total'. All values are 0.
+                    */
+                    $blankStatsArray = $this->initializeStatsArray($subcats);
+                    /* Initialize values for all of the endpoints using the array
+                     * just created. This step is done to prevent undefined index
+                     * notices from appearing in the PHP logs for uninitialzed keys.
+                     */
 
-                // Data
-                if (!isset($tpl_data['data'])) {
-                    $tpl_data['data'] = $blankStatsArray;
-                }
-                // Data => Visit_Label
-                if (!isset($tpl_data['data'][$vl])) {
-                    $tpl_data['data'][$vl] = $blankStatsArray;
-                }
-                // Data => Subproject
-                if (!isset($tpl_data['data'][$subproj])) {
-                    $tpl_data['data'][$subproj] = $blankStatsArray;
-                }
-                // Data => Subproject => Visit_label
-                if (!isset($tpl_data['data'][$subproj][$vl])) {
-                    $tpl_data['data'][$subproj][$vl] = $blankStatsArray;
-                }
-                // Data => Subproject => Center
-                if (!isset($tpl_data['data'][$subproj][$C])) {
-                    $tpl_data['data'][$subproj][$C] = $blankStatsArray;
-                }
-                // Data => Subproject => Center => Visit_Label
-                if (!isset($tpl_data['data'][$subproj][$C][$vl])) {
-                    $tpl_data['data'][$subproj][$C][$vl] = $blankStatsArray;
-                }
-                // Data => Center
-                if (!isset($tpl_data['data'][$C])) {
-                    $tpl_data['data'][$C] = $blankStatsArray;
-                }
-                // Data => Center => Visit_Label
-                if (!isset($tpl_data['data'][$C][$vl])) {
-                    $tpl_data['data'][$C][$vl] = $blankStatsArray;
-                }
+                    // Data
+                    if (!isset($tpl_data['data'])) {
+                        $tpl_data['data'] = $blankStatsArray;
+                    }
+                    // Data => Visit_Label
+                    if (!isset($tpl_data['data'][$vl])) {
+                        $tpl_data['data'][$vl] = $blankStatsArray;
+                    }
+                    // Data => Subproject
+                    if (!isset($tpl_data['data'][$subproj])) {
+                        $tpl_data['data'][$subproj] = $blankStatsArray;
+                    }
+                    // Data => Subproject => Visit_label
+                    if (!isset($tpl_data['data'][$subproj][$vl])) {
+                        $tpl_data['data'][$subproj][$vl] = $blankStatsArray;
+                    }
+                    // Data => Subproject => Center
+                    if (!isset($tpl_data['data'][$subproj][$C])) {
+                        $tpl_data['data'][$subproj][$C] = $blankStatsArray;
+                    }
+                    // Data => Subproject => Center => Visit_Label
+                    if (!isset($tpl_data['data'][$subproj][$C][$vl])) {
+                        $tpl_data['data'][$subproj][$C][$vl] = $blankStatsArray;
+                    }
+                    // Data => Center
+                    if (!isset($tpl_data['data'][$C])) {
+                        $tpl_data['data'][$C] = $blankStatsArray;
+                    }
+                    // Data => Center => Visit_Label
+                    if (!isset($tpl_data['data'][$C][$vl])) {
+                        $tpl_data['data'][$C][$vl] = $blankStatsArray;
+                    }
 
-                // Update the $subcat and total values for each element.
-                // Data
-                $tpl_data['data'][$subcat] += $row['val'];
-                $tpl_data['data']['total'] += $row['val'];
-                // Data => Visit_Label
-                $tpl_data['data'][$vl][$subcat] += $row['val'];
-                $tpl_data['data'][$vl]['total'] += $row['val'];
-                // Data => Subproject
-                $tpl_data['data'][$subproj][$subcat] += $row['val'];
-                $tpl_data['data'][$subproj]['total'] += $row['val'];
-                // Data => Subproject => Visit_Label
-                $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
-                $tpl_data['data'][$subproj][$vl]['total'] += $row['val'];
-                // Data => Subproject => Center
-                $tpl_data['data'][$subproj][$C][$subcat] += $row['val'];
-                $tpl_data['data'][$subproj][$C]['total'] += $row['val'];
-                // Data => Subproject => Center => Visit_Label
-                $tpl_data['data'][$subproj][$C][$vl][$subcat]  = $row['val'];
-                $tpl_data['data'][$subproj][$C][$vl]['total'] += $row['val'];
-                // Data => Center
-                $tpl_data['data'][$C][$subcat] += $row['val'];
-                $tpl_data['data'][$C]['total'] += $row['val'];
-                // Data => Center => Visit_Label
-                $tpl_data['data'][$C][$vl][$subcat] += $row['val'];
-                $tpl_data['data'][$C][$vl]['total'] += $row['val'];
+                    // Update the $subcat and total values for each element.
+                    // Data
+                    $tpl_data['data'][$subcat] += $row['val'];
+                    $tpl_data['data']['total'] += $row['val'];
+                    // Data => Visit_Label
+                    $tpl_data['data'][$vl][$subcat] += $row['val'];
+                    $tpl_data['data'][$vl]['total'] += $row['val'];
+                    // Data => Subproject
+                    $tpl_data['data'][$subproj][$subcat] += $row['val'];
+                    $tpl_data['data'][$subproj]['total'] += $row['val'];
+                    // Data => Subproject => Visit_Label
+                    $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
+                    $tpl_data['data'][$subproj][$vl]['total'] += $row['val'];
+                    // Data => Subproject => Center
+                    $tpl_data['data'][$subproj][$C][$subcat] += $row['val'];
+                    $tpl_data['data'][$subproj][$C]['total'] += $row['val'];
+                    // Data => Subproject => Center => Visit_Label
+                    $tpl_data['data'][$subproj][$C][$vl][$subcat] = $row['val'];
+                    $tpl_data['data'][$subproj][$C][$vl]['total'] += $row['val'];
+                    // Data => Center
+                    $tpl_data['data'][$C][$subcat] += $row['val'];
+                    $tpl_data['data'][$C]['total'] += $row['val'];
+                    // Data => Center => Visit_Label
+                    $tpl_data['data'][$C][$vl][$subcat] += $row['val'];
+                    $tpl_data['data'][$C][$vl]['total'] += $row['val'];
+                }
             }
+        } else {
+            $tpl_data['scan_done_exists'] = false;
         }
+
         $smarty->assign($tpl_data);
         $html = $smarty->fetch("table_statistics.tpl");
         return $html;
@@ -334,52 +343,44 @@ class Stats_MRI extends \NDB_Form
         } else {
             $MRI_Type = $scan_types[$_REQUEST['mri_type']];
         }
-        //TODO IBIS
-        if ($MRI_Type==='t1w') {
-            $MRI_Type ='T1';
-        } elseif ($MRI_Type=='t2w') {
-            $MRI_Type ='T2';
-        } elseif ($MRI_Type=='dti') {
-            $MRI_Type ='DTI';
-        } elseif ($MRI_Type=='ep2d_bold') {
-            $MRI_Type ='BOLD';
-        } elseif ($MRI_Type=='DTI65' || $MRI_Type=='DTI65_B1000' ) {
-            $MRI_Type ='Spectroscopy';
-        }
 
         $MRI_Type_Field = $MRI_Type . "_Scan_Done";
-        $MRIHeader      = "$MRI_Type Breakdown";
-        $CaseStatement  = "
+        $MRIHeader = "$MRI_Type Breakdown";
+        $CaseStatement = "
                           CASE($MRI_Type_Field)
                           WHEN 'Partial' THEN 'Partial Run'
                           WHEN 'No' THEN 'No Scan'
                           ELSE 'Complete'
                           END";
 
-        $result = $DB->pselect(
-            "SELECT s.SubprojectID,
+        // Check if the mri_parameter_form contains the necessary columns before
+        // running the query
+        $result = array();
+        if ($DB->columnExists('mri_parameter_form', $MRI_Type . "_Scan_Done")) {
+            $result = $DB->pselect(
+                "SELECT s.SubprojectID,
                     s.CenterID,
                     s.Visit_label as VLabel,
                     $CaseStatement as Subcat,
                     COUNT(*) as val
-              FROM mri_parameter_form m
+                FROM mri_parameter_form m
                     JOIN flag f USING (CommentID)
                     JOIN session s ON (f.SessionID=s.ID)
                     JOIN candidate c ON (c.CandID=s.CandID)
-              WHERE s.Current_stage <> 'Recycling Bin'
-                    AND f.Administration <> 'None'
+                WHERE s.Current_stage <> 'Recycling Bin'
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND f.CommentID NOT LIKE 'DDE%'
                     AND s.CenterID <> '1'
                     $suproject_query
                     $Param_Project
-              GROUP BY Subcat,
+                GROUP BY Subcat,
                     s.SubprojectID,
                     s.CenterID,
                     s.Visit_label",
-            $bigTable_params
-        );
+                $bigTable_params
+            );
+        }
 
         $M_Visits = \Utility::getExistingVisitLabels($currentProject);
         $this->tpl_data['MRI_Done_Table'] = $this->renderStatsTable(

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -70,7 +70,8 @@ class Stats_MRI extends \NDB_Form
      * @param string  $Subsection        the value of Subsection=''
      * @param string  $disclamer         the value of disclamer=''
      * @param ?string $projectID         the value of projectID is null
-     * @param bool    $scanDoneExists    whether the "Scan done" column exists in the database
+     * @param bool    $scanDoneExists    whether the "Scan done" column exists in
+     *                                   the database
      *
      * @return string
      */

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -70,7 +70,7 @@ class Stats_MRI extends \NDB_Form
      * @param string  $Subsection        the value of Subsection=''
      * @param string  $disclamer         the value of disclamer=''
      * @param ?string $projectID         the value of projectID is null
-     * @param bool    $scanDoneExists    does the column exist in the databse
+     * @param bool    $scanDoneExists    whether the "Scan done" column exists in the database
      *
      * @return string
      */

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -84,7 +84,7 @@
             </tbody>
         </table>
     {if $mri_table_exists}
-        {$MRI_Done_Table}
+      {$MRI_Done_Table}
     {else}
         <br><br>
         <h2>Oops</h2>

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -18,229 +18,236 @@
 <p>{$Disclamer}</p>
 
 <div class="row">
-    {if $Subsection=="demographics" }
-        <div class="col-sm-4">
-            {html_options id="DemographicInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
-        </div>
-        <input type="checkbox" id="showVL" checked/> Show Visit Labels
-        <button onClick="updateDemographicInstrument()" class="btn btn-primary btn-small">Submit Query</button>
-    {/if}
+  {if $Subsection=="demographics" }
+    <div class="col-sm-4">
+      {html_options id="DemographicInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
+    </div>
+    <input type="checkbox" id="showVL" checked/> Show Visit Labels
+    <button onClick="updateDemographicInstrument()" class="btn btn-primary btn-small">Submit Query</button>
+  {/if}
 
-    {if $Subsection==mri }
-        <div class="col-sm-2">
-            {html_options id="mri_type" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
-        </div>
-        <input type="checkbox" id="showVL" checked/> Show Visit Labels
-        <button onClick="updateMRITable()" class="btn btn-primary btn-small">Submit Query</button>
-    {/if}
+  {if $Subsection=="mri" }
+    <div class="col-sm-2">
+      {html_options id="mri_type" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
+    </div>
+    <input type="checkbox" id="showVL" checked/> Show Visit Labels
+    <button onClick="updateMRITable()" class="btn btn-primary btn-small">Submit Query</button>
+  {/if}
 
-    {if $Subsection=="data_entry" }
-        <div class="col-sm-2">
-            {html_options id="BehaviouralInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
-        </div>
-        <input type="checkbox" id="showVL" checked/> Show Visit Labels
-        <button onClick="updateBehaviouralInstrument()" class="btn btn-primary btn-small">Submit Query</button>
-    {/if}
+  {if $Subsection=="data_entry" }
+    <div class="col-sm-2">
+      {html_options id="BehaviouralInstrument" options=$DropdownOptions name="$DropdownName" selected=$DropdownSelected class="form-control"}
+    </div>
+    <input type="checkbox" id="showVL" checked/> Show Visit Labels
+    <button onClick="updateBehaviouralInstrument()" class="btn btn-primary btn-small">Submit Query</button>
+  {/if}
 </div>
-
 <br>
-<table id="bigtable" class="data table table-primary table-bordered dynamictable">
-    <thead>
-        <tr>
-            <th rowspan="1" id="tpcol">Subproject</th>
-            {assign var='colspan' value=count($Subcategories)}
-            {foreach key=proj item=name from=$Subprojects}
-                <th colspan="{$colspan}">{$name|capitalize}</th>
-            {/foreach}
-            <th colspan="{$colspan}">Total Across Subprojects</th>
-        </tr>
-        <tr>
-            <th>Categories</th>
-            {foreach key=proj item=name from=$Subprojects}
-                {* Go through each category once, and add the total
-                   for each cohort *}
-                {foreach key=subcategory item=category from=$Subcategories}
-                    <th>{$category}</th>
-                {/foreach}
-            {/foreach}
 
-            {* And then each category once for the totals *}
-            {foreach key=subcategory item=category from=$Subcategories}
-                <th>{$category}</th>
-            {/foreach}
-        </tr>
+{if $scan_done_exists}
+  <table id="bigtable" class="data table table-primary table-bordered dynamictable">
+    <thead>
+    <tr>
+      <th rowspan="1" id="tpcol">Subproject</th>
+      {assign var='colspan' value=count($Subcategories)}
+      {foreach key=proj item=name from=$Subprojects}
+        <th colspan="{$colspan}">{$name|capitalize}</th>
+      {/foreach}
+      <th colspan="{$colspan}">Total Across Subprojects</th>
+    </tr>
+    <tr>
+      <th>Categories</th>
+      {foreach key=proj item=name from=$Subprojects}
+        {* Go through each category once, and add the total
+           for each cohort *}
+        {foreach key=subcategory item=category from=$Subcategories}
+          <th>{$category}</th>
+        {/foreach}
+      {/foreach}
+
+      {* And then each category once for the totals *}
+      {foreach key=subcategory item=category from=$Subcategories}
+        <th>{$category}</th>
+      {/foreach}
+    </tr>
     </thead>
     <tbody>
-        <tr>
-            {foreach item=center from=$Centers}
-            {* Calculation for the colspan is:
-                     (number of subprojects + 1 for total)
-                     x
-                     (number of subcategories + 1 for percent)
-                     +1 for timepoint list
-            *}
-            {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
-            <th>{$center.LongName}</th>
-            <th colspan="{$colspan}" width="50%"><br></th>
-        </tr>
-        {foreach item=visit from=$Visits key=title}
-            <tr id="visitrow">
-                {assign var="rowtotal" value="0"}
-                <td>{$title}</td>
-                {foreach key="proj" item="value" from=$Subprojects}
-                    {assign var="subtotal" value="0" }
-                    {foreach key=sub item=subcat from=$Subcategories}
-                        {if $subcat@index eq 0}
-                            {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]}
-                            {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total}}
-                            {if $subtotal > 0 and $Numerator > 0}
-                                {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
-                            {else}
-                                {assign var="percent" value='0'}
-                            {/if}
-                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
-                        {else}
-                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"}</td>
-                        {/if}
-                    {/foreach}
-                {/foreach}
-                {* Totals for row *}
-                {foreach key=sub item=subcat from=$Subcategories}
-                    {if $subcat@index eq 0}
-                        {assign var="Numerator" value=$data[$center.ID][$visit][$Subcategories.0]}
-                        {assign var="rowtotal" value=$data[$center.ID][$visit].total}
-                        {if $rowtotal > 0 and $Numerator > 0}
-                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$rowtotal format="%.0f"}}
-                        {else}
-                            {assign var="percent" value='0'}
-                        {/if}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
-                    {else}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"}</td>
-                    {/if}
-                {/foreach}
-            </tr>
+    <tr>
+      {foreach item=center from=$Centers}
+      {* Calculation for the colspan is:
+               (number of subprojects + 1 for total)
+               x
+               (number of subcategories + 1 for percent)
+               +1 for timepoint list
+      *}
+      {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
+      <th>{$center.LongName}</th>
+      <th colspan="{$colspan}" width="50%"><br></th>
+    </tr>
+    {foreach item=visit from=$Visits key=title}
+      <tr id="visitrow">
+        {assign var="rowtotal" value="0"}
+        <td>{$title}</td>
+        {foreach key="proj" item="value" from=$Subprojects}
+          {assign var="subtotal" value="0" }
+          {foreach key=sub item=subcat from=$Subcategories}
+            {if $subcat@index eq 0}
+              {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]}
+              {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total}}
+              {if $subtotal > 0 and $Numerator > 0}
+                {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
+              {else}
+                {assign var="percent" value='0'}
+              {/if}
+              <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+            {else}
+              <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$center.ID][$visit][$subcat]|default:"0"}</td>
+            {/if}
+          {/foreach}
         {/foreach}
-        <tr>
-            <td class="subtotal">Site Total Across All Visits</td>
-            {assign var="totalsitetotal" value="0"}
-            {foreach key=proj item=value from=$Subprojects}
-                {assign var="sitetotal" value="0"}
-                {foreach key=sub item=subcat from=$Subcategories}
-                    {if $subcat@index eq 0}
-                        {assign var="Numerator" value=$data[$proj][$center.ID][$Subcategories.0]}
-                        {assign var="sitetotal" value=$data[$proj][$center.ID].total}
-                        {if $sitetotal > 0 and $Numerator > 0}
-                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$sitetotal format="%.0f"}}
-                        {else}
-                            {assign var="percent" value='0'}
-                        {/if}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
-                    {else}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"}</td>
-                    {/if}
-                {/foreach}
-            {/foreach}
-            {foreach key=sub item=subcat from=$Subcategories}
-                {if $subcat@index eq 0}
-                    {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]}
-                    {assign var="totalsitetotal" value=$data[$center.ID].total}
-                    {if $totalsitetotal > 0 and $Numerator > 0}
-                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totalsitetotal format="%.0f"}}
-                    {else}
-                        {assign var="percent" value='0'}
-                    {/if}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
-                {else}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"}</td>
-                {/if}
-            {/foreach}
-        </tr>
+        {* Totals for row *}
+        {foreach key=sub item=subcat from=$Subcategories}
+          {if $subcat@index eq 0}
+            {assign var="Numerator" value=$data[$center.ID][$visit][$Subcategories.0]}
+            {assign var="rowtotal" value=$data[$center.ID][$visit].total}
+            {if $rowtotal > 0 and $Numerator > 0}
+              {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$rowtotal format="%.0f"}}
+            {else}
+              {assign var="percent" value='0'}
+            {/if}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+          {else}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$center.ID][$visit][$subcat]|default:"0"}</td>
+          {/if}
         {/foreach}
-
-
-
-        {* Totals at the bottom *}
-        <tr>
-            {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
-            <th>Total</th>
-            <th colspan="{$colspan}" width="50%"></th>
-        </tr>
-        {foreach from=$Visits item=visit key=title}
-            <tr id="visitrow">
-                <td>{$title}</td>
-                {foreach from=$Subprojects key=proj item=value}
-                    {assign var="subtotal" value="0" }
-                    {foreach key=sub item=subcat from=$Subcategories}
-                        {if $subcat@index eq 0}
-                            {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]}
-                            {assign var="subtotal" value={$data[$proj][$visit].total}}
-                            {if $subtotal > 0 and $Numerator > 0}
-                                {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
-                            {else}
-                                {assign var="percent" value='0'}
-                            {/if}
-                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"} ({$percent}%)</td>
-                        {else}
-                            <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"}</td>
-                        {/if}
-                    {/foreach}
-                {/foreach}
-                {assign var="finaltotal" value="0" }
-                {foreach key=sub item=subcat from=$Subcategories}
-                    {if $subcat@index eq 0}
-                        {assign var="Numerator" value=$data[$visit][$Subcategories.0]}
-                        {assign var="finaltotal" value=$data[$visit].total}
-                        {if $finaltotal > 0 and $Numerator > 0}
-                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$finaltotal format="%.0f"}}
-                        {else}
-                            {assign var="percent" value='0'}
-                        {/if}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"} ({$percent}%)</td>
-                    {else}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"}</td>
-                    {/if}
-                {/foreach}
-            </tr>
+      </tr>
+    {/foreach}
+    <tr>
+      <td class="subtotal">Site Total Across All Visits</td>
+      {assign var="totalsitetotal" value="0"}
+      {foreach key=proj item=value from=$Subprojects}
+        {assign var="sitetotal" value="0"}
+        {foreach key=sub item=subcat from=$Subcategories}
+          {if $subcat@index eq 0}
+            {assign var="Numerator" value=$data[$proj][$center.ID][$Subcategories.0]}
+            {assign var="sitetotal" value=$data[$proj][$center.ID].total}
+            {if $sitetotal > 0 and $Numerator > 0}
+              {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$sitetotal format="%.0f"}}
+            {else}
+              {assign var="percent" value='0'}
+            {/if}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
+          {else}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$center.ID][$subcat]|default:"0"}</td>
+          {/if}
         {/foreach}
+      {/foreach}
+      {foreach key=sub item=subcat from=$Subcategories}
+        {if $subcat@index eq 0}
+          {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]}
+          {assign var="totalsitetotal" value=$data[$center.ID].total}
+          {if $totalsitetotal > 0 and $Numerator > 0}
+            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totalsitetotal format="%.0f"}}
+          {else}
+            {assign var="percent" value='0'}
+          {/if}
+          <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"} ({$percent}%)</td>
+        {else}
+          <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$center.ID][$subcat]|default:"0"}</td>
+        {/if}
+      {/foreach}
+    </tr>
+    {/foreach}
 
-        <tr>
-            <td class="total">Grand Total</td>
-            {foreach key=proj item=name from=$Subprojects}
-                {* Calculate the total instead of just looking it up, because of the potential
-                   for invalid visit labels throwing off the lookup, or some visits intentionally
-                   being excluded from stats *}
-                {assign var="total" value="0"}
-                {foreach key=sub item=subcat from=$Subcategories}
-                    {if $subcat@index eq 0}
-                        {assign var="Numerator" value=$data[$proj][$Subcategories.0]}
-                        {assign var="total" value=$data[$proj].total}
-                        {if $total > 0 and $Numerator > 0}
-                            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$total format="%.0f"}}
-                        {else}
-                            {assign var="percent" value='0'}
-                        {/if}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"} ({$percent}%)</td>
-                    {else}
-                        <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"}</td>
-                    {/if}
-                {/foreach}
-            {/foreach}
-            {* Totals for grand total *}
-            {foreach key=sub item=subcat from=$Subcategories}
-                {if $subcat@index eq 0}
-                    {assign var="Numerator" value=$data[$Subcategories.0]}
-                    {assign var="totaltotal" value=$data.total}
-                    {if $totaltotal > 0 and $Numerator > 0}
-                        {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totaltotal format="%.0f"}}
-                    {else}
-                        {assign var="percent" value='0'}
-                    {/if}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"} ({$percent}%)</td>
-                {else}
-                    <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"}</td>
-                {/if}
-            {/foreach}
-        </tr>
+
+
+    {* Totals at the bottom *}
+    <tr>
+      {assign var='colspan' value=(count($Subcategories))*(count($Subprojects)+1)}
+      <th>Total</th>
+      <th colspan="{$colspan}" width="50%"></th>
+    </tr>
+    {foreach from=$Visits item=visit key=title}
+      <tr id="visitrow">
+        <td>{$title}</td>
+        {foreach from=$Subprojects key=proj item=value}
+          {assign var="subtotal" value="0" }
+          {foreach key=sub item=subcat from=$Subcategories}
+            {if $subcat@index eq 0}
+              {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]}
+              {assign var="subtotal" value={$data[$proj][$visit].total}}
+              {if $subtotal > 0 and $Numerator > 0}
+                {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
+              {else}
+                {assign var="percent" value='0'}
+              {/if}
+              <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"} ({$percent}%)</td>
+            {else}
+              <td class="{$subcat|lower|regex_replace:"/ /":"_"}">{$data[$proj][$visit][$subcat]|default:"0"}</td>
+            {/if}
+          {/foreach}
+        {/foreach}
+        {assign var="finaltotal" value="0" }
+        {foreach key=sub item=subcat from=$Subcategories}
+          {if $subcat@index eq 0}
+            {assign var="Numerator" value=$data[$visit][$Subcategories.0]}
+            {assign var="finaltotal" value=$data[$visit].total}
+            {if $finaltotal > 0 and $Numerator > 0}
+              {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$finaltotal format="%.0f"}}
+            {else}
+              {assign var="percent" value='0'}
+            {/if}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"} ({$percent}%)</td>
+          {else}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} total">{$data[$visit][$subcat]|default:"0"}</td>
+          {/if}
+        {/foreach}
+      </tr>
+    {/foreach}
+
+    <tr>
+      <td class="total">Grand Total</td>
+      {foreach key=proj item=name from=$Subprojects}
+        {* Calculate the total instead of just looking it up, because of the potential
+           for invalid visit labels throwing off the lookup, or some visits intentionally
+           being excluded from stats *}
+        {assign var="total" value="0"}
+        {foreach key=sub item=subcat from=$Subcategories}
+          {if $subcat@index eq 0}
+            {assign var="Numerator" value=$data[$proj][$Subcategories.0]}
+            {assign var="total" value=$data[$proj].total}
+            {if $total > 0 and $Numerator > 0}
+              {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$total format="%.0f"}}
+            {else}
+              {assign var="percent" value='0'}
+            {/if}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"} ({$percent}%)</td>
+          {else}
+            <td class="{$subcat|lower|regex_replace:"/ /":"_"} subtotal">{$data[$proj][$subcat]|default:"0"}</td>
+          {/if}
+        {/foreach}
+      {/foreach}
+      {* Totals for grand total *}
+      {foreach key=sub item=subcat from=$Subcategories}
+        {if $subcat@index eq 0}
+          {assign var="Numerator" value=$data[$Subcategories.0]}
+          {assign var="totaltotal" value=$data.total}
+          {if $totaltotal > 0 and $Numerator > 0}
+            {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totaltotal format="%.0f"}}
+          {else}
+            {assign var="percent" value='0'}
+          {/if}
+          <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"} ({$percent}%)</td>
+        {else}
+          <td class="{$subcat|lower|regex_replace:"/ /":"_"} total subtotal">{$data[$subcat]|default:"0"}</td>
+        {/if}
+      {/foreach}
+    </tr>
     </tbody>
-</table>
+  </table>
+{else}
+  <br><br>
+  <h2>Oops</h2>
+  <p> It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database.<br>
+    In order to display the statistics for the scan type, make sure the mri_parameter_form table contains a column in the exact format SCANTYPE_Scan_done</p>
+{/if}

--- a/modules/user_accounts/templates/form_my_preferences.tpl
+++ b/modules/user_accounts/templates/form_my_preferences.tpl
@@ -93,7 +93,7 @@
             <input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit" />
         </div>
         <div class="col-sm-2">
-            <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" onClick="this.form.reset()" />
+            <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" />
         </div>
     </div>
 

--- a/modules/user_accounts/templates/form_my_preferences.tpl
+++ b/modules/user_accounts/templates/form_my_preferences.tpl
@@ -93,7 +93,7 @@
             <input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit" />
         </div>
         <div class="col-sm-2">
-            <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" />
+            <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" onClick="this.form.reset()" />
         </div>
     </div>
 


### PR DESCRIPTION
### Brief summary of changes
The imaging tab of statistics depends on the scan types defined in the `mri_scan_type` table. each scan type is crossmatched with a column in the `mri_parameter_form` table. if that column does not exist the SQL query is now bypassed and an error message is displayed stating that the column does not exist

> to review use the hide white spaces changes option

### This resolves issue...

- [ ] Github? #4545

### To test this change...

- [ ] make sure the imaging tab of statistics loads even if the mri_parameter_form does not have all the necessary columns
