### PR TITLE
[Testing] Add a progress bar when phan is run from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 checkstatic: phpdev
 	npm run lint:php
 	npm run lint:javascript
-	vendor/bin/phan
+	vendor/bin/phan --progress-bar
 
 unittests: phpdev
 	vendor/bin/phpunit --configuration test/phpunit.xml


### PR DESCRIPTION
<img width="632" alt="Screen Shot 2019-07-17 at 12 45 38" src="https://user-images.githubusercontent.com/4022790/61394381-f7f07a00-a890-11e9-807f-c58f4e5d4cc2.png">

Adds a visual indicator of phan's progress when running `make checkstatic`.