### PR TITLE
[Media] Fix HTTP response codes when uploading files

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -36,7 +36,7 @@ function editFile()
     $db   =& Database::singleton();
     $user =& User::singleton();
     if (!$user->hasPermission('media_write')) {
-        header("HTTP/1.1 403 Forbidden");
+        showMediaError("Permission Denied", 403);
         exit;
     }
 
@@ -46,7 +46,7 @@ function editFile()
     $idMediaFile = $req['idMediaFile'];
 
     if (!$idMediaFile) {
-        showMediaError("Error! Invalid media file ID!");
+        showMediaError("Media ID $idMediaFile not found", 404);
     }
 
     $updateValues = [
@@ -58,7 +58,7 @@ function editFile()
     try {
         $db->update('media', $updateValues, ['id' => $idMediaFile]);
     } catch (DatabaseException $e) {
-        showMediaError("Could not update the file. Please try again!");
+        showMediaError("Could not update the file. Please try again!", 500);
     }
 
 }
@@ -82,7 +82,7 @@ function uploadFile()
     $config = NDB_Config::singleton();
     $user   =& User::singleton();
     if (!$user->hasPermission('media_write')) {
-        header("HTTP/1.1 403 Forbidden");
+        showMediaError("Permission Denied", 403);
         exit;
     }
 
@@ -90,13 +90,15 @@ function uploadFile()
     $mediaPath = $config->getSetting('mediaPath');
 
     if (!isset($mediaPath)) {
-        showMediaError("Error! Media path is not set in Loris Settings!");
-        exit;
+        showMediaError(
+            "Media path not set in Loris settings! "
+            . "Please contact your LORIS administrator",
+            500
+        );
     }
 
     if (!file_exists($mediaPath)) {
-        showMediaError("Error! The upload folder '$mediaPath' does not exist!");
-        exit;
+        showMediaError("Error! The upload folder '$mediaPath' does not exist!", 404);
     }
 
     // Process posted data
@@ -110,7 +112,7 @@ function uploadFile()
 
     // If required fields are not set, show an error
     if (!isset($_FILES) || !isset($pscid) || !isset($visit) || !isset($site)) {
-        showMediaError("Please fill in all required fields!");
+        showMediaError("Please fill in all required fields!", 400);
         return;
     }
     $fileName  = preg_replace('/\s/', '_', $_FILES["file"]["name"]);
@@ -118,7 +120,7 @@ function uploadFile()
     $extension = pathinfo($fileName)['extension'];
 
     if (!isset($extension)) {
-        showMediaError("Please make sure your file has a valid extension!");
+        showMediaError("Please make sure your file has a valid extension!", 400);
         return;
     }
 
@@ -138,7 +140,8 @@ function uploadFile()
     if (!isset($sessionID) || strlen($sessionID) < 1) {
         showMediaError(
             "Error! A session does not exist for candidate '$pscid'' " .
-            "and visit label '$visit'."
+            "and visit label '$visit'.",
+            404
         );
 
         return;
@@ -165,10 +168,10 @@ function uploadFile()
             $db->insertOnDuplicateUpdate('media', $query);
             $uploadNotifier->notify(array("file" => $fileName));
         } catch (DatabaseException $e) {
-            showMediaError("Could not upload the file. Please try again!");
+            showMediaError("Could not upload the file. Please try again!", 500);
         }
     } else {
-        showMediaError("Could not upload the file. Please try again!");
+        showMediaError("Could not upload the file. Please try again!", 500);
     }
 }
 
@@ -181,7 +184,7 @@ function viewData()
 {
     $user =& User::singleton();
     if (!$user->hasPermission('media_read')) {
-        header("HTTP/1.1 403 Forbidden");
+        showMediaError("Permission denied", 403);
         exit;
     }
     echo json_encode(getUploadFields());
@@ -328,15 +331,17 @@ function getUploadFields()
  * Utility function to return errors from the server
  *
  * @param string $message error message to display
+ * @param int    $code    The HTTP response code to
+ *                        use with the message
  *
  * @return void
  */
-function showMediaError($message)
+function showMediaError($message, $code)
 {
     if (!isset($message)) {
         $message = 'An unknown error occurred!';
     }
-    header('HTTP/1.1 500 Internal Server Error');
+    http_response_code($code);
     header('Content-Type: application/json; charset=UTF-8');
     die(json_encode(['message' => $message]));
 }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -91,7 +91,7 @@ function uploadFile()
 
     if (!isset($mediaPath)) {
         showMediaError(
-            "Media path not set in Loris settings! "
+            "Media path not set in LORIS settings! "
             . "Please contact your LORIS administrator",
             500
         );


### PR DESCRIPTION
All types of errors were being returned to the user as
internal server error. This was clearly incorrect in
some situations where the error was caused by user error.

Update the showMediaError to take a status code to go
with it, and at the same time improved some error messages
(such as permission denied, which didn't include any
message at all before this change.)