### PR TITLE
[Examiner] Fixing Errors while saving the form

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -201,17 +201,12 @@ class EditExaminer extends \NDB_Form
                         'TID' => $testID,
                     )
                 );
-                if (is_null($oldVals)) {
-                    throw new \LorisException(
-                        'No old certification values found for specified '
-                        . 'examiner and test IDs.'
-                    );
+                if (!empty($oldVals)) {
+                    // since there is an ORDER BY in pselect
+                    // $oldVals[0] corresponds to the latest date
+                    $oldVal  = $oldVals[0]['new'] ?? null;
+                    $oldDate = $oldVals[0]['new_date'] ?? null;
                 }
-
-                // since there is an ORDER BY in pselect
-                // $oldVals[0] corresponds to the latest date
-                $oldVal  = $oldVals[0]['new'] ?? null;
-                $oldDate = $oldVals[0]['new_date'] ?? null;
 
                 $oldCertification = $DB->pselectRow(
                     "SELECT pass, date_cert, comment
@@ -223,58 +218,54 @@ class EditExaminer extends \NDB_Form
                     )
                 );
 
-                if (is_null($oldCertification)) {
-                    throw new \LorisException(
-                        'No old data certification found for specified '
-                        . 'examiner and test IDs.'
-                    );
-                }
+                if (!empty($oldCertification)) {
 
-                // If one of the values was changed
-                if ($oldCertification['pass'] != $certStatus
-                    || $oldCertification['comment'] != $comment
-                    || $oldCertification['date_cert'] != $date_cert
-                ) {
-                    // Update the certification entry
-                    $data = array(
-                        'pass'    => $certStatus,
-                        'comment' => $comment,
-                    );
-                    if ($date_cert != "") {
-                        $data['date_cert'] = $date_cert;
-                    }
-                    $DB->update(
-                        'certification',
-                        $data,
-                        array(
-                            'examinerID' => $examinerID,
-                            'testID'     => $testID,
-                        )
-                    );
-
-                    // Add a new entry to the certification history table
-                    if ($oldDate != $date_cert || $oldVal != $certStatus) {
+                    // If one of the values was changed
+                    if ($oldCertification['pass'] != $certStatus
+                        || $oldCertification['comment'] != $comment
+                        || $oldCertification['date_cert'] != $date_cert
+                    ) {
+                        // Update the certification entry
                         $data = array(
-                            'col'         => 'pass',
-                            'old'         => $oldVal,
-                            'new'         => $certStatus,
-                            'primaryVals' => $certID,
-                            'testID'      => $testID,
-                            'visit_label' => $visit_label,
-                            'changeDate'  => date("Y-m-d H:i:s"),
-                            'userID'      => $_SESSION['State']->getUsername(),
-                            'type'        => 'U',
+                            'pass'    => $certStatus,
+                            'comment' => $comment,
                         );
-                        if ($oldDate != "") {
-                            $data['old_date'] = $oldDate;
-                        }
                         if ($date_cert != "") {
-                            $data['new_date'] = $date_cert;
+                            $data['date_cert'] = $date_cert;
                         }
-                        $DB->insert(
-                            'certification_history',
-                            $data
+                        $DB->update(
+                            'certification',
+                            $data,
+                            array(
+                                'examinerID' => $examinerID,
+                                'testID'     => $testID,
+                            )
                         );
+
+                        // Add a new entry to the certification history table
+                        if ($oldDate != $date_cert || $oldVal != $certStatus) {
+                            $data = array(
+                                'col'         => 'pass',
+                                'old'         => $oldVal,
+                                'new'         => $certStatus,
+                                'primaryVals' => $certID,
+                                'testID'      => $testID,
+                                'visit_label' => $visit_label,
+                                'changeDate'  => date("Y-m-d H:i:s"),
+                                'userID'      => $_SESSION['State']->getUsername(),
+                                'type'        => 'U',
+                            );
+                            if ($oldDate != "") {
+                                $data['old_date'] = $oldDate;
+                            }
+                            if ($date_cert != "") {
+                                $data['new_date'] = $date_cert;
+                            }
+                            $DB->insert(
+                                'certification_history',
+                                $data
+                            );
+                        }
                     }
                 }
             }
@@ -457,8 +448,7 @@ class EditExaminer extends \NDB_Form
             $testID   = $DB->pselectOne(
                 "SELECT ID
                  FROM test_names
-                 WHERE Test_name
-                 LIKE CONCAT('%', :testName, '%')",
+                 WHERE Test_name =:testName",
                 array('testName' => $testName)
             );
             $instruments[$testID] = $certificationInstrument['#'];


### PR DESCRIPTION
## Brief summary of changes
This fixes 

- https://github.com/aces/Loris/issues/5423 (I think this bug is caused as an impact of #4914. The phan rule addition changed the behavior of the examiner module a little bit. So I am replacing the Loris Exception with some` if `cases in the code.
- https://github.com/aces/Loris/issues/5544


#### Testing instructions (if applicable)

1) Try to create a new examiner and edit the examiner details by just clicking 'Save' with no data or with just one instrument details filled. It will throw 500 error. Check out to  this branch and try testing with the same case and see if the issue is resolved

2)  Add Certification instruments with similar naming (like BMI, BMI_version_2 etc)  and try to load the edit examiner page. It will throw 500 error.  Check out to this branch and try testing with the same case and see if the issue is resolved


#### Links to related tickets (GitHub, Redmine, ...)

*
