### PR TITLE
[Router] Fix ajax scripts with built in PHP web server

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -17,7 +17,6 @@
  *  @link     https://github.com/aces/Loris-Trunk
  */
 
-
 // This error log should be uncommented once a reasonable number of
 // modules have been updated to give some urgency to people who are
 // still using ajax/ directories. For now, it would generate too much

--- a/htdocs/router.php
+++ b/htdocs/router.php
@@ -12,7 +12,7 @@
  */
 
 
-$url     = ltrim($_SERVER['REQUEST_URI'], "/");
+$url     = ltrim($_SERVER['PHP_SELF'], "/");
 $request = $_SERVER['REQUEST_URI'];
 
 if ($request != '/'

--- a/htdocs/router.php
+++ b/htdocs/router.php
@@ -12,7 +12,9 @@
  */
 
 
-$url     = ltrim($_SERVER['PHP_SELF'], "/");
+$url     = ltrim($_SERVER['REQUEST_URI'], "/");
+$urlpath = ltrim($_SERVER['PHP_SELF'], "/");
+
 $request = $_SERVER['REQUEST_URI'];
 
 if ($request != '/'
@@ -26,7 +28,7 @@ if ($request != '/'
 }
 if (preg_match(
     '#^([a-zA-Z_-]+)/ajax/([a-zA-Z0-9_.-/]+)$#',
-    $url
+    $urlpath
 )
 ) {
     // RewriteRule
@@ -34,7 +36,7 @@ if (preg_match(
     //      /AjaxHelper.php?Module=$1&script=$2 [QSA]
     // NOT SURE IF THIS WORKS IF FILE IS NOT SPECIFIED
 
-    $getParams = explode("/", $url);
+    $getParams = explode("/", $urlpath);
 
     $_GET["Module"] = $getParams[0];
     $_GET['script'] = $getParams[2];

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -26,7 +26,6 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris-Trunk
  */
-
 require_once "Email.class.inc";
 
 //TODO: or split it into two files... :P

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -140,7 +140,11 @@ class NDB_Client
         }
 
         // API Detect
-        if (strpos($_SERVER['REDIRECT_URL'], '/api/v0.0.3-dev/') !== false) {
+        if (strpos(
+            $_SERVER['REDIRECT_URL'] ?? $_SERVER['REQUEST_URI'] ?? '',
+            '/api/v0.0.3-dev/'
+        ) !== false
+        ) {
             session_cache_limiter('private');
         }
 


### PR DESCRIPTION
When running under "php -S", the router does not correctly
match paths that have query params, because the $_SERVER['REQUEST_URI']
includes the "?foo=bar" part of the URI, which causes the
regex matching to fail.

This updates the code to use $_SERVER['PHP_SELF'], which
only contains the path portion of the URL. (However, since
the regex is only used for routing, the host is irrelevant
at this point.)

To test this change load a URL which contains query parameters
(in particular, any ajax call) using the built in PHP web serer.