### PR TITLE
Enable shellcheck on all shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ checkstatic: phpdev
 	npm run lint:php
 	npm run lint:javascript
 	vendor/bin/phan
+	bash -c 'shopt -s globstar nullglob; GLOBIGNORE="vendor*:node_modules*"; shellcheck **/*.{sh,ksh,bash}'
 
 unittests: phpdev
 	vendor/bin/phpunit --configuration test/phpunit.xml


### PR DESCRIPTION
## Brief summary of changes

Enable shellcheck on all scripts inside loris

Find things like #5159 before they bite.
