### PR TITLE
[Data Dict] Update Data Dictionary module to use Data Framework

### DIFF
--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -115,10 +115,10 @@ class DataDictIndex extends Component {
             },
         },
         {
-            label: 'Field',
+            label: 'Source Field',
             show: true,
             filter: {
-                name: 'Field',
+                name: 'Source Field',
                 type: 'text',
             },
         },

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -77,7 +77,7 @@ class DataDictIndex extends Component {
         <td
           contentEditable="true"
           className="description"
-          onBlur={updateDict(rowData[1])}>
+          onBlur={updateDict(rowData.Name)}>
             {cell}
         </td>
       );

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -1,5 +1,7 @@
-import FilterForm from 'FilterForm';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Loader from 'Loader';
+import FilterableDataTable from 'FilterableDataTable';
 
 /**
  * Data Dictionary Page.
@@ -14,71 +16,38 @@ import Loader from 'Loader';
  * @version 1.0.0
  *
  * */
-class DataDictIndex extends React.Component {
+class DataDictIndex extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
+      data: {},
+      error: false,
       isLoaded: false,
-      filter: {},
-      hiddenHeaders: [],
     };
 
-    /**
-     * Set filter to the element's ref for filtering
-     */
-    this.filter = null;
-    this.setFilterRef = (element) => {
-      this.filter = element;
-    };
-
-    /**
-     * Bind component instance to custom methods
-     */
     this.fetchData = this.fetchData.bind(this);
