### PR TITLE
[media] Correct explainer text in the Upload tab

### DIFF
--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -78,7 +78,7 @@ class MediaUploadForm extends Component {
         File name must begin with <b>[PSCID]_[Visit Label]_[Instrument]</b><br/>
         For example, for candidate <i>ABC123</i>, visit <i>V1</i> for
         <i>Body Mass Index</i> the file name should be prefixed by:
-        <b> ABC123_V1_Body_Mass_Index</b><br/>
+        <b> ABC123_V1_bmi</b><br/>
         File cannot exceed {this.props.maxUploadSize}
       </span>
     );

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-core": "^6.26.3",
+    "npm": "^6.9.0",
     "prop-types": "^15.6.2",
     "sweetalert2": "^7.29.2"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "babel-core": "^6.26.3",
-    "npm": "^6.9.0",
     "prop-types": "^15.6.2",
     "sweetalert2": "^7.29.2"
   },


### PR DESCRIPTION
change the example text to meet expectation of the code


### This resolves issue...
https://github.com/aces/Loris/issues/4571 

### To test this change...
go to media and upload a file for instrument Body Mass Index (BMI)
