### PR TITLE
[jsx/DataTable] Default sort order by first column

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -16,7 +16,7 @@ class DataTable extends Component {
         rows: 20,
       },
       sort: {
-       column: 0,
+       column: -1,
        ascending: true,
       },
     };


### PR DESCRIPTION
### Brief summary of changes

At the moment, all data tables are by default sorted in ascending order by the second column. we want to sort by default the first 'No.' column

this PR fixes the default column value and restores it to what it was before this testing round