### PR TITLE
[Issue tracker] Fix loading of "new issue"

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -98,7 +98,7 @@ function editIssue()
     // Get changed values to save in history
     $historyValues = getChangedValues($issueValues, $issueID);
 
-    if (!empty($issueID) || $issueID != 0) {
+    if (!empty($issueID)) {
         $db->update('issues', $issueValues, ['issueID' => $issueID]);
     } else {
         $issueValues['reporter']    = $user->getData('UserID');
@@ -656,7 +656,7 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
 
     //Now get issue values
     $issueData = getIssueData();
-    if (!empty($_GET['issueID'])) { //if an existing issue
+    if (!empty($_GET['issueID']) && $_GET['issueID'] != "new") { //if an existing issue
         $issueID    = $_GET['issueID'];
         $issueData  = getIssueData($issueID);
         $desc       = $db->pselect(

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -656,7 +656,9 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
 
     //Now get issue values
     $issueData = getIssueData();
-    if (!empty($_GET['issueID']) && $_GET['issueID'] != "new") { //if an existing issue
+    if (!empty($_GET['issueID'])
+        && $_GET['issueID'] != "new"
+    ) { //if an existing issue
         $issueID    = $_GET['issueID'];
         $issueData  = getIssueData($issueID);
         $desc       = $db->pselect(

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -214,7 +214,7 @@ class IssueTrackerIndex extends Component {
 
     const addIssue = () => {
       window.location.replace(
-        loris.BaseURL+'/issue_tracker/issue/?issueID=0'
+        loris.BaseURL+'/issue_tracker/issue/new'
       );
     };
     const actions = [

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -132,7 +132,11 @@ class Issue extends \NDB_Form
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $results = [];
-        preg_match('#/issue/([0-9]+|new)$#', $request->getURI()->getPath(), $results);
+        preg_match(
+            '#/issue/([0-9]+|new)$#',
+            $request->getURI()->getPath(),
+            $results
+        );
         $this->issueID = $results[1] ?? null;
         if (empty($this->issueID) && $this->issueID != "new") {
             // Should probably be a bad request, but we don't have a 400.tpl

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -132,9 +132,9 @@ class Issue extends \NDB_Form
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $results = [];
-        preg_match('#/issue/([0-9]+)$#', $request->getURI()->getPath(), $results);
+        preg_match('#/issue/([0-9]+|new)$#', $request->getURI()->getPath(), $results);
         $this->issueID = $results[1] ?? null;
-        if (empty($this->issueID)) {
+        if (empty($this->issueID) && $this->issueID != "new") {
             // Should probably be a bad request, but we don't have a 400.tpl
             // template.
             return new \Loris\Http\Error($request, 404, "Issue not found");


### PR DESCRIPTION
Fix the loading of the form for the "new issue" page on
the issue tracker. It currently just displays an error
page after clicking the link.

Fixes #4811