### PR TITLE
[ReadTheDocs] Fix bad rendering

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 # THIS DOCUMENTATION IS UNDER CONSTRUCTION
 
-Please visit https://github.com/aces/Loris/wiki for support.
+Please visit the [GitHub Wiki](https://github.com/aces/Loris/wiki) for support.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Longitudinal Online Research and Imaging System (LORIS)
 site_url: http://loris.ca/
 repo_url: https://github.com/aces/Loris
-edit_uri: https://github.com/aces/Loris/minor/
+edit_uri: https://github.com/aces/Loris/minor/blob/docs/
 nav:
     - Home: index.md
     - API: API/LorisRESTAPI_v0.0.3.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Longitudinal Online Research and Imaging System (LORIS)
 site_url: http://loris.ca/
 repo_url: https://github.com/aces/Loris
-edit_uri: https://github.com/aces/Loris/minor/blob/docs/
+edit_uri: https://github.com/aces/Loris/blob/minor/docs/
 nav:
     - Home: index.md
     - API: API/LorisRESTAPI_v0.0.3.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: http://loris.ca/
 repo_url: https://github.com/aces/Loris
 edit_uri: https://github.com/aces/Loris/blob/minor/docs/
 nav:
-    - Home: index.md
+    - Home: docs/index.md
     - API: API/LorisRESTAPI_v0.0.3.md
     - Wiki: wiki/index.md
 theme: readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
-site_name: LORIS
+site_name: Longitudinal Online Research and Imaging System (LORIS)
+site_url: http://loris.ca/
 repo_url: https://github.com/aces/Loris
-pages:
+edit_uri: https://github.com/aces/Loris/minor/
+nav:
     - Home: index.md
     - API: API/LorisRESTAPI_v0.0.3.md
     - Wiki: wiki/index.md


### PR DESCRIPTION
## Brief summary of changes

**After this Read The Docs should actually work --> https://acesloris.readthedocs.io/en/latest/**

Right now the docs are building properly but the home page renders as the default RTD landing page so it looks like it's broken because nothing shows up.

e.g. if you visit the link below it looks like nothing works, but if you visit https://acesloris.readthedocs.io/en/latest/API/LorisRESTAPI_v0.0.3/ you can see that the docs are building fine except for the home page.

This makes the home page (docs/index.md) explicit so everything should render nicely. (I tested this on my local copy.)

This PR also provides a functional Edit link which leads readers back to the repo.

The key `pages` is reverted to `nav` because this is actually more appropriate for newer versions of mkdocs, it turns out.