### PR TITLE
Remove scroll bar of frozen headers

### DIFF
--- a/htdocs/bootstrap/css/custom-css.css
+++ b/htdocs/bootstrap/css/custom-css.css
@@ -195,7 +195,7 @@ table th {
 
 .frozenHeader {
     position: absolute;
-    overflow-x: auto;
+    overflow-x: hidden;
 }
 
 .headerColm {


### PR DESCRIPTION
## Brief summary of changes

Fixes https://github.com/aces/Loris/issues/5068 and second issue in  https://github.com/aces/Loris/issues/5067

#### Testing instructions (if applicable)

1. Test any frozen headers on minor and then on this branch. both issues will be gone. headers however still slightly misaligned with data rows

#### Links to related tickets (GitHub, Redmine, ...)

* https://redmine.cbrain.mcgill.ca/issues/14227
