### PR TITLE
Update the code comments and the code documentation to refer to lorisform instead of quickform

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -68,7 +68,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     var $dateOfAdministration;
 
     /**
-     * Additional form defaults - should only be used for quickform
+     * Additional form defaults - should only be used for lorisform
      * static elements!
      *
      * @access private
@@ -143,7 +143,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
     /**
      * True if the instrument page is being loaded by a script
-     * such as the quickform_parser where all elements should be added to form,
+     * such as the lorisform_parser where all elements should be added to form,
      * ignoring age-dependent or other conditional display logic in the form.
      * To be called from within individual instrument forms.
      */
@@ -500,7 +500,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _setDefaultsArray(array $defaults): array
     {
-        //Convert date/time fields into quickform date/timestamps
+        //Convert date/time fields into lorisform date/timestamps
         if (empty($this->dateTimeFields)) {
             $this->dateTimeFields = array("Date_taken");
         }
@@ -511,7 +511,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $defaults['Candidate_Age']
                 = $defaults['Candidate_Age'] . " (Age out of range)";
         }
-        //Convert select multiple elements into a quickform array
+        //Convert select multiple elements into a lorisform array
         if (!empty($this->_selectMultipleElements)) {
             foreach ($this->_selectMultipleElements AS $elname) {
                 if (isset($defaults[$elname])
@@ -1065,7 +1065,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     abstract function getSubtestList(): array;
 
     /**
-     * Marks an element in the quickform object as being required (for
+     * Marks an element in the lorisform object as being required (for
      * use with the requiredIf rule)
      *
      * @param string $elementName the element to add to the required list
@@ -1081,10 +1081,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
 
     /**
-     * Convert a quickform date or timestamp into a database acceptable
+     * Convert a lorisform date or timestamp into a database acceptable
      * (and storable) date or time
      *
-     * @param array $formDateValue the quickform date/timestamp array
+     * @param array $formDateValue the lorisform date/timestamp array
      *
      * @return string the date or timestamp from the database
      * @access private
@@ -1147,7 +1147,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @param string $databaseValue the date or timestamp from the database
      *
-     * @return array the quickform date/timestamp array
+     * @return array the lorisform date/timestamp array
      */
     function _getQuickformDate(string $databaseValue)
     {

--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -11,7 +11,7 @@
  *
  * Input:
  * data_dictionary_builder.php takes as input the ip_output.txt file (generated
- * by quickform_parser.php) and inserts records for each field of each
+ * by lorisform_parser.php) and inserts records for each field of each
  * discovered NDB_BVL_Instrument. To be complete, this tool must be run on an
  * ip_output.txt file that was constructed from all instruments.
  *

--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -3,7 +3,7 @@
 
 /**
  * generate_tables_sql.php takes the ip_output.txt file generated from
- * quickform_parser.php and outputs an sql build file for the table of each
+ * lorisform_parser.php and outputs an sql build file for the table of each
  * instrument it finds in the ip_output.txt file.  These sql files are output
  * to the tables_sql/ subdirectory.
  *

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -3,7 +3,7 @@
 
 /**
  * generate_tables_sql.php takes the ip_output.txt file generated from
- * quickform_parser.php and outputs an sql build file for the table of each
+ * lorisform_parser.php and outputs an sql build file for the table of each
  * instrument it finds in the ip_output.txt file.  These sql files are output
  * to the tables_sql/ subdirectory.
  *

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -57,9 +57,9 @@ foreach ($files AS $file) {
     echo "Initializing instrument object...\n";
     $obj->setup(null, null);
 
-    //Some instruments ought not be parsed with the quickform_parser
+    //Some instruments ought not be parsed with the lorisform_parser
     if ((in_array($obj->testName, $instrumentsToSkip))) {
-        echo "quickform_parser will    skip file {$file}\n";
+        echo "lorisform_parser will    skip file {$file}\n";
         continue;
     }
 


### PR DESCRIPTION
### Brief summary of changes

In some instances of the code, we still refer to `quickform_parser.php` in the documentation/comments while the script has been renamed to `lorisform_parser.php`. This PR corrects those misleading instances.

### This resolves issue...

No issue reported as this was found while testing the data dictionary builder tool and looking for `quickform_parser.php`.

### To test this change...

Nothing to test since this is only comments and documentation changes
