### PR TITLE
Fix instrument level breadcrumb

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2608,6 +2608,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $timepoint  = \TimePoint::singleton($sessionid);
         $candid     = $timepoint->getCandID();
         $pscid      = $this->getPSCID();
+        $instrument = $this->testName;
 
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
@@ -2624,8 +2625,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ),
             new \LORIS\Breadcrumb(
                 $this->getFullName(),
-                ''
+                "/instruments/$instrument/?commentID=$this->commentID"
             )
+
         );
     }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2627,7 +2627,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $this->getFullName(),
                 "/instruments/$instrument/?commentID=$this->commentID"
             )
-
         );
     }
 


### PR DESCRIPTION
### Brief summary of changes

Instrument level breadcrumb lead to the dashboard. This PR fixes the issue and the breadcrumb now return to the instrument page.

### This resolves issue...

- [x] Github #4892

### To test this change...

- [ ] go to any instrument page and click on the instrument breadcrumb. It should not lead you to the dashboard anymore compared to 21.0

