### PR TITLE
[media][editForm.js] Use study's start/end date as min/max values for Date of Administration field

### DIFF
--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -131,8 +131,8 @@ class MediaEditForm extends Component {
           <DateElement
             name='dateTaken'
             label='Date of Administration'
-            minYear='2000'
-            maxYear='2017'
+            minYear={this.state.Data.startYear}
+            maxYear={this.state.Data.endYear}
             onUserInput={this.setFormData}
             ref='dateTaken'
             value={this.state.formData.dateTaken}


### PR DESCRIPTION
## Brief summary of changes
Follow up to #5248.
Issue: Resolves #5361 

Date of administartion min and max year are currently hard-coded, but should use the config values of study start and end date.

#### Testing instructions (if applicable)

1. Edit a form. Make sure you can enter any date between the study's start and end year. 

#### Links to related tickets (GitHub, Redmine, ...)

* #5361 
* #5248.
