### PR TITLE
[instrument_list] remove notices when no instruments are loaded in battery

### DIFF
--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -377,7 +377,8 @@ class Instrument_List_ControlPanel extends \TimePoint
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 
         // loop the list and check the Data Entry status
-        $ddeConflictDetected =false;
+        $ddeConflictDetected = false;
+        $dataEntry           = '';
         foreach ($batteryList as $instrument) {
             $status = new \NDB_BVL_InstrumentStatus();
             $status->select($instrument['CommentID']);


### PR DESCRIPTION
### Brief summary of changes

This notice shows when the instrument list has no instruments

```
[Wed May 22 16:24:36.707496 2019] [php7:notice] [pid 21890] [client 132.216.56.93:54728] PHP Notice:  Undefined variable: dataEntry in /var/www/loris/modules/instrument_list/php/instrument_list_controlpanel.class.inc on line 439
[Wed May 22 16:24:36.707825 2019] [php7:notice] [pid 21890] [client 132.216.56.93:54728] PHP Notice:  Undefined variable: dataEntry in /var/www/loris/modules/instrument_list/php/instrument_list_controlpanel.class.inc on line 444
[Wed May 22 16:24:36.708003 2019] [php7:notice] [pid 21890] [client 132.216.56.93:54728] PHP Notice:  Undefined variable: dataEntry in /var/www/loris/modules/instrument_list/php/instrument_list_controlpanel.class.inc on line 444

```

### To test this change...

- [ ] find a candidate with a timepoint with no populated instruments (ie Raisinbread DCC211)
- [ ] check your error log for notices similar to the ones in the description