### PR TITLE
[Config] Add settingEnabled() helper function

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -415,6 +415,20 @@ class NDB_Config
     }
 
     /**
+     * Helper function to determine whether a setting with a boolean value is
+     * enabled, i.e. equal to "true".
+     * Since settings are returned as strings, this must be done as a string
+     * comparison.
+     *
+     * @param string $name The name of the setting to retrieve. This setting
+     *                      should have a boolean value in the config file or DB.
+     * @return bool True if the setting is equal to "true".
+     */
+    function settingEnabled(string $name) {
+        return $this->getSetting($name) === 'true';
+    }
+
+    /**
      * Get list of projects for this projects, given a ProjectID.
      *
      * @param integer $ProjectID The ProjectID we want settings for

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -422,9 +422,11 @@ class NDB_Config
      *
      * @param string $name The name of the setting to retrieve. This setting
      *                      should have a boolean value in the config file or DB.
+     *
      * @return bool True if the setting is equal to "true".
      */
-    function settingEnabled(string $name) {
+    function settingEnabled(string $name): bool
+    {
         return $this->getSetting($name) === 'true';
     }
 

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -427,7 +427,8 @@ class NDB_Config
      */
     function settingEnabled(string $name): bool
     {
-        return $this->getSetting($name) === 'true';
+        $val = $this->getSetting($name);
+        return $val === 'true' || $val === '1';
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -546,11 +546,13 @@ class User extends UserPermissions
     {
 
         // If the project is configured to disable the Pwned Password check,
-        // always return false (meanning that the password has not been pwned).
-        if ('true' !== \NDB_Factory::singleton()->config()->getSetting(
-            'usePwnedPasswordsAPI'
-        )
-        ) {
+        // always return false (meaning that the password has not been pwned
+        // and the submitted password is acceptable).
+        $checkPwned = \NDB_Factory::singleton()
+            ->config()
+            ->settingEnabled('usePwnedPasswordsAPI');
+
+        if (!$checkPwned) {
             return false;
         }
 


### PR DESCRIPTION
## Brief summary of changes

Adds a new helper function `settingEnabled` to determine whether a boolean-style config setting is enabled or not.

This is designed to add some syntactic sugar and  hide some of the implementation details of our Config library from calling code. 

The calling code only cares whether a setting is enabled. Developers shouldn't need to concern  themselves with doing a strict string type comparison on config settings.

e.g. this code:

```php
if ($config->getSetting('useEDC') === 'true') {
    ...
}
```

can now be written as

```php
if ($config->settingEnabled('useEDC')) {
    ...
}
```

I feel like this is an improvement because it's a bit cleaner. I think it removes some potential confusion also as it's not immediately clear why LORIS code is doing a string check for something that looks like a bool.