### PR TITLE
[jsx/Form.js] Make rendering label for SelectElement and TextboxElement optional

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -938,7 +938,7 @@ class TextboxElement extends Component {
           {requiredHTML}
         </label>
       );
-      inputclass = 'col-sm-9';
+      inputClass = 'col-sm-9';
     }
 
     return (

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -472,13 +472,26 @@ class SelectElement extends Component {
     // Default to empty string for regular select and to empty array for 'multiple' select
     const value = this.props.value || (multiple ? [] : '');
 
-    return (
-      <div className={elementClass}>
+    // Label prop needs to be provided to render label
+    // (including empty label i.e. <SelectElement label='' />)
+    // and retain formatting. If label prop is not provided at all, the input
+    // element will take up the whole row.
+    let label = null;
+    let inputClass = 'col-sm-12';
+    if (this.props.label || this.props.label == '') {
+      label = (
         <label className="col-sm-3 control-label" htmlFor={this.props.label}>
           {this.props.label}
           {requiredHTML}
         </label>
-        <div className="col-sm-9">
+      );
+      inputClass = 'col-sm-9';
+    }
+
+    return (
+      <div className={elementClass}>
+        {label}
+        <div className={inputClass}>
           <select
             name={this.props.name}
             multiple={multiple}
@@ -508,7 +521,6 @@ SelectElement.propTypes = {
     PropTypes.array,
   ]),
   id: PropTypes.string,
-  class: PropTypes.string,
   multiple: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -521,10 +533,8 @@ SelectElement.propTypes = {
 SelectElement.defaultProps = {
   name: '',
   options: {},
-  label: '',
   value: undefined,
   id: null,
-  class: '',
   multiple: false,
   disabled: false,
   required: false,
@@ -914,13 +924,27 @@ class TextboxElement extends Component {
       elementClass = 'row form-group has-error';
     }
 
-    return (
-      <div className={elementClass}>
+
+    // Label prop needs to be provided to render label
+    // (including empty label i.e. <TextboxElement label='' />)
+    // and retain formatting. If label prop is not provided at all, the input
+    // element will take up the whole row.
+    let label = null;
+    let inputClass = 'col-sm-12';
+    if (this.props.label || this.props.label == '') {
+      label = (
         <label className="col-sm-3 control-label" htmlFor={this.props.id}>
           {this.props.label}
           {requiredHTML}
         </label>
-        <div className="col-sm-9">
+      );
+      inputclass = 'col-sm-9';
+    }
+
+    return (
+      <div className={elementClass}>
+        {label}
+        <div className={inputClass}>
           <input
             type="text"
             className="form-control"
@@ -953,7 +977,6 @@ TextboxElement.propTypes = {
 
 TextboxElement.defaultProps = {
   name: '',
-  label: '',
   value: '',
   id: null,
   disabled: false,


### PR DESCRIPTION
## Brief summary of changes

This PRs allows the ability to render SelectElements and TextboxElements without its label. If a label prop is provided, the label will render and take up 3 spaces in the row, with the input element taking up the rest of the 9 spaces. This is also the case if the label prop is an empty string. If a label prop is not provided at all, the default is that the label won't be rendered at all and the input element takes up all 12 spaces of the row.

This change is useful for modules such as login that still need to be reactified and have input elements without labels:

<img width="393" alt="Screenshot 2019-09-06 13 52 44" src="https://user-images.githubusercontent.com/17415878/64449416-d3a16480-d0ad-11e9-91d0-48d1d86f6151.png">

This PR pulls out some code from https://github.com/aces/Loris/pull/4395

#### Testing instructions (if applicable)

1. This change shouldn't affect any existing SelectElements and TextboxElements in loris. Browse different modules, and see if any of them are missing labels or have weird formatting. Make sure you run `make` before testing
