### PR TITLE
Move Response objects to explicit JSON namespace

### DIFF
--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -174,7 +174,7 @@ class FilesUploadHandler implements RequestHandlerInterface
              * calling code wants to overwrite the file.
              */
             if (file_exists($targetPath) && $this->overwrite !== true) {
-                return new \LORIS\Http\Response\Conflict(
+                return new \LORIS\Http\Response\JSON\Conflict(
                     'This file has already been uploaded.'
                 );
             }

--- a/src/Api/Endpoints/Login.php
+++ b/src/Api/Endpoints/Login.php
@@ -96,7 +96,7 @@ class Login extends Endpoint
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         if (count($request->getAttribute('pathparts')) !== 1) {
-            return new \LORIS\Http\Response\NotFound();
+            return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         switch ($request->getMethod()) {
@@ -107,7 +107,7 @@ class Login extends Endpoint
                 $password = $requestdata['password'] ?? null;
 
                 if ($user === null || $password === null) {
-                    return new \LORIS\Http\Response\BadRequest(
+                    return new \LORIS\Http\Response\JSON\BadRequest(
                         'Missing username or password'
                     );
                 }
@@ -121,7 +121,7 @@ class Login extends Endpoint
                             array('token' => $token)
                         );
                     } else {
-                        return new \LORIS\Http\Response\InternalServerError(
+                        return new \LORIS\Http\Response\JSON\InternalServerError(
                             'Unacceptable JWT key'
                         );
                     }
@@ -134,7 +134,7 @@ class Login extends Endpoint
                 return (new \LORIS\Http\Response())
                 ->withHeader('Allow', $this->allowedMethods());
             default:
-                return new \LORIS\Http\Response\MethodNotAllowed(
+                return new \LORIS\Http\Response\JSON\MethodNotAllowed(
                     $this->allowedMethods()
                 );
         }

--- a/src/Api/Endpoints/Project/Candidates.php
+++ b/src/Api/Endpoints/Project/Candidates.php
@@ -87,7 +87,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $pathparts = $request->getAttribute('pathparts');
 
         if (count($pathparts) > 1) {
-            return new \LORIS\Http\Response\NotFound();
+            return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         return (new \LORIS\Http\Response())

--- a/src/Api/Endpoints/Project/Images.php
+++ b/src/Api/Endpoints/Project/Images.php
@@ -80,7 +80,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         $pathparts = $request->getAttribute('pathparts');
         if (count($pathparts) > 1) {
-            return new \LORIS\Http\Response\NotFound();
+            return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         return (new \LORIS\Http\Response())

--- a/src/Api/Endpoints/Project/Instruments.php
+++ b/src/Api/Endpoints/Project/Instruments.php
@@ -107,7 +107,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 true
             );
         } catch (\Exception $e) {
-            return new \LORIS\Http\Response\NotFound();
+            return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         $endpoint = new Instrument($this->project, $instrument);

--- a/src/Api/Endpoints/Project/Project.php
+++ b/src/Api/Endpoints/Project/Project.php
@@ -118,7 +118,7 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 $handler = new Visits($this->project);
                 break;
             default:
-                return new \LORIS\Http\Response\NotFound();
+                return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         $newrequest = $request

--- a/src/Api/Endpoints/Projects.php
+++ b/src/Api/Endpoints/Projects.php
@@ -102,7 +102,7 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $project = \NDB_Factory::singleton()
                 ->project($pathparts[1]);
         } catch (\NotFound $e) {
-            return new \LORIS\Http\Response\NotFound();
+            return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         $endpoint = new Project\Project($project);

--- a/src/Http/Response/JSON/BadRequest.php
+++ b/src/Http/Response/JSON/BadRequest.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
- * File contains the PSR15 ResponseInterface implementation for
- * Not Modified responses.
+ * File contains the PSR7 ResponseInterface implementation for
+ * Bad Request responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 304 Not Modified.
+ * to use in LORIS specific for 400 Bad Request.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class NotModified extends JsonResponse
+class BadRequest extends JsonResponse
 {
     /**
-     * Create a Json response specific to 404 Not Found
+     * Create a Json response specific to 400 Bad Request
      *
-     * @param string $etag The endpoint etag
+     * @param string $msg The error message
      */
-    public function __construct(string $etag)
+    public function __construct(string $msg = 'bad request')
     {
-        $headers = array('ETag' => $etag);
-        parent::__construct(null, 304, $headers);
+        $body = array('error' => $msg);
+        parent::__construct($body, 400);
     }
 }

--- a/src/Http/Response/JSON/Conflict.php
+++ b/src/Http/Response/JSON/Conflict.php
@@ -1,27 +1,26 @@
 <?php declare(strict_types=1);
 /**
- * File contains the PSR7 ResponseInterface implementation for
- * OK responses.
+ * File contains the PSR15 ResponseInterface implementation for
+ * Conflict responses.
  *
  * PHP Version 7
  *
  * @category PSR15
  * @package  Http
  * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
- * @author   John Saigle <john.saigle@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specifically for the 200 OK Response.
+ * to use in LORIS specific for 409 Conflict.
  *
  * @category PSR15
  * @package  Http
@@ -29,20 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class OK extends JsonResponse
+class Conflict extends JsonResponse
 {
     /**
-     * Create a Json response containing the 200 OK Response
+     * Create a Json response specific to 409 Conflict
      *
-     * @param array $body Data to convert to JSON.
-     * @param array $headers Array of headers to use at initialization.
-     *
-     * @return void
+     * @param string $msg The error message
      */
-    public function __construct(
-        array $body = [],
-        array $headers = []
-    ) {
-        parent::__construct($body, 200, $headers);
+    public function __construct(string $msg = 'conflict')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 409);
     }
 }

--- a/src/Http/Response/JSON/Created.php
+++ b/src/Http/Response/JSON/Created.php
@@ -15,7 +15,7 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 

--- a/src/Http/Response/JSON/Forbidden.php
+++ b/src/Http/Response/JSON/Forbidden.php
@@ -11,7 +11,7 @@
 * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
 * @link     https://www.github.com/aces/Loris/
 */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 

--- a/src/Http/Response/JSON/InternalServerError.php
+++ b/src/Http/Response/JSON/InternalServerError.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
  * File contains the PSR15 ResponseInterface implementation for
- * Not Found responses.
+ * Internal Server Error responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 404 Not Found.
+ * to use in LORIS specific for 500 Internal Server Error.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class NotFound extends JsonResponse
+class InternalServerError extends JsonResponse
 {
     /**
-     * Create a Json response specific to 404 Not Found
+     * Create a Json response specific to 500 Internal Server Error
      *
      * @param string $msg The error message
      */
-    public function __construct(string $msg = 'not found')
+    public function __construct(string $msg = 'internal server error')
     {
         $body = array('error' => $msg);
-        parent::__construct($body, 404);
+        parent::__construct($body, 500);
     }
 }

--- a/src/Http/Response/JSON/MethodNotAllowed.php
+++ b/src/Http/Response/JSON/MethodNotAllowed.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
  * File contains the PSR15 ResponseInterface implementation for
- * Not Implemented responses.
+ * Method Not Allowed responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 501 Not Implemented.
+ * to use in LORIS specific for 405 Method Not Allowed.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +28,23 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class NotImplemented extends JsonResponse
+class MethodNotAllowed extends JsonResponse
 {
     /**
-     * Create a Json response specific to 501 Not Implemented
+     * The server MUST generate an Allow header field in a 405 response
+     * containing a list of the target resource's currently supported methods.
      *
-     * @param string $msg The error message
+     * @param array  $allowedmethods The list of supported methods
+     * @param string $msg            The error message
+     *
+     * @see RFC 7231, section 6.5.5: 405 Method Not Allowed
      */
-    public function __construct(string $msg = 'not implemented')
-    {
-        $body = array('error' => $msg);
-        parent::__construct($body, 501);
+    public function __construct(
+        array $allowedmethods,
+        string $msg = 'method not allowed'
+    ) {
+        $body    = array('error' => $msg);
+        $headers = array('Allow' => $allowedmethods);
+        parent::__construct($body, 405, $headers);
     }
 }

--- a/src/Http/Response/JSON/NotFound.php
+++ b/src/Http/Response/JSON/NotFound.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
  * File contains the PSR15 ResponseInterface implementation for
- * Internal Server Error responses.
+ * Not Found responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 500 Internal Server Error.
+ * to use in LORIS specific for 404 Not Found.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class InternalServerError extends JsonResponse
+class NotFound extends JsonResponse
 {
     /**
-     * Create a Json response specific to 500 Internal Server Error
+     * Create a Json response specific to 404 Not Found
      *
      * @param string $msg The error message
      */
-    public function __construct(string $msg = 'internal server error')
+    public function __construct(string $msg = 'not found')
     {
         $body = array('error' => $msg);
-        parent::__construct($body, 500);
+        parent::__construct($body, 404);
     }
 }

--- a/src/Http/Response/JSON/NotImplemented.php
+++ b/src/Http/Response/JSON/NotImplemented.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
  * File contains the PSR15 ResponseInterface implementation for
- * Unauthorized responses.
+ * Not Implemented responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 401 Unauthorized.
+ * to use in LORIS specific for 501 Not Implemented.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Unauthorized extends JsonResponse
+class NotImplemented extends JsonResponse
 {
     /**
-     * Create a Json response specific to 401 Unauthorized
+     * Create a Json response specific to 501 Not Implemented
      *
      * @param string $msg The error message
      */
-    public function __construct(string $msg = 'unauthorized')
+    public function __construct(string $msg = 'not implemented')
     {
         $body = array('error' => $msg);
-        parent::__construct($body, 401);
+        parent::__construct($body, 501);
     }
 }

--- a/src/Http/Response/JSON/NotModified.php
+++ b/src/Http/Response/JSON/NotModified.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
- * File contains the PSR7 ResponseInterface implementation for
- * Bad Request responses.
+ * File contains the PSR15 ResponseInterface implementation for
+ * Not Modified responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 400 Bad Request.
+ * to use in LORIS specific for 304 Not Modified.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class BadRequest extends JsonResponse
+class NotModified extends JsonResponse
 {
     /**
-     * Create a Json response specific to 400 Bad Request
+     * Create a Json response specific to 404 Not Found
      *
-     * @param string $msg The error message
+     * @param string $etag The endpoint etag
      */
-    public function __construct(string $msg = 'bad request')
+    public function __construct(string $etag)
     {
-        $body = array('error' => $msg);
-        parent::__construct($body, 400);
+        $headers = array('ETag' => $etag);
+        parent::__construct(null, 304, $headers);
     }
 }

--- a/src/Http/Response/JSON/OK.php
+++ b/src/Http/Response/JSON/OK.php
@@ -1,26 +1,27 @@
 <?php declare(strict_types=1);
 /**
- * File contains the PSR15 ResponseInterface implementation for
- * Conflict responses.
+ * File contains the PSR7 ResponseInterface implementation for
+ * OK responses.
  *
  * PHP Version 7
  *
  * @category PSR15
  * @package  Http
  * @author   Xavier Lecours Boucher <xavier.lecours@mcin.ca>
+ * @author   John Saigle <john.saigle@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  *
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 409 Conflict.
+ * to use in LORIS specifically for the 200 OK Response.
  *
  * @category PSR15
  * @package  Http
@@ -28,16 +29,20 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Conflict extends JsonResponse
+class OK extends JsonResponse
 {
     /**
-     * Create a Json response specific to 409 Conflict
+     * Create a Json response containing the 200 OK Response
      *
-     * @param string $msg The error message
+     * @param array $body Data to convert to JSON.
+     * @param array $headers Array of headers to use at initialization.
+     *
+     * @return void
      */
-    public function __construct(string $msg = 'conflict')
-    {
-        $body = array('error' => $msg);
-        parent::__construct($body, 409);
+    public function __construct(
+        array $body = [],
+        array $headers = []
+    ) {
+        parent::__construct($body, 200, $headers);
     }
 }

--- a/src/Http/Response/JSON/Unauthorized.php
+++ b/src/Http/Response/JSON/Unauthorized.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 /**
  * File contains the PSR15 ResponseInterface implementation for
- * Method Not Allowed responses.
+ * Unauthorized responses.
  *
  * PHP Version 7
  *
@@ -14,13 +14,13 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 
 /**
  * A LORIS Http Response is an implementation of the PSR15 ResponseInterface
- * to use in LORIS specific for 405 Method Not Allowed.
+ * to use in LORIS specific for 401 Unauthorized.
  *
  * @category PSR15
  * @package  Http
@@ -28,23 +28,16 @@ use \LORIS\Http\Response\JsonResponse;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class MethodNotAllowed extends JsonResponse
+class Unauthorized extends JsonResponse
 {
     /**
-     * The server MUST generate an Allow header field in a 405 response
-     * containing a list of the target resource's currently supported methods.
+     * Create a Json response specific to 401 Unauthorized
      *
-     * @param array  $allowedmethods The list of supported methods
-     * @param string $msg            The error message
-     *
-     * @see RFC 7231, section 6.5.5: 405 Method Not Allowed
+     * @param string $msg The error message
      */
-    public function __construct(
-        array $allowedmethods,
-        string $msg = 'method not allowed'
-    ) {
-        $body    = array('error' => $msg);
-        $headers = array('Allow' => $allowedmethods);
-        parent::__construct($body, 405, $headers);
+    public function __construct(string $msg = 'unauthorized')
+    {
+        $body = array('error' => $msg);
+        parent::__construct($body, 401);
     }
 }


### PR DESCRIPTION
Move ambiguously named HTTP response classes which only handle JSON responses to an explicit JSON sub-directory/namespace.

This should avoid confusion by making the fact that they're only useful for JSON more explicit.