### PR TITLE
[dataquery] Fixed broken link for 'deleteAll' and fixed save error on query names that contain spaces

### DIFF
--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -173,7 +173,7 @@ class DataQueryApp extends Component {
       for (let i = 0; i < this.state.queryIDs[key].length; i += 1) {
         let curRequest;
         curRequest = Promise.resolve(
-          $.ajax(loris.BaseURL + '/AjaxHelper.php?Module=dataquery&script=GetDoc.php&DocID=' + this.state.queryIDs[key][i]), {
+          $.ajax(loris.BaseURL + '/AjaxHelper.php?Module=dataquery&script=GetDoc.php&DocID=' + encodeURIComponent(this.state.queryIDs[key][i])), {
             data: {
               DocID: this.state.queryIDs[key][i]
             },
@@ -233,12 +233,11 @@ class DataQueryApp extends Component {
     // Used to save the current query
 
     let filter = this.saveFilterGroup(this.state.filter);
-    let queryName = name.replace(/ /g,'_');
 
     $.post(loris.BaseURL + '/AjaxHelper.php?Module=dataquery&script=saveQuery.php', {
       Fields: this.state.selectedFields,
       Filters: filter,
-      QueryName: queryName,
+      QueryName: name,
       SharedQuery: shared,
       OverwriteQuery: override
     }, (data) => {

--- a/modules/dataquery/jsx/react.app.js
+++ b/modules/dataquery/jsx/react.app.js
@@ -233,11 +233,12 @@ class DataQueryApp extends Component {
     // Used to save the current query
 
     let filter = this.saveFilterGroup(this.state.filter);
+    let queryName = name.replace(/ /g,'_');
 
     $.post(loris.BaseURL + '/AjaxHelper.php?Module=dataquery&script=saveQuery.php', {
       Fields: this.state.selectedFields,
       Filters: filter,
-      QueryName: name,
+      QueryName: queryName,
       SharedQuery: shared,
       OverwriteQuery: override
     }, (data) => {

--- a/modules/dataquery/jsx/react.fieldselector.js
+++ b/modules/dataquery/jsx/react.fieldselector.js
@@ -317,7 +317,7 @@ class FieldSelector extends Component {
 
   deleteAll() {
     // Deletes all fields the currently selected category
-    let i, index, fieldName;
+    let i, index, fieldName, category, isFile;
     for (i in this.state.categoryFields[this.state.selectedCategory]) {
       fieldName = this.state.categoryFields[this.state.selectedCategory][i].key[1];
       category = this.state.categoryFields[this.state.selectedCategory][i].key[0];


### PR DESCRIPTION
### Brief summary of changes
This PR addresses the issues reported in #5364 
1. The `Delete All` link in DQT was broken and not actually deselecting the fields. 
2. You couldn't save a query if it had a space in the name. No error was displayed, it just wouldn't save. The code now replaces any space by underscores. 

#### Testing instructions (if applicable)

1. Head over to DQT. 
2. Add some fields to your query. 
3. Attempt to deselect those fields using the `Delete All` button. 
4. Try saving a query that has spaces in the name. When you refresh, your query should appear. 

#### Links to related tickets (GitHub, Redmine, ...)

* #5364
* aces/CCNA#3342
