### PR TITLE
[Data Framework] Update candidate list to use data framework

### DIFF
--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -20,17 +20,8 @@ namespace LORIS\candidate_list;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Candidate_List extends \DataFrameworkMenu {
-    public function __construct(
-        \Module $module,
-        string $page,
-        string $identifier,
-        string $commentID,
-        string $formname
-    ) {
-        parent::__construct($module, $page, $identifier, $commentID, $formname);
-    }
-
+class Candidate_List extends \DataFrameworkMenu
+{
     /**
      * Overloading this method to allow access to site users (their own site only)
      * and users w/ multisite privs
@@ -54,7 +45,8 @@ class Candidate_List extends \DataFrameworkMenu {
      *
      * @return bool always true
      */
-    public function useSiteFilter() : bool {
+    public function useSiteFilter() : bool
+    {
         return true;
     }
 
@@ -105,12 +97,12 @@ class Candidate_List extends \DataFrameworkMenu {
         }
 
         return [
-            'site'              => $site_options,
-            'project'           => $project_options,
-            'subproject'        => $subproject_options,
-            'participantstatus' => $participant_status_options,
-            'useedc'            => $config->getSetting("useEDC"),
-        ];
+                'site'              => $site_options,
+                'project'           => $project_options,
+                'subproject'        => $subproject_options,
+                'participantstatus' => $participant_status_options,
+                'useedc'            => $config->getSetting("useEDC"),
+               ];
     }
 
     /**

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -20,9 +20,16 @@ namespace LORIS\candidate_list;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Candidate_List extends \NDB_Menu_Filter
-{
-    var $AjaxModule = true;
+class Candidate_List extends \DataFrameworkMenu {
+    public function __construct(
+        \Module $module,
+        string $page,
+        string $identifier,
+        string $commentID,
+        string $formname
+    ) {
+        parent::__construct($module, $page, $identifier, $commentID, $formname);
+    }
 
     /**
      * Overloading this method to allow access to site users (their own site only)
@@ -42,71 +49,23 @@ class Candidate_List extends \NDB_Menu_Filter
     }
 
     /**
-     * Sets up all the class variables needed for the candidate_list menu
-     * filter
+     * Tells the base class that this page's provisioner can support
+     * the UserSiteMatch filter.
      *
-     * @return void
+     * @return bool always true
      */
-    function _setupVariables()
-    {
-        $user   = \User::singleton();
-        $config = \NDB_Config::singleton();
-
-        $this->skipTemplate = true;
-
-        // set the class variables
-        $this->columns = array(
-                          'c.PSCID',
-                          'c.CandID AS DCCID',
-                          'GROUP_CONCAT(DISTINCT s.Visit_label) AS VisitLabel',
-                          'psc.Name AS RegistrationSite',
-                          'GROUP_CONCAT(DISTINCT sp.title) as Subproject',
-                          'c.Entity_type AS EntityType',
-                          'MAX(s.Scan_done) as scanDone',
-                          'COALESCE(pso.Description,"Active") AS ParticipantStatus',
-                          'DATE_FORMAT(c.DoB,\'%Y-%m-%d\') AS DoB',
-                          'c.Sex',
-                          'COUNT(DISTINCT s.Visit_label) AS VisitCount',
-                          "IFNULL(MIN(feedback_bvl_thread.Status+0),0) AS Feedback",
-                          'max(s.Current_stage) AS LatestVisitStatus',
-                          'p.Name as Project',
-                         );
-
-        if ($config->getSetting("useEDC") === "true") {
-            $this->columns[] = 'DATE_FORMAT((c.EDC),\'%Y-%m-%d\') AS EDC';
-        }
-
-        $this->query = " FROM candidate c
-            LEFT JOIN psc ON (c.RegistrationCenterID=psc.CenterID)
-            LEFT JOIN session s ON (c.CandID = s.CandID AND s.Active = 'Y')
-            LEFT JOIN feedback_bvl_thread
-                ON (c.CandID=feedback_bvl_thread.CandID)
-            LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
-            LEFT JOIN participant_status_options pso
-                ON (ps.participant_status=pso.ID)
-            LEFT JOIN Project p ON (c.ProjectID=p.ProjectID)
-            LEFT JOIN subproject sp ON (s.SubprojectID=sp.SubprojectID)
-            WHERE c.Active = 'Y'";
-
-        if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr     = implode(",", $user->getCenterIDs());
-            $this->query .= " AND c.RegistrationCenterID IN (" . $site_arr . ")";
-        }
-
-        //'COALESCE(pso.ID,1) AS Participant_Status',
-        $this->group_by = 'c.CandID, psc.Name, c.PSCID, c.Sex';
-        $this->order_by = 'c.PSCID ASC';
+    public function useSiteFilter() : bool {
+        return true;
     }
 
-
     /**
-     * Create the form for the candidate_list menu page
+     * Return the list of field options required to be serialized to JSON
+     * in order to render the frontend.
      *
-     * @return void
+     * @return array
      */
-    function setup()
+    function getFieldOptions() : array
     {
-        parent::setup();
         // Relying on a side-effect of the the server process module to autoload
         // its namespace.
         \Module::factory('candidate_parameters');
@@ -145,15 +104,13 @@ class Candidate_List extends \NDB_Menu_Filter
             $participant_status_options[$name] = $name;
         }
 
-        $this->fieldOptions = [
-                               'site'              => $site_options,
-                               'project'           => $project_options,
-                               'subproject'        => $subproject_options,
-                               'participantstatus' => $participant_status_options,
-                               'useedc'            => $config->getSetting("useEDC"),
-                              ];
-
-        return true;
+        return [
+            'site'              => $site_options,
+            'project'           => $project_options,
+            'subproject'        => $subproject_options,
+            'participantstatus' => $participant_status_options,
+            'useedc'            => $config->getSetting("useEDC"),
+        ];
     }
 
     /**
@@ -185,6 +142,16 @@ class Candidate_List extends \NDB_Menu_Filter
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb('Access Profile', "/$this->name")
         );
+    }
+
+    /**
+     * Gets the data source for this menu filter.
+     *
+     * @return \LORIS\Data\Provisioner
+     */
+    public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
+    {
+        return new CandidateListRowProvisioner();
     }
 }
 

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This class implements a data Instance which represents a single
+ * row in the candidate list menu table.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\candidate_list;
+
+/**
+ * A CandidateListRow represents a row in the Candidate List menu table.
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class CandidateListRow implements \LORIS\Data\DataInstance
+{
+    protected $DBRow;
+    protected $CenterID;
+
+    /**
+     * Create a new CandidateListRow
+     *
+     * @param array   $row The row (in the same format as \Database::pselectRow
+     *                     returns
+     * @param integer $cid The centerID affiliated with this row.
+     */
+    public function __construct(array $row, $cid)
+    {
+        $this->DBRow    = $row;
+        $this->CenterID = $cid;
+    }
+
+    /**
+     * Implements \LORIS\Data\DataInstance interface for this row.
+     *
+     * @return string the row data.
+     */
+    public function toJSON() : string
+    {
+        return json_encode($this->DBRow);
+    }
+
+    /**
+     * Returns the CenterID for this row, for filters such as
+     * \LORIS\Data\Filters\UserSiteMatch to match again.
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID()
+    {
+        return $this->CenterID;
+    }
+}

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -59,7 +59,7 @@ class CandidateListRow implements \LORIS\Data\DataInstance
      *
      * @return integer The CenterID
      */
