### PR TITLE
[candidate_list] fix react table url with undefined param

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -93,7 +93,7 @@ class CandidateListIndex extends Component {
    */
   formatColumn(column, cell, row) {
     if (column === 'PSCID' && this.props.hasPermission('access_all_profiles')) {
-      let url = this.props.baseURL + '/' + row['DCCID'] + '/';
+      let url = this.props.baseURL + '/' + row[1] + '/';
       return <td><a href ={url}>{cell}</a></td>;
     }
     if (column === 'Feedback') {


### PR DESCRIPTION
Click the PSCID URL link gets 500 error.

Test: click the PSCID link in the react table to test.
![PSCIDLINK](https://user-images.githubusercontent.com/9876007/67584086-e41fa400-f71a-11e9-931e-c2d236a4d9cf.gif)
