### PR TITLE
[Login page] Fix notice about undefined index REDIRECT_URL

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -140,7 +140,10 @@ class NDB_Client
         }
 
         // API Detect
-        if (strpos($_SERVER['REDIRECT_URL'], '/api/v0.0.3-dev/') !== false) {
+        if (strpos(
+            $_SERVER['REDIRECT_URL'] ?? $_SERVER['REQUEST_URI'] ?? '',
+            '/api/v0.0.3-dev/') !== false
+        ) {
             session_cache_limiter('private');
         }
 

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -142,7 +142,8 @@ class NDB_Client
         // API Detect
         if (strpos(
             $_SERVER['REDIRECT_URL'] ?? $_SERVER['REQUEST_URI'] ?? '',
-            '/api/v0.0.3-dev/') !== false
+            '/api/v0.0.3-dev/'
+        ) !== false
         ) {
             session_cache_limiter('private');
         }


### PR DESCRIPTION
Fix warning printing on login page about 'Undefined index REDIRECT_URL'
when run under the built in PHP web server. REDIRECT_URL is only available
under apache.