### PR TITLE
[Core] Create UserProjectMatch filter

### DIFF
--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -49,6 +49,18 @@ class Candidate_List extends \DataFrameworkMenu
     {
         return true;
     }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always true
+     */
+    public function useProjectFilter() : bool
+    {
+        return true;
+    }
+
     /**
      * Return the list of field options required to be serialized to JSON
      * in order to render the frontend.

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -29,6 +29,7 @@ class CandidateListRow implements \LORIS\Data\DataInstance
 {
     protected $DBRow;
     protected $CenterID;
+    protected $ProjectID;
 
     /**
      * Create a new CandidateListRow
@@ -36,11 +37,13 @@ class CandidateListRow implements \LORIS\Data\DataInstance
      * @param array   $row The row (in the same format as \Database::pselectRow
      *                     returns
      * @param integer $cid The centerID affiliated with this row.
+     * @param integer $pid The projectID affiliated with this row.
      */
-    public function __construct(array $row, int $cid)
+    public function __construct(array $row, int $cid, int $pid)
     {
-        $this->DBRow    = $row;
-        $this->CenterID = $cid;
+        $this->DBRow     = $row;
+        $this->CenterID  = $cid;
+        $this->ProjectID = $pid;
     }
 
     /**
@@ -62,5 +65,16 @@ class CandidateListRow implements \LORIS\Data\DataInstance
     public function getCenterID(): int
     {
         return $this->CenterID;
+    }
+
+    /**
+     * Returns the ProjectID for this row, for filters such as
+     * \LORIS\Data\Filters\UserProjectMatch to match again.
+     *
+     * @return integer The ProjectID
+     */
+    public function getProjectID(): int
+    {
+        return $this->ProjectID;
     }
 }

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -58,7 +58,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                 IFNULL(MIN(feedback_bvl_thread.Status+0),0) AS Feedback,
                 max(s.Current_stage) AS LatestVisitStatus,
                 p.Name AS RegistrationProject,
-                c.RegistrationCenterID
+                c.RegistrationCenterID,
                 c.RegistrationProjectID
                 $maybeEDC
                 FROM candidate c
@@ -94,8 +94,8 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // user's sites, but for now this maintains the previous
         // behaviour of requiring the registration site to match
         // one of the user's sites.
-        $cid = (int )$row['RegistrationCenterID'];
-        $pid = (int )$row['RegistrationProjectID'];
+        $cid = (int) $row['RegistrationCenterID'];
+        $pid = (int) $row['RegistrationProjectID'];
         unset($row['RegistrationCenterID']);
         unset($row['RegistrationProjectID']);
         return new CandidateListRow($row, $cid, $pid);

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -59,6 +59,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                 max(s.Current_stage) AS LatestVisitStatus,
                 p.Name AS RegistrationProject,
                 c.RegistrationCenterID
+                c.RegistrationProjectID
                 $maybeEDC
                 FROM candidate c
                     LEFT JOIN psc ON (c.RegistrationCenterID=psc.CenterID)
@@ -94,7 +95,9 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // behaviour of requiring the registration site to match
         // one of the user's sites.
         $cid = (int )$row['RegistrationCenterID'];
+        $pid = (int )$row['RegistrationProjectID'];
         unset($row['RegistrationCenterID']);
-        return new CandidateListRow($row, $cid);
+        unset($row['RegistrationProjectID']);
+        return new CandidateListRow($row, $cid, $pid);
     }
 }

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -170,10 +170,10 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this-> _testFilter(self::$DCCID, "1 rows", '300001');
         $this-> _testFilter(self::$DCCID, "0 rows", 'test');
         $this-> _testFilter(self::$visitLabel, "362", 'V1');
-        $this-> _testFilter(self::$visitLabel, "261", 'V2');
-        $this-> _testFilter(self::$site, "8 rows", '1');
+        $this-> _testFilter(self::$visitLabel, "223", 'V2');
+        $this-> _testFilter(self::$site, "6 rows", '1');
         $this-> _testFilter(self::$site, "168", '2');
-        $this-> _testFilter(self::$entityType, "8 rows", '1');
+        $this-> _testFilter(self::$entityType, "438", '1');
 
         // test advanced filter - sex
         // Switch to Advanced mode
@@ -182,9 +182,9 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
                "return document.querySelector('$btn').click()"
            );
            //female
-           $this-> _testFilter(self::$sex, "20 rows displayed of 334", '1');
+           $this-> _testFilter(self::$sex, "20 rows displayed of 228", '1');
            // male
