### PR TITLE
[DICOM archive - Data Framework] Make DICOM archive menu filter use the DataFrameworkMenu 

### DIFF
--- a/modules/dicom_archive/jsx/dicom_archive.js
+++ b/modules/dicom_archive/jsx/dicom_archive.js
@@ -162,7 +162,7 @@ class DicomArchive extends Component {
       <FilterableDataTable
         name="dicom_filter"
         title='Dicom Archive'
-        data={this.state.data.data}
+        data={this.state.data.Data}
         fields={fields}
         getFormattedCell={this.formatColumn}
       />

--- a/modules/dicom_archive/jsx/dicom_archive.js
+++ b/modules/dicom_archive/jsx/dicom_archive.js
@@ -155,6 +155,7 @@ class DicomArchive extends Component {
       }},
       {label: 'TarchiveID', show: false},
       {label: 'SessionID', show: false},
+      {label: 'CenterID', show: false},
     ];
 
     return (

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -66,9 +66,7 @@ class Dicom_Archive extends \DataFrameworkMenu
             $site_options[$name] = $name;
         }
 
-        return [
-            'sites' => $site_options,
-        ];
+        return [ 'sites' => $site_options ];
     }
 
     /**

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -25,7 +25,7 @@ namespace LORIS\dicom_archive;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris-Trunk/
  */
-class Dicom_Archive extends \NDB_Menu_Filter
+class Dicom_Archive extends \DataFrameworkMenu
 {
     var $dicomArchiveSettings;
     public $AjaxModule = true;
@@ -43,19 +43,34 @@ class Dicom_Archive extends \NDB_Menu_Filter
     }
 
     /**
-     * Set up the variables required by NDB_Menu_Filter class for constructing
-     * a query
+     * Tells the base class that this page's provisioner can support
+     * the UserSiteMatch filter.
      *
-     * @return void
+     * @return bool always true
      */
-    function _setupVariables()
+    public function useSiteFilter() : bool
     {
-        // Rest the filter because this is broken with react modules
-        $this->_resetFilters();
+        return false;
+    }
 
-        $this->skipTemplate = true;
+    /**
+     * Return the list of field options required to be serialized to JSON
+     * in order to render the frontend.
+     *
+     * @return array
+     */
+    function getFieldOptions() : array
+    {
+        // get the list of sites available for the user
+        $list_of_sites = \Utility::getSiteList();
 
-        $this->columns = [];
+        foreach ($list_of_sites as $id => $name) {
+            $site_options[$name] = $name;
+        }
+
+        return [
+            'sites' => $site_options,
+        ];
     }
 
     /**
@@ -63,56 +78,9 @@ class Dicom_Archive extends \NDB_Menu_Filter
      *
      * @return \LORIS\Data\Provisioner
      */
