### PR TITLE
[new_profile] Fix 6 digit years & month functionality

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -976,6 +976,27 @@ class DateElement extends Component {
     this.handleChange = this.handleChange.bind(this);
   }
 
+  componentDidMount() {
+    if (!Modernizr.inputtypes.month) {
+      let monthInputs = $('input[type=month]');
+      monthInputs.datepicker({
+        dateFormat: 'yy-mm',
+        changeMonth: true,
+        changeYear: true,
+        yearRange: '1900:' + new Date().getFullYear(),
+        constrainInput: true,
+        onChangeMonthYear: (y, m, d) => {
+          // Update date in the input field
+          $(this).datepicker('setDate', new Date(y, m - 1, d.selectedDay));
+        },
+      });
+      monthInputs.attr('placeholder', 'yyyy-mm');
+      monthInputs.on('keydown paste', (e) => {
+        e.preventDefault();
+      });
+    }
+  }
+
   handleChange(e) {
     this.props.onUserInput(this.props.name, e.target.value, e.target.id, 'date');
   }
@@ -990,6 +1011,17 @@ class DateElement extends Component {
       requiredHTML = <span className="text-danger">*</span>;
     }
 
+    // Handle date format
+    let format = this.props.dateFormat;
+    let inputType = 'date';
+    let minFullDate = this.props.minYear + '-01-01';
+    let maxFullDate = this.props.maxYear + '-12-31';
+    if (!format.match(/d/i)) {
+      inputType = 'month';
+      minFullDate = this.props.minYear + '-01';
+      maxFullDate = this.props.maxYear + '-12';
+    }
+
     return (
       <div className="row form-group">
         <label className="col-sm-3 control-label" htmlFor={this.props.label}>
@@ -998,12 +1030,12 @@ class DateElement extends Component {
         </label>
         <div className="col-sm-9">
           <input
-            type="date"
+            type={inputType}
             className="form-control"
             name={this.props.name}
             id={this.props.id}
-            min={this.props.minYear}
-            max={this.props.maxYear}
+            min={minFullDate}
+            max={maxFullDate}
             onChange={this.handleChange}
             value={this.props.value || ''}
             required={required}
@@ -1022,6 +1054,7 @@ DateElement.propTypes = {
   id: PropTypes.string,
   maxYear: PropTypes.string,
   minYear: PropTypes.string,
+  dateFormat: PropTypes.string,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
   onUserInput: PropTypes.func,
@@ -1032,8 +1065,9 @@ DateElement.defaultProps = {
   label: '',
   value: '',
   id: null,
-  maxYear: '9999-12-31',
-  minYear: '1000-01-01',
+  maxYear: '9999',
+  minYear: '1000',
+  dateFormat: 'YMd',
   disabled: false,
   required: false,
   onUserInput: function() {

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1011,15 +1011,25 @@ class DateElement extends Component {
       requiredHTML = <span className="text-danger">*</span>;
     }
 
+    // Check if props minYear and maxYear are valid values if supplied
+    let minYear = this.props.minYear;
+    let maxYear = this.props.maxYear;
+    if (this.props.minYear === '' || this.props.minYear === null) {
+      minYear = '1000';
+    }
+    if (this.props.maxYear === '' || this.props.maxYear === null) {
+      maxYear = '9999';
+    }
+
     // Handle date format
     let format = this.props.dateFormat;
     let inputType = 'date';
-    let minFullDate = this.props.minYear + '-01-01';
-    let maxFullDate = this.props.maxYear + '-12-31';
+    let minFullDate = minYear + '-01-01';
+    let maxFullDate = maxYear + '-12-31';
     if (!format.match(/d/i)) {
       inputType = 'month';
-      minFullDate = this.props.minYear + '-01';
-      maxFullDate = this.props.maxYear + '-12';
+      minFullDate = minYear + '-01';
+      maxFullDate = maxYear + '-12';
     }
 
     return (

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -978,16 +978,28 @@ class DateElement extends Component {
 
   componentDidMount() {
     if (!Modernizr.inputtypes.month) {
-      let monthInputs = $('input[type=month]');
+      // Check if props minYear and maxYear are valid values if supplied
+      let minYear = this.props.minYear;
+      let maxYear = this.props.maxYear;
+      if (this.props.minYear === '' || this.props.minYear === null) {
+        minYear = '1000';
+      }
+      if (this.props.maxYear === '' || this.props.maxYear === null) {
+        maxYear = '9999';
+      }
+      let monthInputs = $('input[name=' + this.props.name+']');
       monthInputs.datepicker({
         dateFormat: 'yy-mm',
         changeMonth: true,
         changeYear: true,
-        yearRange: '1900:' + new Date().getFullYear(),
+        yearRange: minYear + ':' + maxYear,
         constrainInput: true,
         onChangeMonthYear: (y, m, d) => {
           // Update date in the input field
           $(this).datepicker('setDate', new Date(y, m - 1, d.selectedDay));
+        },
+        onSelect: (dateText, picker) => {
+          this.props.onUserInput(this.props.name, dateText);
         },
       });
       monthInputs.attr('placeholder', 'yyyy-mm');

--- a/modules/new_profile/jsx/NewProfileIndex.js
+++ b/modules/new_profile/jsx/NewProfileIndex.js
@@ -142,6 +142,8 @@ class NewProfileIndex extends React.Component {
     let site = null;
     let minYear = this.state.configData.minYear;
     let maxYear = this.state.configData.maxYear;
+    let dateFormat = this.state.configData.dobFormat;
+
     if (this.state.configData['edc'] === 'true') {
       edc =
         <div>
@@ -150,6 +152,7 @@ class NewProfileIndex extends React.Component {
             label = "Expected Date of Confinement"
             minYear = {minYear}
             maxYear = {maxYear}
+            dateFormat = {dateFormat}
             onUserInput = {this.setFormData}
             value = {this.state.formData.edcDate}
             required = {true}
@@ -159,6 +162,7 @@ class NewProfileIndex extends React.Component {
             label = "Confirm EDC"
             minYear = {minYear}
             maxYear = {maxYear}
+            dateFormat = {dateFormat}
             onUserInput = {this.setFormData}
             value = {this.state.formData.edcDateConfirm}
             required = {true}
@@ -197,6 +201,7 @@ class NewProfileIndex extends React.Component {
             label = "Date of Birth"
             minYear = {minYear}
             maxYear = {maxYear}
+            dateFormat = {dateFormat}
             onUserInput = {this.setFormData}
             value = {this.state.formData.dobDate}
             required = {true}
@@ -206,6 +211,7 @@ class NewProfileIndex extends React.Component {
             label = "Date of Birth Confirm"
             minYear = {minYear}
             maxYear = {maxYear}
+            dateFormat = {dateFormat}
             onUserInput = {this.setFormData}
             value = {this.state.formData.dobDateConfirm}
             required = {true}

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -162,8 +162,8 @@ class New_Profile extends \NDB_Form
                       'female' => 'Female',
                      );
         $pscidSet  = "false";
-        $minYear   = $startYear - $ageMax;
-        $maxYear   = $endYear - $ageMin;
+        $minYear   = (isset($startYear, $ageMax)) ? $startYear - $ageMax : null;
+        $maxYear   = (isset($endYear, $ageMin)) ? $endYear - $ageMin : null;
 
         // Get sites for the select dropdown
         $user_list_of_sites = $user->getData('CenterIDs');
@@ -257,7 +257,9 @@ class New_Profile extends \NDB_Form
         if (strtolower($dobFormat) == 'ym' || strtolower($dobFormat) == 'my') {
             // Dates still need to be submitted into the database in format
             // YYYY-DD-MM. This is a last check before _process is called.
-            if ($config->getSetting('useEDC') == "true" && strlen($values['edcDate']) < 10) {
+            if ($config->getSetting('useEDC') == "true"
+                && strlen($values['edcDate']) < 10
+            ) {
                 $errors['edcFormat'] = 'EDC is not in valid date format.';
             }
             if (strlen($values['dobDate']) < 10) {

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -257,7 +257,7 @@ class New_Profile extends \NDB_Form
         if (strtolower($dobFormat) == 'ym' || strtolower($dobFormat) == 'my') {
             // Dates still need to be submitted into the database in format
             // YYYY-DD-MM. This is a last check before _process is called.
-            if (strlen($values['dobDate']) < 10 || strlen($values['edcDate'] < 10)) {
+            if (strlen($values['dobDate']) < 10 || strlen($values['edcDate']) < 10) {
                 $errors['dobFormat'] = 'Dates have an invalid date format.';
             }
         }

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -226,10 +226,10 @@ class New_Profile extends \NDB_Form
 
         // Validate DOB fields
         if (empty($values['dobDate'])) {
-            $errors['dobDate'] = 'Date of Birth field is required';
+            $errors['dobDate'] = 'Date of Birth field is required.';
         }
         if (empty($values['dobDateConfirm'])) {
-            $errors['dobDateConfirm'] = 'Confirm Date of Birth field is required';
+            $errors['dobDateConfirm'] = 'Confirm Date of Birth field is required.';
         }
         if ($values['dobDate'] != $values['dobDateConfirm']) {
             $errors['dobDate'] = 'Date of Birth fields must match.';
@@ -239,16 +239,26 @@ class New_Profile extends \NDB_Form
         if ($config->getSetting('useEDC') == "true") {
             if (empty($values['edcDate'])) {
                 $errors['edcDate'] = 'Expected Date of Confinement field is
-                                      required';
+                                      required.';
             }
 
             if (empty($values['edcDateConfirm'])) {
-                $errors['edcDateConfirm'] = 'Confirm EDC field is required';
+                $errors['edcDateConfirm'] = 'Confirm EDC field is required.';
             }
 
             if ($values['edcDate'] != $values['edcDateConfirm']) {
                 $errors['edDate'] = 'Expected Date of Confinement fields must
                                      match.';
+            }
+        }
+
+        // Validate date format
+        $dobFormat = $config->getSetting('dobFormat')
+        if (strtolower($dobFormat) == 'ym' || strtolower($dobFormat) == 'my') {
+            // Dates still need to be submitted into the database in format YYYY-DD-MM
+            // This is a last check before _process is called
+            if (strlen($values['dobDate']) < 10 || strlen($values['edcDate'] < 10) {
+                $errors['dobFormat'] = 'Dates have an invalid date format.';
             }
         }
 

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -257,8 +257,12 @@ class New_Profile extends \NDB_Form
         if (strtolower($dobFormat) == 'ym' || strtolower($dobFormat) == 'my') {
             // Dates still need to be submitted into the database in format
             // YYYY-DD-MM. This is a last check before _process is called.
-            if (strlen($values['dobDate']) < 10 || strlen($values['edcDate']) < 10) {
-                $errors['dobFormat'] = 'Dates have an invalid date format.';
+            if ($config->getSetting('useEDC') == "true" && strlen($values['edcDate']) < 10) {
+                $errors['edcFormat'] = 'EDC is not in valid date format.';
+
+            }
+            if (strlen($values['dobDate']) < 10) {
+                $errors['dobFormat'] = 'DOB is not in valid date format.';
             }
         }
 

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -253,11 +253,11 @@ class New_Profile extends \NDB_Form
         }
 
         // Validate date format
-        $dobFormat = $config->getSetting('dobFormat')
+        $dobFormat = $config->getSetting('dobFormat');
         if (strtolower($dobFormat) == 'ym' || strtolower($dobFormat) == 'my') {
-            // Dates still need to be submitted into the database in format YYYY-DD-MM
-            // This is a last check before _process is called
-            if (strlen($values['dobDate']) < 10 || strlen($values['edcDate'] < 10) {
+            // Dates still need to be submitted into the database in format
+            // YYYY-DD-MM. This is a last check before _process is called.
+            if (strlen($values['dobDate']) < 10 || strlen($values['edcDate'] < 10)) {
                 $errors['dobFormat'] = 'Dates have an invalid date format.';
             }
         }

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -259,7 +259,6 @@ class New_Profile extends \NDB_Form
             // YYYY-DD-MM. This is a last check before _process is called.
             if ($config->getSetting('useEDC') == "true" && strlen($values['edcDate']) < 10) {
                 $errors['edcFormat'] = 'EDC is not in valid date format.';
-
             }
             if (strlen($values['dobDate']) < 10) {
                 $errors['dobFormat'] = 'DOB is not in valid date format.';

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2070,7 +2070,14 @@ class LorisForm
                     null :
                     $this->form[$tp['groupName']]['elements'][$tp['index']];
                 if (!$el) {
-                    $arr[$key] = $_REQUEST[$key];
+                    $value = $_REQUEST[$key];
+                    // If the value is coming from a React DateElement with input type='month'
+                    // and is missing the dd part, convert month-year format to a valid
+                    // SQL format (i.e. yyyy-mm-dd)
+                    if (strlen($value) === 7 && strpos(strtolower($key), 'date')) {
+                        $value = sprintf("%s-01", $value);
+                    }
+                    $arr[$key] = $value;
                     continue;
                 }
             } else {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2071,9 +2071,9 @@ class LorisForm
                     $this->form[$tp['groupName']]['elements'][$tp['index']];
                 if (!$el) {
                     $value = $_REQUEST[$key];
-                    // If the value is coming from a React DateElement with input type='month'
-                    // and is missing the dd part, convert month-year format to a valid
-                    // SQL format (i.e. yyyy-mm-dd)
+                    // If the value is coming from a React DateElement with input
+                    // type='month' and is missing the dd part, convert month-year
+                    // format to a valid SQL format (i.e. yyyy-mm-dd)
                     if (strlen($value) === 7 && strpos(strtolower($key), 'date')) {
                         $value = sprintf("%s-01", $value);
                     }


### PR DESCRIPTION
fixes https://github.com/aces/Loris/issues/4728 and https://github.com/aces/Loris/issues/4564

to test:
- [ ] on test.loris.ca or 21.0-release branch, type in the year by keyboard into any date element. you will be able to enter a 6 digit year
- [ ] on this branch, you can only enter 4 digits on Chrome. The max attribute is broken on Firefox
- [ ] repeat the above with dob format in Configurations set to 'Ym' or 'YM'

caveat: Firefox allows 5/6 digit years because the "max" attribute breaks on that browser