### PR TITLE
[imaging_browser] corrected echo time and repetition not being displayed

### DIFF
--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -221,11 +221,11 @@ class ViewSession extends \NDB_Form
             $SeriesNumber        = $FileObj->getParameter('series_number');
             $SeriesUID           = $FileObj->getParameter('series_instance_uid');
             $EchoTime            = number_format(
-                (int)$FileObj->getParameter('echo_time')*1000,
+                (int)($FileObj->getParameter('echo_time') * 1000),
                 2
             );
             $RepetitionTime      = number_format(
-                (int)$FileObj->getParameter('repetition_time') * 1000,
+                (int)($FileObj->getParameter('repetition_time') * 1000),
                 2
             );
             $SliceThickness      = number_format(


### PR DESCRIPTION
## Brief summary of changes

The echo time in the header info section always displayed 0 for values below 1s.

Example: echo_time = 0.030 => the (int) before its value makes the echo_time becomes 0 then we multiply it by 1000 = 0
However, the value displayed in the front end should be 30ms not 0ms...

That simple bug fix fixes it.

#### Testing instructions (if applicable)

1. Look at the echo time value on aces/bugfix (it will display 0 if echo_time < 1, 1 if 1 < echo_time < 2 ...)
2. Checkout this branch and you will see that the actual echo_time is displayed in ms


