### PR TITLE
Fix php linter

### DIFF
--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Run PHP -l on everything to ensure there's no syntax
 # errors.
-find modules htdocs php src -name '*.php' -o -name '*.class.inc' -print0 |xargs -0 -n1 /usr/bin/php -l >/dev/null
+find modules htdocs php src -name '*.class.inc' -print0 -o -name '*.php' -print0 |xargs -0 -n1 /usr/bin/php -l >/dev/null  
 
 # Run PHPCS on the entire libraries directory.
 vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries php/exceptions php/installer || exit $?;

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -3,10 +3,7 @@ set -euo pipefail
 
 # Run PHP -l on everything to ensure there's no syntax
 # errors.
-for i in `ls php/libraries/*.class.inc modules/*/php/* modules/*/ajax/* htdocs/*.php htdocs/*/*.php`;
-do
-  php -l $i >/dev/null || exit $?;
-done
+find modules htdocs php src -name '*.php' -o -name '*.class.inc' -print0 |xargs -0 -n1 /usr/bin/php -l >/dev/null
 
 # Run PHPCS on the entire libraries directory.
 vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries php/exceptions php/installer || exit $?;

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Run PHP -l on everything to ensure there's no syntax
 # errors.
-find modules htdocs php src -name '*.class.inc' -print0 -o -name '*.php' -print0 |xargs -0 -n1 /usr/bin/php -l >/dev/null  
+find docs modules htdocs php src -name '*.class.inc' -print0 -o -name '*.php' -print0 |xargs -0 -n1 php -l >/dev/null  
 
 # Run PHPCS on the entire libraries directory.
 vendor/bin/phpcs --standard=docs/LorisCS.xml php/libraries php/exceptions php/installer || exit $?;


### PR DESCRIPTION
## Brief summary of changes
With the introduction of php subdirectories in modules, run-php-linter fails. This uses `find` instead of `ls` to create the file list.

#### Testing instructions (if applicable)
create a subdirectory in a `module/?/php`. 
add a `.php` or `.class.inc` file in the directory.
test with a syntax error and without.
`./test/run-php-linter.sh` should exit if an error is found. 

