### PR TITLE
[imaging_uploader] fix forbidden file types that could be uploaded

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -82,7 +82,7 @@ class UploadForm extends Component {
 
     const fileName = data.mriFile.name;
     // Make sure file is of type .zip|.tgz|.tar.gz format
-    const properExt = new RegExp('\.(zip|tgz|tar.gz)$');
+    const properExt = new RegExp('\.(zip|tgz|tar\.gz)$');
     if (!fileName.match(properExt)) {
       swal({
         title: 'Invalid extension for the uploaded file!',

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -82,7 +82,7 @@ class UploadForm extends Component {
 
     const fileName = data.mriFile.name;
     // Make sure file is of type .zip|.tgz|.tar.gz format
-    const properExt = new RegExp('.(zip|tgz|tar.gz)$');
+    const properExt = new RegExp('\.(zip|tgz|tar.gz)$');
     if (!fileName.match(properExt)) {
       swal({
         title: 'Invalid extension for the uploaded file!',
@@ -92,7 +92,7 @@ class UploadForm extends Component {
       });
 
       let errorMessage = {
-        mriFile: 'The file ' + fileName + ' is not of type .tgz, .tar.gz or .zip.',
+        mriFile: 'The file ' + fileName + ' must be of type .tgz, .tar.gz or .zip.',
         candID: undefined,
         pSCID: undefined,
         visitLabel: undefined,

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -81,6 +81,34 @@ class UploadForm extends Component {
     }
 
     const fileName = data.mriFile.name;
+    // Make sure file is of type .zip|.tgz|.tar.gz format
+    const properExt = new RegExp('.(zip|tgz|tar.gz)$');
+    if (!fileName.match(properExt)) {
+      swal({
+        title: 'Invalid extension for the uploaded file!',
+        text: 'Filename extension does not match .zip, .tgz or .tar.gz ',
+        type: 'error',
+        confirmButtonText: 'OK',
+      });
+
+      let errorMessage = {
+        mriFile: 'The file ' + fileName + ' is not of type .tgz, .tar.gz or .zip.',
+        candID: undefined,
+        pSCID: undefined,
+        visitLabel: undefined,
+      };
+
+      let hasError = {
+        mriFile: true,
+        candID: false,
+        pSCID: false,
+        visitLabel: false,
+      };
+
+      this.setState({errorMessage, hasError});
+      return;
+    }
+
     if (data.IsPhantom === 'N') {
       if (!data.candID || !data.pSCID || !data.visitLabel) {
         swal({
@@ -89,33 +117,6 @@ class UploadForm extends Component {
           type: 'error',
           confirmButtonText: 'OK',
         });
-        return;
-      }
-      // Make sure file is of type .zip|.tgz|.tar.gz format
-      const properExt = new RegExp('.(zip|tgz|tar.gz)$');
-      if (!fileName.match(properExt)) {
-        swal({
-          title: 'Invalid extension for the uploaded file!',
-          text: 'Filename extension does not match .zip, .tgz or .tar.gz ',
-          type: 'error',
-          confirmButtonText: 'OK',
-        });
-
-        let errorMessage = {
-          mriFile: 'The file ' + fileName + ' is not of type .tgz, .tar.gz or .zip.',
-          candID: undefined,
-          pSCID: undefined,
-          visitLabel: undefined,
-        };
-
-        let hasError = {
-          mriFile: true,
-          candID: false,
-          pSCID: false,
-          visitLabel: false,
-        };
-
-        this.setState({errorMessage, hasError});
         return;
       }
     }

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -291,6 +291,19 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $file_name_error = "";
         $config          = \NDB_Config::singleton();
         $file_name       = $file->fileInfo['name'];
+
+        ///////////////////////////////////////////////////////////////////////
+        ////////////// Checks to see if the file is of type////////////////////
+        //////////////.gz, .zip or .tgz////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////
+        if (!$this->isCompressed($temp_file)) {
+            array_push(
+                $errors["mriFile"],
+                "The file $file_name is not of type".
+                " .tgz, .tar.gz or .zip."
+            );
+        }
+
         ///////////////////////////////////////////////////////////////////////
         /////////Validate the advanced Options only if it's not a Phantom//////
         ///////////////////////////////////////////////////////////////////////
@@ -390,17 +403,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                      ", and has the extension .tgz, tar.gz or .zip";
             }
         }
-        ///////////////////////////////////////////////////////////////////////
-        ////////////// Checks to see if the file is of type////////////////////
-        //////////////.gz, .zip or .tgz////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        if (!$this->isCompressed($temp_file)) {
-            array_push(
-                $errors["mriFile"],
-                "The file $file_name is not of type".
-                " .tgz, .tar.gz or .zip."
-            );
-        }
+
         ///////////////////////////////////////////////////////////////////////
         //////// Make sure there's no existing identical entry ////////////////
         //////// for "new" scans //////////////////////////////////////////////


### PR DESCRIPTION
## Brief summary of changes

This fixes the issue of any file type being able to be uploaded when the 'Phantom Scans' was set to 'Yes'. 

#### Testing instructions (if applicable)

1. make sure you cannot upload file types different than `.zip`, `.tgz` or `.tar.gz` both when 'Phantom Scans' is set to 'Yes' and 'No'

#### Links to related tickets (GitHub, Redmine, ...)

* #5526
