### PR TITLE
[User Accounts] Add integration tests for password change logic

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -487,7 +487,6 @@ class Edit_User extends \NDB_Form
             $user->update($set);
         }
 
-
         // Now set the password. Note that this field is named incorrectly
         // and represents a plaintext password, not a hash.
         if (isset($values['Password_hash'], $values['Password_expiry'])) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -486,6 +486,8 @@ class Edit_User extends \NDB_Form
             $user = \User::factory($this->identifier);
             $user->update($set);
         }
+
+
         // Now set the password. Note that this field is named incorrectly
         // and represents a plaintext password, not a hash.
         if (isset($values['Password_hash'], $values['Password_expiry'])) {
@@ -497,7 +499,7 @@ class Edit_User extends \NDB_Form
                 new \DateTime($values['Password_expiry'])
             );
         } else if (isset($values['Password_hash'])) {
-            // If just the Password_hash value is present, no not specify a
+            // If just the Password_hash value is present, do not specify a
             // custom expiry date. This will set the password to expire in
             // 6 months from the current date (handled in updatePassword()).
             $user->updatePassword(

--- a/modules/user_accounts/test/TestPlan.md
+++ b/modules/user_accounts/test/TestPlan.md
@@ -28,14 +28,14 @@ When creating or editing a user: (subtest: edit_user)
       - First name,
       - Last name,
       - Email.
-10. If password and confirmed password do not match, an error should be displayed.
+10. If password and confirmed password do not match, an error should be displayed. [Automated]
 11. Email fields containing submitted with invalid formats should generate an error. 
      
 * Ensure the confirm email text field is not displayed on the edit user page (and only on the create new user page).
 
 12. For an existing active user, edit the user's account and click 'Generate new password' and check 'Send email'.
-    Save. Check that an email is sent to the user with the new password. Check that the password rules are enforced 
-    for this new password. Check that after logging in, the user is immediately asked to update his/her password.
+    Save. Check that an email is sent to the user with the new password. 
+    Check that after logging in, the user is immediately asked to update his/her password.
 13. Check that if creating a new user an email is sent to him/her (requires email server). Also check that when a new
     user is logging in for the first time he/she is asked to change his/her password.
     1. Check that when creating a new user, leading and trailing spaces in the username are stripped.
@@ -43,7 +43,7 @@ When creating or editing a user: (subtest: edit_user)
     3. Check that you can delete one of the additional fields (organization, fax, etc...) that was previously set and that the save is performed.
 14. Check that if generating a new password for a user an email is sent to that user containing the new password (requires
     email server).
-15. Check that when editing a user account it is not possible to set the password to its actual value (i.e. it needs to change).
+15. Check that when editing a user account it is not possible to set the password to its actual value (i.e. it needs to change). [Automated]
 16. Verify that if the editor does not have permission 'Across all sites add and edit users' then the site drop-down list is populated with
     the editor's associated sites, otherwise all sites are displayed.
 17. Check that if the 'Display additional information' entry is set to false in the Configuration module, fields Degree,
@@ -86,8 +86,8 @@ On the My Preferences page:
 ==========================
 
 36. Check that all users (even those with NO permissions) have access to the My Preferences page.
-37. Change the user’s password.  Check that the password rules are enforced.
-38. Check that if password and confirmed password do not match you get an error.
+37. Change the user’s password.  Check that the password rules are enforced. [Automated]
+38. Check that if password and confirmed password do not match you get an error. [Automated]
 39. Check that saving fails if any field is left blank (except password).
 40. Check that if you do not enter an email address that is syntactically valid you get an error.
 41. Modify any field on the page and save, and go to the User Account page. Check that the modifications are

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -292,6 +292,26 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function _verifyUserModification($page, $userId, $fieldName, $newValue)
     {
+
+        // Submit the change
+        $this->submitUserData($page, $userId, $fieldName, $newValue);
+
+        // Verify changes appear on the page
+        $this->_accessUser($page, $userId);
+        $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
+        if ($field->getTagName() == 'input') {
+            $this->assertEquals($field->getAttribute('value'), $newValue);
+        } else {
+            $selectField = new WebDriverSelect($field);
+            $this->assertEquals(
+                $selectField->getFirstSelectedOption()->getText(),
+                $newValue
+            );
+        }
+    }
+
+    function submitUserData($page, $userId, $fieldName, $newValue)
+    {
         $this->_accessUser($page, $userId);
         $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
         if ($field->getTagName() == 'input') {
@@ -315,19 +335,29 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $projectsOption->selectByValue("1");
         }
         $this->safeClick(WebDriverBy::Name('fire_away'));
-
-        $this->_accessUser($page, $userId);
-        $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
-        if ($field->getTagName() == 'input') {
-            $this->assertEquals($field->getAttribute('value'), $newValue);
-        } else {
-            $selectField = new WebDriverSelect($field);
-            $this->assertEquals(
-                $selectField->getFirstSelectedOption()->getText(),
-                $newValue
-            );
-        }
     }
+
+    function verifyPasswordErrors($page, $userId): void {
+        $this->_accessUser($page, $userId);
+        $password = $this->safeFindElement(
+            WebDriverBy::Name('Password_hash')
+        );
+        $confirmPassword = $this->safeFindElement(
+            WebDriverBy::Name('__Confirm')
+        );
+
+        // Ensure the passwords match.
+        assertEqual($password, $confirmPassword);
+        
+        $this->submitUserData(
+            'user_accounts',
+            'UnitTester',
+            'Email',
+            'newemail@example.com'
+        );
+
+    }
+
     /**
      * Does one of two things: either accesses the My Preferences page of the
      * current user of the user account page for the user whose ID is passed

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -23,12 +23,26 @@ require_once __DIR__
  */
 class UserAccountsIntegrationTest extends LorisIntegrationTest
 {
-    private const UNIT_TESTER_EMAIL = 'tester@example.com'
-    private const UNIT_TESTER_EMAIL_NEW = 'tester@example.com'
-    private const FORM_FIELD_PASSWORD = 'Password_hash';
-    private const FORM_FIELD_CONFIRM_PASSWORD = '__Confirm';
+    // The paths to the pages to which the form must submit.
+    private const FILEPATH_EDITUSER      = 'user_accounts';
+    private const FILEPATH_MYPREFERENCES = 'user_accounts/my_preferences';
+    // The names of the form elements for the Password and Confirm Password
+    // fields.
+    private const FORM_FIELD_PASSWORD        = 'Password_hash';
+    private const FORM_FIELD_CONFIRMPASSWORD = '__Confirm';
+    // Regular (non-admin) user details
+    private const UNITTESTER_USERNAME  = 'UnitTester';
+    private const UNITTESTER_REALNAME  = 'Unit Tester';
+    private const UNITTESTER_EMAIL     = 'tester@example.com';
+    private const UNITTESTER_EMAIL_NEW = 'newemail@example.com';
+    // Admin user details
+    private const ADMIN_USERNAME  = 'admin';
+    private const ADMIN_REALNAME  = 'Admin account';
+    private const ADMIN_EMAIL     = 'admin@example.com';
+    private const ADMIN_EMAIL_NEW = 'tester@example.com';
 
-    private static $_UNIT_TESTER = array(
+
+    private static $_UNITTESTER = array(
         'Data Coordinating Center',
         'UnitTester',
         'Unit Tester',
@@ -36,7 +50,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         'Y',
         'N',
     );
-    private static $_ADMIN       = array(
+    private static $_ADMIN      = array(
         'Data Coordinating Center',
         'admin',
         'Admin account',
@@ -174,30 +188,35 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function testUserAccountEdits()
     {
+        // Test changing first name
         $this->_verifyUserModification(
             'user_accounts',
             'UnitTester',
             'First_name',
             'NewFirst'
         );
+        // Test changing last name
         $this->_verifyUserModification(
             'user_accounts',
             'UnitTester',
             'Last_name',
             'NewLast'
         );
+        // Test changing 'Active' status
         $this->_verifyUserModification(
             'user_accounts',
             'UnitTester',
             'Active',
             'No'
         );
+        // Test changing Email
         $this->_verifyUserModification(
             'user_accounts',
             'UnitTester',
             'Email',
             'newemail@example.com'
         );
+        // Test changing Approval status
         $this->_verifyUserModification(
             'user_accounts',
             'UnitTester',
@@ -231,6 +250,35 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             'newemail@example.com'
         );
     }
+
+    /**
+     * Ensure that password errors are successfully triggered on the
+     * My Preferences page.
+     *
+     * @return void
+     */
+    function testMyPreferencesPasswordErrors()
+    {
+        $this->_verifyPasswordErrors(
+            self::FILEPATH_MYPREFERENCES,
+            self::UNITTESTER_USERNAME
+        );
+    }
+
+    /**
+     * Ensure that password errors are successfully triggered on the Edit User
+     * page.
+     *
+     * @return void
+     */
+    function testEditUserPasswordErrors()
+    {
+        $this->_verifyPasswordErrors(
+            self::FILEPATH_EDITUSER,
+            self::UNITTESTER_USERNAME
+        );
+    }
+
     /**
      * Tests that the creation of a new user works.
      *
@@ -298,7 +346,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     function _verifyUserModification($page, $userId, $fieldName, $newValue)
     {
         // Submit the change
-        $this->submitUserData($page, $userId, $fieldName, $newValue);
+        $this->submit($page, $userId);
 
         // Verify changes appear on the page
         $this->_accessUser($page, $userId);
@@ -316,6 +364,11 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
 
     /**
      * Submit user data to the form specified by $page.
+     *
+     * @param string $page   The page to submit to.
+     * @param string $userId ID of the user to modify.
+     *
+     * @return void
      */
     function submit($page, $userId): void
     {
@@ -331,10 +384,22 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $projectsOption  = new WebDriverSelect($projectsElement);
             $projectsOption->selectByValue("1");
         }
+        // 'fire_away' is the name of the Submit button on the form.
         $this->safeClick(WebDriverBy::Name('fire_away'));
     }
 
-    function setValue($fieldName, $newValue): void {
+    /**
+     * Finds a field on the page and changes its value.
+     * This function should be followed by a submission of a form in order
+     * to actually take effect.
+     *
+     * @param string $fieldName The CSS name of the field.
+     * @param string $newValue  The new value for that field.
+     *
+     * @return void
+     */
+    function setValue($fieldName, $newValue): void
+    {
         $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
         if ($field->getTagName() == 'input') {
             $field->clear();
@@ -345,54 +410,146 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         }
     }
 
-    function verifyPasswordNotEqualToEmail($page, $userId): void {
+    /**
+     * Runs all of the password tests for a page.
+     *
+     * @param string $page   The page to submit to.
+     * @param string $userId The user to edit
+     *
+     * @return void
+     */
+    function _verifyPasswordErrors($page, $userId): void
+    {
+        $this->_verifyPasswordMustNotEqualEmail($page, $userId);
+        $this->_verifyPasswordAndConfirmPasswordMustMatch($page, $userId);
+        $this->_verifyNewPasswordMustBeDifferent($page, $userId);
+    }
+
+    /**
+     * Ensures that the user cannot set their password to be the same value
+     * as their email address.
+     *
+     * @param string $page   The page to submit to.
+     * @param string $userId The user to edit
+     *
+     * @return void
+     */
+    function _verifyPasswordMustNotEqualEmail($page, $userId): void
+    {
+        // Make sure the user's email is set to a known value
+        $this->_verifyUserModification(
+            $page,
+            'UnitTester',
+            'Email',
+            self::UNITTESTER_EMAIL_NEW
+        );
+        // Try changing the password to the same value.
+        $this->_sendPasswordValues($page, $userId, self::UNITTESTER_EMAIL_NEW);
+        // This text comes from the class constants in Edit User/My Preferences
+        assertContains('cannot be your email', $this->getBody());
+    }
+
+    /**
+     * Ensures that the module checks that the password and confirm password
+     * field match.
+     *
+     * @param string $page   The page to submit to.
+     * @param string $userId The user to edit
+     *
+     * @return void
+     */
+    function _verifyPasswordAndConfirmPasswordMustMatch($page, $userId): void
+    {
+        // Send two different random strings to the password and confirm
+        // password values.
+        $this->_sendPasswordValues(
+            $page,
+            $userId,
+            \Utility::randomString(),
+            \Utility::randomString()
+        );
+        // This text comes from the class constants in Edit User/My Preferences
+        assertContains('do not match', $this->getBody());
+    }
+
+    /**
+     * Ensures that the module checks that the password and confirm password
+     * field match.
+     *
+     * @param string $page   The page to submit to.
+     * @param string $userId The user to edit
+     *
+     * @return void
+     */
+    function _verifyNewPasswordMustBeDifferent($page, $userId): void
+    {
+        $newPassword = \Utility::randomString();
+        // Change the user's password to $newPassword
+        $this->_sendPasswordValues(
+            $page,
+            $userId,
+            $newPassword
+        );
+        // Change the password again using the same value. This should cause
+        // and error.
+        $this->_sendPasswordValues(
+            $page,
+            $userId,
+            $newPassword
+        );
+        // This text comes from the class constants in Edit User/My Preferences
+        assertContains('New and old passwords are identical', $this->getBody());
+    }
+
+    /**
+     * Loads a module, sets the password and confirm password value, submits
+     * the form, and reloads the page.
+     *
+     * @param string $page            The module to load
+     * @param string $userId          The user to edit.
+     * @param string $password        The plaintext password to use
+     * @param string $confirmPassword The plaintext password to use. Will be
+     *                                set equal to $password by default.
+     *
+     * @return void
+     */
+    function _sendPasswordValues(
+        string $page,
+        string $userId,
+        string $password,
+        string $confirmPassword = ''
+    ): void {
+        // Go to page
         $this->_accessUser($page, $userId);
-        // Set Password and Confirm Password equal to the user's email
+        // Set Password and Confirm Password form values to be equal to the
+        // user's email.
         $this->setValue(
             self::FORM_FIELD_PASSWORD,
-            self::UNIT_TESTER_EMAIL_NEW
+            self::UNITTESTER_EMAIL_NEW
         );
         $this->setValue(
-            self::FORM_FIELD_PASSWORD_CONFIRM,
-            self::UNIT_TESTER_EMAIL_NEW
+            self::FORM_FIELD_CONFIRMPASSWORD,
+            ($confirmPassword === '') ? $password : $confirmPassword,
         );
         $this->submit(
             $page,
             $userId
         );
-        
+
         // Reload
         $this->_accessUser($page, $userId);
-        assertContains('', $this->getBody());
     }
 
-    function getBody() {
+    /**
+     * Returns the body text of the page.
+     *
+     * @return string The HTML body.
+     */
+    function getBody(): string
+    {
         return $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-    }
-
-    function verifyPasswordErrors($page, $userId): void {
-        $this->_accessUser($page, $userId);
-        // Set the password 
-        $passwordElement = $this->safeFindElement(
-            WebDriverBy::Name('Password_hash')
-        );
-        $confirmPasswordElement = $this->safeFindElement(
-            WebDriverBy::Name('__Confirm')
-        );
-
-        $passwordValue = $passwordElement->getAttribute('value');
-        $confirmPasswordValue = $confirmPasswordElement->getAttribute('value');
-
-        
-        $this->submitUserData(
-            'user_accounts',
-            'UnitTester',
-            'Email',
-            'newemail@example.com'
-        );
-
     }
 
     /**

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -333,7 +333,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      * and checks that the modification was updated on the front-end.
      *
      * @param string $page      either 'user_accounts' or
-                                'user_accounts/my_preferences'.
+     *                          'user_accounts/my_preferences'.
      * @param string $userId    ID of the user to modify.
      * @param string $fieldName name of the field (on the HTML page) that should
      *                          be modified.
@@ -364,6 +364,9 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                 $newValue
             );
         }
+    }
+
+    function _verifyPasswordErrorMessageDisplayed($page, $userId, $fieldName, $newValue) {
     }
 
     /**
@@ -440,13 +443,15 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function _verifyPasswordMustNotEqualEmail($page, $userId): void
     {
-        // Make sure the user's email is set to a known value
+        // Make sure the user's email is set to a known value. This will also
+        // load the page.
         $this->_verifyUserModification(
             $page,
             'UnitTester',
             'Email',
             self::UNITTESTER_EMAIL_NEW
         );
+
         // Try changing the password to the same value.
         $this->_sendPasswordValues($page, $userId, self::UNITTESTER_EMAIL_NEW);
         // This text comes from the class constants in Edit User/My Preferences
@@ -542,9 +547,6 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $page,
             $userId
         );
-
-        // Reload
-        $this->_accessUser($page, $userId);
     }
 
     /**

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -352,7 +352,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $this->setValue($fieldName, $newValue);
         $this->submit($page, $userId);
 
-        // Reload 
+        // Reload
         $this->_accessUser($page, $userId);
 
         // Verify changes appear on the page

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -529,11 +529,9 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     ): void {
         // Go to page
         $this->_accessUser($page, $userId);
-        // Set Password and Confirm Password form values to be equal to the
-        // user's email.
         $this->setValue(
             self::FORM_FIELD_PASSWORD,
-            self::UNITTESTER_EMAIL_NEW
+            $password
         );
         $this->setValue(
             self::FORM_FIELD_CONFIRMPASSWORD,

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -345,12 +345,17 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function _verifyUserModification($page, $userId, $fieldName, $newValue)
     {
+        // Load the page
+        $this->_accessUser($page, $userId);
+
         // Set the value and submit the changes
         $this->setValue($fieldName, $newValue);
         $this->submit($page, $userId);
 
-        // Reload and verify changes appear on the page
+        // Reload 
         $this->_accessUser($page, $userId);
+
+        // Verify changes appear on the page
         $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
         if ($field->getTagName() == 'input') {
             $this->assertEquals($field->getAttribute('value'), $newValue);

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -529,7 +529,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         );
         $this->setValue(
             self::FORM_FIELD_CONFIRMPASSWORD,
-            ($confirmPassword === '') ? $password : $confirmPassword,
+            ($confirmPassword === '') ? $password : $confirmPassword
         );
         $this->submit(
             $page,

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -109,8 +109,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     function testUserAccountsMyPreferencesDoespageLoad()
     {
         $this->safeGet($this->url . "/user_accounts/my_preferences/");
-        $this->getBody();
-        $this->assertContains("My Preferences", $bodyText);
+        $this->assertContains("My Preferences", $this->getBody());
     }
     /**
      * Tests that searching for users using thei user IDs works
@@ -366,9 +365,6 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         }
     }
 
-    function _verifyPasswordErrorMessageDisplayed($page, $userId, $fieldName, $newValue) {
-    }
-
     /**
      * Submit user data to the form specified by $page.
      *
@@ -508,7 +504,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         );
         // This text comes from the class constants in Edit User/My Preferences
         $this->assertContains(
-            'New and old passwords are identical', 
+            'New and old passwords are identical',
             $this->getBody()
         );
     }

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -332,7 +332,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
 
     /**
      * Modifies a field on either the user account or my preferences page
-     * and checks that the modification was recorded in the database.
+     * and checks that the modification was updated on the front-end.
      *
      * @param string $page      either 'user_accounts' or
                                 'user_accounts/my_preferences'.
@@ -345,10 +345,11 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function _verifyUserModification($page, $userId, $fieldName, $newValue)
     {
-        // Submit the change
+        // Set the value and submit the changes
+        $this->setValue($fieldName, $newValue);
         $this->submit($page, $userId);
 
-        // Verify changes appear on the page
+        // Reload and verify changes appear on the page
         $this->_accessUser($page, $userId);
         $field = $this->safeFindElement(WebDriverBy::Name($fieldName));
         if ($field->getTagName() == 'input') {

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -109,9 +109,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     function testUserAccountsMyPreferencesDoespageLoad()
     {
         $this->safeGet($this->url . "/user_accounts/my_preferences/");
-        $bodyText = $this->safeFindElement(
-            WebDriverBy::cssSelector("body")
-        )->getText();
+        $this->getBody();
         $this->assertContains("My Preferences", $bodyText);
     }
     /**
@@ -452,7 +450,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         // Try changing the password to the same value.
         $this->_sendPasswordValues($page, $userId, self::UNITTESTER_EMAIL_NEW);
         // This text comes from the class constants in Edit User/My Preferences
-        assertContains('cannot be your email', $this->getBody());
+        $this->assertContains('cannot be your email', $this->getBody());
     }
 
     /**
@@ -475,7 +473,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             \Utility::randomString()
         );
         // This text comes from the class constants in Edit User/My Preferences
-        assertContains('do not match', $this->getBody());
+        $this->assertContains('do not match', $this->getBody());
     }
 
     /**
@@ -504,7 +502,10 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $newPassword
         );
         // This text comes from the class constants in Edit User/My Preferences
-        assertContains('New and old passwords are identical', $this->getBody());
+        $this->assertContains(
+            'New and old passwords are identical', 
+            $this->getBody()
+        );
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -492,7 +492,7 @@ class User extends UserPermissions
         \Password $password,
         ?\DateTime $expiry = null
     ): void {
-        if (password_verify($this->userInfo['Email'], $password)) {
+        if (password_verify($this->userInfo['Email'], (string) $password)) {
             throw new \InvalidArgumentException(
                 'Password cannot be set to email'
             );

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -492,8 +492,12 @@ class User extends UserPermissions
         \Password $password,
         ?\DateTime $expiry = null
     ): void {
+        if (password_verify($this->userInfo['Email'], $password)) {
+            throw new \InvalidArgumentException(
+                'Password cannot be set to email'
+            );
+        }
         // Set default expiry date value to 6 months in the future.
-
         $expiry = $expiry ?? new \DateTime(
             date('Y-m-d', strtotime('+6 months'))
         );

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -246,7 +246,6 @@ class UserTest extends TestCase
         $this->_userInfo['Password_hash'] = $passwordHash;
         $this->_userInfoComplete['Password_hash'] = $passwordHash;
 
-
         $this->_user = \User::factory(self::USERNAME);
     }
 


### PR DESCRIPTION
## Brief summary of changes

Integration tests now verify:
* "Password" and "Confirm password" must match
* Password must not match email
* Password must be changed (i.e. submitting the same password as you had before gives an error)

This is done for both "My Preferences" and "Edit User"

This PR also does some refactoring of the file to make it easier to add to going forward.

### Documentation changed

* User Accounts test plan

## Related

* Resolves #5416 