### PR TITLE
Fixing bugs introduced when optimizing DataTable

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -424,7 +424,7 @@ class DataTable extends Component {
 
             let row = {};
             this.props.fields
-              .forEach((field, k) => {row[field.label] = rowData[k]});
+              .forEach((field, k) => row[field.label] = rowData[k]);
 
             // Get custom cell formatting if available
             if (this.props.getFormattedCell) {

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -287,7 +287,7 @@ class DataTable extends Component {
           }
           break;
         default:
-            searchString = data.toLowerCase();
+            searchString = data ? data.toString().toLowerCase() : '';
             if (exactMatch) {
               result = (searchString === searchKey);
             } else if (opposite) {
@@ -309,7 +309,7 @@ class DataTable extends Component {
       let match = false;
       for (let i = 0; i < filterData.length; i += 1) {
         searchKey = filterData[i].toLowerCase();
-        searchString = data.toString().toLowerCase();
+        searchString = data ? data.toString().toLowerCase() : '';
 
         match = (searchString.indexOf(searchKey) > -1);
         if (match) {
@@ -410,6 +410,7 @@ class DataTable extends Component {
         let rowIndex = index[i].RowIdx;
         let rowData = this.props.data[rowIndex];
         let curRow = [];
+        filteredData.push(rowData);
 
         // Iterates through headers to populate row columns
         // with corresponding data
@@ -421,13 +422,16 @@ class DataTable extends Component {
             let celldata = rowData[j];
             let cell = null;
 
-
+            const row = {};
+            this.props.fields.forEach((field, k) => {
+              row[field.label] = rowData[k];
+            });
             // Get custom cell formatting if available
             if (this.props.getFormattedCell) {
                 cell = this.props.getFormattedCell(
                     this.props.fields[j].label,
                     celldata,
-                    rowData
+                    row
                 );
             }
             if (cell !== null) {
@@ -591,4 +595,3 @@ DataTable.defaultProps = {
 };
 
 export default DataTable;
-

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -422,10 +422,10 @@ class DataTable extends Component {
             let celldata = rowData[j];
             let cell = null;
 
-            const row = {};
-            this.props.fields.forEach((field, k) => {
-              row[field.label] = rowData[k];
-            });
+            let row = {};
+            this.props.fields
+              .forEach((field, k) => {row[field.label] = rowData[k]});
+
             // Get custom cell formatting if available
             if (this.props.getFormattedCell) {
                 cell = this.props.getFormattedCell(


### PR DESCRIPTION
When optimising the Datatable, #5299 introduced some bugs in the file. This PR removes those bugs.

1. It maps the headers to values to allow the `this.props.getFormattedCell` to function properly.
2. It pushes `rowData` to `filterData` so that when downloading the CSV, only the filtered data is passed.
3. Checks for cases where `data=null` because `null.toLowerCase()` cannot be executed.

There are still issues with pagination, which could be fixed in either this or another PR.

