### PR TITLE
Add new phan rule PhanMismatchReturn

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -21,7 +21,6 @@ return [
 		"PhanUndeclaredVariableDim",
 		"PhanUndeclaredClassMethod",
 		"PhanTypeMismatchArgument",
-		"PhanTypeMismatchReturn",
 		"PhanTypeMismatchProperty",
         "PhanTypeSuspiciousStringExpression",
 	],

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -369,7 +369,7 @@ class DirectDataEntryMainPage
             $this->tpl_data['complete']  = true;
 
             $this->updateStatus('Complete');
-            $Responses      = $DB->update(
+            $DB->update(
                 $this->TestName,
                 array(
                  'Date_taken' => date('Y-m-d'),
@@ -378,7 +378,7 @@ class DirectDataEntryMainPage
                  'CommentID' => $this->CommentID,
                 )
             );
-            $Responses_flag = $DB->update(
+            $DB->update(
                 'flag',
                 array(
                  'Data_entry'     => 'Complete',

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -208,7 +208,9 @@ class Create_Timepoint extends \NDB_Form
                         WHERE CenterID =:cid",
                         array('cid' => $siteID)
                     );
-                    $psc_labelOptions[$siteID] = $center['Name'];
+                    if (!is_null($center['Name'])) {
+                        $psc_labelOptions[$siteID] = $center['Name'];
+                    }
                 }
             }
             $this->addSelect('psc', 'Site', $psc_labelOptions);

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -208,7 +208,7 @@ class Create_Timepoint extends \NDB_Form
                         WHERE CenterID =:cid",
                         array('cid' => $siteID)
                     );
-                    if (!is_null($center['Name'])) {
+                    if (!is_null($center)) {
                         $psc_labelOptions[$siteID] = $center['Name'];
                     }
                 }

