### PR TITLE
[candidate_parameters] Fixing breadcrumb 

### DIFF
--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -74,4 +74,22 @@ class Candidate_Parameters extends \NDB_Form
             )
         );
     }
+
+    /**
+     * Generate a breadcrumb trail for this page.
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        $candidate =& \Candidate::singleton((int)$this->identifier);
+        $candID    = $candidate->getCandID();
+
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb(
+                'Candidate Parameters',
+                "/candidate_parameters/?candID=$candID&identifier=$candID"
+            )
+        );
+    }
 }

--- a/modules/candidate_parameters/test/TestPlan.md
+++ b/modules/candidate_parameters/test/TestPlan.md
@@ -9,6 +9,7 @@
 3. Click on the *Return to Timepoint List* button and ensure it goes to the correct timepoint list page.
 4. Make sure all tabs render.
 5. Ensure you stay on the same tab when you refresh.
+6. Ensure that you stay on the same page when clicking on the `Candidate Parameters` breadcrumb.
 
 ### Candidate Information Tab
 5. Confirm that all the fields in this panel correspond to what's stored in the candidate table and the corresponding parameter_candidate.


### PR DESCRIPTION
## Brief summary of changes
When clicking on the breadcrumb in `Candidate Parameters`, the CandID was not being included in the link and thus was throwing a 500 error (specifically in the `Consent Status` tab). See screenshot.

![image](https://user-images.githubusercontent.com/34260251/66598126-54042b00-eb6e-11e9-98d3-1951a75d5fad.png)


#### Testing instructions (if applicable)

1. Click the breadcrumb and ensure that you stay on the same page.

