### PR TITLE
Very simple script to install system dependencies for development instances of LORIS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean dev all check checkstatic unittests test phpdev javascript
+.PHONY: clean dev all check checkstatic unittests test phpdev javascript devdependencies
 
 all: VERSION javascript
 	composer install --no-dev
@@ -14,7 +14,11 @@ javascript:
 	npm install
 	npm run compile
 
-dev: VERSION phpdev javascript
+dev: VERSION devdependencies phpdev javascript 
+
+devdependencies:
+	./tools/install_dev_dependencies.sh
+
 
 clean:
 	rm -f smarty/templates_c/*

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ javascript:
 dev: VERSION devdependencies phpdev javascript 
 
 devdependencies:
-	./tools/install_dev_dependencies.sh
+	./tools/install-dev-dependencies.sh
 
 
 clean:

--- a/tools/install-dev-dependencies.sh
+++ b/tools/install-dev-dependencies.sh
@@ -33,17 +33,17 @@ do
    fi
 done
 
-# Last updated for LORIS version: 21.0.2
+# Last updated for LORIS version: 22.0.0
 export PHP='7.2'
 declare -a dependencies=(
+"make"
 "curl"
+"git"
 "wget"
 "zip"
 "unzip"
 "php-json"
-"make"
 "software-properties-common"
-"php-ast"
 "php$PHP"
 "php$PHP-mysql"
 "php$PHP-xml"
@@ -60,10 +60,13 @@ declare -a dependencies=(
 echo "Updating apt package directory..."
 sudo apt update > /dev/null
 
-## Install all dependencies using sudo
+# Install all dependencies using sudo
 for i in "${dependencies[@]}"
 do
    echo "Installing dependency '$i' using apt...."
    sudo apt install -f -y "$i"
 done
 
+# Install php-ast using pecl as the Ubuntu version is too old.
+# This is required for phan to operate.
+sudo pecl install -f ast-1.0.3

--- a/tools/install-dev-dependencies.sh
+++ b/tools/install-dev-dependencies.sh
@@ -43,7 +43,6 @@ declare -a dependencies=(
 "zip"
 "unzip"
 "software-properties-common"
-"php$PHP"
 "php$PHP-mysql"
 "php$PHP-xml"
 "php$PHP-json"

--- a/tools/install-dev-dependencies.sh
+++ b/tools/install-dev-dependencies.sh
@@ -42,7 +42,6 @@ declare -a dependencies=(
 "wget"
 "zip"
 "unzip"
-"php-json"
 "software-properties-common"
 "php$PHP"
 "php$PHP-mysql"

--- a/tools/install_dev_dependencies.sh
+++ b/tools/install_dev_dependencies.sh
@@ -53,8 +53,10 @@ declare -a dependencies=(
 "libapache2-mod-php$PHP"
 )
 
-echo "Adding 'ppa:ondrej/php' (needed for newer versions of PHP)...."
-sudo add-apt-repository ppa:ondrej/php
+## XXX If you're unable to install the above PHP packages, uncomment the
+# following lines.
+# echo "Adding 'ppa:ondrej/php' (needed for newer versions of PHP)...."
+# sudo add-apt-repository ppa:ondrej/php
 echo "Updating apt package directory..."
 sudo apt update > /dev/null
 

--- a/tools/install_dev_dependencies.sh
+++ b/tools/install_dev_dependencies.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Installs dependencies required for LORIS development.
+
+declare -a prereqs=(
+"php"
+"apache2"
+"composer"
+"nodejs"
+)
+
+# Verify prerequisites installed
+for i in "${prereqs[@]}"
+do
+   # `command` is a cross-platform way to figure out whether these commands are
+   # installed.
+   command -v "$i" > /dev/null
+   if [ ! "$?" -eq "0" ]; then
+       echo "ERROR: the command '$i' does not appear to be installed on this system."
+       echo "$i is required for development but cannot be installed by this script."
+       echo "Please install $i and run this script again"
+       exit 1
+   else
+       echo "Requirement $i appears to be satisfied"
+   fi
+done
+
+# Last updated for LORIS version: 21.0.2
+export PHP='7.2'
+declare -a dependencies=(
+"curl"
+"wget"
+"zip"
+"unzip"
+"php-json"
+"make"
+"software-properties-common"
+"php-ast"
+"php$PHP"
+"php$PHP-mysql"
+"php$PHP-xml"
+"php$PHP-json"
+"php$PHP-mbstring"
+"php$PHP-gd"
+"libapache2-mod-php$PHP"
+)
+
+echo "Updating apt package directory..."
+sudo apt update > /dev/null
+
+## Install all dependencies using sudo
+for i in "${dependencies[@]}"
+do
+   echo "Installing dependency '$i' using apt...."
+   sudo apt install -f -y "$i"
+done
+

--- a/tools/install_dev_dependencies.sh
+++ b/tools/install_dev_dependencies.sh
@@ -9,9 +9,10 @@ if [[ ! " ${debian[*]} " =~ " $os_distro " ]]; then
     exit 0;
 fi
 
+# apache2 is not included here because a developer may use a different server
+# config, such as the builtin PHP web server.
 declare -a prereqs=(
 "php"
-"apache2"
 "composer"
 "nodejs" # TODO this should check for a version >= 8.0
 )

--- a/tools/install_dev_dependencies.sh
+++ b/tools/install_dev_dependencies.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 
-# Installs dependencies required for LORIS development.
+# Installs dependencies required for LORIS development on Ubuntu
+
+os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')
+debian=("Debian" "Ubuntu")
+if [[ ! " ${debian[*]} " =~ " $os_distro " ]]; then
+    echo "Only Debian and Ubuntu are supported by $0."
+    exit 0;
+fi
 
 declare -a prereqs=(
 "php"
 "apache2"
 "composer"
-"nodejs"
+"nodejs" # TODO this should check for a version >= 8.0
 )
 
 # Verify prerequisites installed

--- a/tools/install_dev_dependencies.sh
+++ b/tools/install_dev_dependencies.sh
@@ -4,7 +4,7 @@
 
 os_distro=$(hostnamectl |awk -F: '/Operating System:/{print $2}'|cut -f2 -d ' ')
 debian=("Debian" "Ubuntu")
-if [[ ! " ${debian[*]} " =~ " $os_distro " ]]; then
+if [[ ! " ${debian[*]} " == *" $os_distro "* ]]; then
     echo "Only Debian and Ubuntu are supported by $0."
     exit 0;
 fi

--- a/tools/install_dev_dependencies.sh
+++ b/tools/install_dev_dependencies.sh
@@ -52,6 +52,8 @@ declare -a dependencies=(
 "libapache2-mod-php$PHP"
 )
 
+echo "Adding 'ppa:ondrej/php' (needed for newer versions of PHP)...."
+sudo add-apt-repository ppa:ondrej/php
 echo "Updating apt package directory..."
 sudo apt update > /dev/null
 


### PR DESCRIPTION
## Brief summary of changes

Getting a developer instance of LORIS working is still harder than it should be.

This is my latest attempt at trying to automate the process a bit. This is a simplified, less robust `bash` rewrite of #4365.

#### Testing instructions (if applicable)

1. On an Ubuntu system, run `make devdependencies`
2. Try running this the next time you need to install LORIS and see whether it helps you.

#### Links to related tickets (GitHub, Redmine, ...)

* Another attempt at the same thing #4365
* Fixes some issues in #4172 
