### PR TITLE
[User Accounts] Fix password bugs: "confirm password" must match; password cannot be email

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -2,7 +2,7 @@
 /**
  * The user account page
  *
- * PHP Version 5,7
+ * PHP Version 7
  *
  * @category Main
  * @package  User_Account
@@ -25,6 +25,10 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Edit_User extends \NDB_Form
 {
+    private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match.';
+    private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are ' .
+                                        'identical: please choose another one';
+
     /**
      * Determines whether this form is in edit or create mode.
      *
@@ -1005,6 +1009,9 @@ class Edit_User extends \NDB_Form
         $DB     = \Database::singleton();
         $errors = array();
 
+        // NOTE The 'Password_hash' key actually represents a plaintext password
+        $plaintext = $values['Password_hash'];
+
         //============================================
         //         Validate UserID and NA_UserID
         //============================================
@@ -1081,19 +1088,25 @@ class Edit_User extends \NDB_Form
                     = 'Please specify password or click Generate new password';
             }
         }
+        // Ensure that the password and confirm password fields match.
+        // TODO This validation should be done on the front-end instead.
+        if ($plaintext !== $values['__Confirm']) {
+            $errors['Password_Group'] = self::PASSWORD_ERROR_NO_MATCH;
+        }
 
         // if password is user-defined, and user wants to change password
         if (empty($values['NA_Password'])
             && (!empty($values['Password_hash']) || !empty($values['__Confirm']))
         ) {
             try {
-                // New password must be different than current one
-                $password        = new \Password($values['Password_hash']);
+                // The Password class is self-validating and will throw an
+                // InvalidArgumentException if the value passed to it is
+                // bad or the input is too weak to be a good password.
+                $password        = new \Password($plaintext);
                 $passwordChanged = \User::factory($this->identifier)
-                    ->passwordChanged($values['Password_hash']);
+                    ->passwordChanged($plaintext);
                 if (! $passwordChanged) {
-                    $errors['Password_Group'] = 'New and old passwords '
-                        . 'are identical: please choose another one';
+                    $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;
                 }
             } catch (\InvalidArgumentException $e) {
                 $errors['Password_Group'] = $e->getMessage();
@@ -1112,7 +1125,7 @@ class Edit_User extends \NDB_Form
 
         if (isset($values['NA_Password'])
             && $values['NA_Password'] == 'on'
-            && $values['Password_hash'] != ''
+            && $plaintext != ''
         ) {
             $errors['Password_Group'] = 'You must leave the password field empty '
                 . 'if you want the system to generate one for you';
@@ -1120,7 +1133,7 @@ class Edit_User extends \NDB_Form
 
         if (is_null($this->identifier)
             && ($values['NA_Password'] != 'on')
-            && empty($values['Password_hash'])
+            && empty($plaintext)
         ) {
             $errors['Password_Group'] = 'Password is required';
         }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -25,6 +25,7 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Edit_User extends \NDB_Form
 {
+    private const PASSWORD_ERROR_IS_EMAIL  = 'Your password cannot be your email.';
     private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match.';
     private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are ' .
                                         'identical: please choose another one';
@@ -1015,6 +1016,7 @@ class Edit_User extends \NDB_Form
         //============================================
         //         Validate UserID and NA_UserID
         //============================================
+
         if ($this->isCreatingNewUser()) {
             // Clicked on "UID == email" and specified a UID
             if (!empty($values['UserID']) && $values['NA_UserID'] == 'on') {
@@ -1070,6 +1072,9 @@ class Edit_User extends \NDB_Form
         //==================================
         //        Password validation
         //==================================
+        if ($values['Email'] === $values['Password_hash']) {
+            $errors['Password_Group'] = self::PASSWORD_ERROR_IS_EMAIL;
+        }
         if (!is_null($this->identifier)) {
             $pass = $DB->pselectOne(
                 "SELECT COALESCE(Password_hash) "

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -23,6 +23,9 @@ namespace LORIS\user_accounts;
  */
 class My_Preferences extends \NDB_Form
 {
+    private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match.';
+    private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are ' .
+                                        'identical: please choose another one';
     /**
      * Computes the initial values this page will be filled with.
      *
@@ -192,6 +195,9 @@ class My_Preferences extends \NDB_Form
         // update the user
         $user->update($set);
 
+        // Now set the password. Note that this field is named incorrectly at this
+        // point in the code and represents a plaintext password, not a hash.
+        // Validation for the password is performed in _validateMyPreferences()
         if (isset($values['Password_hash'])) {
             $user->updatePassword(new \Password($values['Password_hash']));
         }
@@ -386,20 +392,32 @@ class My_Preferences extends \NDB_Form
         $DB     = \Database::singleton();
         $errors = array();
 
+        // NOTE The 'Password_hash' key actually represents a plaintext password
+        $plaintext = $values['Password_hash'];
+
+        // Ensure that the password and confirm password fields match.
+        // TODO This validation should be done on the front-end instead.
+        if ($values['Password_hash'] !== $values['__Confirm']) {
+            $errors['Password_Group'] = self::PASSWORD_ERROR_NO_MATCH;
+            return $errors;
+        }
+
         // if password is user-defined, and user wants to change password
         if (!empty($values['Password_hash'])) {
             try {
-                $password = new \Password($values['Password_hash']);
-                // New password must be different than current one
-                if (! \User::factory($this->identifier)->passwordChanged(
-                    $values['Password_hash']
-                )
-                ) {
-                    $errors['Password_hash'] = 'New and old passwords '
-                        . 'are identical: please choose another one';
+                // The Password class is self-validating and will throw an
+                // InvalidArgumentException if the value passed to it is
+                // bad or the input is too weak to be a good password.
+                //
+                // NOTE 'Password_hash' is actually plaintext, not a hash.
+                $password        = new \Password($plaintext);
+                $passwordChanged = \User::factory($this->identifier)
+                    ->passwordChanged($plaintext);
+                if (! $passwordChanged) {
+                    $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;
                 }
             } catch (\InvalidArgumentException $e) {
-                $errors['Password_hash'] = $e->getMessage();
+                $errors['Password_Group'] = $e->getMessage();
             }
         }
 

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -23,6 +23,7 @@ namespace LORIS\user_accounts;
  */
 class My_Preferences extends \NDB_Form
 {
+    private const PASSWORD_ERROR_IS_EMAIL  = 'Your password cannot be your email.';
     private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match.';
     private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are ' .
                                         'identical: please choose another one';
@@ -394,6 +395,10 @@ class My_Preferences extends \NDB_Form
 
         // NOTE The 'Password_hash' key actually represents a plaintext password
         $plaintext = $values['Password_hash'];
+
+        if ($values['Email'] === $plaintext) {
+            $errors['Password_Group'] = self::PASSWORD_ERROR_IS_EMAIL;
+        }
 
         // Ensure that the password and confirm password fields match.
         // TODO This validation should be done on the front-end instead.


### PR DESCRIPTION
## Brief summary of changes

Password and Confirm Password on the front-end don't need to match on major. This check was removed by mistake during Password refactoring.

#### Testing instructions (if applicable)

1. For both Edit User and My Preferences, try creating a new password and enter something different in the Confirm field. You should get an error message.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5417 
* Resolves #5416 