### PR TITLE
[core] 2019 06 03 fix id generation

### DIFF
--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -86,7 +86,7 @@ abstract class IdentifierGenerator
         if (count($this->getExistingIDs()) < 1) {
             return str_pad(
                 strval($this->minValue),
-                $this->length,
+                is_null($this->length) ? 4 : $this->length,
                 "0",
                 STR_PAD_LEFT
             );

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -84,7 +84,7 @@ abstract class IdentifierGenerator
     {
         // If this is the first ID ever created, return the minimum value.
         if (count($this->getExistingIDs()) < 1) {
-            return $this->minValue;
+            return str_pad(strval($this->minValue), $this->length, "0", STR_PAD_LEFT);
         }
         // Create the new ID by incrementing the value of the $id parameter OR
         // by incrementing the highest existing ID.

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -84,7 +84,12 @@ abstract class IdentifierGenerator
     {
         // If this is the first ID ever created, return the minimum value.
         if (count($this->getExistingIDs()) < 1) {
-            return str_pad(strval($this->minValue), $this->length, "0", STR_PAD_LEFT);
+            return str_pad(
+                strval($this->minValue),
+                $this->length,
+                "0",
+                STR_PAD_LEFT
+            );
         }
         // Create the new ID by incrementing the value of the $id parameter OR
         // by incrementing the highest existing ID.

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -84,7 +84,7 @@ abstract class IdentifierGenerator
     {
         // If this is the first ID ever created, return the minimum value.
         if (count($this->getExistingIDs()) < 1) {
-            if (!is_int($this-length)) {
+            if (!is_int($this->length)) {
                 throw new Exception(
                     "minimum ID length not configured in project/config.xml"
                 );

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -84,9 +84,14 @@ abstract class IdentifierGenerator
     {
         // If this is the first ID ever created, return the minimum value.
         if (count($this->getExistingIDs()) < 1) {
+            if (!is_int($this-length)) {
+                throw new Exception(
+                    "minimum ID length not configured in project/config.xml"
+                );
+            }
             return str_pad(
                 strval($this->minValue),
-                is_null($this->length) ? 4 : $this->length,
+                $this->length,
                 "0",
                 STR_PAD_LEFT
             );


### PR DESCRIPTION
### Brief summary of changes
fix creation of first ID in sequential mode with min value. 


### This resolves issue...
Currently create a php fatal error

### To test this change...
- create a new test site
- set PSCID generation to sequential with min value `"min"=1`
- create a first candidate for this site PSCID should be `<sitealias>0001` if `"minLength"=4` as been set.