-           $this-> _testFilter(self::$sex, "20 rows displayed of 328", '2');
+           $this-> _testFilter(self::$sex, "20 rows displayed of 210", '2');
 
     }
     /**

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -169,7 +169,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this-> _testFilter(self::$PSCID, "1 rows", 'MTL001');
         $this-> _testFilter(self::$DCCID, "1 rows", '300001');
         $this-> _testFilter(self::$DCCID, "0 rows", 'test');
-        $this-> _testFilter(self::$visitLabel, "374", 'V1');
+        $this-> _testFilter(self::$visitLabel, "362", 'V1');
         $this-> _testFilter(self::$visitLabel, "261", 'V2');
         $this-> _testFilter(self::$site, "8 rows", '1');
         $this-> _testFilter(self::$site, "168", '2');

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -172,7 +172,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this-> _testFilter(self::$visitLabel, "362", 'V1');
         $this-> _testFilter(self::$visitLabel, "223", 'V2');
         $this-> _testFilter(self::$site, "7 rows", '1');
-        $this-> _testFilter(self::$site, "168", '2');
+        $this-> _testFilter(self::$site, "165", '2');
         $this-> _testFilter(self::$entityType, "438", '1');
 
         // test advanced filter - sex

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -171,7 +171,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this-> _testFilter(self::$DCCID, "0 rows", 'test');
         $this-> _testFilter(self::$visitLabel, "362", 'V1');
         $this-> _testFilter(self::$visitLabel, "223", 'V2');
-        $this-> _testFilter(self::$site, "6 rows", '1');
+        $this-> _testFilter(self::$site, "7 rows", '1');
         $this-> _testFilter(self::$site, "168", '2');
         $this-> _testFilter(self::$entityType, "438", '1');
 

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -173,7 +173,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this-> _testFilter(self::$visitLabel, "223", 'V2');
         $this-> _testFilter(self::$site, "7 rows", '1');
         $this-> _testFilter(self::$site, "165", '2');
-        $this-> _testFilter(self::$entityType, "438", '1');
+        $this-> _testFilter(self::$entityType, "7 rows", '1');
 
         // test advanced filter - sex
         // Switch to Advanced mode

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -182,7 +182,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
                "return document.querySelector('$btn').click()"
            );
            //female
-           $this-> _testFilter(self::$sex, "20 rows displayed of 228", '1');
+           $this-> _testFilter(self::$sex, "20 rows displayed of 225", '1');
            // male
            $this-> _testFilter(self::$sex, "20 rows displayed of 210", '2');
 

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -44,9 +44,20 @@ class Dicom_Archive extends \DataFrameworkMenu
      * Tells the base class that this page's provisioner can support
      * the UserSiteMatch filter.
      *
-     * @return bool always true
+     * @return bool always false
      */
     public function useSiteFilter() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always false
