### PR TITLE
[Configuration] remove `use projects` details and project-subproject relation check from the test plan

### DIFF
--- a/modules/configuration/test/TestPlan.md
+++ b/modules/configuration/test/TestPlan.md
@@ -31,8 +31,8 @@
 
 ## Project
 
-1. Click on the project link at the top of the page and confirm that it brings you to project configuration page.[Manual Test]
+1. Click on the project link at the top of the page and confirm that it brings you to the project configuration page.[Manual Test]
 2. Click the 'New ProjectID' in the left column navigation. Try to add a new project.[Manual Test]
 3. Test editing a currently existing project. Test resetting the form as well with the reset button.[Manual Test]
 4. Test the breadcrumb to see if you can navigate back to the main config page.[Automation Test]
-5. Go back to the project configuration page and click on the subproject link and confirm that it bring you to the subproject configuration page.[Manual Test]
+5. Go back to the project configuration page and click on the subproject link and confirm that it brings you to the subproject configuration page.[Manual Test]

--- a/modules/configuration/test/TestPlan.md
+++ b/modules/configuration/test/TestPlan.md
@@ -31,11 +31,8 @@
 
 ## Project
 
-1. Set 'Use projects' to 'Yes' in the config module. Refresh the page. Click on the project link at the top of the page and confirm that it brings you to project configuration page.[Manual Test]
+1. Click on the project link at the top of the page and confirm that it brings you to project configuration page.[Manual Test]
 2. Click the 'New ProjectID' in the left column navigation. Try to add a new project.[Manual Test]
 3. Test editing a currently existing project. Test resetting the form as well with the reset button.[Manual Test]
-4. Confirm that the related subprojects are correct. This information comes from the project_rel table in the database.[Manual Test]
-5. Test the breadcrumb to see if you can navigate back to the main config page.[Automation Test]
-6. Set 'Use projects' to 'No' in the config module. Ensure that the link to the project configuration page no longer appears.
-   [Automation Test on Travis CI]
-
+4. Test the breadcrumb to see if you can navigate back to the main config page.[Automation Test]
+5. Go back to the project configuration page and click on the subproject link and confirm that it bring you to the subproject configuration page.[Manual Test]


### PR DESCRIPTION
### Brief summary of changes

correct the test plan for latest update in the config page (use projects yes/no button) and 
removed the project-subproject relation check

### This resolves issue...
-  https://github.com/aces/Loris/issues/4771 
- https://github.com/aces/Loris/issues/4772

### To test this change...

open the TestPlan for the configuration module and check  section `Project`
