### PR TITLE
[Statistics / Behavioural Statistics] Fix permission issue where users were allowed to see statistics from sites they don't have access to. 

### DIFF
--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -63,24 +63,23 @@ class Stats_Behavioural extends \NDB_Form
     {
         parent::setup();
 
-        $DB    =& \Database::singleton();
-        $user  = \User::singleton();
+        $DB   =& \Database::singleton();
+        $user = \User::singleton();
 
-	$query =
-            "SELECT CONCAT('C', CenterID) as ID,
+        $query = "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
                     IFNULL(PSCArea,Name) as LongName,
                     Name as ShortName
-              FROM psc
-              WHERE CenterID <> '1'
-                    AND Study_site = 'Y'";
+                  FROM psc
+                  WHERE CenterID <> '1'
+                        AND Study_site = 'Y'";
 
-	if (!$user->hasPermission('access_all_profiles')) {
+        if (!$user->hasPermission('access_all_profiles')) {
             $site_arr = implode(",", $user->getCenterIDs());
             $query   .= " AND CenterID IN (" . $site_arr . ")";
         }
 
-	$centers = $DB->pselect($query, array());
+        $centers = $DB->pselect($query, array());
 
         $this->tpl_data['Centers'] = $centers;
 

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -77,7 +77,7 @@ class Stats_Behavioural extends \NDB_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $sitesString = implode(",", $user->getCenterIDs());
-            $query   .= " AND CenterID IN (" . $site_arr . ")";
+            $query   .= " AND CenterID IN (" . $sitesString . ")";
         }
 
         $centers = $DB->pselect($query, array());

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -65,7 +65,7 @@ class Stats_Behavioural extends \NDB_Form
 
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
-        $user = $factory->user();
+        $user    = $factory->user();
 
         $query = "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
@@ -77,7 +77,7 @@ class Stats_Behavioural extends \NDB_Form
 
         if (!$user->hasPermission('access_all_profiles')) {
             $sitesString = implode(",", $user->getCenterIDs());
-            $query   .= " AND CenterID IN (" . $sitesString . ")";
+            $query      .= " AND CenterID IN (" . $sitesString . ")";
         }
 
         $centers = $DB->pselect($query, array());

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -65,7 +65,7 @@ class Stats_Behavioural extends \NDB_Form
 
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
-        $user = \User::singleton();
+        $user = \NDB_Factory::singleton()->user();
 
         $query = "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -76,7 +76,7 @@ class Stats_Behavioural extends \NDB_Form
                         AND Study_site = 'Y'";
 
         if (!$user->hasPermission('access_all_profiles')) {
-            $site_arr = implode(",", $user->getCenterIDs());
+            $sitesString = implode(",", $user->getCenterIDs());
             $query   .= " AND CenterID IN (" . $site_arr . ")";
         }
 

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -63,7 +63,8 @@ class Stats_Behavioural extends \NDB_Form
     {
         parent::setup();
 
-        $DB   =& \Database::singleton();
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
         $user = \User::singleton();
 
         $query = "SELECT CONCAT('C', CenterID) as ID,

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -63,18 +63,24 @@ class Stats_Behavioural extends \NDB_Form
     {
         parent::setup();
 
-        $DB =& \Database::singleton();
+        $DB    =& \Database::singleton();
+        $user  = \User::singleton();
 
-        $centers = $DB->pselect(
+	$query =
             "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
                     IFNULL(PSCArea,Name) as LongName,
                     Name as ShortName
               FROM psc
               WHERE CenterID <> '1'
-                    AND Study_site = 'Y'",
-            array()
-        );
+                    AND Study_site = 'Y'";
+
+	if (!$user->hasPermission('access_all_profiles')) {
+            $site_arr = implode(",", $user->getCenterIDs());
+            $query   .= " AND CenterID IN (" . $site_arr . ")";
+        }
+
+	$centers = $DB->pselect($query, array());
 
         $this->tpl_data['Centers'] = $centers;
 

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -65,7 +65,7 @@ class Stats_Behavioural extends \NDB_Form
 
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
-        $user = \NDB_Factory::singleton()->user();
+        $user = $factory->user();
 
         $query = "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -67,20 +67,25 @@ class Stats_Behavioural extends \NDB_Form
         $DB      = $factory->database();
         $user    = $factory->user();
 
-        $query = "SELECT CONCAT('C', CenterID) as ID,
+        //SITES
+        if ($user->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList();
+        } else {
+            $list_of_sites = $user->getStudySites();
+        }
+        $sitesString = implode(",", array_keys($list_of_sites));
+
+        $centers = $DB->pselect(
+            "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
                     IFNULL(PSCArea,Name) as LongName,
                     Name as ShortName
-                  FROM psc
-                  WHERE CenterID <> '1'
-                        AND Study_site = 'Y'";
-
-        if (!$user->hasPermission('access_all_profiles')) {
-            $sitesString = implode(",", $user->getCenterIDs());
-            $query      .= " AND CenterID IN (" . $sitesString . ")";
-        }
-
-        $centers = $DB->pselect($query, array());
+              FROM psc
+              WHERE CenterID <> '1'
+                    AND Study_site = 'Y'
+	            AND CenterID IN (" . $sitesString . ")",
+            array()
+        );
 
         $this->tpl_data['Centers'] = $centers;
 
@@ -148,6 +153,7 @@ class Stats_Behavioural extends \NDB_Form
                     AND s.Current_stage <> 'Recycling Bin'
                     AND f.CommentID NOT LIKE 'DDE%'
                     AND s.CenterID <> '1'
+	            AND s.CenterID IN (" . $sitesString . ")
                     $suproject_query
                     $Param_Project
                 GROUP by s.ID, s.CenterID, VLabel, f.Data_Entry",
@@ -205,20 +211,21 @@ class Stats_Behavioural extends \NDB_Form
         }
         // DDE STATS
         $result = $DB->pselect(
-            "SELECT s.CenterID, 
-                f.Data_Entry as Data_Entry, 
-                s.visit_label as VLabel,
-                COUNT(s.CandID) as val
+            "SELECT s.CenterID,
+                    f.Data_Entry as Data_Entry,
+                    s.visit_label as VLabel,
+                    COUNT(s.CandID) as val
                 FROM session as s
-                    JOIN candidate as c ON (s.CandID=c.CandID)
-                    JOIN flag as f ON (f.SessionID=s.ID)
-                WHERE s.Active='Y' 
-                AND s.Current_stage <> 'Recycling Bin'
-                AND f.CommentID LIKE 'DDE%' 
-                AND c.Active='Y'
-                AND s.CenterID <> '1'
-                $suproject_query
-                $Param_Project
+                    JOIN candidate as c ON(s.CandID=c.CandID)
+                    JOIN flag as f ON(f.SessionID=s.ID)
+                WHERE s.Active = 'Y'
+                    AND s.Current_stage <> 'Recycling Bin'
+                    AND f.CommentID LIKE 'DDE%'
+                    AND c.Active = 'Y'
+                    AND s.CenterID <> '1'
+                    AND s.CenterID IN(" . $sitesString . ")
+                    $suproject_query
+                    $Param_Project
                 GROUP BY s.CenterID, VLabel, f.Data_Entry",
             $this->params ?? array()
         );

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -63,7 +63,7 @@ class Stats_Behavioural extends \NDB_Form
     {
         parent::setup();
 
-        $factory = NDB_Factory::singleton();
+        $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
         $user = \NDB_Factory::singleton()->user();
 


### PR DESCRIPTION
#### Description of the issue
A user with role Data Entry was able to see statistics from sites it does not belong/have access

For example if there are two users and two sites:

user Site 1 is associate only to Site_1.
user Site 2 is associate only to Site_2.

(Both of them have the role Data Entry and nothing more in the permissions)
When going to MainMenu->Reports->Statistics->Behavioural Statistics

The user of Site 1 is able to see the statistics for Site 2 and vice versa

![oneSiteAffilationMultipleSiteReport](https://user-images.githubusercontent.com/37309344/65798278-40ed6600-e13f-11e9-877d-a963c6b7befb.png)

#### Testing instructions
Now each user should be able to see only the statistics for the sites it belong/have access

![oneSiteAffilationOneSiteReport](https://user-images.githubusercontent.com/37309344/65798376-742ff500-e13f-11e9-91af-b8758f8cfa7c.png)

#### Note:
This is a temp fix based on 21.0-released. A major refractory still pending.