### PR TITLE
Traivs issue - bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ services:
 - docker
 
 install:
-- sudo apt-get update
 - sudo apt-get install -y libapparmor1
 - pecl install -f ast-0.1.6
 - sudo apt-get install npm


### PR DESCRIPTION
fix failed issue.
Travis gets updated.
[Do not run apt-get upgrade in your build as it downloads up to 500MB of packages and significantly extends your build time.]
