### PR TITLE
[Phan] Re-add PhanTypeSuspiciousStringExpression rule

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -22,8 +22,7 @@ return [
 		"PhanUndeclaredClassMethod",
 		"PhanTypeMismatchArgument",
 		"PhanTypeMismatchReturn",
-		"PhanTypeMismatchProperty",
-        "PhanTypeSuspiciousStringExpression"
+		"PhanTypeMismatchProperty"
 	],
 	"analyzed_file_extensions" => ["php", "inc"],
 	"directory_list" => [


### PR DESCRIPTION
## Brief summary of changes

This rule should've been added in #4345 but wasn't. Might've been a rebase error on my part.