### PR TITLE
[Instruments] Remove notice for undefined property: preview

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -157,7 +157,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * True if the page is being previewed from the instrument builder,
      * and not really loaded. only applies to LINST instrument.
      */
-    var $preview = false;
+    public $preview = false;
 
     /**
      * Factory generates a new instrument instance of type

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -154,6 +154,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     var $WrapperDateWithStatusElements = array();
 
     /**
+     * True if the page is being previewed from the instrument builder,
+     * and not really loaded. only applies to LINST instrument.
+     */
+    var $preview = false;
+
+    /**
      * Factory generates a new instrument instance of type
      * $instrument, and runs the setup() method on that new
      * instrument.

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -37,12 +37,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
     var $LinstLines = array();
 
     /**
-     * True if the page is being previewed from the instrument builder,
-     * and not really loaded.
-     */
-    var $preview = false;
-
-    /**
      * Sets up the variables required for a LINST instrument to load
      *
      * @param string|null $commentID The CommentID being loaded


### PR DESCRIPTION
### Brief summary of changes
The `preview` variable was defined in the instrument LINST class. it is being referred to from the `NDB_Caller` class however so notices are being sent out every time a non-LINST instrument is loaded

```
[Wed May 22 14:15:16.875450 2019] [php7:notice] [pid 21882] [client 132.216.56.93:53922] PHP Notice:  Undefined property: NDB_BVL_Instrument_mri_parameter_form::$preview in /var/www/loris/php/libraries/NDB_Caller.class.inc on line 453, referer: https://abou-haider-dev.loris.ca/instrument_list/?candID=587630&sessionID=1053
```

### To test this change...

- [ ] check your error log when opening an instrument before and after this PR