### PR TITLE
[Script] Add script to generate fake candidates

### DIFF
--- a/tools/deprecated/create_candidates.php
+++ b/tools/deprecated/create_candidates.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This script inserts 5000 candidates. The CandIDs are consecutive instead
+ * of random, the PSCID is dccXXXX where XXXX is an incrementing integer, and
+ * the rest of the data is hardcoded.
+ *
+ * This is intended to stress test the candidate_list module with large numbers
+ * of candidates and is not intended to produce realistic data.
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Various <example@example.com>
+ * @license  Loris license
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+set_include_path(
+    get_include_path().":".
+    __DIR__."/../project/tools:".
+    __DIR__."/../php/tools:"
+);
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "generic_includes.php";
+
+
+/*
+ * Return true if either "candid" if candid exists,
+ * "pscid" if pscid exists, or the empty string if
+ * neither exists.
+ */
+function checkExists($candid, $pscid) : string {
+    global $DB;
+    $val = $DB->pselectOne("SELECT CandID FROM candidate WHERE CandID=:cndid",
+        array('cndid' => $candid)
+    );
+    if (!empty($val)) {
+        return "candid";
+    }
+    $val = $DB->pselectOne("SELECT PSCID FROM candidate WHERE PSCID=:pscid",
+        array('pscid' => $pscid)
+    );
+    if (!empty($val)) {
+        return "pscid";
+    }
+    return "";
+}
+
+
+$count = 0;
+$lastcandid = 100000;
+$lastpscid = 0;
+
+while($count < 5000) {
+    $pscid = sprintf("dcc%04.d", $lastpscid);
+    switch(checkExists($lastcandid, $pscid)) {
+    case "candid":
+        $lastcandid++;
+        break;
+    case "pscid":
+        $lastpscid++;
+        break;
+    default:
+        print "Creating $lastcandid/$pscid\n";
+
+        $DB->insert("candidate",
+            [ 'CandID' => $lastcandid,
+            'PSCID' => $pscid,
+            'DoB' => '2004-02-02',
+            'Sex' => 'Male',
+            'RegistrationCenterID' => 1,
+            'RegistrationProjectID' => 1,
+            'Active' => 'Y',
+            'Date_active' => '2008-01-31',
+            'Entity_type' => 'Human']
+        );
+        $lastpscid++;
+        $lastcandid++;
+        $count++;
+        break;
+    }
+}


### PR DESCRIPTION
This adds a script used to generate a large number of candidates
for testing #5299. The candidates are not realistic or even necessarily
valid, but only intended to see how the candidate_list data table
holds up with a large amount of data  (I tested with up to 20,000 candidates.)

This needs a lot of work to be made robust enough to be useable
for general purpose testing and is unlikely to be maintained, so
is added directly to the "deprecated" directory, but I'm sending it
to LORIS at @maltheism's request.
