### PR TITLE
[Imaging Browser] Fix loading of dropdowns in MRI QC

### DIFF
--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -123,7 +123,7 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
         }
         $CommentTpl['selected'] = $comments
             ->getMRIValue(
-                intval($comment_array['field'])
+                $comment_array['field']
             );
     }
 

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -207,7 +207,7 @@ class FeedbackMRI
      *
      * @return string value of $fieldName in mri table
      */
-    function getMRIValue(int $fieldName): string
+    function getMRIValue(string $fieldName): string
     {
         // choke if not a volume instance
         if ($this->objectType != 'volume') {

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -203,7 +203,7 @@ class FeedbackMRI
     /**
      * Gets the value of a single field in the MRI table
      *
-     * @param int $fieldName field to select from in mri table
+     * @param string $fieldName field to select from in mri table
      *
      * @return string value of $fieldName in mri table
      */


### PR DESCRIPTION
The fieldname was incorrectly being cast to an int, which
was resulting in the ParameterTypeID not being found when
loading the value after having been saved.

Fixes #4784.