### PR TITLE
[Install] Fix Database connection edge-case that resulted in 500 error

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -297,12 +297,16 @@ class Installer
     {
         $DB = Database::singleton();
         try {
-            $DB->connect(
+            $success = $DB->connect(
                 $values['dbname'],
                 $values['dbadminuser'],
                 $values['dbadminpassword'],
                 $values['dbhost']
             );
+
+            if (! $success) {
+                throw new \DatabaseException('Could not connect to database');
+            }
         } catch (\Exception $e) {
             if (!empty($DB->lastErr)) {
                 $this->_lastErr = $DB->lastErr;


### PR DESCRIPTION
## Brief summary of changes

There was a slight issue with the logic during the install process that swallowed a DB exeption in favour of returning false; however, the return value of this function was never checked so the code kept trying to function without a DB connection. This could give a 500 error in some cases, making the install look messy and hard to debug.

This PR simply checks the return status of the `connect` function and throws a DB exception if it is false.

## To test

* Try to install a fresh LORIS. Provide incorrect DB information and use these installation settings:

<img width="717" alt="Screen Shot 2019-10-16 at 11 09 53" src="https://user-images.githubusercontent.com/4022790/66933912-bb572a80-f007-11e9-8228-50e77d6f917e.png">

You will get a blank page (500 error).

* On this branch, do the same thing. You will get a front-end error message with MySQL debug information.

## Related

* #5311  