### PR TITLE
[Test] unittests for NDB_Page.class.inc

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -164,7 +164,9 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Wrapper to create a header
      * FIXME: Setting the name to null is not a good idea because the name
-     *        is the key to the element in the form array! -Alexandra Livadas
+     *        is the key to the element in the form array. It's been changed
+     *        to a ' ' string so that the method can be unit tested but ideally
+     *        there should be a name param. -Alexandra Livadas
      *
      * @param string $header The text to put in the header
      *
@@ -172,7 +174,7 @@ class NDB_Page implements RequestHandlerInterface
      */
     function addHeader($header)
     {
-        $this->form->addElement('header', null, $header);
+        $this->form->addElement('header', ' ', $header);
     }
 
     /**
@@ -199,7 +201,7 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Wrapper to create a static label to the current page
      * FIXME: Setting the name to null is not a good idea because the name
-     *        is the key to the element in the form array! -Alexandra Livadas
+     *        is the key to the element in the form array. -Alexandra Livadas
      *
      * @param string $label The text to add to the label.
      *
@@ -266,25 +268,21 @@ class NDB_Page implements RequestHandlerInterface
      * Adds a date field (without an accompanying not answered option) to the
      * current page.
      *
-     * FIXME: 'style' is not a valid attribute that is set in the
-     *        LorisForm::createBase method, so it is not actually used.
-     *        - Alexandra Livadas
-     *
      * @param string $field   The name of the date field
      * @param string $label   Label to attach to the date field in the frontend
      * @param array  $options Options to pass to HTML_QuickForm
      * @param array  $attr    Extra HTML attributes to add to the date group.
      *
      * @return void
+     *
+     * @note The 'style' information was removed because it is not an attribute
+     *       added to an element in the LorisForm library. -Alexandra Livadas
      */
     function addBasicDate(
         $field,
         $label,
         $options=array(),
-        $attr=array(
-               'class' => 'form-control input-sm',
-               'style' => 'max-width:33%; display:inline-block;',
-              )
+        $attr=array('class' => 'form-control input-sm')
     ) {
         if ($options === array() && !empty($this->dateOptions)) {
             $options = $this->dateOptions;
@@ -295,12 +293,6 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Wrapper to create a checkbox
      *
-     * FIXME: The optional array is never actually put into the element
-     *        because LorisForm::addHeader does not take it as a parameter.
-     *        The 'class' attribute should be added to the 'options' array
-     *        instead and the optional array should be removed.
-     *        - Alexandra Livadas
-     *
      * @param string $name     The field name of this checkbox
      * @param string $label    The label to attach to this checkbox
      * @param array  $options  Options to pass to QuickForm for this
@@ -309,12 +301,18 @@ class NDB_Page implements RequestHandlerInterface
      *                         to the checkbox
      *
      * @return void
+     *
+     * @note The optional array is never actually put into the element
+     *       because LorisForm::addHeader does not take it as a parameter.
+     *       The 'class' attribute is now added to the $options array instead
+     *       whereas before it was in the $optional array.
+     *        - Alexandra Livadas
      */
     function addCheckbox($name, $label, $options, $optional=array())
     {
-        $optional = array_merge(
+        $options = array_merge(
             array('class' => 'form-control input-sm'),
-            $optional
+            $options
         );
         $this->form->addElement('advcheckbox', $name, $label, $options, $optional);
     }
@@ -427,10 +425,16 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $format  See QuickForm documentation.
      *
      * @return void
+     *
+     * @note The fourth parameter ($format) was removed because
+     *       LorisForm::addRule does not have this fourth parameter. It is
+     *       still included in the function declaration because this function
+     *       may be called with four parameters elsewhere in the codebase!
+     *       - Alexandra Livadas
      */
     function addRule($element, $message, $type, $format=null)
     {
-        $this->form->addRule($element, $message, $type, $format);
+        $this->form->addRule($element, $message, $type);
     }
 
     /**
@@ -453,17 +457,23 @@ class NDB_Page implements RequestHandlerInterface
      * Adds a group (array of elements created by $this->create*
      * wrappers) to the current page.
      *
-     * @param array  $elements   The group of elements to add to the page
-     * @param string $name       The name to give this group
-     * @param string $label      A label to attach to the group
-     * @param string $separator  The separator to use between group elements
-     * @param string $appendName ????
+     * @param array  $elements  The group of elements to add to the page
+     * @param string $name      The name to give this group
+     * @param string $label     A label to attach to the group
+     * @param string $delimiter The separator to use between group elements
+     * @param string $options   An optional array to include prefix_wrapper and
+     *                          postfix_wrapper strings - html that will be
+     *                          placed before and after the group html
      *
      * @return void
+     *
+     * @note The names of the last two parameters were changed to match
+     *       the parameters of LorisForm::addGroup and make their purposes
+     *       more clear - Alexandra Livadas
      */
-    function addGroup($elements, $name, $label, $separator, $appendName=null)
+    function addGroup($elements, $name, $label, $delimiter, $options=null)
     {
-        $this->form->addGroup($elements, $name, $label, $separator, $appendName);
+        $this->form->addGroup($elements, $name, $label, $delimiter, $options);
     }
 
     /**
@@ -487,6 +497,11 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Create a QuickForm label element but does not add it to the form
+     *
+     * FIXME: LorisForm::createElement does not use the label parameter when
+     *        the element type is "static". Also, the $labelString paramter here
+     *        has been placed as the fourth parameter which is actually the $options
+     *        array in the createElement function! - Alexandra Livadas
      *
      * @param string $labelString The label to attach to the element
      *
@@ -541,10 +556,6 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates a QuickForm date element but does not add it to the form.
      *
-     * FIXME: 'style' is not a supported attribute that is added in the
-     *        LorisForm::createBase method. This should be changed or removed.
-     *        - Alexandra Livadas
-     *
      * @param string $field       The fieldname for this date field
      * @param string $label       The label to attach to this date
      * @param array  $dateOptions List of options to pass to QuickForm
@@ -552,15 +563,15 @@ class NDB_Page implements RequestHandlerInterface
      *                            group.
      *
      * @return array representing date element
+     *
+     * @note The 'style' information was removed because it is not an attribute
+     *       added to an element in the LorisForm library. -Alexandra Livadas
      */
     function createDate(
         $field,
         $label,
         $dateOptions=null,
-        $attr=array(
-               'class' => 'form-control input-sm',
-               'style' => 'max-width:33%; display:inline-block;',
-              )
+        $attr=array('class' => 'form-control input-sm')
     ) {
         return $this->form->createElement(
             "date",

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -163,10 +163,6 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Wrapper to create a header
-     * FIXME: Setting the name to null is not a good idea because the name
-     *        is the key to the element in the form array. It's been changed
-     *        to a ' ' string so that the method can be unit tested but ideally
-     *        there should be a name param. -Alexandra Livadas
      *
      * @param string $header The text to put in the header
      *
@@ -174,7 +170,7 @@ class NDB_Page implements RequestHandlerInterface
      */
     function addHeader($header)
     {
-        $this->form->addElement('header', ' ', $header);
+        $this->form->addElement('header', null, $header);
     }
 
     /**
@@ -200,8 +196,6 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Wrapper to create a static label to the current page
-     * FIXME: Setting the name to null is not a good idea because the name
-     *        is the key to the element in the form array. -Alexandra Livadas
      *
      * @param string $label The text to add to the label.
      *

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -434,7 +434,7 @@ class NDB_Page implements RequestHandlerInterface
      */
     function addRule($element, $message, $type, $format=null)
     {
-        $this->form->addRule($element, $message, $type);
+        $this->form->addRule($element, $message, $type, $format);
     }
 
     /**

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -91,6 +91,8 @@ class NDB_Page implements RequestHandlerInterface
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
+     * FIXME: $formname is never used. - Alexandra Livadas
+     *
      * @param Module $module     The test name being accessed
      * @param string $page       The subtest being accessed (may be an empty string)
      * @param string $identifier The identifier for the data to load on this page
@@ -161,6 +163,8 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Wrapper to create a header
+     * FIXME: Setting the name to null is not a good idea because the name
+     *        is the key to the element in the form array! -Alexandra Livadas
      *
      * @param string $header The text to put in the header
      *
@@ -194,6 +198,8 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Wrapper to create a static label to the current page
+     * FIXME: Setting the name to null is not a good idea because the name
+     *        is the key to the element in the form array! -Alexandra Livadas
      *
      * @param string $label The text to add to the label.
      *
@@ -260,6 +266,10 @@ class NDB_Page implements RequestHandlerInterface
      * Adds a date field (without an accompanying not answered option) to the
      * current page.
      *
+     * FIXME: 'style' is not a valid attribute that is set in the
+     *        LorisForm::createBase method, so it is not actually used.
+     *        - Alexandra Livadas
+     *
      * @param string $field   The name of the date field
      * @param string $label   Label to attach to the date field in the frontend
      * @param array  $options Options to pass to HTML_QuickForm
@@ -285,6 +295,12 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Wrapper to create a checkbox
      *
+     * FIXME: The optional array is never actually put into the element
+     *        because LorisForm::addHeader does not take it as a parameter.
+     *        The 'class' attribute should be added to the 'options' array
+     *        instead and the optional array should be removed.
+     *        - Alexandra Livadas
+     *
      * @param string $name     The field name of this checkbox
      * @param string $label    The label to attach to this checkbox
      * @param array  $options  Options to pass to QuickForm for this
@@ -305,6 +321,8 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Wrapper to create a radio button
+     * FIXME: Should this be "addRadioGroup"? There is no method
+     *        that just adds 1 radio element. - Alexandra Livadas
      *
      * @param string $name       The field name of this radio button
      * @param string $groupLabel The label to attach to this group of
@@ -523,6 +541,10 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates a QuickForm date element but does not add it to the form.
      *
+     * FIXME: 'style' is not a supported attribute that is added in the
+     *        LorisForm::createBase method. This should be changed or removed.
+     *        - Alexandra Livadas
+     *
      * @param string $field       The fieldname for this date field
      * @param string $label       The label to attach to this date
      * @param array  $dateOptions List of options to pass to QuickForm
@@ -551,6 +573,8 @@ class NDB_Page implements RequestHandlerInterface
 
     /**
      * Creates an HTML checkbox but does not add it to the form.
+     *
+     * FIXME: $closer is never used or explained. - Alexandra Livadas
      *
      * @param string $field   The fieldname for this checkbox
      * @param string $label   The label to attach to this checkbox

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -113,8 +113,6 @@ class NDB_PageTest extends TestCase
     /**
      * Test that addHeader calls addElement from LorisForm and properly adds
      * an element to the page's form
-     * FIXME: Ideally the name should not be ' '. See the fixme comment in
-     *        the addHeader method. - Alexandra Livadas
      *
      * @covers NDB_Page::addHeader
      * @return void
@@ -124,9 +122,8 @@ class NDB_PageTest extends TestCase
         $this->_page->addHeader("test_header");
         $this->assertEquals(
             array('label' => 'test_header',
-                  'type'  => 'header',
-                  'name'  => ' '),
-            $this->_page->form->form[' ']
+                  'type'  => 'header'),
+            current($this->_page->form->form)
         );
     }
 
@@ -153,22 +150,17 @@ class NDB_PageTest extends TestCase
     /**
      * Test that addLabel calls addElement from LorisForm and properly adds
      * an element to the page's form
-     * FIXME: This is incomplete because the addLabel
-     *        method sets the name value to null which makes it hard to 
-     *        define the element or to find it in the form->form array! 
-     *        See fixme comment in addLabel method -Alexandra Livadas
      *
      * @covers NDB_Page::addLabel
      * @return void
      */
     public function testAddLabel()
     {
-        $this->markTestIncomplete("This test is incomplete!");
         $this->_page->addLabel("test_label");
         $this->assertEquals(
             array('label' => 'test_label',
                   'type'  => 'static'),
-            $this->_page->form->form['anonymous1']
+            current($this->_page->form->form)
         );
     }
 

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -12,7 +12,7 @@
  */
 use PHPUnit\Framework\TestCase;
 /**
- * Unit test for NDB_Config class
+ * Unit tests for NDB_Config class
  *
  * @category Tests
  * @package  Main
@@ -121,7 +121,6 @@ class NDB_PageTest extends TestCase
      */
     public function testAddHeader()
     {
-        //$this->markTestIncomplete("This test is incomplete!");
         $this->_page->addHeader("test_header");
         $this->assertEquals(
             array('label' => 'test_header',
@@ -617,23 +616,6 @@ class NDB_PageTest extends TestCase
     }
 
     /**
-     * Test that display returns a string of content in JSON form if the format
-     * variable is set to 'json'
-     *
-     * @covers NDB_Page::display
-     * @return void
-     *
-     * @note This test is incomplete because format is a protected var that 
-     *       cannot be set here. - Alexandra Livadas
-     */
-    public function testDisplayWithJSONFormat()
-    {
-        $this->markTestIncomplete("This test is incomplete");
-        //$this->_page->format = 'json';
-        $this->assertEquals("", $this->_page->display());
-    }
-
-    /**
      * Test that display returns an empty string if skipTemplate is true
      *
      * @covers NDB_Page::display
@@ -661,11 +643,10 @@ class NDB_PageTest extends TestCase
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
         $factory = NDB_Factory::singleton();
         $factory->setConfig($configMock);
-        $smartyMock = $this->getMockBuilder('Smarty_NeuroDB')
+        $smarty = $this->getMockBuilder(Smarty_NeuroDB::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $smartyMock->expects($this->any())
-            ->method('fetch')
+        $smarty->expects($this->any())->method('fetch')
             ->willReturn("fetch was called!");
         $this->_page->form->freeze();
         $this->assertEquals("fetch was called!", $this->_page->display());

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -113,22 +113,21 @@ class NDB_PageTest extends TestCase
     /**
      * Test that addHeader calls addElement from LorisForm and properly adds
      * an element to the page's form
-     * FIXME: This is incomplete because the addHeader method sets the name value
-     *        to null which makes it hard to define the element or to find it in the
-     *        form->form array! See fixme commmet in addHeader method 
-     *        - Alexandra Livadas
+     * FIXME: Ideally the name should not be ' '. See the fixme comment in
+     *        the addHeader method. - Alexandra Livadas
      *
      * @covers NDB_Page::addHeader
      * @return void
      */
     public function testAddHeader()
     {
-        $this->markTestIncomplete("This test is incomplete!");
+        //$this->markTestIncomplete("This test is incomplete!");
         $this->_page->addHeader("test_header");
         $this->assertEquals(
             array('label' => 'test_header',
-                  'type'  => 'header'),
-            $this->_page->form->form['anonymous1']
+                  'type'  => 'header',
+                  'name'  => ' '),
+            $this->_page->form->form[' ']
         );
     }
 
@@ -155,11 +154,10 @@ class NDB_PageTest extends TestCase
     /**
      * Test that addLabel calls addElement from LorisForm and properly adds
      * an element to the page's form
-     * FIXME: Same as testAddHeader: This is incomplete because the addLabel
+     * FIXME: This is incomplete because the addLabel
      *        method sets the name value to null which makes it hard to 
      *        define the element or to find it in the form->form array! 
-     *        See fixme commmet in addHeader method
-     *        - Alexandra Livadas
+     *        See fixme commment in addLabel method -Alexandra Livadas
      *
      * @covers NDB_Page::addLabel
      * @return void
@@ -169,9 +167,9 @@ class NDB_PageTest extends TestCase
         $this->markTestIncomplete("This test is incomplete!");
         $this->_page->addLabel("test_label");
         $this->assertEquals(
-            array('label'   => 'test_label',
-                  'type'    => 'static'),
-            $this->_page->form->form['anonymous2']
+            array('label' => 'test_label',
+                  'type'  => 'static'),
+            $this->_page->form->form['anonymous1']
         );
     }
 
@@ -288,7 +286,8 @@ class NDB_PageTest extends TestCase
         $this->assertEquals(
             array('name'    => 'test_name',
                   'label'   => 'test_label',
-                  'type'    => 'advcheckbox'),
+                  'type'    => 'advcheckbox',
+                  'class' => 'form-control input-sm'),
             $this->_page->form->form['test_name']
         );
     }
@@ -296,8 +295,6 @@ class NDB_PageTest extends TestCase
     /**
      * Test that addRadio calls LorisForm::addGroup and properly creates a 
      * group of radio elements.
-     *
-     * @note See fixme comment for NDB_Page::addRadio
      *
      * @covers NDB_Page::addRadio
      * @return void
@@ -387,6 +384,172 @@ class NDB_PageTest extends TestCase
     }
 
     /**
+     * Test that addPassword calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addPassword
+     * @return void
+     */
+    public function testAddPassword()
+    {
+        $this->_page->addPassword("test_name", "test_label");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'password',
+                  'class'   => 'form-control input-sm'),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addRule calls the LorisForm::addRule method and adds
+     * the rule attribute to the given element
+     *
+     * @covers NDB_Page::addRule
+     * @return void
+     */
+    public function testAddRule()
+    {
+        $this->_page->addBasicText("abc", "Hello", array());
+        $this->_page->addRule("abc", "Required!", "required");
+        $this->assertTrue($this->_page->form->form['abc']['required']);
+        $this->assertEquals(
+            'Required!', $this->_page->form->form['abc']['requireMsg']
+        );
+    }
+
+    /**
+     * Test that addGroup calls LorisForm::addGroup and adds a group of elements
+     * to the form correctly
+     *
+     * @covers NDB_Page::addGroup
+     * @return void
+     */
+    public function testAddGroup()
+    {
+        $text1 = $this->_page->createText("test_name1", "test_label1");
+        $text2 = $this->_page->createText("test_name2", "test_label2");
+        $this->_page->addGroup(
+            array($text1, $text2), "test_group", "group_label", ", "
+        );
+        $result = array('name'      => 'test_group',
+                        'type'      => 'group',
+                        'label'     => 'group_label',
+                        'delimiter' => ', ',
+                        'options'   => null,
+                        'elements'  => array($text1, $text2));
+        $this->assertEquals(
+            $result,
+            $this->_page->form->form['test_group']
+        );    
+    }
+
+    /**
+     * Test that addGroupRule calls LorisForm::addGroupRule and adds the correct
+     * rules and rule messages to the given group's elements
+     *
+     * @covers NDB_Page::addGroupRule
+     * @return void
+     */
+    public function testAddGroupRule()
+    {
+        $text1 = $this->_page->createText("test_name1", "test_label1");
+        $text2 = $this->_page->createText("test_name2", "test_label2");
+        $this->_page->addGroup(
+            array($text1, $text2), "test_group", "group_label", ", "
+        );
+        $testRules = array(
+                         array(
+                             array("Message for text1!", 'required')),
+                         array(
+                             array("Message for text2!", 'numeric')));
+        $this->_page->addGroupRule("test_group", $testRules);
+
+        $this->assertTrue(
+            $this->_page->form->form['test_group']['elements'][0]['required']
+        );
+        $this->assertEquals(
+            "Message for text1!",
+            $this->_page->form->form['test_group']['elements'][0]['requireMsg']
+        );
+        $this->assertTrue(
+            $this->_page->form->form['test_group']['elements'][1]['numeric']
+        );
+        $this->assertEquals(
+            "Message for text2!",
+            $this->_page->form->form['test_group']['elements'][1]['numericMsg']
+        );
+    }
+
+    /**
+     * Test that createSelect returns an array representing a select element
+     *
+     * @covers NDB_Page::createSelect
+     * @return void
+     */
+    public function testCreateSelect()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field',
+                  'label' => 'test_label',
+                  'type' => 'select',
+                  'class' => 'form-control input-sm',
+                  'options' => null),
+            $this->_page->createSelect("test_field", "test_label")
+        );
+    }
+
+    /**
+     * Test that createLabel returns an array representing a label element
+     *
+     * FIXME: This is incomplete because the createLabel function needs
+     *        to be updated. See the fixme comment above NDB_Page::createLabel
+     *        - Alexandra Livadas
+     *
+     * @covers NDB_Page::createLabel
+     * @return void
+     */
+    public function testCreateLabel()
+    {
+        $this->markTestIncomplete("This test is incomplete");
+    }
+
+    /**
+     * Test that createText returns an array representing a text element
+     *
+     * @covers NDB_Page::createText
+     * @return void
+     */
+    public function testCreateText()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field',
+                  'label' => 'test_label',
+                  'type' => 'text',
+                  'class' => 'form-control input-sm'),
+            $this->_page->createText("test_field", "test_label")
+        );
+    }
+
+    /**
+     * Test that createTextArea returns an array representing a textarea element
+     *
+     * @covers NDB_Page::createTextArea
+     * @return void
+     */
+    public function testCreateTextArea()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field',
+                  'label' => 'test_label',
+                  'type' => 'textarea',
+                  'class' => 'form-control input-sm'),
+            $this->_page->createTextArea("test_field", "test_label")
+        );
+    }
+
+    /**
      * Test that createDate returns an array representing a date element
      *
      * @covers NDB_Page::createDate
@@ -401,6 +564,55 @@ class NDB_PageTest extends TestCase
                   'class' => 'form-control input-sm',
                   'options' => null),
             $this->_page->createDate("test_field", "test_label")
+        );
+    }
+
+    /**
+     * Test that createCheckbox returns an array representing an advcheckbox element
+     *
+     * @covers NDB_Page::createCheckbox
+     * @return void
+     */
+    public function testCreateCheckbox()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field',
+                  'label' => 'test_label',
+                  'type' => 'advcheckbox'),
+            $this->_page->createCheckbox("test_field", "test_label")
+        );
+    }
+
+    /**
+     * Test that createRadio returns an array representing a radio element
+     *
+     * @covers NDB_Page::createRadio
+     * @return void
+     */
+    public function testCreateRadio()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field',
+                  'label' => 'test_label',
+                  'type' => 'radio'),
+            $this->_page->createRadio("test_field", "test_label")
+        );
+    }
+
+    /**
+     * Test that createPassword returns an array representing a password element
+     *
+     * @covers NDB_Page::createPassword
+     * @return void
+     */
+    public function testCreatePassword()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field',
+                  'label' => 'test_label',
+                  'type' => 'password',
+                  'class' => 'form-control input-sm'),
+            $this->_page->createPassword("test_field", "test_label")
         );
     }
 }

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -615,4 +615,59 @@ class NDB_PageTest extends TestCase
             $this->_page->createPassword("test_field", "test_label")
         );
     }
