### PR TITLE
[imaging uploader] Automatically populate PSCID, CandID & visit label based on the filename upon upload

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -27,7 +27,6 @@ class UploadForm extends Component {
     };
 
     this.onFormChange = this.onFormChange.bind(this);
-    this.getDisabledStatus = this.getDisabledStatus.bind(this);
     this.submitForm = this.submitForm.bind(this);
     this.uploadFile = this.uploadFile.bind(this);
   }
@@ -71,17 +70,6 @@ class UploadForm extends Component {
       form: form,
       formData: formData,
     });
-  }
-
-  /*
-   Returns false if Phantom Scans is set to No, and true otherwise
-   Result disables the element that calls the function
-   */
-  getDisabledStatus(phantomScans) {
-    if (phantomScans === 'N') {
-      return false;
-    }
-    return true;
   }
 
   submitForm() {

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -57,6 +57,16 @@ class UploadForm extends Component {
 
     formData[field] = value;
 
+    if (field === 'mriFile') {
+      if (value.name !== '') {
+        let patientName = value.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
+        let ids = patientName.split('_', 3);
+        formData.candID = ids[1];
+        formData.pSCID = ids[0];
+        formData.visitLabel = ids[2];
+      }
+    }
+
     this.setState({
       form: form,
       formData: formData,
@@ -85,66 +95,16 @@ class UploadForm extends Component {
     const fileName = data.mriFile.name;
     if (data.IsPhantom === 'N') {
       if (!data.candID || !data.pSCID || !data.visitLabel) {
-        return;
-      }
-      // Make sure file follows PSCID_CandID_VL[_*].zip|.tgz|.tar.gz format
-      const pcv = data.pSCID + '_' + data.candID + '_' + data.visitLabel;
-      const properName = new RegExp('^' + pcv + '(_|.)');
-      const properExt = new RegExp('.(zip|tgz|tar.gz)$');
-      if (!fileName.match(properName)) {
         swal({
-          title: 'Filename does not match other fields!',
-          text: 'Filename and values in the PSCID, CandID ' +
-          'and Visit Label fields of the form do not match. Please ' +
-          'verify that the information entered in the ' +
-          'fields or the filename are correct.',
+          title: 'Incorrect file name!',
+          text: 'Could not determine PSCID, CandID and Visit Label based on the filename!\n',
           type: 'error',
           confirmButtonText: 'OK',
         });
-        let fieldMsg = 'Field does not match the filename!';
-
-        let errorMessage = {
-          mriFile: 'Filename does not match other fields!',
-          candID: undefined,
-          pSCID: undefined,
-          visitLabel: undefined,
-        };
-
-        let hasError = {
-          mriFile: true,
-          candID: false,
-          pSCID: false,
-          visitLabel: false,
-        };
-
-        // check filename fields individually to decide
-        // which fields to apply error message
-        // use limit of 2 to avoid splitting the visit label
-        let fileNameParts = fileName.split('_', 2);
-        if (data.pSCID !== fileNameParts[0]) {
-          errorMessage.pSCID = fieldMsg;
-          hasError.pSCID = true;
-        }
-
-        if (data.candID !== fileNameParts[1]) {
-          errorMessage.candID = fieldMsg;
-          hasError.candID = true;
-        }
-
-        // offset for visit label is size of the two parts plus 2 _'s
-        let visitLabelOffset = fileNameParts[0].length + fileNameParts[1].length + 2;
-        let fileNameRemains = fileName.substr(visitLabelOffset);
-        // only check that this part of the filename begins with
-        // the field, last part of file name includes optional
-        // specifiers + file extension
-        if (fileNameRemains.indexOf(data.visitLabel) !== 0) {
-          errorMessage.visitLabel = fieldMsg;
-          hasError.visitLabel = true;
-        }
-
-        this.setState({errorMessage, hasError});
         return;
       }
+      // Make sure file is of type .zip|.tgz|.tar.gz format
+      const properExt = new RegExp('.(zip|tgz|tar.gz)$');
       if (!fileName.match(properExt)) {
         swal({
           title: 'Invalid extension for the uploaded file!',
@@ -391,9 +351,8 @@ class UploadForm extends Component {
             <TextboxElement
               name='candID'
               label='CandID'
-              onUserInput={this.onFormChange}
-              disabled={this.getDisabledStatus(this.state.formData.IsPhantom)}
-              required={!this.getDisabledStatus(this.state.formData.IsPhantom)}
+              disabled={true}
+              required={false}
               hasError={this.state.hasError.candID}
               errorMessage={this.state.errorMessage.candID}
               value={this.state.formData.candID}
@@ -401,20 +360,17 @@ class UploadForm extends Component {
             <TextboxElement
               name='pSCID'
               label='PSCID'
-              onUserInput={this.onFormChange}
-              disabled={this.getDisabledStatus(this.state.formData.IsPhantom)}
-              required={!this.getDisabledStatus(this.state.formData.IsPhantom)}
+              disabled={true}
+              required={false}
               hasError={this.state.hasError.pSCID}
               errorMessage={this.state.errorMessage.pSCID}
               value={this.state.formData.pSCID}
             />
-            <SelectElement
+            <TextboxElement
               name='visitLabel'
               label='Visit Label'
-              options={this.props.form.visitLabel.options}
-              onUserInput={this.onFormChange}
-              disabled={this.getDisabledStatus(this.state.formData.IsPhantom)}
-              required={!this.getDisabledStatus(this.state.formData.IsPhantom)}
+              disabled={true}
+              required={false}
               hasError={this.state.hasError.visitLabel}
               errorMessage={this.state.errorMessage.visitLabel}
               value={this.state.formData.visitLabel}

--- a/modules/imaging_uploader/test/TestPlan.md
+++ b/modules/imaging_uploader/test/TestPlan.md
@@ -12,8 +12,8 @@
    Uploader table on the 'fly', as fields are being filled out. Ensure that this works no matter what page of results
    from the query to the uploads table you are currently on. Ensure that 'Clear Filters' button works.
    [Manual Testing]      
-5. Ensure that the 'Upload' tab has the CandID, PSCID, and Visit Label greyed out upon loading. These greyed out fields remain
-   as such if the 'Phantom Scans' is set to Yes, and become fillable and required fields if 'Phantom Scans' is set to No.  
+5. Ensure that the 'Upload' tab has the CandID, PSCID, and Visit Label greyed out. These greyed out fields remain
+   empty if the 'Phantom Scans' is set to Yes, and are properly filled based on the uploaded filename if 'Phantom Scans' is set to No.  
    [Manual Testing]
 6. Test validation errors for 'CandID', 'PSCID', and 'Visit Label' in the 'Upload' tab and ensure that the appropriate
    error messages are displayed under the relevant form elements.
@@ -47,7 +47,6 @@
    - A file that is not of type `.tgz` or `tar.gz` or `.zip` (e.g. a `.jpg` or `.txt`)
    - A file that exceeds the max upload size
    - A file that that does not match the `PSCID_CandID_VisitLabel` convention
-      (once the PSCID, CandID, and Visit Label fields of the form have been validated)
 
    [Manual Testing]
 


### PR DESCRIPTION
## Brief summary of changes

Modified the behaviour of the upload tab of the imaging uploader module. PSCID, CandID and Visit Label fields are now automatically populated based on the name of the selected file to be uploaded.

#### Testing instructions (if applicable)

1. Follow the test plan of the module

#### Links to related tickets (GitHub, Redmine, ...)

* [x] Resolves #2909

#### Caveats for existing projects

Note that there has been a change of behaviour for the upload tab of the imaging uploader module. The PSCID, CandID and Visit Label fields are now populated automatically based on the name of the file to be uploaded when a scan is not a phantom scan.