### PR TITLE
[DQT] Fix crash when CouchDB values not set in project/config.xml

### DIFF
--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -59,17 +59,16 @@ class Dataquery extends \NDB_Form
             $couchConfig['adminpass']
         );
         if (!$couchConfigValid) {
-            throw new \ConfigException(
-                'Missing CouchDB configuration settings. Cannot load ' .
-                'Data Query Tool.'
-            );
             error_log(
                 'Data Query Tool cannot be loaded due to missing ' .
                 'configuration settings. Ensure that `dbName`, `hostname`, ' .
                 '`port`, `admin` and `adminpass` values are properly ' .
                 'configured in project/config.xml'
             );
-            return;
+            throw new \ConfigException(
+                'Missing CouchDB configuration settings. Cannot load ' .
+                'Data Query Tool.'
+            );
         }
         $couch = \NDB_Factory::singleton()->couchDB(
             $couchConfig['dbName'],

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -59,8 +59,10 @@ class Dataquery extends \NDB_Form
             $couchConfig['adminpass']
         );
         if (!$couchConfigValid) {
-            echo 'Missing CouchDB configuration settings. Cannot load ' .
-                'Data Query Tool.';
+            throw new \ConfigException(
+                'Missing CouchDB configuration settings. Cannot load ' .
+                'Data Query Tool.'
+            );
             error_log(
                 'Data Query Tool cannot be loaded due to missing ' .
                 'configuration settings. Ensure that `dbName`, `hostname`, ' .

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -2,7 +2,7 @@
 /**
  * Data Querying Module
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Data_Querying_Module
  * @package  Loris
@@ -15,7 +15,7 @@ namespace LORIS\dataquery;
 /**
  * Data Querying Module
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Data_Querying_Module
  * @package  Loris
@@ -51,7 +51,25 @@ class Dataquery extends \NDB_Form
         $username    = $user->getUsername();
         $config      = \NDB_Config::singleton();
         $couchConfig = $config->getSetting('CouchDB');
-        $couch       = \NDB_Factory::singleton()->couchDB(
+        $couchConfigValid = isset(
+            $couchConfig['dbName'],
+            $couchConfig['hostname'],
+            $couchConfig['port'],
+            $couchConfig['admin'],
+            $couchConfig['adminpass']
+        );
+        if (!$couchConfigValid) {
+            echo 'Missing CouchDB configuration settings. Cannot load ' .
+                'Data Query Tool.';
+            error_log(
+                'Data Query Tool cannot be loaded due to missing ' .
+                'configuration settings. Ensure that `dbName`, `hostname`, ' .
+                '`port`, `admin` and `adminpass` values are properly ' .
+                'configured in project/config.xml'
+            );
+            return;
+        }
+        $couch = \NDB_Factory::singleton()->couchDB(
             $couchConfig['dbName'],
             $couchConfig['hostname'],
             intval($couchConfig['port']),


### PR DESCRIPTION
### Brief summary of changes
If your `project/config.xml` file does not contain entries for `CouchDB` values, LORIS crashes with a blank page. 

This PR prints a simple error message and logs a more informative error instead of crashing.

### To test this change...

- [ ] Modify your `project/config.xml` so that it does not contain all of the settings necessary for a CouchDB connection, i.e. delete any one of `port`, `hostname`, `admin`, `adminpass` or `dbName`
- [ ] Navigate to the DQT. The page should be blank and return a 500 error. 
- [ ] On this branch, an error message will appear instead. Details will be shown in the error log.
