### PR TITLE
[candidate_parameters] Add 'Date of Birth' tab

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -101,7 +101,8 @@ INSERT INTO `permissions` VALUES
     (53,'instrument_manager_write', 'Instrument Manager: Install new instruments via file upload', 2),
     (54,'publication_view', 'Publication - Access to module', 2),
     (55,'publication_propose', 'Publication - Propose a project', 2),
-    (56,'publication_approve', 'Publication - Approve or reject proposed publication projects', 2);
+    (56,'publication_approve', 'Publication - Approve or reject proposed publication projects', 2),
+    (57, 'candidate_dob_edit', 'Edit dates of birth', 2);
 
 
 INSERT INTO `user_perm_rel` (userID, permID)

--- a/SQL/New_patches/2019_07_02_Add_Edit_DoB_Permissions.sql
+++ b/SQL/New_patches/2019_07_02_Add_Edit_DoB_Permissions.sql
@@ -1,0 +1,5 @@
+INSERT INTO permissions (code, description, categoryID) VALUES
+    ("candidate_dob_edit","Edit dates of birth",2);
+    
+INSERT INTO user_perm_rel VALUES
+    (1, (SELECT permID FROM permissions WHERE code='candidate_dob_edit'));

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1424,7 +1424,7 @@ class StaticElement extends Component {
           {this.props.label}
         </label>
         <div className="col-sm-9">
-          <p className="form-control-static">{this.props.text}</p>
+          <p className={this.props.class}>{this.props.text}</p>
         </div>
       </div>
     );
@@ -1442,6 +1442,7 @@ StaticElement.propTypes = {
 StaticElement.defaultProps = {
   label: '',
   text: null,
+  class: 'form-control-static',
 };
 
 /**

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -55,6 +55,10 @@ case 'consentStatus':
     editConsentStatusFields($db, $user);
     break;
 
+case 'candidateDOB':
+    editCandidateDOB($db, $user);
+    break;
+
 default:
     header("HTTP/1.1 404 Not Found");
     exit;
@@ -523,5 +527,34 @@ function editConsentStatusFields($db, $user)
             }
             $db->insert('candidate_consent_history', $updateHistory);
         }
+    }
+}
+
+/**
+ * Handles the updating of candidate's date of birth.
+ *
+ * @param Database $db   database object
+ * @param User     $user user object
+ *
+ * @throws DatabaseException
+ *
+ * @return void
+ */
+function editCandidateDOB(\Database $db, \User $user): void
+{
+    $candID       = $_POST['candID'];
+    $dob          = $_POST['dob'];
+    $strippedDate = null;
+    if (!empty($dob)) {
+        $config    = \NDB_Config::singleton();
+        $dobFormat = $config->getSetting('dobFormat');
+        if ($dobFormat === 'YM') {
+            $strippedDate = date("Y-m", strtotime($dob))."-01";
+        }
+        $db->update(
+            'candidate',
+            array('DoB' => $strippedDate ?? $dob),
+            array('CandID' => $candID)
+        );
     }
 }

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -542,7 +542,7 @@ function editConsentStatusFields($db, $user)
  */
 function editCandidateDOB(\Database $db, \User $user): void
 {
-    $candID       = $_POST['candID'];
+    $candID       = new CandID($_POST['candID']);
     $dob          = $_POST['dob'];
     $strippedDate = null;
     if (!empty($dob)) {
@@ -554,7 +554,7 @@ function editCandidateDOB(\Database $db, \User $user): void
         $db->update(
             'candidate',
             array('DoB' => $strippedDate ?? $dob),
-            array('CandID' => $candID)
+            array('CandID' => $candID->__toString())
         );
     }
 }

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -500,7 +500,6 @@ function getConsentStatusHistory($pscid)
 /**
  * Handles the fetching of candidate's date of birth.
  *
- *
  * @return array
  */
 function getDOBFields(): array
@@ -515,9 +514,9 @@ function getDOBFields(): array
     $pscid         = $candidateData['PSCID'] ?? null;
     $dob           = $candidateData['DoB'] ?? null;
     $result        = [
-                      'pscid'  => $pscid,
-                      'candID' => $candID->__toString(),
-                      'dob'    => $dob,
-                     ];
+        'pscid'  => $pscid,
+        'candID' => $candID->__toString(),
+        'dob'    => $dob,
+    ];
     return $result;
 }

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -500,7 +500,6 @@ function getConsentStatusHistory($pscid)
 /**
  * Handles the fetching of candidate's date of birth.
  *
- * @throws DatabaseException
  *
  * @return array
  */

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -48,6 +48,9 @@ case 'participantStatus':
 case 'consentStatus':
     echo json_encode(getConsentStatusFields());
     exit;
