### PR TITLE
Enable bash strict checking on all shell scripts

### DIFF
--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 if [ "$DEBUG" == "true" ]
 then

--- a/test/dockerized-unit-tests.sh
+++ b/test/dockerized-unit-tests.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 if [ "$DEBUG" == "true" ]
 then

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -14,6 +14,8 @@
 #       *  Database connection credentials: specify credentials to the test DB which you create in step 1
 #       *  Set sandbox mode to 1: <sandbox>1</sandbox>
 
+set -euo pipefail
+
 host="127.0.0.1"
 database="LorisTest"
 username="SQLTestUser"

--- a/test/run-js-linter.sh
+++ b/test/run-js-linter.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 # NOTE: To use this script, run `npm run lint:javascript`
 
 # Run ESLint on Loris modules

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Run PHP -l on everything to ensure there's no syntax
 # errors.

--- a/test/unittests.sh
+++ b/test/unittests.sh
@@ -14,6 +14,8 @@
 #       *  Database connection credentials: specify credentials to LorisTest DB which you create in step 1
 #       *  Set sandbox mode to 1: <sandbox>1</sandbox>
 
+set -euo pipefail
+
 # set environment variable LORIS_DB_CONFIG to test config.xml file
 host="127.0.0.1"
 database="LorisTest"

--- a/test/wait-for-services.sh
+++ b/test/wait-for-services.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Wrapper script which waits until MySQL and Selenium are up and serving requests.
 
-set -e
+set -euo pipefail
 
 cmd="$@"
 

--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Creates a stub LORIS project directory at the location passed as the first argument
+set -euo pipefail
+
 for d in data libraries instruments templates tables_sql modules; do
     mkdir -p "${1}/${d}"
 done

--- a/tools/deprecated/dump_all_tables_data_only.sh
+++ b/tools/deprecated/dump_all_tables_data_only.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -euo pipefail
+
 GIT_MYSQL=/[BACKUP_LOCATION]
 DATABASE="Demo"
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This will:
@@ -6,6 +6,8 @@
 #   2. Log the installation in the logs directory
 # This will only install the database components and LORIS config file.
 #
+
+set -euo pipefail
 
 # Must be run interactively.
 if ! test -t 0 -a -t 1 -a -t 2 ; then

--- a/tools/package_files.sh
+++ b/tools/package_files.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Reads a list of files from stdin and packages them up into a tar file
+
+set -euo pipefail
 
 GetConfigOption() {
         eval $1=`sed -n -e "/$2/ { s/^[ \t\n]*//; s/[ \t\n]*$//; s#<[/]*$2>##gp }" ../project/config.xml`


### PR DESCRIPTION
## Brief summary of changes
- standardize bash shebang
- enable strict checking for all scripts

#### Testing instructions (if applicable)
These scripts need to be used in their expected operation to see if this exposes any bugs
