### PR TITLE
[Media Uploader] Bugfix date of administration field

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -414,7 +414,7 @@ function checkDateTaken($dateTaken)
         }
 
         $now  = new DateTime();
-        $diff = date_diff($date, $now)->format("%R%a");
+        $diff = intval(date_diff($date, $now)->format("%R%a"));
         if ($diff < 0) {
             showMediaError("Date of administration cannot be in the future", 400);
         }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -416,7 +416,7 @@ function checkDateTaken($dateTaken)
         $now  = new DateTime();
         $diff = date_diff($date, $now)->format("%R%a");
         if ($diff < 0) {
-            showMediaError("Date of administration can not be in the future", 400);
+            showMediaError("Date of administration cannot be in the future", 400);
         }
     }
 }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -414,7 +414,7 @@ function checkDateTaken($dateTaken)
         }
 
         $now  = new DateTime();
-        $diff = date_diff($date, $now)->format("%a");
+        $diff = date_diff($date, $now)->format("%R%a");
         if ($diff < 0) {
             showMediaError("Date of administration can not be in the future", 400);
         }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -415,7 +415,7 @@ function checkDateTaken($dateTaken)
 
         $now  = new DateTime();
         $diff = date_diff($date, $now)->format("%a");
-        if ($diff > 0) {
+        if ($diff < 0) {
             showMediaError("Date of administration can not be in the future", 400);
         }
     }


### PR DESCRIPTION
## Brief summary of changes
This PR fixes issue reported in #4998. When entering a date in the past and attempting to upload a file, you get an error saying that the date cannot be in the future. 

date_diff is used to find the difference between the date entered and now. 
`$now - $date` returns a positive number if `$date` is in the past, therefore the PR simply switches the comparison operator. 

#### Testing instructions (if applicable)

1. Try uploading a media file with a date in the past, should work fine.
2. Try uploading a media file with a date in the future, should get the expected message that date cannot be in the future.

