### PR TITLE
[user_accounts] fix react table url with undefined param

### DIFF
--- a/modules/user_accounts/jsx/userAccountsIndex.js
+++ b/modules/user_accounts/jsx/userAccountsIndex.js
@@ -66,7 +66,7 @@ class UserAccountsIndex extends Component {
         result = <td>{cell.join('; ')}</td>;
         break;
       case 'Username':
-        url = loris.BaseURL + '/user_accounts/edit_user/' + row.Username;
+        url = loris.BaseURL + '/user_accounts/edit_user/' + row[1];
         result = <td><a href ={url}>{cell}</a></td>;
         break;
       case 'Active':


### PR DESCRIPTION
Click the username URL link gets 500 error.
![Oct-25-2019](https://user-images.githubusercontent.com/9876007/67584505-cbfc5480-f71b-11e9-99ed-2698eda91eb8.gif)
Test: click the username link in the react table to test.
