### PR TITLE
[Cand. Params] Users with cand param edit permission should be able to view module 

### DIFF
--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -29,8 +29,6 @@ namespace LORIS\candidate_parameters;
  */
 class Candidate_Parameters extends \NDB_Form
 {
-    public $hasWritePermission = false;
-
     /**
      * Check user permissions
      *
@@ -40,11 +38,12 @@ class Candidate_Parameters extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        // Set global permission to control access
-        // to different modules of candidate_parameters page
-        $this->hasWritePermission = $user->hasPermission('candidate_parameter_edit');
-
-        return $user->hasPermission('candidate_parameter_view');
+        return $user->hasAnyPermission(
+            array(
+             'candidate_parameter_view',
+             'candidate_parameter_edit',
+            )
+        );
     }
 
     /**

--- a/modules/quality_control/php/quality_control.class.inc
+++ b/modules/quality_control/php/quality_control.class.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file contains the NDB_Menu_Filter_media class
+ * This file contains the Quality_Control class
  *
  * PHP Version 7
  *
@@ -8,13 +8,13 @@
  * @package  Quality_Control
  * @author   Liza Levitis <llevitis.mcin@gmail.com>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/CCNA/
+ * @link     https://www.github.com/aces/Loris
  */
 namespace LORIS\quality_control;
 
 /**
- * Main class for quality control module corresponding to /quality_control/ URL
- * Tools section of the LorisMenu.
+ * Main class for quality control module corresponding to /quality_control/
+ * endpoint.
  *
  * PHP Version 7
  *
@@ -22,13 +22,11 @@ namespace LORIS\quality_control;
  * @package  Quality_Control
  * @author   Liza Levitis <llevitis.mcin@gmail.com>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/CCNA/
+ * @link     https://www.github.com/aces/Loris
  */
 class Quality_Control extends \NDB_Menu_Filter
 {
-    public $hasWritePermission = false;
-    public $AjaxModule         = true;
-    public $hasHidePermission  = false;
+    public $AjaxModule = true;
     public $fieldOptions;
 
     /**
@@ -41,8 +39,7 @@ class Quality_Control extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        //create user object
-        $this->hasHidePermission = $user->hasPermission("superuser");
+        // FIXME This module should have its own permission.
         return $user->hasPermission('data_team_helper');
     }
 

--- a/modules/quality_control/php/quality_control_behavioral.class.inc
+++ b/modules/quality_control/php/quality_control_behavioral.class.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file contains the NDB_Menu_Filter_media class
+ * This file contains the Quality_Control_Behavioral class.
  *
  * PHP Version 7
  *
@@ -8,13 +8,12 @@
  * @package  Quality_Control
  * @author   Liza Levitis <llevitis.mcin@gmail.com>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/CCNA/
+ * @link     https://www.github.com/aces/Loris
  */
 namespace LORIS\quality_control;
 
 /**
- * Main class for quality control module corresponding to /quality_control/ URL
- * Tools section of the LorisMenu.
+ * Quality_Control_Behavioral class.
  *
  * PHP Version 7
  *
@@ -22,12 +21,11 @@ namespace LORIS\quality_control;
  * @package  Quality_Control
  * @author   Liza Levitis <llevitis.mcin@gmail.com>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/CCNA/
+ * @link     https://www.github.com/aces/Loris
  */
 class Quality_Control_Behavioral extends \NDB_Menu_Filter
 {
-    public $hasWritePermission = false;
-    public $AjaxModule         = true;
+    public $AjaxModule = true;
     public $fieldOptions;
 
     /**
@@ -40,7 +38,7 @@ class Quality_Control_Behavioral extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        //create user object
+        // FIXME This module should have its own permission
         return $user->hasPermission('data_team_helper');
     }
 


### PR DESCRIPTION
## Brief summary of changes

Previously only users with `candidate_parameter_view` could view the module. This allows users with `candidate_parameter_edit` to view it also.

I also cleaned up some unused code and documentation (probably introduced via copy-pasting).

#### Testing instructions (if applicable)

1. Ensure that with only the `candidate_parameter_edit` permission that you're able to view the data in the module.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5372 
