### PR TITLE
[Clean up] deletion of the full MINC header entry from parameter_file as not used anymore

### DIFF
--- a/SQL/New_patches/2019_07_04_remove_header_row_from_parameter_file_and_convert_back_to_Value_field_to_text.sql
+++ b/SQL/New_patches/2019_07_04_remove_header_row_from_parameter_file_and_convert_back_to_Value_field_to_text.sql
@@ -1,0 +1,3 @@
+DELETE FROM parameter_file WHERE ParameterTypeID=(SELECT ParameterTypeID FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file');
+DELETE FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file';
+ALTER TABLE parameter_file MODIFY Value TEXT;


### PR DESCRIPTION
### Brief summary of changes

Until now, the whole header of a MINC file was dumped into a row of parameter_file, taking a lot of space in the database and the SQL dump created for that table, while not being used at all.

During the imaging meeting of July 4th, a decision has been made to no longer store that row to gain some space in the database, hence, removing it from the imaging pipeline code.

This is linked to https://github.com/aces/Loris-MRI/pull/453 PR on the LORIS-MRI side.

Note: the API does not look specifically for that header but dumps all the values present in the `parameter_file` table so no changes were needed.

### This resolves issue...

- [x] Github https://github.com/aces/Loris-MRI/issues/388

### To test this change...

- [ ] Make sure the SQL patch run correctly
