### PR TITLE
[Document Repository] Include path in web server error log

### DIFF
--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -391,7 +391,7 @@ class Files extends \NDB_Page
             }
             if (!mkdir($uploadPath, 0770)) {
                 throw new \LorisException(
-                    "User can't make a directory."
+                    "Cannot create directory $uploadPath."
                 );
             }
         }


### PR DESCRIPTION
Update error message when there's a failure to create a
directory in the document repository, so that the sysadmin
can try and figure out what's happening. (This exception
message shows up in the web server error logs, not to the
user.)