### PR TITLE
Fix make clean build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev: VERSION phpdev javascript
 clean:
 	rm -f smarty/templates_c/*
 	rm -f VERSION
-	rm -f vendor
+	rm -rf vendor
 
 # Perform static analysis checks
 checkstatic: phpdev


### PR DESCRIPTION
The vendor directory created by composer is a directory, not
a file, so it needs to be deleted with "rm -rf", not "rm -f".

## Brief summary of changes


#### Testing instructions (if applicable)

1.

#### Links to related tickets (GitHub, Redmine, ...)

*
