### PR TITLE
[Candidate List] Fix broken links to individual profiles (on major)

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -92,8 +92,10 @@ class CandidateListIndex extends Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
+    const DCCID = 1;
     if (column === 'PSCID' && this.props.hasPermission('access_all_profiles')) {
-      let url = this.props.baseURL + '/' + row['DCCID'] + '/';
+      // Generate link to Access Profile module in the PSCID column.
+      let url = this.props.baseURL + '/' + row[DCCID] + '/';
       return <td><a href ={url}>{cell}</a></td>;
     }
     if (column === 'Feedback') {


### PR DESCRIPTION
## Brief summary of changes

`row['DCCID']` was giving `undefined` because the row is returned with numeric indices, not string keys.

#### Testing instructions (if applicable)

1. On major, go to candidate list and try clicking a PSCID link. You will get a 404.
2. On my branch, do the same. You will get the right info.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5346 
