### PR TITLE
[DQT] Fix info tab showing instead of query results

### DIFF
--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -899,6 +899,7 @@ class DataQueryApp extends Component {
       TabId='Info'
       UpdatedTime={this.props.UpdatedTime}
       Loading={this.state.loading}
+      Active={this.state.ActiveTab == 'Info'}
     />);
 
     // Add the field select tab
@@ -911,6 +912,7 @@ class DataQueryApp extends Component {
       Visits={this.props.Visits}
       fieldVisitSelect={this.fieldVisitSelect}
       Loading={this.state.loading}
+      Active={this.state.ActiveTab == 'DefineFields'}
     />);
 
     // Add the filter builder tab
@@ -922,6 +924,7 @@ class DataQueryApp extends Component {
         updateFilter={this.updateFilter}
         Visits={this.props.Visits}
         Loading={this.state.loading}
+        Active={this.state.ActiveTab == 'DefineFilters'}
       />
     );
 
@@ -930,6 +933,7 @@ class DataQueryApp extends Component {
     tabs.push(<ViewDataTabPane
       key='ViewData'
       TabId='ViewData'
+      Active={this.state.ActiveTab == 'ViewData'}
       Fields={this.state.fields}
       Criteria={this.state.criteria}
       Sessions={this.getSessions()}
@@ -948,6 +952,7 @@ class DataQueryApp extends Component {
     tabs.push(<StatsVisualizationTabPane
       key='Statistics'
       TabId='Statistics'
+      Active={this.state.ActiveTab == 'Statistics'}
       Fields={this.state.rowData.RowHeaders}
       Data={this.state.rowData.rowdata}
       Loading={this.state.loading}

--- a/modules/dataquery/jsx/react.tabs.js
+++ b/modules/dataquery/jsx/react.tabs.js
@@ -682,7 +682,7 @@ class StatsVisualizationTabPane extends Component {
         </table>
       );
 
-      let content = (
+      content = (
         <div>
           <h2>Basic Statistics</h2>
           {statsTable}

--- a/modules/dataquery/jsx/react.tabs.js
+++ b/modules/dataquery/jsx/react.tabs.js
@@ -81,7 +81,7 @@ class InfoTabPane extends Component {
       <TabPane
         Title='Welcome to the Data Query Tool'
         TabId={this.props.TabId}
-        Active={true}
+        Active={this.props.Active}
         Loading={this.props.Loading}
       >
         <p>Data was last updated on {this.props.UpdatedTime}.</p>
@@ -119,6 +119,7 @@ class FieldSelectTabPane extends Component {
       <TabPane
         TabId={this.props.TabId}
         Loading={this.props.Loading}
+        Active={this.props.Active}
       >
         <FieldSelector
           title='Fields'
@@ -149,6 +150,7 @@ class FilterSelectTabPane extends Component {
                        updateFilter={this.props.updateFilter}
                        filter={this.props.filter}
                        Visits={this.props.Visits}
+                       Active={this.props.Active}
         />
       </TabPane>
     );
@@ -356,6 +358,7 @@ class ViewDataTabPane extends Component {
       <TabPane
         TabId={this.props.TabId}
         Loading={this.props.Loading}
+        Active={this.props.Active}
       >
         <h2>Query Criteria</h2>
         {criteria}
@@ -643,7 +646,7 @@ class StatsVisualizationTabPane extends Component {
 
 
       for (let i = 0; i < this.props.Fields.length; i += 1) {
-        rows.push(<tr>
+        rows.push(<tr key={'fields_'.concat(i)}>
           <td>{this.props.Fields[i]}</td>
           <td>{min[i]}</td>
           <td>{max[i]}</td>
@@ -692,7 +695,7 @@ class StatsVisualizationTabPane extends Component {
       );
     }
     return (
-      <TabPane TabId={this.props.TabId} Loading={this.props.Loading}>
+      <TabPane TabId={this.props.TabId} Loading={this.props.Loading} Active={this.props.Active}>
         {content}
       </TabPane>
     );


### PR DESCRIPTION
### Brief summary of changes
Using the Active property of TabPane to "select" the Active tab

Bonus: fix Warning: Each child in an array or iterator should have a unique "key" prop in the render method of `StatsVisualizationTabPane`

### This resolves issue...

- [ ] Github? https://github.com/aces/Loris/issues/4905


