### PR TITLE
Add new phan rule PhanTypeExpectedObjectPropAccessButGotNull to static analysis

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -16,7 +16,6 @@ return [
 	"scalar_implicit_cast" => false,
 	"ignore_undeclared_variables_in_global_scope" => false,
 	"suppress_issue_types" => [
-        "PhanTypeExpectedObjectPropAccessButGotNull",
         "PhanTypeInvalidDimOffset",
 		"PhanUndeclaredMethod",
 		"PhanUndeclaredVariableDim",


### PR DESCRIPTION
We get this rule for free! No existing issues in LORIS.