### PR TITLE
[install] add make into install.sh - make easy to install Loris.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -262,4 +262,6 @@ else
     exit 1
 fi
 
+make --file=../Makefile
+
 echo "Installation complete."


### PR DESCRIPTION
Users don't need to run make command.
