### PR TITLE
[Issue Tracker] Fix "Watching" filter and duplicated rows in issue tracker

### DIFF
--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -63,12 +63,12 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             LEFT JOIN session s
               ON (i.sessionID = s.ID)
             LEFT JOIN issues_watching w
-              ON (i.issueID = w.issueID)
+              ON (i.issueID = w.issueID AND w.userID=:username)
             LEFT JOIN issues_comments ic
               ON (i.issueID = ic.issueID)
             GROUP BY i.issueID, w.userID
             ORDER BY i.issueID DESC",
-            array()
+            array('username' => $userID)
         );
     }
 


### PR DESCRIPTION
The query for the issue tracker was joining the issues_watching table for
the watching filter, but not restricting the join to the current user. This
resulted in the row being duplicated n times for the number of watchers,
and the "Watching?" filter returning rows if there were any watchers, not
only the current user.

Fixes #4810, #4813.