-    public function getCenterID()
+    public function getCenterID(): int
     {
         return $this->CenterID;
     }

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -37,7 +37,7 @@ class CandidateListRow implements \LORIS\Data\DataInstance
      *                     returns
      * @param integer $cid The centerID affiliated with this row.
      */
-    public function __construct(array $row, $cid)
+    public function __construct(array $row, int $cid)
     {
         $this->DBRow    = $row;
         $this->CenterID = $cid;

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This class implements a data Instance which represents a single
  * row in the candidate list menu table.

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -86,7 +86,7 @@ clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
      *
      * @return \LORIS\Data\DataInstance An instance representing this row.
      */
-    public function getInstance($row) : \LORIS\Data\DataInstance
+    public function getInstance(array $row) : \LORIS\Data\DataInstance
     {
         // XXX This should probably be updated to allow users
         // to access candidates who have any session at one of the

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -93,7 +93,7 @@ clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // user's sites, but for now this maintains the previous
         // behaviour of requiring the registration site to match
         // one of the user's sites.
-        $cid = $row['RegistrationCenterID'];
+        $cid = (int )$row['RegistrationCenterID'];
         unset($row['RegistrationCenterID']);
         return new CandidateListRow($row, $cid);
     }

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * This file implements a data provisioner to get all possible rows
  * for the candidate list menu page.

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -28,7 +28,7 @@ namespace LORIS\candidate_list;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
+class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     /**
      * Create a CandidateListRowProvisioner, which gets rows for

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This file implements a data provisioner to get all possible rows
+ * for the candidate list menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\candidate_list;
+
+/**
+ * This class implements a data provisioner to get all possible rows
+ * for the candidate list menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Imaging
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
+{
+    /**
+     * Create a CandidateListRowProvisioner, which gets rows for 
+     * the candidate_list menu table.
+     */
+    function __construct()
+    {
+        $config = \NDB_Config::singleton();
+        $maybeEDC = '';
+
+        if ($config->getSetting("useEDC") === "true") {
+            $maybeEDC = ", DATE_FORMAT((c.EDC),'%Y-%m-%d') AS EDC";
+        }
+        parent::__construct(
+            "SELECT
+                c.PSCID,
+                c.CandID AS DCCID,
+                GROUP_CONCAT(DISTINCT s.Visit_label) AS VisitLabel,
+                psc.Name AS RegistrationSite,
+                GROUP_CONCAT(DISTINCT sp.title) AS Subproject,
+                c.Entity_type AS EntityType,
+                MAX(s.Scan_done) AS scanDone,
+                COALESCE(pso.Description,'Active') AS ParticipantStatus,
+                DATE_FORMAT(c.DoB,'%Y-%m-%d') AS DoB,
+                c.Sex,
+                COUNT(DISTINCT s.Visit_label) AS VisitCount,
+                IFNULL(MIN(feedback_bvl_thread.Status+0),0) AS Feedback,
+                max(s.Current_stage) AS LatestVisitStatus,
+                p.Name AS Project,
+                c.RegistrationCenterID
+                $maybeEDC
+                FROM candidate c
+                    LEFT JOIN psc ON (c.RegistrationCenterID=psc.CenterID)
+                    LEFT JOIN session s ON (c.CandID = s.CandID AND s.Active = 'Y')
+                    LEFT JOIN feedback_bvl_thread
+                        ON (c.CandID=feedback_bvl_thread.CandID)
+                    LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
+                    LEFT JOIN participant_status_options pso
+                        ON (ps.participant_status=pso.ID)
+                    LEFT JOIN Project p ON (c.ProjectID=p.ProjectID)
+                    LEFT JOIN subproject sp ON (s.SubprojectID=sp.SubprojectID)
+                WHERE c.Active = 'Y'
+                GROUP BY c.CandID, psc.Name, c.PSCID, c.Sex
+                ORDER BY c.PSCID ASC
+            ",
+            array()
+        );
+    }
+
+    /**
+     * Returns an instance of a CandidateListRow object for a given
+     * table row.
+     *
+     * @param array $row The database row from the LORIS Database class.
+     *
+     * @return \LORIS\Data\DataInstance An instance representing this row.
+     */
+    public function getInstance($row) : \LORIS\Data\DataInstance
+    {
+        // XXX This should probably be updated to allow users
+        // to access candidates who have any session at one of the
+        // user's sites, but for now this maintains the previous
+        // behaviour of requiring the registration site to match
+        // one of the user's sites.
+        $cid = $row['RegistrationCenterID'];
+        unset($row['RegistrationCenterID']);
+        return new CandidateLIstRow($row, $cid);
+    }
+}

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -31,12 +31,12 @@ namespace LORIS\candidate_list;
 clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     /**
-     * Create a CandidateListRowProvisioner, which gets rows for 
+     * Create a CandidateListRowProvisioner, which gets rows for
      * the candidate_list menu table.
      */
     function __construct()
     {
-        $config = \NDB_Config::singleton();
+        $config   = \NDB_Config::singleton();
         $maybeEDC = '';
 
         if ($config->getSetting("useEDC") === "true") {

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -86,7 +86,7 @@ clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
      *
      * @return \LORIS\Data\DataInstance An instance representing this row.
      */
-    public function getInstance(array $row) : \LORIS\Data\DataInstance
+    public function getInstance($row) : \LORIS\Data\DataInstance
     {
         // XXX This should probably be updated to allow users
         // to access candidates who have any session at one of the

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -95,6 +95,6 @@ clASs CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // one of the user's sites.
         $cid = $row['RegistrationCenterID'];
         unset($row['RegistrationCenterID']);
-        return new CandidateLIstRow($row, $cid);
+        return new CandidateListRow($row, $cid);
     }
 }

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+/**
+ * This class implements a DataframeWorkMenu, a specific type of
+ * menu filter where the front end is generated from React and the
+ * data comes from a \LORIS\Data\Provisioner.
+ *
+ * PHP Version 5
+ *
+ * @category Behavioural
+ * @package  Main
+ * @author   Loris team <info-loris.mni@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+
+/**
+ * A DataFrameworkMenu is a type of menu (filterable data table)
+ * where the data comes from the LORIS data framework, and the
+ * formatting comes from React.
+ *
+ * "Menu" type data tables usually have one column which is clickable
+ * on the formatting, and form the entry point of most LORIS modules.
+ *
+ * @category Behavioural
+ * @package  Main
+ * @author   Loris team <info-loris.mni@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+abstract class DataFrameworkMenu extends NDB_Menu_Filter
+{
+
+    /**
+     * Constructor for a DataFrameworkMenu class. This signature must match
+     * the base NDB_Page type in order for LORIS to be able to load the page.
+     *
+     * @param Module $module     The test name being accessed
+     * @param string $page       The subtest being accessed (may be an empty string)
+     * @param string $identifier The identifier for the data to load on this page
+     * @param string $commentID  The CommentID to load the data for
+     * @param string $formname   The name to give this form
+     */
+    public function __construct(
+        \Module $module,
+        string $page,
+        string $identifier,
+        string $commentID,
+        string $formname
+    ) {
+        parent::__construct($module, $page, $identifier, $commentID, $formname);
+
+        $this->AjaxModule        = true;
+        $this->skipTemplate      = true;
+        $this->includeSiteFilter = true;
+    }
+
+    /**
+     * Determines whether the DataProvisioner should filter out rows which
+     * do not match the user's site.
+     *
+     * @return bool true if the data provisioner should filter non-matching sites.
+     */
+    abstract public function useSiteFilter() : bool;
+
+    /**
+     * Items to add to the JSON fieldOptions key, which React components
+     * can use for formatting. This is used to send data dependent options
+     * to the frontend.
+     *
+     * @return array An array of data-context sensitive GUI options.
+     */
+    abstract protected function getFieldOptions() : array ;
+
+    /**
+     * Return the base Provisioner, without any filters applied.
+     *
+     * @return \LORIS\Data\Provisioner the basic data provisioner
+     */
+    abstract public function getBaseDataProvisioner() : \LORIS\Data\Provisioner;
+
+    /**
+     * Return a data provisioner of the same type as BaseDataProvisioner, with
+     * default LORIS filters applied. A subclass may override this to remove (or
+     * change) filters.
+     *
+     * @return \LORIS\Data\Provisioner a provisioner with default filters added
+     */
+    public function getDataProvisionerWithFilters() : \LORIS\Data\Provisioner
+    {
+        $provisioner = $this->getBaseDataProvisioner();
+
+        $user = \User::singleton();
+
+        // UserSiteMatch throws an exception if used on a model without a getCenterID
+        // or getCenterIDs function, so we only apply it on sub-classes that
+        // specifically say they support it.
+        if ($this->useSiteFilter()
+            && $user->hasPermission("access_all_profiles") == false
+        ) {
+            $provisioner = $provisioner->filter(
+                new \LORIS\Data\Filters\UserSiteMatch()
+            );
+        }
+        return $provisioner;
+
+    }
+
+    /**
+     * Converts the results of this menu filter to a JSON format to be retrieved
+     * with ?format=json
+     *
+     * @return string a json encoded string of the headers and data from this table
+     */
+    public function toJSON()
+    {
+        $table = (new \LORIS\Data\Table())
+            ->withDataFrom($this->getDataProvisionerWithFilters());
+        $arr   = array_map(
+            function ($row) {
+                return array_values($row);
+            },
+            json_decode($table->toJSON(\User::singleton()), true)
+        );
+
+        return json_encode(
+            [
+             'Data'         => $arr,
+             'fieldOptions' => $this->getFieldOptions(),
+            ]
+        );
+
+        return json_encode($arr);
+    }
+}
+

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -17,7 +17,7 @@
 /**
  * A DataFrameworkMenu is a type of menu (filterable data table)
  * where the data comes from the LORIS data framework, and the
- * formatting comes from React.
+ * formatting is done by React.
  *
  * "Menu" type data tables usually have one column which is clickable
  * on the formatting, and form the entry point of most LORIS modules.

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -1,11 +1,11 @@
 <?php declare(strict_types=1);
 
 /**
- * This class implements a DataframeWorkMenu, a specific type of
+ * This class implements a DataFrameworkMenu, a specific type of
  * menu filter where the front end is generated from React and the
  * data comes from a \LORIS\Data\Provisioner.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Behavioural
  * @package  Main

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -17,10 +17,16 @@
 /**
  * A DataFrameworkMenu is a type of menu (filterable data table)
  * where the data comes from the LORIS data framework, and the
- * formatting is done by React.
+ * formatting is done by React. They are often used as a landing
+ * page for a LORIS module.
  *
- * "Menu" type data tables usually have one column which is clickable
- * on the formatting, and form the entry point of most LORIS modules.
+ * "Menu" type data tables are pages where data relevant to a specific
+ * domain are presented in a table and accompanied by filters as well as
+ * a mechanism to navigate from a row in the table to a page with details
+ * of that row's specific data instance details. This class's toJSON
+ * returns an object containing the data from the LORIS data framework
+ * for the table, and the fieldOptions required to build the filters
+ * for any dynamic filters.
  *
  * @category Behavioural
  * @package  Main

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -50,9 +50,8 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
     ) {
         parent::__construct($module, $page, $identifier, $commentID, $formname);
 
-        $this->AjaxModule        = true;
-        $this->skipTemplate      = true;
-        $this->includeSiteFilter = true;
+        $this->AjaxModule   = true;
+        $this->skipTemplate = true;
     }
 
     /**

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -349,7 +349,7 @@ class File_Upload
             return false;
         }
         //Test each method
-        $methods = $this->fileHAndlers[$field]['methods'];
+        $methods = $this->fileHandlers[$field]['methods'];
         if (is_iterable($methods)) {
             // Phan thinks methods is a string and fails below without
             // this check, but the class only ever seems to set it to an

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -350,7 +350,7 @@ class File_Upload
         }
         //Test each method
         $methods = $this->fileHandlers[$field]['methods'];
-        if (is_iterable($methods)) {
+        if (!is_iterable($methods)) {
             // Phan thinks methods is a string and fails below without
             // this check, but the class only ever seems to set it to an
             // array, so if somehow it become a string in a non-obvious

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -349,7 +349,17 @@ class File_Upload
             return false;
         }
         //Test each method
-        foreach ($this->fileHandlers[$field]['methods'] AS $method) {
+        $methods = $this->fileHAndlers[$field]['methods'];
+        if (is_iterable($methods)) {
+            // Phan thinks methods is a string and fails below without
+            // this check, but the class only ever seems to set it to an
+            // array, so if somehow it become a string in a non-obvious
+            // code path, throw an exception.
+            throw new \UnexpectedValueException(
+                "Invalid internal state of FileHandler. Expected array of methods"
+            );
+        }
+        foreach ($methods AS $method) {
             if (!method_exists($test, $method)) {
                 $this->setError(
                     $field,


### PR DESCRIPTION
This updates the candidate_list module to use the LORIS data framework. It does so by adding a new abstract DataFrameworkMenu class, which can be extended in order to remove some of the boilerplate of converting menu filters to the data framework.

In order to use the DataFrameworkMenu class, an implementation must supply:

1. a getFieldOptions function which returns a list of fieldOptions to include in the array for the frontend
2. a getBaseDataProvisioner function which returns a data provisioner
3.  a useSiteFilter function which returns whether or not the data provisioner should have the UserSiteFilter match applied.

In return, the class takes care of using that dataprovisioner, adding default LORIS data filters, and serializing to JSON in the format expected by react menu filters.