### PR TITLE
[API] Fix PUT /candidates/visits

### DIFF
--- a/htdocs/api/v0.0.3-dev/candidates/Visit.php
+++ b/htdocs/api/v0.0.3-dev/candidates/Visit.php
@@ -250,6 +250,10 @@ class Visit extends \Loris\API\Candidates\Candidate
      */
     function createNew($CandID, $subprojectID, $VL, $CID)
     {
+        // Temporary fix until \TimePoint::isValidVisitLabel
+        // supports StudyEntities.
+        $CandID = intval($CandID->__toString());
+
         try {
             \TimePoint::isValidVisitLabel($CandID, $subprojectID, $VL);
         } catch (\LorisException $e) {
@@ -258,7 +262,7 @@ class Visit extends \Loris\API\Candidates\Candidate
             $this->safeExit(0);
         }
 
-        $cand        = \Candidate::singleton($candID);
+        $cand        = \Candidate::singleton($CandID);
         $sessionSite = \Site::singleton($CID);
 
         \TimePoint::createNew($cand, $subprojectID, $VL, $sessionSite);


### PR DESCRIPTION
### Brief summary of changes
casting CandID object into an integer to fit Timepoint::validateVisitLabel signature


### This resolves issue...

- [x] Github? #4885

### To test this change...
Send a PUT request to /candidates/<candid>/<visit_label> . A 201 should be returned

