### PR TITLE
update php version in docker

### DIFF
--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM php:7.2-fpm
 
 RUN apt-get update && \
     apt-get install -y mysql-client

--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,7 +1,7 @@
 FROM php:7.2.2-fpm
 
 RUN apt-get update && \
-    apt-get install -y mysql-client zlib1g-dev
+    apt-get install -y mysql-client
 
 # Install extensions through the scripts the container provides
 RUN docker-php-ext-install pdo_mysql

--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,7 +1,7 @@
 FROM php:7.2.2-fpm
 
 RUN apt-get update && \
-    apt-get install -y mysql-client
+    apt-get install -y mysql-client zlib1g-dev
 
 # Install extensions through the scripts the container provides
 RUN docker-php-ext-install pdo_mysql

--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.2.2-fpm
 
 RUN apt-get update && \
     apt-get install -y mysql-client


### PR DESCRIPTION
Update PHP version from php7.2 to php7.2-fpm to pass Travis.
Package mysql-client is not available in php7.2 docker image.