### PR TITLE
[imaging_browser] fixed query for the imaging browser

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -178,7 +178,7 @@ CREATE TABLE `session` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `CandID` int(6) NOT NULL DEFAULT '0',
   `CenterID` integer unsigned NOT NULL,
-  `ProjectID` int(10) unsigned NOT NULL,
+  `ProjectID` int(10) unsigned DEFAULT NULL,
   `VisitNo` smallint(5) unsigned DEFAULT NULL,
   `Visit_label` varchar(255) NOT NULL,
   `SubprojectID` int(10) unsigned DEFAULT NULL,

--- a/SQL/New_patches/2019-07-01_add_projects_to_sessions.sql
+++ b/SQL/New_patches/2019-07-01_add_projects_to_sessions.sql
@@ -4,8 +4,8 @@ ALTER TABLE project_subproject_rel DROP FOREIGN KEY `FK_project_subproject_rel_P
 -- Change/add project ID fields to INT(10) consistently accross tables
 ALTER TABLE project_subproject_rel CHANGE COLUMN ProjectID ProjectID int(10) unsigned NOT NULL;
 ALTER TABLE Project CHANGE COLUMN ProjectID ProjectID int(10) unsigned NOT NULL AUTO_INCREMENT;
-ALTER TABLE candidate CHANGE COLUMN ProjectID RegistrationProjectID int(10) unsigned NOT NULL;
-ALTER TABLE session ADD COLUMN ProjectID int(10) unsigned NOT NULL;
+ALTER TABLE candidate CHANGE COLUMN ProjectID RegistrationProjectID int(10) unsigned DEFAULT NULL;
+ALTER TABLE session ADD COLUMN ProjectID int(10) unsigned DEFAULT NULL;
 
 -- Re-add necessary FOREIGN KEY constraints
 ALTER TABLE project_subproject_rel ADD CONSTRAINT `FK_project_subproject_rel_ProjectID` FOREIGN KEY (`ProjectID`) REFERENCES `Project` (`ProjectID`) ON DELETE CASCADE;

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -196,7 +196,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
             FROM psc AS p 
               JOIN session s ON (s.CenterID=p.CenterID) 
               JOIN candidate c ON (c.CandID=s.CandID) 
-              LEFT JOIN Project ON (c.ProjectID=Project.ProjectID)
+              LEFT JOIN Project ON (s.ProjectID=Project.ProjectID)
               JOIN files f ON (f.SessionID=s.ID) 
               LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID) 
               JOIN mri_acquisition_dates md ON (md.SessionID=s.ID)


### PR DESCRIPTION
## Brief summary of changes

This fixes the query for the imaging browser by taking the ProjectID from the session table instead of the candidate table.

#### Testing instructions

1. Test that loading imaging browser on 22.0 fails
2. Test that after running the SQL patches it works again

#### Special note: 
The following patch (`SQL/New_patches//2019-07-01_add_projects_to_sessions.sql`) should be modified so that the `ProjectID` is populated correctly in the `session` table when studies have `scanner` candidates that are not associated to projects.
The update statement in that file should have been:
```
UPDATE session s JOIN candidate c ON s.CandID=c.CandID SET ProjectID=c.RegistrationProjectID WHERE PSCID != 'scanner';
```
@driusan @ridz1208 What should I do about this one? Should I create a new patch or just modify the one with the update since this is from a patch for that release? Let me know.

