### PR TITLE
Checking for logged in users

### DIFF
--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,7 +1,7 @@
 FROM php:7.2
 
 RUN apt-get update && \
-    apt-get install -y mariadb
+    apt-get install -y mariadb-client
 
 # Install extensions through the scripts the container provides
 RUN docker-php-ext-install pdo_mysql

--- a/Dockerfile.test.php7
+++ b/Dockerfile.test.php7
@@ -1,7 +1,7 @@
 FROM php:7.2
 
 RUN apt-get update && \
-    apt-get install -y mysql-client
+    apt-get install -y mariadb
 
 # Install extensions through the scripts the container provides
 RUN docker-php-ext-install pdo_mysql


### PR DESCRIPTION
This add a call to `hasAccess` function in `/projects` to lomit the access to logged in users only.


This also add mariadb-client to DockerFile.php7 because it was never added in 21.0

#### Testing instructions (if applicable)
1. send a curl request to /projects or any subendpoints before being logged in. It should return a `HTTP/1.1 401 Unauthorized` response code with `{"error":"unauthorized"}` as body content.

