### PR TITLE
[Tools] Add script for changing config settings

### DIFF
--- a/smarty/templates/install.tpl
+++ b/smarty/templates/install.tpl
@@ -174,33 +174,27 @@
             </fieldset>
             <fieldset>
                 <legend>Options</legend>
-            <div>
-                <div class="col-md-2">
-                    <label for="use_existing_database">Use existing database:</label>
-                </div>
-                <div class="col-md-9">
-                    <input type="checkbox" id="use_existing_database" name="use_existing_database" value="on" {($use_existing_database == 'on') ? 'checked' : ''}/>
-                                        Check this if the database already exists but does not have Loris installed yet
-                </div>
+            <div class="col-md-12">
+                <label for="use_existing_database">Use existing database:</label>
             </div>
-            <div>
-                <div class="col-md-2">
-                    <label for="use_existing_tables">Use existing tables:</label>
-                </div>
-                <div class="col-md-10">
-                    <input type="checkbox" id="use_existing_tables" name="use_existing_tables" value="on" {($use_existing_tables == 'on') ? 'checked' : ''}/>
-                                        Check this if you already installed Loris at the specified database
-                </div>
+            <div class="col-md-12">
+                <input type="checkbox" id="use_existing_database" name="use_existing_database" value="on" {($use_existing_database == 'on') ? 'checked' : ''}/>
+                                    Check this if the database already exists but does not have Loris installed yet
             </div>
-            <div>
-                <div class="col-md-2">
-                    <label for="use_existing_configs">Use existing configs:</label>
-                </div>
-                <div class="col-md-10">
-                    <input type="checkbox" id="use_existing_configs" name="use_existing_configs" value="on" {($do_not_update_config == 'on') ? 'checked' : ''}/>
-                                        Check this if you don't want to update the configuration.
-                                    <em>(You really should update the configuration if possible, though)</em>
-                </div>
+            <div class="col-md-12">
+                <label for="use_existing_tables">Use existing tables:</label>
+            </div>
+            <div class="col-md-12">
+                <input type="checkbox" id="use_existing_tables" name="use_existing_tables" value="on" {($use_existing_tables == 'on') ? 'checked' : ''}/>
+                                    Check this if you already installed Loris at the specified database
+            </div>
+            <div class="col-md-12">
+                <label for="use_existing_configs">Use existing configs:</label>
+            </div>
+            <div class="col-md-12">
+                <input type="checkbox" id="use_existing_configs" name="use_existing_configs" value="on" {($do_not_update_config == 'on') ? 'checked' : ''}/>
+                                    Check this if you don't want to update the configuration.
+                                <em>(You really should update the configuration if possible, though)</em>
             </div>
             </fieldset>
             <input type="hidden" name="formname" value="validaterootaccount" />

--- a/tools/setconfig.php
+++ b/tools/setconfig.php
@@ -36,12 +36,21 @@ if (count($args) < MIN_NUMBER_OF_ARGS) {
 $setting = $args[1];
 $value   = $args[2];
 
-$id= $DB->pselectOne(
-    "SELECT ID FROM ConfigSettings WHERE Name=:config",
+$config = $DB->pselectRow(
+    "SELECT ID, AllowMultiple FROM ConfigSettings WHERE Name=:config",
     array('config' => $setting)
 );
-if (!is_numeric($id) || $id <= 0) {
+
+if (count($config) === 0) {
     die("Invalid config name");
+}
+
+$multiple = $config['AllowMultiple'];
+if ($multiple == '1') {
+    die(
+        "Script only valid on single value settings. " .
+        "Please use the LORIS frontend to change $setting."
+    );
 }
 
 // Determine whether to insert or update

--- a/tools/setconfig.php
+++ b/tools/setconfig.php
@@ -1,0 +1,57 @@
+#!/usr/bin/php
+<?php
+/**
+ * This script sets a config setting in the database.
+ *
+ * It does no validation of whether the value provided
+ * is a valid value for the settings, it just blindly updates
+ * or inserts the value into the config table.
+ *
+ * This script may be useful when either the frontend
+ * config admin page is unavailable because of a bad
+ * config value, or when giving instructions to a user
+ * in a situation where describing what to type is
+ * easier than describing where to click on the frontend.
+ *
+ * PHP Version 7
+ *
+ * @category Tools
+ * @package  Loris
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "generic_includes.php";
+const MIN_NUMBER_OF_ARGS = 3;
+$args = $argv;
+if ($args[0] == 'php') {
+	$args = array_slice($argv, 1);
+}
+if (count($args) < MIN_NUMBER_OF_ARGS) {
+	fwrite(STDERR, "Usage: setconfig.php setting value\n");
+	exit(2);
+}
+
+$setting = $args[1];
+$value   = $args[2];
+
+$id= $DB->pselectOne(
+    "SELECT ID FROM ConfigSettings WHERE Name=:config",
+    array('config' => $setting)
+);
+if (!is_numeric($id) || $id <= 0) {
+    die("Invalid config name");
+}
+
+// Determine whether to insert or update
+$newconfig = (int )$DB->pselectOne(
+    "SELECT COUNT(*) FROM Config WHERE ConfigID=:id",
+    array('id' => $id)
+);
+
+if($newconfig === 0) {
+    $DB->insert("Config", array('Value' => $value, 'ConfigID' => $id));
+} else {
+    $DB->update("Config", array('Value' => $value), array('ConfigID' => $id));
+}

--- a/tools/setconfig.php
+++ b/tools/setconfig.php
@@ -41,11 +41,13 @@ $config = $DB->pselectRow(
     array('config' => $setting)
 );
 
-if (count($config) === 0) {
+if (count($config ?? []) === 0) {
     die("Invalid config name");
 }
 
+$id       = $config['ID'];
 $multiple = $config['AllowMultiple'];
+
 if ($multiple == '1') {
     die(
         "Script only valid on single value settings. " .


### PR DESCRIPTION
This adds a new script to change the config settings
in the database without SQL access. This may be is useful
when the Config module page is unavailable due to bad
paths or otherwise when providing user support, where
it can be easier to just tell the user what to type
copy/paste in a terminal than describe where to find
a setting on the frontend.

## Brief summary of changes


#### Testing instructions (if applicable)

1.

#### Links to related tickets (GitHub, Redmine, ...)

*
