### PR TITLE
[Core/Install] Improve UNIX permission usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ changes in the following format: PR #1234***
 
 #### Core
 - Menus are now maintained by modules and no longer in the SQL database (PR #5839)
-- Very old instrument relying on QuickForm may have issues due to code changes (PR #4928)
+- Very old instruments relying on QuickForm may have issues due to code changes (PR #4928)
+- Unix user permissions have been updated which may affect access to files. New
+documentation for file permissions has been added to the README.md file (PR #5323)
 
 #### Modules 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 
 ```bash
 # Create lorisadmin user and group
-sudo groupadd lorisadmin
 # Give lorisadmin `sudo` permission. This is required for the install process
 # in order to automatically generate Apache configuration files.
 # Sudo privileges can be revoked once the install is completed.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 # in order to automatically generate Apache configuration files.
 # Sudo privileges can be revoked once the install is completed.
     sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-# Add apache and lorisadmin to the lorisadmin group
-    sudo groupadd -a -G lorisadmin lorisadmin
+# Add apache to the lorisadmin group
     sudo groupadd -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
     sudo passwd lorisadmin

--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 
 ```bash
 # Create lorisadmin user and group
-    sudo groupadd lorisadmin
+sudo groupadd lorisadmin
 # Give lorisadmin `sudo` permission. This is required for the install process
 # in order to automatically generate Apache configuration files.
 # Sudo privileges can be revoked once the install is completed.
-    sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
+sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 # Add apache to the lorisadmin group
-    sudo groupadd -a -G lorisadmin www-data
+sudo groupadd -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
-    sudo passwd lorisadmin
-    sudo mkdir -m 755 -p /var/www/$projectname
-    sudo chown lorisadmin.lorisadmin /var/www/$projectname
-    su - lorisadmin
+sudo passwd lorisadmin
+sudo mkdir -m 755 -p /var/www/$projectname
+sudo chown lorisadmin.lorisadmin /var/www/$projectname
+su - lorisadmin
 ```
 
  <i>$projectname ⇾ "loris" or one-word project name</i>

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 # Sudo privileges can be revoked once the install is completed.
 sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 # Add apache to the lorisadmin group
-sudo groupadd -a -G lorisadmin www-data
+sudo usermod -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
 sudo passwd lorisadmin
 sudo mkdir -m 755 -p /var/www/$projectname

--- a/README.md
+++ b/README.md
@@ -42,20 +42,24 @@ These dependencies are subject to change so be sure to verify your version of My
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.
 
-1. Set up LINUX user lorisadmin, with `sudo` privilege, and create LORIS base directory:
+1. Set up LINUX user and group lorisadmin and create LORIS base directory:
 
 ```bash
-sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-sudo passwd lorisadmin
-su - lorisadmin
+# Create lorisadmin user and group
+    sudo groupadd lorisadmin
+# Give lorisadmin `sudo` permission. This is required for the install process
+# in order to automatically generate Apache configuration files.
+# Sudo privileges can be revoked once the install is completed.
+    sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
+# Add apache and lorisadmin to the lorisadmin group
+    sudo groupadd -a -G lorisadmin lorisadmin
+    sudo groupadd -a -G lorisadmin www-data
+# Set the password for the lorisadmin account
+    sudo passwd lorisadmin
+    sudo mkdir -m 755 -p /var/www/$projectname
+    sudo chown lorisadmin.lorisadmin /var/www/$projectname
+    su - lorisadmin
 ```
-
- <b>Important: All steps from this point forward must be executed by lorisadmin user</b>
-
- ```bash
- sudo mkdir -m 775 -p /var/www/$projectname
- sudo chown lorisadmin.lorisadmin /var/www/$projectname
- ```
 
  <i>$projectname ⇾ "loris" or one-word project name</i>
 

--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 for d in data libraries instruments templates tables_sql modules; do
-    mkdir -p "${1}/${d}"
+    mkdir -p -m 750 "${1}/${d}"
 done
 

--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 for d in data libraries instruments templates tables_sql modules; do
-    mkdir -p -m 750 "${1}/${d}"
+    mkdir -p "${1}/${d}"
 done
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -138,7 +138,6 @@ elif [[ " ${redhat[*]} " == *" $os_distro "* ]]; then
     sudo chown apache.apache ../smarty/templates_c
     # Make Apache the group for project directory, so that the web based install
     # can write the config.xml file.
-    sudo chgrp apache ../project
     sudo chmod 770 ../project
 else
     echo "$os_distro Linux distribution detected. We currently do not support this. "


### PR DESCRIPTION
## Brief summary of changes

This PR improves the way UNIX permissions are used in LORIS.

### Summary
#### Old permissions

* `lorisadmin` owns all files
* `lorisadmin` has sudo
* `www-data`/`apache2` selectively owns and is the group for web-writable files
    * e.g. `drwxrwxrwx 2 www-data    www-data 4096 Oct  9 16:30 user_uploads`
*  Uses the same permissions as `lorisadmin`
* Typical permission codes: `775`, for directories, `664` for files 
* **Result**: On certain files and folders, Apache gets to do everything `lorisadmin` can do

#### New permissions
* `lorisadmin` owns all files
* `lorisadmin` has sudo
* `lorisadmin` is the group for all files
    * e.g. `drwxrwxrwx 2 lorisadmin    lorisadmin 4096 Oct  9 16:30 user_uploads`
* `www-data`/`apache2` is part of the `lorisadmin` group
* Typical permission codes: `755` for directories, `644` for files.
* **Result**: Certain group permissions on files can be used to limit `www-data`/`apache2` access.

### Why?

More details in #5297. In short:

1. **Simplifies install** - no need to selectively `chgrp` to apache2 or www-data user
2. **Prerequisite for creating a Debian package** - the `lintian` tool causes LORIS to fail because of odd permission codes like `775` and `664`. See #5057 
3. **Easier maintenance** - everything is now `lorisadmin.lorisadmin`. Permissions can be tracked using GitHub rather than changed manually.
4. **This is how UNIX permissions are usually used**.
5. Brings us closer to the principle of least-privilege.

### Testing instructions

1. Test the install according to the new instructions. Ensure that LORIS still works.

### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5057 
* Related #5297 