+case 'candidateDOB':
+    echo json_encode(getDOBFields());
+    exit;
 default:
     header("HTTP/1.1 404 Not Found");
     exit;
@@ -492,4 +495,30 @@ function getConsentStatusHistory($pscid)
           $formattedHistory[$key] = $consentHistory;
     }
     return $formattedHistory;
+}
+
+/**
+ * Handles the fetching of candidate's date of birth.
+ *
+ * @throws DatabaseException
+ *
+ * @return array
+ */
+function getDOBFields(): array
+{
+    $candID = new CandID($_GET['candID']);
+    $db     = \Database::singleton();
+    // Get PSCID
+    $candidateData = $db->pselectRow(
+        'SELECT PSCID,DoB FROM candidate where CandID =:candid',
+        array('candid' => $candID->__toString())
+    );
+    $pscid         = $candidateData['PSCID'] ?? null;
+    $dob           = $candidateData['DoB'] ?? null;
+    $result        = [
+                      'pscid'  => $pscid,
+                      'candID' => $candID->__toString(),
+                      'dob'    => $dob,
+                     ];
+    return $result;
 }

--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -1,0 +1,157 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import Loader from 'Loader';
+import swal from 'sweetalert2';
+
+class CandidateDOB extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data: {},
+      formData: {
+        dob: null,
+      },
+      error: false,
+      isLoaded: false,
+    };
+
+    this.fetchData = this.fetchData.bind(this);
+    this.setFormData = this.setFormData.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentDidMount() {
+    this.fetchData()
+    .then(() => this.setState({isLoaded: true}));
+  }
+
+  fetchData() {
+    return fetch(this.props.dataURL, {credentials: 'same-origin'})
+      .then((resp) => resp.json())
+      .then((data) => this.setState({data: data, formData: data}))
+      .catch((error) => {
+        this.setState({error: true});
+        console.error(error);
+      });
+  }
+
+  setFormData(formElement, value) {
+    let formData = this.state.formData;
+    formData[formElement] = value;
+    this.setState({
+      formData: formData,
+    });
+  }
+
+  render() {
+    if (this.state.error) {
+        return <h3>An error occured while loading the page.</h3>;
+    }
+
+    if (!this.state.isLoaded) {
+        return <Loader/>;
+    }
+
+    let disabled = true;
+    let updateButton = null;
+    if (loris.userHasPermission('candidate_dob_edit')) {
+        disabled = false;
+        updateButton = <ButtonElement label='Update' />;
+    }
+    return (
+      <div className='row'>
+        <FormElement
+          name='candidateDOB'
+          onSubmit={this.handleSubmit}
+          ref='form'
+          class='col-md-6'
+        >
+          <StaticElement
+            label='PSCID'
+            text={this.state.data.pscid}
+          />
+          <StaticElement
+            label='DCCID'
+            text={this.state.data.candID}
+          />
+          <StaticElement
+            label='Disclaimer:'
+            text='Any changes to the date of birth requires an administrator to run the fix_candidate_age script.'
+            class='form-control-static text-danger bg-danger col-sm-10'
+          />
+          <DateElement
+            label='Date Of Birth:'
+            name='dob'
+            value={this.state.formData.dob}
+            onUserInput={this.setFormData}
+            disabled={disabled}
+            required={true}
+          />
+          {updateButton}
+        </FormElement>
+      </div>
+    );
+  }
+
+  /**
+   * Handles form submission
+   *
+   * @param {event} e - Form submission event
+   */
+  handleSubmit(e) {
+    e.preventDefault();
+
+    let today = new Date();
+    let dd = String(today.getDate()).padStart(2, '0');
+    let mm = String(today.getMonth() + 1).padStart(2, '0'); // January is 0!
+    let yyyy = today.getFullYear();
+    today = yyyy + '-' + mm + '-' + dd;
+
+    let dob = this.state.formData.dob ?
+      this.state.formData.dob : null;
+    if (dob > today) {
+      swal('Error!', 'Date of birth cannot be later than today!', 'error');
+      return;
+    }
+    // Set form data and upload the media file
+    let formData = this.state.formData;
+    let formObject = new FormData();
+    for (let key in formData) {
+      if (formData.hasOwnProperty(key)) {
+        if (formData[key] !== '') {
+          formObject.append(key, formData[key]);
+        }
+      }
+    }
+
+    formObject.append('tab', this.props.tabName);
+
+    fetch(this.props.action, {
+        method: 'POST',
+        cache: 'no-cache',
+        credentials: 'same-origin',
+        body: formObject,
+    })
+    .then((resp) => {
+        if (resp.ok && resp.status === 200) {
+            swal('Success!', 'Date of birth updated.', 'success').then((result) => {
+                if (result.value) {
+                    this.fetchData();
+                }
+            });
+        } else {
+            swal('Error!', 'Something went wrong', 'error');
+        }
+    })
+    .catch((error) => {
+        console.error(error);
+    });
+  }
+}
+CandidateDOB.propTypes = {
+  dataURL: PropTypes.string,
+  tabName: PropTypes.string,
+  action: PropTypes.string,
+};
+export default CandidateDOB;

