### PR TITLE
[Statistics] Fix render stats table to only render the MRI error on the MRI page

### DIFF
--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -75,6 +75,8 @@ class Stats_Demographic extends \NDB_Form
      * @param string  $subsection       the value of subsection=''
      * @param string  $disclamer        the value of disclamer=''
      * @param ?string $projectID        the value of projectID is null
+     * @param bool    $renderTable      whether to render the table or display a
+     *                                  default error message
      *
      * @return string
      */
@@ -90,7 +92,8 @@ class Stats_Demographic extends \NDB_Form
         array $data,
         $subsection='',
         $disclamer='',
-        $projectID=null
+        $projectID=null,
+        $renderTable=true
     ): string {
         // This line replaces the empty $projectID string with null
         // `$projectID ?? null` would retain empty strings.
@@ -143,6 +146,7 @@ class Stats_Demographic extends \NDB_Form
             }
 
         }
+        $tpl_data['render_table'] = $renderTable;
         $smarty->assign($tpl_data);
         $html = $smarty->fetch('table_statistics.tpl');
         return $html;

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -70,8 +70,8 @@ class Stats_MRI extends \NDB_Form
      * @param string  $Subsection        the value of Subsection=''
      * @param string  $disclamer         the value of disclamer=''
      * @param ?string $projectID         the value of projectID is null
-     * @param bool    $scanDoneExists    whether the "Scan done" column exists in
-     *                                   the database
+     * @param bool    $renderTable       whether to render the table or display a
+     *                                   default error message
      *
      * @return string
      */
@@ -87,7 +87,7 @@ class Stats_MRI extends \NDB_Form
         $Subsection="",
         $disclamer='',
         $projectID=null,
-        $scanDoneExists = true
+        $renderTable=true
     ): string {
 
         $tpl_data = array();
@@ -201,7 +201,7 @@ class Stats_MRI extends \NDB_Form
             }
         }
 
-        $tpl_data['scan_done_exists'] = $scanDoneExists;
+        $tpl_data['render_table'] = $renderTable;
         $smarty->assign($tpl_data);
         $html = $smarty->fetch("table_statistics.tpl");
         return $html;

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -44,7 +44,7 @@
 </div>
 <br>
 
-{if $scan_done_exists}
+{if $render_table}
   <table id="bigtable" class="data table table-primary table-bordered dynamictable">
     <thead>
     <tr>
@@ -245,7 +245,8 @@
     </tr>
     </tbody>
   </table>
-{else}
+{elseif $Subsection=="mri"}
+  {*The rendertable was set to false, which means there is a problem preventing the table from rendering. In the case of MRI, the problem is the ScanDone column not existing in the database*}
   <br><br>
   <h2>Oops</h2>
   <p> It seems like the scan type selected does not have a corresponding column in the mri_parameter_form table in the database.<br>


### PR DESCRIPTION
## Brief summary of changes
The stats table in 21.0.0 is used in the demographics tab as well as the MRI tab, for the MRI tab, additional check were added to display an error message when the scan type is not associated with a `scan_type_scan_done` field i nthe MRI parameter form.

The demographics however should never display that error message since the error does not apply to it.

In this PR, the error flag was renamed from `scan_done_exists` to `render_table` to make it more generic for all tabs and an additional check was added to only display that error message on the MRI tab.  

#### Testing instructions (if applicable)

1. try loading the demographics tab, no errors should be displayed
2. try loading the Imaging tab, errors should only be displayed IF the selected scan does not have a `Scan_Done` column in the `mri_parameter_form` table

#### Links to related tickets (GitHub, Redmine, ...)

* #4912
