### PR TITLE
[User account] Fixes user name containing a space

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -80,7 +80,7 @@ class Edit_User extends \NDB_Form
         $defaults = array();
 
         if (!$this->isCreatingNewUser()) {
-            $user = \User::factory($this->identifier);
+            $user = \User::factory(urldecode($this->identifier));
             // get the user defaults
             $defaults = $user->getData();
             // remove the password hash


### PR DESCRIPTION
### Brief summary of changes

Solves the 500 error for username with spaces.

### This resolves issue...

- [ ] Redmine? #

- [x] Github? #4742

### To test this change...

- [x] Make user containing a space and see issue details for more information. 
