### PR TITLE
[Examiner] Bugfix for pselectRow returning multiple rows (certification_history)

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -201,8 +201,8 @@ class EditExaminer extends \NDB_Form
                     )
                 );
 
-                $oldVal = isset($oldVals[0]) ? $oldVals[0]['new'] : null;
-                $oldDate = isset($oldVals[0]) ? $oldVals[0]['new_date'] : null;
+                $oldVal = $oldVals[0]['new'] ?? null;
+                $oldDate = $oldVals[0]['new_date'] ?? null;
 
 
                 $oldCertification = $DB->pselectRow(

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -201,9 +201,8 @@ class EditExaminer extends \NDB_Form
                     )
                 );
 
-                $oldVal = $oldVals[0]['new'] ?? null;
+                $oldVal  = $oldVals[0]['new'] ?? null;
                 $oldDate = $oldVals[0]['new_date'] ?? null;
-
 
                 $oldCertification = $DB->pselectRow(
                     "SELECT pass, date_cert, comment

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -194,13 +194,15 @@ class EditExaminer extends \NDB_Form
                      FROM certification_history ch
                      LEFT JOIN certification c ON (c.certID=ch.primaryVals)
                      WHERE c.examinerID=:EID AND ch.testID=:TID
-                     ORDER BY changeDate DESC",
+                     ORDER BY changeDate DESC LIMIT 1",
                     array(
                      'EID' => $examinerID,
                      'TID' => $testID,
                     )
                 );
 
+		// since there is an ORDER BY in pselect
+		// $oldVals[0] corresponds to the latest date
                 $oldVal  = $oldVals[0]['new'] ?? null;
                 $oldDate = $oldVals[0]['new_date'] ?? null;
 

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -201,8 +201,8 @@ class EditExaminer extends \NDB_Form
                     )
                 );
 
-		        // since there is an ORDER BY in pselect
-		        // $oldVals[0] corresponds to the latest date
+                // since there is an ORDER BY in pselect
+                // $oldVals[0] corresponds to the latest date
                 $oldVal  = $oldVals[0]['new'] ?? null;
                 $oldDate = $oldVals[0]['new_date'] ?? null;
 

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -201,8 +201,8 @@ class EditExaminer extends \NDB_Form
                     )
                 );
 
-		// since there is an ORDER BY in pselect
-		// $oldVals[0] corresponds to the latest date
+		        // since there is an ORDER BY in pselect
+		        // $oldVals[0] corresponds to the latest date
                 $oldVal  = $oldVals[0]['new'] ?? null;
                 $oldDate = $oldVals[0]['new_date'] ?? null;
 

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -189,7 +189,7 @@ class EditExaminer extends \NDB_Form
             } else { // update to a test certification for the examiner
 
                 //select history events
-                $oldVals = $DB->pselectRow(
+                $oldVals = $DB->pselect(
                     "SELECT ch.new, ch.new_date
                      FROM certification_history ch
                      LEFT JOIN certification c ON (c.certID=ch.primaryVals)
@@ -201,8 +201,9 @@ class EditExaminer extends \NDB_Form
                     )
                 );
 
-                $oldVal  = $oldVals['new'];
-                $oldDate = $oldVals['new_date'];
+                $oldVal = isset($oldVals[0]) ? $oldVals[0]['new'] : null;
+                $oldDate = isset($oldVals[0]) ? $oldVals[0]['new_date'] : null;
+
 
                 $oldCertification = $DB->pselectRow(
                     "SELECT pass, date_cert, comment


### PR DESCRIPTION
## Brief summary of changes
Bugfix for DomainException that was being thrown in examiner module. Please see ticket that is linked below for full description of the issue that this resolves. 

#### Testing instructions (if applicable)

1. Update a certification for any examiner. 
2. Refresh the page and ensure that no 500 error is thrown.

#### Links to related tickets (GitHub, Redmine, ...)
#4980
