### PR TITLE
[install CentOS] httpd.conf configuration instructions

### DIFF
--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -104,6 +104,11 @@ Customize and Verify your settings:
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
 Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `loris/docs/config/apache2-site` for setup of `VirtualHost` in the loris.conf file you will create. Adjust the parameters according to your configuration.
+```
+- %LORISROOT%    i.e. /var/www/loris
+- %PROJECTNAME%  i.e loris
+- %LOGDIRECTORY%  .i.e /var/log/httpd
+```
 
 Finally, restart apache:
 ```bash

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -111,7 +111,6 @@ Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS en
 ```
 <VirtualHost *:80>  # change from 80 to 443 if you enable SSL
         ServerAdmin webmaster@localhost
-        ServerName your.Loris.url.here
 
         DocumentRoot /var/www/%LORISROOT%/htdocs/
         <Directory />

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -134,7 +134,7 @@ Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS en
         # alert, emerg.
         LogLevel warn
 
-        CustomLog /var/log/httpd/loris-access.log combined
+        CustomLog %LOGDIRECTORY%/loris-access.log combined
         ServerSignature Off
 
         #SSLEngine Off  # change to On to enable, after updating cert paths$

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -103,6 +103,31 @@ Customize and Verify your settings:
  * DocumentRoot should point to `/var/www/loris/htdocs`
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
+Modify the Apache configuration file for our production environment.
+```
+sudo open -e /usr/local/etc/httpd/httpd.conf
+```
+
+**a.** Find & modify the `ServerName` to:
+```
+ServerName <production_server>
+```
+
+**b.** Find the lines for `DocumentRoot` and `Directory` in Apache and change them to:
+```
+DocumentRoot "/var/www/loris/htdocs/"
+<Directory "/var/www/loris/htdocs/">
+```
+
+**c.** In the same `<Directory>` block, modify `AllowOverride` to allow all:
+```
+# AllowOverride controls what directives may be placed in .htaccess files.
+# It can be "All", "None", or any combination of the keywords:
+#   AllowOverride FileInfo AuthConfig Limit
+#
+AllowOverride All
+```
+
 Finally, restart apache:
 ```bash
 sudo systemctl restart httpd

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -110,7 +110,7 @@ vi /etc/httpd/conf/httpd.conf
 
 **a.** Find & modify the `ServerName` to:
 ```
-ServerName your.Loris.url.here:443
+ServerName your.Loris.url.here:80
 ```
 
 **b.** Find the lines for `DocumentRoot` and `Directory` in Apache and change them to:

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -118,7 +118,7 @@ Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS en
                 Options FollowSymLinks
                 AllowOverride All
         </Directory>
-        <Directory /var/www/loris/htdocs/>
+        <Directory /var/www/%LORISROOT%/htdocs/>
                 Options Indexes FollowSymLinks MultiViews
                 AllowOverride All
                 Order allow,deny

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -113,7 +113,7 @@ Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS en
         ServerAdmin webmaster@localhost
         ServerName your.Loris.url.here
 
-        DocumentRoot /var/www/loris/htdocs/
+        DocumentRoot /var/www/%LORISROOT%/htdocs/
         <Directory />
                 Options FollowSymLinks
                 AllowOverride All

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -103,47 +103,7 @@ Customize and Verify your settings:
  * DocumentRoot should point to `/var/www/loris/htdocs`
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
-Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. Adjust the following parameters to according to your configuration
-
-- %LORISROOT%    i.e. /var/www/loris
-- %PROJECTNAME%  i.e loris
-- %LOGDIRECTORY%  .i.e /var/log/httpd
-```
-<VirtualHost *:80>  # change from 80 to 443 if you enable SSL
-        ServerAdmin webmaster@localhost
-
-        DocumentRoot /var/www/%LORISROOT%/htdocs/
-        <Directory />
-                Options FollowSymLinks
-                AllowOverride All
-        </Directory>
-        <Directory /var/www/%LORISROOT%/htdocs/>
-                Options Indexes FollowSymLinks MultiViews
-                AllowOverride All
-                Order allow,deny
-                allow from all
-        </Directory>
-
-         php_value include_path .:/usr/share/php:%LORISROOT%/project/libraries:%LORISROOT%/php/libraries
-
-        #DirectoryIndex main.php index.html
-
-        ErrorLog /var/log/httpd/loris-error.log
-
-        # Possible values include: debug, info, notice, warn, error, crit,
-        # alert, emerg.
-        LogLevel warn
-
-        CustomLog %LOGDIRECTORY%/loris-access.log combined
-        ServerSignature Off
-
-        #SSLEngine Off  # change to On to enable, after updating cert paths$
-        #SSLCertificateFile /etc/pki/tls/certs/%PROJECTNAME%.pem
-        #SSLCertificateKeyFile /etc/pki/tls/private/%PROJECTNAME%.key
-        #SSLCACertificateFile /etc/pki/tls/certs/CA-cert.pem
-
-</VirtualHost>
-```
+Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `docs/config/apache2-site` for setup of `VirtualHost` in the loris.conf file you will create. Adjust the parameters according to your configuration.
 
 Finally, restart apache:
 ```bash

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -103,29 +103,43 @@ Customize and Verify your settings:
  * DocumentRoot should point to `/var/www/loris/htdocs`
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
-Modify the Apache configuration file for our production environment.
+Create the Apache configuration `/etc/httpd/conf.id/loris.conf` for our production environment.
 ```
-Edit /etc/httpd/conf/httpd.conf as follows (may require sudo-ing the text editor command)
-```
+<VirtualHost *:80>  # change from 80 to 443 if you enable SSL
+        ServerAdmin webmaster@localhost
+        ServerName your.Loris.url.here
 
