### PR TITLE
[dicom_archive] fixed the metadata not being displayed in the view details page

### DIFF
--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -91,8 +91,11 @@ class ViewDetails extends \NDB_Form
     {
         switch ($table) {
         case "tarchive":
-            $query = "SELECT * FROM $table WHERE TarchiveID =:ID";
-            $array = $this->DB->pselectRow($query, array('ID' => $tarchiveID));
+            $query        = "SELECT * FROM $table WHERE TarchiveID =:ID";
+            $tarchiveData = $this->DB->pselectRow(
+                $query,
+                array('ID' => $tarchiveID)
+            );
             break;
         case "tarchive_series":
             $query        = "SELECT * FROM $table WHERE TarchiveID =:ID


### PR DESCRIPTION
## Brief summary of changes

The metadata displayed at the top of the DICOM archive view details page were not populated. This fixes the bug.

#### Testing instructions (if applicable)

1. checkout 22.0 and check that the metadata are not populated in the view details page
2. checkout this branch and check that the metadata are populated

#### Links to related tickets (GitHub, Redmine, ...)

* #5447 
