### PR TITLE
[Issue Tracker] Fix javascript console warning multisite user

### DIFF
--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -273,11 +273,21 @@ class IssueForm extends Component {
     $.ajax(this.props.DataURL, {
       dataType: 'json',
       success: function(data) {
+        let newIssue = !data.issueData.issueID;
+        let formData = data.issueData;
+        // ensure that if the user is at multiple sites and
+        // its a new issue, the centerID (which is a dropdown)
+        // is set to the empty option instead of an array of
+        // the user's sites.
+        if (newIssue) {
+            formData.centerID = null;
+        }
+
         this.setState({
           Data: data,
           isLoaded: true,
           issueData: data.issueData,
-          formData: data.issueData,
+          formData: formData,
           isNewIssue: !data.issueData.issueID,
         });
       }.bind(this),


### PR DESCRIPTION
Fix a warning that appears in the javascript console when a user
has multiple sites affiliated.

Fixes #4727.