### PR TITLE
[Imaging Browser] Fix Invalid argument support for foreach error

### DIFF
--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -71,6 +71,9 @@ class Imaging_Session_ControlPanel
 
         $linkedInstruments
             = $config->getSetting('ImagingBrowserLinkedInstruments');
+        if (!is_array($linkedInstruments)) {
+            $linkedInstruments = array();
+        }
 
         $links = array();
         foreach ($linkedInstruments as $k=>$v) {


### PR DESCRIPTION
When no linkedInstruments config setting are defined, $config->getSetting()
can return an empty string. This results in a warning about invalid
argument in foreach in the imaging browser control panel.

This simply converts anything that isn't an array into an empty
array to fix the warning.
