### PR TITLE
[DQT] Fix PHP Notices

### DIFF
--- a/modules/dataquery/ajax/datadictionary.php
+++ b/modules/dataquery/ajax/datadictionary.php
@@ -30,7 +30,8 @@ $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['adminpass']
 );
 
-if ($_REQUEST['category']) {
+$results = array();
+if (isset($_REQUEST['category']) && $_REQUEST['category']) {
     $category = urlencode($_REQUEST['category']);
 
     $results = $cdb->queryView(
@@ -42,7 +43,7 @@ if ($_REQUEST['category']) {
          "endkey"   => "[\"$category\", \"ZZZZZZZZ\"]",
         )
     );
-} else if ($_REQUEST['key']) {
+} else if (isset($_REQUEST['key']) && $_REQUEST['key']) {
     $key = explode('%2C', urlencode($_REQUEST['key']));
 
     $results = $cdb->queryView(


### PR DESCRIPTION
## Brief summary of changes

When `ajax/datadictionary.php` is called, Notices are generated when the `category` or `key` params are checked when not present in the request.