### PR TITLE
[imaging_browser] Fix imaging browser query merge mix ups...

### DIFF
--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -24,32 +24,6 @@ namespace LORIS\brainbrowser;
  */
 class Brainbrowser extends \NDB_Page
 {
-
-    /**
-     * Determine whether the user has permission to view this page
-     *
-     * @param \User $user The user whose access is being checked
-     *
-     * @return bool whether the user hass access
-     */
-    function _hasAccess(\User $user) : bool
-    {
-        /* User has access if they have an 'all site' permission or if they are
-        * part of a study site and are permitted to view their own site.
-         */
-        return $user->hasAnyPermission(
-                array(
-                    'imaging_browser_view_allsites',
-                    'imaging_browser_phantom_allsites',
-                    'imaging_browser_phantom_ownsite',
-                )
-            )
-            || (
-                $user->hasStudySite()
-                && $user->hasPermission('imaging_browser_view_site')
-            );
-    }
-
     /**
      * Override base function to include brainbrowser javascript files
      * and dependencies

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -24,6 +24,32 @@ namespace LORIS\brainbrowser;
  */
 class Brainbrowser extends \NDB_Page
 {
+
+    /**
+     * Determine whether the user has permission to view this page
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool whether the user hass access
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        /* User has access if they have an 'all site' permission or if they are
+        * part of a study site and are permitted to view their own site.
+         */
+        return $user->hasAnyPermission(
+                array(
+                    'imaging_browser_view_allsites',
+                    'imaging_browser_phantom_allsites',
+                    'imaging_browser_phantom_ownsite',
+                )
+            )
+            || (
+                $user->hasStudySite()
+                && $user->hasPermission('imaging_browser_view_site')
+            );
+    }
+
     /**
      * Override base function to include brainbrowser javascript files
      * and dependencies

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -181,7 +181,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               Project.Name as project,
               s.Visit_label as visitLabel,
               $PendingFailSubquery as Visit_QC_Status,
-              md.AcquisitionDate as First_Acquisition,
+              DATE_FORMAT(MIN(pf.Value), \"%Y-%m-%d\") as First_Acquisition,
               FROM_UNIXTIME(MIN(f.InsertTime)) as First_Insertion,
               FROM_UNIXTIME(MAX(fqc.QCLastChangeTime)) as Last_QC,
               $NewDataSubquery as New_Data,
@@ -199,7 +199,8 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               LEFT JOIN Project ON (s.ProjectID=Project.ProjectID)
               JOIN files f ON (f.SessionID=s.ID) 
               LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID) 
-              JOIN mri_acquisition_dates md ON (md.SessionID=s.ID)
+              JOIN parameter_file pf ON (f.FileID=pf.FileID)
+              JOIN parameter_type pt USING (ParameterTypeID)
               LEFT JOIN mri_scan_type modality ON 
                 (f.AcquisitionProtocolID=modality.ID)
               $left_joins 


### PR DESCRIPTION
## Brief summary of changes

One PR removed the `mri_acquisition_dates` table on major, the data framework was done on minor so when minor got pulled to major, the query in the data framework still referenced to the deleted `mri_acquisition_dates` causing the imaging browser to not work on new instances of LORIS. I did not pick that up on the first PR as I still had the `mri_acquisition_dates` in my database... :(

Anyway, this PR should fix testing (hopefully once and for all ;)).

#### Testing instructions (if applicable)

1. Make sure the `mri_acquisition_dates` does not exist your database
2. Verify that the imaging browser module loads


