### PR TITLE
[examiner] Add a ConfigurationException When Certification Disabled

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -32,6 +32,7 @@ class EditExaminer extends \NDB_Form
      *
      * @return bool
      * @throws \LorisException
+     * @throws \ConfigurationException
      */
     function _hasAccess(\User $user) : bool
     {
@@ -50,8 +51,8 @@ class EditExaminer extends \NDB_Form
 
         if ($certification['EnableCertification'] ?? false) {
             $cids      = $DB->pselect(
-                "SELECT epr.centerID 
-                 FROM examiners e 
+                "SELECT epr.centerID
+                 FROM examiners e
                   LEFT JOIN examiners_psc_rel epr ON (e.examinerID=epr.examinerID)
                  WHERE e.examinerID=:EID",
                 array('EID' => $this->identifier)
@@ -69,7 +70,9 @@ class EditExaminer extends \NDB_Form
                 = $user->hasPermission('examiner_multisite');
             return $permitted || $permittedAllSites;
         }
-        return false;
+        throw new \ConfigurationException(
+            "Certification Disabled in config.xml"
+        );
     }
 
     /**
@@ -84,7 +87,7 @@ class EditExaminer extends \NDB_Form
 
         // get the certification results for the given examiner
         $result = $DB->pselect(
-            "SELECT testID, pass, date_cert, comment 
+            "SELECT testID, pass, date_cert, comment
              FROM certification
              WHERE examinerID=:EID",
             array('EID' => $this->identifier)
@@ -126,7 +129,7 @@ class EditExaminer extends \NDB_Form
 
             // Get the certificationID if it exists
             $certID = $DB->pselectOne(
-                "SELECT certID 
+                "SELECT certID
                  FROM certification
                  WHERE examinerID=:EID AND testID=:TID",
                 array(
@@ -156,7 +159,7 @@ class EditExaminer extends \NDB_Form
                 );
 
                 $certID = $DB->pselectOne(
-                    "SELECT certID 
+                    "SELECT certID
                      FROM certification
                      WHERE examinerID =:EID and testID=:TID",
                     array(


### PR DESCRIPTION
### Brief summary of changes

Cannot access Edit Examiner page when you have permissions to view and edit examiner but your certification is not enabled in config.xml. This PR adds a ConfigurationException so that if your certification is not enabled, you will get an error message that reads "LORIS configuration settings are invalid or missing and as a result execution cannot proceed" instead of "You do not have access to this page."

### This resolves issue...

- [ ] Github? #4717

### To test this change...

- [ ] `<EnableCertification>`**0**`</EnableCertification>` in config.xml should result in "LORIS configuration settings are invalid or missing and as a result execution cannot proceed" message 
- [ ] `<EnableCertification>`**1**`</EnableCertification>` in config.xml should allow you to view the EditExaminer page 

