### PR TITLE
[DQT] Fix data not loading

### DIFF
--- a/modules/dataquery/jsx/react.tabs.js
+++ b/modules/dataquery/jsx/react.tabs.js
@@ -164,11 +164,15 @@ class ViewDataTabPane extends Component {
     this.state = {
       sessions: []
     };
-    this.runQuery = this.props.runQuery.bind(this);
+    this.runQuery = this.runQuery.bind(this);
     this.changeDataDisplay = this.changeDataDisplay.bind(this);
     this.getOrCreateProgressElement = this.getOrCreateProgressElement.bind(this);
     this.getOrCreateDownloadLink = this.getOrCreateDownloadLink.bind(this);
     this.downloadData = this.downloadData.bind(this);
+  }
+
+  runQuery() {
+    this.props.runQuery(this.props.Fields, this.props.Sessions);
   }
 
   changeDataDisplay(displayID) {

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -441,7 +441,7 @@ class CouchDB
 
         $handler->open();
         $handler->write($url . " HTTP/1.0\r\n");
-        $handler->write("Content-Length: " . strlen(json_encode($data)) . "\r\n");
+        $handler->write("Content-Length: " . strlen($data) . "\r\n");
         $handler->write("Content-type: application/json\r\n");
 
         $handler->write(


### PR DESCRIPTION
### Brief summary of changes

1. runQuery javascript function was called with the expected parameters.
2. Content-Lenght header value now fit the content-length of the data sent.

### This resolves issue...

- [ ] Github? #4864 

### To test this change...
Go to DQT, select fields, run query... does results appear? For some reason, the tab shows the info tab content instead of results... the tester need to switch tabs. 
See:  https://github.com/aces/Loris/issues/4905

# If this sentence shows up it means I didn't read the instructions! .... Not
