### PR TITLE
Add project to PSCID generation 

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -5,6 +5,7 @@
 CREATE TABLE `Project` (
     `ProjectID` INT(10) unsigned NOT NULL AUTO_INCREMENT,
     `Name` VARCHAR(255) NULL,
+    `Alias` char(4) NOT NULL,
     `recruitmentTarget` INT(6) Default NULL,
     PRIMARY KEY (`ProjectID`)
 ) ENGINE = InnoDB  DEFAULT CHARSET=utf8;

--- a/SQL/New_patches/2019-10-05-Add_alias_to_projects.sql
+++ b/SQL/New_patches/2019-10-05-Add_alias_to_projects.sql
@@ -1,1 +1,3 @@
-ALTER TABLE `Project` ADD COLUMN `Alias` char(4) NOT NULL AFTER `Name`;
+ALTER TABLE `Project` ADD COLUMN `Alias` char(4) DEFAULT NULL AFTER `Name`;
+UPDATE Project SET Alias=UPPER(LEFT(Name,4)) WHERE Alias IS NULL;
+ALTER TABLE `Project` CHANGE COLUMN `Alias` `Alias` char(4) NOT NULL;

--- a/SQL/New_patches/2019-10-05-Add_alias_to_projects.sql
+++ b/SQL/New_patches/2019-10-05-Add_alias_to_projects.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Project` ADD COLUMN `Alias` char(4) NOT NULL AFTER `Name`;

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -75,6 +75,8 @@ class New_Profile extends \NDB_Form
         if (count($centerIDs) <= 1 && !isset($values['site'])) {
             $values['site'] = $centerIDs[0];
         }
+        //TODO: add similar logic to projects when user-projects association is
+        //incorporated.
 
         /* Create the candidate and retrieve its ID.
          * Use form values when present, otherwise default to null.
@@ -85,7 +87,7 @@ class New_Profile extends \NDB_Form
             $values['edcDate'] ?? null,
             $values['sex'],
             $values['pscid'] ?? null,
-            isset($values['project']) ? intval($values['project']) : null
+            intval($values['project'])
         );
 
         /* Update front-end data. Use passed PSCID when present, otherwise

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -289,11 +289,14 @@ class New_Profile extends \NDB_Form
                 $site =& \Site::singleton($values['site']);
             }
 
+            $project = \Project::getProjectFromID(intval($values['project']));
+
             if (empty($values['pscid'])) {
                 $errors['pscid'] = 'PSCID must be specified';
             } elseif (!\Candidate::validatePSCID(
                 $values['pscid'],
-                $site->getSiteAlias()
+                $site->getSiteAlias(),
+                $project->getAlias()
             )
             ) {
                 $errors['pscid'] = 'PSCID does not match the required structure';

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -272,7 +272,10 @@ class Candidate
         );
 
         if ($config->getSetting('useExternalID') === 'true') {
-            $externalID = (new \ExternalIDGenerator())->generate();
+            $externalID = (new \ExternalIDGenerator(
+                $site->getSiteAlias(),
+                $project->getAlias()
+            ))->generate();
             $setArray['ExternalID'] = $externalID;
         }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -210,6 +210,8 @@ class Candidate
 
         $site = \Site::singleton($centerID);
 
+        $project = \Project::getProjectFromID($registrationProjectID);
+
         $user = \User::singleton($_SESSION['State']->getUsername());
 
         // figure out how to generate PSCID
@@ -234,7 +236,12 @@ class Candidate
             }
 
             // check pscid structure
-            if (!Candidate::validatePSCID($PSCID, $site->getSiteAlias())) {
+            if (!Candidate::validatePSCID(
+                $PSCID,
+                $site->getSiteAlias(),
+                $project->getAlias()
+            )
+            ) {
                 throw new LorisException(
                     "PSCID has an invalid structure",
                     PSCID_INVALID_STRUCTURE
@@ -242,7 +249,11 @@ class Candidate
             }
 
         } else {
-            $PSCID = (new \PSCIDGenerator($site->getSiteAlias()))->generate();
+            $PSCID = (new \PSCIDGenerator(
+                $site->getSiteAlias(),
+                $project->getAlias()
+            )
+            )->generate();
         }
 
         // Insert the new candidate into the database if everything is fine.
@@ -670,16 +681,21 @@ class Candidate
      * Validate's that a PSCID matches the format defined by project
      * config
      *
-     * @param string      $PSCID      The PSCID to validate
-     * @param string|null $siteAbbrev (optional) The site of the candidate
-     *                                being validated to check against appropriate
-     *                                parts of PSCID definition
+     * @param string $PSCID         The PSCID to validate
+     * @param string $siteAbbrev    The site of the candidate
+     *                              being validated to check
+     *                              against appropriate parts
+     *                              of PSCID definition
+     * @param string $projectAbbrev The project of the candidate
+     *                              being validated to check against appropriate
+     *                              parts of PSCID definition
      *
      * @return boolean True if PSCID is valid, false otherwise
      */
     static public function validatePSCID(
         string $PSCID,
-        ?string $siteAbbrev = null
+        string $siteAbbrev,
+        string $projectAbbrev
     ): bool {
 
         $factory = NDB_Factory::singleton();
@@ -688,7 +704,8 @@ class Candidate
         $PSCIDSettings = $config->getSetting('PSCID');
         $regex         = Utility::structureToPCRE(
             $PSCIDSettings['structure'],
-            $siteAbbrev
+            $siteAbbrev,
+            $projectAbbrev
         );
         //preg_match returns 1 on success.
         return preg_match($regex, $PSCID) === 1;

--- a/php/libraries/ExternalIDGenerator.php
+++ b/php/libraries/ExternalIDGenerator.php
@@ -27,13 +27,16 @@ class ExternalIDGenerator extends SiteIDGenerator
     /**
      * Generates ExternalIDs.
      *
-     * @param ?string $prefix The site prefix to prepend to the ID value.
+     * @param string $siteAlias    To be appended to the ID value. Usually an
+     *                             abbreviation for the name of a site.
+     * @param string $projectAlias To be appended to the ID value. Usually an
+     *                             abbreviation for the name of a project.
      *
      * @return void
      */
-    public function __construct(?string $prefix = null)
+    public function __construct(string $siteAlias, string $projectAlias)
     {
         $this->kind = 'ExternalID';
-        parent::__construct($prefix);
+        parent::__construct($siteAlias, $projectAlias);
     }
 }

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -33,7 +33,7 @@ abstract class IdentifierGenerator
     protected $length;
     protected $minValue;
     protected $maxValue;
-    protected $prefix = '';
+    protected $siteAlias = '';
 
     /**
      * Generates a new unused identifier to represent a Candidate in LORIS.

--- a/php/libraries/PSCIDGenerator.php
+++ b/php/libraries/PSCIDGenerator.php
@@ -28,13 +28,14 @@ class PSCIDGenerator extends SiteIDGenerator
     /**
      * Generate PSCIDs.
      *
-     * @param ?string $prefix The site prefix to prepend to the ID value.
+     * @param string $siteAlias    The site prefix to prepend to the ID value.
+     * @param string $projectAlias The project prefix to prepend to the ID value.
      *
      * @return void
      */
-    public function __construct(?string $prefix = null)
+    public function __construct(string $siteAlias, string $projectAlias)
     {
         $this->kind = 'PSCID';
-        parent::__construct($prefix);
+        parent::__construct($siteAlias, $projectAlias);
     }
 }

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -169,9 +169,9 @@ class Project
         $factory->database()->insert(
             'Project',
             array(
-             'Name'              => $projectName,
-             'Alias'             => $projectAlias,
-             'recruitmentTarget' => $recruitmentTarget,
+                'Name'              => $projectName,
+                'Alias'             => $projectAlias,
+                'recruitmentTarget' => $recruitmentTarget,
             )
         );
 

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -32,6 +32,7 @@ class Project
      */
     private $_projectId;
     private $_projectName;
+    private $_projectAlias;
     private $_recruitmentTarget;
 
     /**
@@ -64,6 +65,7 @@ class Project
                     SELECT
                       projectId,
                       name,
+                      Alias,
                       recruitmentTarget as recTarget
                     FROM
                       Project
@@ -80,6 +82,7 @@ class Project
 
             $project->_projectId         = (int) $projectData['projectId'];
             $project->_projectName       = $projectData['name'];
+            $project->_projectAlias      = $projectData['Alias'];
             $project->_recruitmentTarget = (integer) $projectData['recTarget'];
 
             self::$_instances[$projectName] = $project;
@@ -89,10 +92,43 @@ class Project
     }
 
     /**
+     * Get a project object from the ID by mapping the ID to a name and using the
+     * singleton function
+     *
+     * @param int $projectID The ID of the project queried
+     *
+     * @return Project
+     *
+     * @throws NotFound
+     */
+    static function getProjectFromID(int $projectID) : \Project
+    {
+        $factory = \NDB_Factory::singleton();
+
+        $projectName = $factory->database()->pSelectOne(
+            "
+                    SELECT
+                      Name,
+                    FROM
+                      Project
+                    WHERE ProjectID = :pid
+                    ",
+            array('pid' => $projectID)
+        );
+
+        if (empty($projectName)) {
+            throw new \NotFound("No project with ID: $projectID");
+        }
+
+        return \Project::singleton($projectName);
+    }
+
+    /**
      * This does the work of creating a new Project by inserting a new entry in the
      * Project table and return the object instance of the newly created project.
      *
      * @param string       $projectName       The project name
+     * @param string       $projectAlias      The project alias
      * @param integer|null $recruitmentTarget The number of expected participants
      *
      * @note If the recruitmentTarget is missing or null, this project
@@ -104,6 +140,7 @@ class Project
      */
     static public function createNew(
         string $projectName,
+        string $projectAlias,
         ?int $recruitmentTarget = null
     ): \Project {
 
@@ -132,8 +169,9 @@ class Project
         $factory->database()->insert(
             'Project',
             array(
-                'name'              => $projectName,
-                'recruitmentTarget' => $recruitmentTarget,
+             'Name'              => $projectName,
+             'Alias'             => $projectAlias,
+             'recruitmentTarget' => $recruitmentTarget,
             )
         );
 
@@ -184,6 +222,34 @@ class Project
     public function setName(string $projectName): void
     {
         $this->_projectName = $projectName;
+    }
+
+    /**
+     * Get this project's alias
+     *
+     * @return string This project's alias
+     */
+    public function getAlias(): string
+    {
+        return $this->_projectAlias;
+    }
+
+    /**
+     * Set this project's alias
+     *
+     * @param string $projectAlias This project's alias
+     *
+     * @return void
+     */
+    public function setAlias(string $projectAlias): void
+    {
+        if (strlen($projectAlias) > 4 ) {
+            throw new ConfigurationException(
+                "The length of the project's alias can not be longer than ".
+                "4 characters."
+            );
+        }
+        $this->_projectAlias = $projectAlias;
     }
 
     /**

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -108,7 +108,7 @@ class Project
         $projectName = $factory->database()->pSelectOne(
             "
                     SELECT
-                      Name,
+                      Name
                     FROM
                       Project
                     WHERE ProjectID = :pid

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -57,9 +57,9 @@ class SiteIDGenerator extends IdentifierGenerator
             str_repeat(strval($this->alphabet[0]), $this->length);
         $this->maxValue = $this->_getIDSetting('max') ??
             str_repeat(
-                strval($this->alphabet[count($this->alphabet) - 1]),
-                $this->length
-            );
+            strval($this->alphabet[count($this->alphabet) - 1]),
+            $this->length
+        );
 
         $this->siteAlias    = $siteAlias;
         $this->projectAlias = $projectAlias;

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -38,7 +38,7 @@ class SiteIDGenerator extends IdentifierGenerator
      * @param string $siteAlias    To be appended to the ID value. Usually an
      *                             abbreviation for the name of a site.
      * @param string $projectAlias To be appended to the ID value. Usually an
-     *                       abbreviation for the name of a project.
+     *                             abbreviation for the name of a project.
      *
      * @return void
      */
@@ -53,9 +53,9 @@ class SiteIDGenerator extends IdentifierGenerator
         // Initialize minimum and maximum allowed values for IDs. Set the values
         // to the lowest/highest character in $alphabet repeated $length times
         // if the min or max is not configured in project/config.xml
-        $this->minValue   = $this->_getIDSetting('min') ??
+        $this->minValue = $this->_getIDSetting('min') ??
             str_repeat(strval($this->alphabet[0]), $this->length);
-        $this->maxValue   = $this->_getIDSetting('max') ??
+        $this->maxValue = $this->_getIDSetting('max') ??
             str_repeat(
                 strval($this->alphabet[count($this->alphabet) - 1]),
                 $this->length
@@ -267,7 +267,9 @@ class SiteIDGenerator extends IdentifierGenerator
             $seqAttributes = array_filter(
                 self::_getSeqAttribute($idStructure, 'type'),
                 function ($x) {
-                    return $x === 'static' || $x === 'siteAbbrev';
+                    return $x === 'static'
+                        || $x === 'siteAbbrev'
+                        || $x === 'projectAbbrev';
                 }
             );
             break;

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -26,18 +26,23 @@ class SiteIDGenerator extends IdentifierGenerator
 {
     /* Either 'PSCID' or 'ExternalID' */
     private const LENGTH = 4;
+
     protected $kind;
+    protected $siteAlias;
+    protected $projectAlias;
 
     /**
      * Creates a new instance of a SiteIDGenerator to create either PSCIDs or
      * ExternalIDs. Relevant properties are extracted from the config.xml file.
      *
-     * @param ?string $siteAbbrevPrefix To be appended to the ID value. Usually an
-     *                                  abbreviation for the name of a site.
+     * @param string $siteAlias    To be appended to the ID value. Usually an
+     *                             abbreviation for the name of a site.
+     * @param string $projectAlias To be appended to the ID value. Usually an
+     *                       abbreviation for the name of a project.
      *
      * @return void
      */
-    public function __construct(?string $siteAbbrevPrefix = null)
+    public function __construct(string $siteAlias, string $projectAlias)
     {
         // Read config settings from project/config.xml to retrieve the
         // alphabet, length, and generation method (sequential or random) used
@@ -52,11 +57,13 @@ class SiteIDGenerator extends IdentifierGenerator
             str_repeat(strval($this->alphabet[0]), $this->length);
         $this->maxValue   = $this->_getIDSetting('max') ??
             str_repeat(
-            strval($this->alphabet[count($this->alphabet) - 1]),
-            $this->length
-        );
-        $this->siteAbbrev = $siteAbbrevPrefix;
-        $this->prefix     = $this->_getIDSetting('prefix');
+                strval($this->alphabet[count($this->alphabet) - 1]),
+                $this->length
+            );
+
+        $this->siteAlias    = $siteAlias;
+        $this->projectAlias = $projectAlias;
+        $this->prefix       = $this->_getIDSetting('prefix');
         $this->validate();
     }
 
@@ -209,10 +216,14 @@ class SiteIDGenerator extends IdentifierGenerator
                         return $seq['#'];
                     }
                 }
+            } elseif ($seqValue === 'siteAbbrev') {
+                return $this->siteAlias;
+            } elseif ($seqValue === 'projectAbbrev') {
+                return $this->projectAlias;
             } else {
-                // The other option, 'siteAbbrev', indicates that the calling
-                // code should prepend a Site Alias to the ID.
-                return $this->siteAbbrev;
+                throw new ConfigurationException(
+                    "Incorrect option $seqValue selected for PSCID generation."
+                );
             }
         }
         // Min, max, and length values should be returned as integers or as

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -299,9 +299,10 @@ class Utility
      * Transforms a config structure (such as in PSCID) into a
      * Perl-compatible regex expression for validation
      *
-     * @param array       $structure  the structure root
-     * @param string|null $siteAbbrev the site abbreviation, sometimes used as part
-     *                                of the PSCID
+     * @param array       $structure     the structure root
+     * @param string|null $siteAbbrev    the site abbreviation, sometimes used as
+     *                                   part of the PSCID
+     * @param string|null $projectAbbrev the project abbreviation
      *
      * @return string the regex pattern
      *
@@ -311,7 +312,8 @@ class Utility
      */
     static function structureToPCRE(
         array $structure,
-        ?string $siteAbbrev = null
+        ?string $siteAbbrev = null,
+        ?string $projectAbbrev = null
     ): string {
         $seqs = $structure['seq'];
         // handle the situation where there exists only one seq
@@ -349,6 +351,9 @@ class Utility
 
             case 'siteAbbrev':
                 $unit .= $siteAbbrev;
+                break;
+            case 'projectAbbrev':
+                $unit .= $projectAbbrev;
                 break;
             } // end switch
 

--- a/raisinbread/RB_files/RB_Project.sql
+++ b/raisinbread/RB_files/RB_Project.sql
@@ -1,9 +1,9 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `Project`;
 LOCK TABLES `Project` WRITE;
-INSERT INTO `Project` (`ProjectID`, `Name`, `recruitmentTarget`) VALUES (1,'Pumpernickel',200);
-INSERT INTO `Project` (`ProjectID`, `Name`, `recruitmentTarget`) VALUES (2,'Rye',150);
-INSERT INTO `Project` (`ProjectID`, `Name`, `recruitmentTarget`) VALUES (3,'Challah',250);
-INSERT INTO `Project` (`ProjectID`, `Name`, `recruitmentTarget`) VALUES (4,'DCP',0);
+INSERT INTO `Project` (`ProjectID`, `Name`, `Alias`, `recruitmentTarget`) VALUES (1,'Pumpernickel','PUMP',200);
+INSERT INTO `Project` (`ProjectID`, `Name`, `Alias`, `recruitmentTarget`) VALUES (2,'Rye','RYE',150);
+INSERT INTO `Project` (`ProjectID`, `Name`, `Alias`, `recruitmentTarget`) VALUES (3,'Challah','CHA',250);
+INSERT INTO `Project` (`ProjectID`, `Name`, `Alias`, `recruitmentTarget`) VALUES (4,'DCP','DCP',0);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -730,12 +730,13 @@ class CandidateTest extends TestCase
     }
 
     /**
-     * Test Candidate::validatePSCID with both valid and invalid PSCID
+     * Test Candidate::validatePSCID with both valid and invalid PSCID genreated
+     * based on site
      *
      * @covers Candidate::validatePSCID
      * @return void
      */
-    public function testValidatePSCID()
+    public function testValidateSitePSCID()
     {
         $seq = array(
                 'seq' => array(
@@ -766,15 +767,64 @@ class CandidateTest extends TestCase
             ->will($this->returnValueMap($this->_configMap));
         $this->assertEquals(
             1,
-            Candidate::validatePSCID('AAA0012', 'AAA'),
+            Candidate::validatePSCID('AAA0012', 'AAA', 'BBB'),
             'Valid PSCID: validatePSCID should return 1'
         );
         $this->assertEquals(
             0,
-            Candidate::validatePSCID('AAA001', 'AAA'),
+            Candidate::validatePSCID('AAA001', 'AAA', 'BBB'),
             'Invalid PSCID: validatePSCID should return 0'
         );
     }
+
+    /**
+     * Test Candidate::validatePSCID with both valid and invalid PSCID
+     * generated based on Project
+     *
+     * @covers Candidate::validatePSCID
+     * @return void
+     */
+    public function testValidateProjectPSCID()
+    {
+        $seq = array(
+            'seq' => array(
+                0 => array(
+                    '#' => '',
+                    '@' => array('type' => 'projectAbbrev'),
+                ),
+                1 => array(
+                    '#' => '',
+                    '@' => array(
+                        'type'      => 'numeric',
+                        'length' => '4',
+                    ),
+                ),
+            ),
+        );
+        $this->_configMap = array(
+            array(
+                'PSCID',
+                array(
+                    'generation' => 'sequential',
+                    'structure'  => $seq,
+                ),
+            ),
+        );
+
+        $this->_configMock->method('getSetting')
+            ->will($this->returnValueMap($this->_configMap));
+        $this->assertEquals(
+            1,
+            Candidate::validatePSCID('BBB0012', 'AAA', 'BBB'),
+            'Valid PSCID: validatePSCID should return 1'
+        );
+        $this->assertEquals(
+            0,
+            Candidate::validatePSCID('BBB001', 'AAA', 'BBB'),
+            'Invalid PSCID: validatePSCID should return 0'
+        );
+    }
+
 
     /**
      * Test getConsents returns correct array of information


### PR DESCRIPTION
## Brief summary of changes
Added option to generate PSCIDs using the project alias instead of the site alias. this is needed by several projects where permissions will be more project oriented then site.

to test:
- in your config.xml change between `static`, `siteAbbrev` and `projectAbbrev` make sure the correct PSCID gets generated