### PR TITLE
Add PHP 7.4 (snapshot build) to TravisCI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 install:
 - sudo apt-get update
 - sudo apt-get install -y libapparmor1
-- sudo apt install -y php-ast
+- pecl install -f ast-1.0.1
 - sudo apt-get install npm
 - make dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   include:
   - php: "7.2"
   - php: "7.3"
+  - php: "7.4snapshot"
 
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
   - php: "7.2"
   - php: "7.3"
   - php: "7.4snapshot"
+  allow_failures:
+  - php: "7.4snapshot"
 
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 install:
 - sudo apt-get update
 - sudo apt-get install -y libapparmor1
-- pecl install -f ast-0.1.6
+- sudo apt install -y php-ast
 - sudo apt-get install npm
 - make dev
 


### PR DESCRIPTION
## Brief summary of changes

PHP 7.4 will be released in 2 months, at the end of November. It would be nice to move LORIS toward this as a minimum version requirement for LORIS 22. #5063 

At the same time PHP 7.2 will stop receiving active support. https://www.php.net/supported-versions.php

Until its release, Travis offers a "snapshot" build which should be equivalent to the rc1 or rc2 of 7.4. This can be updated after the official release, but for now this gives us a chance to see how LORIS is doing.
