### PR TITLE
[New Profile] Fix TypeError when creating candidate with "user" generation method

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -286,7 +286,7 @@ class New_Profile extends \NDB_Form
             } else {
                 // user has multiple sites,
                 // so validate PSCID against the Site selected
-                $site =& \Site::singleton($values['site']);
+                $site =& \Site::singleton((int) $values['site']);
             }
 
             $project = \Project::getProjectFromID(intval($values['project']));


### PR DESCRIPTION
## Summary

Fixes an issue when creating a new profile. This was originally sent to bugfix but the PR got auto-closed.

## Testing

Using the "user" generation method, try creating a new profile. 

You'll get a freeze on the front-end and a TypeError on the back-end. 

This should fix it.