### PR TITLE
[jsx/ButtonElement] Bring classname out to a prop with default

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1552,7 +1552,7 @@ class ButtonElement extends Component {
 
   render() {
     return (
-      <div className="row form-group">
+      <div className={this.props.className}>
         <div className={this.props.columnSize}>
           <button
             name={this.props.name}
@@ -1572,12 +1572,17 @@ ButtonElement.propTypes = {
   name: PropTypes.string,
   label: PropTypes.string,
   type: PropTypes.string,
+  className: PropTypes.string,
+  buttonClass: PropTypes.string,
+  columnSize: PropTypes.string,
   onUserInput: PropTypes.func,
 };
 
 ButtonElement.defaultProps = {
+  name: '',
   label: 'Submit',
   type: 'submit',
+  className: 'row form-group',
   buttonClass: 'btn btn-primary',
   columnSize: 'col-sm-9 col-sm-offset-3',
   onUserInput: function() {


### PR DESCRIPTION
## Brief summary of changes

All this PR does is essentially pull out the classname "row form-group" into a default value for a prop called className. This change does not affect any existing ButtonElements out there, but does allow any future ones to have a custom class name for its wrapper div.

En plus, I have added some missing props to the ButtonElement.propTypes object, and added an empty string default to this.props.name which didn't have one previously.

#### Testing instructions

1. Run `make` on this branch and test a couple reactified buttons in Loris. Make sure they are rendered from the ButtonElement in Form.js. There should be no changes whatsoever to these existing buttons.