### PR TITLE
[tools/raisinbread exporter] Use config.xml credentials

### DIFF
--- a/tools/exporters/DB_dump_table_data.php
+++ b/tools/exporters/DB_dump_table_data.php
@@ -35,6 +35,18 @@ $tableNames = $DB->pselectCol("
                       WHERE TABLE_SCHEMA =:dbn",
     array("dbn"=>$databaseInfo['database'])
 );
+
+$dbUser = $databaseInfo["quatUser"];
+$dbPassword = $databaseInfo["quatPassword"];
+$dbHost = $databaseInfo["host"];
+
+if (empty($dbUser) || empty($dbPassword) || empty($dbHost)) {
+    echo "\n\n Some database credentials are missing, please make sure administrator 
+    credentials (quatUser, quatPassword) and a host value are available in your 
+    configuration file. \n\n";
+    die();
+}
+
 /*
  * Definitions of the flags used in the command below (ORDERING is IMPORTANT):
  * --complete-insert -> Use complete INSERT statements that include column names
@@ -54,11 +66,13 @@ $tableNames = $DB->pselectCol("
  *                      values to accommodate for timezone differences.
  */
 
+
 // Loop through all tables to generate insert statements for each.
 foreach ($tableNames as $tableName) {
     $paths = \NDB_Config::singleton()->getSetting('paths');
     $filename = $paths['base'] . "/raisinbread/RB_files/RB_$tableName.sql";
-    exec('mysqldump '.$databaseInfo['database'].' '.
+    exec('mysqldump -u '.$dbUser.' -p'.$dbPassword.' -h '.$dbHost.' '.
+        $databaseInfo['database'].' '.
         '--complete-insert '.
         '--no-create-db '.
         '--no-create-info '.

--- a/tools/exporters/DB_dump_table_data.php
+++ b/tools/exporters/DB_dump_table_data.php
@@ -41,7 +41,7 @@ $dbPassword = $databaseInfo["quatPassword"];
 $dbHost = $databaseInfo["host"];
 
 if (empty($dbUser) || empty($dbPassword) || empty($dbHost)) {
-    echo "\n\n Some database credentials are missing, please make sure administrator 
+    echo "\n\n Some database credentials are missing, please ensure administrator 
     credentials (quatUser, quatPassword) and a host value are available in your 
     configuration file. \n\n";
     die();

--- a/tools/exporters/DB_dump_table_data.php
+++ b/tools/exporters/DB_dump_table_data.php
@@ -71,8 +71,8 @@ if (empty($dbUser) || empty($dbPassword) || empty($dbHost)) {
 foreach ($tableNames as $tableName) {
     $paths = \NDB_Config::singleton()->getSetting('paths');
     $filename = $paths['base'] . "/raisinbread/RB_files/RB_$tableName.sql";
-    exec('mysqldump -u '.$dbUser.' -p'.$dbPassword.' -h '.$dbHost.' '.
-        $databaseInfo['database'].' '.
+    exec('mysqldump -u '.escapeshellarg($dbUser).' -p'.escapeshellarg($dbPassword).' -h '.escapeshellarg($dbHost).' '.
+        escapeshellarg($databaseInfo['database']).' '.
         '--complete-insert '.
         '--no-create-db '.
         '--no-create-info '.


### PR DESCRIPTION
## Brief summary of changes

The previous iteration of the script was dependent on the existence of a mysql configuration file (`.my.cnf` for example). this instead makes it depend on the quat values in the configuration file