### PR TITLE
[Core] Forbid running the install script as root

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -13,6 +13,11 @@ if ! test -t 0 -a -t 1 -a -t 2 ; then
     exit 2
 fi
 
+if [ $(id -u) = 0 ]; then
+   echo "This script must not be run as root"
+   exit 1
+fi
+
 # Create logs directory, if needed.
 mkdir -p logs
 


### PR DESCRIPTION
## Brief summary of changes

Using the install script with root permissions causes issues because it will create files and folders inaccessible to the `lorisadmin` user. The script executes just fine without it so we may as well prevent less experienced developers from getting stuck.

In general we shouldn't require root level permissions to do anything because that opens all kinds of cans of worms from a usability and security perspective. 

#### Testing instructions (if applicable)

1. Within the `tools/` directory, run `sudo bash install.sh`. The script should exit with an error message
2. Without sudo, make sure the same command starts the script normally.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5008 
