### PR TITLE
[Documentation] Add ACES security file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy, ACE lab projects
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities by email to the lead developers and maintainers
+at the ACE lab. We have set up an email address specifically for this purpose:
+
+  [security@mcin.ca](mailto:security@mcin.ca)
+
+You can use this email address for reporting anything of a sensitive nature,
+for all the main projects ([CBRAIN](https://github.com/aces/cbrain), [LORIS](https://github.com/aces/Loris) etc)
+or any of the other sub projects. For general issues that do not have a sensitive nature, please
+use the standard issue trackers of each repository.
+
+We will get back to you by email to acknowledge the report and maybe ask for more information.
+
+Thank you,
+
+The ACE lab development team.


### PR DESCRIPTION
### Brief summary of changes

This adds a `SECURITY.md` file to the repository. It is a copy of the one written by @prioux at https://raw.githubusercontent.com/aces/.github/master/SECURITY.md.