--- a/modules/data_integrity_flag/php/data_integrity_flag.class.inc
+++ b/modules/data_integrity_flag/php/data_integrity_flag.class.inc
@@ -76,7 +76,7 @@ class Data_Integrity_Flag extends \NDB_Menu_Filter
             || !isset($req['date'])
             || !isset($req['flagStatus'])
         ) {
-            return "Error";
+            return;
         }
         $req = \Utility::asArray($req);
         // comment may not be set since it is not a required field

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -43,7 +43,7 @@ if ($_POST['action'] == 'upload'
     } else {
         $target_path = $base_path . $fileName;
         if (move_uploaded_file($_FILES["file"]["tmp_name"], $target_path)) {
-            $success = $DB->insert(
+            $DB->insert(
                 'data_release',
                 array(
                  'file_name'   => $fileName,
@@ -68,7 +68,7 @@ if ($_POST['action'] == 'upload'
                  'upload_date' => $upload_date,
                 )
             );
-            $success = $DB->insert(
+            $DB->insert(
                 'data_release_permissions',
                 array(
                  'userid'          => $user_ID,

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -134,7 +134,6 @@ class Datadict extends \NDB_Menu_Filter
             )
         );
         $this->addBasicText('keyword', "Search keyword");
-        return true;
     }
 
     /**

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -89,7 +89,6 @@ class ViewDetails extends \NDB_Form
     */
     function _getTarchiveData($tarchiveID, $table, $order)
     {
-        $array = array();
         switch ($table) {
         case "tarchive":
             $query = "SELECT * FROM $table WHERE TarchiveID =:ID";
@@ -98,7 +97,7 @@ class ViewDetails extends \NDB_Form
         case "tarchive_series":
             $query = "SELECT * FROM $table WHERE TarchiveID =:ID
                 ORDER BY :OField";
-            $array = $this->DB->pselect(
+            $tarchiveData = $this->DB->pselect(
                 $query,
                 array(
                  'ID'     => $tarchiveID,
@@ -109,7 +108,7 @@ class ViewDetails extends \NDB_Form
             if ($this->_setProtocols()) {
                 $previousSeriesDescription = '';
                 $previousProtocolName      = '';
-                foreach ($array as &$series) {
+                foreach ($tarchiveData as &$series) {
                     $seriesDescription = $series['SeriesDescription'];
                     // if the same series, do not compute the protocol name again,
                     // use the previous one
@@ -127,7 +126,7 @@ class ViewDetails extends \NDB_Form
         case "tarchive_files":
             $query = "SELECT * FROM $table WHERE TarchiveID =:ID
                 ORDER BY :OField";
-            $array = $this->DB->pselect(
+            $tarchiveData = $this->DB->pselect(
                 $query,
                 array(
                  'ID'     => $tarchiveID,
@@ -137,7 +136,7 @@ class ViewDetails extends \NDB_Form
             break;
         }
 
-        return $array;
+        return $tarchiveData ?? array();
     }
     /**
     * Validates PatientName and PatientID,
@@ -322,7 +321,7 @@ class ViewDetails extends \NDB_Form
         try {
             $query = "SELECT Scan_type FROM mri_scan_type WHERE ID=:ID";
             $array = $this->DB->pselectRow($query, array('ID' => $id));
-            return $array['Scan_type'];
+            return $array['Scan_type'] ?? 'Unknown';
         } catch (\LorisException $e) {
             return "Unknown";
         }

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -95,7 +95,7 @@ class ViewDetails extends \NDB_Form
             $array = $this->DB->pselectRow($query, array('ID' => $tarchiveID));
             break;
         case "tarchive_series":
-            $query = "SELECT * FROM $table WHERE TarchiveID =:ID
+            $query        = "SELECT * FROM $table WHERE TarchiveID =:ID
                 ORDER BY :OField";
             $tarchiveData = $this->DB->pselect(
                 $query,
@@ -124,7 +124,7 @@ class ViewDetails extends \NDB_Form
             }
             break;
         case "tarchive_files":
-            $query = "SELECT * FROM $table WHERE TarchiveID =:ID
+            $query        = "SELECT * FROM $table WHERE TarchiveID =:ID
                 ORDER BY :OField";
             $tarchiveData = $this->DB->pselect(
                 $query,

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -89,6 +89,7 @@ class ViewDetails extends \NDB_Form
     */
     function _getTarchiveData($tarchiveID, $table, $order)
     {
+        $array = array();
         switch ($table) {
         case "tarchive":
             $query = "SELECT * FROM $table WHERE TarchiveID =:ID";

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -75,16 +75,14 @@ class DocTree extends \NDB_Page
     /**
      * This method will return an array of document_repository_categories
      *
-     * @return ResponseInterface The outgoing PSR7 response
+     * @return array All the data from the document_repository_categories table
      */
     public function getTreeData()
     {
-          $DB       = \Database::singleton();
-          $category = $DB->pselect(
-              "SELECT * FROM document_repository_categories",
-              array()
-          );
-          return $category;
+        return \Database::singleton()->pselect(
+            "SELECT * FROM document_repository_categories",
+            array()
+        );
     }
     /**
      * This method will return an array of all children's categories
@@ -119,7 +117,7 @@ class DocTree extends \NDB_Page
      *
      * @return array the result
      */
-    Public function getParents($data, $id)
+    public function getParents($data, $id)
     {
         $arr = array();
         foreach ($data as $v) {
@@ -133,8 +131,7 @@ class DocTree extends \NDB_Page
                 }
             }
         }
-            return $arr;
-
+        return $arr;
     }
     /**
      * This method will return a json of the parent's categroies and

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -193,7 +193,6 @@ class Document_Repository extends \NDB_Menu_Filter_Form
         }
         $this->group_by = '';
         $this->order_by = 'v.File_name';
-        return true;
     }
 
     /**

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -128,6 +128,12 @@ class Document_Repository extends \NDB_Menu_Filter_Form
                 $query        = "SELECT * FROM document_repository_categories".
                             " where id=$parent_id";
                 $value        = $DB->pselectRow($query, array());
+                if (is_null($value)) {
+                    throw new \LorisException(
+                        'Could not find data for specified parent ID. '
+                        . 'Cannot parse category.'
+                    );
+                }
                 $categoryName = $value['category_name'] . ">" . $categoryName;
             }
         } while ($value['parent_id'] != 0);

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -123,11 +123,11 @@ class Document_Repository extends \NDB_Menu_Filter_Form
             $categoryName = $value['category_name'];
         do {
             if ($value['parent_id'] != 0) {
-                $depth       += 1;
-                $parent_id    = $value['parent_id'];
-                $query        = "SELECT * FROM document_repository_categories".
+                $depth    += 1;
+                $parent_id = $value['parent_id'];
+                $query     = "SELECT * FROM document_repository_categories".
                             " where id=$parent_id";
-                $value        = $DB->pselectRow($query, array());
+                $value     = $DB->pselectRow($query, array());
                 if (is_null($value)) {
                     throw new \LorisException(
                         'Could not find data for specified parent ID. '

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -285,7 +285,7 @@ class Files extends \NDB_Page
     * @return array An array containing the category name and ID for file
     *               categories in the document repository.
     */
-    function parseCategory($value): array
+    function parseCategory(array $value): array
     {
         $id           = $value['id'];
         $depth        = 0;

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -293,12 +293,12 @@ class Files extends \NDB_Page
         $categoryName = $value['category_name'];
         do {
             if ($value['parent_id'] != 0) {
-                $depth       += 1;
-                $parent_id    = $value['parent_id'];
-                $query        = "SELECT * FROM document_repository_categories".
+                $depth    += 1;
+                $parent_id = $value['parent_id'];
+                $query     = "SELECT * FROM document_repository_categories".
                             " WHERE id=:parent_id";
-                $where        = array('parent_id' => $parent_id);
-                $value        = $DB->pselectRow($query, $where);
+                $where     = array('parent_id' => $parent_id);
+                $value     = $DB->pselectRow($query, $where);
                 if (is_null($value)) {
                     throw new \LorisException(
                         'No parent category found for specified parentID. '

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -299,6 +299,12 @@ class Files extends \NDB_Page
                             " WHERE id=:parent_id";
                 $where        = array('parent_id' => $parent_id);
                 $value        = $DB->pselectRow($query, $where);
+                if (is_null($value)) {
+                    throw new \LorisException(
+                        'No parent category found for specified parentID. '
+                        . 'Cannot parse categories.'
+                    );
+                }
                 $categoryName = $value['category_name'] . ">" . $categoryName;
             }
         } while ($value['parent_id'] != 0);
@@ -403,7 +409,7 @@ class Files extends \NDB_Page
         ) {
                 $uploadedFile->moveTo($uploadPath.$fileName);
 
-                $success = $DB->insert(
+                $DB->insert(
                     'document_repository',
                     array(
                      'File_category' => $category,

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -200,6 +200,12 @@ class EditExaminer extends \NDB_Form
                      'TID' => $testID,
                     )
                 );
+                if (is_null($oldVals)) {
+                    throw new \LorisException(
+                        'No old certification values found for specified '
+                        . 'examiner and test IDs.'
+                    );
+                }
 
                 $oldVal  = $oldVals['new'];
                 $oldDate = $oldVals['new_date'];
@@ -213,6 +219,13 @@ class EditExaminer extends \NDB_Form
                      'TID' => $testID,
                     )
                 );
+
+                if (is_null($oldCertification)) {
+                    throw new \LorisException(
+                        'No old data certification found for specified '
+                        . 'examiner and test IDs.'
+                    );
+                }
 
                 // If one of the values was changed
                 if ($oldCertification['pass'] != $certStatus

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -116,7 +116,6 @@ class Examiner extends \NDB_Menu_Filter_Form
                                'site'        => 'epr.centerID',
                                'radiologist' => 'COALESCE(e.radiologist, 0)',
                               );
-        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -200,7 +200,6 @@ class CNV_Browser extends \NDB_Menu_Filter
                 'Platform'           => 'genotyping_platform.Name',
                );
         $this->formToFilter = $ftf;
-        return true;
     }
 
     /**
@@ -342,8 +341,6 @@ class CNV_Browser extends \NDB_Menu_Filter
         $this->addSelect('Array_Report', 'Array Report:', $Array_Report_options);
         $this->addBasicText('Markers', 'Markers:');
         $this->addBasicText('Validation_Method', 'Validation Method:');
-
-        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -243,8 +243,6 @@ class CpG_Browser extends \NDB_Menu_Filter
                                   'gca.design_type',
                                   'gca.Strand',
                                  );
-
-        return true;
     }
 
     /**
@@ -426,8 +424,6 @@ class CpG_Browser extends \NDB_Menu_Filter
             'dmr'
         );
         $this->addSelect('DMR', 'DMR:', $Base_options);
-
-        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -249,8 +249,6 @@ class Genomic_Browser extends \NDB_Menu_Filter
                                  'full'  => 'All fields',
                                 );
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
-
-        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/genomic_file_uploader.class.inc
@@ -143,8 +143,6 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
         $this->tpl_data['upload_allowed'] = $user->hasPermission(
             'genomic_data_manager'
         );
-
-        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/gwas_browser.class.inc
+++ b/modules/genomic_browser/php/gwas_browser.class.inc
@@ -149,8 +149,6 @@ class GWAS_Browser extends \NDB_Menu_Filter
         $this->addBasicText('Estimate', 'Estimate:');
         $this->addBasicText('StdErr', 'Std Err:');
         $this->addBasicText('Pvalue', 'P-value:');
-
-        return true;
     }
 
     /**

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -223,8 +223,6 @@ class SNP_Browser extends \NDB_Menu_Filter
                );
 
         $this->formToFilter = $ftf;
-
-        return true;
     }
 
     /**
@@ -376,8 +374,6 @@ class SNP_Browser extends \NDB_Menu_Filter
         $this->addSelect('Array_Report', 'Array Report:', $Array_Report_options);
         $this->addBasicText('Markers', 'Markers:');
         $this->addBasicText('Validation_Method', 'Validation Method:');
-
-        return true;
     }
 
     /**

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -40,7 +40,7 @@ class Edit_Help_Content extends \NDB_Form
      /**
       * Returns default help content of the page
       *
-      * @return ?array An associative array containing the title and content
+      * @return array An associative array containing the title and content
       *         for the default help information.
       */
     function _getDefaults()
@@ -53,6 +53,8 @@ class Edit_Help_Content extends \NDB_Form
             htmlspecialchars($_REQUEST['section']) : '';
         $safeSubsection = $_REQUEST['subsection'] ?
             htmlspecialchars($_REQUEST['subsection']) : '';
+
+        $defaults = array();
 
         if (isset($_REQUEST['helpID'])) {
             $helpID = htmlspecialchars($_REQUEST['helpID']);

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -40,7 +40,8 @@ class Edit_Help_Content extends \NDB_Form
      /**
       * Returns default help content of the page
       *
-      * @return array
+      * @return ?array An associative array containing the title and content
+      *         for the default help information.
       */
     function _getDefaults()
     {

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -89,7 +89,7 @@ class HelpFile
         // insert a help file
         $DB->insert('help', $set);
         // return the help ID
-        return $DB->lastInsertID;
+        return intval($DB->lastInsertID);
     }
 
 
@@ -281,7 +281,7 @@ class HelpFile
             $parentData = $result;
 
             // check if we're done recursing
-            if ($level != $stopat) {
+            if (is_array($parentData) && $level != $stopat) {
                 // make the parent
                 $parent =& HelpFile::factory($this->data['parentID']);
 

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -292,7 +292,7 @@ class HelpFile
             }
         }
 
-        return $parentData;
+        return $parentData ?? array();
     }
 
     /**

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -265,20 +265,17 @@ class HelpFile
     function parentData($stopat = 1, $level = 1)
     {
         // create DB object
-        $DB =& \Database::singleton();
+        $DB = \Database::singleton();
 
         $parentData = array();
 
         if ($this->data['parentID'] > 0) {
-            $result = $DB->pselectRow(
+            $parentData = $DB->pselectRow(
                 "SELECT helpID, topic, $level as level
                  FROM help
                  WHERE helpID = :HID",
                 array('HID' => $this->data['parentID'])
             );
-
-            // add the parent to the array
-            $parentData = $result;
 
             // check if we're done recursing
             if (is_array($parentData) && $level != $stopat) {

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -87,7 +87,7 @@ class HelpFile
         $DB =& \Database::singleton();
 
         // insert a help file
-        $success = $DB->insert('help', $set);
+        $DB->insert('help', $set);
         // return the help ID
         return $DB->lastInsertID;
     }
@@ -103,12 +103,10 @@ class HelpFile
     function update($set)
     {
         // create DB object
-        $DB =& \Database::singleton();
+        $DB = \Database::singleton();
 
         // update the help file
-        $success = $DB->update('help', $set, array('helpID' => $this->helpID));
-
-        return true;
+        $DB->update('help', $set, array('helpID' => $this->helpID));
     }
 
     /**

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -87,14 +87,19 @@ class Imaging_Session_ControlPanel
                  'v_sessions_id' => $this->sessionID,
                 )
             );
+            if (is_null($qresult)) {
+                throw new \LorisException(
+                    'Could not find linked instruments for specified '
+                    . 'test name and session ID'
+                );
+            }
             $links[] = array(
                         "FEName"    => $qresult['Full_name'],
                         "BEName"    => $v,
                         "CommentID" => $qresult['CommentID'],
                        );
         }
-        $subjectData['links']
-            = (empty($links)) ? "" : $links;
+        $subjectData['links'] = (empty($links)) ? "" : $links;
 
         $candidate =& \Candidate::singleton($timePoint->getCandID());
 
@@ -165,6 +170,12 @@ class Imaging_Session_ControlPanel
             $query,
             array("sid" => $this->sessionID)
         );
+        if (is_null($qcstatus)) {
+            throw new \LorisException(
+                'Could not find QC status information for specified '
+                . 'session ID'
+            );
+        }
 
         $subjectData['mriqcstatus']  = $qcstatus['MRIQCStatus'];
         $subjectData['mriqcpending'] = $qcstatus['MRIQCPending'];

--- a/modules/imaging_browser/php/mrinavigation.class.inc
+++ b/modules/imaging_browser/php/mrinavigation.class.inc
@@ -56,7 +56,7 @@ class MRINavigation
     * Parses the request into hostname/params, so that it can be
     * reconstructed into a link which has the same parameters
     *
-    * @return string $urlParams parameters
+    * @return array $urlParams The URL parameters extracted from the request.
     */
     function _splitURL()
     {

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -707,6 +707,12 @@ class ViewSession extends \NDB_Form
             FROM session WHERE ID=:SID",
             array('SID' => $_REQUEST['sessionID'])
         );
+        if (is_null($qcstatus)) {
+            throw new \LorisException(
+                'Could not find QC status information for the supplied '
+                . 'session ID'
+            );
+        }
         $subjectData['mriqcstatus']  = $qcstatus['MRIQCStatus'];
         $subjectData['mriqcpending'] = $qcstatus['MRIQCPending'];
         $subjectData['mricaveat']    = $qcstatus['MRICaveat'];

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -420,7 +420,7 @@ class ViewSession extends \NDB_Form
                 $updateSet = \Utility::nullifyEmpty($updateSet, 'QCStatus');
                 if (!empty($QCExists)) {
                     $updateWhere['FileID'] = $curFileID;
-                    $success = $this->DB->update(
+                    $this->DB->update(
                         'files_qcstatus',
                         $updateSet,
                         $updateWhere
@@ -498,7 +498,7 @@ class ViewSession extends \NDB_Form
                         $params
                     ) > 0
                     ) {
-                        $success = $this->DB->delete('files_qcstatus', $updateWhere);
+                        $this->DB->delete('files_qcstatus', $updateWhere);
                     }
                 } else {
                     if ($this->DB->pselectOne(
@@ -513,7 +513,7 @@ class ViewSession extends \NDB_Form
                                       'QCLastChangeTime' => time(),
                                      );
                         $updateSet = \Utility::nullifyEmpty($updateSet, 'Selected');
-                        $success   = $this->DB->update(
+                        $this->DB->update(
                             'files_qcstatus',
                             $updateSet,
                             $updateWhere
@@ -525,7 +525,7 @@ class ViewSession extends \NDB_Form
                                       'QCFirstChangeTime' => time(),
                                      );
                         $insertSet = \Utility::nullifyEmpty($insertSet, 'Selected');
-                        $success   = $this->DB->insert('files_qcstatus', $insertSet);
+                        $this->DB->insert('files_qcstatus', $insertSet);
                     }
                 }
             }
@@ -576,7 +576,7 @@ class ViewSession extends \NDB_Form
                     = $updateSet['MRIQCLastChangeTime'];
             }
             $updateSet = \Utility::nullifyEmpty($updateSet, 'MRIQCStatus');
-            $success   = $this->DB->update(
+            $this->DB->update(
                 'session',
                 $updateSet,
                 array('ID' => $this->sessionID)

--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -41,8 +41,8 @@ $row       = $DB->pselectRow(
     $query,
     array('uploadId' => $uploadId)
 );
-$inserting = $row['Inserting'];
-$insertionComplete = $row['InsertionComplete'];
+$inserting = $row['Inserting'] ?? '';
+$insertionComplete = $row['InsertionComplete'] ?? '';
 
 /* Get the active notifications from table notification_spool. Only get the ones
  *  with Verbose == 'N' if summary is set to true.
@@ -65,7 +65,7 @@ echo json_encode(
     array(
      'inserting'         => $inserting,
      'insertionComplete' => $insertionComplete,
-     'notifications'     => $notifications,
+     'notifications'     => $notifications ?? '',
     )
 );
 

--- a/modules/imaging_uploader/php/file_decompress.class.inc
+++ b/modules/imaging_uploader/php/file_decompress.class.inc
@@ -60,12 +60,11 @@ class File_Decompress
      *  This function will automatically detect the file-type
      * and will decompress the file by calling the appropriate function
      *
-     * @return boolean returns false if the decompressiong fails
-     *  and true otherwise
+     * @return boolean|string returns false if the decompressiong fails
+     *  and true otherwise. Returns the file name when unzipping.
      */
     function decompressFile()
     {
-
         if ((preg_match("/.tgz/i", $this->file_name))
             || (preg_match("/.tar.gz/i", $this->file_name))
         ) {
@@ -137,7 +136,7 @@ class File_Decompress
      * extracting it to the destination folder and
      * then closing the zip-archive handler
      *
-     * @return int
+     * @return string
      */
     function unzip()
     {

--- a/modules/imaging_uploader/php/file_decompress.class.inc
+++ b/modules/imaging_uploader/php/file_decompress.class.inc
@@ -149,7 +149,7 @@ class File_Decompress
             $zip->close();
         }
 
-        return $file_name;
+        return $file_name ?? '';
     }
 }
 

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -95,7 +95,6 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                                'Visit_label' => 's.Visit_label',
                                'IsPhantom'   => 'mu.IsPhantom',
                               );
-        return true;
     }
      /**
      * Sets up the menu filter items for the imaging uploader
@@ -136,7 +135,6 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             header('Content-Type: application/json; charset=UTF-8');
             exit(json_encode(['errors' => $errors]));
         }
-        return true;
     }
     /**
      * Returns true if the _saveFile has successfully
@@ -144,7 +142,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      *
      * @param array $values the array of values from the form
      *
-     * @return true on success, false othewise
+     * @return bool true on success, false othewise
      */
     function _process($values)
     {
@@ -337,9 +335,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                      ':vlabel' => $visit_label,
                     ]
                 );
-                if (sizeOf($candidate) == 0 || (sizeOf($candidate) !== 0
-                    && $candidate["candid"] !== $candid)
-                ) {
+                if (is_null($candidate) || $candidate["candid"] !== $candid) {
                     array_push(
                         $errors["candID"],
                         "The CandID " . $candid .
@@ -635,35 +631,25 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     * @param string $file The full filename including directory.
     * @param Array  $args The list of arguments
     *
-    * @return bool  $success if operation succeeded
+    * @return string  $success if operation succeeded
     */
     function getTargetDirectory($file, $args)
     {
-        $user_name = $args['user_id'] ?? null;
-        if (($user_name==null) || (!(isset($user_name)))) {
-            $user      = \User::singleton();
-            $user_name = $user->getUsername();
-        }
-
-        $output ="$user_name/";
-
-        return $output;
+        return sprintf("%s/", 
+            $args['user_id'] ?? \User::singleton()->getUsername()
+        );
     }
     /**
     * The function isCompressed returns true if the file is
     * compressed (gzip or zip) or false otherwise
     *
-    * @param string $file The full filename including directory.
+    * @param string $file The full filename including directory
     *
-    * @return bool  $success if operation succeeded
+    * @return bool Whether the file is compressed 
     */
     function isCompressed($file)
     {
-        $file_info =  mime_content_type($file);
-        if (preg_match('/zip/', $file_info, $matches)) {
-            return true;
-        }
-        return false;
+        return strpos(mime_content_type($file), 'zip') !== false;
     }
     /**
     * The function removes the uploaded file from the /tmp directory

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -635,7 +635,8 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     */
     function getTargetDirectory($file, $args)
     {
-        return sprintf("%s/", 
+        return sprintf(
+            "%s/",
             $args['user_id'] ?? \User::singleton()->getUsername()
         );
     }
@@ -645,7 +646,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
     *
     * @param string $file The full filename including directory
     *
-    * @return bool Whether the file is compressed 
+    * @return bool Whether the file is compressed
     */
     function isCompressed($file)
     {

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -421,7 +421,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     * @param string $columnname the value of column name
     * @param string $type       the value of the type
     *
-    * @return string
+    * @return ?string
     */
     protected function checkType($tablename, $columnname, $type)
     {

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -736,7 +736,7 @@ function getIssueData($issueID=null)
             "LEFT JOIN session s ON (i.sessionID=s.ID) " .
             "WHERE issueID=:issueID",
             ['issueID' => $issueID]
-        );
+        ) ?? array();
     }
 
     return [

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -96,23 +96,19 @@ class Issue extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        $db      = \Database::singleton();
         $issueID = $this->issueID;
         if (!$issueID) {
             return true;
         }
-        $issueData = $db->pselectRow(
+        $issueData = \Database::singleton()->pselectRow(
             "SELECT centerID FROM issues WHERE issueID=:issueID",
-            ['issueID' => $issueID]
+            array('issueID' => $issueID)
         );
-        if (in_array($issueData['centerID'], $user->getData('CenterIDs'))
+        return (is_null($issueData)
+            || in_array($issueData['centerID'], $user->getData('CenterIDs'))
             || ($user->hasPermission('access_all_profiles'))
             || (!empty($issueData['centerID']))
-        ) {
-            return true;
-        } else {
-            return false;
-        }
+        );
     }
     /**
      * Handle the incoming request for an issue. This extracts URLs of the form
@@ -125,7 +121,7 @@ class Issue extends \NDB_Form
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $results = [];
+        $results = array();
         preg_match(
             '#/issue/([0-9]+|new)$#',
             $request->getURI()->getPath(),

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -131,7 +131,7 @@ class PasswordExpiry extends \NDB_Form
             return array('password' => 'Password pwned.');
         }
 
-        return true;
+        return array();
     }
 
     /**

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -168,7 +168,7 @@ class RequestAccount extends \NDB_Form
 
         if ($result == 0) {
             // insert into DB only if email address doesn't exist
-            $success = $DB->insert('users', $vals);
+            $DB->insert('users', $vals);
             // Get the ID of the new user and insert into user_psc_rel
             $user_id = $DB->getLastInsertId();
 

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -47,7 +47,7 @@ class Edit extends \NDB_Form
                 "SELECT id FROM media WHERE id = :mid",
                 array('mid' => $idMediaFile)
             );
-            if (count($result) < 1) {
+            if (empty($result)) {
                 header('Location: ' . $baseURL . '/media/');
             }
         } else {

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -118,7 +118,6 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
         $this->tpl_data['mri_protocol_data']   = $this->getMRIProtocolData();
         $this->tpl_data['mri_protocol_header']
             = array_keys($this->tpl_data['mri_protocol_data'][0]);
-        return true;
     }
 
     /**
@@ -149,7 +148,6 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
         $this->addBasicText('SeriesUID', 'SeriesUID:');
         $this->addBasicText('SeriesDescription', 'Series Description:');
         $this->addBasicDate('TimeRun', 'Time Run', $dateOptions);
-        return true;
     }
 
     /**

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -403,8 +403,6 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             $sites = array('' => 'All User Sites') + $sites;
         }
         $this->addSelect('Site', 'Site', $sites);
-
-        return true;
     }
 
 

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -384,7 +384,6 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         }
         $this->addSelect('Site', 'Site', $sites);
 
-        return true;
     }
     /**
      * Gathers JS dependecies and merge them with the parent

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -175,7 +175,7 @@ class New_Profile extends \NDB_Form
                     "SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid",
                     array('cid' => $siteID)
                 );
-                if (is_array($center)) {
+                if (!is_null($center)) {
                     $psc_labelOptions[$siteID] = $center['Name'];
                 }
             }

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -175,7 +175,9 @@ class New_Profile extends \NDB_Form
                     "SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid",
                     array('cid' => $siteID)
                 );
-                $psc_labelOptions[$siteID] = $center['Name'];
+                if (is_array($center)) {
+                    $psc_labelOptions[$siteID] = $center['Name'];
+                }
             }
         }
         $site = $psc_labelOptions;

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -521,6 +521,11 @@ function editProject() : void
         'WHERE PublicationID=:pid',
         array('pid' => $id)
     );
+    if (empty($pubData)) {
+        throw new \LorisException(
+            'Could not find publication data for specified ID'
+        );
+    }
 
     // build array of changed values
     $toUpdate        = array();

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -439,7 +439,7 @@ function notify($pubID, $type) : void
         );
         throw new \LorisException('Invalid publication ID specified.');
     }
-    $url  = $config->getSetting('url');
+    $url = $config->getSetting('url');
 
     $emailData['Title']       = $data['Title'];
     $emailData['Date']        = $data['DateProposed'];

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -432,6 +432,13 @@ function notify($pubID, $type) : void
         "WHERE PublicationID=:pubID",
         array('pubID' => $pubID)
     );
+    if (is_null($data)) {
+        error_log(
+            'No data found for publication with ID $pudID. Cannot send '
+            . 'email.'
+        );
+        throw new \LorisException('Invalid publication ID specified.');
+    }
     $url  = $config->getSetting('url');
 
     $emailData['Title']       = $data['Title'];

--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -75,7 +75,7 @@ class View_Project extends \NDB_Form
                 "SELECT PublicationID FROM publication WHERE PublicationID = :pid",
                 array('pid' => $pubID)
             );
-            if (count($result) < 1) {
+            if (count($result ?? array()) < 1) {
                 header('Location: ' . $baseURL . '/publication/');
             }
         } else {

--- a/modules/server_processes_manager/php/serverprocesslauncher.class.inc
+++ b/modules/server_processes_manager/php/serverprocesslauncher.class.inc
@@ -70,7 +70,7 @@ class ServerProcessLauncher
      *
      * @param AbstractServerProcess $process the process that was just started
      *
-     * @return void
+     * @return string
      * @throws \InvalidArgumentException if the process is null or if either the
      *                                  PID or the process start time is null.
      */
@@ -128,7 +128,7 @@ class ServerProcessLauncher
      *
      * @param AbstractServerProcess $process process to launch.
      *
-     * @return int ID of the process saved in the database.
+     * @return ?int ID of the process saved in the database.
      *
      * @throws \LorisException if the process cannot be launched successfully.
      */
@@ -152,7 +152,7 @@ class ServerProcessLauncher
             );
         }
 
-        return $this->_saveProcess($process);
+        return intval($this->_saveProcess($process));
     }
 
     /**

--- a/modules/server_processes_manager/php/serverprocesslauncher.class.inc
+++ b/modules/server_processes_manager/php/serverprocesslauncher.class.inc
@@ -161,7 +161,7 @@ class ServerProcessLauncher
      * @param int    $mriUploadId    ID of the MRI upload in the mri_upload table.
      * @param string $sourceLocation location of the MRI file
      *
-     * @return int ID (in the database) of the launched process or null
+     * @return ?int ID (in the database) of the launched process or null
      *             if the process could not be run
      */
     public function mriUpload($mriUploadId, $sourceLocation)

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -52,9 +52,9 @@ class Statistics_Mri_Site extends Statistics_Site
      *
      * @param string $issue the value of issue
      *
-     * @return void
+     * @return string
      */
-    function _getIssueName($issue)
+    function _getIssueName(string $issue)
     {
         switch($issue) {
         case "Tarchive_Missing":
@@ -199,6 +199,9 @@ class Statistics_Mri_Site extends Statistics_Site
         $sqlRow = "SELECT CenterID as ID,".
                   " PSCArea as Name FROM psc WHERE CenterID=:cid";
         $center = $DB->pselectRow($sqlRow, array('cid' => $_REQUEST['CenterID']));
+        if (is_null($center)){
+            throw new \LorisException('Invalid CenterID specified'); 
+        }
         $id     = $center['ID'];
         $name   = $center['Name'];
         // List of all visits. Add to it any time a new one is seen, so

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -199,11 +199,11 @@ class Statistics_Mri_Site extends Statistics_Site
         $sqlRow = "SELECT CenterID as ID,".
                   " PSCArea as Name FROM psc WHERE CenterID=:cid";
         $center = $DB->pselectRow($sqlRow, array('cid' => $_REQUEST['CenterID']));
-        if (is_null($center)){
-            throw new \LorisException('Invalid CenterID specified'); 
+        if (is_null($center)) {
+            throw new \LorisException('Invalid CenterID specified');
         }
-        $id     = $center['ID'];
-        $name   = $center['Name'];
+        $id   = $center['ID'];
+        $name = $center['Name'];
         // List of all visits. Add to it any time a new one is seen, so
         // that we can iterate over it to display later, and leave blank
         // cells for ones that are missing for a given issue in the

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -178,8 +178,8 @@ class Statistics_Site extends \NDB_Menu
                 $sqlRow,
                 array('cid' => $_REQUEST['CenterID'])
             );
-            $centerID = $center['ID'];
-            $name     = $center['Name'];
+            $centerID = $center['ID'] ?? '';
+            $name     = $center['Name'] ?? '';
         } else {
             $name     = 'All';
             $centerID = '';

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -157,9 +157,9 @@ class Stats_Behavioural extends \NDB_Form
             $c      =& $this->tpl_data['behaviour']['C' . $center];
 
             if (isset($c[$vl]['total'])) {
-                $c[$vl]['total'] += $row['val'];
+                $c[$vl]['total'] += intval($row['val']);
             } else {
-                $c[$vl]['total'] = $row['val'];
+                $c[$vl]['total'] = intval($row['val']);
             }
             if (isset($c['all']['total'])) {
                 $c['all']['total'] += $row['val'];

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -153,7 +153,7 @@ class Stats_Behavioural extends \NDB_Form
             // so that they don't wrap. Note that "c"(enter array) needs to
             // be a reference since we'll be modifying it.
             $center = $row['CenterID'];
-            $vl     = $row['VLabel'];
+            $vl     = intval($row['VLabel']);
             $c      =& $this->tpl_data['behaviour']['C' . $center];
 
             if (isset($c[$vl]['total'])) {
@@ -219,7 +219,7 @@ class Stats_Behavioural extends \NDB_Form
 
         foreach ($result as $row) {
             $center = $row['CenterID'];
-            $vl     = $row['VLabel'];
+            $vl     = intval($row['VLabel']);
             $c      =& $this->tpl_data['dde']['C' . $center];
 
             if (isset($c[$vl]['total'])) {

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -298,12 +298,12 @@ class Stats_MRI extends \NDB_Form
             $scan_types[$row['ID']] = $row['Scan_type'];
         }
 
-        $scans_selected =array();
+        $scans_selected = array();
         if ($_REQUEST['Scans'] ?? '') {
             $scans_selected_input = explode(",", $_REQUEST['Scans']);
         }
         if (empty($scans_selected_input)) {
-            $scans_selected =$scan_types;
+            $scans_selected = $scan_types ?? array();
         } else {
             foreach ($scans_selected_input as $key => $scid) {
                 $scans_selected[$scid] =$scan_types[$scid];

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -155,7 +155,8 @@ class Timepoint_List extends \NDB_Menu
                     "SELECT CenterID as ID, Alias FROM psc WHERE CenterID =:cid",
                     array('cid' => $centerID)
                 );
-                $this->tpl_data['timePoints'][$x]['CenterName'] = $center['Alias'] ?? '';
+                $this->tpl_data['timePoints'][$x]['CenterName']
+                    = $center['Alias'] ?? '';
 
                 // create feedback object for the time point
                 $feedback = \NDB_BVL_Feedback::singleton(

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -155,7 +155,7 @@ class Timepoint_List extends \NDB_Menu
                     "SELECT CenterID as ID, Alias FROM psc WHERE CenterID =:cid",
                     array('cid' => $centerID)
                 );
-                $this->tpl_data['timePoints'][$x]['CenterName'] = $center['Alias'];
+                $this->tpl_data['timePoints'][$x]['CenterName'] = $center['Alias'] ?? '';
 
                 // create feedback object for the time point
                 $feedback = \NDB_BVL_Feedback::singleton(

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -437,9 +437,9 @@ class Edit_User extends \NDB_Form
         // update the user
         if ($this->isCreatingNewUser()) {
             // insert a new user
-            $success = \User::insert($set);
-            $user    = \User::factory($set['UserID']);
-            $uid     = $user->getData('ID');
+            \User::insert($set);
+            $user = \User::factory($set['UserID']);
+            $uid  = $user->getData('ID');
             foreach ($us_curr_sites as $site) {
                 $DB->insert(
                     'user_psc_rel',
@@ -451,8 +451,8 @@ class Edit_User extends \NDB_Form
             }
         } else {
             // update the user
-            $user    = \User::factory($this->identifier);
-            $success = $user->update($set);
+            $user = \User::factory($this->identifier);
+            $user->update($set);
         }
 
         // Now set the password. Note that this field is named incorrectly

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -43,7 +43,7 @@ class Edit_User extends \NDB_Form
      *
      * @param \User $editor The user who is accessing this page
      *
-     * @return true if user has access, false otherwise.
+     * @return bool true if user has access, false otherwise.
      */
     function _hasAccess(\User $editor) : bool
     {
@@ -466,7 +466,7 @@ class Edit_User extends \NDB_Form
         // change to the user's permission set since all the checkboxes are
         // disabled)
         if (!$this->_isEditingOwnAccount()) {
-            $success = $user->removePermissions();
+            $user->removePermissions();
             // Check for new permissions
             if (!empty($permIDs)) {
                 foreach ($permIDs as $permID) {
@@ -1188,12 +1188,16 @@ class Edit_User extends \NDB_Form
      * @param \Database $DB    database object.
      * @param string    $email user's email.
      *
-     * @return string error message if email is invalid, null otherwise.
+     * @return ?string error message if email is invalid, null otherwise.
      */
-    private function _getEmailError(\Database $DB, $email)
+    private function _getEmailError(\Database $DB, string $email): ?string
     {
         // remove illegal characters
         $email = filter_var($email, FILTER_SANITIZE_EMAIL);
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            // If email not syntactically valid
+            return "Invalid email address";
+        }
 
         // check email address' uniqueness
         $query  = "SELECT COUNT(*) FROM users WHERE Email = :VEmail ";
@@ -1207,9 +1211,6 @@ class Edit_User extends \NDB_Form
         // Email already exists in database
         if ($result > 0) {
             return 'The email address already exists';
-        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            // If email not syntactically valid
-            return "Invalid email address";
         }
 
         return null;

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -189,7 +189,7 @@ class My_Preferences extends \NDB_Form
             }
         }
         // update the user
-        $success = $user->update($set);
+        $user->update($set);
 
         // Now set the password. Note that this field is named incorrectly at this
         // point in the code and represents a plaintext password, not a hash.

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -466,12 +466,16 @@ class My_Preferences extends \NDB_Form
      * @param \Database $DB    database object.
      * @param string    $email user's email.
      *
-     * @return string error message if email is invalid, null otherwise.
+     * @return ?string error message if email is invalid, null otherwise.
      */
-    private function _getEmailError(\Database $DB, $email)
+    private function _getEmailError(\Database $DB, $email): ?string
     {
         // remove illegal characters
         $email = filter_var($email, FILTER_SANITIZE_EMAIL);
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            // If email not syntactically valid
+            return "Invalid email address";
+        }
 
         // check email address' uniqueness
         $query  = "SELECT COUNT(*) FROM users WHERE Email = :VEmail ";
@@ -485,9 +489,6 @@ class My_Preferences extends \NDB_Form
         // Email already exists in database
         if ($result > 0) {
             return 'The email address already exists';
-        } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            // If email not syntactically valid
-            return "Invalid email address";
         }
 
         return null;

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -134,7 +134,6 @@ class User_Accounts extends \NDB_Menu_Filter
                                'actives'          => $yesNoOptions,
                                'pendingApprovals' => $yesNoOptions,
                               );
-        return true;
     }
     /**
      * Gathers JS dependecies and merge them with the parent

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -106,7 +106,7 @@ class Installer
     /**
      * Check that composer has already been run by.
      *
-     * @return true if composer has been run
+     * @return bool true if composer has been run
      */
     private function _checkComposerRan()
     {
@@ -117,7 +117,7 @@ class Installer
      * Check that the system being installed on meets all LORIS dependencies
      * which can be checked.
      *
-     * @return true if system is dependable.
+     * @return bool true if system is dependable.
      */
     public function checkSystemDependenciesValid()
     {
@@ -170,7 +170,7 @@ class Installer
      *
      * @param array $values The POSTed values for the database to be created.
      *
-     * @return true on success, false on error.
+     * @return bool true on success, false on error.
      */
     function createMySQLDB($values)
     {
@@ -209,7 +209,7 @@ class Installer
      *
      * @param array $values The POSTed values from the client.
      *
-     * @return true on success, false on failure.
+     * @return bool true on success, false on failure.
      */
     function sourceSchema($values)
     {
@@ -265,9 +265,9 @@ class Installer
      * Get the Base URL that this LORIS instance appears to be installed under
      * by checking the URL that the user is accessing.
      *
-     * @return string the LORIS base URL.
+     * @return ?string the LORIS base URL.
      */
-    function getBaseURL()
+    function getBaseURL(): ?string
     {
         // This is apparently the most reliable way to figure out if
         // the requery is over http or https.. $_SERVER[REQUEST_SCHEME]
@@ -277,7 +277,7 @@ class Installer
             || (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])
             && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
         ) {
-               $RequestScheme = 'https';
+            $RequestScheme = 'https';
         }
         if (isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
             return $RequestScheme . '://' . $_SERVER['HTTP_HOST']
@@ -292,7 +292,7 @@ class Installer
      *
      * @param array $values The values from the POST request.
      *
-     * @return true on success, false on error
+     * @return bool true on success, false on error
      */
     function updateBaseConfig($values)
     {
@@ -366,7 +366,7 @@ class Installer
      * @param string   $file The file to source into the database that $DB
      *                       is connected to.
      *
-     * @return true on success, false on failure.
+     * @return bool true on success, false on failure.
      */
     private function _sourceSchemaFile($DB, $file)
     {
@@ -388,7 +388,7 @@ class Installer
      *                      dbadminpassword, dbhost, lorismysqluser, and
      *                      lorismysqlpassword
      *
-     * @return true on success, false on error
+     * @return bool true on success, false on error
      */
     function createMySQLAccount($values)
     {
@@ -501,7 +501,7 @@ class Installer
      *                      dbname, dbadminuser, dbadminpassword, dbhost,
      *                      frontenduser, and frontendpassword
      *
-     * @return true on success
+     * @return bool true on success
      */
     function resetFrontEndAdmin($values)
     {
@@ -555,7 +555,7 @@ class Installer
     /**
      * Returns whether or not the config.xml file should be writable.
      *
-     * @return true if the file should be writable.
+     * @return bool true if the file should be writable.
      */
     function configWritable()
     {
@@ -609,7 +609,7 @@ class Installer
      * @param array $values An associative array with keys for dbhost,
      *                      lorismysqluser, lorismysqlpassword, and dbname
      *
-     * @return true
+     * @return bool true
      */
     function writeConfig($values)
     {

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -713,7 +713,7 @@ class CouchDB
         }
 
         if ($full_json) {
-            return $query;
+            return $query ?? array();
         }
         $data = json_decode($query ?? '', true);
         if (is_null($data)) {

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -72,8 +72,8 @@ class Database
      * @param boolean $trackChanges boolean determining if changes should be
      *                              logged to the history table
      *
-     * @return object Database
-     * @throws DatabaseException
+     * @return \Database
+     * @throws \DatabaseException
      * @access public
      */
     static function &singleton(
@@ -82,7 +82,7 @@ class Database
         string $password     = '',
         string $host         = '',
         bool   $trackChanges = true
-    ) {
+    ): \Database {
 
         static $connections = array();
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -300,9 +300,9 @@ class Database
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the row
      *
-     * @return void
+     * @return bool
      */
-    public function insertOnDuplicateUpdate($table, $set)
+    public function insertOnDuplicateUpdate(string $table, array $set): bool
     {
         return $this->_realinsert($table, $set, true, false, true);
     }
@@ -318,10 +318,12 @@ class Database
      * @param string $table the table into which to insert the row
      * @param array  $set   the values with which to fill the row
      *
-     * @return void
+     * @return bool
      */
-    public function unsafeInsertOnDuplicateUpdate($table, $set)
-    {
+    public function unsafeInsertOnDuplicateUpdate(
+        string $table, 
+        array $set
+    ): bool {
         return $this->_realinsert($table, $set, false, false, true);
     }
 

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -321,7 +321,7 @@ class Database
      * @return bool
      */
     public function unsafeInsertOnDuplicateUpdate(
-        string $table, 
+        string $table,
         array $set
     ): bool {
         return $this->_realinsert($table, $set, false, false, true);

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -206,9 +206,10 @@ class FeedbackMRI
      *
      * @param string $fieldName field to select from in mri table
      *
-     * @return string value of $fieldName in mri table
+     * @return string|bool value of $fieldName in mri table or false when
+     *                      no information found in the database
      */
-    function getMRIValue(string $fieldName): string
+    function getMRIValue(string $fieldName)
     {
         // choke if not a volume instance
         if ($this->objectType != 'volume') {
@@ -287,7 +288,7 @@ class FeedbackMRI
 
         // build the query
         if ($updateNeeded) {
-            $success = $DB->update(
+            $DB->update(
                 'parameter_file',
                 array('Value' => $value),
                 array(
@@ -296,7 +297,7 @@ class FeedbackMRI
                 )
             );
         } else {
-            $success = $DB->insert(
+            $DB->insert(
                 'parameter_file',
                 array(
                  'Value'           => $value,

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -480,6 +480,7 @@ class File_Upload
       */
     function getSplitFilename($name)
     {
+        // NOTE This could probably be better written using pathinfo()
         if (strstr($name, ".")) {
             $extpos       =strrpos($name, ".");
             $file['name'] =substr($name, 0, $extpos);

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1196,7 +1196,7 @@ class LorisForm
     /**
      * Reimplements the HTML_QuickForm validate API.
      *
-     * @return true if all registered rules passed
+     * @return bool true if all registered rules passed
      */
     function validate()
     {
@@ -2219,13 +2219,9 @@ class LorisForm
      *
      * @return string the error message of the element
      */
-    function getElementError($el)
+    function getElementError($el): string
     {
-        if (isset($this->errors[$el])) {
-            return $this->errors[$el];
-        }
-
-        return;
+        return $this->errors[$el] ?? '';
     }
 
     /**
@@ -2312,7 +2308,7 @@ class LorisFormFileElement extends LorisFormElement
     /**
      * Returns true if the file was uploaded by the user.
      *
-     * @return true if the file was uploaded by the user.
+     * @return bool true if the file was uploaded by the user.
      */
     function isUploadedFile()
     {
@@ -2326,7 +2322,7 @@ class LorisFormFileElement extends LorisFormElement
      * @param string $destinationDir      The directory to move the file into
      * @param string $destinationFileName The filename to use in that directory.
      *
-     * @return void
+     * @return bool
      */
     function moveUploadedFile($destinationDir, $destinationFileName)
     {

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -379,12 +379,12 @@ class NDB_BVL_Battery
      *
      * @return string A test name
      */
-    static function getInstrumentNameForCommentId($commentId)
+    public static function getInstrumentNameForCommentId($commentId)
     {
-        $db    =& Database::singleton();
-        $query = "SELECT Test_name FROM flag WHERE CommentID=:CID";
-        $instrumentName = $db->pselectOne($query, array('CID' => $commentId));
-        return $instrumentName;
+        return \Database::singleton()->pselectOne(
+            "SELECT Test_name FROM flag WHERE CommentID=:CID",
+            array('CID' => $commentId)
+        );
     }
 
     /**

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -536,7 +536,7 @@ class NDB_BVL_Battery
      *
      * @param string $testName The test name that we want a commentID for
      *
-     * @return string the commentID generated
+     * @return ?string the commentID generated
      */
     function _createCommentID($testName)
     {
@@ -616,6 +616,6 @@ class NDB_BVL_Battery
         $query = "SELECT COUNT(*) AS counter FROM test_names WHERE Test_name=:TN";
         $row   = $DB->pselectRow($query, array('TN' => $testName));
 
-        return $row['counter'] >= 1;
+        return ($row['counter'] ?? 0) >= 1;
     } // end _assertValidInstrument()
 }

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -225,7 +225,7 @@ class NDB_BVL_Battery
             )
         );
 
-        return $commentID;
+        return $commentID ?? '';
     } // end addInstrument()
 
     /**

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -195,10 +195,10 @@ class NDB_BVL_Battery
         $obj = NDB_BVL_Instrument::factory($testName, '', '');
 
         // insert into the test table
-        $success = $DB->insert($obj->table, array('CommentID' => $commentID));
+        $DB->insert($obj->table, array('CommentID' => $commentID));
 
         // insert into the flag table
-        $success = $DB->insert(
+        $DB->insert(
             'flag',
             array(
              'SessionID' => $sessionData['SessionID'],
@@ -212,10 +212,10 @@ class NDB_BVL_Battery
         $ddeCommentID = 'DDE_'.$commentID;
 
         // insert the dde into the test table
-        $success = $DB->insert($obj->table, array('CommentID' => $ddeCommentID));
+        $DB->insert($obj->table, array('CommentID' => $ddeCommentID));
 
         // insert the dde into the flag table
-        $success = $DB->insert(
+        $DB->insert(
             'flag',
             array(
              'SessionID' => $sessionData['SessionID'],
@@ -226,7 +226,6 @@ class NDB_BVL_Battery
         );
 
         return $commentID;
-
     } // end addInstrument()
 
     /**
@@ -557,7 +556,8 @@ class NDB_BVL_Battery
      * @param integer $SessionID The session ID to generate a CommentID for
      * @param string  $Test_name The test name which the CommentID will be for.
      *
-     * @return string A Validly formatted CommentID
+     * @return ?string A Validly formatted CommentID or null if information
+     *                  is missing in the database.
      */
     static function generateCommentID($SessionID, $Test_name)
     {

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -362,9 +362,9 @@ class NDB_BVL_Feedback
      *                                        threads, otherwise only returns
      *                                        active threads
      *
-     * @return string the higest-order status of an active thread
+     * @return ?string the higest-order status of an active thread
      */
-    function getMaxThreadStatus($select_inactive_threads)
+    function getMaxThreadStatus($select_inactive_threads): ?string
     {
         // new DB Object
         $db =& Database::singleton();

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -292,7 +292,7 @@ class NDB_BVL_Feedback
                    'Description' => $description,
                   );
         $db->insert("feedback_bvl_type", $values);
-        return $db->getLastInsertId();
+        return intval($db->getLastInsertId());
     }
 
     /**
@@ -827,7 +827,7 @@ class NDB_BVL_Feedback
 
         if (is_array($setArray) && count($setArray)>0) {
             // update the thread only if the form data was changed
-            $success = $db->update('feedback_bvl_thread', $setArray, $whereArray);
+            $db->update('feedback_bvl_thread', $setArray, $whereArray);
         }
 
     }
@@ -842,16 +842,16 @@ class NDB_BVL_Feedback
     function deleteThread($feedbackID)
     {
         // new DB Object
-        $db =& Database::singleton();
+        $db = \Database::singleton();
 
         // DELETE the thread's entries
-        $success = $db->delete(
+        $db->delete(
             'feedback_bvl_entry',
             array("FeedbackID" => $feedbackID)
         );
 
         // DELETE the thread
-        $success = $db->delete(
+        $db->delete(
             'feedback_bvl_thread',
             array("FeedbackID" => '$feedbackID')
         );

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -796,7 +796,7 @@ class NDB_BVL_Feedback
         // FIXME: I don't think the third parameter is correct, but I'm not sure
         // what it's supposed to be, and I'm not sure if this code is even used
         // at all.
-        $success = $this->createEntry($feedbackID, $comment, '');
+        $this->createEntry($feedbackID, $comment, '');
 
         // force private threads to status='comment'
         if ($public=='N') {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -292,6 +292,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         //get config
         $config = \NDB_Config::singleton();
         $instrumentPermissions = $config->getSetting("instrumentPermissions");
+        $instrumentPerms       = array();
 
         //check if instrumentPermissions are being used.
         if (!is_array($instrumentPermissions)) {

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -92,6 +92,12 @@ class NDB_BVL_InstrumentStatus
             FROM flag
             WHERE CommentID=:CID";
         $row   = $db->pselectRow($query, array('CID' => $this->_commentID));
+        if (is_null($row)) {
+            throw new \LorisException(
+                'No information exists in the database for the specified '
+                . 'CommentID. Cannot build InstrumentStatus object'
+            );
+        }
 
         // store the statuses into the _status property
         $this->_status = $row;

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -44,7 +44,7 @@ class NDB_Client
      *
      * @param string|null $configFile Path on filesystem to config.xml file
      *
-     * @return true on success
+     * @return bool true on success, false otherwise
      */
     function initialize(?string $configFile = null)
     {

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -109,6 +109,13 @@ class NDB_Factory
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
         if (self::$config !== null) {
+            // The below suppression is necessary to satisfy phan. It flags an
+            // error here because the function is declared to return
+            // NDB_Config and phan doesn't understand MockNDB_Config (as it is
+            // generated dynamically by PHPUnit).
+            // We know this will always return \NDB_Config since this is guaranteed
+            // by the return type of the function.
+            // @phan-suppress-next-line PhanTypeMismatchReturn
             return self::$config;
         }
         if ($this->Testing) {
@@ -154,6 +161,13 @@ class NDB_Factory
     function user(): \User
     {
         if (self::$_user !== null) {
+            // The below suppression is necessary to satisfy phan. It flags an
+            // error here because the function is declared to return
+            // User and phan doesn't understand MockUser (as it is
+            // generated dynamically by PHPUnit).
+            // We know this will always return \User since this is guaranteed
+            // by the return type of the function.
+            // @phan-suppress-next-line PhanTypeMismatchReturn
             return self::$_user;
         }
         if ($this->Testing) {

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -109,7 +109,7 @@ class NDB_Factory
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
         if ($this->Testing) {
-            $config = Mock::generate("NDB_Config"); 
+            $config = Mock::generate("NDB_Config");
         } else {
             $config = NDB_Config::singleton($configfile);
             return $config;
@@ -179,8 +179,8 @@ class NDB_Factory
             if ($db_ref !== null) {
                 return $db_ref;
             }
-            //Mock::generate("Database");
-            self::$testdb = new MockDatabase();
+            self::$testdb = Mock::generate("Database");
+            //self::$testdb = new MockDatabase();
         } else {
             $db_ref = &self::$db;
             if ($db_ref !== null) {

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -104,7 +104,7 @@ class NDB_Factory
      *
      * @param string|null $configfile Location of XML file to parse config from
      *
-     * @return NDB_Config A config singleton
+     * @return \NDB_Config A config singleton
      */
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
@@ -130,20 +130,19 @@ class NDB_Factory
      * Set config
      * (Can used for injecting test doubles)
      *
-     * @param NDB_Config $config config object
+     * @param \NDB_Config $config config object
      *
-     * @return NDB_Config config object which was passed in
+     * @return void
      */
-    public function setConfig(\NDB_Config $config): \NDB_Config
+    public function setConfig(\NDB_Config $config): void
     {
         self::$config = $config;
-        return $config;
     }
 
     /**
      * Return either a real or mock Loris User object.
      *
-     * @return User A user singleton
+     * @return \User A user singleton
      */
     function user(): \User
     {
@@ -194,7 +193,7 @@ class NDB_Factory
             if ($db_ref !== null) {
                 return $db_ref;
             }
-            self::$db = Database::singleton();
+            self::$db = \Database::singleton();
         }
         $config = $this->config();
         $dbc    = $config->getSetting('database');

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -104,18 +104,25 @@ class NDB_Factory
      *
      * @param string|null $configfile Location of XML file to parse config from
      *
-     * @return \NDB_Config A config singleton
+     * @return NDB_Config A config singleton
      */
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
-        $config = self::$config;
-        if ($config === null) {
-            $config = $this->Testing ?
-                new MockNDB_Config()
-                : NDB_Config::singleton($configfile);
-            $this->setConfig($config);
+        if (self::$config !== null) {
+            return self::$config;
+        }
+        if ($this->Testing) {
+            //Mock::generate("NDB_Config");
+            $config = new MockNDB_Config();
+        } else {
+            $config = NDB_Config::singleton($configfile);
+            return $config;
         }
 
+        self::$config = $config;
+        // NDB_Config::singleton() is already loading the config file
+        // in a better way. this needs to be modified
+        $config->load($configfile);
         return $config;
     }
 
@@ -123,32 +130,33 @@ class NDB_Factory
      * Set config
      * (Can used for injecting test doubles)
      *
-     * @param \NDB_Config $config config object
+     * @param NDB_Config $config config object
      *
-     * @return void
+     * @return NDB_Config config object which was passed in
      */
-    public function setConfig(\NDB_Config $config): void
+    public function setConfig(\NDB_Config $config): \NDB_Config
     {
         self::$config = $config;
+        return $config;
     }
 
     /**
      * Return either a real or mock Loris User object.
      *
-     * @return \User A user singleton
+     * @return User A user singleton
      */
     function user(): \User
     {
-        $user = self::$_user;
-        if ($user === null) {
-            // Set user to a new MockUser if testing. Otherwise set to the
-            // User singleton.
-            $user = $this->setUser(
-                $this->Testing ?
-                new MockUser()
-                : \User::singleton()
-            );
+        if (self::$_user !== null) {
+            return self::$_user;
         }
+        if ($this->Testing) {
+            Mock::generate("User");
+            $user = new MockUser();
+        } else {
+            $user = \User::singleton();
+        }
+        self::$_user = $user;
         return $user;
     }
 
@@ -173,10 +181,20 @@ class NDB_Factory
      */
     function database(): \Database
     {
+        $db_ref = null;
         if ($this->Testing) {
-            $db_ref = &self::$testdb ?? new MockDatabase();
+            $db_ref = &self::$testdb;
+            if ($db_ref !== null) {
+                return $db_ref;
+            }
+            //Mock::generate("Database");
+            self::$testdb = new MockDatabase();
         } else {
-            $db_ref = &self::$db ?? \Database::singleton();
+            $db_ref = &self::$db;
+            if ($db_ref !== null) {
+                return $db_ref;
+            }
+            self::$db = Database::singleton();
         }
         $config = $this->config();
         $dbc    = $config->getSetting('database');
@@ -188,8 +206,6 @@ class NDB_Factory
                 'Could not configure database for LORIS'
             );
         }
-
-        $dbc = $this->config()->getSetting('database');
         $db_ref->connect(
             $dbc['database'],
             $dbc['username'],

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -153,8 +153,8 @@ class NDB_Factory
      */
     function user(): \User
     {
-        if (self::$_user !== null) {	
-            return self::$_user;	
+        if (self::$_user !== null) {
+            return self::$_user;
         }
         if ($this->Testing) {
             Mock::generate("User");

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -108,17 +108,6 @@ class NDB_Factory
      */
     function config(?string $configfile = '../project/config.xml'): \NDB_Config
     {
-        // If the path to the config file is null, use the default location
-        // of the file created by the install script.
-        // NOTE: Calling config(null) is different than calling config()
-        // without any arguments.
-        // The latter call will result in $configfile being initialized to the
-        // default param value above. This check handles the former case when
-        // a value of NULL is passed to the function.
-        if (is_null($configfile)) {
-            $configfile = '../project/config.xml';
-        }
-
         if (self::$config !== null) {
             // The below suppression is necessary to satisfy phan. It flags an
             // error here because the function is declared to return
@@ -131,14 +120,14 @@ class NDB_Factory
             return self::$config;
         }
         if ($this->Testing) {
-            $config = new MockNDB_Config();
+            $config     = new MockNDB_Config();
             $configfile = '../test/config.xml';
         } else {
             $config = NDB_Config::singleton($configfile);
         }
 
         self::$config = $config;
-        
+
         // The below suppression is necessary to satisfy phan. It flags an
         // error here because the function is declared to return
         // NDB_Config and phan doesn't understand MockNDB_Config (as it is

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -151,6 +151,7 @@ class NDB_Factory
     function user(): \User
     {
         if ($this->Testing) {
+            Mock::generate("User");
             $user = new MockUser();
         } else {
             $user = \User::singleton();

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -119,6 +119,13 @@ class NDB_Factory
         // NDB_Config::singleton() is already loading the config file
         // in a better way. this needs to be modified
         $config->load($configfile);
+        // The below suppression is necessary to satisfy phan. It flags an
+        // error here because the function is declared to return
+        // NDB_Config and phan doesn't understand MockNDB_Config (as it is
+        // generated dynamically by PHPUnit).
+        // We know this will always return \NDB_Config since this is guaranteed
+        // by the return type of the function.
+        // @phan-suppress-next-line PhanTypeMismatchReturn
         return $config;
     }
 

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -108,6 +108,9 @@ class NDB_Factory
      */
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
+        if (self::$config !== null) {
+            return self::$config;
+        }
         if ($this->Testing) {
             $config = new MockNDB_Config();
         } else {
@@ -150,6 +153,9 @@ class NDB_Factory
      */
     function user(): \User
     {
+        if (self::$_user !== null) {	
+            return self::$_user;	
+        }
         if ($this->Testing) {
             Mock::generate("User");
             $user = new MockUser();

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -122,7 +122,6 @@ class NDB_Factory
             $config = new MockNDB_Config();
         } else {
             $config = NDB_Config::singleton($configfile);
-            return $config;
         }
 
         self::$config = $config;

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -112,7 +112,7 @@ class NDB_Factory
         // of the file created by the install script.
         // NOTE: Calling config(null) is different than calling config()
         // without any arguments.
-        // The latter call will result in $configfile being initialized to the 
+        // The latter call will result in $configfile being initialized to the
         // default param value above. This check handles the former case when
         // a value of NULL is passed to the function.
         if (is_null($configfile)) {
@@ -126,25 +126,26 @@ class NDB_Factory
             // generated dynamically by PHPUnit).
             // We know this will always return \NDB_Config since this is guaranteed
             // by the return type of the function.
+            //
             // @phan-suppress-next-line PhanTypeMismatchReturn
             return self::$config;
         }
         if ($this->Testing) {
             $config = new MockNDB_Config();
+            $configfile = '../test/config.xml';
         } else {
             $config = NDB_Config::singleton($configfile);
         }
 
         self::$config = $config;
-        // NDB_Config::singleton() is already loading the config file
-        // in a better way. this needs to be modified
-        $config->load($configfile);
+        
         // The below suppression is necessary to satisfy phan. It flags an
         // error here because the function is declared to return
         // NDB_Config and phan doesn't understand MockNDB_Config (as it is
         // generated dynamically by PHPUnit).
         // We know this will always return \NDB_Config since this is guaranteed
         // by the return type of the function.
+        //
         // @phan-suppress-next-line PhanTypeMismatchReturn
         return $config;
     }

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -109,7 +109,7 @@ class NDB_Factory
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
         if ($this->Testing) {
-            $config = Mock::generate("NDB_Config");
+            $config = MockNDB_Config();
         } else {
             $config = NDB_Config::singleton($configfile);
             return $config;
@@ -144,7 +144,7 @@ class NDB_Factory
     function user(): \User
     {
         if ($this->Testing) {
-            $user = Mock::generate("User");
+            $user = MockUser();
         } else {
             $user = \User::singleton();
         }
@@ -179,8 +179,8 @@ class NDB_Factory
             if ($db_ref !== null) {
                 return $db_ref;
             }
-            self::$testdb = Mock::generate("Database");
-            //self::$testdb = new MockDatabase();
+            //self::$testdb = Mock::generate("Database");
+            self::$testdb = new MockDatabase();
         } else {
             $db_ref = &self::$db;
             if ($db_ref !== null) {

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -106,8 +106,19 @@ class NDB_Factory
      *
      * @return NDB_Config A config singleton
      */
-    function config(?string $configfile = "../project/config.xml"): \NDB_Config
+    function config(?string $configfile = '../project/config.xml'): \NDB_Config
     {
+        // If the path to the config file is null, use the default location
+        // of the file created by the install script.
+        // NOTE: Calling config(null) is different than calling config()
+        // without any arguments.
+        // The latter call will result in $configfile being initialized to the 
+        // default param value above. This check handles the former case when
+        // a value of NULL is passed to the function.
+        if (is_null($configfile)) {
+            $configfile = '../project/config.xml';
+        }
+
         if (self::$config !== null) {
             // The below suppression is necessary to satisfy phan. It flags an
             // error here because the function is declared to return

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -109,7 +109,7 @@ class NDB_Factory
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
         if ($this->Testing) {
-            $config = MockNDB_Config();
+            $config = new MockNDB_Config();
         } else {
             $config = NDB_Config::singleton($configfile);
             return $config;
@@ -144,7 +144,7 @@ class NDB_Factory
     function user(): \User
     {
         if ($this->Testing) {
-            $user = MockUser();
+            $user = new MockUser();
         } else {
             $user = \User::singleton();
         }

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -108,18 +108,14 @@ class NDB_Factory
      */
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
-        if (self::$config !== null) {
-            return self::$config;
-        }
-        $config = NDB_Config::singleton($configfile);
-        if ($this->Testing) {
-            $config = new MockNDB_Config();
+        $config = self::$config;
+        if ($config === null) {
+            $config = $this->Testing ?
+                new MockNDB_Config()
+                : NDB_Config::singleton($configfile);
+            $this->setConfig($config);
         }
 
-        self::$config = $config;
-        // NDB_Config::singleton() is already loading the config file
-        // in a better way. this needs to be modified
-        $config->load($configfile);
         return $config;
     }
 
@@ -143,16 +139,16 @@ class NDB_Factory
      */
     function user(): \User
     {
-        if (self::$_user !== null) {
-            return self::$_user;
+        $user = self::$_user;
+        if ($user === null) {
+            // Set user to a new MockUser if testing. Otherwise set to the
+            // User singleton.
+            $user = $this->setUser(
+                $this->Testing ?
+                new MockUser()
+                : \User::singleton()
+            );
         }
-        if ($this->Testing) {
-            Mock::generate("User");
-            $user = new MockUser();
-        } else {
-            $user = \User::singleton();
-        }
-        self::$_user = $user;
         return $user;
     }
 
@@ -177,20 +173,10 @@ class NDB_Factory
      */
     function database(): \Database
     {
-        $db_ref = null;
         if ($this->Testing) {
-            $db_ref = &self::$testdb;
-            if ($db_ref !== null) {
-                return $db_ref;
-            }
-            //Mock::generate("Database");
-            self::$testdb = new MockDatabase();
+            $db_ref = &self::$testdb ?? new MockDatabase();
         } else {
-            $db_ref = &self::$db;
-            if ($db_ref !== null) {
-                return $db_ref;
-            }
-            self::$db = \Database::singleton();
+            $db_ref = &self::$db ?? \Database::singleton();
         }
         $config = $this->config();
         $dbc    = $config->getSetting('database');
@@ -202,6 +188,8 @@ class NDB_Factory
                 'Could not configure database for LORIS'
             );
         }
+
+        $dbc = $this->config()->getSetting('database');
         $db_ref->connect(
             $dbc['database'],
             $dbc['username'],

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -108,12 +108,8 @@ class NDB_Factory
      */
     function config(?string $configfile = "../project/config.xml"): \NDB_Config
     {
-        if (self::$config !== null) {
-            return self::$config;
-        }
         if ($this->Testing) {
-            //Mock::generate("NDB_Config");
-            $config = new MockNDB_Config();
+            $config = Mock::generate("NDB_Config"); 
         } else {
             $config = NDB_Config::singleton($configfile);
             return $config;
@@ -147,12 +143,8 @@ class NDB_Factory
      */
     function user(): \User
     {
-        if (self::$_user !== null) {
-            return self::$_user;
-        }
         if ($this->Testing) {
-            Mock::generate("User");
-            $user = new MockUser();
+            $user = Mock::generate("User");
         } else {
             $user = \User::singleton();
         }

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -111,12 +111,9 @@ class NDB_Factory
         if (self::$config !== null) {
             return self::$config;
         }
+        $config = NDB_Config::singleton($configfile);
         if ($this->Testing) {
-            //Mock::generate("NDB_Config");
             $config = new MockNDB_Config();
-        } else {
-            $config = NDB_Config::singleton($configfile);
-            return $config;
         }
 
         self::$config = $config;

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -167,13 +167,15 @@ class NDB_Form extends NDB_Page
      * Processes the values and saves to database. Usually overridden
      * by form instance.
      *
+     * NOTE Maybe this should be an abstract function?
+     *
      * @param array $values form values
      *
      * @return void
      */
     function _process($values)
     {
-        return true;
+        return;
     }
 
     /**

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -2,7 +2,7 @@
 /**
  * This class features the code for the Menu Filter.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Behavioural
  * @package  Main
@@ -160,8 +160,6 @@ class NDB_Menu_Filter extends NDB_Menu
 
         // build the menu
         $this->_build();
-
-        return true;
     }
 
     /**
@@ -406,7 +404,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function _setFilterForm()
     {
-        return true;
+        return;
     }
     /**
     * Gets the base query
@@ -661,9 +659,6 @@ class NDB_Menu_Filter extends NDB_Menu
             }
             $x++;
         }
-
-        return true;
-    }
 
     /**
      * Displays the menu page

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -659,6 +659,7 @@ class NDB_Menu_Filter extends NDB_Menu
             }
             $x++;
         }
+    }
 
     /**
      * Displays the menu page

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -196,15 +196,15 @@ abstract class NDB_Notifier_Abstract
      */
     private function _getAdminUser(): array
     {
-        $result           = \Database::singleton()->pselectRow(
+        $result = \Database::singleton()->pselectRow(
             "SELECT ID, Real_name, Email FROM users WHERE UserID='admin'",
             array()
         );
         if (is_null($result)) {
             return array();
         }
-        $info_array       = array();
-        $info_array['ID'] = $result['ID'];
+        $info_array          = array();
+        $info_array['ID']    = $result['ID'];
         $info_array['name']  = $result['Real_name'];
         $info_array['email'] = $result['Email'];
         return $info_array;

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -172,9 +172,9 @@ abstract class NDB_Notifier_Abstract
     /**
      * Getter for user issuing notification
      *
-     * @return array   User issuing notification in form [ID,name,email]
+     * @return \User issuing the notification
      */
-    public function getNotifier(): array
+    public function getNotifier(): \User
     {
         return $this->notifier;
     }
@@ -200,6 +200,9 @@ abstract class NDB_Notifier_Abstract
             "SELECT ID, Real_name, Email FROM users WHERE UserID='admin'",
             array()
         );
+        if (is_null($result)) {
+            return array();
+        }
         $info_array       = array();
         $info_array['ID'] = $result['ID'];
         $info_array['name']  = $result['Real_name'];

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -187,7 +187,7 @@ class SinglePointLogin
      * @param string $token The token extracted from the
      *                      Authorization: Bearer header
      *
-     * @return true if the session is valid, false otherwise
+     * @return bool true if the session is valid, false otherwise
      */
     function JWTAuthenticate(string $token): bool
     {
@@ -199,14 +199,12 @@ class SinglePointLogin
         //$jwt = \Firebase\JWT\JWT::encode($token, $sharedKey);
         try {
             $decoded = \Firebase\JWT\JWT::decode($token, $sharedKey, array("HS256"));
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             return false;
         }
 
         $decodedArray    = (array) $decoded;
-        $this->_username
-            = isset($decodedArray['user'])
-                ? $decodedArray['user'] : 'Unknown';
+        $this->_username = $decodedArray['user'] ?? 'Unknown';
         return isset($decodedArray['user'])
             && !$this->accountLocked($decodedArray['user']);
     }
@@ -572,7 +570,7 @@ class SinglePointLogin
          * logging in. This will always be the case in our CI environment.
          * The user should not be disabled in this case.
          */
-        if (is_null($row['Login_timestamp'])) {
+        if (is_null($row) || is_null($row['Login_timestamp'])) {
             return false;
         }
         $last_login = new DateTime($row['Login_timestamp']);

--- a/php/libraries/Site.class.inc
+++ b/php/libraries/Site.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file contains the class for the Site object
  *
@@ -32,7 +32,7 @@ class Site
      *
      * @return Site An object representing this site
      */
-    static function &singleton($centerID)
+    static function &singleton(int $centerID)
     {
         static $siteList = array();
         if (!isset($siteList[$centerID])) {
@@ -62,7 +62,7 @@ class Site
         $this->_siteInfo['CenterID'] = $centerID;
 
         // make a local reference to the Database object
-        $db =& Database::singleton();
+        $db = \Database::singleton();
 
         $query  = "SELECT Name, PSCArea, Alias, MRI_alias, Account, Study_site
                       FROM psc
@@ -72,7 +72,7 @@ class Site
         //store site data in the object property
         if (is_array($result) && count($result) > 0) {
             foreach ($result as $key=>$value) {
-                $this->_siteInfo[$key] = $value;
+                $this->_siteInfo[$key] = strval($value);
             }
         } else {
             throw new Exception("Invalid site");
@@ -86,7 +86,7 @@ class Site
      */
     function getCenterName(): string
     {
-        return $this->_siteInfo['Name'];
+        return strval($this->_siteInfo['Name']);
     }
 
     /**
@@ -106,7 +106,7 @@ class Site
      */
     function getSiteAlias(): string
     {
-        return $this->_siteInfo['Alias'];
+        return strval($this->_siteInfo['Alias']);
     }
 
     /**
@@ -116,7 +116,7 @@ class Site
      */
     function getSiteMRIAlias(): string
     {
-        return $this->_siteInfo['MRI_alias'];
+        return strval($this->_siteInfo['MRI_alias']);
     }
 
     /**
@@ -126,7 +126,7 @@ class Site
      */
     function getSiteAccount(): string
     {
-        return $this->_siteInfo['Account'];
+        return strval($this->_siteInfo['Account']);
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -146,22 +146,17 @@ class User extends UserPermissions
 
 
     /**
-     * Inserts a user
+     * Inserts data into the `users` table.
      *
      * @param array $set The array formatted for use in a Database call
      *
-     * @return bool True
+     * @return void
      * @access public
      * @static
      */
-    public static function insert(array $set): bool
+    public static function insert(array $set): void
     {
-        // create DB object
-        $DB =& Database::singleton();
-
-        $DB->insert('users', $set);
-
-        return true;
+        \Database::singleton()->insert('users', $set);
     }
 
 
@@ -170,21 +165,16 @@ class User extends UserPermissions
      *
      * @param array $set The array formatted for use in a Database call
      *
-     * @return bool True
+     * @return void
      * @access public
      */
-    public function update(array $set): bool
+    public function update(array $set): void
     {
-        // create DB object
-        $DB =& Database::singleton();
-
-        $DB->update(
+        \Database::singleton()->update(
             'users',
             $set,
             array('UserID' => $this->userInfo['UserID'])
         );
-
-        return true;
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -40,7 +40,7 @@ class User extends UserPermissions
      *
      * @param string|null $username Identifies the user
      *
-     * @return User
+     * @return \User A User object if the User specified by $username exists
      * @access public
      */
     public static function &factory(?string $username = null): \User
@@ -69,6 +69,11 @@ class User extends UserPermissions
             GROUP BY users.ID";
 
         $row = $DB->pselectRow($query, array('UID' => $username));
+
+        if (is_null($row)) {
+            $obj = new \LORIS\AnonymousUser();
+            return $obj;
+        }
 
         // get user sites
         $user_centerID_query =  $DB->pselect(

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -91,11 +91,10 @@ class UserPermissions
         // values extracted for this user from the database.
         if (is_array($results) and !empty($results)) {
             foreach ($results AS $row) {
-                if (empty($row['userID']) || empty($row['code'])) {
+                if (empty($row['userID'])) {
+                    $this->permissions[$row['code']] = false;
                     continue;
                 }
-                // The line below may not be necessary as the $query already
-                // filters for a userID matching this user...
                 $userMatch = $row['userID'] === $this->userID;
                 $this->permissions[$row['code']] = $userMatch;
             }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -75,7 +75,7 @@ class UserPermissions
     function setPermissions(): void
     {
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \Database::singleton();
 
         // get all the permissions for this user
         $query = "SELECT p.code, pr.userID FROM permissions p
@@ -87,16 +87,17 @@ class UserPermissions
         // reset the array
         $this->permissions = array();
 
-        // fill the array
+        // Fill the permissions array of this UserPermissions object with the
+        // values extracted for this user from the database.
         if (is_array($results) and !empty($results)) {
             foreach ($results AS $row) {
-                if (!empty($row['userID'])
-                    && $row['userID'] === $this->userID
-                ) {
-                    $this->permissions[$row['code']] = true;
-                } else {
-                    $this->permissions[$row['code']] = false;
+                if (empty($row['userID']) || empty($row['code'])) {
+                    continue;
                 }
+                // The line below may not be necessary as the $query already
+                // filters for a userID matching this user...
+                $userMatch = $row['userID'] === $this->userID; 
+                $this->permissions[$row['code']] = $userMatch;
             }
         }
     }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -69,10 +69,10 @@ class UserPermissions
     /**
      * Loads the users's permissions
      *
-     * @return bool
+     * @return void
      * @access private
      */
-    function setPermissions(): bool
+    function setPermissions(): void
     {
         // create DB object
         $DB =& Database::singleton();
@@ -88,16 +88,17 @@ class UserPermissions
         $this->permissions = array();
 
         // fill the array
-        foreach ($results AS $row) {
-            if (!empty($row['userID'])
-                && $row['userID'] === $this->userID
-            ) {
-                $this->permissions[$row['code']] = true;
-            } else {
-                $this->permissions[$row['code']] = false;
+        if (is_array($results) and !empty($results)) {
+            foreach ($results AS $row) {
+                if (!empty($row['userID'])
+                    && $row['userID'] === $this->userID
+                ) {
+                    $this->permissions[$row['code']] = true;
+                } else {
+                    $this->permissions[$row['code']] = false;
+                }
             }
         }
-        return true;
     }
 
 
@@ -193,10 +194,10 @@ class UserPermissions
      *
      * @param array $set Array of permission IDs to add
      *
-     * @return bool True
+     * @return void
      * @note   If saving permissions, remove all permissions first
      */
-    function addPermissions(array $set): bool
+    function addPermissions(array $set): void
     {
         // create DB object
         $DB = \Database::singleton();
@@ -214,8 +215,6 @@ class UserPermissions
 
         // refresh the user permissions
         $this->setPermissions();
-
-        return true;
     }
 
 
@@ -224,23 +223,23 @@ class UserPermissions
      *
      * @param array|null $set Array of permission IDs to remove
      *
-     * @return bool
+     * @return void
      * @note   Passing no arguments deletes all permissions
      */
-    function removePermissions(?array $set = null): bool
+    function removePermissions(?array $set = null): void
     {
         // create DB object
         $DB =& Database::singleton();
         if (is_null($set)) {
             // remove all permissions
-            $success = $DB->delete(
+            $DB->delete(
                 'user_perm_rel',
                 array('userID' => $this->userID)
             );
         } else {
             // remove the permissions
             foreach ($set as $value) {
-                $success = $DB->delete(
+                $DB->delete(
                     'user_perm_rel',
                     array(
                      'userID' => $this->userID,
@@ -251,9 +250,7 @@ class UserPermissions
         }
 
         // refresh the user permissions
-        $success = $this->setPermissions();
-
-        return true;
+        $this->setPermissions();
     }
 
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -96,7 +96,7 @@ class UserPermissions
                 }
                 // The line below may not be necessary as the $query already
                 // filters for a userID matching this user...
-                $userMatch = $row['userID'] === $this->userID; 
+                $userMatch = $row['userID'] === $this->userID;
                 $this->permissions[$row['code']] = $userMatch;
             }
         }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -685,7 +685,7 @@ class Utility
      * @param string|null $name       If specified, return fields for this
      *                           parameter_type name
      *
-     * @return ?array Format: array(
+     * @return  ?array Format: array(
      *              0 => array(
      *                   'SourceField' => value
      *                   'Name'        => name

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -905,9 +905,7 @@ class Utility
      */
     static function getLanguageList(): array
     {
-        $DB = \Database::singleton();
-
-        $languagesDB = $DB->pselect(
+        $languagesDB = \Database::singleton()->pselect(
             "SELECT language_id, language_label
              FROM language",
             array()

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -685,7 +685,7 @@ class Utility
      * @param string|null $name       If specified, return fields for this
      *                           parameter_type name
      *
-     * @return  Array of the form array(
+     * @return ?array Format: array(
      *              0 => array(
      *                   'SourceField' => value
      *                   'Name'        => name
@@ -701,9 +701,9 @@ class Utility
         ?string $instrument = null,
         ?string $commentID = null,
         ?string $name = null
-    ): array {
+    ): ?array {
 
-        $DB =& \Database::singleton();
+        $DB = \Database::singleton();
         //get sourcefield using instrument
         $sourcefields = array();
         if (!is_null($instrument)) {

--- a/src/Api/Endpoints/Project/Images.php
+++ b/src/Api/Endpoints/Project/Images.php
@@ -99,7 +99,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
      *
-     * @return array
+     * @return array|\Psr\Http\Message\ResponseInterface
      */
     private function _toArray(ServerRequestInterface $request)
     {

--- a/src/Api/Endpoints/Project/Instrument.php
+++ b/src/Api/Endpoints/Project/Instrument.php
@@ -94,7 +94,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $pathparts = $request->getAttribute('pathparts');
         if (count($pathparts) > 1) {
-            return new \LORIS\Http\Responsei\NotFound();
+            return new \LORIS\Http\Response\NotFound();
         }
 
         return (new \LORIS\Http\Response())
@@ -121,7 +121,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $this->responseCache[$instrumentname] = $this->instrument->toJSON();
         }
 
-        return $this->responseCache[$instrumentname];
+        return array($this->responseCache[$instrumentname]);
     }
 
     /**

--- a/src/Middleware/MiddlewareChainer.php
+++ b/src/Middleware/MiddlewareChainer.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * File defines the MiddlewareChainer interface.
  *
@@ -34,5 +34,5 @@ interface MiddlewareChainer extends MiddlewareInterface
      *
      * @return MiddlewareChainer
      */
-    public function withMiddleware(MiddlewareChainer $next) : MiddlewareChainer;
+    public function withMiddleware(MiddlewareChainer $next);
 }

--- a/src/Middleware/MiddlewareChainerMixin.php
+++ b/src/Middleware/MiddlewareChainerMixin.php
@@ -43,7 +43,7 @@ trait MiddlewareChainerMixin
      *
      * @param MiddlewareChainer $next The middleware to append
      *
-     * @return MiddlewareChainer A new middleware queue with $next appended
+     * @return MiddlewareChainerMixin A new middleware queue with $next appended
      */
     public function withMiddleware(MiddlewareChainer $next) :MiddlewareChainer
     {

--- a/src/Middleware/MiddlewareChainerMixin.php
+++ b/src/Middleware/MiddlewareChainerMixin.php
@@ -43,9 +43,10 @@ trait MiddlewareChainerMixin
      *
      * @param MiddlewareChainer $next The middleware to append
      *
-     * @return MiddlewareChainerMixin A new middleware queue with $next appended
+     * @return MiddlewareChainer|MiddlewareChainerMixin A new middleware queue 
+     *                                              with $next appended
      */
-    public function withMiddleware(MiddlewareChainer $next) :MiddlewareChainer
+    public function withMiddleware(MiddlewareChainer $next): MiddlewareChainer
     {
         $new = clone $this;
         $cur = $new;

--- a/src/Middleware/MiddlewareChainerMixin.php
+++ b/src/Middleware/MiddlewareChainerMixin.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Defines a MiddlewareChainerMixin trait to aid in the
  * implementation of Middleware chains.
@@ -43,10 +43,10 @@ trait MiddlewareChainerMixin
      *
      * @param MiddlewareChainer $next The middleware to append
      *
-     * @return MiddlewareChainer|MiddlewareChainerMixin A new middleware queue 
+     * @return MiddlewareChainer A new middleware queue 
      *                                              with $next appended
      */
-    public function withMiddleware(MiddlewareChainer $next): MiddlewareChainer
+    public function withMiddleware(MiddlewareChainer $next)
     {
         $new = clone $this;
         $cur = $new;

--- a/src/Middleware/ResponseGenerator.php
+++ b/src/Middleware/ResponseGenerator.php
@@ -63,7 +63,7 @@ class ResponseGenerator implements MiddlewareInterface, MiddlewareChainer
      *
      * @return MiddlewareChainer The same MiddlewareChainer, unmodified.
      */
-    public function withMiddleware(MiddlewareChainer $next) :MiddlewareChainer
+    public function withMiddleware(MiddlewareChainer $next)
     {
         return $this;
     }

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -409,7 +409,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @param webDriverElement $clickable The element to be clicked
      *
-     * @return void Once the element is stale.
+     * @return ?bool
      */
     public function clickToLoadNewPage($clickable)
     {
@@ -431,7 +431,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @param string $url The url to get.
      *
-     * @return void
+     * @return ?\RemoteWebDriver
      */
     function safeGet($url)
     {


### PR DESCRIPTION
### Brief summary of changes

This PR adds the new phan rule PhanMismatchReturn which flags code that is declared to return a type but in reality returns a different type. e.g.

```php
/**
* @return int
*/
function returnInt() {
    return 'hello';
}
```

Turns out we do this all over the place in LORIS so this PR is pretty big.

A lot of phan errors came up related to https://github.com/aces/Loris/pull/4308 so this PR also fixes a lot of those.

There are also minor optimizations/rewrites of functions that were needlessly complicated. In pretty much every case the replacements should be logically equivalent and hopefully more maintainable.