-**a.** Find & modify the `ServerName` to:
-```
-ServerName your.Loris.url.here
-```
+        DocumentRoot /var/www/loris/htdocs/
+        <Directory />
+                Options FollowSymLinks
+                AllowOverride All
+        </Directory>
+        <Directory /var/www/loris/htdocs/>
+                Options Indexes FollowSymLinks MultiViews
+                AllowOverride All
+                Order allow,deny
+                allow from all
+        </Directory>
 
-**b.** Find the lines for `DocumentRoot` and `Directory` in Apache and change them to:
-```
-DocumentRoot "%LORISROOT%/htdocs/"
-<Directory "%LORISROOT%/htdocs/">
-```
+        php_value include_path .:/usr/share/php:/var/www/loris/project/libr$
 
-**c.** In the same `<Directory>` block, modify `AllowOverride` to allow all:
-```
-# AllowOverride controls what directives may be placed in .htaccess files.
-# It can be "All", "None", or any combination of the keywords:
-#   AllowOverride FileInfo AuthConfig Limit
-#
-AllowOverride All
+        #DirectoryIndex main.php index.html
+
+        ErrorLog /var/log/httpd/loris-error.log
+
+        # Possible values include: debug, info, notice, warn, error, crit,
+        # alert, emerg.
+        LogLevel warn
+
+        CustomLog /var/log/httpd/loris-access.log combined
+        ServerSignature Off
+
+        #SSLEngine Off  # change to On to enable, after updating cert paths$
+        #SSLCertificateFile /etc/apache2/ssl/loris-cert.pem
+        #SSLCertificateKeyFile /etc/apache2/ssl/loris-key.pem
+        #SSLCACertificateFile /etc/apache2/ssl/CA-cacert.pem
+
+</VirtualHost>
 ```
 
 Finally, restart apache:

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -105,7 +105,7 @@ Customize and Verify your settings:
 
 Modify the Apache configuration file for our production environment.
 ```
-sudo ed /etc/httpd/conf/httpd.conf
+Edit /etc/httpd/conf/httpd.conf as follows (may require sudo-ing the text editor command)
 ```
 
 **a.** Find & modify the `ServerName` to:

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -110,7 +110,7 @@ vi /etc/httpd/conf/httpd.conf
 
 **a.** Find & modify the `ServerName` to:
 ```
-ServerName your.Loris.url.here
+ServerName your.Loris.url.here:443
 ```
 
 **b.** Find the lines for `DocumentRoot` and `Directory` in Apache and change them to:

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -103,7 +103,7 @@ Customize and Verify your settings:
  * DocumentRoot should point to `/var/www/loris/htdocs`
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
-Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `loris/docs/config/apache2-site` for setup of `VirtualHost` in the loris.conf file you will create. Adjust the parameters according to your configuration.
+Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `loris/docs/config/apache2-site` for setup of `<VirtualHost>` in the loris.conf file you will create. Adjust the parameters according to your configuration.
 ```
 - %LORISROOT%    i.e. /var/www/loris
 - %PROJECTNAME%  i.e loris

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -138,9 +138,9 @@ Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS en
         ServerSignature Off
 
         #SSLEngine Off  # change to On to enable, after updating cert paths$
-        #SSLCertificateFile /etc/apache2/ssl/loris-cert.pem
-        #SSLCertificateKeyFile /etc/apache2/ssl/loris-key.pem
-        #SSLCACertificateFile /etc/apache2/ssl/CA-cacert.pem
+        #SSLCertificateFile /etc/pki/tls/certs/%PROJECTNAME%.pem
+        #SSLCertificateKeyFile /etc/pki/tls/private/%PROJECTNAME%.key
+        #SSLCACertificateFile /etc/pki/tls/certs/CA-cert.pem
 
 </VirtualHost>
 ```

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -105,7 +105,7 @@ Customize and Verify your settings:
 
 Modify the Apache configuration file for our production environment.
 ```
-sudo open -e /etc/httpd/conf/httpd.conf
+sudo ed /etc/httpd/conf/httpd.conf
 ```
 
 **a.** Find & modify the `ServerName` to:

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -125,7 +125,7 @@ Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS en
                 allow from all
         </Directory>
 
