### PR TITLE
Correct 'minLength' to 'length' for PSCID generation

### DIFF
--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -40,7 +40,7 @@
             <generation>sequential</generation>
             <structure>
                 <seq type="siteAbbrev"/>
-                <seq type="alphanumeric" length="4"/> <!-- Ex: AAA1-->
+                <seq type="alphanumeric" length="4"/> <!-- Ex: AAA0001-->
             </structure>
         </PSCID>
         

--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -40,7 +40,7 @@
             <generation>sequential</generation>
             <structure>
                 <seq type="siteAbbrev"/>
-                <seq type="alphanumeric" minLength="4"/> <!-- Ex: AAA1-->
+                <seq type="alphanumeric" length="4"/> <!-- Ex: AAA1-->
             </structure>
         </PSCID>
         

--- a/test/config.xml
+++ b/test/config.xml
@@ -36,7 +36,7 @@
             <generation>sequential</generation>
             <structure>
                 <seq type="siteAbbrev"/>
-                <seq type="alphanumeric" minLength="4"/> <!-- Ex: AAA1-->
+                <seq type="alphanumeric" length="4"/> <!-- Ex: AAA0001-->
             </structure>
         </PSCID>
         

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -438,7 +438,7 @@ class CandidateTest extends TestCase
                                 '#' => '',
                                 '@' => array(
                                         'type'      => 'numeric',
-                                        'minLength' => '4',
+                                        'length' => '4',
                                        ),
                                ),
                          ),


### PR DESCRIPTION
## Brief summary of changes

This should've been updated in #4241 but I overlooked it. 

`minLength` hasn't existed since the above PR was merged; now it is just length.

There is an [extended conversation](https://github.com/aces/Loris/pull/4469#pullrequestreview-288703473) on this topic in another PR which is how this came up.

There is another lingering instance of minLength and maxLength being used in Utility and this has to do with user-generated PSCID formats. I'm leaving this out of this PR and have opened #5227 to speak about this case.