### PR TITLE
[Imaging Uploader] Fix browse data table

### DIFF
--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -10,7 +10,7 @@ import UploadForm from './UploadForm';
 class ImagingUploader extends Component {
   constructor(props) {
     super(props);
-    loris.hiddenHeaders = ['PatientName'];
+    loris.hiddenHeaders = ['PatientName', 'SessionID'];
 
     this.state = {
       isLoaded: false,
@@ -140,13 +140,24 @@ class ImagingUploader extends Component {
       if (!cell || cell === '0') {
         return (<td></td>);
       }
+      const url = loris.BaseURL
+                  + '/dicom_archive/viewDetails/?tarchiveID='
+                  + cell;
+      return (
+        <td style={cellStyle}>
+          <a href={url}>View details</a>
+        </td>
+      );
     }
 
     if (column === 'Number Of MincInserted') {
       if (cell > 0) {
+        const url = loris.BaseURL
+                    + '/imaging_browser/viewSession/?sessionID='
+                    + row.SessionID;
         return (
           <td style={cellStyle}>
-            <a onClick={this.handleClick.bind(null, row.CandID)}>{cell}</a>
+            <a href={url}>{cell}</a>
           </td>
         );
       }
@@ -159,6 +170,7 @@ class ImagingUploader extends Component {
              row['Number Of MincCreated'] - row['Number Of MincInserted'];
 
         let patientName = row.PatientName;
+        console.log('patient name' + patientName);
         violatedScans = <a onClick={this.openViolatedScans.bind(null, patientName)}>
            ({numViolatedScans} violated scans)
          </a>;
@@ -174,18 +186,6 @@ class ImagingUploader extends Component {
     }
 
     return (<td style={cellStyle}>{cell}</td>);
-  }
-
-  /**
-   * Handles clicks on 'Number Of MincInserted' cells
-   *
-   * @param {string} dccid - dccid
-   * @param {object} e - event info
-   */
-  handleClick(dccid, e) {
-    loris.loadFilteredMenuClickHandler('imaging_browser/', {
-      DCCID: dccid,
-    })(e);
   }
 
   /**

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -121,8 +121,8 @@ class ImagingUploader extends Component {
       }
 
       if (cell === 'Success') {
-        const created = row['Number Of MincCreated'];
-        const inserted = row['Number Of MincInserted'];
+        const created = row['Number Of MINC Created'];
+        const inserted = row['Number Of MINC Inserted'];
         return (
           <td style={cellStyle}>
           {cell} ({inserted} out of {created})
@@ -150,7 +150,7 @@ class ImagingUploader extends Component {
       );
     }
 
-    if (column === 'Number Of MincInserted') {
+    if (column === 'Number Of MINC Inserted') {
       if (cell > 0) {
         const url = loris.BaseURL
                     + '/imaging_browser/viewSession/?sessionID='
@@ -163,14 +163,13 @@ class ImagingUploader extends Component {
       }
     }
 
-    if (column === 'Number Of MincCreated') {
+    if (column === 'Number Of MINC Created') {
       let violatedScans;
-      if (row['Number Of MincCreated'] - row['Number Of MincInserted'] > 0) {
+      if (row['Number Of MINC Created'] - row['Number Of MINC Inserted'] > 0) {
         let numViolatedScans =
-             row['Number Of MincCreated'] - row['Number Of MincInserted'];
+             row['Number Of MINC Created'] - row['Number Of MINC Inserted'];
 
         let patientName = row.PatientName;
-        console.log('patient name' + patientName);
         violatedScans = <a onClick={this.openViolatedScans.bind(null, patientName)}>
            ({numViolatedScans} violated scans)
          </a>;

--- a/modules/imaging_uploader/jsx/ImagingUploader.js
+++ b/modules/imaging_uploader/jsx/ImagingUploader.js
@@ -10,11 +10,11 @@ import UploadForm from './UploadForm';
 class ImagingUploader extends Component {
   constructor(props) {
     super(props);
+    loris.hiddenHeaders = ['PatientName'];
 
     this.state = {
       isLoaded: false,
       filter: {},
-      hiddenHeaders: ['PatientName'],
     };
 
     /**
@@ -88,7 +88,7 @@ class ImagingUploader extends Component {
    */
   formatColumn(column, cell, rowData, rowHeaders) {
     // If a column if set as hidden, don't display it
-    if (this.state.hiddenHeaders.indexOf(column) > -1) {
+    if (loris.hiddenHeaders.indexOf(column) > -1) {
       return null;
     }
 
@@ -96,7 +96,7 @@ class ImagingUploader extends Component {
     let row = {};
     rowHeaders.forEach((header, index) => {
       row[header] = rowData[index];
-    });
+    }, this);
 
     // Default cell style
     const cellStyle = {whiteSpace: 'nowrap'};

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -63,17 +63,17 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             . "IF(InsertionComplete=0, 'Failure', 'Success'))) as Progress";
         // set the class variables
         $this->columns      = array(
-                               'UploadID',
+                               'UploadID AS Upload_ID',
                                $progressSelectPart,
                                's.CandID',
                                'c.PSCID',
                                's.Visit_label',
-                               'UploadLocation',
-                               'UploadDate',
-                               'UploadedBy',
+                               'UploadLocation AS Upload_Location',
+                               'UploadDate AS Upload_Date',
+                               'UploadedBy AS Uploaded_By',
                                'mu.TarchiveID AS Tarchive_Info',
-                               'number_of_mincCreated',
-                               'number_of_mincInserted',
+                               'number_of_mincCreated AS Number_of_MINC_Created',
+                               'number_of_mincInserted AS Number_of_MINC_Inserted',
                                'ta.PatientName',
                                's.ID AS SessionID',
                               );

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -75,6 +75,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                                'number_of_mincCreated',
                                'number_of_mincInserted',
                                'ta.PatientName',
+                               's.ID AS SessionID',
                               );
         $this->validFilters = array(
                                's.CandID',


### PR DESCRIPTION
### Brief summary of changes

The data table of the browser page of the imaging uploader showed several flaws:
- a PatientName name column was present in the header of the table but not the content (was not properly hidden)
- The Tarchive Info column showed the tarchiveID instead of the "View details" link to the DICOM archive module for that tarchive ID
- The Number of MINCs created column leads to the ViewSession page of the imaging browser since a given upload will always be linked to only one SessionID. 
- The header row has prettier strings for the eyes

### This resolves issue...

- [x] Github #4866

### To test this change...

Check that the improvements mentioned above works better in this PR than on the current 21.0 branch.
