### PR TITLE
[Imaging Browser] Hide Sequence Type in data table

### DIFF
--- a/modules/imaging_browser/jsx/imagingBrowserIndex.js
+++ b/modules/imaging_browser/jsx/imagingBrowserIndex.js
@@ -142,7 +142,7 @@ class ImagingBrowserIndex extends Component {
       {label: 'New Data', show: true},
       {label: 'Links', show: true},
       {label: 'SessionID', show: false},
-      {label: 'Sequence Type', show: true, filter: {
+      {label: 'Sequence Type', show: false, filter: {
         name: 'sequenceType',
         type: 'multiselect',
         options: options.sequenceTypes,


### PR DESCRIPTION
The imaging browser data table had a "Sequence Type" column
added by #4692.

This was unintentional, as the data is only there for the
filter. The table does not properly format/display it and
will likely not scale to large protocols.

This sets the column back to hidden, but the filter should
still work.