+     */
+    public function useProjectFilter() : bool
     {
         return false;
     }

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -47,13 +47,25 @@ class Media extends \DataFrameworkMenu
     }
 
     /**
-     * {@inheritDoc}
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
      *
      * @return bool true
      */
     public function useSiteFilter(): bool
     {
         return true;
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool false
+     */
+    public function useProjectFilter() : bool
+    {
+        return false;
     }
 
     /**

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -48,7 +48,7 @@ class Media extends \DataFrameworkMenu
 
     /**
      * Tells the base class that this page's provisioner can support
-     * the UserSitetMatch filter.
+     * the UserSiteMatch filter.
      *
      * @return bool true
      */

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -48,7 +48,7 @@ class Media extends \DataFrameworkMenu
 
     /**
      * Tells the base class that this page's provisioner can support
-     * the UserProjectMatch filter.
+     * the UserSitetMatch filter.
      *
      * @return bool true
      */

--- a/modules/media/php/mediafile.class.inc
+++ b/modules/media/php/mediafile.class.inc
@@ -65,7 +65,7 @@ class MediaFile implements \LORIS\Data\DataInstance
      * Returns the ProjectID for this instance, for filters such as
      * \LORIS\Data\Filters\UserProjectMatch to match against.
      *
-     * @return integer The CenterID
+     * @return integer The ProjectID
      */
     public function getProjectID(): int
     {

--- a/modules/media/php/mediafile.class.inc
+++ b/modules/media/php/mediafile.class.inc
@@ -52,13 +52,24 @@ class MediaFile implements \LORIS\Data\DataInstance
 
     /**
      * Returns the CenterID for this instance, for filters such as
-     * \LORIS\Data\Filters\UserSiteMatch to match again.
+     * \LORIS\Data\Filters\UserSiteMatch to match against.
      *
      * @return integer The CenterID
      */
     public function getCenterID(): int
     {
         return $this->DBRow['centerId'];
+    }
+
+    /**
+     * Returns the ProjectID for this instance, for filters such as
+     * \LORIS\Data\Filters\UserProjectMatch to match against.
+     *
+     * @return integer The CenterID
+     */
+    public function getProjectID(): int
+    {
+        return $this->DBRow['projectId'];
     }
 
     /**

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -43,16 +43,17 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
                     l.language_label as languageLabel,
                     (SELECT Full_name FROM test_names
                       WHERE Test_name=m.instrument) as fullName,
-               			s.CenterID as centerId,
-               			m.uploaded_by as uploadedBy,
-               			m.date_taken as dateTaken,
-               			substring(m.comments, 1, 50) as comments,
-               			m.date_uploaded as dateUploaded,
-               			m.file_type as fileType,
-               			s.CandID as candidateId,
-               			s.ID as sessionId,
-               			m.hide_file as hideFile,
-               			m.id
+               		s.CenterID as centerId,
+               		s.ProjectID as projectId,
+               		m.uploaded_by as uploadedBy,
+               		m.date_taken as dateTaken,
+               		substring(m.comments, 1, 50) as comments,
+               		m.date_uploaded as dateUploaded,
+               		m.file_type as fileType,
+               		s.CandID as candidateId,
+               		s.ID as sessionId,
+               		m.hide_file as hideFile,
+               		m.id
              FROM media m
              INNER JOIN session s ON m.session_id = s.ID
              INNER JOIN candidate c ON c.CandID=s.CandID

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -69,6 +69,14 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
     abstract public function useSiteFilter() : bool;
 
     /**
+     * Determines whether the DataProvisioner should filter out rows which
+     * do not match the user's project.
+     *
+     * @return bool true if the data provisioner should filter non-matching projects.
+     */
+    abstract public function useProjectFilter() : bool;
+
+    /**
      * Items to add to the JSON fieldOptions key, which React components
      * can use for formatting. This is used to send data dependent options
      * to the frontend.
@@ -105,6 +113,11 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
         ) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\UserSiteMatch()
+            );
+        }
+        if ($this->useProjectFilter()) {
+            $provisioner = $provisioner->filter(
+                new \LORIS\Data\Filters\UserProjectMatch()
             );
         }
         return $provisioner;

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -99,6 +99,9 @@ class User extends UserPermissions
             "SELECT ProjectID FROM user_project_rel upr WHERE upr.UserId=:uid",
             array('uid' => $row['ID'])
         );
+        foreach ($user_pid as $k=>$pid) {
+            $user_pid[$k] = intval($pid);
+        }
 
         // Get examiner information
         $examiner_check = $DB->pselect(

--- a/src/Data/Filters/UserProjectMatch.php
+++ b/src/Data/Filters/UserProjectMatch.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file provides an implementation of the UserProjectMatch filter.
+ *
+ * PHP Version 7
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+namespace LORIS\Data\Filters;
+
+/**
+ * UserProjectMatch filters out data for any resource which is not part of one of the
+ * user's projects. For a DataInstance to be compatible with the UserProjectMatch
+ * filter, it must implement a getProjectIDs or getProjectID method which returns
+ * an integer (or array) of ProjectIDs that the data belongs to. The data will be
+ * filtered out unless the User is a member of at least one project that the resource
+ * DataInstance is a member of.
+ *
+ * @category   Data
+ * @package    Main
+ * @subpackage Data
+ * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class UserProjectMatch implements \LORIS\Data\Filter
+{
+    /**
+     * Implements the \LORIS\Data\Filter interface
+     *
+     * @param \User                    $user     The user that the data is being
+     *                                           filtered for.
+     * @param \LORIS\Data\DataInstance $resource The data being filtered.
+     *
+     * @return bool true if the user has a project in common with the data
+     */
+    public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
+    {
+        if (method_exists($resource, 'getProjectIDs')) {
+            // If the Resource belongs to multiple ProjectIDs, the user can
+            // access the data if the user is part of any of those projects.
+            $resourceProjects = $resource->getProjectIDs();
+            foreach ($resourceProjects as $project) {
+                if ($user->hasProject($project)) {
+                    return true;
+                }
+            }
+            return false;
+        } elseif (method_exists($resource, 'getProjectID')) {
+            $resourceProject = $resource->getProjectID();
+            if (!is_null($resourceProject)) {
+                return $user->hasProject($resourceProject);
+            }
+            // We don't know if the resource thought a null ProjectID
+            // should mean "no one can access it" or "anyone can access
+            // it", so throw an exception.
+            throw new \LorisException("getProjectID on resource returned null");
+        }
+        throw new \LorisException(
+            "Can not implement UserProjectMatch on a resource type that has no projects."
+        );
+    }
+}

--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -43,7 +43,7 @@ class UserSiteMatch implements \LORIS\Data\Filter
     {
         if (method_exists($resource, 'getCenterIDs')) {
             // If the Resource belongs to multiple CenterIDs, the user can
-            // access the data if the user is part of any of thos centers.
+            // access the data if the user is part of any of those centers.
             $resourceSites = $resource->getCenterIDs();
             foreach ($resourceSites as $site) {
                 if ($user->hasCenter($site)) {


### PR DESCRIPTION
## Brief summary of changes
Creation of the userProjectMatch filter for the data framework and implementing it on the candidate_list and media modules.

With this filter you should now be able to restrict the data in  the data-table by both sites and projects.

#### Testing instructions (if applicable)

1. assign a specific set of projects to your user and make sure the user is only able to access candidates and media files from those specific projects.
