### PR TITLE
[Candidate Parameters] fix permission check

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -13,36 +13,49 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-$user =& \User::singleton();
+$user = \User::singleton();
 if (!$user->hasPermission('candidate_parameter_edit')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }
 
-if (isset($_POST['tab'] ?? '')) {
-    $tab = $_POST['tab'];
-
-    $db =& \Database::singleton();
-
-    if ($tab == "candidateInfo") {
-        editCandInfoFields($db, $user);
-    } else if ($tab == "probandInfo") {
-        editProbandInfoFields($db, $user);
-    } else if ($tab == "familyInfo") {
-        editFamilyInfoFields($db, $user);
-    } else if ($tab == "deleteFamilyMember") {
-        deleteFamilyMember($db, $user);
-    } else if ($tab == "participantStatus") {
-        editParticipantStatusFields($db, $user);
-    } else if ($tab == "consentStatus") {
-        editConsentStatusFields($db, $user);
-    } else {
-        header("HTTP/1.1 404 Not Found");
-        exit;
-    }
+$tab = $_POST['tab'] ?? '';
+if ($tab === '') {
+    header("HTTP/1.1 400 Bad Request");
+    exit;
 }
 
+$db = \Database::singleton();
 
+switch($tab) {
+case 'candidateInfo':
+    editCandInfoFields($db, $user);
+    break;
+
+case 'probandInfo':
+    editProbandInfoFields($db, $user);
+    break;
+
+case 'familyInfo':
+    editFamilyInfoFields($db, $user);
+    break;
+
+case 'deleteFamilyMember':
+    deleteFamilyMember($db, $user);
+    break;
+
+case 'participantStatus':
+    editParticipantStatusFields($db, $user);
+    break;
+
+case 'consentStatus':
+    editConsentStatusFields($db, $user);
+    break;
+
+default:
+    header("HTTP/1.1 404 Not Found");
+    exit;
+}
 
 /**
  * Handles the updating of Candidate Info

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -12,11 +12,17 @@
  * @license  Loris license
  * @link     https://github.com/aces/Loris-Trunk
  */
-if (isset($_POST['tab'])) {
+
+$user =& \User::singleton();
+if (!$user->hasPermission('candidate_parameter_edit')) {
+    header("HTTP/1.1 403 Forbidden");
+    exit;
+}
+
+if (isset($_POST['tab'] ?? '')) {
     $tab = $_POST['tab'];
 
-    $db   =& \Database::singleton();
-    $user =& \User::singleton();
+    $db =& \Database::singleton();
 
     if ($tab == "candidateInfo") {
         editCandInfoFields($db, $user);
@@ -50,11 +56,6 @@ if (isset($_POST['tab'])) {
  */
 function editCandInfoFields($db, $user)
 {
-    if (!$user->hasPermission('candidate_parameter_edit')) {
-        header("HTTP/1.1 403 Forbidden");
-        exit;
-    }
-
     $candID = $_POST['candID'];
 
     // Process posted data
@@ -132,10 +133,6 @@ function editCandInfoFields($db, $user)
  */
 function editProbandInfoFields($db, $user)
 {
-    if (!$user->hasPermission('candidate_parameter_edit')) {
-        header("HTTP/1.1 403 Forbidden");
-        exit;
-    }
     //Sanitizing the post data
     $sanitize = array_map('htmlentities', $_POST);
     $candID   = $sanitize['candID'];
@@ -202,11 +199,6 @@ function editProbandInfoFields($db, $user)
  */
 function editFamilyInfoFields($db, $user)
 {
-    if (!$user->hasPermission('candidate_parameter_edit')) {
-        header("HTTP/1.1 403 Forbidden");
-        exit;
-    }
-
     $candID = $_POST['candID'];
 
     // Process posted data
@@ -302,11 +294,6 @@ function editFamilyInfoFields($db, $user)
  */
 function deleteFamilyMember($db, $user)
 {
-    if (!$user->hasPermission('candidate_parameter_edit')) {
-        header("HTTP/1.1 403 Forbidden");
-        exit;
-    }
-
     $candID         = $_POST['candID'];
     $familyMemberID = $_POST['familyDCCID'];
 
@@ -338,11 +325,6 @@ function deleteFamilyMember($db, $user)
  */
 function editParticipantStatusFields($db, $user)
 {
-    if (!$user->hasPermission('candidate_parameter_edit')) {
-        header("HTTP/1.1 403 Forbidden");
-        exit;
-    }
-
     $candID = $_POST['candID'];
 
     // Process posted data
@@ -397,11 +379,6 @@ function editParticipantStatusFields($db, $user)
  */
 function editConsentStatusFields($db, $user)
 {
-    if (!$user->hasPermission('candidate_parameter_edit')) {
-        header('HTTP/1.1 403 Forbidden');
-        exit;
-    }
-
     // Get CandID
     $candIDParam = $_POST['candID'];
     $candID      = (isset($candIDParam) && $candIDParam !== 'null') ?

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -12,22 +12,33 @@
  * @license  Loris license
  * @link     https://github.com/aces/Loris-Trunk
  */
-if (isset($_GET['data'])) {
-    $data = $_GET['data'];
-    if ($data == "candidateInfo") {
-        echo json_encode(getCandInfoFields());
-    } else if ($data == "probandInfo") {
-        echo json_encode(getProbandInfoFields());
-    } else if ($data == "familyInfo") {
-        echo json_encode(getFamilyInfoFields());
-    } else if ($data == "participantStatus") {
-        echo json_encode(getParticipantStatusFields());
-    } else if ($data == "consentStatus") {
-        echo json_encode(getConsentStatusFields());
-    } else {
-        header("HTTP/1.1 404 Not Found");
-        exit;
-    }
+$user = \NDB_Factory::singleton()->user();
+if (!$user->hasPermission('candidate_parameter_edit')) {
+    header("HTTP/1.1 403 Forbidden");
+    exit;
+}
+
+$data = $_GET['data'] ?? '';
+
+switch($data) {
+case 'candidateInfo':
+    echo json_encode(getCandInfoFields());
+    exit;
+case 'probandInfo':
+    echo json_encode(getProbandInfoFields());
+    exit;
+case 'familyInfo':
+    echo json_encode(getFamilyInfoFields());
+    exit;
+case 'participantStatus':
+    echo json_encode(getParticipantStatusFields());
+    exit;
+case 'consentStatus':
+    echo json_encode(getConsentStatusFields());
+    exit;
+default:
+    header("HTTP/1.1 404 Not Found");
+    exit;
 }
 
 /**
@@ -379,10 +390,15 @@ function getParticipantStatusHistory($candID)
  */
 function getConsentStatusFields()
 {
+    if (!isset($_GET['candID'])) {
+        header("HTTP/1.1 400 Bad Request");
+        exit;
+    }
+
     $candID = $_GET['candID'];
 
     $db        = \Database::singleton();
-    $candidate = \Candidate::singleton($candID);
+    $candidate = \Candidate::singleton((int) $candID);
 
     // get pscid
     $pscid = $candidate->getPSCID();

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -19,6 +19,10 @@ if (!$user->hasPermission('candidate_parameter_edit')) {
 }
 
 $data = $_GET['data'] ?? '';
+if ($data == '') {
+    header("HTTP/1.1 400 Bad Request");
+    exit;
+}
 
 switch($data) {
 case 'candidateInfo':


### PR DESCRIPTION
The requesting user must have candidate_parameter_edit, not just being authenticated.

Also fix `\Candidate::singleton((int) $candID);` call with a string. It wad generating an error : 
`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Candidate::singleton() must be of the type integer, string given`