### PR TITLE
[RaisinBread] Adding instructions on how to delete the RB tables

### DIFF
--- a/raisinbread/README.md
+++ b/raisinbread/README.md
@@ -49,6 +49,14 @@ cat SQL/0000-00-00-schema.sql \
     raisinbread/RB_files/*.sql | mysql
 ```
 
+Note: to empty and delete all RaisinBread tables, use the following command in the 
+main LORIS root directory
+```
+cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql \
+    SQL/9999-99-99-drop_tables.sql | mysql
+```
+
+
 ##### Configuring
 In order to be able to load the LORIS front-end while using the RaisinBread dataset 
 some configurations are necessary.

--- a/raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql
+++ b/raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql
@@ -1,0 +1,7 @@
+-- Drop RB instrument tables
+DROP TABLE IF EXISTS `aosi`;
+DROP TABLE IF EXISTS `bmi`;
+DROP TABLE IF EXISTS `medical_history`;
+DROP TABLE IF EXISTS `mri_parameter_form`;
+DROP TABLE IF EXISTS `radiology_review`;
+DROP TABLE IF EXISTS `testtest`;

--- a/raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql
+++ b/raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql
@@ -4,4 +4,3 @@ DROP TABLE IF EXISTS `bmi`;
 DROP TABLE IF EXISTS `medical_history`;
 DROP TABLE IF EXISTS `mri_parameter_form`;
 DROP TABLE IF EXISTS `radiology_review`;
-DROP TABLE IF EXISTS `testtest`;


### PR DESCRIPTION
## Brief summary of changes

This includes instructions on how to delete a RB dataset when needing to empty a database with the RB dataset. It includes a patch to delete first the instrument tables and then uses the already existant `9999-99-99-drop_tables.sql` in the SQL directory.

#### Testing instructions (if applicable)

1. Try running the delete instructions in the README.md and check that all tables from the RB dataset were removed.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #4990
