### PR TITLE
[Travis] Update Dockerfile to use MariaDB instead of MySQL

### DIFF
--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,7 +1,7 @@
 FROM php:7.2
 
 RUN apt-get update && \
-    apt-get install -y mysql-client
+    apt-get install -y mariadb-client
 
 # Install extensions through the scripts the container provides
 RUN docker-php-ext-install pdo_mysql


### PR DESCRIPTION
The base docker image for PHP was upgraded to add support
for Debian Buster 6 days ago. Debian Buster doesn't ship with
MySQL, but instead uses the (compatible) MariaDB client. This
updates the docker file to install mariadb-client instead of
mysql-client, and fix the Travis errors that are currently
happening when building the LORIS docker image.

See also: https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u,
https://github.com/docker-library/php/commit/ccbe53516fa2fd2d3b0ba680b83148b443a6ccf1