### PR TITLE
[candidate_list] Check If DCCID is an Integer String

### DIFF
--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -84,30 +84,32 @@ class ValidateIDs extends \NDB_Page
 
         // Ensure CandID and PSCID are both passed.
         $gets = $request->getQueryParams();
-        if (!isset($gets['CandID']) || !isset($gets['PSCID'])) {
-            return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
-                ->withStatus(400)
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        "Must provide PSCID and CandID to validate"
-                    )
-                );
-        }
 
-        // Return "0" or "1" based on whether it exists or not.
-        // We always return a 200 error code and not a 404, because
-        // even if the CandID doesn't exist or match, the validateids
-        // endpoint still exists and has a valid response.
-        $exists = \Candidate::candidateExists(
-            $gets['CandID'],
-            $gets['PSCID']
-        ) ? "1" : "0";
+        if (!ctype_digit($gets['CandID'])) {
+            $exists = "0";
+        } else {
+            if (!isset($gets['CandID']) || !isset($gets['PSCID'])) {
+                return (new \LORIS\Http\Response())
+                    ->withHeader("Content-Type", "text/plain")
+                    ->withStatus(400)
+                    ->withBody(
+                        new \LORIS\Http\StringStream(
+                            "Must provide PSCID and CandID to validate"
+                        )
+                    );
+            }
+            // Return "0" or "1" based on whether it exists or not.
+            // We always return a 200 error code and not a 404, because
+            // even if the CandID doesn't exist or match, the validateids
+            // endpoint still exists and has a valid response.
+            $exists = \Candidate::candidateExists(
+                $gets['CandID'],
+                $gets['PSCID']
+            ) ? "1" : "0";
+        }
         return (new \LORIS\Http\Response())
             ->withHeader("Content-Type", "text/plain")
             ->withStatus(200)
             ->withBody(new \LORIS\Http\StringStream($exists));
-
     }
 }
-


### PR DESCRIPTION
### Brief summary of changes
Open Profile gets stuck validating when you try to input a DCCID that contains alphabet characters. This PR adds a validation to check if DCCID is an integer.

### This resolves issue...

- [ ] Github? #4887

### To test this change...

- [ ] Uncheck the "Across all sites access candidate profiles" permission to be able to view the Open Profile button
- [ ] Ensure invalid IDs and invalid ID combinations result in an alert/error message 