### PR TITLE
[issue_tracker] Fixes An error occurred when loading the form!

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -687,7 +687,7 @@ ORDER BY dateAdded LIMIT 1",
         }
         $issueData['commentHistory'] = getComments($issueID);
         $issueData['othersWatching'] = getWatching($issueID);
-        $issueData['desc']           = $desc[0]['issueComment'];
+        $issueData['desc']           = $desc[0]['issueComment'] ?? '';
     }
     $issueData['comment'] = null;
 

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -66,7 +66,7 @@ class IssueTrackerIndex extends Component {
     case 'Issue ID':
       link = (
         <a
-          href={loris.BaseURL+'/issue_tracker/issue/'+row['Issue ID']}
+          href={loris.BaseURL+'/issue_tracker/issue/'+cell}
         >
           {cell}
         </a>


### PR DESCRIPTION
## Brief summary of changes

Two small solutions for fixing the "An error occurred when loading the form!" frontend message.

#### Testing instructions (if applicable)

1. Pull PR
2. Test on Rasinbread data.
3. Click an issue from the table column "Issue ID" and no error with PR changes.

