### PR TITLE
[candidate_parameters][bugfix] getData returning candID object was breaking in react

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -115,7 +115,7 @@ function getCandInfoFields()
 
     $result = [
         'pscid'                => $pscid,
-        'candID'               => $candID,
+        'candID'               => $candID->__toString(),
         'caveatReasonOptions'  => $caveat_options,
         'flagged_caveatemptor' => $flag,
         'flagged_reason'       => $reason,
@@ -196,7 +196,7 @@ function getProbandInfoFields()
 
     $result = [
         'pscid'            => $pscid,
-        'candID'           => $candID,
+        'candID'           => $candID->__toString(),
         'ProbandSex'       => $sex,
         'ProbandDoB'       => $dob,
         'ageDifference'    => $ageDifference,
@@ -270,7 +270,7 @@ function getFamilyInfoFields()
 
     $result = [
         'pscid'                 => $pscid,
-        'candID'                => $candID,
+        'candID'                => $candID->__toString(),
         'candidates'            => $candidates,
         'existingFamilyMembers' => $familyMembers,
     ];
@@ -346,7 +346,7 @@ function getParticipantStatusFields()
 
     $result = [
         'pscid'                 => $pscid,
-        'candID'                => $candID,
+        'candID'                => $candID->__toString(),
         'statusOptions'         => $statusOptions,
         'required'              => $required,
         'reasonOptions'         => $reasonOptions,
@@ -433,7 +433,7 @@ function getConsentStatusFields()
 
     $result = [
         'pscid'           => $pscid,
-        'candID'          => $candID,
+        'candID'          => $candID->__toString(),
         'consentStatuses' => $status,
         'consentDates'    => $date,
         'withdrawals'     => $withdrawalDate,


### PR DESCRIPTION
## Brief summary of changes
This is a fix for #5434 in which the forms were loading and then disappearing quickly afterwards.
I've attached a screenshot of what was appearing in the console. 

![image](https://user-images.githubusercontent.com/34260251/68147243-ab947d00-ff07-11e9-8114-0f0382f82908.png)

If you follow the link of the minified error, react documentation specifies the following:
`Objects are not valid as a React child (found: object with keys {}).`

Essentially, when returning the CandID object in the getData.php file, react freaks out because it expecting a string and cannot render the object that was passed.

#### Testing instructions (if applicable)

1. Try accessing the candidate parameter module and ensure that it loads.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5434 
