### PR TITLE
[Core/Instrument] added default date value to getCandidateAge function

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2084,13 +2084,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * the date will be calculated based on the value of the Date_taken
      * field in the database.
      *
-     * @param string $date (optional) The date that the age is to
+     * @param ?string $date (optional) The date that the age is to
      *                     be calculated based on.
      *
      * @return array The age of the candidate in an array containing years, months
      *         and days.
      */
-    function getCandidateAge(string $date = null): array
+    function getCandidateAge(?string $date = null): array
     {
         $dates = array(
                   'Date_taken' => $this->getFieldValue('Date_taken'),

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2090,7 +2090,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * @return array The age of the candidate in an array containing years, months
      *         and days.
      */
-    function getCandidateAge(string $date): array
+    function getCandidateAge(string $date = null): array
     {
         $dates = array(
                   'Date_taken' => $this->getFieldValue('Date_taken'),


### PR DESCRIPTION
## Brief summary of changes

Was getting the following error when running the tool script `fix_candidate_age.php`. 

```
lorisadmin@jcallegaro-dev:/var/www/loris/tools/data_integrity$ php fix_candidate_age.php confirm
Instrument: Teams_Visit_Checklist_V4 (12-Month Visit (Visit 4) Checklist)
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function NDB_BVL_Instrument::getCandidateAge(), 0 passed in /var/www/loris/tools/data_integrity/fix_candidate_age.php on line 125 and exactly 1 expected in /var/www/loris/php/libraries/NDB_BVL_Instrument.class.inc:2093
Stack trace:
#0 /var/www/loris/tools/data_integrity/fix_candidate_age.php(125): NDB_BVL_Instrument->getCandidateAge()
#1 {main}
  thrown in /var/www/loris/php/libraries/NDB_BVL_Instrument.class.inc on line 2093

```
Since the documentation in Instrument class says that date is optional for the function getCandidateAge(), i think it's best to add a default date = null.

#### Testing instructions (if applicable)

1. Run the script `fix_candidate_age.php`.

#### Links to related tickets (GitHub, Redmine, ...)

* #5006
