### PR TITLE
[candidate_parameter] Consent Status data validation bugfix

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -482,7 +482,7 @@ function editConsentStatusFields($db, $user)
                     // consent date and empty withdrawal date still required
                     // old withdrawal may be filled in
                 if (($oldStatus === null || $oldStatus === 'no') && !empty($date)
-                    && (empty($withdrawal) || !empty($oldWithdrawal))
+                    && ((empty($oldWithdrawal) && empty($withdrawal)) || (!empty($oldWithdrawal) && !empty($withdrawal)))
                 ) {
                     $validated = true;
                 } else if ($oldStatus === 'yes' && !empty($date)

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -482,7 +482,8 @@ function editConsentStatusFields($db, $user)
                     // consent date and empty withdrawal date still required
                     // old withdrawal may be filled in
                 if (($oldStatus === null || $oldStatus === 'no') && !empty($date)
-                    && ((empty($oldWithdrawal) && empty($withdrawal)) || (!empty($oldWithdrawal) && !empty($withdrawal)))
+                    && ((empty($oldWithdrawal) && empty($withdrawal)) 
+                       || (!empty($oldWithdrawal) && !empty($withdrawal)))
                 ) {
                     $validated = true;
                 } else if ($oldStatus === 'yes' && !empty($date)

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -482,8 +482,8 @@ function editConsentStatusFields($db, $user)
                     // consent date and empty withdrawal date still required
                     // old withdrawal may be filled in
                 if (($oldStatus === null || $oldStatus === 'no') && !empty($date)
-                    && ((empty($oldWithdrawal) && empty($withdrawal)) 
-                       || (!empty($oldWithdrawal) && !empty($withdrawal)))
+                    && ((empty($oldWithdrawal) && empty($withdrawal))
+                    || (!empty($oldWithdrawal) && !empty($withdrawal)))
                 ) {
                     $validated = true;
                 } else if ($oldStatus === 'yes' && !empty($date)

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -479,8 +479,7 @@ function editConsentStatusFields($db, $user)
                     return;
                 }
             } else { // If no status stays no or record existed as NULL
-                    // consent date and empty withdrawal date still required
-                    // old withdrawal may be filled in
+                    // consent date required and withdrawal date unchanged
                 if (($oldStatus === null || $oldStatus === 'no') && !empty($date)
                     && ((empty($oldWithdrawal) && empty($withdrawal))
                     || (!empty($oldWithdrawal) && !empty($withdrawal)))

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -488,7 +488,7 @@ function editConsentStatusFields($db, $user)
                          'cn'    => $consentName,
                         )
                     );
-                    // If consent was 'yes' at some point, withdrawal date is not empty
+                    // If consent was 'yes' at some point, withdrawal date is !empty
                     // if it was never 'yes', withdrawal date should be empty
                     // Either is valid.
                     if ((!empty($withdrawal) && $countYesStatusHistory > 0)


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the logic for data validation on consent status tab. As it stands, if no status stays no or record existed as NULL the validation checks that :
1. consent date **is not** empty
2. withdrawal date **is** empty

However, if Consent Status at one point changes from 'YES' to 'NO' ==> user must fill in date of withdrawal. Therefore, consents that = 'NO' and have non-empty dates of withdrawal are considered non-valid (Displays error message).


#### Testing instructions (if applicable)

1. Change consent from 'yes' to 'no'. Fill in date of withdrawal & submit.
2. Change some other consent or date or simply re-submit the same form. 
3. Make sure you don't get a data validation error.

