### PR TITLE
[acknowledgement] Remove edit buttons from UI when the user has no edit permission

### DIFF
--- a/modules/acknowledgements/jsx/acknowledgementsIndex.js
+++ b/modules/acknowledgements/jsx/acknowledgementsIndex.js
@@ -384,7 +384,12 @@ class AcknowledgementsIndex extends Component {
       }},
     ];
     const actions = [
-      {name: 'addAcknowledgement', label: 'Add Acknowledgement', action: this.openModalForm},
+      {
+        name: 'addAcknowledgement',
+        label: 'Add Acknowledgement',
+        action: this.openModalForm,
+        show: this.props.hasPermission('acknowledgements_edit'),
+      },
     ];
 
     return (


### PR DESCRIPTION
## Brief summary of changes

This changes allows the display of the 'Add Acknowledgement' button only if the user has `acknowledgements_edit` permission.

#### Testing instructions (if applicable)

1. Check that the button 'Add Acknowledgement' renders when a user has `acknowledgements_edit` permission
2. Check that the button 'Add Acknowledgement' does not render when a user has only `acknowledgements_view` permission

#### Links to related tickets (GitHub, Redmine, ...)

* #5407 
