### PR TITLE
[tools/install.sh] fix for other operating systems

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -155,10 +155,15 @@ chmod 770 ../smarty/templates_c
 
 # Changing group to 'www-data' or 'apache' to give permission to create directories in Document Repository module
 # Detecting distribution
-os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')
+if ! os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')  2> /dev/null
+then
+  os_distro="other"
+else
+  os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')
+fi
 
 debian=("Debian" "Ubuntu")
-redhat=("Red" "CentOS" "Fedora" "Oracle") 
+redhat=("Red" "CentOS" "Fedora" "Oracle")
 
 if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
     mkdir -p ../modules/document_repository/user_uploads

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -155,7 +155,7 @@ chmod 770 ../smarty/templates_c
 
 # Changing group to 'www-data' or 'apache' to give permission to create directories in Document Repository module
 # Detecting distribution
-if ! os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')  2> /dev/null
+if ! os_distro=$(hostnamectl 2>/dev/null)
 then
   os_distro="other"
 else


### PR DESCRIPTION
## Brief summary of changes

Allows the shell script to continue if the command "hostnamectl" is not found.
Note: Let me know if the else statement is unnecessary.

#### Testing instructions (if applicable)

1. Test on macOS
2. Test on Ubuntu or centOS

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5262
