### PR TITLE
[Candidate List] change visitLabel filter to dropdown, fix link issue

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -39,7 +39,7 @@ class Filter extends Component {
   onFieldUpdate(name, value, id, type) {
     const searchParams = new URLSearchParams(location.search);
     const filter = JSON.parse(JSON.stringify(this.props.filter));
-    const exactMatch = (!(type === 'textbox' || type === 'date'));
+    const exactMatch = (!(type === 'textbox' || type === 'date' || type === 'select'));
     if (value === null || value === '' || (value.constructor === Array && value.length === 0)) {
       delete filter[name];
       searchParams.delete(name);

--- a/jsx/FilterForm.js
+++ b/jsx/FilterForm.js
@@ -132,7 +132,6 @@ class FilterForm extends Component {
       } else { // null and undefined handled here
         filter[key].value = '';
       }
-      filter[key].exactMatch = (type === 'SelectElement' || type === 'select');
     }
     if (filter && key && value === '') {
       delete filter[key];

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -92,7 +92,7 @@ class CandidateListIndex extends Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
-    if (column === 'PSCID' && this.props.hasPermission('access_all_profiles')) {
+    if (column === 'PSCID') {
       let url = this.props.baseURL + '/' + row['DCCID'] + '/';
       return <td><a href ={url}>{cell}</a></td>;
     }
@@ -155,7 +155,8 @@ class CandidateListIndex extends Component {
         show: false,
         filter: {
           name: 'visitLabel',
-          type: 'text',
+          type: 'select',
+          options: options.visitlabel,
         },
       },
       {

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -115,6 +115,9 @@ class Candidate_List extends \NDB_Menu_Filter
         $user   = \User::singleton();
         $config = \NDB_Config::singleton();
 
+        // get the list of visit labels
+        $visit_label_options = \Utility::getVisitList();
+
         // get the list of sites available for the user
         if ($user->hasPermission('access_all_profiles')) {
             $list_of_sites = \Utility::getSiteList();
@@ -146,6 +149,7 @@ class Candidate_List extends \NDB_Menu_Filter
         }
 
         $this->fieldOptions = [
+                               'visitlabel'       => $visit_label_options,
                                'site'              => $site_options,
                                'project'           => $project_options,
                                'subproject'        => $subproject_options,

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -149,7 +149,7 @@ class Candidate_List extends \NDB_Menu_Filter
         }
 
         $this->fieldOptions = [
-                               'visitlabel'       => $visit_label_options,
+                               'visitlabel'        => $visit_label_options,
                                'site'              => $site_options,
                                'project'           => $project_options,
                                'subproject'        => $subproject_options,

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -169,7 +169,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this-> _testFilter(self::$PSCID, "1 rows", 'MTL001');
         $this-> _testFilter(self::$DCCID, "1 rows", '300001');
         $this-> _testFilter(self::$DCCID, "0 rows", 'test');
-        $this-> _testFilter(self::$visitLabel, "374", 'V1');
+        $this-> _testFilter(self::$visitLabel, "375", 'V1');
         $this-> _testFilter(self::$visitLabel, "261", 'V2');
         $this-> _testFilter(self::$site, "8 rows", '1');
         $this-> _testFilter(self::$site, "168", '2');

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -26,7 +26,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
     //filter location
     static $PSCID          = ".col-xs-12:nth-child(2) > .row .form-control";
     static $DCCID          = ".col-xs-12:nth-child(3) > .row .form-control";
-    static $visitLabel     = ".col-xs-12:nth-child(4) .form-control";
+    static $visitLabel     = ".col-xs-12:nth-child(4) .form-control, select";
     static $site           = ".col-xs-12:nth-child(5) .form-control, select";
     static $entityType     = ".col-xs-12:nth-child(7) .form-control, select";
     static $sex            = "#candidateList_filter > div > div > fieldset >".


### PR DESCRIPTION
## Brief summary of changes
This PR does two things:
1. It changes the visit label filter from a textbox to a dropdown. 
2. It addresses the issue reported in #5360 in which if a user does not have `across all sites` permission, links to the candidate profiles do not appear. However, the list of candidates returned in the table is already based on their permissions and only displays the candidates that they SHOULD have access to. 

#### Testing instructions (if applicable)
1. Try filtering by visit label 
2. Remove the `across all site` permission and see if you are able to access profiles. 

#### Links to related tickets (GitHub, Redmine, ...)
* #5360
* #5359
