### PR TITLE
[php/libraries] Module.class.inc fixes slash bug when including directory for endpoint.

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -85,6 +85,7 @@ class Module extends \LORIS\Router\PrefixRouter implements RequestHandlerInterfa
                     $fpath = $mpath . "/php/"
                     . strtolower(substr($class, strlen("LORIS\\$name\\")))
                     . ".class.inc";
+                    $fpath = str_replace('\\', '/', $fpath);
                     if (!file_exists($fpath)) {
                         throw new \NotFound(
                             "Could not load module `$name`: file `$fpath` " .


### PR DESCRIPTION
## Brief summary of changes

This bugfix fixes the incorrect slash in front of the class name and such as when including a directory for endpoint php classes.

Example: module/php/endpoints/classnames.class.inc 
Instead of the usual module/php/classnames.class.inc