### PR TITLE
[API v0.0.2] fix the image QC endpoint

### DIFF
--- a/htdocs/api/v0.0.2/.htaccess
+++ b/htdocs/api/v0.0.2/.htaccess
@@ -27,7 +27,7 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/instruments/([a-zA-Z0-9_.]+)/d
 ## Imaging API related URLs
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images$ candidates/visits/Images.php?CandID=$1&VisitLabel=$2&PrintImages=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/qc/imaging$ candidates/visits/qc/Imaging.php?CandID=$1&VisitLabel=$2&PrintQC=true [L]
-RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/qc$ candidates/visits/images/qc/Qc.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageQC=true [L]
+RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/qc$ candidates/visits/images/qc/QC.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageQC=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/format/raw$ candidates/visits/images/format/Raw.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintRawFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/format/thumbnail$ candidates/visits/images/format/Thumbnail.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintThumbnailFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)$ candidates/visits/images/Image.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageData=true [L]


### PR DESCRIPTION
### Brief summary of changes

The link to `QC.php` script was incorrect in `htdocs/api/.htaccess` which resulted in the following error:
Not Found
The requested URL /api/v0.0.2/candidates/visits/images/qc/Qc.php was not found on this server.

Example: https://test.loris.ca/api/v0.0.2/candidates/475906/V3/images/demo_475906_V3_t2_001.mnc/qc

Note: bug only present in v0.0.2 (v0.0.3-dev was working fine)

### This resolves issue...

No tickets created as the bug was fixed when found.

### To test this change...

