### PR TITLE
[login] check for X-FORWARDED-FOR before REMOTE_ADDR

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -239,7 +239,8 @@ class SinglePointLogin
                      'Failcode'        => null,
                      'Login_timestamp' => date('Y-m-d H:i:s'),
                      'IP_address'      => $_SERVER['HTTP_X_FORWARDED_FOR']
-                         ?? $_SERVER['REMOTE_ADDR'],
+                         ?? $_SERVER['REMOTE_ADDR']
+                         ?? 'Unknown',
                      'Page_requested'  => isset($_SERVER['REQUEST_URI'])
                                               ? $_SERVER['REQUEST_URI']
                                               : 'Unknown',

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -238,9 +238,8 @@ class SinglePointLogin
                      'Success'         => 'Y',
                      'Failcode'        => null,
                      'Login_timestamp' => date('Y-m-d H:i:s'),
-                     'IP_address'      => isset($_SERVER['REMOTE_ADDR'])
-                                              ? $_SERVER['REMOTE_ADDR']
-                                              : 'Unknown',
+                     'IP_address'      => $_SERVER['HTTP_X_FORWARDED_FOR']
+                         ?? $_SERVER['REMOTE_ADDR'],
                      'Page_requested'  => isset($_SERVER['REQUEST_URI'])
                                               ? $_SERVER['REQUEST_URI']
                                               : 'Unknown',


### PR DESCRIPTION
### Brief summary of changes
the `user_login_history` table of the database has been logging the IP address of the proxy instead of the real IP of the user. to prevent that, we are checking for an IP address set in the `X-FORWARDED-FOR` variable and only if that is NULL we are fetching the `REMOTE_ADDR` and setting it.