### PR TITLE
Do not allow whitespace characters in user names.

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -978,11 +978,11 @@ class Edit_User extends \NDB_Form
 
                 // Check that user name does not contain a whitespace character
                 if (preg_match('/\s/', $effectiveUID)) {
-                    // Note: email adresses can contain comments which themselves can
-                    // contain spaces
+                    // Note: email addresses can contain comments which themselves
+                    // can contain spaces
                     if ($values['NA_UserID'] == 'on') {
                         $errors['UserID_Group']
-                            = 'You cannot have the user name match an email adress'
+                            = 'You cannot have the user name match an email address'
                             . ' that contains a whitespace character';
                     } else {
                         $errors['UserID_Group']

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -973,7 +973,21 @@ class Edit_User extends \NDB_Form
 
                 if (strlen($effectiveUID) > 255) {
                     $errors['UserID_Group']
-                        = 'The user name must not exsceed 255 characters';
+                        = 'The user name must not exceed 255 characters';
+                }
+
+                // Check that user name does not contain a whitespace character
+                if (preg_match('/\s/', $effectiveUID)) {
+                    // Note: email adresses can contain comments which themselves can
+                    // contain spaces
+                    if ($values['NA_UserID'] == 'on') {
+                        $errors['UserID_Group']
+                            = 'You cannot have the user name match an email adress'
+                            . ' that contains a whitespace character';
+                    } else {
+                        $errors['UserID_Group']
+                            = 'Whitespace characters are not allowed in user names';
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Brief summary of changes

Spaces are not allowed anymore in user names. This PR implements this new restriction.

### This resolves issue...

- [ ] Github? #4742

### To test this change...

- [ ] Try creating a new user with a username that contains a whitespace character and ensure you cannot.
- [ ] Create a new user and set the user name to be the user's email address. Enter an email address that contains a whitespace (e.g an email with an embedded comment that contains a space, as in crusty(the clown)@simsons.com) and try clicking 'Save'. Ensure that you get an error message.

This replaces #4744, which is now closed.