### PR TITLE
[JSX] Improve handling of empty multilselects

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -69,7 +69,7 @@ class Filter extends Component {
           element = <SelectElement key={filter.name} options={filter.options}/>;
           break;
         case 'multiselect':
-          element = <SelectElement key={filter.name} options={filter.options} multiple={true}/>;
+          element = <SelectElement key={filter.name} options={filter.options} multiple={true} emptyOption={false}/>;
           break;
         case 'date':
           element = <DateElement key={filter.name}/>;

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -40,7 +40,7 @@ class Filter extends Component {
     const searchParams = new URLSearchParams(location.search);
     const filter = JSON.parse(JSON.stringify(this.props.filter));
     const exactMatch = (!(type === 'textbox' || type === 'date'));
-    if (value === null || value === '') {
+    if (value === null || value === '' || (value.constructor === Array && value.length === 0)) {
       delete filter[name];
       searchParams.delete(name);
     } else {


### PR DESCRIPTION
This fixes 2 bugs relating to the handling of how "nothing" is handled in multiselects.

1. The empty option is removed, because it has undefined semantics and the way that it works for single selects (ie. act as no filter) is better expressed by simply unselecting everything
2. A bug regarding unselecting everything from a multiselect is fixed. Before this, it was filtering out all results, instead of resetting the filter to not filter anything.

Fixes #4794, #4713