### PR TITLE
[API] Fix the image brainbrowser endpoint of the API

### DIFF
--- a/htdocs/api/v0.0.2/.htaccess
+++ b/htdocs/api/v0.0.2/.htaccess
@@ -28,6 +28,7 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/instruments/([a-zA-Z0-9_.]+)/d
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images$ candidates/visits/Images.php?CandID=$1&VisitLabel=$2&PrintImages=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/qc/imaging$ candidates/visits/qc/Imaging.php?CandID=$1&VisitLabel=$2&PrintQC=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/qc$ candidates/visits/images/qc/QC.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageQC=true [L]
+RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/format/brainbrowser$ candidates/visits/images/format/BrainBrowser.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintBBFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/format/raw$ candidates/visits/images/format/Raw.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintRawFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/format/thumbnail$ candidates/visits/images/format/Thumbnail.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintThumbnailFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)$ candidates/visits/images/Image.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageData=true [L]

--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -28,6 +28,7 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/instruments/([a-zA-Z0-9_.]+)/d
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images$ candidates/visits/Images.php?CandID=$1&VisitLabel=$2&PrintImages=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/qc/imaging$ candidates/visits/qc/Imaging.php?CandID=$1&VisitLabel=$2&PrintQC=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)/qc$ candidates/visits/images/qc/QC.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageQC=true [L]
+RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.]+)/format/brainbrowser$ candidates/visits/images/format/BrainBrowser.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintBBFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)/format/raw$ candidates/visits/images/format/Raw.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintRawFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)/format/thumbnail$ candidates/visits/images/format/Thumbnail.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintThumbnailFormat=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images/([a-zA-Z0-9_.-]+)$ candidates/visits/images/Image.php?CandID=$1&VisitLabel=$2&Filename=$3&PrintImageData=true [L]


### PR DESCRIPTION
### Brief summary of changes

This PR fixes the `format/brainbrowser` endpoint of an image for both version of the APIs. The link to the `BrainBrowser.php` API script was not present in either `.htaccess` file

### This resolves issue...

No issue reported as the bug was fixed as soon as found.

### To test this change...

- [ ] 

