### PR TITLE
[Core] Fix static PSCID generation

### DIFF
--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -37,7 +37,7 @@ class SiteIDGenerator extends IdentifierGenerator
      *
      * @return void
      */
-    public function __construct(?string $prefix = null)
+    public function __construct(?string $siteAbbrevPrefix = null)
     {
         // Read config settings from project/config.xml to retrieve the
         // alphabet, length, and generation method (sequential or random) used
@@ -55,7 +55,8 @@ class SiteIDGenerator extends IdentifierGenerator
                 strval($this->alphabet[count($this->alphabet) - 1]),
                 $this->length
             );
-        $this->prefix   = $prefix ?? $this->_getIDSetting('prefix');
+        $this->siteAbbrev = $siteAbbrevPrefix;
+        $this->prefix   = $this->_getIDSetting('prefix');
         $this->validate();
     }
 
@@ -210,9 +211,8 @@ class SiteIDGenerator extends IdentifierGenerator
                 }
             } else {
                 // The other option, 'siteAbbrev', indicates that the calling
-                // code should prepend a Site Alias to the ID. Since the config
-                // file does not know what this will be, return null.
-                return null;
+                // code should prepend a Site Alias to the ID.
+                return $this->siteAbbrev;
             }
         }
         // Min, max, and length values should be returned as integers or as

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -32,7 +32,7 @@ class SiteIDGenerator extends IdentifierGenerator
      * Creates a new instance of a SiteIDGenerator to create either PSCIDs or
      * ExternalIDs. Relevant properties are extracted from the config.xml file.
      *
-     * @param ?string $prefix To be appended to the ID value. Usually an
+     * @param ?string $siteAbbrevPrefix To be appended to the ID value. Usually an
      *                       abbreviation for the name of a site.
      *
      * @return void
@@ -48,15 +48,15 @@ class SiteIDGenerator extends IdentifierGenerator
         // Initialize minimum and maximum allowed values for IDs. Set the values
         // to the lowest/highest character in $alphabet repeated $length times
         // if the min or max is not configured in project/config.xml
-        $this->minValue = $this->_getIDSetting('min') ??
+        $this->minValue   = $this->_getIDSetting('min') ??
             str_repeat(strval($this->alphabet[0]), $this->length);
-        $this->maxValue = $this->_getIDSetting('max') ??
+        $this->maxValue   = $this->_getIDSetting('max') ??
             str_repeat(
                 strval($this->alphabet[count($this->alphabet) - 1]),
                 $this->length
             );
         $this->siteAbbrev = $siteAbbrevPrefix;
-        $this->prefix   = $this->_getIDSetting('prefix');
+        $this->prefix     = $this->_getIDSetting('prefix');
         $this->validate();
     }
 


### PR DESCRIPTION
## Brief summary of changes
The `static` PSCID generation was not working anymore because the `$prefix` was never null since the site abbreviation always exist. the logic of choosing `siteAbbrev` vs `static` was moved in this PR to the if/else statement of the `prefix case`

#### Testing instructions (if applicable)

1. modify your config.xml to use a static option.
2. check that the static string gets prepended
3. change the config.xml to use the siteAbbrev
4. check that the correct site Alias gets prepended

#### Links to related tickets (GitHub, Redmine, ...)

* PR changing the logic https://github.com/aces/Loris/pull/4241
* Resolves https://github.com/aces/Loris/issues/5268
