### PR TITLE
[imaging uploader] Display error message in the Submission Error pop up at the time of upload

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -281,23 +281,26 @@ class UploadForm extends Component {
       // - Updates errorMessage and hasError so relevant errors are displayed on form
       // - Returns to Upload tab
       error: (error, textStatus, errorThrown) => {
-        swal({
-          title: 'Submission error!',
-          type: 'error',
-        });
         let errorMessage = this.state.errorMessage;
         let hasError = this.state.hasError;
+        let messageToPrint = '';
         errorMessage = (error.responseJSON || {}).errors || 'Submission error!';
         for (let i in errorMessage) {
           if (errorMessage.hasOwnProperty(i)) {
             errorMessage[i] = errorMessage[i].toString();
             if (errorMessage[i].length) {
               hasError[i] = true;
+              messageToPrint += errorMessage[i] + '\n';
             } else {
               hasError[i] = false;
             }
           }
         }
+        swal({
+          title: 'Submission error!',
+          text: messageToPrint,
+          type: 'error',
+        });
         this.setState({uploadProgress: -1, errorMessage: errorMessage, hasError: hasError});
       },
     });


### PR DESCRIPTION
### Brief summary of changes

This PR add the display of the error message in the submission error pop up window at the time of upload of larger files than authorized.

### This resolves issue...

- [x] Github? https://github.com/aces/Loris/issues/4569

### To test this change...

- [ ] Try to upload a scan larger than what is permitted in `php.ini` and see if the error message displays in the Submission Error pop up