+
+    /**
+     * Test that display returns a string of content in JSON form if the format
+     * variable is set to 'json'
+     *
+     * @covers NDB_Page::display
+     * @return void
+     *
+     * @note This test is incomplete because format is a protected var that 
+     *       cannot be set here. - Alexandra Livadas
+     */
+    public function testDisplayWithJSONFormat()
+    {
+        $this->markTestIncomplete("This test is incomplete");
+        //$this->_page->format = 'json';
+        $this->assertEquals("", $this->_page->display());
+    }
+
+    /**
+     * Test that display returns an empty string if skipTemplate is true
+     *
+     * @covers NDB_Page::display
+     * @return void
+     */
+    public function testDisplayWithSkipTemplateTrue()
+    {
+        $this->_page->skipTemplate = true;
+        $this->assertEquals("", $this->_page->display());
+    }
+
+    /**
+     * Test that display uses a Smarty_NeuroDB object to return an html of the
+     * page object. 
+     *
+     * @covers NDB_Page::display
+     * @return void
+     *
+     * @note This test is incomplete because it uses Smarty_NeuroDB which needs
+     *       to use a mock object. - Alexandra Livadas
+     */
+    public function testDisplayWithFormFrozen()
+    {
+        $this->markTestIncomplete("This test is incomplete!");
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        $factory = NDB_Factory::singleton();
+        $factory->setConfig($configMock);
+        $smartyMock = $this->getMockBuilder('Smarty_NeuroDB')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $smartyMock->expects($this->any())
+            ->method('fetch')
+            ->willReturn("fetch was called!");
+        $this->_page->form->freeze();
+        $this->assertEquals("fetch was called!", $this->_page->display());
+    }
 }

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -156,7 +156,7 @@ class NDB_PageTest extends TestCase
      * FIXME: This is incomplete because the addLabel
      *        method sets the name value to null which makes it hard to 
      *        define the element or to find it in the form->form array! 
