### PR TITLE
[data_team_helper] fixed broken link that should redirect to candidate's timepoint

### DIFF
--- a/modules/data_team_helper/jsx/behavioural_qc_module.js
+++ b/modules/data_team_helper/jsx/behavioural_qc_module.js
@@ -134,7 +134,7 @@ class IncompleteCandidatesRow extends Component {
     return (
       <tr key={row.id} >
         <td>
-          <a href={this.props.BaseURL + '/instruments_list/?candID=' +
+          <a href={this.props.BaseURL + '/instrument_list/?candID=' +
               row.candid +
               '&sessionID=' + row.SessionID}
           >


### PR DESCRIPTION
## Brief summary of changes
This PR fixes a broken link reported in #5376

#### Testing instructions (if applicable)

1. Make sure all links in data team helper module are working as expected 

#### Links to related tickets (GitHub, Redmine, ...)

* #5376 
* aces/CCNA#3375