-    function getDataProvisioner() : \LORIS\Data\Provisioner
+    function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $provisioner = new DicomArchiveRowProvisioner();
-
-        $user = \User::singleton();
-
-        if ($user->hasPermission("access_all_profiles") == false) {
-            $provisioner = $provisioner->filter(
-                new \LORIS\Data\Filters\UserSiteMatch()
-            );
-        }
-        $provisioner = $provisioner->map(new DICOMArchiveAnonymizer());
-        return $provisioner;
-    }
-
-    /**
-     * Converts the results of this menu filter to a JSON format to be retrieved
-     * with ?format=json
-     *
-     * @return string a json encoded string of the headers and data from this table
-     */
-    function toJSON()
-    {
-        $table = (new \LORIS\Data\Table())
-            ->withDataFrom($this->getDataProvisioner());
-        $arr   = array_map(
-            function ($row) {
-                return array_values($row);
-            },
-            json_decode($table->toJSON(\User::singleton()), true)
-        );
-        $options = array('sites' => \Utility::getSiteList());
-        return json_encode(
-            [
-             'data'         => $arr,
-             'fieldOptions' => $options,
-            ]
-        );
-    }
-
-    /**
-     * Converts the data from the data table to an array suitable for JSON
-     * serialiation. Overrides the base class in order to enforce name regex
-     * rules.
-     *
-     * @return array of data from dicom_archive menu filter
-     */
-    function toArray()
-    {
-        return json_decode($this->toJSON());
+        return new DicomArchiveRowProvisioner();
     }
 
     /**

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -27,8 +27,6 @@ namespace LORIS\dicom_archive;
  */
 class Dicom_Archive extends \DataFrameworkMenu
 {
-    var $dicomArchiveSettings;
-    public $AjaxModule = true;
 
     /**
      * Determine whether the user has permission to view this page
@@ -80,7 +78,11 @@ class Dicom_Archive extends \DataFrameworkMenu
      */
     function getBaseDataProvisioner() : \LORIS\Data\Provisioner
     {
-        return new DicomArchiveRowProvisioner();
+        $provisioner = new DicomArchiveRowProvisioner();
+
+        $provisioner = $provisioner->map(new DICOMArchiveAnonymizer());
+
+        return $provisioner;
     }
 
     /**

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -76,21 +76,21 @@ class DICOMArchiveAnonymizer implements Mapper
         );
         if (!preg_match(
             "/$pNameRegex/",
-            $newrow['Patient Name']
+            $newrow['patientName']
         )
             && !preg_match(
                 "/$legoPhanRegex/",
-                $newrow['Patient Name']
+                $newrow['patientName']
             )
             && !preg_match(
                 "/$livingPhanRegex/",
-                $newrow['Patient Name']
+                $newrow['patientName']
             )
         ) {
-            $newrow['Patient Name'] = 'INVALID - HIDDEN';
+            $newrow['patientName'] = 'INVALID - HIDDEN';
         }
-        if (!preg_match("/$pIDRegex/", $newrow['Patient ID'] ?? '')) {
-            $newrow['Patient ID'] = 'INVALID - HIDDEN';
+        if (!preg_match("/$pIDRegex/", $newrow['patientID'] ?? '')) {
+            $newrow['patientID'] = 'INVALID - HIDDEN';
         }
         return new DICOMArchiveRow($newrow, $cid);
     }

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -47,13 +47,14 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
             'View Images' AS `MRI Browser`,
             (SELECT GROUP_CONCAT(SeriesUID) FROM tarchive_series e WHERE
                     e.TarchiveID=t.TarchiveID GROUP BY e.TarchiveID) AS seriesUID,
-            s.CenterID AS site,
+            psc.Name AS site,
             t.TarchiveID AS TarchiveID,
             s.ID AS SessionID,
             s.CenterID AS CenterID
             FROM tarchive t
                   LEFT JOIN session s ON (s.ID=t.SessionID)
                   LEFT JOIN candidate c ON (c.CandID=s.CandID)
+                  LEFT JOIN psc ON (psc.CenterID=s.CenterID)
             WHERE COALESCE(c.Active, 'Y')='Y' AND COALESCE(s.Active, 'Y')='Y'",
             array()
         );

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -37,20 +37,20 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
     function __construct()
     {
         parent::__construct(
-            "SELECT t.PatientID as `Patient ID`,
-            t.PatientName as `Patient Name`,
-            t.PatientSex as Sex,
-            t.PatientDoB as `Date of birth`,
-            t.DateAcquired as Acquisition,
-            t.ArchiveLocation as Archive_Location,
-            'View Details' as Metadata,
-            'View Images' as `MRI Browser`,
+            "SELECT t.PatientID AS patientID,
+            t.PatientName AS patientName,
+            t.PatientSex AS sex,
+            t.PatientDoB AS dateOfBirth,
+            t.DateAcquired AS acquisitionDate,
+            t.ArchiveLocation AS archiveLocation,
+            'View Details' AS Metadata,
+            'View Images' AS `MRI Browser`,
             (SELECT GROUP_CONCAT(SeriesUID) FROM tarchive_series e WHERE
-                    e.TarchiveID=t.TarchiveID GROUP BY e.TarchiveID) as SeriesUID,
-            s.CenterID as Site,
-            t.TarchiveID as TarchiveID,
-            s.ID as SessionID,
-            s.CenterID
+                    e.TarchiveID=t.TarchiveID GROUP BY e.TarchiveID) AS seriesUID,
+            s.CenterID AS site,
+            t.TarchiveID AS TarchiveID,
+            s.ID AS SessionID,
+            s.CenterID AS CenterID
             FROM tarchive t
                   LEFT JOIN session s ON (s.ID=t.SessionID)
                   LEFT JOIN candidate c ON (c.CandID=s.CandID)
@@ -69,7 +69,7 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-            $cid = $row['CenterID'];
+            $cid = (int) $row['CenterID'];
             unset($row['CenterID']);
             return new DICOMArchiveRow($row, $cid);
     }


### PR DESCRIPTION
## Brief summary of changes

This updates the DICOM archive module to use the DataFrameworkMenu class.

#### Testing instructions (if applicable)

1. Follow the test plan of the module to make sure there was no change in behaviour

