### PR TITLE
[Issue Tracker] Fix incorrect links to individual issues

### DIFF
--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -56,7 +56,7 @@ class IssueTrackerIndex extends Component {
     case 'Title':
       link = (
         <a
-          href={loris.BaseURL+'/issue_tracker/issue/?issueID='+row['Issue ID']}
+          href={loris.BaseURL+'/issue_tracker/issue/'+row['Issue ID']}
         >
           {row.Title}
         </a>
@@ -66,7 +66,7 @@ class IssueTrackerIndex extends Component {
     case 'Issue ID':
       link = (
         <a
-          href={loris.BaseURL+'/issue_tracker/issue/?issueID='+row['Issue ID']}
+          href={loris.BaseURL+'/issue_tracker/issue/'+row['Issue ID']}
         >
           {cell}
         </a>

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -131,7 +131,9 @@ class Issue extends \NDB_Form
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $this->issueID = $request->getQueryParams()['issueID'];
+        $results = [];
+        preg_match('#/issue/([0-9]+)$#', $request->getURI()->getPath(), $results);
+        $this->issueID = $results[1] ?? null;
         if (empty($this->issueID)) {
             // Should probably be a bad request, but we don't have a 400.tpl
             // template.


### PR DESCRIPTION
There was a regression introduced in #4112 where the issue tracker
links reverted to getting the ID from a query parameter instead
of the URL. This was done inconsistently, and as a result some
places loaded URLs such as "...&issueID=?issueID=1". This fixes
the links to parse the ID from the URL, so that issues can now
be loaded with the php development web server.