### PR TITLE
[Login/Password Expiry] Fix bug preventing "same password" message from being seen

### DIFF
--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -61,6 +61,12 @@ class SinglePointLogin
         // We store the username requesting the the password reset on the
         // PHP session superglobal so that the password expiry page can
         // trust it.
+        if ($_SERVER['REQUEST_URI'] == "/login/password-expiry/") {
+            // Prevent a loop to the same page if we got here
+            // while on the password expiry page, which can prevent
+            // error messages from being seen.
+            return;
+        }
         $_SESSION['PasswordExpiredForUser'] = $_POST['username'];
         header("HTTP/1.1 303 See Other");
         header("Location: /login/password-expiry/");


### PR DESCRIPTION
The SinglePoint login was redirecting the password-expiry page to the
password-expiry page when the same password was entered, which was
resulting in the error message disappearing before it got to the
login module. This suppresses the redirection if that was already the
page destination.

Fixes #4756