### PR TITLE
Show error when installdb.php can not connect to database

### DIFF
--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -225,8 +225,7 @@ class Database
             return true;
         } catch(\Exception $e) {
             error_log($e->getMessage());
-            $this->lastErr = "Exceptional error connecting to the database "
-            . $database . ".";
+            $this->lastErr = $e->getMessage();
             return false;
         }
 

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -216,11 +216,12 @@ class Installer
         $DB = Database::singleton();
 
         if ($DB->connect(
-                $values['dbname'],
-                $values['dbadminuser'],
-                $values['dbadminpassword'],
-                $values['dbhost']
-            ) === false) {
+            $values['dbname'],
+            $values['dbadminuser'],
+            $values['dbadminpassword'],
+            $values['dbhost']
+        ) === false
+        ) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
             } else {

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -215,14 +215,12 @@ class Installer
     {
         $DB = Database::singleton();
 
-        try {
-            $DB->connect(
+        if ($DB->connect(
                 $values['dbname'],
                 $values['dbadminuser'],
                 $values['dbadminpassword'],
                 $values['dbhost']
-            );
-        } catch (\Exception $e) {
+            ) === false) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;
             } else {


### PR DESCRIPTION
The code which checks if the connection to the database failed
was assuming $db->connect() throws an Exception. However,
$db->connect() catches all exceptions and returns false.

Check return value so that an error is displayed to the user
if the credentials are incorrect on the first page of installer.