### PR TITLE
[Install] Use "command" instead of "which" to determine if a binary is installed

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -69,7 +69,7 @@ if ! [ $BASH ] ; then
     exit 2
 fi
 
-if [[ -n $(which php) ]]; then
+if [[ -n $(command -v php) ]]; then
     echo ""
     echo "PHP appears to be installed."
 else
@@ -78,7 +78,7 @@ else
     exit 2;
 fi
 
-if [[ -n $(which composer) ]]; then
+if [[ -n $(command -v composer) ]]; then
     echo ""
     echo "PHP Composer appears to be installed."
     composer_scr="composer install --no-dev"


### PR DESCRIPTION
## Brief summary of changes

Using `command -v` is POSIX standard. `which` can also give weird path results sometimes so we should avoid it.

#### Testing instructions (if applicable)

1. The install script should work as normal

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5298 
