### PR TITLE
[Issue Tracker] Fix watching dropdown when editing issue

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -124,23 +124,6 @@ function editIssue()
         emailUser($issueID, $issueValues['assignee']);
     }
 
-    // Adding editor to the watching table unless they don't want to be added.
-    if ($_POST['watching'] == 'Yes') {
-        $nowWatching = array(
-                        'userID'  => $user->getData('UserID'),
-                        'issueID' => $issueID,
-                       );
-        $db->replace('issues_watching', $nowWatching);
-    } else if ($_POST['watching'] == "No") {
-        $db->delete(
-            'issues_watching',
-            array(
-             'issueID' => $issueID,
-             'userID'  => $user->getData('UserID'),
-            )
-        );
-    }
-
     // Adding others from multiselect to watching table.
     if (isset($_POST['othersWatching'])) {
 
@@ -664,8 +647,9 @@ WHERE Parent IS NOT NULL ORDER BY Label ",
     if (!empty($_GET['issueID'])
         && $_GET['issueID'] != "new"
     ) { //if an existing issue
-        $issueID    = $_GET['issueID'];
-        $issueData  = getIssueData($issueID);
+        $issueID   = $_GET['issueID'];
+        $issueData = getIssueData($issueID);
+
         $desc       = $db->pselect(
             "SELECT issueComment
 FROM issues_comments WHERE issueID=:i
@@ -680,7 +664,11 @@ ORDER BY dateAdded LIMIT 1",
              'userID'  => $user->getData('UserID'),
             )
         );
-        $issueData['watching']       = is_array($isWatching) ? "No" : "Yes";
+        if ($isWatching === null) {
+            $issueData['watching'] = "No";
+        } else {
+            $issueData['watching'] = "Yes";
+        }
         $issueData['commentHistory'] = getComments($issueID);
         $issueData['othersWatching'] = getWatching($issueID);
         $issueData['desc']           = $desc[0]['issueComment'];

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -147,6 +147,23 @@ function editIssue()
             }
         }
     }
+
+    // Add editor to the watching table unless they don't want to be added.
+    if ($_POST['watching'] == 'Yes') {
+        $nowWatching = array(
+                        'userID'  => $user->getData('UserID'),
+                        'issueID' => $issueID,
+                       );
+        $db->replace('issues_watching', $nowWatching);
+    } else if ($_POST['watching'] == 'No') {
+        $db->delete(
+            'issues_watching',
+            array(
+             'issueID' => $issueID,
+             'userID'  => $user->getData('UserID'),
+            )
+        );
+    }
     return ['issueID' => $issueID];
 }
 

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -147,7 +147,6 @@ function editIssue()
             }
         }
     }
-
     return ['issueID' => $issueID];
 }
 


### PR DESCRIPTION
Fix changing the "Watching?" dropdown when editing an issue. There
were 2 problems:
1. The code was checking if a statement returned an array to determine
   if there was data. Comparing to null is more reliable.
2. The Watching? insert statement was done before Other watchers. This
   was unreliable, since Other Watchers starts by deleting all watches.

Fixing both of these issues resolves both the saving and display of
the Watching? dropdown when editing an issue.

Fixes #4582