### PR TITLE
[brainbrowser] Add permissions to view the module

### DIFF
--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -37,16 +37,16 @@ class Brainbrowser extends \NDB_Page
         * part of a study site and are permitted to view their own site.
          */
         return $user->hasAnyPermission(
-                array(
-                    'imaging_browser_view_allsites',
-                    'imaging_browser_phantom_allsites',
-                    'imaging_browser_phantom_ownsite',
-                )
+            array(
+                'imaging_browser_view_allsites',
+                'imaging_browser_phantom_allsites',
+                'imaging_browser_phantom_ownsite',
             )
-            || (
-                $user->hasStudySite()
-                && $user->hasPermission('imaging_browser_view_site')
-            );
+        )
+        || (
+            $user->hasStudySite()
+            && $user->hasPermission('imaging_browser_view_site')
+        );
     }
 
     /**

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -29,7 +29,7 @@ class Brainbrowser extends \NDB_Page
      *
      * @param \User $user The user whose access is being checked
      *
-     * @return bool whether the user hass access
+     * @return bool whether the user has access
      */
     function _hasAccess(\User $user) : bool
     {

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -25,6 +25,31 @@ namespace LORIS\brainbrowser;
 class Brainbrowser extends \NDB_Page
 {
     /**
+     * Determine whether the user has permission to view this page
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool whether the user hass access
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        /* User has access if they have an 'all site' permission or if they are
+        * part of a study site and are permitted to view their own site.
+         */
+        return $user->hasAnyPermission(
+                array(
+                    'imaging_browser_view_allsites',
+                    'imaging_browser_phantom_allsites',
+                    'imaging_browser_phantom_ownsite',
+                )
+            )
+            || (
+                $user->hasStudySite()
+                && $user->hasPermission('imaging_browser_view_site')
+            );
+    }
+
+    /**
      * Override base function to include brainbrowser javascript files
      * and dependencies
      *


### PR DESCRIPTION
#### Brief summary of changes

In the test plan, we mention that only users with imaging browser permissions can view the scans in BB. Added the check for user permission before loading the module.

#### Testing instructions (if applicable)

1. Try out the following URL on RB dataset <your_VM>/brainbrowser/?minc_id=[134] with a user that do not have imaging browser permission. This should lead you to a "No permission" with a redirect link to the dashboard.

#### Links to related tickets (GitHub, Redmine, ...)

* #5473
