### PR TITLE
[Media] Fix errors for users with no media_write permission

### DIFF
--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -209,7 +209,8 @@ class MediaEditForm extends Component {
         this.props.fetchData();
       },
       error: function(err) {
-        swal('Upload Error!', '', 'error');
+        let msg = err.responseJSON.message || 'Error updating file';
+        swal(msg, '', 'error');
         console.error(err);
       },
     });

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -84,16 +84,20 @@ class MediaIndex extends Component {
       result = <td className={style}>{this.state.fieldOptions.sites[cell]}</td>;
       break;
     case 'Edit Metadata':
-      const editButton = (
-        <TriggerableModal title="Edit Media File" label="Edit">
-          <MediaEditForm
-            DataURL={`${loris.BaseURL}/media/ajax/FileUpload.php?action=getData&idMediaFile=${row['Edit Metadata']}`}
-            action={`${loris.BaseURL}/media/ajax/FileUpload.php?action=edit`}
-            fetchData={this.fetchData /* this should be passed to onSubmit function
-                   upon refactoring editForm.js*/}
-          />
-        </TriggerableModal>
-      );
+      let editButton = <div />;
+      if (this.props.hasPermission('media_write')) {
+        editButton = (
+            <TriggerableModal title="Edit Media File" label="Edit">
+                    <MediaEditForm
+                DataURL={`${loris.BaseURL}/media/ajax/FileUpload.php?action=getData&idMediaFile=${row['Edit Metadata']}`}
+                action={`${loris.BaseURL}/media/ajax/FileUpload.php?action=edit`}
+                /* this should be passed to onSubmit function
+                   upon refactoring editForm.js*/
+                fetchData={this.fetchData }
+                    />
+            </TriggerableModal>
+        );
+      }
       result = <td className={style}>{editButton}</td>;
       break;
     }

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -84,9 +84,10 @@ class MediaIndex extends Component {
       result = <td className={style}>{this.state.fieldOptions.sites[cell]}</td>;
       break;
     case 'Edit Metadata':
-      let editButton = <div />;
-      if (this.props.hasPermission('media_write')) {
-        editButton = (
+      if (!this.props.hasPermission('media_write')) {
+          return;
+      }
+      const editButton = (
             <TriggerableModal title="Edit Media File" label="Edit">
                     <MediaEditForm
                 DataURL={`${loris.BaseURL}/media/ajax/FileUpload.php?action=getData&idMediaFile=${row['Edit Metadata']}`}
@@ -96,8 +97,7 @@ class MediaIndex extends Component {
                 fetchData={this.fetchData }
                     />
             </TriggerableModal>
-        );
-      }
+      );
       result = <td className={style}>{editButton}</td>;
       break;
     }
@@ -122,7 +122,7 @@ class MediaIndex extends Component {
     * queried columns in _setupVariables() in media.class.inc
     */
     const options = this.state.fieldOptions;
-    const fields = [
+    let fields = [
       {label: 'File Name', show: true, filter: {
         name: 'fileName',
         type: 'text',
@@ -171,8 +171,10 @@ class MediaIndex extends Component {
         options: options.hidden,
         hide: !this.props.hasPermission('superUser'),
       }},
-      {label: 'Edit Metadata', show: true},
     ];
+    if (this.props.hasPermission('media_write')) {
+      fields.push({label: 'Edit Metadata', show: true});
+    }
     const tabs = [{id: 'browse', label: 'Browse'}];
     const uploadTab = () => {
       if (this.props.hasPermission('media_write')) {


### PR DESCRIPTION
This fixes 2 problems when a user does not have write permission:
1. The reason the update failed is not given to the user.
2. The user should not have seen the button in the first place.

Fixes #4737.