### PR TITLE
[PHPCS] Make type hinting mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ changes in the following format: PR #1234***
 
 #### Core
 - Menus are now maintained by modules and no longer in the SQL database (PR #5839)
+- Unix user permissions have been updated which may affect access to files. New
+documentation for file permissions has been added to the README.md file (PR #5323)
 
 #### Modules 
 ##### module1

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 # Sudo privileges can be revoked once the install is completed.
 sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 # Add apache to the lorisadmin group
-sudo groupadd -a -G lorisadmin www-data
+sudo usermod -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
 sudo passwd lorisadmin
 sudo mkdir -m 755 -p /var/www/$projectname

--- a/README.md
+++ b/README.md
@@ -40,20 +40,24 @@ These dependencies are subject to change so be sure to verify your version of My
 
 Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.
 
-1. Set up LINUX user lorisadmin, with `sudo` privilege, and create LORIS base directory:
+1. Set up LINUX user and group lorisadmin and create LORIS base directory:
 
 ```bash
-sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-sudo passwd lorisadmin
-su - lorisadmin
+# Create lorisadmin user and group
+    sudo groupadd lorisadmin
+# Give lorisadmin `sudo` permission. This is required for the install process
+# in order to automatically generate Apache configuration files.
+# Sudo privileges can be revoked once the install is completed.
+    sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
+# Add apache and lorisadmin to the lorisadmin group
+    sudo groupadd -a -G lorisadmin lorisadmin
+    sudo groupadd -a -G lorisadmin www-data
+# Set the password for the lorisadmin account
+    sudo passwd lorisadmin
+    sudo mkdir -m 755 -p /var/www/$projectname
+    sudo chown lorisadmin.lorisadmin /var/www/$projectname
+    su - lorisadmin
 ```
-
- <b>Important: All steps from this point forward must be executed by lorisadmin user</b>
-
- ```bash
- sudo mkdir -m 775 -p /var/www/$projectname
- sudo chown lorisadmin.lorisadmin /var/www/$projectname
- ```
 
  <i>$projectname ⇾ "loris" or one-word project name</i>
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 # in order to automatically generate Apache configuration files.
 # Sudo privileges can be revoked once the install is completed.
     sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-# Add apache and lorisadmin to the lorisadmin group
-    sudo groupadd -a -G lorisadmin lorisadmin
+# Add apache to the lorisadmin group
     sudo groupadd -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
     sudo passwd lorisadmin

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 
 ```bash
 # Create lorisadmin user and group
-sudo groupadd lorisadmin
 # Give lorisadmin `sudo` permission. This is required for the install process
 # in order to automatically generate Apache configuration files.
 # Sudo privileges can be revoked once the install is completed.

--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 
 ```bash
 # Create lorisadmin user and group
-    sudo groupadd lorisadmin
+sudo groupadd lorisadmin
 # Give lorisadmin `sudo` permission. This is required for the install process
 # in order to automatically generate Apache configuration files.
 # Sudo privileges can be revoked once the install is completed.
-    sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
+sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
 # Add apache to the lorisadmin group
-    sudo groupadd -a -G lorisadmin www-data
+sudo groupadd -a -G lorisadmin www-data
 # Set the password for the lorisadmin account
-    sudo passwd lorisadmin
-    sudo mkdir -m 755 -p /var/www/$projectname
-    sudo chown lorisadmin.lorisadmin /var/www/$projectname
-    su - lorisadmin
+sudo passwd lorisadmin
+sudo mkdir -m 755 -p /var/www/$projectname
+sudo chown lorisadmin.lorisadmin /var/www/$projectname
+su - lorisadmin
 ```
 
  <i>$projectname ⇾ "loris" or one-word project name</i>

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -59,7 +59,7 @@ class LorisForm
      *
      * @param string $name    The form name of the element being added
      * @param string $label   The label to attach to the GUI in the form
-     * @param array  $attribs An array of extra HTML attributes to be
+     * @param ?array $attribs An array of extra HTML attributes to be
      *                        added to this element.
      *
      * @return array describing the form element

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -479,7 +479,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @param string $field   The field name for this select
      * @param string $label   The label to attach to the element
-     * @param array  $options Extra options to pass to QuickForm
+     * @param ?array $options Extra options to pass to QuickForm
      * @param array  $attr    Extra HTML attributes to add to the element
      *
      * @return array representing select element
@@ -487,7 +487,7 @@ class NDB_Page implements RequestHandlerInterface
     function createSelect(
         $field,
         $label,
-        $options=null,
+        ?array $options=null,
         $attr=array('class' => 'form-control input-sm')
     ) {
         return $this->form->createElement("select", $field, $label, $options, $attr);

--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 for d in data libraries instruments templates tables_sql modules; do
-    mkdir -p "${1}/${d}"
+    mkdir -p -m 750 "${1}/${d}"
 done
 

--- a/tools/create-project.sh
+++ b/tools/create-project.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 for d in data libraries instruments templates tables_sql modules; do
-    mkdir -p -m 750 "${1}/${d}"
+    mkdir -p "${1}/${d}"
 done
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -138,7 +138,6 @@ elif [[ " ${redhat[*]} " == *" $os_distro "* ]]; then
     sudo chown apache.apache ../smarty/templates_c
     # Make Apache the group for project directory, so that the web based install
     # can write the config.xml file.
-    sudo chgrp apache ../project
     sudo chmod 770 ../project
 else
     echo "$os_distro Linux distribution detected. We currently do not support this. "


### PR DESCRIPTION
## Brief summary of changes

PHPCS now makes type hinting mandatory for function parameters and return types. You can add them automatically based on PHPDocs using `phpcbf`. `mixed` annotations don't result in any changes.

#### Links to related tickets (GitHub, Redmine, ...)

* This is a revamp of #4064 
* Resolves #4282 
* Resolves #4271 
* Resolves #4284 