### PR TITLE
[JSX] Enabled Data Mapping for CSV Downloads

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -497,6 +497,14 @@ class DataTable extends Component {
       csvData = filteredData;
     }
 
+    // Map cell data to proper values if applicable.
+    if (this.props.getMappedCell) {
+      csvData = csvData
+      .map((row, i) => this.props.fields
+        .map((field, j) => this.props.getMappedCell(field.label, row[j]));
+      );
+    }
+
     let header = this.props.hide.rowsPerPage === true ? '' : (
       <div className="table-header">
         <div className="row">

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -84,6 +84,14 @@ class DataTable extends Component {
   }
 
   downloadCSV(csvData) {
+    // Map cell data to proper values if applicable.
+    if (this.props.getMappedCell) {
+      csvData = csvData
+      .map((row, i) => this.props.fields
+        .map((field, j) => this.props.getMappedCell(field.label, row[j]))
+      );
+    }
+
     let csvworker = new Worker(loris.BaseURL + '/js/workers/savecsv.js');
 
     csvworker.addEventListener('message', function(e) {
@@ -495,14 +503,6 @@ class DataTable extends Component {
     let csvData = this.props.data;
     if (this.props.filter && filteredData.length > 0) {
       csvData = filteredData;
-    }
-
-    // Map cell data to proper values if applicable.
-    if (this.props.getMappedCell) {
-      csvData = csvData
-      .map((row, i) => this.props.fields
-        .map((field, j) => this.props.getMappedCell(field.label, row[j]));
-      );
     }
 
     let header = this.props.hide.rowsPerPage === true ? '' : (

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -64,6 +64,7 @@ class FilterableDataTable extends Component {
         filter={this.state.filter}
         actions={this.props.actions}
         getFormattedCell={this.props.getFormattedCell}
+        getMappedCell={this.props.getMappedCell}
         folder={this.props.folder}
         nullTableShow={this.props.nullTableShow}
       />

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -22,6 +22,7 @@ class MediaIndex extends Component {
 
     this.fetchData = this.fetchData.bind(this);
     this.formatColumn = this.formatColumn.bind(this);
+    this.mapColumn = this.mapColumn.bind(this);
   }
 
   componentDidMount() {
@@ -54,7 +55,7 @@ class MediaIndex extends Component {
    *
    * @return {string} a mapped value for the table cell at a given column
    */
-  mapContainerColumns(column, value) {
+  mapColumn(column, value) {
     switch (column) {
       case 'Site':
         return this.state.fieldOptions.sites[value];
@@ -217,6 +218,7 @@ class MediaIndex extends Component {
             data={this.state.data}
             fields={fields}
             getFormattedCell={this.formatColumn}
+            getMappedCell={this.mapColumn}
           />
         </TabPane>
         {uploadTab()}

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -47,6 +47,23 @@ class MediaIndex extends Component {
   }
 
   /**
+   * Modify value of specified column cells in the Data Table component
+   *
+   * @param {string} column - column name
+   * @param {string} value - cell value
+   *
+   * @return {string} a mapped value for the table cell at a given column
+   */
+  mapContainerColumns(column, value) {
+    switch (column) {
+      case 'Site':
+        return this.state.fieldOptions.sites[value];
+      default:
+        return value;
+    }
+  }
+
+  /**
    * Modify behaviour of specified column cells in the Data Table component
    *
    * @param {string} column - column name
@@ -56,6 +73,7 @@ class MediaIndex extends Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
+    cell = this.mapContainerColumns(column, cell);
     // Set class to 'bg-danger' if file is hidden.
     const style = (row['File Visibility'] === '1') ? 'bg-danger' : '';
     let result = <td className={style}>{cell}</td>;
@@ -81,7 +99,7 @@ class MediaIndex extends Component {
       }
       break;
     case 'Site':
-      result = <td className={style}>{this.state.fieldOptions.sites[cell]}</td>;
+      result = <td className={style}>{cell}</td>;
       break;
     case 'Edit Metadata':
       if (!this.props.hasPermission('media_write')) {

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -74,7 +74,7 @@ class MediaIndex extends Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
-    cell = this.mapContainerColumns(column, cell);
+    cell = this.mapColumn(column, cell);
     // Set class to 'bg-danger' if file is hidden.
     const style = (row['File Visibility'] === '1') ? 'bg-danger' : '';
     let result = <td className={style}>{cell}</td>;


### PR DESCRIPTION
## Summary
Because the `getFormatedCell` function often both formats AND maps data, there was a developing issue where the downloaded data in the form of CSV did not represent what was shown in the datatable, but rather the initial data before mapping - therefore downloading keys rather than values.

This PR fixes this by allowing developers to disentangle mapping and formatting. A function can be created which checks the value of the parameter `column` and then changes the value correspondingly. This function can then be passed as a prop to the `FilterableDataTable` component which will take care of the rest.

E.G. from the Biobank module:
```
 83   mapContainerColumns(column, value) {                                          
 84     switch (column) {                                                           
 85       case 'Type':                                                              
 86         return this.props.options.container.types[value].label;                 
 87       case 'Status':                                                            
 88         return this.props.options.container.stati[value].label;                 
 89       case 'Projects':                                                          
 90         return value.map((id) => this.props.options.projects[id]);              
 91       case 'Site':                                                              
 92         return this.props.options.centers[value];                               
 93       case 'Parent Barcode':                                                    
 94         return (value && this.props.data.containers[value].barcode);            
 95       default:                                                                  
 96         return value;                                                           
 97     }                                                                           
 98   } 
```

The formatting function can then make use of this mapping before setting formatting styles:
```
100   formatContainerColumns(column, value, row) {                                  
101     value = this.mapContainerColumns(column, value);                            
102     switch (column) {                                                           
103       case 'Barcode':                                                           
104         return <td><Link to={`/barcode=${value}`}>{value}</Link></td>;          
105       case 'Status':                                                            
106         const style = {};                                                       
107         switch (value) {                                                        
108           case 'Available':                                                     
109             style.color = 'green';                                              
110             break;                                                              
111           case 'Reserved':                                                      
112             style.color = 'orange';                                             
113             break;                                                              
114           case 'Dispensed':                                                     
115             style.color = 'red';                                                
116             break;                                                              
117           case 'Discarded':                                                     
118             style.color = 'red';                                                
119             break;                                                              
120         }                                                                       
121         return <td style={style}>{value}</td>;                                  
122       case 'Projects':                                                          
123         return <td>{value.join(', ')}</td>;                                     
124       case 'Parent Barcode':                                                    
125         return <td><Link to={`/barcode=${value}`}>{value}</Link></td>;          
126       default:                                                                  
127         return <td>{value}</td>;                                                
128     }                                                                           
129   }   
```