### PR TITLE
Add opt-in option to auto run "make checkstatic" locally upon git push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,2 @@
+#!/bin/bash
+make checkstatic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ issues and/or Redmine tickets (if applicable).
 * Before sending any pull request, make sure you run our static analysis tools 
 using the command `make checkstatic` and fix any resulting errors. Otherwise,
   your pull request will fail our automatic testing and we will not be able
-  to merge it. If you run the command `make githooks`, git will automatically
+  to merge it. If you run the command `git config core.hooksPath .githooks`, git will automatically
   run `make checkstatic` when you do a git push.
 * Try and make all changes backwards-compatible with existing installations.  
 * If you must change something in a non-backwards-compatible way - or if it 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,9 @@ issues and/or Redmine tickets (if applicable).
 * Add your new automated tests to TravisCI in the `.travis.yml`.
 * Before sending any pull request, make sure you run our static analysis tools 
 using the command `make checkstatic` and fix any resulting errors. Otherwise,
-      your pull request will fail our automatic testing and we will not be able
-      to merge it.
+  your pull request will fail our automatic testing and we will not be able
+  to merge it. If you run the command `make githooks`, git will automatically
+  run `make checkstatic` when you do a git push.
 * Try and make all changes backwards-compatible with existing installations.  
 * If you must change something in a non-backwards-compatible way - or if it 
 would affect the data or custom code of a study - document this in your pull 

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,3 @@ unittests: phpdev
 
 # Perform all tests that don't require an install.
 check: checkstatic unittests
-
-# Configures githooks for this repository to be .githooks instead of the default
-# .git/hooks/ (which is ignored).
-githooks:
-	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ unittests: phpdev
 # Perform all tests that don't require an install.
 check: checkstatic unittests
 
-# Configure githooks for this repository to be .githooks instead of the default
+# Configures githooks for this repository to be .githooks instead of the default
 # .git/hooks/ (which is ignored).
 githooks:
 	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,8 @@ unittests: phpdev
 
 # Perform all tests that don't require an install.
 check: checkstatic unittests
+
+# Configure githooks for this repository to be .githooks instead of the default
+# .git/hooks/ (which is ignored).
+githooks:
+	git config core.hooksPath .githooks


### PR DESCRIPTION
## Brief summary of changes

This PR adds a git hook that will run `make checkstatic` for you when you do `git push`. It will stop the push from going through if `make checkstatic` fails. The idea is to encourage developers to fix static analysis errors locally before pushing to GitHub. This should help accelerate code review and prevent clogging up Travis. 

This is opt-in; you can enable it by running `make githooks` just once.

## Testing

1. Checkout this branch and run `make githooks`
2. Create a new branch and try to do a `git push`. `make checkstatic` should trigger.

## Related

This is a remake of #5246 that using plain git hooks instead of requiring a 3rd-party library.