### PR TITLE
[Tools] Add script to delete and refresh raisinbread data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,4 @@ unittests: phpdev
 check: checkstatic unittests
 
 testdata:
-	cd tools/ && php raisinbread_refresh.php
-	cd ..
+	php tools/raisinbread_refresh.php

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean dev all check checkstatic unittests test phpdev javascript
+.PHONY: clean dev all check checkstatic unittests test phpdev javascript raisinbread
 
 all: VERSION javascript
 	composer install --no-dev
@@ -32,3 +32,7 @@ unittests: phpdev
 
 # Perform all tests that don't require an install.
 check: checkstatic unittests
+
+raisinbread:
+	cd tools/ && php raisinbread_refresh.php
+	cd ..

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean dev all check checkstatic unittests test phpdev javascript raisinbread
+.PHONY: clean dev all check checkstatic unittests test phpdev javascript testdata
 
 all: VERSION javascript
 	composer install --no-dev

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ unittests: phpdev
 # Perform all tests that don't require an install.
 check: checkstatic unittests
 
-raisinbread:
+testdata:
 	cd tools/ && php raisinbread_refresh.php
 	cd ..

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -15,6 +15,7 @@ declare -a tools_list=(
     'assign_missing_instruments.php'
     'detect_duplicated_commentids.php'
     'generic_includes.php'
+    'raisinbread_refresh.php'
     'setconfig.php'
 )
 vendor/bin/phpcs --standard=test/LorisCS.xml --extensions=php,inc php/ htdocs/ modules/ "${tools_list[@]/#/tools/}" || exit $?;

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -3,23 +3,30 @@
 /**
  * This script is intended for developers working with test data. It DROPs all
  * LORIS core tables as well as "Raisinbread" test instrument tables.
- * For this reason, it should obviously not be run on any server wil live data.
+ * For this reason, it should obviously not be run on any server with live data.
  *
- * After dropping the tables, it will source the Raisinbread test data using
- * the commands found in raisinbread/README.md.
+ * The `sandbox` flag in config.xml is checked for this very reason. The script
+ * will abort if it is not set to 1.
  *
- * The script also restores the url and host config settings to their pre-drop
- * values. This prevents an issue where a developer will need to manually
- * change these values in a MySQL shell when they are not hosting a LORIS
- * on localhost.
+ * After dropping the tables, the script will source the Raisinbread test data 
+ * using the commands found in raisinbread/README.md.
+ *
+ * The script also restores the url, base, and host config settings to their 
+ * pre-drop values. This prevents an issue where a developer will need to 
+ * manually change these values in a MySQL shell when they are not hosting a 
+ * LORIS on localhost.
  *
  * Finally, the script runs tools/resetpassword.php so that the default admin
  * password with the Raisinbread data set is not used.
  *
  * In order to prevent accidental data loss, the script prompts the user to
- * manually type the exact name of the database which will be affected. It
- * also requires the user to manually enter their database password before
- * dropping and importing.
+ * manually type the exact name of the database which will be affected.
+ *
+ * In normal cases, the database connection will be established via the 
+ * credentials in the config file. However, if the database tables have already
+ * been deleted then this will not work. In this case it is still possible to
+ * import Raisinbread data if the user has properly set up a MySQL configuration
+ * file and provides the name of their LORIS database.
  *
  * PHP Version 7
  *

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -61,7 +61,7 @@ try {
     if (! $config->getSetting('dev')['sandbox']) {
         throw new \LorisException(
             "Config file indicates that this is not a sandbox. Aborting to " .
-            "prevent accidental data loss."
+            "prevent accidental data loss." . PHP_EOL
         );
     }
     $dbname = $dbInfo['database'];
@@ -79,7 +79,7 @@ try {
     echo 'Could not connect to the database in the Config file.' .
         'It\'s possible that the LORIS tables have already been dropped.' .
         PHP_EOL;
-    echo 'Continue attempting to install Raisinbread database? (yN)' . PHP_EOL;
+    echo 'Continue attempting to install Raisinbread database? (y/N)' . PHP_EOL;
     $input = trim(fgets(STDIN));
 
     if (mb_strtolower($input) !== 'y') {
@@ -108,7 +108,7 @@ $mysqlCommand = <<<CMD
 mysql -A $dbname
 CMD;
 
-// Test whether a connection to MySQL is possible via a config file.
+// Test whether a connection to MySQL is possible via a MySQL config file.
 // If not, read DB information from the config file. This method is not as 
 // preferable because it generates MySQL warnings due to the password being
 // supplied via a command-line argument.
@@ -256,8 +256,8 @@ function restoreConfigSetting(string $name, string $value): void
             IN (SELECT cs.ID FROM ConfigSettings cs WHERE cs.Name = '$name')"
         );
     } catch (\DatabaseException $e) {
-        echo "Couldn't config setting. " .
-            "This may need to be manually if your LORIS is not hosted at " .
+        echo "Couldn't restore config setting $name." .
+            "This may need to be set manually if your LORIS is not hosted at " .
             "localhost." .
             PHP_EOL;
     }

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -269,7 +269,7 @@ function dropRemainingTables(array $tables) {
     foreach ($tables as $table) {
         $commands[] = "DROP TABLE IF EXISTS $table;";
     }
-    $commands = ["SET FOREIGN_KEY_CHECKS = 1;"];
+    $commands[] = "SET FOREIGN_KEY_CHECKS = 1;";
     $script = <<<SCRIPT
 $mysqlCommand -e '%s'
 SCRIPT;

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -66,8 +66,10 @@ try {
     }
     $dbname = $dbInfo['database'];
     $host = $dbInfo['host'];
-    $username = $dbInfo['username'];
-    $password = $dbInfo['password'];
+    // The "quat" user and password should be configured to a user with DROP
+    // and CREATE permissions for the database.
+    $username = $dbInfo['quatUser'];
+    $password = $dbInfo['quatPassword'];
 
     $urlConfigSetting = $config->getSetting('url');
     $baseConfigSetting = $config->getSetting('base');

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -120,7 +120,7 @@ CMD;
 }
 
 // Drop tables
-echo PHP_EOL .'Dropping LORIS tables....' . PHP_EOL;
+echo PHP_EOL .'[*] Dropping LORIS tables....' . PHP_EOL;
 dropTables();
 
 // Print the names of remaining tables, if any. Some tables may remain if they
@@ -181,6 +181,7 @@ if (isset($hostConfigSetting)) {
 
 // Trigger a password reset because the password for `admin` in the Raisinbread
 // database is public.
+echo "[*] Changing the admin password..." . PHP_EOL;
 echo 'Please choose a new password for the admin user:' . PHP_EOL;
 runCommand('php resetpassword.php admin');
 
@@ -243,6 +244,7 @@ function runCommand(string $command): void
  */
 function restoreConfigSetting(string $name, string $value): void 
 {
+    echo "[*] Restoring config settings..." . PHP_EOL;
     echo "Restoring config setting `$name` to value `$value`"
         . PHP_EOL . PHP_EOL;
     try {

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -78,7 +78,7 @@ try {
     echo 'Continue attempting to install Raisinbread database? (yN)' . PHP_EOL;
     $input = trim(fgets(STDIN));
 
-    if (strtolower($input) !== 'y') {
+    if (mb_strtolower($input) !== 'y') {
         die;
     }
     echo PHP_EOL . 'Please enter the name of your database:' . PHP_EOL;

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -47,7 +47,7 @@ INFO;
 echo $info;
 
 $cwd = getcwd();
-if (substr_compare($cwd, 'tools', strlen($cwd) - strlen('tools')) !== 0) {
+if (substr_compare($cwd, 'tools', mb_strlen($cwd) - mb_strlen('tools')) !== 0) {
     die('Please run this script from the tools/ directory.' . PHP_EOL);
 }
 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -72,7 +72,7 @@ echo PHP_EOL .'Dropping LORIS tables....' . PHP_EOL;
 echo 'You will be prompted for your database password.' . PHP_EOL;
 $dropCommand = <<<DROP
 cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql \
-    SQL/9999-99-99-drop_tables.sql | mysql -A $dbname -u $username -h $host -p
+    SQL/9999-99-99-drop_tables.sql | mysql -A "$dbname" -u "$username" -h "$host" -p
 DROP;
 exec($dropCommand, $output, $exitStatus);
 if ($exitStatus) {
@@ -97,7 +97,7 @@ cat SQL/0000-00-00-schema.sql \
     raisinbread/instruments/instrument_sql/medical_history.sql \
     raisinbread/instruments/instrument_sql/mri_parameter_form.sql \
     raisinbread/instruments/instrument_sql/radiology_review.sql \
-    raisinbread/RB_files/*.sql | mysql -A $dbname -u $username -h $host -p
+    raisinbread/RB_files/*.sql | mysql -A "$dbname" -u "$username" -h "$host" -p
 IMPORT;
 exec($importCommand, $output, $exitStatus);
 if ($exitStatus) {

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -47,6 +47,9 @@ echo $info;
 
 echo "\e[0;31m*** Executing this script will result in the LOSS OF DATA! ***\e[0m\n";
 
+printHeader(
+    'Testing connection to database. No data will be affected at this point.'
+);
 try {
     // Require generic libraries. In some cases, this can fail if this script
     // has already dropped tables as the generic_includes.php requires a
@@ -56,7 +59,6 @@ try {
     $urlConfigSetting  = $config->getSetting('url');
     $baseConfigSetting = $config->getSetting('base');
     $hostConfigSetting = $config->getSetting('host');
-
 } catch (\DatabaseException $e) {
     printWarning(
         "Could not connect to the database in the Config file. " .
@@ -68,8 +70,6 @@ try {
     if (mb_strtolower($input) !== 'y') {
         die;
     }
-    echo PHP_EOL . 'Please enter the name of your database:' . PHP_EOL;
-    $dbname = trim(fgets(STDIN));
 }
 
 // Get database information from project's configuration file.
@@ -99,7 +99,6 @@ if ($input !== $dbname) {
     die(printWarning('Input did not match database name. Exiting.'));
 }
 
-printHeader('Testing connection to database.');
 $mysqlCommand = <<<CMD
 mysql -A $dbname
 CMD;

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -296,10 +296,8 @@ function restoreConfigSetting(string $name, string $value): void
             IN (SELECT cs.ID FROM ConfigSettings cs WHERE cs.Name = '$name')"
         );
     } catch (\DatabaseException $e) {
-        echo "Couldn't restore config setting $name." .
-            "This may need to be set manually if your LORIS is not hosted at " .
-            "localhost." .
-            PHP_EOL;
+        echo "Couldn't restore setting $name. This may need to be set manually."
+            . PHP_EOL;
     }
 }
 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -99,9 +99,7 @@ if ($input !== $dbname) {
     die(printWarning('Input did not match database name. Exiting.'));
 }
 
-$mysqlCommand = <<<CMD
-mysql -A $dbname
-CMD;
+$mysqlCommand = sprintf("mysql -A %s", escapeshellarg($dbname));
 
 echo 'Checking connection via MySQL configuration file...' . PHP_EOL;
 // Test whether a connection to MySQL is possible via a MySQL config file.
@@ -129,9 +127,13 @@ if ($status != 0) {
     }
 
     // Try connecting by supplying parameters on command line.
-    $mysqlCommand = <<<CMD
-mysql -A "$dbname" -u "$username" -h "$host" -p$password
-CMD;
+    $mysqlCommand = sprintf(
+        "mysql -A %s -u %s -h %s -p%s",
+        escapeshellarg($dbname),
+        escapeshellarg($username),
+        escapeshellarg($host),
+        escapeshellarg($password)
+    );
     exec($mysqlCommand . ' -e "show tables;" 2>&1 1>/dev/null', $output, $status);
     print_r($output);
     if ($status != 0) {

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -38,13 +38,15 @@
  */
 
 $info = <<<INFO
-This script is used by LORIS developers to empty their databases and replace
+This script is used by LORIS developers to DELETE DATA and replace
 them with new test data.
 
 
 INFO;
 
 echo $info;
+
+echo "\e[0;31;40m*** WARNING this will result in the LOSS OF DATA ***\e[0m\n";
 
 $cwd = getcwd();
 if (substr_compare($cwd, 'tools', mb_strlen($cwd) - mb_strlen('tools')) !== 0) {
@@ -91,7 +93,7 @@ try {
 
 
 echo <<<CONFIRMATION
-Please re-type the database name `$dbname` to confirm you wish to drop tables
+Please type the database name `$dbname` to confirm you wish to drop tables
 and import test data: 
 CONFIRMATION;
 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -46,7 +46,7 @@ INFO;
 
 echo $info;
 
-echo "\e[0;31;40m*** WARNING this will result in the LOSS OF DATA ***\e[0m\n";
+echo "\e[0;31m*** Executing this script will result in the LOSS OF DATA! ***\e[0m\n";
 
 $cwd = getcwd();
 if (substr_compare($cwd, 'tools', mb_strlen($cwd) - mb_strlen('tools')) !== 0) {
@@ -123,6 +123,20 @@ CMD;
 echo PHP_EOL .'Dropping LORIS tables....' . PHP_EOL;
 dropTables();
 
+// Print the names of remaining tables, if any. Some tables may remain if they
+// have been created at a different time during development and are not
+// deleted by the above script. Issues with e.g. foreign keys can be a source
+// of error and so it is useful to know what tables remain.
+exec(
+    "$mysqlCommand -e 'SHOW TABLES;'",
+    $tables,
+    $status
+);
+array_shift($tables); // remove the column name
+if (count($tables) > 0) {
+    echo "\e[33mWARNING: Untracked tables still exist in the database:\e[0m\n";
+    array_walk($tables, 'printBulletPoint');
+}
 
 // Source LORIS core tabes
 echo <<<INFO
@@ -236,4 +250,15 @@ function restoreConfigSetting(string $name, string $value): void
             "localhost." .
             PHP_EOL;
     }
+}
+
+/**
+ * Print a formatted and indented bullet point.
+ *
+ * @param string $line
+ *
+ * return @void
+ */
+function printBulletPoint(string $line) {
+    echo "\t* $line\n";
 }

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -54,7 +54,7 @@ try {
     // Require generic libraries. In some cases, this can fail if this script
     // has already dropped tables as the generic_includes.php requires a
     // database connection.
-    require_once 'generic_includes.php';
+    include_once 'generic_includes.php';
 
     $urlConfigSetting  = $config->getSetting('url');
     $baseConfigSetting = $config->getSetting('base');
@@ -73,10 +73,10 @@ try {
 }
 
 // Get database information from project's configuration file.
-$config = $config ?? \NDB_Factory::singleton()->config();
-$dbInfo = $config->getSettingFromXML('database');
-$dbname = $dbInfo['database'];
-$host   = $dbInfo['host'];
+$config   = $config ?? \NDB_Factory::singleton()->config();
+$dbInfo   = $config->getSettingFromXML('database');
+$dbname   = $dbInfo['database'];
+$host     = $dbInfo['host'];
 $username = $dbInfo['adminUser'];
 $password = $dbInfo['adminPassword'];
 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -67,7 +67,7 @@ try {
     $hostConfigSetting = $config->getSetting('host');
 
     echo <<<CONFIRMATION
-    Please type the database name `$dbname` to confirm you wish to drop tables
+    Please type the name of your database to confirm you wish to drop tables
     and import test data: 
 CONFIRMATION;
 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -172,12 +172,6 @@ function runPatch(string $file): void
     );
 }
 
-function sqlFileFilter(string $file): bool
-{
-    return pathinfo($file)['extension'] === 'sql';
-}
-
-
 /**
  * A wrapper around `exec()` built-in function with basic error reporting.
  *

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -53,28 +53,9 @@ try {
     // database connection.
     require_once 'generic_includes.php';
 
-    if (! $config->getSetting('dev')['sandbox']) {
-        fwrite(
-            STDERR,
-            "Config file indicates that this is not a sandbox. Aborting to " .
-            "prevent accidental data loss." . PHP_EOL
-        );
-        exit(1);
-    }
-
     $urlConfigSetting  = $config->getSetting('url');
     $baseConfigSetting = $config->getSetting('base');
     $hostConfigSetting = $config->getSetting('host');
-
-    echo <<<CONFIRMATION
-    Please type the name of your database to confirm you wish to drop tables
-    and import test data: 
-CONFIRMATION;
-
-    $input = trim(fgets(STDIN));
-    if ($input !== $dbname) {
-        die(printWarning('Input did not match database name. Exiting.'));
-    }
 
 } catch (\DatabaseException $e) {
     printWarning(
@@ -99,6 +80,24 @@ $host   = $dbInfo['host'];
 $username = $dbInfo['adminUser'];
 $password = $dbInfo['adminPassword'];
 
+if (! $config->getSetting('dev')['sandbox']) {
+    fwrite(
+        STDERR,
+        "Config file indicates that this is not a sandbox. Aborting to " .
+        "prevent accidental data loss." . PHP_EOL
+    );
+    exit(1);
+}
+
+echo <<<CONFIRMATION
+Please type the name of your database `$dbname` to confirm you wish to drop
+tables and import test data: 
+CONFIRMATION;
+
+$input = trim(fgets(STDIN));
+if ($input !== $dbname) {
+    die(printWarning('Input did not match database name. Exiting.'));
+}
 
 printHeader('Testing connection to database.');
 $mysqlCommand = <<<CMD

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -267,6 +267,7 @@ function dropRemainingTables(array $tables) {
     foreach ($tables as $table) {
         $commands[] = "DROP TABLE IF EXISTS $table;";
     }
+    $commands = ["SET FOREIGN_KEY_CHECKS = 1;"];
     $script = <<<SCRIPT
 $mysqlCommand -e '%s'
 SCRIPT;

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+/**
+ * This script is intended for developers working with test data. It DROPs all
+ * LORIS core tables as well as "Raisinbread" test instrument tables.
+ * For this reason, it should obviously not be run on any server wil live data.
+ *
+ * After dropping the tables, it will source the Raisinbread test data using
+ * the commands found in raisinbread/README.md.
+ *
+ * The script also restores the url and host config settings to their pre-drop
+ * values. This prevents an issue where a developer will need to manually
+ * change these values in a MySQL shell when they are not hosting a LORIS
+ * on localhost.
+ *
+ * Finally, the script runs tools/resetpassword.php so that the default admin
+ * password with the Raisinbread data set is not used.
+ *
+ * In order to prevent accidental data loss, the script prompts the user to
+ * manually type the exact name of the database which will be affected. It
+ * also requires the user to manually enter their database password before
+ * dropping and importing.
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   John Saigle <john.saigle@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+
+$info = <<<INFO
+This script is used by LORIS developers to empty their databases and replace
+them with new test data.
+DO NOT RUN THIS SCRIPT ON PRODUCTION.
+
+
+INFO;
+
+echo $info;
+
+try {
+    require_once 'generic_includes.php';
+
+    $dbInfo = $config->getSettingFromXML('database');
+    $dbname = $dbInfo['database'];
+    $host = $dbInfo['host'];
+    $username = $dbInfo['username'];
+
+    $urlConfigSetting = $config->getSetting('url');
+    $hostConfigSetting = $config->getSetting('host');
+
+    echo 'Please enter the name of your database to continue.' . PHP_EOL;
+} catch (\DatabaseException $e) {
+    echo 'Could not connect to the database in the Config file.' .
+        'It\'s possible that the LORIS tables have been dropped already.' .
+        PHP_EOL;
+}
+
+$input = trim(fgets(STDIN));
+
+if ($input !== $dbname) {
+    die(
+        "Input did not match the name of the database in the config.xml file "
+        . "`$dbname`. Exiting as a precaution to prevent data loss."
+        . PHP_EOL
+    );
+}
+
+// Drop tables
+echo PHP_EOL .'Dropping LORIS tables....' . PHP_EOL;
+echo 'You will be prompted for your database password.' . PHP_EOL;
+$dropCommand = <<<DROP
+cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql \
+    SQL/9999-99-99-drop_tables.sql | mysql -A $dbname -u $username -h $host -p
+DROP;
+exec($dropCommand, $output, $exitStatus);
+if ($exitStatus) {
+    echo 'An error occurred when trying to drop tables' . PHP_EOL;
+    print_r($output);
+    die;
+}
+
+// Source Raisinbread tables
+echo PHP_EOL .'Importing Raisinbread tables into database.... ' .
+    'This may take some time.' . PHP_EOL;
+echo 'You will be prompted for your database password.' . PHP_EOL;
+$importCommand = <<<IMPORT
+cat SQL/0000-00-00-schema.sql \
+    SQL/0000-00-01-Permission.sql \
+    SQL/0000-00-02-Menus.sql \
+    SQL/0000-00-03-ConfigTables.sql \
+    SQL/0000-00-04-Help.sql \
+    SQL/0000-00-05-ElectrophysiologyTables.sql \
+    raisinbread/instruments/instrument_sql/aosi.sql \
+    raisinbread/instruments/instrument_sql/bmi.sql \
+    raisinbread/instruments/instrument_sql/medical_history.sql \
+    raisinbread/instruments/instrument_sql/mri_parameter_form.sql \
+    raisinbread/instruments/instrument_sql/radiology_review.sql \
+    raisinbread/RB_files/*.sql | mysql -A $dbname -u $username -h $host -p
+IMPORT;
+exec($importCommand, $output, $exitStatus);
+if ($exitStatus) {
+    echo 'An error occurred when trying to import tables' . PHP_EOL;
+    print_r($output);
+    die;
+}
+
+
+if (isset($urlConfigSetting, $hostConfigSetting)) {
+    echo "Restoring URL to `$urlConfigSetting` and host to $hostConfigSetting"
+        . PHP_EOL . PHP_EOL;
+    try {
+        $DB->run(
+            "UPDATE Config c 
+            SET c.Value='$urlConfigSetting'
+            WHERE c.ConfigID
+            IN (SELECT cs.ID FROM ConfigSettings cs WHERE cs.Name = 'url')"
+        );
+        $DB->run(
+            "UPDATE Config c 
+            SET c.Value='$hostConfigSetting'
+            WHERE c.ConfigID
+            IN (SELECT cs.ID FROM ConfigSettings cs WHERE cs.Name = 'host')"
+        );
+    } catch (\DatabaseException $e) {
+        echo "Couldn't restore url and host config settings. " .
+            "This may need to be manually if your LORIS is not hosted at " .
+            "localhost." .
+            PHP_EOL;
+    }
+}
+
+echo 'Please choose a new password for the admin user:' . PHP_EOL;
+exec('php tools/resetpassword.php admin');
+    
+
+


### PR DESCRIPTION
## Brief summary of changes

This script will dump your raisinbread database and then re-import the data. It automates the steps in [raisinbread/README.md](https://github.com/aces/Loris/tree/minor/raisinbread).

* It will also restore your `url`, `base`, `host` settings so that LORIS won't break if you're not hosting it on `localhost`.

* It will ask you to change the front-end `admin` password so you can login to LORIS without using the public Raisinbread password.

* I've added `make testdata` as a quick way to refresh your database.

* This can also be used upon switching between branches so that you never get an issue where your database is broken because of sync issues.

~~As a precaution I decided to force the user of this script to manually type in the database name of the database they want to effectively delete. This should help prevent data loss. Feel free to suggest a different security mechanism.~~

UPDATE I incorporated Rida's suggestion to force the script to exit if the `sandbox` flag is not set in config.xml.


#### Testing instructions (if applicable)

1. Checkout the branch.
2. run `make testdata` OR go to `tools/` and run `php raisinbread_refresh.php`
3. Verify that you have fresh Raisinbread data and that your front-end still works.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5255.
