### PR TITLE
[tools] fix message to install composer,

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -84,7 +84,9 @@ else
     echo ""
     echo "PHP Composer does not appear to be installed. Please install it before running this script."
     echo ""
-    echo "(e.g. curl -sS https://getcomposer.org/installer | php)"
+    echo "(e.g. wget https://getcomposer.org/installer"
+    echo "php installer --install-dir=/usr/local/bin --filename=composer)"
+    echo "while having root permission)";
     exit 2;
 fi
 
@@ -153,6 +155,8 @@ debian=("Debian" "Ubuntu")
 redhat=("Red" "CentOS" "Fedora" "Oracle") 
 
 if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
+    mkdir ../modules/document_repository/user_uploads
+    mkdir ../modules/data_release/user_uploads
     sudo chown www-data.www-data ../modules/document_repository/user_uploads
     sudo chown www-data.www-data ../modules/data_release/user_uploads
     sudo chown www-data.www-data ../smarty/templates_c
@@ -161,6 +165,8 @@ if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
     sudo chgrp www-data ../project
     sudo chmod 770 ../project
 elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
+    mkdir ../modules/document_repository/user_uploads
+    mkdir ../modules/data_release/user_uploads
     sudo chown apache.apache ../modules/document_repository/user_uploads
     sudo chown apache.apache ../modules/data_release/user_uploads
     sudo chown apache.apache ../smarty/templates_c


### PR DESCRIPTION
### Brief summary of changes
- change the message on how to install composer if not already done
- create user_uploads dir if are not existing before changing group ownership

### This resolves issue...
https://github.com/aces/Loris/issues/4825
https://github.com/aces/Loris/issues/4824 (first item only)

### To test this change...
for the message, run the script on a server where composer is not installed (or not accessible), check that new instruction are showne.

For second part run the script on a new installation of Loris (in a new directory i.e. /tmp or ~/) and check that the 2 directories are created and have group set to www-data (Ubuntu)
