### PR TITLE
[Timepoint list] Clarifying test plan

### DIFF
--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -1,15 +1,15 @@
 # Timepoint List - Test Plan:
 
 1.  **Module access permissions**
-    - For a candidate of the same site as your user, accessing the timepoint_list module should not require any permission.
+    - For a candidate of the same site as your user, accessing the timepoint_list module via the url should not require any permission.
     - For a candidate of a different site than your user, ensure that either 
         - `access_all_profiles` permission is required 
         - or that the candidate's registration site is the same as the user's site
 2. **Action buttons** 
     - For a candidate of a different site than your user, attempt to access the timepoint list via the url. The page should load with a message of 'Permission Denied' which redirects the user back to the homepage.
     - For a candidate of the same site as your user, there should be 2 additional buttons: 
-        1. "Create time point". (links to create_timepoint module for that candidate)
-        2. One of "Edit Candidate Info" or "View Candidate Info" according to your user permissions :
+        1. "Create time point". (links to create_timepoint module for that candidate) if your user has permission `data_entry`
+        2. One of "Edit Candidate Info" or "View Candidate Info" for candidates matching your user's sites according to your user permissions:
             - "Edit Candidate Info" if your user has the `candidate_parameters_edit` permission.
             - "View Candidate Info" if your user has the `candidate_parameters_view` permission.
 3.  **Button links**


### PR DESCRIPTION
### Brief summary of changes

The test plan was not clear enough on which permission is required in order to view the "Create time point", "Edit Candidate Info" and "View Candidate Info" buttons on the timepoint list page. This PR clarifies those.

### This resolves issue...

- [x] Github? #4843

### To test this change...