-        php_value include_path .:/usr/share/php:/var/www/loris/project/libr$
+         php_value include_path .:/usr/share/php:%LORISROOT%/project/libraries:%LORISROOT%/php/libraries
 
         #DirectoryIndex main.php index.html
 

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -105,18 +105,18 @@ Customize and Verify your settings:
 
 Modify the Apache configuration file for our production environment.
 ```
-vi /etc/httpd/conf/httpd.conf
+sudo open -e /etc/httpd/conf/httpd.conf
 ```
 
 **a.** Find & modify the `ServerName` to:
 ```
-ServerName your.Loris.url.here:80
+ServerName your.Loris.url.here
 ```
 
 **b.** Find the lines for `DocumentRoot` and `Directory` in Apache and change them to:
 ```
-DocumentRoot "/var/www/loris/htdocs/"
-<Directory "/var/www/loris/htdocs/">
+DocumentRoot "%LORISROOT%/htdocs/"
+<Directory "%LORISROOT%/htdocs/">
 ```
 
 **c.** In the same `<Directory>` block, modify `AllowOverride` to allow all:

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -103,7 +103,11 @@ Customize and Verify your settings:
  * DocumentRoot should point to `/var/www/loris/htdocs`
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
-Create the Apache configuration `/etc/httpd/conf.id/loris.conf` for our production environment.
+Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. Adjust the following parameters to according to your configuration
+
+- %LORISROOT%    i.e. /var/www/loris
+- %PROJECTNAME%  i.e loris
+- %LOGDIRECTORY%  .i.e /var/log/httpd
 ```
 <VirtualHost *:80>  # change from 80 to 443 if you enable SSL
         ServerAdmin webmaster@localhost

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -103,7 +103,7 @@ Customize and Verify your settings:
  * DocumentRoot should point to `/var/www/loris/htdocs`
  * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd /var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
 
-Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `docs/config/apache2-site` for setup of `VirtualHost` in the loris.conf file you will create. Adjust the parameters according to your configuration.
+Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `loris/docs/config/apache2-site` for setup of `VirtualHost` in the loris.conf file you will create. Adjust the parameters according to your configuration.
 
 Finally, restart apache:
 ```bash

--- a/README.CentOS7.md
+++ b/README.CentOS7.md
@@ -105,12 +105,12 @@ Customize and Verify your settings:
 
 Modify the Apache configuration file for our production environment.
 ```
-sudo open -e /usr/local/etc/httpd/httpd.conf
+vi /etc/httpd/conf/httpd.conf
 ```
 
 **a.** Find & modify the `ServerName` to:
 ```
-ServerName <production_server>
+ServerName your.Loris.url.here
 ```
 
 **b.** Find the lines for `DocumentRoot` and `Directory` in Apache and change them to:


### PR DESCRIPTION
## Brief summary of changes

The httpd.conf needs the DocumentRoot and <Directory "path"> modified.  Similar the ServerName needs to be configured. The installation guide of CentOS didn't inform the user about the step but now it does with the PR.

#### Links to related tickets (GitHub, Redmine, ...)

* https://github.com/aces/Loris/issues/5454
