### PR TITLE
Fix dicom archive test plan item2

### DIFF
--- a/modules/dicom_archive/test/TestPlan.md
+++ b/modules/dicom_archive/test/TestPlan.md
@@ -2,7 +2,7 @@
 
 1.  Access the 'DICOM Archive' under 'Imaging' Tab and check to see if the user has permission
     [Automation Testing]
-2.  Click on 'Selection Filter' to show and hide the Filter options
+2.  Under 'Selection Filter' section, verfiy that the following Filter options exist: Patient ID, Patient Name, Sex, Date of Birth, Acquisition Date, Archive Location, Series UID, Site.
     [Manual Testing]
 3.  Choose a parameter from the 'Selection Filter' that applies: [Automation Testing]
      - Select the right 'Site'


### PR DESCRIPTION
### Brief summary of changes
This fixed the documentation of 'Dicom Archive' module TestPlan Item 2, since 'Selection Filter' became not clickable in the newer version.

### This resolves issue...
- [ ] Github? #4707

### To test this change...
- [ ] Check 'Dicom Archive' module TestPlan Item 2, should be `Under 'Selection Filter' section, verfiy that the following Filter options exist: Patient ID, Patient Name, Sex, Date of Birth, Acquisition Date, Archive Location, Series UID, Site. [Manual Testing]`