### PR TITLE
[jsx/DataTable.js] fix toggle sort order

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -42,7 +42,7 @@ class DataTable extends Component {
 
   setSortColumn(column) {
     if (this.state.sort.column === column) {
-      this.props.toggleSortOrder();
+      this.toggleSortOrder();
     } else {
       this.updateSortColumn(column);
     }


### PR DESCRIPTION
### Brief summary of changes

Fixes an issue with being unable to toggle sort again, after clicking one of the column headers of the DataTable.

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4687

### To test this change...

- [x] Checkout PR, go to a module making use of the FilteredDataTable and attempt clicking on one of the column headers. Example Issue_tracker. 
