### PR TITLE
[Statistics / Demographic Statistics] Fix permission issue where users were allowed to see demographic statistics from sites they don't have access to.

### DIFF
--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -218,6 +218,18 @@ class Stats_Demographic extends \NDB_Form
             $this->params['sid'] = $demographicSite;
         }
 
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+        $user    = $factory->user();
+
+        //SITES
+        if ($user->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList();
+        } else {
+            $list_of_sites = $user->getStudySites();
+        }
+        $sitesString = implode(",", array_keys($list_of_sites));
+
         $centers = $db->pselect(
             "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
@@ -225,7 +237,8 @@ class Stats_Demographic extends \NDB_Form
                     Name as ShortName
             FROM psc
             WHERE CenterID <> '1'
-            AND Study_site = 'Y'",
+		    AND Study_site = 'Y'
+	            AND CenterID IN (" . $sitesString . ")",
             array()
         );
 
@@ -260,6 +273,7 @@ class Stats_Demographic extends \NDB_Form
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'
                           AND s.CenterID <> '1'
+	            	  AND s.CenterID IN (" . $sitesString . ")
                           AND c.Entity_type != 'Scanner'
                           AND c.Active = 'Y'
                           $paramProject
@@ -287,6 +301,7 @@ class Stats_Demographic extends \NDB_Form
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'
                           AND s.CenterID <> '1'
+	            	  AND s.CenterID IN (" . $sitesString . ")
                           AND c.Entity_type != 'Scanner'
                           AND c.Active='Y'
                           AND (ps.participant_status=1
@@ -316,6 +331,7 @@ class Stats_Demographic extends \NDB_Form
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'
                           AND s.CenterID <> '1'
+	            	  AND s.CenterID IN (" . $sitesString . ")
                           AND c.Entity_type != 'Scanner'
                           AND c.Active='Y'
                           AND ps.participant_status=5
@@ -341,6 +357,7 @@ class Stats_Demographic extends \NDB_Form
                       WHERE coalesce(s.active, 'Y')='Y'
                           AND c.RegistrationCenterID <> '1'
                           AND s.CenterID <> '1'
+	            	  AND s.CenterID IN (" . $sitesString . ")
                           AND c.Entity_type != 'Scanner'
                           AND c.Active='Y'
                           AND (ps.participant_status=1 OR
@@ -372,6 +389,7 @@ class Stats_Demographic extends \NDB_Form
                       WHERE coalesce(s.active, 'Y')='Y'
                           AND c.RegistrationCenterID <> '1'
                           AND s.CenterID <> '1'
+	            	  AND s.CenterID IN (" . $sitesString . ")
                           AND c.Entity_type != 'Scanner'
                           AND c.Active='Y'
                           AND (ps.participant_status=1
@@ -405,6 +423,7 @@ class Stats_Demographic extends \NDB_Form
                       WHERE coalesce(s.active, 'Y')='Y'
                           AND c.RegistrationCenterID <> '1'
                           AND s.CenterID <> '1'
+	            	  AND s.CenterID IN (" . $sitesString . ")
                           AND c.Entity_type != 'Scanner'
                           AND (ps.participant_status=1
                           OR ps.participant_status IS NULL)
@@ -448,6 +467,7 @@ class Stats_Demographic extends \NDB_Form
                 WHERE s.Active='Y'
                 AND c.RegistrationCenterID <> '1'
                 AND s.CenterID <> '1'
+		AND s.CenterID IN (" . $sitesString . ")
                 AND f.Data_entry='Complete'
                 AND f.Administration='All'
                 AND f.CommentID NOT LIKE 'DDE%'
@@ -467,6 +487,7 @@ class Stats_Demographic extends \NDB_Form
                 WHERE s.Active='Y' 
                     AND c.RegistrationCenterID <> '1'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     $paramProject
                     AND f.CommentID NOT LIKE 'DDE%'
                     AND (f.Data_entry IS NULL OR f.Data_entry <> 'Complete')
@@ -503,6 +524,7 @@ class Stats_Demographic extends \NDB_Form
                 FROM session s
                 JOIN candidate c ON (s.CandID=c.CandID)
                 WHERE s.active='Y' AND s.CenterID <> '1' 
+		AND s.CenterID IN (" . $sitesString . ")
                 AND c.RegistrationCenterID <> '1'
                 AND (s.Current_stage IN ('Visit', 'Screening', 'Approval')
                 $subprojectQuery)


### PR DESCRIPTION
### Description

A user with role Data Entry was able to see **demographic** statistics from sites it does not belong/have access

For example if there are two users and two sites:
user Site 1 is associate only to Site_1.
user Site 2 is associate only to Site_2.

(Both of them have the role Data Entry and nothing more in the permissions)
When going to MainMenu->Reports->Statistics->**Demographic** Statistics
The user of Site 1 is able to see the statistics for Site 2 and vice versa

#### Testing instructions

Now each user should be able to see only the **demographic** statistics for the sites it belong/have access

#### Links to related tickets (GitHub, Redmine, ...)

* #5086 
