### PR TITLE
[Data Team Helper] Remove untrue statement from DTH README

### DIFF
--- a/modules/data_team_helper/README.md
+++ b/modules/data_team_helper/README.md
@@ -26,6 +26,3 @@ There are no configurations for this module.
 The Data Team Helper module links to the feedback module, the
 conflict resolver, and the data entry for particular instruments.
 
-Note: The Data Team Helper module is listed as "Quality Control"
-in the default LORIS menu.
-


### PR DESCRIPTION
Remove reference to the Data Team Helper module being listed as
"Quality Control" in the LORIS menu (which in fact links to the
quality_control module.)

Fixes #5503.