### PR TITLE
[mri_violation ] Fix resolved violated scans duplication

### DIFF
--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -205,17 +205,19 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                               time_run
                    )
                 ) as hash,
-                mri_protocol_violated_scans.ID as join_id,                
+                mpvs.ID as join_id,                
                 p.CenterID as Site,
                 violations_resolved.Resolved as Resolved
-            FROM mri_protocol_violated_scans 
+            FROM mri_protocol_violated_scans AS mpvs
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mri_protocol_violated_scans.ID 
+            ON (violations_resolved.ExtID=mpvs.ID 
             AND violations_resolved.TypeTable='mri_protocol_violated_scans')
             LEFT JOIN candidate c
-            ON (mri_protocol_violated_scans.CandID = c.CandID)
+            ON (mpvs.CandID = c.CandID)
             LEFT JOIN session s
-            ON (mri_protocol_violated_scans.CandID = s.CandID)
+            ON (SUBSTRING_INDEX(mpvs.PatientName,'_',-1) = s.Visit_label 
+                AND mpvs.CandID = s.CandID
+            )
             LEFT JOIN psc p
             ON (p.CenterID = s.CenterID)
             WHERE Resolved <> '0'"
@@ -230,27 +232,27 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 SeriesUID,
                 md5(concat_WS(':',MincFile,PatientName,SeriesUID,TimeRun))
                    as hash,
-                mri_violations_log.LogID as join_id,
+                mrl.LogID as join_id,
                 p.CenterID as Site,
                 violations_resolved.Resolved as Resolved
-            FROM mri_violations_log 
+            FROM mri_violations_log AS mrl
             LEFT JOIN mri_scan_type 
-            ON (mri_scan_type.ID=mri_violations_log.Scan_type)
+            ON (mri_scan_type.ID=mrl.Scan_type)
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mri_violations_log.LogID 
+            ON (violations_resolved.ExtID=mrl.LogID 
             AND violations_resolved.TypeTable='mri_violations_log')
             LEFT JOIN candidate c
-            ON (mri_violations_log.CandID=c.CandID)
+            ON (mrl.CandID=c.CandID)
             LEFT JOIN session s
-            ON (mri_violations_log.CandID = s.CandID)
+            ON (mrl.Visit_label = s.Visit_label AND mrl.CandID = s.CandID)
             LEFT JOIN psc p
             ON (p.CenterID = s.CenterID)
             WHERE Resolved <> '0'"
             . " UNION " .
             "SELECT PatientName,
                 TimeRun,
-                c.ProjectID as Project,
-                s.SubprojectID as Subproject,
+                null,
+                null,
                 MincFile,
                 null,
                 Reason, 
@@ -258,18 +260,12 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 md5(concat_WS(':',MincFile,PatientName,SeriesUID,TimeRun))
                    as hash,
                 MRICandidateErrors.ID as join_id,
-                p.CenterID as Site,
+                null,
                 violations_resolved.Resolved as Resolved
             FROM MRICandidateErrors
             LEFT JOIN violations_resolved
             ON (violations_resolved.ExtID=MRICandidateErrors.ID 
             AND violations_resolved.TypeTable='MRICandidateErrors')
-            LEFT JOIN candidate c
-            ON (SUBSTRING_INDEX(MRICandidateErrors.PatientName,'_',1)=c.PSCID)
-            LEFT JOIN session s
-            ON (c.CandID = s.CandID)
-            LEFT JOIN psc p
-            ON (p.CenterID = s.CenterID)
             WHERE Resolved <> '0')
             as v LEFT JOIN psc site ON (site.CenterID = v.Site) 
             LEFT JOIN Project as pjct ON (v.Project = pjct.ProjectID)

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -512,7 +512,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         //testing search by site
         $this->_searchTest(
             "Site",
-            "Montreal"
+            "TESTinPSC"
         );
 
     }

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -512,7 +512,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         //testing search by site
         $this->_searchTest(
             "Site",
-            "TESTinPSC"
+            "Montreal"
         );
 
     }

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -76,6 +76,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
              'UserID'       => '1',
              'MRIQCStatus'  => 'Pass',
              'SubprojectID' => '6666',
+             'Visit_label'  => 'Test1',
             )
         );
         $this->DB->insert(
@@ -87,7 +88,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
              'UserID'       => '2',
              'MRIQCStatus'  => 'Pass',
              'SubprojectID' => '6666',
-             'Visit_label'  => 'test',
+             'Visit_label'  => 'Test1',
             )
         );
 
@@ -148,7 +149,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             array(
              'ID'                 => '1001',
              'CandID'             => '999888',
-             'PatientName'        => '[Test]PatientName',
+             'PatientName'        => '[Test]PatientName_Test1',
              'time_run'           => '2009-06-29 04:00:44',
              'minc_location'      => 'assembly/test/test/mri/test/test.mnc',
              'series_description' => 'Test Description',
@@ -161,7 +162,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             array(
              'ID'                 => '1002',
              'CandID'             => '999777',
-             'PatientName'        => '[name]test_test',
+             'PatientName'        => '[name]test_Test1',
              'time_run'           => '2008-06-29 04:00:44',
              'minc_location'      => 'assembly/test2/test2/mri/test2/test2.mnc',
              'series_description' => 'Test Series Description',


### PR DESCRIPTION
This pull request fixes a bug in the MRI violations module for which it displays the same violations more than once if a candidate has visits that are spread across multiple subprojects.

How to test this PR:
Pick one candidate that shows in the MRI violations module and that has multiple visits. If all these visits are all from the same subproject, manually edit one in the `session` table so that it has a different subprojectID than all other visits (could be NULL) and:
1) check that you can reproduce the bug on 20.0-release
2) check that the bug is fixed by this PR

See also: https://github.com/aces/Loris/issues/4781

(Note: a similar fix had been sent for the unresolved tab of the module, see https://github.com/aces/Loris/pull/3860)
