### PR TITLE
[Login] Fix issue where expired passwords could not be updated on major

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -96,7 +96,7 @@ class PasswordExpiry extends \NDB_Form
             return array('password' => $e->getMessage());
         }
 
-        if (!$this->_user::passwordChanged($_POST['password'])) {
+        if (!$this->_user->passwordChanged($_POST['password'])) {
             $this->tpl_data['error_message'] = 'You cannot keep the same password';
             return array('password' => 'You cannot keep the same password');
         }
@@ -114,7 +114,7 @@ class PasswordExpiry extends \NDB_Form
      */
     function _process($values)
     {
-        $this->user::updatePassword(new \Password($values['password']));
+        $this->_user->updatePassword(new \Password($values['password']));
 
         // The password is no longer expired after updating it.
         unset($_SESSION['PasswordExpiredForUser']);


### PR DESCRIPTION
## Brief summary of changes

The password expiry code was making static calls to `updatePassword` and `passwordChanged` in the User class which are non-static methods. This created errors such as `PHP Fatal error:  Uncaught Error: Using $this when not in object context`, making it impossible to update an expired password.

This is due to an oversight in #4411, so it only affects `aces/major`.

#### Testing instructions (if applicable)

1. Checkout `aces/major` and run `make dev`.
2. Update a user to have an expired password (i.e. change the `Password_expiry` field in the `users` table to be a date earlier than the current date).
3. Login to LORIS. The password expiry screen should appear.
4. You will get an undecorated 403 error when trying to update your password.
5. Checkout this branch and run `make dev`.
6. Repeat step 3. The password should update normally.
