### PR TITLE
[Imaging Browser QC] Fix Notices when loading imaging browser MRI QC window

### DIFF
--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -39,7 +39,7 @@ $comments = new FeedbackMRI($_REQUEST['fileID'] ?? '', $_REQUEST['sessionID'] ??
 /*
  * UPDATE SECTION
  */
-if ($_POST['fire_away']) {
+if (isset($_POST['fire_away']) && $_POST['fire_away']) {
     // clear all predefined comments
     $comments->clearAllComments();
 
@@ -145,8 +145,8 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
         $PredefinedTpl['predefined_text'] = $predefined_comment_text['Comment'];
 
         // print the comment text
-        $Saved = $saved_comments[$comment_type_id];
-        if ($Saved['predefined'][$predefined_comment_id]) {
+        $Saved = $saved_comments[$comment_type_id] ?? array();
+        if ($Saved['predefined'][$predefined_comment_id] ?? false) {
             $CommentTpl['predefined'][$j]['checked'] = true;
         }
         $j++;
@@ -154,7 +154,7 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
 
     // print a form element for a free-form comment
     $CommentTpl['type']       = $comment_type_id;
-    $CommentTpl['saved_text'] = $saved_comments[$comment_type_id]['text'];
+    $CommentTpl['saved_text'] = $saved_comments[$comment_type_id]['text'] ?? '';
     $i++;
 }
 

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -146,6 +146,7 @@ class FeedbackMRI
 
         $result = $DB->pselect($query, array());
 
+        $comments = array();
         // build the output array
         if (is_array($result)) {
             foreach ($result as $row) {
@@ -347,8 +348,8 @@ class FeedbackMRI
                     $overallType = $CTID;
                     $overallName = array(
                                     'name'   => stripslashes($CommentName),
-                                    'field'  => $statusField['field'],
-                                    'values' => $statusField['values'],
+                                    'field'  => $statusField['field'] ?? 'overall',
+                                    'values' => $statusField['values'] ?? '',
                                    );
                 } else {
                     // add a row to the output array


### PR DESCRIPTION
The top of the imaging browser qc popup contained the following warnings for me:

```
Notice: Undefined index: fire_away in /Users/driusan/Code/Loris/htdocs/feedback_mri_popup.php on line 43

Notice: Undefined variable: comments in /Users/driusan/Code/Loris/php/libraries/FeedbackMRI.class.inc on line 164

Notice: Undefined variable: comments in /Users/driusan/Code/Loris/php/libraries/FeedbackMRI.class.inc on line 164

Notice: Undefined variable: statusField in /Users/driusan/Code/Loris/php/libraries/FeedbackMRI.class.inc on line 350

Notice: Undefined variable: statusField in /Users/driusan/Code/Loris/php/libraries/FeedbackMRI.class.inc on line 351
```

This fixes them so that the window loads cleanly.