### PR TITLE
[API v0.0.2] Fix API candidate level instrument endpoint

### DIFF
--- a/htdocs/api/v0.0.2/candidates/InstrumentData.php
+++ b/htdocs/api/v0.0.2/candidates/InstrumentData.php
@@ -95,7 +95,7 @@ class InstrumentData extends \Loris\API\Candidates\Candidate\Instruments
             $this->Instrument = \NDB_BVL_Instrument::factory(
                 $Instrument,
                 $CommentID,
-                null,
+                '',
                 true
             );
         } catch(\Exception $e) {


### PR DESCRIPTION
### Brief summary of changes

Instrument endpoint on the candidate level (https://test.loris.ca/api/v0.0.2/candidates/475906/V3/instruments/bmi) returned a 500 error. This PR fixes the issue.

Note: this error was found only on v0.0.2 (v0.0.3-dev worked fine)

### This resolves issue...

No issues reported as the bug was fixed in this PR directly

### To test this change...

- [ ] 
