### PR TITLE
Add ghooks: forces "make checkstatic" before git push and "make dev" after git merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-google": "0.9.1",
     "eslint-loader": "2.1.0",
     "eslint-plugin-react": "7.11.1",
+    "ghooks": "^2.0.4",
     "prop-types": "latest",
     "react": "^16.4.2",
     "react-addons-create-fragment": "^15.6.2",
@@ -51,5 +52,11 @@
   "bugs": {
     "url": "https://github.com/aces/Loris/issues"
   },
-  "homepage": "https://github.com/aces/Loris"
+  "homepage": "https://github.com/aces/Loris",
+  "config": {
+      "ghooks": {
+          "pre-push": "make checkstatic",
+          "post-merge": "make dev"
+      }
+  }
 }


### PR DESCRIPTION
## Brief summary of changes

Adds a new developer dependency `ghooks` that forces certain actions to be run when certain `git` events are triggered.

Two hooks are added here with the following results:

* When using `git push`, `make checkstatic` must exit successfully or the push will fail.
* When using `git merge` or `git pull`, `make dev` will be run automatically.

This should help development by:
* forcing developers to fix `phan`, `phpcs`, and `eslint` errors locally rather than waiting for Travis (and often another developer) to tell them that there is an issue with their code.
* Preventing confusion when a developer switches branches and forgets to recompile their JavaScript code