-    this.updateFilter = this.updateFilter.bind(this);
-    this.resetFilters = this.resetFilters.bind(this);
     this.formatColumn = this.formatColumn.bind(this);
   }
 
   componentDidMount() {
-    this.fetchData();
+    this.fetchData()
+      .then( () => this.setState({isLoaded: true}));
   }
 
   /**
    * Retrive data from the provided URL and save it in state
-   * Additionaly add hiddenHeaders to global loris variable
-   * for easy access by columnFormatter.
+   *
+   * @return {object}
    */
   fetchData() {
-    $.ajax(this.props.DataURL, {
-      method: 'GET',
-      dataType: 'json',
-      success: (data) => {
-        this.setState({
-          data: data,
-          isLoaded: true,
+    return fetch(this.props.dataURL, {credentials: 'same-origin'})
+        .then((resp) => resp.json())
+        .then((data) => this.setState({data}))
+        .catch((error) => {
+            this.setState({error: true});
+            console.error(error);
         });
-      },
-      error: (error) => console.error(error),
-    });
-  }
-
-  /**
-   * Set this.state.filter to the input filter object
-   *
-   * @param {object} filter - the filter object
-   */
-  updateFilter(filter) {
-    this.setState({filter});
-  }
-
-  // TODO: deprecate clearing filters via refs in future refactoring.
-  /**
-   * Reset the filter elements with textInput refs to empty values
-   */
-  resetFilters() {
-    this.filter.clearFilter();
   }
 
   /**
@@ -92,9 +61,6 @@ class DataDictIndex extends React.Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, rowData, rowHeaders) {
-    if (this.state.hiddenHeaders.indexOf(column) > -1) {
-      return null;
-    }
     const hasEditPermission = loris.userHasPermission('data_dict_edit');
     if (column === 'Description' && hasEditPermission) {
       let updateDict = (name) => {
@@ -120,45 +86,84 @@ class DataDictIndex extends React.Component {
   }
 
   render() {
+    if (this.state.error) {
+        return <h3>An error occured while loading the page.</h3>;
+    }
+
     // Waiting for async data to load
     if (!this.state.isLoaded) {
       return <Loader/>;
     }
 
+    let options = this.state.data.fieldOptions;
+    let fields = [
+        {
+            label: 'Source From',
+            show: true,
+            filter: {
+                name: 'Source From',
+                type: 'select',
+                options: options.sourceFrom,
+            },
+        },
+        {
+            label: 'Name',
+            show: true,
+            filter: {
+                name: 'Name',
+                type: 'text',
+            },
+        },
+        {
+            label: 'Field',
+            show: true,
+            filter: {
+                name: 'Field',
+                type: 'text',
+            },
+        },
+        {
+            label: 'Description',
+            show: true,
+            filter: {
+                name: 'Description',
+                type: 'text',
+            },
+        },
+        {
+            label: 'Description Status',
+            show: true,
+            filter: {
+                name: 'DescriptionStatus',
+                type: 'select',
+                options: {
+                    'empty': 'Empty',
+                    'modified': 'Modified',
+                    'unchanged': 'Unchanged',
+                },
+            },
+        },
+    ];
     return (
-      <div>
-        <FilterForm
-          Module="datadict"
-          name="data_dict_filter"
-          id="data_dict_filter"
-          ref={this.setFilterRef}
-          columns={2}
-          formElements={this.state.data.form}
-          onUpdate={this.updateFilter}
-          filter={this.state.filter}>
-          <ButtonElement
-            label="Clear Filters"
-            type="reset"
-            onUserInput={this.resetFilters}
-          />
-        </FilterForm>
-        <StaticDataTable
-          Data={this.state.data.Data}
-          Headers={this.state.data.Headers}
-          Filter={this.state.filter}
-          getFormattedCell={this.formatColumn}
+        <FilterableDataTable
+           name="datadict"
+           data={this.state.data.Data}
+           fields={fields}
+           getFormattedCell={this.formatColumn}
         />
-      </div>
     );
   }
 }
 
-$(function() {
-  const dataDictIndex = (
-    <div className="page-datadict">
-        <DataDictIndex DataURL={`${loris.BaseURL}/datadict/?format=json`} />
-    </div>
-  );
-  ReactDOM.render(dataDictIndex, document.getElementById('lorisworkspace'));
-});
+DataDictIndex.propTypes = {
+    dataURL: PropTypes.string.isRequired,
+};
 
+window.addEventListener('load', () => {
+  ReactDOM.render(
+      <DataDictIndex
+        dataURL={`${loris.BaseURL}/datadict/?format=json`}
+      />,
+      document.getElementById('lorisworkspace')
+  );
+});

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -59,8 +59,9 @@ class Datadict extends \DataFrameworkMenu
      */
     public function getFieldOptions() : array
     {
-        $instruments = \Utility::getAllInstruments();
-        return array('sourceFrom' => $instruments);
+        return array(
+                'sourceFrom' => \Utility::getAllInstruments(),
+               );
     }
 
     /**

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -104,4 +104,8 @@ class Datadict extends \DataFrameworkMenu
             new \LORIS\Breadcrumb('Data Dictionary', "/$this->name")
         );
     }
+
+    public function useProjectFilter() : bool {
+        return false;
+    }
 }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -105,7 +105,13 @@ class Datadict extends \DataFrameworkMenu
         );
     }
 
-    public function useProjectFilter() : bool {
+    /**
+     * The datadict module does not have any concept of a project.
+     *
+     * @return bool
+     */
+    public function useProjectFilter() : bool
+    {
         return false;
     }
 }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -60,8 +60,8 @@ class Datadict extends \DataFrameworkMenu
     public function getFieldOptions() : array
     {
         return array(
-                'sourceFrom' => \Utility::getAllInstruments(),
-               );
+            'sourceFrom' => \Utility::getAllInstruments(),
+        );
     }
 
     /**

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -2,7 +2,7 @@
 /**
  * Datadict module
  *
- * PHP version 5
+ * PHP version 7
  *
  * @category Datadict
  * @package  Main
@@ -14,7 +14,7 @@ namespace LORIS\datadict;
 /**
  * Datadict module
  *
- * PHP version 5
+ * PHP version 7
  *
  * @category Datadict
  * @package  Main
@@ -23,11 +23,8 @@ namespace LORIS\datadict;
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-class Datadict extends \NDB_Menu_Filter
+class Datadict extends \DataFrameworkMenu
 {
-    var $AjaxModule   = true;
-    var $skipTemplate = true;
-
     /**
      * Overloading this method to allow access to site users (their own site
      * only) and users w/ multisite privs
@@ -43,147 +40,37 @@ class Datadict extends \NDB_Menu_Filter
     }
 
     /**
-     * Setup variables function
+     * The data dictionary has no sites affiliated with it and as
+     * such can not add site filters without an exception being
+     * thrown
      *
-     * @note   Setup variables function
-     * @return string
+     * @return bool
      */
-    function _buildQuery(): string
+    public function useSiteFilter() : bool
     {
-        $select = " SELECT DISTINCT
-         pt.sourceFrom as source_from,
-         pt.name as name,
-         pt.sourceField as source_field,
-         coalesce(pto.description,pt.description) as description,
-         CASE
-           WHEN COALESCE(pto.description,pt.description) = '' THEN 'Empty'
-           WHEN pto.name IS NOT NULL THEN 'Modified'
-           WHEN pto.name IS NULL THEN 'Unchanged'
-         END as description_status ";
-
-        $joins = " FROM parameter_type pt
-        LEFT JOIN parameter_type_override pto USING (Name)
-        WHERE pt.Queryable=1 ";
-        $query = $select . $joins;
-        return $query;
+        return false;
     }
 
     /**
-     * Setup variables function
+     * Returns a list of instruments to use as the "Source From"
+     * filter options
      *
-     * @return void
+     * @return array Dynamic field options
      */
