### PR TITLE
[API] Fix POST /candidates response format

### DIFF
--- a/htdocs/api/v0.0.3-dev/Candidates.php
+++ b/htdocs/api/v0.0.3-dev/Candidates.php
@@ -183,7 +183,7 @@ class Candidates extends APIBase
         }
 
         $candidateinfo = array(
-                          'CandID'  => $candidate->getCandID,
+                          'CandID'  => $candidate->getCandID(),
                           'Project' => $candidate->getProjectTitle(),
                           'PSCID'   => $candidate->getPSCID(),
                           'Site'    => $candidate->getCandidateSite(),

--- a/htdocs/api/v0.0.3-dev/Candidates.php
+++ b/htdocs/api/v0.0.3-dev/Candidates.php
@@ -103,7 +103,8 @@ class Candidates extends APIBase
      */
     public function handlePOST()
     {
-        $data = $this->RequestData;
+        $candid = null;
+        $data   = $this->RequestData;
         if ($data === null) {
             $this->header("HTTP/1.1 400 Bad Request");
             $this->error("Can't parse data");
@@ -162,10 +163,6 @@ class Candidates extends APIBase
                     $data['Candidate']['Sex'],
                     $data['Candidate']['PSCID']
                 );
-                $this->header("HTTP/1.1 201 Created");
-                $this->JSON = [
-                               'Meta' => ["CandID" => $candid],
-                              ];
             } catch(\LorisException $e) {
                 $this->header("HTTP/1.1 400 Bad Request");
                 $this->safeExit(0);
@@ -173,20 +170,30 @@ class Candidates extends APIBase
 
         }
 
+        $candidate = \Candidate::singleton($candid);
+
         if (isset($data['Candidate']['Project'])) {
             $projectName = $data['Candidate']['Project'];
             $project     = \Project::singleton($projectName);
             if (!empty($project)) {
-                \Candidate::singleton($candid)->setData(
+                $candidate->setData(
                     array('ProjectID' => $project->getId())
                 );
             }
         }
 
+        $candidateinfo = array(
+                          'CandID'  => $candidate->getCandID,
+                          'Project' => $candidate->getProjectTitle(),
+                          'PSCID'   => $candidate->getPSCID(),
+                          'Site'    => $candidate->getCandidateSite(),
+                          'EDC'     => $candidate->getCandidateEDC(),
+                          'DoB'     => $candidate->getCandidateDoB(),
+                          'Sex'     => $candidate->getCandidateSex(),
+                         );
+
         $this->header("HTTP/1.1 201 Created");
-        $this->JSON = [
-                       'Meta' => ["CandID" => $candid],
-                      ];
+        $this->JSON = $candidateinfo;
     }
 
     /**
@@ -230,7 +237,7 @@ class Candidates extends APIBase
      * @param string $sex      Biological sex of the candidate to be created
      * @param string $PSCID    PSCID of the candidate to be created
      *
-     * @return none
+     * @return int $candID      candidate id of the new candidate
      */
     public function createNew($centerID, $DoB, $edc, $sex, $PSCID)
     {

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -465,7 +465,7 @@ class Candidate
      */
     function getCenterID(): int
     {
-        return $this->candidateInfo["RegistrationCenterID"];
+        return intval($this->candidateInfo["RegistrationCenterID"]);
     }
 
     /**


### PR DESCRIPTION
### Brief summary of changes
The documentation of v0.0.3-dev differ from v0.0.2 for POST request sent to /candidates.
A `CandidateObject` should be returned instead of the CandID alone

This adds the CandidateObject to the response.

### This resolves issue...

- [x] Github? #4881 

### To test this change...
Send a POST request to /candidates and see if the response format fits the documentation 