### PR TITLE
[Install] Add -p to mkdir so install doesn't fail

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -161,8 +161,8 @@ debian=("Debian" "Ubuntu")
 redhat=("Red" "CentOS" "Fedora" "Oracle") 
 
 if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
-    mkdir ../modules/document_repository/user_uploads
-    mkdir ../modules/data_release/user_uploads
+    mkdir -p ../modules/document_repository/user_uploads
+    mkdir -p ../modules/data_release/user_uploads
     sudo chown www-data.www-data ../modules/document_repository/user_uploads
     sudo chown www-data.www-data ../modules/data_release/user_uploads
     sudo chown www-data.www-data ../smarty/templates_c
@@ -171,8 +171,8 @@ if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
     sudo chgrp www-data ../project
     sudo chmod 770 ../project
 elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
-    mkdir ../modules/document_repository/user_uploads
-    mkdir ../modules/data_release/user_uploads
+    mkdir -p ../modules/document_repository/user_uploads
+    mkdir -p ../modules/data_release/user_uploads
     sudo chown apache.apache ../modules/document_repository/user_uploads
     sudo chown apache.apache ../modules/data_release/user_uploads
     sudo chown apache.apache ../smarty/templates_c


### PR DESCRIPTION
## Brief summary of changes

Adds `-p` flag to `mkdir` so that the install script won't fail when `user_uploads/` already exists (for whatever reason) in doc_repo or data_release.

Fixes #5244.