-     *        See fixme commment in addLabel method -Alexandra Livadas
+     *        See fixme comment in addLabel method -Alexandra Livadas
      *
      * @covers NDB_Page::addLabel
      * @return void

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -1,0 +1,406 @@
+<?php declare(strict_types=1);
+/**
+ * Unit tests for NDB_Page class
+ *
+ * PHP Version 7
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+use PHPUnit\Framework\TestCase;
+/**
+ * Unit test for NDB_Config class
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Shen Wang <alexandra.livadas@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NDB_PageTest extends TestCase
+{
+
+    /**
+     * The NDB_Page object used for testing
+     *
+     * @var NDB_Page
+     */
+    private $_page;
+
+    /**
+     * The Module object used for testing
+     *
+     * @var Module
+     */
+    private $_module;
+
+    /**
+     * This method is called before each test is executed
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->_module = new Module("test_module", "php/libraries/");
+        $this->_page = new NDB_Page(
+            $this->_module, "test_page", "515", "123", "test_form"
+        );
+    }
+
+    /**
+     * This method is called after each test is executed
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Test that the _construct function sets all variables correctly
+     *
+     * @covers NDB_Page::_construct
+     * @return void
+     */
+    public function testConstruct()
+    {
+        $this->assertEquals("test_module", $this->_page->name);
+        $this->assertEquals("test_page", $this->_page->page);
+        $this->assertEquals("515", $this->_page->identifier);
+        $this->assertEquals("123", $this->_page->commentID);
+        $this->assertEquals("test_page", $this->_page->template);
+    }
+
+    /**
+     * Test that setTemplateVar correctly sets a value in the 
+     * tpl_data array and that getTemplateData returns the correct information
+     *
+     * @covers NDB_Page::setTemplateVar
+     * @covers NDB_Page::getTemplateData
+     * @return void
+     */
+    public function testSetAndGetTemplateVar()
+    {
+        $this->_page->setTemplateVar("test_var", "test_value");
+        $data = $this->_page->getTemplateData();
+        $this->assertEquals("test_value", $data['test_var']);
+    }
+
+    /**
+     * Test that addFile calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addFile
+     * @return void
+     */
+    public function testAddFile()
+    {
+        $this->_page->addFile("test_name", "test_label");
+        $this->assertEquals(
+            array('name'  => 'test_name',
+                  'label' => 'test_label',
+                  'type'  => 'file',
+                  'class' => 'fileUpload'), 
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addHeader calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     * FIXME: This is incomplete because the addHeader method sets the name value
+     *        to null which makes it hard to define the element or to find it in the
+     *        form->form array! See fixme commmet in addHeader method 
+     *        - Alexandra Livadas
+     *
+     * @covers NDB_Page::addHeader
+     * @return void
+     */
+    public function testAddHeader()
+    {
+        $this->markTestIncomplete("This test is incomplete!");
+        $this->_page->addHeader("test_header");
+        $this->assertEquals(
+            array('label' => 'test_header',
+                  'type'  => 'header'),
+            $this->_page->form->form['anonymous1']
+        );
+    }
+
+    /**
+     * Test that addSelect calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addSelect
+     * @return void
+     */
+    public function testAddSelect()
+    {
+        $this->_page->addSelect("test_name", "test_label", array());
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'select',
+                  'class'   => 'form-control input-sm',
+                  'options' => array()),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addLabel calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     * FIXME: Same as testAddHeader: This is incomplete because the addLabel
+     *        method sets the name value to null which makes it hard to 
+     *        define the element or to find it in the form->form array! 
+     *        See fixme commmet in addHeader method
+     *        - Alexandra Livadas
+     *
+     * @covers NDB_Page::addLabel
+     * @return void
+     */
+    public function testAddLabel()
+    {
+        $this->markTestIncomplete("This test is incomplete!");
+        $this->_page->addLabel("test_label");
+        $this->assertEquals(
+            array('label'   => 'test_label',
+                  'type'    => 'static'),
+            $this->_page->form->form['anonymous2']
+        );
+    }
+
+    /**
+     * Test that addScoreColumn calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addScoreColumn
+     * @return void
+     */
+    public function testAddScoreColumn()
+    {
+        $this->_page->addScoreColumn("test_name", "test_label");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'static'),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addBasicText calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addBasicText
+     * @return void
+     */
+    public function testAddBasicText()
+    {
+        $this->_page->addBasicText("test_name", "test_label");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'text',
+                  'class'   => 'form-control input-sm'),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addBasicTextArea calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addBasicTextArea
+     * @return void
+     */
+    public function testAddBasicTextArea()
+    {
+        $this->_page->addBasicTextArea("test_name", "test_label");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'textarea',
+                  'class'   => 'form-control input-sm'),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addBasicDate calls addElement from LorisForm and properly adds
+     * an element to the page's form when dateOptions is not set. Since
+     * dateOptions is not set, the options array should remain empty. 
+     *
+     * @covers NDB_Page::addBasicDate
+     * @return void
+     */
+    public function testAddBasicDateWithNoDateOptions()
+    {
+        $this->_page->addBasicDate("test_name", "test_label");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'date',
+                  'class'   => 'form-control input-sm',
+                  'options' => array()),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addBasicDate calls addElement from LorisForm and properly adds
+     * an element to the page's form when dateOptions is set. Since
+     * dateOptions is set, the options array should have information in it.
+     *
+     * @covers NDB_Page::addBasicDate
+     * @return void
+     */
+    public function testAddBasicDateWithDateOptionsSet()
+    {
+        $this->_page->dateOptions = array('someOption' => 'true');
+        $this->_page->addBasicDate("test_name", "test_label");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'date',
+                  'class'   => 'form-control input-sm',
+                  'options' => array('someOption' => 'true')),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addCheckbox calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     * TODO: Update this test once addCheckbox method is fixed.
+     *
+     * @covers NDB_Page::addCheckbox
+     * @return void
+     */
+    public function testAddCheckbox()
+    {
+        $this->_page->addCheckbox("test_name", "test_label", array());
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => 'test_label',
+                  'type'    => 'advcheckbox'),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addRadio calls LorisForm::addGroup and properly creates a 
+     * group of radio elements.
+     *
+     * @note See fixme comment for NDB_Page::addRadio
+     *
+     * @covers NDB_Page::addRadio
+     * @return void
+     */
+    public function testAddRadio()
+    {
+        $radios = array(
+                      array('label' => 'label1',
+                            'value' => 'value1'),
+                      array('label' => 'label2',
+                            'value' => 'value2'));
+        $elementsArray = array(
+                             array('name' => 'test_radio',
+                                   'label' => 'label1',
+                                   'value' => 'value1',
+                                   'type' => 'radio',
+                                   'class' => 'form-control input-sm'),
+                             array('name' => 'test_radio',
+                                   'label' => 'label2',
+                                   'value' => 'value2',
+                                   'type' => 'radio',
+                                   'class' => 'form-control input-sm'));
+        $this->_page->addRadio("test_radio", "group_label", $radios);
+        $this->assertEquals(
+            array('name' => 'test_radio_group',
+                  'label' => 'group_label', 
+                  'type' => 'group',
+                  'delimiter' => ' ',
+                  'options' => false,
+                  'elements' => $elementsArray),
+            $this->_page->form->form['test_radio_group']
+        );
+    }
+
+    /** 
+     * Test that addHidden calls addElement from LorisForm and properly adds
+     * an element to the page's form
+     *
+     * @covers NDB_Page::addHidden
+     * @return void
+     */
+    public function testAddHidden()
+    {
+        $this->_page->addHidden("test_name", "test_value");
+        $this->assertEquals(
+            array('name'    => 'test_name',
+                  'label'   => null,
+                  'value'   => 'test_value',
+                  'type'    => 'hidden'),
+            $this->_page->form->form['test_name']
+        );
+    }
+
+    /**
+     * Test that addTextAreaGroup adds a group of elements that consists of
+     * a text area element and a 'not_answered' select element.
+     *
+     * @covers NDB_Page::addTextAreaGroup
+     * @return void
+     */
+    public function testAddTextAreaGroup()
+    {
+        $options = array(''             => '',
+                         'not_answered' => 'Not Answered');
+        $elementsArray = array(
+                             array('name' => 'test_field',
+                                   'label' => '', 
+                                   'type' => 'textarea',
+                                   'class' => 'form-control input-sm'),
+                             array('name' => 'test_field_status',
+                                   'label' => '', 
+                                   'type' => 'select',
+                                   'options' => $options,
+                                   'class' => 'form-control input-sm not-answered')
+                         );
+
+        $this->_page->addTextAreaGroup("test_field", "test_label");
+        $this->assertEquals(
+            array('name' => 'test_field_group',
+                  'type' => 'group',
+                  'label' => 'test_label',
+                  'delimiter' => ' ',
+                  'options' => false,
+                  'elements' => $elementsArray),
+            $this->_page->form->form['test_field_group']
+        );
+    }
+
+    /**
+     * Test that createDate returns an array representing a date element
+     *
+     * @covers NDB_Page::createDate
+     * @return void
+     */
+    public function testCreateDate()
+    {
+        $this->assertEquals(
+            array('name' => 'test_field', 
+                  'label' => 'test_label',
+                  'type' => 'date',
+                  'class' => 'form-control input-sm',
+                  'options' => null),
+            $this->_page->createDate("test_field", "test_label")
+        );
+    }
+}


### PR DESCRIPTION
## Brief summary of changes

Unit tests for the [NDB_Page.class.inc](https://github.com/aces/Loris/blob/major/php/libraries/NDB_Page.class.inc) library. 

**I've also added a lot of FIXME comments to NDB_Page.class.inc because some methods have code smells.**

#### Testing instructions (if applicable)
Run `npm run tests:unit -- --filter NDB_Page` or check out Travis.

#### Links to related tickets 

* #4423 -- GSOC "to-do" list
