### PR TITLE
[Readme] fixing code formatting typo in main Ubuntu readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 5. Apache configuration
 
 If your apache configuration was not completed by the Install script, run the following enable rewriting of LORIS, enable your `$projectname` site, and restart apache:  (run by user who has root privileges)
-    ```bash
+    
+```bash
     sudo a2enmod rewrite
     sudo a2dissite default
     sudo a2ensite $projectname
@@ -110,5 +111,4 @@ LORIS is made by staff developers at the McGill Centre for Integrative Neuroscie
 See [LORIS.ca](www.loris.ca) for our current team, the history of LORIS, and our **Technical Papers**.
 
 The original (pre-GitHub) LORIS development team from 1999-2010 included: Dario Vins, Alex Zijdenbos, Jonathan Harlap, Matt Charlet, Andrew Corderey, Sebastian Muehlboeck, and Samir Das.  
-
 

--- a/README.md
+++ b/README.md
@@ -38,50 +38,49 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 
 1. Set up LINUX user lorisadmin, with `sudo` privilege, and create LORIS base directory:
 
-    ```
-    sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
-    sudo passwd lorisadmin
-    su - lorisadmin
-    ```
+```bash
+sudo useradd -U -m -G sudo -s /bin/bash lorisadmin
+sudo passwd lorisadmin
+su - lorisadmin
+```
 
-    <b>Important: All steps from this point forward must be executed by lorisadmin user</b>
+ <b>Important: All steps from this point forward must be executed by lorisadmin user</b>
 
-    ```
-    sudo mkdir -m 775 -p /var/www/$projectname
-    sudo chown lorisadmin.lorisadmin /var/www/$projectname
-    ```
+ ```bash
+ sudo mkdir -m 775 -p /var/www/$projectname
+ sudo chown lorisadmin.lorisadmin /var/www/$projectname
+ ```
 
-    <i>$projectname ⇾ "loris" or one-word project name</i>
+ <i>$projectname ⇾ "loris" or one-word project name</i>
 
 2. Get the code:
-    Download the latest release from the [releases page](https://github.com/aces/Loris/releases) and
-    extract it to `/var/www/$projectname`
+Download the latest release from the [releases page](https://github.com/aces/Loris/releases) and extract it to `/var/www/$projectname`
 
 3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
 
-    For more information, please read the [Installing Loris wiki page](https://github.com/aces/Loris/wiki/Installing-Loris).
+For more information, please read the [Installing Loris wiki page](https://github.com/aces/Loris/wiki/Installing-Loris).
 
-    ```
-    cd /var/www/$projectname/tools
-    ./install.sh
-    ```
+ ```bash
+ cd /var/www/$projectname/tools
+ ./install.sh
+ ```
 
 4. Run the makefile (use `make dev` if you are setting up a development sandbox)
-    ```bash
-    cd /var/www/$projectname
-    make
-    ```
+ ```bash
+ cd /var/www/$projectname
+ make
+ ```
 
 5. Apache configuration
 
 If your apache configuration was not completed by the Install script, run the following enable rewriting of LORIS, enable your `$projectname` site, and restart apache:  (run by user who has root privileges)
     
-    ```bash
-    sudo a2enmod rewrite
-    sudo a2dissite default
-    sudo a2ensite $projectname
-    sudo service apache2 reload
-    ```
+```bash
+sudo a2enmod rewrite
+sudo a2dissite default
+sudo a2ensite $projectname
+sudo service apache2 reload
+```
     
 6. Go to http://localhost/installdb.php and follow the instructions to finalize LORIS installation, then restart apache.
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,12 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 5. Apache configuration
 
 If your apache configuration was not completed by the Install script, run the following enable rewriting of LORIS, enable your `$projectname` site, and restart apache:  (run by user who has root privileges)
-```bash
+    ```bash
     sudo a2enmod rewrite
     sudo a2dissite default
     sudo a2ensite $projectname
     sudo service apache2 reload
+    ```
 6. Go to http://localhost/installdb.php and follow the instructions to finalize LORIS installation, then restart apache.
 
 7. Follow the [Setup Guide in the LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) to complete your post-installation setup and configuration, and for more documentation.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If your apache configuration was not completed by the Install script, run the fo
     sudo a2ensite $projectname
     sudo service apache2 reload
     ```
+    
 6. Go to http://localhost/installdb.php and follow the instructions to finalize LORIS installation, then restart apache.
 
 7. Follow the [Setup Guide in the LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) to complete your post-installation setup and configuration, and for more documentation.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this 
 
 If your apache configuration was not completed by the Install script, run the following enable rewriting of LORIS, enable your `$projectname` site, and restart apache:  (run by user who has root privileges)
     
-```bash
+    ```bash
     sudo a2enmod rewrite
     sudo a2dissite default
     sudo a2ensite $projectname


### PR DESCRIPTION
Fixing a minor formatting issue in the Ubuntu readme
This resolves #5424 reported by @johnsaigle

This is issued to master not 22-release since 22-release's readme isn't quite up to date

Testing instructions 

- [ ]  View the Readme on Github. check if it renders properly. 
