### PR TITLE
[Config] Fix error message in the project page of the configuration module

### DIFF
--- a/modules/configuration/js/project.js
+++ b/modules/configuration/js/project.js
@@ -18,9 +18,15 @@ $(document).ready(function() {
         }
         
         var errorClosure = function(i, form) {
-            return function() {
-                $(form.find(".saveStatus")).text("Failed to save, same name already exist!").css({ 'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+          if (isNaN(recruitmentTarget)) {
+            return function () {
+              $(form.find(".saveStatus")).text("Failed to save, recruitment target must be an integer!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
             }
+          } else {
+            return function () {
+              $(form.find(".saveStatus")).text("Failed to save, same name already exist!").css({'color': 'red'}).fadeIn(500).delay(1000).fadeOut(500);
+            }
+          }
         }
 
         jQuery.ajax(


### PR DESCRIPTION
### Brief summary of changes

This PR customizes the error message shown in the configuration module under the project section when someone tries to save a target recruitment that is not a number. Now proper error message is displayed to the user telling them that the recruitment target must be a number.

### This resolves issue...

- [x] Github? #4770

### To test this change...

- [ ] Try to save a project with a string instead of a number in the target recruitment box, a proper error message should appear

