### PR TITLE
[Configuration] Moved MINCToolsPath from config.xml to the Config module

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -74,7 +74,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'mediaPath', 'Path to uploaded media files', 1, 0, 'text', ID, 'Media', 9 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_uploads', 'Path to uploaded publications', 1, 0, 'web_path', ID, 'Publications', 10 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_deletions', 'Path to deleted publications', 1, 0, 'web_path', ID, 'Deleted Publications', 11 FROM ConfigSettings WHERE Name="paths";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'minctools_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'web_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
@@ -188,7 +188,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/Genomic-Data/" FROM Co
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSettings WHERE Name="mediaPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/" FROM ConfigSettings WHERE Name="publication_uploads";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/to_be_deleted/" FROM ConfigSettings WHERE Name="publication_deletions";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="minctools_path";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="MINCToolsPath";
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -74,6 +74,8 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'mediaPath', 'Path to uploaded media files', 1, 0, 'text', ID, 'Media', 9 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_uploads', 'Path to uploaded publications', 1, 0, 'web_path', ID, 'Publications', 10 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_deletions', 'Path to deleted publications', 1, 0, 'web_path', ID, 'Deleted Publications', 11 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'minctools_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
+
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'css', 'CSS file used for rendering (default main.css)', 1, 0, 'text', ID, 'CSS file', 1 FROM ConfigSettings WHERE Name="gui";
@@ -186,6 +188,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/PATH/TO/Genomic-Data/" FROM Co
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSettings WHERE Name="mediaPath";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/" FROM ConfigSettings WHERE Name="publication_uploads";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/to_be_deleted/" FROM ConfigSettings WHERE Name="publication_deletions";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="minctools_path";
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";

--- a/SQL/New_patches/2019-10-09_move_MINCToolsPath_configuration_to_Config_tables.sql
+++ b/SQL/New_patches/2019-10-09_move_MINCToolsPath_configuration_to_Config_tables.sql
@@ -1,0 +1,2 @@
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'minctools_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="minctools_path";

--- a/SQL/New_patches/2019-10-09_move_MINCToolsPath_configuration_to_Config_tables.sql
+++ b/SQL/New_patches/2019-10-09_move_MINCToolsPath_configuration_to_Config_tables.sql
@@ -1,2 +1,2 @@
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'minctools_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="minctools_path";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'web_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="MINCToolsPath";

--- a/docs/config/config.xml
+++ b/docs/config/config.xml
@@ -117,7 +117,4 @@
         </instrument>
     </instrumentPermissions>
 
-    <!-- MINC TOOLS PATH -->
-    <MINCToolsPath>%MINCTOOLSPATH%</MINCToolsPath>
-
 </config>

--- a/modules/brainbrowser/README.md
+++ b/modules/brainbrowser/README.md
@@ -38,5 +38,5 @@ for access details.
 
 ## Configurations
 
-For Brainbrowser to load the MINC images successfully, the `config.xml` option 
+For Brainbrowser to load the MINC images successfully, the configuration path option 
 `MINCToolsPath` should point to the path where the MINC toolkit is installed.

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -92,5 +92,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (95,49,'1000');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (96,100,'environment');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (97,70,'/data-raisinbread/');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (98,93,'V1');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (99,101,'%MINCToolsPath%');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -92,6 +92,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (95,49,'1000');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (96,100,'environment');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (97,70,'/data-raisinbread/');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (98,93,'V1');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (99,101,'%MINCToolsPath%');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (99,101,'');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_ConfigSettings.sql
+++ b/raisinbread/RB_files/RB_ConfigSettings.sql
@@ -97,5 +97,6 @@ INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMult
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (98,'publication_deletions','Path to deleted publications',1,0,'web_path',26,'Deleted Publications',11);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (99,'usePwnedPasswordsAPI','Whether to query the Have I Been Pwned password API on password changes to prevent the usage of common and breached passwords',1,0,'boolean',1,'Enable \"Pwned Password\" check',22);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (100,'EnvironmentFile','Name of the environment file that need to be sourced for the imaging pipeline',1,0,'text',69,'Name of the environment file',20);
+INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (101,'MINCToolsPath','Path to the MINC tools',1,0,'web_path',26,'Path to the MINC tools',12);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/config/config.xml
+++ b/raisinbread/config/config.xml
@@ -138,7 +138,4 @@
         </instrument>
     </instrumentPermissions>
 
-    <!-- MINC TOOLS PATH -->
-    <MINCToolsPath>%MINCTOOLSPATH%</MINCToolsPath>
-
 </config>

--- a/test/config.xml
+++ b/test/config.xml
@@ -146,7 +146,4 @@
         </instrument>
     </instrumentPermissions>
 
-    <!-- MINC TOOLS PATH -->
-    <MINCToolsPath>%MINCTOOLSPATH%</MINCToolsPath>
-
 </config>


### PR DESCRIPTION
## Brief summary of changes

This PR moves the config setting `MINCToolsPath` from `config.xml` to the Config tables.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5019 
