### PR TITLE
[Travis] Update php-ast from 1.0.1 to 1.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 install:
 - sudo apt-get update
 - sudo apt-get install -y libapparmor1
-- pecl install -f ast-1.0.1
+- pecl install -f ast-1.0.3
 - sudo apt-get install npm
 - make dev
 


### PR DESCRIPTION
## Brief summary of changes

> [php-ast 1.0.3+ is recommended for compatibility with future Phan releases.](https://github.com/phan/phan/wiki/Getting-Started#installing-dependencies)

I'm hoping this will also fix the PHP 7.4 build failure that seems to be caused by pecl.
