### PR TITLE
[Testing] Cleanup phan file and make explicit the settings we are using

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -37,18 +37,18 @@ return [
     "suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",
-		"PhanUndeclaredMethod",
+        "PhanUndeclaredMethod",
         "PhanTypeMismatchDimFetch",
-		"PhanTypeMismatchReturn",
-		"PhanUndeclaredClassMethod",
-		"PhanTypeMismatchArgument",
-		"PhanTypeMismatchProperty",
+        "PhanTypeMismatchReturn",
+        "PhanUndeclaredClassMethod",
+        "PhanTypeMismatchArgument",
+        "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",
-<<<<<<< HEAD
         "PhanPossiblyUndeclaredVariable",
         "PhanNoopNew",
-		"PhanNonClassMethodCall",
-        "PhanTypeSuspiciousStringExpression"
+        "PhanNonClassMethodCall",
+        "PhanUndeclaredVariableDim",
+        "PhanTypeSuspiciousStringExpression",
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -77,16 +77,6 @@ return [
         // because Phan disables xdebug by default.
         "xdebug"     => "vendor/phan/phan/.phan/internal_stubs/xdebug.phan_php",
     ],
-
-    // The line below is required to prevent PhanUndeclaredVariable problems in
-    // the bvl_feedback ajax scripts. They all require() a file in this directory
-    // that declares the $feedbackThread variable. Phan doesn't know about this.
-    //
-    // Toggling the below rule to true is the suggested fix by the phan devs.
-    // see https://github.com/phan/phan/issues/1650.
-    //
-    // When the module is refactored, this line should be deleted.
-    'ignore_undeclared_variables_in_global_scope' => true,
     'plugins' => [
         //'UnreachableCodePlugin',
     ]

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -14,7 +14,7 @@ return [
     // suspicious code.
     "minimum_severity" => 5,
     // TODO: Update this value to the minimum required by LORIS.
-    "target_php_version" => "7.2",
+    "target_php_version" => "7.3",
     // FIXME: allow_missing_properties should be false, but there's
     // too many other things to fix first.
     "allow_missing_properties" => true,
@@ -77,7 +77,7 @@ return [
         // because Phan disables xdebug by default.
         "xdebug"     => "vendor/phan/phan/.phan/internal_stubs/xdebug.phan_php",
     ],
-    'plugins' => [
-        //'UnreachableCodePlugin',
+    "plugins" => [
+        "UnreachableCodePlugin",
     ]
 ];

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -48,9 +48,6 @@ return [
         "PhanPossiblyUndeclaredVariable",
         "PhanNoopNew",
         "PhanNonClassMethodCall",
-        "PhanUndeclaredVariableDim",
-        "PhanTypeSuspiciousStringExpression",
-        "PhanNonClassMethodCall",
         "PhanTypeSuspiciousStringExpression"
     ],
     "analyzed_file_extensions" => ["php", "inc"],

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -30,6 +30,9 @@ return [
 	"ignore_undeclared_variables_in_global_scope" => true,
     // FIXME: We should add this.
     "dead_code_detection" => false,
+    // FIXME: We should add this. Note that dead_code_detection also covers
+    // unused_variable_detection. It might be a good idea to enable this first.
+    "unused_variable_detection" => false,
 	"suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -38,7 +38,6 @@ return [
         "PhanUndeclaredMethod",
         "PhanTypeMismatchDimFetch",
         "PhanTypeMismatchReturn",
-        "PhanUndeclaredVariableDim",
         "PhanUndeclaredClassMethod",
         "PhanTypeMismatchArgument",
         "PhanTypeMismatchProperty",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,20 +1,33 @@
 <?php
 
 return [
-	"backward_compatibility_checks" => true,
 	// The docs on quick_mode at
-	// https://github.com/etsy/phan/wiki/Incrementally-Strengthening-Analysis
+	// https://github.com/phan/phan/wiki/Incrementally-Strengthening-Analysis
 	// don't seem reasonable. They claim that quick_mode=true add more errors.
 	// This is false on the assumption that that's a typo.
 	// It doesn't seem to have any effect on LORIS's codebase anyways.
 	"quick_mode" => false,
 	"analyze_signature_compatibility" => true,
+    // The default severity level for phan is 5. After removing all the
+    // suppressed rules, we should consider reducing this value to detect more
+    // suspicious code.
+    'minimum_severity' => 5,
+    // TODO: Update this value to the minimum required by LORIS.
+    'target_php_version' => '7.2',
 	// FIXME: allow_missing_properties should be false, but there's
 	// too many other things to fix first.
 	"allow_missing_properties" => true,
 	"null_casts_as_any_type" => false,
 	"scalar_implicit_cast" => false,
-	"ignore_undeclared_variables_in_global_scope" => false,
+    // The line below is required to prevent PhanUndeclaredVariable problems in
+    // the bvl_feedback ajax scripts. They all require() a file in this directory
+    // that declares the $feedbackThread variable. Phan doesn't know about this.
+    //
+    // Toggling the below rule to true is the suggested fix by the phan devs.
+    // see https://github.com/phan/phan/issues/1650.
+    //
+    // When the module is refactored, this line should be deleted.
+	"ignore_undeclared_variables_in_global_scope" => true,
 	"suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",
@@ -43,7 +56,7 @@ return [
         "test"
 	],
 	"exclude_analysis_directory_list" => [
-		"vendor",
+		"vendor"
 	],
     'autoload_internal_extension_signatures' => [
         // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,25 +1,25 @@
 <?php
 
 return [
-    "backward_compatibility_checks" => true,
-	// The docs on quick_mode at
-	// https://github.com/phan/phan/wiki/Incrementally-Strengthening-Analysis
-	// don't seem reasonable. They claim that quick_mode=true add more errors.
-	// This is false on the assumption that that's a typo.
-	// It doesn't seem to have any effect on LORIS's codebase anyways.
-	"quick_mode" => false,
-	"analyze_signature_compatibility" => true,
+"backward_compatibility_checks" => true,
+    // The docs on quick_mode at
+    // https://github.com/phan/phan/wiki/Incrementally-Strengthening-Analysis
+    // don't seem reasonable. They claim that quick_mode=true add more errors.
+    // This is false on the assumption that that's a typo.
+    // It doesn't seem to have any effect on LORIS's codebase anyways.
+    "quick_mode" => false,
+    "analyze_signature_compatibility" => true,
     // The default severity level for phan is 5. After removing all the
     // suppressed rules, we should consider reducing this value to detect more
     // suspicious code.
     "minimum_severity" => 5,
     // TODO: Update this value to the minimum required by LORIS.
     "target_php_version" => "7.2",
-	// FIXME: allow_missing_properties should be false, but there's
-	// too many other things to fix first.
-	"allow_missing_properties" => true,
-	"null_casts_as_any_type" => false,
-	"scalar_implicit_cast" => false,
+    // FIXME: allow_missing_properties should be false, but there's
+    // too many other things to fix first.
+    "allow_missing_properties" => true,
+    "null_casts_as_any_type" => false,
+    "scalar_implicit_cast" => false,
     // The line below is required to prevent PhanUndeclaredVariable problems in
     // the bvl_feedback ajax scripts. They all require() a file in this directory
     // that declares the $feedbackThread variable. Phan doesn't know about this.
@@ -28,13 +28,13 @@ return [
     // see https://github.com/phan/phan/issues/1650.
     //
     // When the module is refactored, this line should be deleted.
-	"ignore_undeclared_variables_in_global_scope" => true,
+    "ignore_undeclared_variables_in_global_scope" => true,
     // FIXME: We should add this.
     "dead_code_detection" => false,
     // FIXME: We should add this. Note that dead_code_detection also covers
     // unused_variable_detection. It might be a good idea to enable this first.
     "unused_variable_detection" => false,
-	"suppress_issue_types" => [
+    "suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",
 		"PhanUndeclaredMethod",
@@ -44,26 +44,34 @@ return [
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",
+<<<<<<< HEAD
         "PhanPossiblyUndeclaredVariable",
         "PhanNoopNew",
+		"PhanNonClassMethodCall",
+        "PhanTypeSuspiciousStringExpression"
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [
-		/* This doesn't include php/installer, because there's
-		   (intentionally) classes in the installer namespace
+		// This doesn't include php/installer, because there's
+		//  (intentionally) classes in the installer namespace
+    ],
+    "analyzed_file_extensions" => ["php", "inc"],
+    "directory_list" => [
+        /* This doesn't include php/installer, because there's
+           (intentionally) classes in the installer namespace
            which redeclare classes from php/libraries, in order
-		   to bootstrap the installer before the config/database
-		   is set up */
-		"php",
-		"htdocs",
-		"modules",
+           to bootstrap the installer before the config/database
+           is set up */
+        "php",
+        "htdocs",
+        "modules",
         "src",
-		"vendor",
+        "vendor",
         "test"
 	],
-	"exclude_analysis_directory_list" => [
-		"vendor"
-	],
+    "exclude_analysis_directory_list" => [
+        "vendor"
+    ],
     "autoload_internal_extension_signatures" => [
         // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,
         // because Phan disables xdebug by default.

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-"backward_compatibility_checks" => true,
+    "backward_compatibility_checks" => true,
     // The docs on quick_mode at
     // https://github.com/phan/phan/wiki/Incrementally-Strengthening-Analysis
     // don't seem reasonable. They claim that quick_mode=true add more errors.

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -11,9 +11,9 @@ return [
     // The default severity level for phan is 5. After removing all the
     // suppressed rules, we should consider reducing this value to detect more
     // suspicious code.
-    'minimum_severity' => 5,
+    "minimum_severity" => 5,
     // TODO: Update this value to the minimum required by LORIS.
-    'target_php_version' => '7.2',
+    "target_php_version" => "7.2",
 	// FIXME: allow_missing_properties should be false, but there's
 	// too many other things to fix first.
 	"allow_missing_properties" => true,
@@ -29,7 +29,7 @@ return [
     // When the module is refactored, this line should be deleted.
 	"ignore_undeclared_variables_in_global_scope" => true,
     // FIXME: We should add this.
-    'dead_code_detection' => false,
+    "dead_code_detection" => false,
 	"suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",
@@ -60,10 +60,10 @@ return [
 	"exclude_analysis_directory_list" => [
 		"vendor"
 	],
-    'autoload_internal_extension_signatures' => [
+    "autoload_internal_extension_signatures" => [
         // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,
         // because Phan disables xdebug by default.
-        'xdebug'     => 'vendor/phan/phan/.phan/internal_stubs/xdebug.phan_php',
+        "xdebug"     => "vendor/phan/phan/.phan/internal_stubs/xdebug.phan_php",
     ],
 
     // The line below is required to prevent PhanUndeclaredVariable problems in
@@ -76,6 +76,6 @@ return [
     // When the module is refactored, this line should be deleted.
     'ignore_undeclared_variables_in_global_scope' => true,
     'plugins' => [
-        'UnreachableCodePlugin'
+        //'UnreachableCodePlugin',
     ]
 ];

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -44,9 +44,7 @@ return [
         "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",
         "PhanPossiblyUndeclaredVariable",
-        "PhanNoopNew",
-        "PhanNonClassMethodCall",
-        "PhanTypeSuspiciousStringExpression"
+        "PhanNoopNew"
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -68,7 +68,7 @@ return [
         "src",
         "vendor",
         "test"
-	],
+    ],
     "exclude_analysis_directory_list" => [
         "vendor"
     ],

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -48,11 +48,6 @@ return [
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [
-        // This doesn't include php/installer, because there's
-        //  (intentionally) classes in the installer namespace
-    ],
-    "analyzed_file_extensions" => ["php", "inc"],
-    "directory_list" => [
         /* This doesn't include php/installer, because there's
            (intentionally) classes in the installer namespace
            which redeclare classes from php/libraries, in order

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -13,8 +13,6 @@ return [
     // suppressed rules, we should consider reducing this value to detect more
     // suspicious code.
     "minimum_severity" => 5,
-    // TODO: Update this value to the minimum required by LORIS.
-    "target_php_version" => "7.3",
     // FIXME: allow_missing_properties should be false, but there's
     // too many other things to fix first.
     "allow_missing_properties" => true,

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -40,6 +40,7 @@ return [
         "PhanUndeclaredMethod",
         "PhanTypeMismatchDimFetch",
         "PhanTypeMismatchReturn",
+        "PhanUndeclaredVariableDim",
         "PhanUndeclaredClassMethod",
         "PhanTypeMismatchArgument",
         "PhanTypeMismatchProperty",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -50,11 +50,13 @@ return [
         "PhanNonClassMethodCall",
         "PhanUndeclaredVariableDim",
         "PhanTypeSuspiciousStringExpression",
-	],
-	"analyzed_file_extensions" => ["php", "inc"],
-	"directory_list" => [
-		// This doesn't include php/installer, because there's
-		//  (intentionally) classes in the installer namespace
+        "PhanNonClassMethodCall",
+        "PhanTypeSuspiciousStringExpression"
+    ],
+    "analyzed_file_extensions" => ["php", "inc"],
+    "directory_list" => [
+        // This doesn't include php/installer, because there's
+        //  (intentionally) classes in the installer namespace
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    "backward_compatibility_checks" => true,
 	// The docs on quick_mode at
 	// https://github.com/phan/phan/wiki/Incrementally-Strengthening-Analysis
 	// don't seem reasonable. They claim that quick_mode=true add more errors.

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -28,6 +28,8 @@ return [
     //
     // When the module is refactored, this line should be deleted.
 	"ignore_undeclared_variables_in_global_scope" => true,
+    // FIXME: We should add this.
+    'dead_code_detection' => false,
 	"suppress_issue_types" => [
         "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",


### PR DESCRIPTION
## Brief summary of changes

* Explicitly declare severity level (unchanged from before)
* ~~Explicitly declare targeted version of PHP version~~ This could cause a problem with Travis
* Update link from the etsy repo to phan
* Remove a duplicate, conflicting setting
* ~~Remove backward compatibility check because we don't need it~~ Dave wants this to stay
* Change tabs to spaces