### PR TITLE
[installdb.php] Fixes sourceSchema not reporting error

### DIFF
--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -371,7 +371,7 @@ class Installer
         $sqls = file_get_contents(__DIR__ . "/../../SQL/0000-00-$file");
         $DB->PDO->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         try {
-            $DB->PDO->query($sqls);
+            $DB->PDO->exec($sqls);
         } catch (\PDOException $err) {
             error_log($err->getMessage());
             return false;

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -374,6 +374,7 @@ class Installer
             $DB->PDO->exec($sqls);
         } catch (\PDOException $err) {
             error_log($err->getMessage());
+            $this->_lastErr = $err->getMessage();
             return false;
         }
         return true;

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -369,12 +369,14 @@ class Installer
     private function _sourceSchemaFile($DB, $file)
     {
         $sqls = file_get_contents(__DIR__ . "/../../SQL/0000-00-$file");
-        if ($DB->PDO->exec($sqls) === false) {
-            $this->_lastErr = "Unknown error sourcing schema file. $file";
+        $DB->PDO->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        try {
+            $DB->PDO->query($sqls);
+        } catch (\PDOException $err) {
+            error_log($err->getMessage());
             return false;
         }
         return true;
-
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

The _sourceSchemaFile function wasn't logging potential errors when running the installdb.php in the browser.

Note: Let me know if you think the current solution could be done differently.

#### Testing instructions (if applicable)

1. Rerun the installdb.php before completing and the error should be logged.

#### Links to related tickets (GitHub, Redmine, ...)

* https://github.com/aces/Loris/issues/5472