--- a/modules/candidate_parameters/jsx/CandidateDOB.js
+++ b/modules/candidate_parameters/jsx/CandidateDOB.js
@@ -1,7 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
-import swal from 'sweetalert2';
 
 class CandidateDOB extends Component {
   constructor(props) {
@@ -111,7 +110,12 @@ class CandidateDOB extends Component {
     let dob = this.state.formData.dob ?
       this.state.formData.dob : null;
     if (dob > today) {
-      swal('Error!', 'Date of birth cannot be later than today!', 'error');
+      swal({
+        title: 'Error!',
+        text: 'Date of birth cannot be later than today!',
+        type: 'error',
+        confrimButtonText: 'OK',
+      });
       return;
     }
     // Set form data and upload the media file
@@ -135,13 +139,22 @@ class CandidateDOB extends Component {
     })
     .then((resp) => {
         if (resp.ok && resp.status === 200) {
-            swal('Success!', 'Date of birth updated.', 'success').then((result) => {
-                if (result.value) {
-                    this.fetchData();
-                }
-            });
+          swal({
+            title: 'Success!',
+            text: 'Date of birth updated!',
+            type: 'success',
+            confrimButtonText: 'OK',
+          });
+          if (result.value) {
+              this.fetchData();
+          }
         } else {
-            swal('Error!', 'Something went wrong', 'error');
+          swal({
+            title: 'Error!',
+            text: 'Something went wrong.',
+            type: 'error',
+            confrimButtonText: 'OK',
+          });
         }
     })
     .catch((error) => {

--- a/modules/candidate_parameters/jsx/CandidateParameters.js
+++ b/modules/candidate_parameters/jsx/CandidateParameters.js
@@ -5,6 +5,7 @@ import ProbandInfo from './ProbandInfo';
 import FamilyInfo from './FamilyInfo';
 import ParticipantStatus from './ParticipantStatus';
 import ConsentStatus from './ConsentStatus';
+import CandidateDOB from './CandidateDOB';
 import {Tabs, TabPane} from 'Tabs';
 
 class CandidateParameters extends Component {
@@ -35,6 +36,7 @@ class CandidateParameters extends Component {
     let tabList = [
       {id: 'candidateInfo', label: 'Candidate Information', component: CandidateInfo},
       {id: 'participantStatus', label: 'Participant Status', component: ParticipantStatus},
+      {id: 'candidateDOB', label: 'Date of Birth', component: CandidateDOB},
     ];
 
     if (loris.config('useProband') === 'true') {

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -56,5 +56,6 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (54,'publication_propose','Publication - Propose a project',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (55,'publication_approve','Publication - Approve or reject proposed publication projects',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (56,'data_release_view','Data Release: View releases',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (57,'candidate_dob_edit','Edit dates of birth',2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
### Brief summary of changes
This PR adds a new tab to candidate parameters which can be used to amend a candidate's date of birth. 

This change is being applied as a result of the DoD meeting which took place on June 25, 2019. To follow is a PR which will add `Date of Death`.

**_[NOTE]:_** I am basing this PR on `21.0-release` branch for now, but will change it to `minor` after release happens.

### To test this change...

- [ ] Navigate to candidate parameters. Make sure that you can only update date of birth if you have the permission `candidate_dob_edit`. Make sure any update to the date actually saves. 

