### PR TITLE
[media] Use study's start/end date as min/max values for Date of Administration field

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -207,6 +207,7 @@ function getUploadFields()
 
     $db   = \NDB_Factory::singleton()->database();
     $user = \User::singleton();
+    $config = \NDB_Config::singleton();
 
     // Select only candidates that have had visit at user's sites
     $qparam       = array();
@@ -231,6 +232,8 @@ function getUploadFields()
     $visitList       = Utility::getVisitList();
     $siteList        = Utility::getSiteList(false);
     $languageList    = Utility::getLanguageList();
+    $startYear       = $config->getSetting('startYear');
+    $endYear         = $config->getSetting('endYear');
 
     // Build array of session data to be used in upload media dropdowns
     $sessionData = array();
@@ -328,6 +331,8 @@ function getUploadFields()
                'mediaFiles'  => array_values(getFilesList()),
                'sessionData' => $sessionData,
                'language'    => $languageList,
+               'startYear'   => $startYear,
+               'endYear'     => $endYear,
               ];
 
     return $result;

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -205,8 +205,8 @@ function viewData()
 function getUploadFields()
 {
 
-    $db   = \NDB_Factory::singleton()->database();
-    $user = \User::singleton();
+    $db     = \NDB_Factory::singleton()->database();
+    $user   = \User::singleton();
     $config = \NDB_Config::singleton();
 
     // Select only candidates that have had visit at user's sites

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -138,8 +138,8 @@ class MediaUploadForm extends Component {
             <DateElement
               name='dateTaken'
               label='Date of Administration'
-              minYear='2000'
-              maxYear='2017'
+              minYear={this.state.Data.startYear}
+              maxYear={this.state.Data.endYear}
               onUserInput={this.setFormData}
               ref='dateTaken'
               value={this.state.formData.dateTaken}


### PR DESCRIPTION
## Brief summary of changes
When uploading a form to media module, you cannot enter a date greater than 2017-12-31. The date of administration field is currently hard-coded to have a minYear of '2000' and a maxYear of '2017'. This PR aims to change this. The min and max year are now determined by the study's start and end year (taken from configuration).

#### Testing instructions (if applicable)

1. Try uploading a file with a date of administration that is within the bounds of the study's start and end year.

