### PR TITLE
Add check for running install script as root.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -28,6 +28,10 @@ exec 1>$LOGPIPE 2>&1
 CWD=`pwd`
 RootDir=`dirname $CWD`
 
+if [ $UID == "0" ]; then
+    echo "install.sh must not be run as root (but should be run as a user with sudo access.)"
+    exit 1
+fi
 
 echo "LORIS Installation Script starting at $START"
 


### PR DESCRIPTION
Provide an error message and die if the user is trying
to run install.sh as root. The install script invokes
sudo, and should not be directly invoked as root.

## Brief summary of changes


#### Testing instructions (if applicable)

1.

#### Links to related tickets (GitHub, Redmine, ...)

*
