### PR TITLE
Add ReadTheDocs build badge to LORIS readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
-[![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
+# [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) [![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
 
 # LORIS Neuroimaging Platform
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) LORIS Neuroimaging Platform 
+# [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris)
+[![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
+
+# LORIS Neuroimaging Platform
 
 ---
 LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web application that provides data- and project-management for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging, genetic and biospecimen data acquired over time or at different sites.


### PR DESCRIPTION
## Brief summary of changes

Adds a build badge to the README of LORIS for ReadTheDocs. This will indicate whether the docs are building successfully for a given version.


<img width="531" alt="Screen Shot 2019-11-25 at 10 28 16" src="https://user-images.githubusercontent.com/4022790/69553527-54b21e80-0f6e-11ea-8c5b-e6cadb2fb523.png">
