### PR TITLE
[Data Provisioner] Throw more explicit exception when CenterID is null

### DIFF
--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -56,9 +56,13 @@ class UserSiteMatch implements \LORIS\Data\Filter
             if (!is_null($resourceSite)) {
                 return $user->hasCenter($resourceSite);
             }
+            // We don't know if the resource thought a null CenterID
+            // should mean "no one can access it" or "anyone can access
+            // it", so throw an exception.
+            throw new \LorisException("getCenterID on resource returned null");
         }
         throw new \LorisException(
-            "Can not implement SiteMatchFilter on a resource type that has no sites."
+            "Can not implement UserSiteMatch on a resource type that has no sites."
         );
     }
 }


### PR DESCRIPTION
When a CenterID is null, the code falls through to the exception, but
the error message is misleading. The resource had a getCenterID, it
just returned null. Add a more explicit error message.
