### PR TITLE
[Imaging Browser] Fix TypeError breaking QC Comments

### DIFF
--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -145,7 +145,7 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
         $PredefinedTpl['predefined_text'] = $predefined_comment_text['Comment'];
 
         // print the comment text
-        $Saved = $saved_comments[$comment_type_id];
+        $Saved = $saved_comments[$comment_type_id] ?? '';
         if ($Saved['predefined'][$predefined_comment_id]) {
             $CommentTpl['predefined'][$j]['checked'] = true;
         }
@@ -154,7 +154,7 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
 
     // print a form element for a free-form comment
     $CommentTpl['type']       = $comment_type_id;
-    $CommentTpl['saved_text'] = $saved_comments[$comment_type_id]['text'];
+    $CommentTpl['saved_text'] = $saved_comments[$comment_type_id]['text'] ?? '';
     $i++;
 }
 

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -76,13 +76,13 @@ class FeedbackMRI
      * Sets (or adds) predefined comments to an object - does NOT clear
      * predefined comments internally
      *
-     * @param array $predefinedCommentIDs an array of integers which are
+     * @param ?array $predefinedCommentIDs an array of integers which are
      *                                    PredefinedCommentID from
      *                                    feedback_mri_predefined_comments table
      *
      * @return bool true if operation succeeded
      */
-    function setPredefinedComments(array $predefinedCommentIDs): bool
+    function setPredefinedComments(?array $predefinedCommentIDs): bool
     {
         // choke if we are passed an empty array
         if (empty($predefinedCommentIDs)) {
@@ -128,13 +128,13 @@ class FeedbackMRI
     /**
      * Gets the comments stored for the object
      *
-     * @return array tree: $cA[$typeID]['predefined'] is an array with integer
+     * @return ?array tree: $cA[$typeID]['predefined'] is an array with integer
      *               keys (PredefinedCommentID) and boolean values (true) and
      *               $cA[$typeID]['text'] is an array of strings (free-form
      *               comments) where $typeID is always the CommentTypeID from
      *               feedback_mri_comment_types table
      */
-    function getComments(): array
+    function getComments(): ?array
     {
         // create DB object
         $DB =& Database::singleton();


### PR DESCRIPTION
### Brief summary of changes

The PR fixes a TypeError occurring in the FeedbackMRI class. This was causing a 500 error in the imaging browser that prevented a user from being able to see or modify QC comments for images.

### This resolves issue...

- [ ] Github? #4722 

### To test this change...

* Instructions to reproduce are in linked issue. Should be fixed on this branch (you should be able to view and save QC comments)
