### PR TITLE
[Test] Update Makefile unittests target to run the 'dockerized' script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ checkstatic: phpdev
 	vendor/bin/phan
 
 unittests: phpdev
-	vendor/bin/phpunit --configuration test/phpunit.xml
+	npm run tests:unit
 
 # Perform all tests that don't require an install.
 check: checkstatic unittests


### PR DESCRIPTION
## Brief summary of changes

We want the unit tests to run inside our docker environment so that everything works nicely. 

This changes the target of the Makefile to run the `npm` unit test script which in turn runs the "dockerized unit tests" script. 