### PR TITLE
[Configuration] Fix issue where a Project could not be added without subproject data

### DIFF
--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -3,7 +3,7 @@
  * This file is used by the Configuration module to update
  * or insert values into the Project table.
  *
- * PHP version 5
+ * PHP version 7
  *
  * @category Main
  * @package  Loris
@@ -12,7 +12,7 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user = \User::singleton();
 if (!$user->hasPermission('config')) {
     header("HTTP/1.1 403 Forbidden");
     exit;
@@ -22,79 +22,55 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize();
 
-$factory     = NDB_Factory::singleton();
-$db          = $factory->database();
-$ProjectList = Utility::getProjectList();
-$recTarget   = empty($_POST['recruitmentTarget'])
-    ? null : $_POST['recruitmentTarget'];
-$projectID   = null;
-// if a new project is created add the new project.php
-// Otherwise, update the existing project.
-if ($_POST['ProjectID'] === 'new') {
-    if (!in_array($_POST['Name'], $ProjectList) && !empty($_POST['Name'])) {
-        $db->insert(
-            "Project",
-            array(
-                "Name"              => $_POST['Name'],
-                "recruitmentTarget" => $recTarget,
-            )
-        );
-        $projectID = $db->getLastInsertId();
-    } else {
-        header("HTTP/1.1 409 Conflict");
-        print '{ "error" : "Conflict" }';
-        exit();
-    }
-} else {
-    $db->update(
-        "Project",
-        array(
-            "Name"              => $_POST['Name'],
-            "recruitmentTarget" => $recTarget,
-        ),
-        array("ProjectID" => $_POST['ProjectID'])
-    );
-    $projectID = $_POST['ProjectID'];
-}
+$factory = NDB_Factory::singleton();
+$db      = $factory->database();
 
-// get values from the database before change to crossmatch with new submission
-$preValues = $db->pselectCol(
-    'SELECT SubprojectID 
-    FROM project_subproject_rel WHERE ProjectID=:pid',
-    array('pid' => $projectID)
-);
+$ProjectList = Utility::getProjectList();
+$projectName = $_POST['Name'] ?? '';
+// FIXME This field should be added to the front-end.
+$projectAlias  = '';
+$recTarget     = empty($_POST['recruitmentTarget'])
+    ? null : $_POST['recruitmentTarget'];
+$projectID     = $_POST['ProjectID'] ?? null;
+$subprojectIDs = $_POST['SubprojectIDs'] ?? array();
+
+$project = null;
+
+// Create or update a Project
+if ($_POST['ProjectID'] === 'new') {
+    // Give Conflict response if this project already exists.
+    if (in_array($_POST['Name'], $ProjectList, true)) {
+        http_response_code(409);
+        echo json_encode(array('error' => 'Conflict'));
+        exit;
+    }
+
+    $project = \Project::createNew($projectName, $projectAlias, $recTarget);
+} else {
+    // Update Project fields
+    $project = \Project::getProjectFromID($projectID);
+    $project->updateName($projectName);
+    $project->updateRecruitmentTarget($recTarget);
+
+}
 
 // Compare submitted values with DB values.
 // It's important not to delete and reinsert the values due to delete cascades on
 // tables referencing project_subproject_rel in the database.
-$subprojectIDs = $_POST['SubprojectIDs'] ?? array();
 if (empty($subprojectIDs)) {
-    http_response_code(400);
+    http_response_code(200);
     exit;
 }
-$toAdd    = array_diff($subprojectIDs, $preValues);
-$toRemove = array_diff($preValues, $subprojectIDs);
 
-foreach ($toAdd as $sid) {
-    $db->insertIgnore(
-        'project_subproject_rel',
-        array(
-            'ProjectID'    => $projectID,
-            'SubprojectID' => $sid,
-        )
-    );
-}
-// the following can cause some deletions from the visit_project_subproject_rel table
-foreach ($toRemove as $sid) {
-    $db->delete(
-        'project_subproject_rel',
-        array(
-            'ProjectID'    => $projectID,
-            'SubprojectID' => $sid,
-        )
-    );
-}
+// Update subprojectIDs if data submitted.
+$preValues = array_column($project->getSubprojects(), 'subprojectId');
+$toAdd     = array_diff($subprojectIDs, $preValues);
+$toRemove  = array_diff($preValues, $subprojectIDs);
+
+$project->insertSubprojectIDs($toAdd);
+$project->deleteSubprojectIDs($toRemove);
+
 header("HTTP/1.1 200 OK");
-print '{ "ok" : "Success" }';
-exit();
+echo json_encode(array('ok' => 'Success'));
+exit;
 

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -225,6 +225,18 @@ class Project
     }
 
     /**
+     * Set this project's name
+     *
+     * @param string $projectName This project's name
+     *
+     * @return void
+     */
+    public function updateName(string $projectName): void
+    {
+        $this->_projectName = $projectName;
+    }
+
+    /**
      * Get this project's alias
      *
      * @return string This project's alias
@@ -244,12 +256,42 @@ class Project
     public function setAlias(string $projectAlias): void
     {
         if (strlen($projectAlias) > 4 ) {
-            throw new ConfigurationException(
+            throw new InvalidArgumentException(
                 "The length of the project's alias can not be longer than ".
                 "4 characters."
             );
         }
         $this->_projectAlias = $projectAlias;
+    }
+
+    /**
+     * Update the Alias field in the databse for this Project.
+     *
+     * @param ?string $alias The new alias. Uses class property when null.
+     *
+     * @return void
+     */
+    public function updateAlias(?string $alias = null): void
+    {
+        $this->_updateField("Alias", $alias ?? $this->_projectAlias);
+    }
+
+    /**
+     * Updates a column in the database corresponding to this Project.
+     *
+     * @param string $field The name of the column to update.
+     * @param mixed  $value The new value
+     *
+     * @return void
+     */
+    private function _updateField(string $field, $value): void
+    {
+        \NDB_Factory::singleton()->database()
+            ->update(
+                "Project",
+                array($field => (string) $value),
+                array("ProjectID" => $this->_projectId)
+            );
     }
 
     /**
@@ -275,6 +317,34 @@ class Project
             $this->_recruitmentTarget = $total;
         }
         return (int)$this->_recruitmentTarget;
+    }
+
+    /**
+     * Set this project's recruitment target
+     *
+     * @param int $target This project's recruitment target
+     *
+     * @return void
+     */
+    public function setRecruitmentTarget(int $target): void
+    {
+        $this->_recruitmentTarget = $target;
+    }
+
+    /**
+     * Update the recruitmentTarget field in the database for this Project.
+     *
+     * @param ?int $target The new recruitmentTarget. Uses class property
+     *                     when null.
+     *
+     * @return void
+     */
+    public function updateRecruitmentTarget(?int $target = null): void
+    {
+        $this->_updateField(
+            "recruitmentTarget",
+            $target ?? $this->_recruitmentTarget
+        );
     }
 
     /**
@@ -306,7 +376,7 @@ class Project
         return array_map(
             function ($row) {
                 return (object) array(
-                    'subprojectId'      => $row['subprojectId'],
+                    'subprojectId'      => (int) $row['subprojectId'],
                     'title'             => $row['title'],
                     'useEDC'            => $row['useEDC'],
                     'windowDifference'  => $row['windowDifference'],
@@ -345,5 +415,50 @@ class Project
             },
             $candidatesData
         );
+    }
+
+    /**
+     * Inserts new subproject IDs into the database, creating a relationship
+     * between them and this project.
+     *
+     * @param int[] $ids The new subprojectIDs.
+     *
+     * @return void
+     */
+    public function insertSubprojectIDs(array $ids): void
+    {
+        $db = \NDB_Factory::singleton()->database();
+        foreach ($ids as $id) {
+            $db->insertIgnore(
+                'project_subproject_rel',
+                array(
+                    'ProjectID'    => $this->_projectId,
+                    'SubprojectID' => $id,
+                )
+            );
+        }
+    }
+
+    /**
+     * Deletes subproject IDs from the database.
+     *
+     * @param int[] $ids The old subprojectIDs to delete.
+     *
+     * @return void
+     */
+    public function deleteSubprojectIDs(array $ids): void
+    {
+        $db = \NDB_Factory::singleton()->database();
+        // The following can cause some deletions from the
+        // visit_project_subproject_rel table.
+        foreach ($ids as $id) {
+            $db->delete(
+                'project_subproject_rel',
+                array(
+                    'ProjectID'    => $this->_projectId,
+                    'SubprojectID' => $id,
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Projects can now be added without requiring that subproject data be configured at the same time. This error was encountered during v.22 release testing.

This PR also refactors the file and adds accessor methods to the Project class to make the code easier to maintain going forward as well as to take advantage of typing.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5511 
