### PR TITLE
[Brainbrowser] Fix image size dropdown

### DIFF
--- a/modules/brainbrowser/jsx/Brainbrowser.js
+++ b/modules/brainbrowser/jsx/Brainbrowser.js
@@ -18,6 +18,7 @@ class BrainBrowser extends Component {
     this.state = {
       defaultPanelSize: 300,
     };
+    this.handleChange = this.handleChange.bind(this);
   }
 
   componentDidMount() {


### PR DESCRIPTION
The value in the image size dropdown was not changing value
because "this" wasn't bound in the handleChange function. This
binds it in the constructor so that it changes to the correct value.

Fixes #4766

Note: I don't have any images to test this on locally, I could only
verify that the dropdown changed value whereas it didn't previously.
