### PR TITLE
Add configuration file for the Stale Bot tool

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,7 @@ daysUntilStale: 60
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: false
 
 # Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled)
 onlyLabels: []

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -37,8 +37,9 @@ markComment: >
   for your contributions.
 
 # Comment to post when removing the stale label.
-# unmarkComment: >
-#   Your comment here.
+unmarkComment: >
+  The Stale label is being removed automatically because some activity has occurred or because the
+  developers have decided that this pull request is important and should not continue to be overlooked.
 
 # Comment to post when closing a stale Issue or Pull Request.
 # closeComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,8 +12,6 @@ onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
-  - pinned
-  - security
   - "Bug Fix"
   - "Security"
   - "Critical to release"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -18,6 +18,7 @@ exemptLabels:
   - "Security"
   - "Critical to release"
   - "Blocked"
+  - "Blocking"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,63 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - "Bug Fix"
+  - "Security"
+  - "Critical to release"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,6 +17,7 @@ exemptLabels:
   - "Bug Fix"
   - "Security"
   - "Critical to release"
+  - "Blocked"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -28,7 +28,7 @@ exemptMilestones: false
 exemptAssignees: false
 
 # Label to use when marking as stale
-staleLabel: wontfix
+staleLabel: "Stale"
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >


### PR DESCRIPTION
## Brief summary of changes

Adds a configuration for [stale bot](https://github.com/probot/stale), a tool that marks inactive issues and PRs and eventually closes them if no action is taken on them.

If used, it should assist with triage and keep us on our toes about what may be slipping through the cracks.

I used the default config file here, modified slightly to match the labels we use.

In order for this to work, someone with Admin privileges must [enable the Stale bot](https://github.com/apps/stale/installations/new). Until then this PR will remain in Draft state.
