### PR TITLE
[Documentation] Changed link to Docker Group info in test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 You will need Docker Engine, Docker Compose, and NodeJS.
 
-Please follow the directions [here](https://docs.docker.com/engine/installation/) to install Docker Engine. Be sure to also [create a Docker group](https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group) so Docker can be run without using `sudo`.
+Please follow the directions [here](https://docs.docker.com/engine/installation/) to install Docker Engine. Be sure to also [create a Docker group](https://docs.docker.com/install/linux/linux-postinstall/) so Docker can be run without using `sudo`.
 
 Next, install Docker Compose:
 


### PR DESCRIPTION
## Brief summary of changes
The setup instructions in the [README.md](https://github.com/aces/Loris/tree/minor/test) includes a link to information on how to create a Docker Group. The link was incorrect and I changed it to point to the correct information!

#### Testing instructions (if applicable)

Take a look at the README and check that the link is correct! It should point to Docker documentation that details how to create a docker group. 

