### PR TITLE
[Breadcrumbs] Instrument test_name to Full Name

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2623,7 +2623,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "/instrument_list/?candID=$candid&sessionID=$sessionid"
             ),
             new \LORIS\Breadcrumb(
-                $this->name,
+                $this->getFullName(),
                 ''
             )
         );


### PR DESCRIPTION
fixes https://github.com/aces/Loris/issues/4808

to test:
- [ ] go to an instrument on test.loris.ca / 21.0-release branch. Breadcrumb should contain test name with underscores and lower case
- [ ] on this branch, the test_name is replace with the instrument's full name