### PR TITLE
[timepoint_list][bugfix] 'View Candidate Info' button wasn't redirecting

### DIFF
--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -66,11 +66,6 @@ Class TimePoint_List_ControlPanel extends \Candidate
         $this->tpl_data['isDataEntryPerson']
             = $user->hasCenterPermission("data_entry", $cand_CenterID);
 
-        $this->tpl_data['candidate_parameters_view']
-            = $user->hasCenterPermission('candidate_parameter_view', $cand_CenterID);
-        $this->tpl_data['candidate_parameters_edit']
-            = $user->hasCenterPermission('candidate_parameter_edit', $cand_CenterID);
-
         //set the baseurl of the tpl_data
         $factory  = \NDB_Factory::singleton();
         $settings = $factory->settings();

--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -6,6 +6,6 @@
     {if $candidate_parameters_edit}
         <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Edit Candidate Info</a>
     {elseif $candidate_parameters_view}
-        <button class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">View Candidate Info</button>
+        <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">View Candidate Info</a>
     {/if}
 {/if}

--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -1,11 +1,5 @@
 
 {if $isDataEntryPerson}
 <a class="btn btn-default" role="button" href="{$baseurl}/create_timepoint/?candID={$candID}&identifier={$candID}">Create time point</a>
-{/if}
-{if $isDataEntryPerson}
-    {if $candidate_parameters_edit}
-        <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Edit Candidate Info</a>
-    {elseif $candidate_parameters_view}
-        <a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">View Candidate Info</a>
-    {/if}
+<a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Candidate Info</a>
 {/if}


### PR DESCRIPTION
## Brief summary of changes
When user has the permissions:
"View candidate parameters" but NOT "Edit candidate parameters", the button is supposed to read "View candidate info" (which it does), but it is not responsive. Clicking on it does not load the candidate parameters page.

Changed the tag in template so that the button in question actually redirects.

#### Testing instructions (if applicable)
1. Assign yourself the appropriate permissions and see if the link redirects to candidate parameters
