### PR TITLE
[Design] Add interface for User objects

### DIFF
--- a/php/libraries/IUser.class.inc
+++ b/php/libraries/IUser.class.inc
@@ -53,12 +53,16 @@ interface IUser
      * Returns true if the user is Active (ie. has been
      * approved and was not explicitly deactivated for
      * other reasons.)
+     *
+     * @return bool
      */
     public function isActive() : bool;
 
     /**
      * Returns true if the user has requested an account
      * which has not yet been reviewed/approved.
+     *
+     * @return bool
      */
     public function pendingApproval() : bool;
 }

--- a/php/libraries/IUser.class.inc
+++ b/php/libraries/IUser.class.inc
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+/**
+ * This file contains an interface to describe a User
+ * in LORIS.
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Main
+ * @author   Dave MacFarlane <dave.macfarlane@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+/**
+ * Interface for User objects.
+ *
+ * This deals with properties that may be accessed regarding
+ * a user.
+ *
+ * @category Main
+ * @package  Main
+ * @author   Dave MacFarlane <dave.macfarlane@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+interface IUser
+{
+    /**
+     * Return the user's full name.
+     *
+     * @return string
+     */
+    public function getFullname(): string;
+
+    /**
+     * Get the user's username. NB. This is
+     * sometimes called the 'UserID' in LORIS
+     * for no known reason.
+     *
+     * @return string
+     */
+    public function getUsername(): string;
+
+    /**
+     * Returns an array of sites a user belongs to.
+     *
+     * @return Site[]
+     */
+    public function getSites(): array;
+
+    /**
+     * Returns true if the user is Active (ie. has been
+     * approved and was not explicitly deactivated for
+     * other reasons.)
+     */
+    public function isActive() : bool;
+
+    /**
+     * Returns true if the user has requested an account
+     * which has not yet been reviewed/approved.
+     */
+    public function pendingApproval() : bool;
+}
+


### PR DESCRIPTION
This adds an interface to describe a User and essential
properties that something which implements User must have.

I started with the User class, removed anything related
to password/permissions (which is a different concern from
describing a User), and removed the functions that were
variations of getSites(), then added Active and Pending
(which are in the User Accounts menu filter.) This is
what remained.

Note that the User class doesn't currently implement this
interface.

## Brief summary of changes


#### Testing instructions (if applicable)

1.

#### Links to related tickets (GitHub, Redmine, ...)

*
