### PR TITLE
Add new phan rule PhanUndeclaredVariableDim to static analysis

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -18,7 +18,7 @@ return [
 	"suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
 		"PhanUndeclaredMethod",
-		"PhanUndeclaredVariableDim",
+        "PhanTypeMismatchDimFetch",
 		"PhanUndeclaredClassMethod",
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchReturn",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -19,7 +19,6 @@ return [
         "PhanTypeInvalidDimOffset",
 		"PhanUndeclaredMethod",
 		"PhanUndeclaredVariableDim",
-        "PhanTypeMismatchDimFetch",
 		"PhanUndeclaredClassMethod",
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchReturn",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -23,7 +23,6 @@ return [
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchReturn",
 		"PhanTypeMismatchProperty",
-		"PhanNonClassMethodCall",
         "PhanTypeSuspiciousStringExpression",
 	],
 	"analyzed_file_extensions" => ["php", "inc"],

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -32,6 +32,7 @@ if (!$user->hasPermission('imaging_browser_qc')
     return;
 }
 
+$tpl_data = array();
 $tpl_data['has_permission'] = $user->hasPermission('imaging_browser_qc');
 
 // instantiate feedback mri object

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -12,6 +12,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
+$tpl_data = array();
 if (isset($_SERVER['HTTP_ORIGIN'])) {
     header("Access-Control-Allow-Origin: " . $_SERVER['HTTP_ORIGIN']);
     header("Access-Control-Allow-Credentials: true");

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -88,9 +88,11 @@ if (!$anonymous) {
     tplFromRequest('dynamictabs');
     // draw the user information table
     try {
-        $user =& User::singleton();
+        $user = \User::singleton();
 
-        $site_arr = $user->getData('CenterIDs');
+        $site_arr    = $user->getData('CenterIDs');
+        $site        = array();
+        $isStudySite = array();
         foreach ($site_arr as $key=>$val) {
             $site[$key]        = & Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -86,6 +86,7 @@ class Candidate_List extends \DataFrameworkMenu
 
         // get the list of subprojects
         $list_of_subprojects = \Utility::getSubprojectList();
+        $subproject_options  = array();
         foreach ($list_of_subprojects as $id => $name) {
             $subproject_options[$name] = $name;
         }
@@ -93,6 +94,7 @@ class Candidate_List extends \DataFrameworkMenu
         // get the list participant status options
         $list_of_participant_status
             = \Candidate::getParticipantStatusOptions();
+        $participant_status_options = array();
         foreach ($list_of_participant_status as $id => $name) {
             $participant_status_options[$name] = $name;
         }

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -72,6 +72,7 @@ class Candidate_List extends \DataFrameworkMenu
         } else {
             $list_of_sites = $user->getStudySites();
         }
+        $site_options = array();
         foreach ($list_of_sites as $id => $name) {
             $site_options[$name] = $name;
         }

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -2,7 +2,7 @@
 /**
  * The configuration module is used to manage the configuration of Loris.
  *
- * PHP version 5
+ * PHP version 7
  *
  * @category Behavioural
  * @package  Main
@@ -14,7 +14,7 @@
 namespace LORIS\configuration;
 
 /**
- * Admin_Config Class
+ * Configuration Class
  *
  * This class is to configure the system settings
  *
@@ -47,22 +47,22 @@ class Configuration extends \NDB_Form
     function setup()
     {
         parent::setup();
-        $config =& \NDB_Config::singleton();
-        $DB     =& \Database::singleton();
+        $config = \NDB_Config::singleton();
+        $DB     = \Database::singleton();
 
-        $scans = $DB->pselect(
+        $scans      = $DB->pselect(
             "SELECT Scan_type
              FROM mri_scan_type",
             array()
         );
+        $scan_types = array('' => '');
         foreach ($scans as $type) {
             $val = $type['Scan_type'];
-            $scan_types[$val] =$val;
+            $scan_types[$val] = $val;
         }
-        $scan_types = array_merge(array('' => ''), $scan_types);
 
-        $instruments = \Utility::getAllInstruments();
-        $instruments = array_merge(array('' => ''), $instruments);
+        $instruments     = \Utility::getAllInstruments();
+        $instruments[''] = '';
 
         $this->tpl_data['parentMenuItems'] = $this->_getParentConfigLabels();
         $this->tpl_data['config']          = $this->_getConfigSettingTree();
@@ -150,6 +150,7 @@ class Configuration extends \NDB_Form
         }
 
         // build a tree from configs array
+        $tree = array();
         foreach ($configs as &$node) {
             $node['Children']  = array();
             $tree[$node['ID']] = &$node;

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -178,8 +178,8 @@ class Create_Timepoint extends \NDB_Form
                         "longer supported in Loris."
                     );
                 }
-                $labelOptions[''] = null;
-                $items            = \Utility::associativeToNumericArray(
+                $labelOptions = array('' => null);
+                $items        = \Utility::associativeToNumericArray(
                     $visitLabel['labelSet']['item']
                 );
                 foreach ($items as $item) {

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -111,7 +111,7 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     /**
      * Handler of parsing category
      *
-     * @param string $value the value
+     * @param array $value the value
      *
      * @return array
      */

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -211,9 +211,10 @@ class Files extends \NDB_Page
         //if user has document repository delete permission
         if ($user->hasPermission('document_repository_delete')) {
             $DB->delete("document_repository", array("record_id" => $rid));
-            $msg_data['deleteDocument'] = $baseURL. "/document_repository/";
-            $msg_data['document']       = $fileName;
-
+            $msg_data = array(
+                         'deleteDocument' => $baseURL. "/document_repository/",
+                         'document'       => $fileName,
+                        );
             $Notifier->notify($msg_data);
         }
 
@@ -222,7 +223,6 @@ class Files extends \NDB_Page
         if (file_exists($path)) {
             unlink($path);
         }
-
     }
     /**
      * Returns a list of categories fields from database
@@ -403,7 +403,7 @@ class Files extends \NDB_Page
         ) {
                 $uploadedFile->moveTo($uploadPath.$fileName);
 
-                $success = $DB->insert(
+                $success  = $DB->insert(
                     'document_repository',
                     array(
                      'File_category' => $category,
@@ -420,8 +420,10 @@ class Files extends \NDB_Page
                      'File_type'     => $fileType,
                     )
                 );
-                $msg_data['newDocument'] = $baseURL . "/document_repository/";
-                $msg_data['document']    = $fileName;
+                $msg_data = array(
+                             'newDocument' => $baseURL . "/document_repository/",
+                             'document'    => $fileName,
+                            );
                 $uploadNotifier->notify($msg_data);
                 $uploadOK = true;
         }

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -280,9 +280,10 @@ class Files extends \NDB_Page
     /**
     * Handler of parsing category
     *
-    * @param string $value the value
+    * @param array $value the value
     *
-    * @return array
+    * @return array An array containing the category name and ID for file
+    *               categories in the document repository.
     */
     function parseCategory($value): array
     {

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -94,6 +94,7 @@ class EditExaminer extends \NDB_Form
         );
 
         // set the form defaults for the page
+        $defaults = array();
         foreach ($result as $row) {
             $defaults['date_cert[' . $row['testID'] . ']']       = $row['date_cert'];
             $defaults['certStatus['      . $row['testID'] . ']'] = $row['pass'];
@@ -317,6 +318,7 @@ class EditExaminer extends \NDB_Form
         $this->tpl_data['instruments'] = $instruments;
 
         // Create the form elements for each certification instrument
+        $group = array();
         foreach ($instruments as $key => $value) {
             $group[] = $this->createSelect(
                 'certStatus['.$key.']',

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -26,9 +26,11 @@ try {
     $m = '';
 }
 if (!empty($m)) {
-    $page            = !empty($_REQUEST['subtest']) ? $_REQUEST['subtest'] : $mname;
-    $help['content'] = $m->getHelp($page);
-    $help['format']  = 'markdown';
+    $page = !empty($_REQUEST['subtest']) ? $_REQUEST['subtest'] : $mname;
+    $help = array(
+             'content' => $m->getHelp($page),
+             'format'  => 'markdown',
+            );
     print json_encode($help);
     ob_end_flush();
     exit(0);

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -46,6 +46,7 @@ class Edit_Help_Content extends \NDB_Form
     {
         $DB = \Database::singleton();
         //Get the default values
+        $defaults = array();
 
         // Sanitize user input
         $safeSection    = $_REQUEST['section'] ?

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -71,6 +71,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
             array()
         );
 
+        $all_scan_types = array();
         foreach ($all_scan_types_2d as $row) {
             $type = $row['Scan_type'];
             $all_scan_types[$row['ID']] = $type;
@@ -124,6 +125,7 @@ class Imaging_Browser extends \NDB_Menu_Filter
             ELSE ''
             END";
 
+        $pass = $qc = $coalesce_desc = $case_desc = array();
         foreach ($scan_id_types as $id => $type) {
             $pass[$id]          = $type . 'pass';
             $qc[$id]            = $type . 'QC';
@@ -213,6 +215,7 @@ END";
         // Initialize the arrays that go into this->columns and
         // $this->headers so that array_merge works even if no
         // $scan_types are set in the configuration module
+        $modalities_subquery    = array();
         $modalities_subquery_as = array();
         $as = array();
 
@@ -300,6 +303,7 @@ END";
             array()
         );
 
+        $all_scan_types = array();
         foreach ($all_scan_types_2d as $row) {
             $type = $row['Scan_type'];
             $all_scan_types[$row['ID']] = $type;
@@ -321,6 +325,7 @@ END";
         $as = array();
         $list_of_projects = array();
 
+        $modalities_subquery = array();
         foreach ($scan_id_types as $key => $value) {
             $modalities_subquery[$key] = $value;
             $as[$key] = $scan_id_types[$key] . '_QC_Status';

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -64,10 +64,12 @@ class Imaging_Session_ControlPanel
     {
         $DB        = \Database::singleton();
         $config    = \NDB_Config::singleton();
-        $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
+        $timePoint = \TimePoint::singleton($_REQUEST['sessionID']);
 
-        $subjectData['sessionID'] = $_REQUEST['sessionID'];
-        $subjectData['candid']    = $timePoint->getCandID();
+        $subjectData = array(
+                        'sessionID' => $_REQUEST['sessionID'],
+                        'candid'    => $timePoint->getCandID(),
+                       );
 
         $linkedInstruments
             = $config->getSetting('ImagingBrowserLinkedInstruments');
@@ -96,7 +98,7 @@ class Imaging_Session_ControlPanel
         $subjectData['links']
             = (empty($links)) ? "" : $links;
 
-        $candidate =& \Candidate::singleton($timePoint->getCandID());
+        $candidate = \Candidate::singleton($timePoint->getCandID());
 
         /* Note: the if statement below prepares parameters to use in an SQL
         * query. The $ID variable is appended directly to a SQL query string;

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -411,13 +411,14 @@ class ViewSession extends \NDB_Form
                     $updateSet['QCFirstChangeTime'] = time();
                 }
 
-                $QCExists  = $this->DB->pselectOne(
+                $QCExists    = $this->DB->pselectOne(
                     "SELECT 'x' 
                     FROM files_qcstatus 
                     WHERE FileID=:FID",
                     $params
                 );
-                $updateSet = \Utility::nullifyEmpty($updateSet, 'QCStatus');
+                $updateSet   = \Utility::nullifyEmpty($updateSet, 'QCStatus');
+                $updateWhere = array();
                 if (!empty($QCExists)) {
                     $updateWhere['FileID'] = $curFileID;
                     $success = $this->DB->update(
@@ -453,7 +454,8 @@ class ViewSession extends \NDB_Form
                 );
 
                 if ($curCaveat == true) {
-                    $file = new \MRIFile($curFileID);
+                    $insertSet = array();
+                    $file      = new \MRIFile($curFileID);
                     $insertSet['SeriesUID']   = $file->getParameter(
                         'series_instance_uid'
                     );
@@ -473,6 +475,7 @@ class ViewSession extends \NDB_Form
                         . $user->getUsername();
 
                     $this->DB->insert("mri_violations_log", $insertSet);
+                    unset($insertSet);
                 }
             }
         }
@@ -694,8 +697,9 @@ class ViewSession extends \NDB_Form
      */
     function getSubjectData()
     {
-        $timePoint =& \TimePoint::singleton($_REQUEST['sessionID']);
+        $timePoint = \TimePoint::singleton($_REQUEST['sessionID']);
 
+        $subjectData = array();
         $subjectData['sessionID']       = $_REQUEST['sessionID'];
         $subjectData['SubprojectID']    = $timePoint->getSubprojectID();
         $subjectData['SubprojectTitle'] = $timePoint->getData('SubprojectTitle');

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -4,7 +4,7 @@
  *
  * Handles issue edits and returns data in response to a front end call.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Loris
  * @package  Issue_Tracker
@@ -18,7 +18,7 @@
  *
  * Handles issue edits and returns data in response to a front end call.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Loris
  * @package  Issue Tracker
@@ -495,9 +495,10 @@ function emailUser($issueID, $changed_assignee)
         array('issueID' => $issueID)
     );
 
-    $msg_data['url']         = $baseurl .
+    $msg_data            = array();
+    $msg_data['url']     = $baseurl .
         "/issue_tracker/issue/" . $issueID;
-    $msg_data['issueID']     = $issueID;
+    $msg_data['issueID'] = $issueID;
     $msg_data['currentUser'] = $user->getUsername();
     $msg_data['title']       = $title;
 

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -73,8 +73,9 @@ class PasswordReset extends \NDB_Form
                   // expire password so user must change it upon login
                   $user->updatePassword($password, '1999-01-01');
                   // send the user an email
-                  $msg_data['study']    = $config->getSetting('title');
-                  $msg_data['url']      = $config->getSetting('url');
+                  $msg_data          = array();
+                  $msg_data['study'] = $config->getSetting('title');
+                  $msg_data['url']   = $config->getSetting('url');
                   $msg_data['realname'] = $user->getData('Real_name');
                   $msg_data['password'] = $password;
                   \Email::send($email, 'lost_password.tpl', $msg_data);

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -32,7 +32,8 @@ class RequestAccount extends \NDB_Form
      */
     function setup()
     {
-        $config = \NDB_Config::singleton();
+        $config   = \NDB_Config::singleton();
+        $tpl_data = array();
         $this->tpl_data['page_title'] = 'Request Account';
 
         $this->addBasicText(
@@ -221,6 +222,7 @@ class RequestAccount extends \NDB_Form
         }
 
         // Verify reCAPTCHA
+        $err = array();
         if (isset($values['g-recaptcha-response']) && isset($reCAPTCHAPrivate)) {
             $recaptcha = new \ReCaptcha\ReCaptcha($reCAPTCHAPrivate);
             $resp      = $recaptcha->verify(

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -168,6 +168,7 @@ class New_Profile extends \NDB_Form
         // Get sites for the select dropdown
         $user_list_of_sites = $user->getData('CenterIDs');
         $num_sites          = count($user_list_of_sites);
+        $psc_labelOptions   = array();
         if ($num_sites > 1) {
             foreach ($user_list_of_sites as $key => $siteID) {
                 $center = $DB->pselectRow(

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -215,7 +215,7 @@ class Next_Stage extends \NDB_Form
     /**
      * Validate function
      *
-     * @param string $values the value
+     * @param array $values the value
      *
      * @return array|bool
      */

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -72,6 +72,7 @@ function getData($db) : array
     sort($bvlVOIs);
 
     // sets keys and values to be equal
+    $allVOIs = array();
     $allVOIs['Behavioral'] = array_combine($bvlVOIs, $bvlVOIs);
 
     // imaging VoIs -- filter out non-human readable DICOM tags

--- a/modules/quality_control/php/quality_control.class.inc
+++ b/modules/quality_control/php/quality_control.class.inc
@@ -64,6 +64,7 @@ class Quality_Control extends \NDB_Menu_Filter
             array()
         );
 
+        $all_scan_types = array();
         foreach ($all_scan_types_2d as $row) {
             $type = $row['Scan_type'];
             $all_scan_types[$row['ID']] = $type;
@@ -267,6 +268,8 @@ class Quality_Control extends \NDB_Menu_Filter
               ];
 
         $scan_types = $this->_getScanTypes();
+        $scans_done = array();
+        $acq_IDs    = array();
         foreach ($scan_types as $scan_type) {
             $query_params        = array('scan_type' => $scan_type);
             $acq_IDs[$scan_type] = $db->pselectOne(

--- a/modules/server_processes_manager/php/serverprocessfactory.class.inc
+++ b/modules/server_processes_manager/php/serverprocessfactory.class.inc
@@ -43,14 +43,14 @@ class ServerProcessFactory
      *                             YYYY-MM-DD HH:MM:SS format
      * @param string $exitText     text output by the process upon completion.
      *
-     * @return string the server process created
+     * @return MriUploadServerProcess the server process created
      * @throws \InvalidArgumentException if the server process type is unknown
      */
     public function getServerProcess(
         $id, $pid, $type, $stdoutFile, $stderrFile,
         $exitCodeFile, $exitCode, $userId,
         $startTime, $endTime, $exitText
-    ) {
+    ): MRIUploadServerProcess {
         if ($type == MriUploadServerProcess::PROCESS_TYPE) {
             return new MriUploadServerProcess(
                 null,

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -78,10 +78,9 @@ class Stats_Behavioural extends \NDB_Form
 
         $this->tpl_data['Centers'] = $centers;
 
-        $projects[null] = 'All Projects';
-        foreach (\Utility::getProjectList() as $key=>$value) {
-            $projects[$key] = $value;
-        }
+        $projects     = \Utility::getProjectList();
+        $projects[''] = 'All Projects';
+
         $this->tpl_data['Projects'] = $projects;
         foreach ($centers as $row) {
             $this->tpl_data['Sites'][$row['NumericID']] = $row['LongName'];

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -170,8 +170,8 @@ class Stats_Demographic extends \NDB_Form
         $this->tpl_data['showTable'] = true;
 
         //PROJECTS
-        $projects = array();
-        $projects[null] = 'All Projects';
+        $projects     = array();
+        $projects[''] = 'All Projects';
         foreach (\Utility::getProjectList() as $key => $value) {
             $projects[$key] = $value;
         }
@@ -226,8 +226,8 @@ class Stats_Demographic extends \NDB_Form
             array()
         );
 
-        $sites = array();
-        $sites[null] ='All sites';
+        $sites     = array();
+        $sites[''] ='All sites';
 
         if (!empty($centers)) {
             foreach ($centers as $row) {

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -170,6 +170,7 @@ class Stats_Demographic extends \NDB_Form
         $this->tpl_data['showTable'] = true;
 
         //PROJECTS
+        $projects = array();
         $projects[null] = 'All Projects';
         foreach (\Utility::getProjectList() as $key => $value) {
             $projects[$key] = $value;
@@ -225,6 +226,7 @@ class Stats_Demographic extends \NDB_Form
             array()
         );
 
+        $sites = array();
         $sites[null] ='All sites';
 
         if (!empty($centers)) {

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -216,7 +216,7 @@ class Stats_MRI extends \NDB_Form
     {
         parent::setup();
 
-        $DB =& \Database::singleton();
+        $DB = \Database::singleton();
 
         $bigTable_params = array();
         $this->params    = array();
@@ -224,6 +224,7 @@ class Stats_MRI extends \NDB_Form
         $this->tpl_data['showTable'] = true;
 
         //PROJECTS
+        $projects = array();
         $projects[null] = 'All Projects';
         foreach (\Utility::getProjectList() as $key => $value) {
             $projects[$key] = $value;
@@ -273,6 +274,7 @@ class Stats_MRI extends \NDB_Form
                 AND Study_site = 'Y'",
             array()
         );
+        $sites = array();
         $sites[null] ="All sites";
         foreach ($centers as $row) {
             $sites[$row['NumericID']] = $row['ShortName'];
@@ -294,6 +296,7 @@ class Stats_MRI extends \NDB_Form
             array()
         );
 
+        $scan_types = array();
         foreach ($Scan_type_results as $row) {
             $scan_types[$row['ID']] = $row['Scan_type'];
         }

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -224,8 +224,8 @@ class Stats_MRI extends \NDB_Form
         $this->tpl_data['showTable'] = true;
 
         //PROJECTS
-        $projects = array();
-        $projects[null] = 'All Projects';
+        $projects     = array();
+        $projects[''] = 'All Projects';
         foreach (\Utility::getProjectList() as $key => $value) {
             $projects[$key] = $value;
         }
@@ -264,7 +264,7 @@ class Stats_MRI extends \NDB_Form
         } else {
             $Param_Site = '';
         }
-        $centers     = $DB->pselect(
+        $centers   = $DB->pselect(
             "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
                     IFNULL(PSCArea,Name) as LongName,
@@ -274,8 +274,8 @@ class Stats_MRI extends \NDB_Form
                 AND Study_site = 'Y'",
             array()
         );
-        $sites = array();
-        $sites[null] ="All sites";
+        $sites     = array();
+        $sites[''] ="All sites";
         foreach ($centers as $row) {
             $sites[$row['NumericID']] = $row['ShortName'];
             if (isset($_REQUEST['MRIsite'])

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -426,6 +426,7 @@ class Edit_User extends \NDB_Form
         //END EXAMINER UPDATE
 
         // make the set
+        $set = array();
         foreach ($values as $key => $value) {
             // Password updates are handled separately
             if (!empty($value) && $key != 'Password_hash') {
@@ -499,6 +500,7 @@ class Edit_User extends \NDB_Form
                 foreach ($supervisorEmails as $email => $checkValue) {
                     if (!empty($permissionsAdded) || !empty($permissionsRemoved)) {
                         if ($checkValue == 'on') {
+                            $msg_data = array();
                             $msg_data['current_user'] = $editor->getFullname();
                             $msg_data['study']        = $config->getSetting('title');
                             $msg_data['realname']     = $values['Real_name'];
@@ -510,6 +512,7 @@ class Edit_User extends \NDB_Form
                                 'permissions_change_notify_supervisor.tpl',
                                 $msg_data
                             );
+                            unset($msg_data);
                         }
                     }
                 }
@@ -524,6 +527,7 @@ class Edit_User extends \NDB_Form
             // create an instance of the config object
             $config = \NDB_Config::singleton();
             // send the user an email
+            $msd_data = array();
             $msg_data['study']    = $config->getSetting('title');
             $msg_data['url']      = $config->getSetting('url');
             $msg_data['realname'] = $values['Real_name'];
@@ -532,6 +536,7 @@ class Edit_User extends \NDB_Form
             $template = (is_null($this->identifier))
                 ? 'new_user.tpl' : 'edit_user.tpl';
             \Email::send($values['Email'], $template, $msg_data);
+            unset($msg_data);
         }
         $this->tpl_data['success'] = true;
         if ($this->isCreatingNewUser()) {
@@ -585,6 +590,7 @@ class Edit_User extends \NDB_Form
         //------------------------------------------------------------
 
         // it is a new user
+        $group = array();
         if ($this->identifier == '') {
             // user name
             $group[] = $this->createText('UserID', 'User name');
@@ -608,6 +614,7 @@ class Edit_User extends \NDB_Form
         }
 
         // password
+        $group = array();
         $group[] = $this->createPassword('Password_hash');
         $group[] = $this->createCheckbox('NA_Password', 'Generate new password');
         $this->addGroup(
@@ -673,6 +680,7 @@ class Edit_User extends \NDB_Form
         }
 
         // email address
+        $group = array();
         $group[] = $this->createText('Email', 'Email address');
         $group[] = $this->createCheckbox('SendEmail', 'Send email to user');
         $this->addGroup(
@@ -694,6 +702,8 @@ class Edit_User extends \NDB_Form
 
         // get user permissions
         $editor = \User::singleton();
+        $siteOptions = array();
+        $site = array();
 
         // center ID
         if ($editor->hasPermission('user_accounts_multisite')) {
@@ -716,8 +726,11 @@ class Edit_User extends \NDB_Form
         );
 
         if ($editor->hasPermission('examiner_multisite')) {
+            $groupA = array();
+            $groupB = array();
+
             //get site aliases
-            $DB      =& \Database::singleton();
+            $DB      = \Database::singleton();
             $aliases = $DB->pselect("SELECT CenterID, Alias FROM psc ", array());
 
             foreach ($aliases as $row) {
@@ -820,6 +833,7 @@ class Edit_User extends \NDB_Form
 
         $perms    = $editor->getPermissionsVerbose();
         $lastRole = '';
+        $group = array();
         foreach ($perms as $row) {
             if ($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
@@ -855,16 +869,15 @@ class Edit_User extends \NDB_Form
 
         //getting users name and emails to create checkboxes
         // to email supervisors on permissions changes
-        $DB_factory = \NDB_Factory::singleton();
-        $DB         = $DB_factory->database();
 
         $query = "SELECT u.Real_Name, u.email FROM permissions p
                   JOIN user_perm_rel up ON (p.permID = up.PermID)
                   JOIN users u ON (u.ID = up.userID)
                   WHERE p.code = 'send_to_dcc'";
 
-        $results = $DB->pselect($query, array());
+        $results = \Database::singleton()->pselect($query, array());
 
+        $group = array();
         $group[] = $this->form->createElement(
             'static',
             null,

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -527,9 +527,9 @@ class Edit_User extends \NDB_Form
             // create an instance of the config object
             $config = \NDB_Config::singleton();
             // send the user an email
-            $msd_data = array();
-            $msg_data['study']    = $config->getSetting('title');
-            $msg_data['url']      = $config->getSetting('url');
+            $msg_data          = array();
+            $msg_data['study'] = $config->getSetting('title');
+            $msg_data['url']   = $config->getSetting('url');
             $msg_data['realname'] = $values['Real_name'];
             $msg_data['username'] = $user->getUsername();
             $msg_data['password'] = $values['Password_hash'];
@@ -614,7 +614,7 @@ class Edit_User extends \NDB_Form
         }
 
         // password
-        $group = array();
+        $group   = array();
         $group[] = $this->createPassword('Password_hash');
         $group[] = $this->createCheckbox('NA_Password', 'Generate new password');
         $this->addGroup(
@@ -680,7 +680,7 @@ class Edit_User extends \NDB_Form
         }
 
         // email address
-        $group = array();
+        $group   = array();
         $group[] = $this->createText('Email', 'Email address');
         $group[] = $this->createCheckbox('SendEmail', 'Send email to user');
         $this->addGroup(
@@ -701,9 +701,9 @@ class Edit_User extends \NDB_Form
         //------------------------------------------------------------
 
         // get user permissions
-        $editor = \User::singleton();
+        $editor      = \User::singleton();
         $siteOptions = array();
-        $site = array();
+        $site        = array();
 
         // center ID
         if ($editor->hasPermission('user_accounts_multisite')) {
@@ -833,7 +833,7 @@ class Edit_User extends \NDB_Form
 
         $perms    = $editor->getPermissionsVerbose();
         $lastRole = '';
-        $group = array();
+        $group    = array();
         foreach ($perms as $row) {
             if ($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
@@ -877,7 +877,7 @@ class Edit_User extends \NDB_Form
 
         $results = \Database::singleton()->pselect($query, array());
 
-        $group = array();
+        $group   = array();
         $group[] = $this->form->createElement(
             'static',
             null,

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -204,9 +204,9 @@ class My_Preferences extends \NDB_Form
             $config = \NDB_Config::singleton();
 
             // send the user an email
-            $msg_data = array();
-            $msg_data['study']    = $config->getSetting('title');
-            $msg_data['url']      = $config->getSetting('url');
+            $msg_data          = array();
+            $msg_data['study'] = $config->getSetting('title');
+            $msg_data['url']   = $config->getSetting('url');
             $msg_data['realname'] = $values['Real_name'];
             $msg_data['username'] = $user->getUsername();
             $msg_data['password'] = $values['Password_hash'];
@@ -305,7 +305,7 @@ class My_Preferences extends \NDB_Form
         $this->addSelect('language_preference', 'Language preference', $languages);
 
         // Notification headers
-        $nGroup = array();
+        $nGroup   = array();
         $nGroup[] = $this->createLabel("Module");
         $nGroup[] = $this->createLabel("Operation");
         $nGroup[] = $this->createLabel("Description");
@@ -326,7 +326,7 @@ class My_Preferences extends \NDB_Form
         $notification_rows =array();
         foreach ($notifier_list as $module=>$operation_services) {
             foreach ($operation_services as $operation=>$services) {
-                $nGroup = array();
+                $nGroup   = array();
                 $nGroup[] = $this->createLabel($module);
                 $nGroup[] = $this->createLabel($operation);
                 $nGroup[] = $this->createLabel($services['desc']);

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -178,6 +178,7 @@ class My_Preferences extends \NDB_Form
             }
         }
         // END NOTIFICATIONS UPDATE
+        $set = array();
         foreach ($values as $key => $value) {
             // Password updates are handled separately. Password_hash is removed
             // from the initial update as otherwise it will be recorded in the
@@ -203,6 +204,7 @@ class My_Preferences extends \NDB_Form
             $config = \NDB_Config::singleton();
 
             // send the user an email
+            $msg_data = array();
             $msg_data['study']    = $config->getSetting('title');
             $msg_data['url']      = $config->getSetting('url');
             $msg_data['realname'] = $values['Real_name'];
@@ -303,6 +305,7 @@ class My_Preferences extends \NDB_Form
         $this->addSelect('language_preference', 'Language preference', $languages);
 
         // Notification headers
+        $nGroup = array();
         $nGroup[] = $this->createLabel("Module");
         $nGroup[] = $this->createLabel("Operation");
         $nGroup[] = $this->createLabel("Description");
@@ -323,6 +326,7 @@ class My_Preferences extends \NDB_Form
         $notification_rows =array();
         foreach ($notifier_list as $module=>$operation_services) {
             foreach ($operation_services as $operation=>$services) {
+                $nGroup = array();
                 $nGroup[] = $this->createLabel($module);
                 $nGroup[] = $this->createLabel($operation);
                 $nGroup[] = $this->createLabel($services['desc']);

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -117,6 +117,7 @@ class User_Accounts extends \NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $list_of_sites = array();
+            $site = array();
             $site_arr      = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = \Site::singleton($val);

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -117,7 +117,7 @@ class User_Accounts extends \NDB_Menu_Filter
         } else {
             // allow only to view own site data
             $list_of_sites = array();
-            $site = array();
+            $site          = array();
             $site_arr      = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = \Site::singleton($val);

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -92,7 +92,7 @@ class BVL_Feedback_Panel
         $this->tpl_data['thread_summary_headers'] = json_encode($summary);
 
         $field_names = Utility::getSourcefields($_REQUEST['test_name'] ?? '');
-        $fields = array();
+        $fields      = array();
         $fields['Across All Fields'] = 'Across All Fields';
         foreach ($field_names as $field_name) {
             $fields[$field_name['SourceField']] = $field_name['SourceField'];

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -92,12 +92,13 @@ class BVL_Feedback_Panel
         $this->tpl_data['thread_summary_headers'] = json_encode($summary);
 
         $field_names = Utility::getSourcefields($_REQUEST['test_name'] ?? '');
-        $Fields['Across All Fields'] = 'Across All Fields';
+        $fields = array();
+        $fields['Across All Fields'] = 'Across All Fields';
         foreach ($field_names as $field_name) {
-            $Fields[$field_name['SourceField']] = $field_name['SourceField'];
+            $fields[$field_name['SourceField']] = $field_name['SourceField'];
         }
 
-        $this->tpl_data['FieldNames'] = json_encode($Fields);
+        $this->tpl_data['FieldNames'] = json_encode($fields);
 
         $smarty = new Smarty_neurodb("bvl_feedback_panel");
         $smarty->assign($this->tpl_data);

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -402,9 +402,10 @@ class FeedbackMRI
         }
 
         // create DB object
-        $DB =& Database::singleton();
+        $DB = \Database::singleton();
 
         // object identifier
+        $set = array();
         if ($this->objectType == 'volume') {
             // per-volume
             $set['FileID'] = $this->fileID;

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -480,6 +480,7 @@ class File_Upload
       */
     function getSplitFilename($name)
     {
+        $file = array();
         if (strstr($name, ".")) {
             $extpos       =strrpos($name, ".");
             $file['name'] =substr($name, 0, $extpos);

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -473,7 +473,7 @@ class File_Upload
       *
       * @param string $name The string file name
       *
-      * @return string split file name
+      * @return array split file name
       * @see    File_Upload::nameToIncremental()
       * @see    File_Upload::nameToUniqueRandom()
       * @see    File_Upload::nameToUniqueTimestamp()

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -227,13 +227,13 @@ class NDB_BVL_Feedback
     static public function getFeedbackTypes()
     {
         // new DB Object
-        $db =& Database::singleton();
 
         $query = "SELECT Feedback_type as Type, Name, Description
             FROM feedback_bvl_type";
 
-        $result = $db->pselect($query, array());
+        $result = \Database::singleton()->pselect($query, array());
 
+        $list = array();
         foreach ($result as $record) {
             $list[$record['Type']] = array(
                                       'Type'  => $record['Type'],

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -438,7 +438,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // because that's part of the DirectEntry template
         // and has Save/Continue and go back buttons
         if (!$this->form->isFrozen() && $this->DataEntryType === 'normal') {
-            $buttons = array();
+            $buttons   = array();
             $buttons[] = $this->form->createElement(
                 'submit',
                 'fire_away',
@@ -1280,7 +1280,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $errors = array();
         //Conditions for the rule to be true, thus the element to be required.
         $rule_outcomes = array();
-        $rules_array = array();
+        $rules_array   = array();
 
         foreach ($rules['rules'] AS $rule) {
             //Loop through the assigned rules (which is the array of formatted
@@ -1593,7 +1593,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                            'not_answered' => 'Not Answered',
                           )
     ): void {
-        $group = array();
+        $group   = array();
         $group[] = $this->createText($field, $label);
         $this->WrapperTextElements[$field] = $group[0];
         $group[] = $this->createSelect(
@@ -1627,7 +1627,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         array $rules=array(),
         string $rule_message='You must specify or select from the drop-down'
     ): void {
-        $group = array();
+        $group   = array();
         $group[] = $this->form->createElement(
             "textarea",
             $field,
@@ -1671,7 +1671,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         array $rules=array(),
         string $rule_message='This field is required.'
     ): void {
-        $group = array();
+        $group   = array();
         $group[] = $this->form->createElement(
             "textarea",
             $field,
@@ -1727,7 +1727,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 . "if you want to leave this time blank.";
         }
 
-        $group = array();
+        $group   = array();
         $group[] = $this->form->createElement(
             "time",
             $field,
@@ -1777,7 +1777,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $options = $this->dateOptions;
         }
 
-        $group = array();
+        $group   = array();
         $group[] = $this->createDate(
             $name . "_date",
             $label,
@@ -1858,7 +1858,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         string $label,
         array $dateArray
     ): void {
-        $group = array();
+        $group   = array();
         $group[] = $this->createDate($name . "_date", null, $dateArray);
         //add to array of dates and times.
         $this->dateTimeFields[] = $name . "_date";
@@ -1911,7 +1911,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         string $field,
         string $label
     ): void {
-        $group = array();
+        $group   = array();
         $group[] = $this->createText($field, $label);
         $this->WrapperNumericElements[$field] = $group[0];
         $group[] = $this->createSelect(
@@ -1948,7 +1948,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function addNumericElementRD(string $field, string $label): void
     {
-        $group = array();
+        $group   = array();
         $group[] = $this->createText($field, $label);
         $group[] = $this->createSelect(
             $field . "_status",

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -438,6 +438,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // because that's part of the DirectEntry template
         // and has Save/Continue and go back buttons
         if (!$this->form->isFrozen() && $this->DataEntryType === 'normal') {
+            $buttons = array();
             $buttons[] = $this->form->createElement(
                 'submit',
                 'fire_away',
@@ -1238,26 +1239,20 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * @param string $group   Empty if a non-grouped element is registering the rule.
      *                        Otherwise, name of the group registering the rule.
      *
-     * @return bool
+     * @return void
      */
     function XINRegisterRule(
         string $elname,
         array $rules,
         string $message="",
         string $group=""
-    ): bool {
-        if (!is_array($rules)) {
-            $rules_array[] = $rules;
-        } else {
-            $rules_array = $rules;
-        }
+    ): void {
         $this->XINRules[$elname]['message'] = $message;
         $this->XINRules[$elname]['group']   = $group;
 
-        foreach ($rules_array AS $rule) {
+        foreach ($rules AS $rule) {
             $this->XINRules[$elname]['rules'][] = $rule;
         }
-        return true;
     }
 
 
@@ -1285,6 +1280,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $errors = array();
         //Conditions for the rule to be true, thus the element to be required.
         $rule_outcomes = array();
+        $rules_array = array();
 
         foreach ($rules['rules'] AS $rule) {
             //Loop through the assigned rules (which is the array of formatted
@@ -1597,6 +1593,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                            'not_answered' => 'Not Answered',
                           )
     ): void {
+        $group = array();
         $group[] = $this->createText($field, $label);
         $this->WrapperTextElements[$field] = $group[0];
         $group[] = $this->createSelect(
@@ -1630,6 +1627,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         array $rules=array(),
         string $rule_message='You must specify or select from the drop-down'
     ): void {
+        $group = array();
         $group[] = $this->form->createElement(
             "textarea",
             $field,
@@ -1673,6 +1671,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         array $rules=array(),
         string $rule_message='This field is required.'
     ): void {
+        $group = array();
         $group[] = $this->form->createElement(
             "textarea",
             $field,
@@ -1728,6 +1727,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 . "if you want to leave this time blank.";
         }
 
+        $group = array();
         $group[] = $this->form->createElement(
             "time",
             $field,
@@ -1777,6 +1777,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $options = $this->dateOptions;
         }
 
+        $group = array();
         $group[] = $this->createDate(
             $name . "_date",
             $label,
@@ -1857,6 +1858,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         string $label,
         array $dateArray
     ): void {
+        $group = array();
         $group[] = $this->createDate($name . "_date", null, $dateArray);
         //add to array of dates and times.
         $this->dateTimeFields[] = $name . "_date";
@@ -1909,6 +1911,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         string $field,
         string $label
     ): void {
+        $group = array();
         $group[] = $this->createText($field, $label);
         $this->WrapperNumericElements[$field] = $group[0];
         $group[] = $this->createSelect(
@@ -1945,6 +1948,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function addNumericElementRD(string $field, string $label): void
     {
+        $group = array();
         $group[] = $this->createText($field, $label);
         $group[] = $this->createSelect(
             $field . "_status",

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -188,6 +188,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     //debugging code
                     echo "<p><b>$elname</b><br> ";
                 }
+                $rules_array = array();
                 foreach ($registered_rules as $registered) {
                     $rules = $registered['rules'];
 
@@ -336,14 +337,14 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      * @param string $group   Empty if a non-grouped element is registering the rule.
      *                        Otherwise, name of the group registering the rule.
      *
-     * @return bool true
+     * @return void
      */
     function XINRegisterRule(
         string $elname,
         array $rules,
         string $message="",
         string $group=""
-    ): bool {
+    ): void {
         // I'm not sure if these are logically the same. I think they should be, but
         // there was a bug introduced by the LINST changes to XINRules to old
         // instruments so I'm making sure that the old code is followed exactly
@@ -352,22 +353,16 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         // the if statement and use the same logic for "old" instruments and "new"
         // instruments
         //  -- Dave
-        if (!is_array($rules)) {
-            $rules_array[] = $rules;
-        } else {
-            $rules_array = $rules;
-        }
         $rule = array(
                  'message' => $message,
                  'group'   => $group,
                  'rules'   => array(),
                 );
 
-        foreach ($rules_array AS $rule_cmd) {
+        foreach ($rules AS $rule_cmd) {
             $rule['rules'][] = $rule_cmd;
         }
         $this->XINRules[$elname][] = $rule;
-        return true;
     }
 
     /**

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -194,10 +194,18 @@ class NDB_Factory
             if ($db_ref !== null) {
                 return $db_ref;
             }
-                self::$db = Database::singleton();
+            self::$db = Database::singleton();
         }
         $config = $this->config();
         $dbc    = $config->getSetting('database');
+        // This check was added to satisfy phan, our static analysis tool.
+        // $db_ref should be set to either a new MockDatabase or a Database
+        // singleton above.
+        if ($db_ref === null) {
+            throw new \ConfigurationException(
+                'Could not configure database for LORIS'
+            );
+        }
         $db_ref->connect(
             $dbc['database'],
             $dbc['username'],

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -711,10 +711,13 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function getCSVData()
     {
-        $list['data']    = $this->_getFullList();
-        $list['headers'] = $this->headers;
+        return $this->arrayToCSV(
+            array(
+                'data' => $this->_getFullList(),
+                'headers' => $this->headers
+            )
+        );
 
-        return $this->arrayToCSV($list);
     }
 
     /**

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -713,8 +713,8 @@ class NDB_Menu_Filter extends NDB_Menu
     {
         return $this->arrayToCSV(
             array(
-                'data' => $this->_getFullList(),
-                'headers' => $this->headers
+             'data'    => $this->_getFullList(),
+             'headers' => $this->headers,
             )
         );
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -319,6 +319,7 @@ class NDB_Page implements RequestHandlerInterface
      */
     function addRadio($name, $groupLabel, $radios, $options=array())
     {
+        $radGroup = array();
         foreach ($radios as $radElement) {
             $tempOptions = array_merge(
                 array(

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -332,6 +332,7 @@ class User extends UserPermissions
     {
         $site_arr         = $this->getCenterIDs();
         $user_study_sites = array();
+        $site = array();
         foreach ($site_arr as $key => $val) {
             $site[$key] = &Site::singleton($val);
             if ($site[$key]->isStudySite()) {

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -928,7 +928,7 @@ class Utility
              FROM language",
             array()
         );
-        $languages = array();
+        $languages   = array();
         foreach ($languagesDB as $language) {
             $languages[$language['language_id']] = $language['language_label'];
         }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -928,6 +928,7 @@ class Utility
              FROM language",
             array()
         );
+        $languages = array();
         foreach ($languagesDB as $language) {
             $languages[$language['language_id']] = $language['language_label'];
         }

--- a/src/Api/Endpoints/Project/Project.php
+++ b/src/Api/Endpoints/Project/Project.php
@@ -157,9 +157,9 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
             $candids = $this->project->getCandidateIds();
 
-            $responsebody = array();
-            $responsebody['Meta']        = $meta;
-            $responsebody['Visits']      = $visits;
+            $responsebody           = array();
+            $responsebody['Meta']   = $meta;
+            $responsebody['Visits'] = $visits;
             $responsebody['Instruments'] = $instruments;
             $responsebody['Candidates']  = $candids;
 

--- a/src/Api/Endpoints/Project/Project.php
+++ b/src/Api/Endpoints/Project/Project.php
@@ -157,6 +157,7 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
             $candids = $this->project->getCandidateIds();
 
+            $responsebody = array();
             $responsebody['Meta']        = $meta;
             $responsebody['Visits']      = $visits;
             $responsebody['Instruments'] = $instruments;

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -132,8 +132,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         );
 
         // User related template variables that used to be in main.php.
-        $site_arr = $this->user->getData('CenterIDs');
-        $site = array();
+        $site_arr    = $this->user->getData('CenterIDs');
+        $site        = array();
         $isStudySite = array();
         foreach ($site_arr as $key => $val) {
             $site[$key]        = & \Site::singleton($val);

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -133,6 +133,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         // User related template variables that used to be in main.php.
         $site_arr = $this->user->getData('CenterIDs');
+        $site = array();
+        $isStudySite = array();
         foreach ($site_arr as $key => $val) {
             $site[$key]        = & \Site::singleton($val);
             $isStudySite[$key] = $site[$key]->isStudySite();

--- a/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
+++ b/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
@@ -76,6 +76,7 @@ class NDB_BVL_Instrument_testtest extends NDB_BVL_Instrument
       $this->addCheckbox('testCheckbox', 'Check this checkbox default value is 1', array('value' => '1'));
       $this->form->addElement("text", 'testText', "text_input", array("class" => "encrypt required"));
       $yesNo = array(null=>"", 'yes'=>"Yes", 'no'=>"No");
+      $group = array();
       $group[] = $this->form->createElement("select","consent", "", $yesNo);
       $this->XINRegisterRule("consent", array("code{@}=={@}"), "Required.", "consent_group");
       $this->form->addGroup($group, "consent_group", "Test selecting 'Yes' from the dropdown menu.", null, false);

--- a/test/unittests/BreadcrumbTrailTest.php
+++ b/test/unittests/BreadcrumbTrailTest.php
@@ -52,7 +52,7 @@ class BreadcrumbTrailTest extends TestCase
     public function testToString($data1, $data2, $c)
     {
 	$this->breadcrumbTrail = new BreadcrumbTrail(new Breadcrumb($data1[0], $data1[1]), new Breadcrumb($data2[0], $data2[1]));
-        $this->assertEquals($c, $this->breadcrumbTrail->__toString());
+        $this->assertEquals($c, $this->breadcrumbTrail);
     }
 
     public function toStringProvider()


### PR DESCRIPTION
Adding this rule makes it so that developers must explicitly declare arrays they are using before referencing keys used in those arrays.

e.g.

```php
function foo() {
     $arr['key'] = 'value';
     return $arr;
}
```

must now be

```php
function foo() {
     $arr = array('key' => 'value');
     // or: $arr = array(); $arr['key'] = 'value';
     return $arr;
}
```

This PR also fixes existing code where this occurs (and does some light cleanup).