### PR TITLE
[DQT] Fix 500 error caused by bad Exception name

### DIFF
--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -65,7 +65,7 @@ class Dataquery extends \NDB_Form
                 '`port`, `admin` and `adminpass` values are properly ' .
                 'configured in project/config.xml'
             );
-            throw new \ConfigException(
+            throw new \ConfigurationException(
                 'Missing CouchDB configuration settings. Cannot load ' .
                 'Data Query Tool.'
             );


### PR DESCRIPTION
## Brief summary of changes

"ConfigException" doesn't exist and causing LORIS to crash when an exception is thrown.

#### Testing instructions (if applicable)

1. Using invalid CouchDB credentials, go the DQT module. LORIS will crash.