### PR TITLE
[install CentOS] Fixes httpd apache module for php is missing

### DIFF
--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -31,9 +31,8 @@ sudo systemctl start httpd
 sudo yum install epel-release
 sudo yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
 sudo yum install yum-utils
-sudo yum-config-manager --enable remi-php72
 sudo yum update
-sudo yum install php72
+sudo yum --enablerepo=remi-php72 install php
 sudo yum install php72-php-fpm php72-php-gd php72-php-json php72-php-mbstring php72-php-mysqlnd php72-php-xml php72-php-xmlrpc php72-php-opcache php72-php-pdo php72-php-mysql
 ```
 ## MariaDB

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -85,7 +85,7 @@ class Edit_User extends \NDB_Form
         $defaults = array();
 
         if (!$this->isCreatingNewUser()) {
-            $user = \User::factory($this->identifier);
+            $user = \User::factory(urldecode($this->identifier));
             // get the user defaults
             $defaults = $user->getData();
             // remove the password hash

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -85,7 +85,7 @@ class Edit_User extends \NDB_Form
         $defaults = array();
 
         if (!$this->isCreatingNewUser()) {
-            $user = \User::factory(urldecode($this->identifier));
+            $user = \User::factory($this->identifier);
             // get the user defaults
             $defaults = $user->getData();
             // remove the password hash


### PR DESCRIPTION
## Brief summary of changes

This PR resolves php missing for httpd (apache) module.

Note: The command "sudo yum-config-manager --enable remi-php72" doesn't actually help change the repos for installation of php72

Please see https://github.com/aces/Loris/issues/5383 for details. 