### PR TITLE
[Statistics / Imaging Statistics] Fix permission issue where users were allowed to see imaging statistics from sites they don't have access to.

### DIFF
--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -216,7 +216,9 @@ class Stats_MRI extends \NDB_Form
     {
         parent::setup();
 
-        $DB =& \Database::singleton();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+        $user    = $factory->user();
 
         $bigTable_params = array();
         $this->params    = array();
@@ -263,6 +265,15 @@ class Stats_MRI extends \NDB_Form
         } else {
             $Param_Site = '';
         }
+
+        //SITES PERMISSIONS
+        if ($user->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList();
+        } else {
+            $list_of_sites = $user->getStudySites();
+        }
+        $sitesString = implode(",", array_keys($list_of_sites));
+
         $centers     = $DB->pselect(
             "SELECT CONCAT('C', CenterID) as ID,
                     CenterID as NumericID,
@@ -270,7 +281,8 @@ class Stats_MRI extends \NDB_Form
                     Name as ShortName
               FROM psc
               WHERE CenterID <> '1'
-                AND Study_site = 'Y'",
+                AND Study_site = 'Y'
+	        AND CenterID IN (" . $sitesString . ")",
             array()
         );
         $sites[null] ="All sites";
@@ -371,6 +383,7 @@ class Stats_MRI extends \NDB_Form
                     AND c.Active='Y'
                     AND f.CommentID NOT LIKE 'DDE%'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     $suproject_query
                     $Param_Project
                 GROUP BY Subcat,
@@ -415,6 +428,7 @@ class Stats_MRI extends \NDB_Form
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     AND fi.FileType='mnc'
                     AND fi.File LIKE CONCAT('%_', :scan, '_%')
                     $suproject_query
@@ -433,6 +447,7 @@ class Stats_MRI extends \NDB_Form
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     AND fi.FileType='mnc'
                     AND fi.File LIKE CONCAT('%_', :scan, '_%')
                     $suproject_query
@@ -462,6 +477,7 @@ class Stats_MRI extends \NDB_Form
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     AND fqc.QCStatus='Pass'
                     AND fi.File LIKE CONCAT('%_', :scan, '_%')
                     $suproject_query
@@ -482,6 +498,7 @@ class Stats_MRI extends \NDB_Form
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     AND fqc.QCStatus='Pass'
                     AND fi.File LIKE CONCAT('%_', :scan, '_%')
                     $suproject_query
@@ -512,6 +529,7 @@ class Stats_MRI extends \NDB_Form
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     AND fqc.QCStatus='Fail'
                     AND fi.File LIKE CONCAT('%_', :scan, '_%')
                     $suproject_query
@@ -532,6 +550,7 @@ class Stats_MRI extends \NDB_Form
                     AND s.Active='Y'
                     AND c.Active='Y'
                     AND s.CenterID <> '1'
+		    AND s.CenterID IN (" . $sitesString . ")
                     AND fqc.QCStatus='Fail'
                     AND fi.File LIKE CONCAT('%_', :scan, '_%')
                     $suproject_query
@@ -564,7 +583,7 @@ class Stats_MRI extends \NDB_Form
      * of statistics totals. They will eventually be passed to tpl_data.
      *
      * @param array $subcategories The subcategories being tracked by this
-     *                              module. Keys of the returned array.
+     *                             module. Keys of the returned array.
      *
      * @return array ('total' => 0, $subcat1 => 0, ..., $subcatN => 0)
      */


### PR DESCRIPTION
### Description

A user with role Data Entry was able to see **imaging** statistics from sites it does not belong/have access

For example if there are two users and two sites:
user Site 1 is associate only to Site_1.
user Site 2 is associate only to Site_2.

(Both of them have the role Data Entry and nothing more in the permissions)

When going to MainMenu->Reports->Statistics->**Imaging** Statistics

The user of Site 1 is able to see the **imaging** statistics for Site 2 and vice versa

#### Testing instructions

Now each user should be able to see only the **imaging** statistics for the sites it belong/have access
