### PR TITLE
[Testing] Add unit tests for User::passwordChanged

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1107,7 +1107,7 @@ class Edit_User extends \NDB_Form
                 // The Password class is self-validating and will throw an
                 // InvalidArgumentException if the value passed to it is
                 // bad or the input is too weak to be a good password.
-                $password        = new \Password($plaintext);
+                $password            = new \Password($plaintext);
                 $isPasswordDifferent = \User::factory($this->identifier)
                     ->isPasswordDifferent($plaintext);
                 if (! $isPasswordDifferent) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1108,9 +1108,9 @@ class Edit_User extends \NDB_Form
                 // InvalidArgumentException if the value passed to it is
                 // bad or the input is too weak to be a good password.
                 $password        = new \Password($plaintext);
-                $passwordChanged = \User::factory($this->identifier)
-                    ->passwordChanged($plaintext);
-                if (! $passwordChanged) {
+                $isPasswordDifferent = \User::factory($this->identifier)
+                    ->isPasswordDifferent($plaintext);
+                if (! $isPasswordDifferent) {
                     $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;
                 }
             } catch (\InvalidArgumentException $e) {

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -416,9 +416,10 @@ class My_Preferences extends \NDB_Form
                 //
                 // NOTE 'Password_hash' is actually plaintext, not a hash.
                 $password        = new \Password($plaintext);
-                $passwordChanged = \User::factory($this->identifier)
-                    ->passwordChanged($plaintext);
-                if (! $passwordChanged) {
+                // New password must be different than current one
+                if (! \User::factory($this->identifier)->isPasswordDifferent(
+                    $values['Password_hash']
+                ) {
                     $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;
                 }
             } catch (\InvalidArgumentException $e) {

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -415,10 +415,11 @@ class My_Preferences extends \NDB_Form
                 // bad or the input is too weak to be a good password.
                 //
                 // NOTE 'Password_hash' is actually plaintext, not a hash.
-                $password        = new \Password($plaintext);
+                $password = new \Password($plaintext);
                 // New password must be different than current one
                 if (! \User::factory($this->identifier)->isPasswordDifferent(
                     $values['Password_hash']
+                )
                 ) {
                     $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;
                 }

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -292,6 +292,26 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function _verifyUserModification($page, $userId, $fieldName, $newValue)
     {
+
+        // Submit the change
+        $this->submitUserData($page, $userId, $fieldName, $newValue);
+
+        // Verify changes appear on the page
+        $this->_accessUser($page, $userId);
+        $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
+        if ($field->getTagName() == 'input') {
+            $this->assertEquals($field->getAttribute('value'), $newValue);
+        } else {
+            $selectField = new WebDriverSelect($field);
+            $this->assertEquals(
+                $selectField->getFirstSelectedOption()->getText(),
+                $newValue
+            );
+        }
+    }
+
+    function submitUserData($page, $userId, $fieldName, $newValue)
+    {
         $this->_accessUser($page, $userId);
         $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
         if ($field->getTagName() == 'input') {
@@ -315,19 +335,29 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $projectsOption->selectByValue("1");
         }
         $this->safeClick(WebDriverBy::Name('fire_away'));
-
-        $this->_accessUser($page, $userId);
-        $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
-        if ($field->getTagName() == 'input') {
-            $this->assertEquals($field->getAttribute('value'), $newValue);
-        } else {
-            $selectField = new WebDriverSelect($field);
-            $this->assertEquals(
-                $selectField->getFirstSelectedOption()->getText(),
-                $newValue
-            );
-        }
     }
+
+    function verifyPasswordErrors($page, $userId): void {
+        $this->_accessUser($page, $userId);
+        $password = $this->safeFindElement(
+            WebDriverBy::Name('Password_hash')
+        );
+        $confirmPassword = $this->safeFindElement(
+            WebDriverBy::Name('__Confirm')
+        );
+
+        // Ensure the passwords match.
+        assertEqual($password, $confirmPassword);
+        
+        $this->submitUserData(
+            'user_accounts',
+            'UnitTester',
+            'Email',
+            'newemail@example.com'
+        );
+
+    }
+
     /**
      * Does one of two things: either accesses the My Preferences page of the
      * current user of the user account page for the user whose ID is passed

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -292,26 +292,6 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function _verifyUserModification($page, $userId, $fieldName, $newValue)
     {
-
-        // Submit the change
-        $this->submitUserData($page, $userId, $fieldName, $newValue);
-
-        // Verify changes appear on the page
-        $this->_accessUser($page, $userId);
-        $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
-        if ($field->getTagName() == 'input') {
-            $this->assertEquals($field->getAttribute('value'), $newValue);
-        } else {
-            $selectField = new WebDriverSelect($field);
-            $this->assertEquals(
-                $selectField->getFirstSelectedOption()->getText(),
-                $newValue
-            );
-        }
-    }
-
-    function submitUserData($page, $userId, $fieldName, $newValue)
-    {
         $this->_accessUser($page, $userId);
         $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
         if ($field->getTagName() == 'input') {
@@ -335,29 +315,19 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $projectsOption->selectByValue("1");
         }
         $this->safeClick(WebDriverBy::Name('fire_away'));
-    }
 
-    function verifyPasswordErrors($page, $userId): void {
         $this->_accessUser($page, $userId);
-        $password = $this->safeFindElement(
-            WebDriverBy::Name('Password_hash')
-        );
-        $confirmPassword = $this->safeFindElement(
-            WebDriverBy::Name('__Confirm')
-        );
-
-        // Ensure the passwords match.
-        assertEqual($password, $confirmPassword);
-        
-        $this->submitUserData(
-            'user_accounts',
-            'UnitTester',
-            'Email',
-            'newemail@example.com'
-        );
-
+        $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
+        if ($field->getTagName() == 'input') {
+            $this->assertEquals($field->getAttribute('value'), $newValue);
+        } else {
+            $selectField = new WebDriverSelect($field);
+            $this->assertEquals(
+                $selectField->getFirstSelectedOption()->getText(),
+                $newValue
+            );
+        }
     }
-
     /**
      * Does one of two things: either accesses the My Preferences page of the
      * current user of the user account page for the user whose ID is passed

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -504,6 +504,11 @@ class User extends UserPermissions
                 'Password_expiry' => $expiry->format(self::MYSQL_DATE_FORMAT),
             )
         );
+        // XXX This class should use DateTime objects instead of strings so
+        // that formatting doens't need to be specified and so that Date math
+        // is simpler and safer.
+        $this->userInfo['Password_hash']   = (string) $password;
+        $this->userInfo['Password_expiry'] = $expiry->format('Y-m-d');
     }
 
     /**
@@ -515,7 +520,7 @@ class User extends UserPermissions
      *
      * @return bool  true if the password has changed, false otherwise.
      */
-    function passwordChanged(
+    function isPasswordDifferent(
         string $plaintextPassword
     ): bool {
         return ! password_verify(

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -518,22 +518,10 @@ class User extends UserPermissions
     function passwordChanged(
         string $plaintextPassword
     ): bool {
-        $passwordQuery = "SELECT Password_hash
-            FROM users
-            WHERE UserID = :UID";
-
-        $current = \NDB_Factory::singleton()->database()->pselectOne(
-            $passwordQuery,
-            array('UID' => $this->getID())
+        return ! password_verify(
+            $plaintextPassword,
+            $this->userInfo['Password_hash']
         );
-
-        if (!is_null($current)) {
-            // The plaintext password must be used here rather than the
-            // Password class.
-            return !password_verify($plaintextPassword, $current);
-        }
-
-        return true;
     }
 }
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -539,7 +539,7 @@ class UserTest extends TestCase
      */
     public function testUpdatePasswordWithExpiryDate()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $oldHash = $this->_user->getData('Password_hash');
         $customDate = '2021-07-18';
 
@@ -553,7 +553,7 @@ class UserTest extends TestCase
             new DateTime($customDate)
         );
         //Re-populate the user object now that the password has been changed
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
 
         $this->assertEquals($customDate, $this->_user->getData('Password_expiry'));
         // This checks that the hash has been updated. There is no way to predict

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -648,7 +648,7 @@ class UserTest extends TestCase
         $this->_mockDB->expects($this->any())
             ->method('pselectOne')
             ->with(
-                $this->stringContains("FROM user_login_history")
+                $this->stringContains("Password_hash")
             )
             ->willReturn(\Utility::randomString());
         // Should return true (i.e. the password has changed) because random
@@ -674,7 +674,7 @@ class UserTest extends TestCase
         $this->_mockDB->expects($this->any())
             ->method('pselectOne')
             ->with(
-                $this->stringContains("FROM user_login_history")
+                $this->stringContains("Password_hash")
             )
             ->willReturn($hash);
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -633,13 +633,13 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test that passwordChanged returns true when the input does not match
+     * Test that isPasswordDifferent returns true when the input does not match
      * the Password_hash in the database.
      * Both the hash and the input are set to different random strings so a
      * match should never occur in this function.
      *
      * @return void
-     * @covers User::passwordChanged
+     * @covers User::isPasswordDifferent
      */
     public function testPasswordChangedReturnsTrue() {
         $this->_user = \User::factory(self::USERNAME);
@@ -650,18 +650,18 @@ class UserTest extends TestCase
         // Should return true (i.e. the password has changed) because random
         // strings should not generate a match.
         $this->assertTrue(
-            $this->_user->passwordChanged(
+            $this->_user->isPasswordDifferent(
                 \Utility::randomString()
             )
         );
     }
 
     /**
-     * Test that passwordChanged returns false when the input matches the
+     * Test that isPasswordDifferent returns false when the input matches the
      * Password_hash in the database.
      *
      * @return void
-     * @covers User::passwordChanged
+     * @covers User::isPasswordDifferent
      */
     public function testPasswordChangedReturnsFalse() {
         $this->_user = \User::factory(self::USERNAME);
@@ -671,7 +671,7 @@ class UserTest extends TestCase
             PASSWORD_DEFAULT
         );
 
-        $this->assertFalse($this->_user->passwordChanged($password));
+        $this->assertFalse($this->_user->isPasswordDifferent($password));
     }
 
     /**

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -240,6 +240,12 @@ class UserTest extends TestCase
                                                );
         $this->_userInfoComplete['CenterIDs'] = array('1', '4');
         $this->_userInfoComplete['ProjectIDs'] = array('1', '3');
+        $passwordHash = (new \Password(
+            $this->_userInfo['Password']
+        ))->__toString();
+        $this->_userInfo['Password_hash'] = $passwordHash;
+        $this->_userInfoComplete['Password_hash'] = $passwordHash;
+
 
         $this->_user = \User::factory(self::USERNAME);
     }
@@ -635,18 +641,12 @@ class UserTest extends TestCase
     /**
      * Test that isPasswordDifferent returns true when the input does not match
      * the Password_hash in the database.
-     * Both the hash and the input are set to different random strings so a
-     * match should never occur in this function.
      *
      * @return void
      * @covers User::isPasswordDifferent
      */
     public function testPasswordChangedReturnsTrue() {
         $this->_user = \User::factory(self::USERNAME);
-        $this->_userInfo['Password_hash'] = password_hash(
-            \Utility::randomString(),
-            PASSWORD_DEFAULT
-        );
         // Should return true (i.e. the password has changed) because random
         // strings should not generate a match.
         $this->assertTrue(
@@ -664,12 +664,16 @@ class UserTest extends TestCase
      * @covers User::isPasswordDifferent
      */
     public function testPasswordChangedReturnsFalse() {
+        // Update the password again to make sure another test hasn't
+        // interfered.
         $this->_user = \User::factory(self::USERNAME);
         $password = $this->_userInfo['Password'];
-        $this->_userInfo['Password_hash'] = password_hash(
-            $password,
-            PASSWORD_DEFAULT
+        $this->_user->updatePassword(
+            new \Password($password)
         );
+
+        //Re-populate the user object now that the password has been changed
+        $this->_user = \User::factory(self::USERNAME);
 
         $this->assertFalse($this->_user->isPasswordDifferent($password));
     }

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -633,24 +633,20 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test that a user cannot keep the same password.
-     *
-     * Uses a random string as the "new password" which is evaluated against 
-     * another random string as the "old password hash". 
-     * This should always return false because passwordChanged checks that its 
-     * input matches the old hash and random strings won't generate a match.
+     * Test that passwordChanged returns true when the input does not match
+     * the Password_hash in the database.
+     * Both the hash and the input are set to different random strings so a
+     * match should never occur in this function.
      *
      * @return void
      * @covers User::passwordChanged
      */
     public function testPasswordChangedReturnsTrue() {
-        $this->_user = \User::factory($this->_username);
-        $this->_mockDB->expects($this->any())
-            ->method('pselectOne')
-            ->with(
-                $this->stringContains("Password_hash")
-            )
-            ->willReturn(\Utility::randomString());
+        $this->_user = \User::factory(self::USERNAME);
+        $this->_userInfo['Password_hash'] = password_hash(
+            \Utility::randomString(),
+            PASSWORD_DEFAULT
+        );
         // Should return true (i.e. the password has changed) because random
         // strings should not generate a match.
         $this->assertTrue(
@@ -661,22 +657,19 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test that a user cannot keep the same password.
+     * Test that passwordChanged returns false when the input matches the
+     * Password_hash in the database.
      *
      * @return void
      * @covers User::passwordChanged
      */
     public function testPasswordChangedReturnsFalse() {
-        $this->_user = \User::factory($this->_username);
-        $password = $this->_userInfoComplete['Password'];
-        $hash = password_hash($password, PASSWORD_DEFAULT);
-
-        $this->_mockDB->expects($this->any())
-            ->method('pselectOne')
-            ->with(
-                $this->stringContains("Password_hash")
-            )
-            ->willReturn($hash);
+        $this->_user = \User::factory(self::USERNAME);
+        $password = $this->_userInfo['Password'];
+        $this->_userInfo['Password_hash'] = password_hash(
+            $password,
+            PASSWORD_DEFAULT
+        );
 
         $this->assertFalse($this->_user->passwordChanged($password));
     }

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -571,7 +571,7 @@ class UserTest extends TestCase
      */
     public function testUpdatePasswordWithoutExpiry()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
 
         $oldHash = $this->_user->getData('Password_hash');
         $newDate = date('Y-m-d', strtotime('+6 months'));
@@ -585,7 +585,7 @@ class UserTest extends TestCase
             new \Password(\Utility::randomString(16))
         );
         //Re-populate the user object now that the password has been changed
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
 
         $this->assertEquals($newDate, $this->_user->getData('Password_expiry'));
         $this->assertNotEquals($oldHash, $this->_user->getData('Password_hash'));
@@ -600,7 +600,7 @@ class UserTest extends TestCase
      */
     public function testHasLoggedInWhenTrue()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $count = 1;
         $this->_mockDB->expects($this->any())
             ->method('pselectOne')
@@ -621,7 +621,7 @@ class UserTest extends TestCase
      */
     public function testHasLoggedInWhenFalse()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $count = 0;
         $this->_mockDB->expects($this->any())
             ->method('pselectOne')

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -225,9 +225,6 @@ class UserTest extends TestCase
         $this->_mockFactory->setDatabase($this->_mockDB);
         $this->_factory->setConfig($this->_mockConfig);
 
-        $this->_userInfo['Password_hash'] = 
-            new \Password($this->_userInfoComplete['Password']);
-
         $this->_userInfoComplete = $this->_userInfo;
         $this->_userInfoComplete['ID'] = '1';
         $this->_userInfoComplete['Privilege'] = '1';

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -28,7 +28,7 @@ class UserTest extends TestCase
      *
      * @var string
      */
-    private const USERNAME = '968775'
+    private const USERNAME = '968775';
     /**
      * Stores user information
      *
@@ -36,7 +36,7 @@ class UserTest extends TestCase
      */
     private $_userInfo
         = array('ID'                     => 1,
-                'UserID'                 => self::USERNAME
+                'UserID'                 => self::USERNAME,
                 'Password'               => 'sufficient length and complexity',
                 'Real_name'              => 'John Doe',
                 'First_name'             => 'John',
@@ -650,12 +650,12 @@ class UserTest extends TestCase
             ->with(
                 $this->stringContains("FROM user_login_history")
             )
-            ->willReturn(\Utility::getRandomString());
+            ->willReturn(\Utility::randomString());
         // Should return true (i.e. the password has changed) because random
         // strings should not generate a match.
         $this->assertTrue(
             $this->_user->passwordChanged(
-                \Utility::getRandomString()
+                \Utility::randomString()
             )
         );
     }

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -28,7 +28,7 @@ class UserTest extends TestCase
      *
      * @var string
      */
-    private $_username;
+    private const USERNAME = '968775'
     /**
      * Stores user information
      *
@@ -36,7 +36,7 @@ class UserTest extends TestCase
      */
     private $_userInfo
         = array('ID'                     => 1,
-                'UserID'                 => '968775',
+                'UserID'                 => self::USERNAME
                 'Password'               => 'sufficient length and complexity',
                 'Real_name'              => 'John Doe',
                 'First_name'             => 'John',
@@ -225,7 +225,8 @@ class UserTest extends TestCase
         $this->_mockFactory->setDatabase($this->_mockDB);
         $this->_factory->setConfig($this->_mockConfig);
 
-        $this->_username = "968775";
+        $this->_userInfo['Password_hash'] = 
+            new \Password($this->_userInfoComplete['Password']);
 
         $this->_userInfoComplete = $this->_userInfo;
         $this->_userInfoComplete['ID'] = '1';
@@ -242,8 +243,8 @@ class UserTest extends TestCase
                                                );
         $this->_userInfoComplete['CenterIDs'] = array('1', '4');
         $this->_userInfoComplete['ProjectIDs'] = array('1', '3');
-        $this->_userInfoComplete['Password_hash'] = 
-            new \Password($this->_userInfoComplete['Password']);
+
+        $this->_user = \User::factory(self::USERNAME);
     }
 
     /**
@@ -271,7 +272,7 @@ class UserTest extends TestCase
     public function testFactoryRetrievesUserInfo()
     {
         $this->_setUpTestDoublesForFactoryUser();
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         //validate _user Info
         $this->assertEquals($this->_userInfoComplete, $this->_user->getData());
     }
@@ -285,7 +286,7 @@ class UserTest extends TestCase
      */
     public function testGetDataForLanguagePreferences()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['language_preference'], 
             $this->_user->getData('language_preference')
@@ -300,7 +301,7 @@ class UserTest extends TestCase
      */
     public function testGetFullname()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['Real_name'],        
             $this->_user->getFullname()
@@ -315,7 +316,7 @@ class UserTest extends TestCase
      */
     public function testGetId()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['ID'],
             $this->_user->getId()
@@ -330,7 +331,7 @@ class UserTest extends TestCase
      */
     public function testGetUsername()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['UserID'],
             $this->_user->getUsername()
@@ -345,7 +346,7 @@ class UserTest extends TestCase
      */
     public function testSiteNames()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             array('psc_test', 'psc_test2'),
             $this->_user->getSiteNames()
@@ -360,7 +361,7 @@ class UserTest extends TestCase
      */
     public function testGetCenterIDs()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['CenterIDs'],
             $this->_user->getCenterIDs()
@@ -375,7 +376,7 @@ class UserTest extends TestCase
      */
     public function testGetLanguagePreference()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertEquals(
             $this->_userInfoComplete['language_preference'],
             $this->_user->getLanguagePreference()
@@ -391,7 +392,7 @@ class UserTest extends TestCase
      */
     public function testGetExaminerSites()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $result = array('1' => array('Y', 1),
                         '4' => array('Y', 1));
         $this->assertEquals(
@@ -410,7 +411,7 @@ class UserTest extends TestCase
      */
     public function testGetStudySites()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $result = array('1' => 'psc_test',
                         '4' => 'psc_test2');
         $this->assertEquals(
@@ -427,7 +428,7 @@ class UserTest extends TestCase
      */
     public function testHasStudySites()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertTrue($this->_user->hasStudySite());
     }
     
@@ -439,7 +440,7 @@ class UserTest extends TestCase
      */
     public function testIsEmailValid()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertTrue($this->_user->isEmailValid());
     }
 
@@ -458,7 +459,7 @@ class UserTest extends TestCase
             "users", 
             array(0=> $invalidEmailInfo)
         );
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertFalse($this->_user->isEmailValid());
     }
  
@@ -470,7 +471,7 @@ class UserTest extends TestCase
      */
     public function testHasCenterWhenTrue()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertTrue($this->_user->hasCenter(4));
     }
 
@@ -482,7 +483,7 @@ class UserTest extends TestCase
      */
     public function testHasCenterWhenFalse()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertFalse($this->_user->hasCenter(5));
     }
 
@@ -494,7 +495,7 @@ class UserTest extends TestCase
      */
     public function testIsUserDCC()
     {
-        $this->_user = \User::factory($this->_username);
+        $this->_user = \User::factory(self::USERNAME);
         $this->assertTrue($this->_user->isUserDCC());
     }
 
@@ -645,7 +646,7 @@ class UserTest extends TestCase
      * @return void
      * @covers User::passwordChanged
      */
-    private function testPasswordChangedReturnsTrue() {
+    public function testPasswordChangedReturnsTrue() {
         $this->_user = \User::factory($this->_username);
         $this->_mockDB->expects($this->any())
             ->method('pselectOne')
@@ -668,7 +669,7 @@ class UserTest extends TestCase
      * @return void
      * @covers User::passwordChanged
      */
-    private function testPasswordChangedReturnsFalse() {
+    public function testPasswordChangedReturnsFalse() {
         $this->_user = \User::factory($this->_username);
         $password = $this->_userInfoComplete['Password'];
         $hash = password_hash($password, PASSWORD_DEFAULT);


### PR DESCRIPTION
## Brief summary of changes

Adds unit tests to the passwordChanged function. 

### Testing

While this adds a unit test, the front-end should still be tested. 
* Item 15 in the [test plan](https://github.com/aces/Loris/blob/major/modules/user_accounts/test/TestPlan.md).

#### Links to related tickets (GitHub, Redmine, ...)

* #5439 reported that a passwordChanged() was not returning a false value, i.e. a user was able to keep the same password. I'm adding this function to prevent this kind of issue going forward.
