### PR TITLE
[New Profile] Fix crash when creating candidate with "user" generation method

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -282,7 +282,7 @@ class New_Profile extends \NDB_Form
             } else {
                 // user has multiple sites,
                 // so validate PSCID against the Site selected
-                $site =& \Site::singleton($values['site']);
+                $site =& \Site::singleton((int) $values['site']);
             }
 
             if (empty($values['pscid'])) {


### PR DESCRIPTION
## Brief summary of changes

A project with the `user` ID generation method is not able to create new candidates. A TypeError occurs because Site must take an int, not a string:

>PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Site::singleton() must be of the type int, string given, called in /var/www/loris/modules/new_profile/php/new_profile.class.inc on line 280

~~This PR fixes the type error.... but candidate creation does still not seem to be possible. See #5331. We should discuss whether this should be fixed or removed.~~

~~In any case, this PR at least stops LORIS from crashing so it's a small step forward.~~

#### Testing instructions (if applicable)

1. See #5331.
