### PR TITLE
[Core: Database] Add array return type to pselect

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -720,12 +720,11 @@ class Database
      *               row returned by the query, and each element is an associative
      *               array representing the row in the format ColumnName => Value
      */
-    function pselect(string $query, array $params)
+    function pselect(string $query, array $params): array
     {
         $this->_printQuery($query, $params);
-        $stmt   = $this->prepare($query);
-        $result = $this->execute($stmt, $params);
-        return $result;
+        $stmt = $this->prepare($query);
+        return $this->execute($stmt, $params);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

`Database->pselect()` now always returns an array, thus removing the need to check if its result is an array before proceeding.

This should be safe as it is just a wrapper for the `execute()` function which already returns an array.

I'm not sure if this has implications for overrides or instruments so for now I'm adding the Caveat label.

## Related

#5318, #4284