### PR TITLE
[Issue Tracker] Display errors to user when creating a new issue

### DIFF
--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -338,7 +338,8 @@ class IssueForm extends Component {
         console.error(err);
         this.setState({submissionResult: 'error'});
         let msgType = 'error';
-        let message = 'Failed to submit issue :(';
+        let message = err.responseJSON.message || 'Failed to submit issue :(';
+
         this.showAlertMessage(msgType, message);
       }.bind(this),
     });


### PR DESCRIPTION
When rules are violated creating a new issue, the JSON includes
a message describing the error, but the front end currently throws
it away and display a generic error message.

This updates it to use the message from the server.

Fixes #4764.