-    function _setupVariables()
+    public function getFieldOptions() : array
     {
-        $query       = $this->_buildQuery();
-        $this->query = " FROM (" . $query . ") as tmp";
-
-        $this->formToFilter = array(
-            'sourceFrom'  => 'pt.sourceFrom',
-            'description' => 'pt.Description',
-        );
-
-        $this->searchKeyword = array(
-            'pt.Name',
-            'pt.sourceField',
-            'pto.description',
-        );
-        // set the class variables
-
-        $this->columns = array(
-            'source_from',
-            'name',
-            'source_field',
-            'description',
-            'description_status',
-        );
-
-        $this->headers = array(
-            'Source From',
-            'Name',
-            'Source Field',
-            'Description',
-            'Description Status',
-        );
-    }
-
-    /**
-     * Set Filter Form
-     *
-     * @return void
-     */
-    function setup()
-    {
-        parent::setup();
-
-        // list of feedback statuses
         $instruments = \Utility::getAllInstruments();
-        $this->addSelect(
-            'sourceFrom',
-            'Instruments',
-            $instruments,
-            array('multiple')
-        );
-        $this->addSelect(
-            'descriptionStatus',
-            'Description Status',
-            array(
-                'empty'     => 'Empty',
-                'modified'  => 'Modified',
-                'unchanged' => 'Unchanged',
-            )
-        );
-        $this->addBasicText('keyword', "Search keyword");
+        return array('sourceFrom' => $instruments);
     }
 
     /**
-     * Add query filters
+     * Gets the data source for this menu filter.
      *
-     * @param string $prepared_key the query string
-     * @param string $key          the key of filter
-     * @param string $val          the value of filter
-     *
-     * @note   Get base query
-     * @return string
-     * @access private
+     * @return \LORIS\Data\Provisioner
      */
-    function _addValidFilters($prepared_key, $key, $val)
+    public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $query = '';
-        if ((!empty($val) || $val === '0') && $key != 'order') {
-            // special rule for dropdowns where value is numeric
-            if (strtolower(substr($key, -8)) == 'centerid'
-                || strtolower(substr($key, -10)) == 'categoryid'
-                || strtolower(substr($key, -6)) == 'sex'
-            ) {
-                $query .= " AND $key = '$val' ";
-            } else {
-                if ($val == 'empty') {
-                    $query .= " AND COALESCE(pto.description,pt.description) = ''";
-                } elseif ($val=='modified') {
-                    $query .= " AND pto.name IS NOT NULL";
-                } elseif ($val=='unmodified') {
-                    $query .= " AND pto.name IS NULL";
-                } else {
-                    $query .= " AND $key LIKE '$val%' ";
-                }
-            }
-        }
-        return $query;
-    }
-
-
-    /**
-     * Converts the results of this menu filter to a JSON format to be retrieved
-     * with ?format=json
-     *
-     * @return string a json encoded string of the headers and data from this table
-     */
-    function toJSON() : string
-    {
-        $result         = $this->toArray();
-        $result['form'] = $this->form->form;
-        return json_encode($result);
+        return new DataDictRowProvisioner();
     }
 
     /**

--- a/modules/datadict/php/datadictrow.class.inc
+++ b/modules/datadict/php/datadictrow.class.inc
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+/**
+ * This class implements a data Instance which represents a single
+ * row in the datadict menu table.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Behavioural
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\datadict;
+
+/**
+ * A DataDictRow represents a row in the datadict menu table.
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Behavioural
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class DataDictRow implements \LORIS\Data\DataInstance
+{
+    protected $DBRow;
+
+    /**
+     * Create a new DataDictRow
+     *
+     * @param array $row The row (in the same format as \Database::pselectRow
+     *                   returns
+     */
+    public function __construct(array $row)
+    {
+        $this->DBRow = $row;
+    }
+
+    /**
+     * Implements \LORIS\Data\DataInstance interface for this row.
+     *
+     * @return string the row data.
+     */
+    public function toJSON() : string
+    {
+        return json_encode($this->DBRow);
+    }
+}

