### PR TITLE
[webpack.config.js] update for build speed and correction

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,12 +67,18 @@ const config = [{
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        use: ['babel-loader'],
-      },
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: ['babel-loader', 'eslint-loader'],
+        use: [
+          {
+            loader: 'babel-loader?cacheDirectory',
+          },
+          {
+            loader: 'eslint-loader',
+            options: {
+              cache: true,
+            },
+          },
+        ],
+        enforce: 'pre',
       },
       {
         test: /\.json$/,


### PR DESCRIPTION
## Brief summary of changes

This PR does two things to webpack.config.js

First change removes unnecessary `test: /\.js$/,` test and since the same functionality is done in the `/\.(js|jsx)$/` test.

Second change adds cache functionality to loader "[babel-loader](https://github.com/babel/babel-loader)" and "[eslint-loader](https://github.com/webpack-contrib/eslint-loader)" which is recommended for build performance (when executing "npm run compile" or "make"). The enforce: "pre" specifies that this is a pre-loader, which helps reinforce that this must run before normal loaders.

Basically turning on cache enables a directory for the loader that's cached in node_modules/.cache
Example: node_modules/.cache/eslint-loader and keeps track of cached files.
Similar: node_modules/.cache/babel-loader

So we will have a performance gain in build time after the first npm run compile.

Note: This PR significantly reduces the npm run compile for me. I went from 10+ seconds to 4 seconds. I'm curious to what everyone else observes for their build time after cache has been created.

#### Testing instructions (if applicable)

1. Checkout PR
2. run make
3. run npm run compile
