### PR TITLE
[brainbrowser] Add possibility to read nii.gz files with BB

### DIFF
--- a/modules/brainbrowser/ajax/image.php
+++ b/modules/brainbrowser/ajax/image.php
@@ -53,7 +53,7 @@ if (!empty($image_file) && !empty($image_path)) {
         header('Content-Type: application/x-mnc');
     }
     header('X-FileID: ' . $_REQUEST['file_id']);
-    readfile($image_path);
+    readgzfile($image_path);
 } else {
     header("HTTP/1.1 404 Not Found");
     exit();


### PR DESCRIPTION
## Brief summary of changes

`nii.gz` files could not be opened with the brainbrowser module. This PR modifies the way we read the image so that if the file is gzipped, it is decompressed first before reading the content of the file.


