### PR TITLE
[ReadTheDocs] Fix build error

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LORIS
 repo_url: https://github.com/aces/Loris
-nav:
+pages:
     - Home: index.md
     - API: API/LorisRESTAPI_v0.0.3.md
     - Wiki: wiki/index.md


### PR DESCRIPTION
## Brief summary of changes

Running into a known issue when ReadTheDocs and Mkdocs compatibility: https://github.com/readthedocs/readthedocs.org/issues/4922

However it looks like the fix is as easy as changing the option from `nav` to `pages`. Both are building for me locally at https://loristest.readthedocs.io/en/latest/ (which is a copy of `minor` as of its latest changes from today). 

Not sure why there's a difference, but this should fix it.