--- a/modules/datadict/php/datadictrowprovisioner.class.inc
+++ b/modules/datadict/php/datadictrowprovisioner.class.inc
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+/**
+ * This file implements a data provisioner to get all possible rows
+ * for the datadict menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Behavioural
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\datadict;
+
+/**
+ * This class implements a data provisioner to get all possible rows
+ * for the datadict menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Behavioural
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class DataDictRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
+{
+    /**
+     * Create a DataDictRowProvisioner, which gets rows for
+     * the datadict menu table.
+     */
+    function __construct()
+    {
+        $config   = \NDB_Config::singleton();
+        $maybeEDC = '';
+
+        parent::__construct(
+            "SELECT DISTINCT
+                pt.sourceFrom as source_from,
+                pt.name as name,
+                pt.sourceField as source_field,
+                coalesce(pto.description,pt.description) as description,
+                CASE
+                    WHEN COALESCE(pto.description,pt.description) = '' THEN 'Empty'
+                    WHEN pto.name IS NOT NULL THEN 'Modified'
+                    WHEN pto.name IS NULL THEN 'Unchanged'
+                END as description_status
+            FROM parameter_type pt
+            LEFT JOIN parameter_type_override pto USING (Name)
+            WHERE pt.Queryable=1
+            ",
+            array()
+        );
+    }
+
+    /**
+     * Returns an instance of a DataDict object for a given
+     * table row.
+     *
+     * @param array $row The database row from the LORIS Database class.
+     *
+     * @return \LORIS\Data\DataInstance An instance representing this row.
+     */
+    public function getInstance($row) : \LORIS\Data\DataInstance
+    {
+        return new DataDictRow($row);
+    }
+}

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -88,7 +88,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
 
                 $this->webDriver->wait(120, 1000)->until(
                     WebDriverExpectedCondition::presenceOfElementLocated(
-                        WebDriverBy::Name("keyword")
+                        WebDriverBy::Name("Name")
                     )
                 );
 
@@ -98,75 +98,10 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
                 $this->assertContains("Data Dictionary", $bodyText);
     }
     /**
-     * Testing keyword filter with testing data
-     *
-     * @return void
-     */
-    function testDataDictSearchKeywordFilters()
-    {
-        $this->safeGet($this->url . "/datadict/");
-
-        $searchKey = $this->webDriver->findElements(
-            WebDriverBy::Name("keyword")
-        );
-
-        $searchKey[0]->sendKeys("NotRealMAGICNUMBER335");
-
-        $name = $this->webDriver->executescript(
-            "return document.querySelector".
-                  "('#dynamictable > tbody > tr > td:nth-child(3)').textContent"
-        );
-            $this->assertContains("TestParameterNotRealMAGICNUMBER335", $name);
-    }
-    /**
-     * Testing keyword filter with testing data not case-sensitive
-     *
-     * @return void
-     */
-    function testDataDictSearchKeywordFiltersnotCaseSensitvie()
-    {
-        $this->safeGet($this->url . "/datadict/");
-
-        $searchKey = $this->webDriver->findElements(
-            WebDriverBy::Name("keyword")
-        );
-
-        $searchKey[0]->sendKeys("notrealMAGICNUMBER335");
-
-        $name = $this->webDriver->executescript(
-            "return document.querySelector".
-                  "('#dynamictable > tbody > tr > td:nth-child(3)').textContent"
-        );
-            $this->assertContains("TestParameterNotRealMAGICNUMBER335", $name);
-    }
-    /**
-     * Testing keyword filter without testing data
-     *
-     * @return void
-     */
-    function testDataDictSearchKeywordFiltersWithoutData()
-    {
-        $this->safeGet($this->url . "/datadict/");
-
-        $searchKey = $this->webDriver->findElements(
-            WebDriverBy::Name("keyword")
-        );
-
-        $searchKey[0]->sendKeys("noExist");
-
-        $res = $this->webDriver->executescript(
-            "return document.querySelector".
-            "('#lorisworkspace > div > div > div.panel.panel-default >".
-            "div.table-header.panel-heading > div > div').textContent"
-        );
-        $this->assertContains("0 rows displayed", $res);
-    }
-
-    /**
-     * Testing UI elements when page loads
-     *
-     * @return void
-     */
+      * Testing UI elements when page loads
+      *
+      * @return void
+      */
     function testPageUIs()
     {
         $this->safeGet($this->url . "/datadict/");

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -98,10 +98,10 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
                 $this->assertContains("Data Dictionary", $bodyText);
     }
     /**
-      * Testing UI elements when page loads
-      *
-      * @return void
-      */
+     * Testing UI elements when page loads
+     *
+     * @return void
+     */
     function testPageUIs()
     {
         $this->safeGet($this->url . "/datadict/");


### PR DESCRIPTION
This updates the datadict module to use the data framework, using
the DataFrameworkMenu class infrastructure that was put in place
in #4918.

This necessitated updating the datadict from an older style of
our React components (where the QuickForm was serialized to
javascript server side) to the a newer form (where most of
the display concerns are handled from React, except for the
dynamic parts which must be sent by implementing getFieldOptions).

Unfortunately, the current React side filtering doesn't support
"Keyword" search in the same manner that was used, so it's
replaced by more consistent/traditional filters for now.

## Brief summary of changes


#### Testing instructions (if applicable)

1.

#### Links to related tickets (GitHub, Redmine, ...)

*
