### PR TITLE
[data_release] Add new permission for viewing only

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -95,13 +95,14 @@ INSERT INTO `permissions` VALUES
     (46,'issue_tracker_developer', 'Can re-assign issues, mark issues as closed, comment on all, edit issues.', 2),
     (47,'imaging_browser_phantom_allsites', 'Can access only phantom data from all sites in Imaging Browser', 2),
     (48,'imaging_browser_phantom_ownsite', 'Can access only phantom data from own site in Imaging Browser', 2),
-    (49,'data_release_upload', 'Data Release: Upload file', 2),
-    (50,'data_release_edit_file_access', 'Data Release: Grant other users view-file permissions', 2),
-    (51,'instrument_manager_read', 'Instrument Manager: View module', 2),
-    (52,'instrument_manager_write', 'Instrument Manager: Install new instruments via file upload', 2),
-    (53,'publication_view', 'Publication - Access to module', 2),
-    (54,'publication_propose', 'Publication - Propose a project', 2),
-    (55,'publication_approve', 'Publication - Approve or reject proposed publication projects', 2);
+    (49,'data_release_view', 'Data Release: View releases', 2),
+    (50,'data_release_upload', 'Data Release: Upload file', 2),
+    (51,'data_release_edit_file_access', 'Data Release: Grant other users view-file permissions', 2),
+    (52,'instrument_manager_read', 'Instrument Manager: View module', 2),
+    (53,'instrument_manager_write', 'Instrument Manager: Install new instruments via file upload', 2),
+    (54,'publication_view', 'Publication - Access to module', 2),
+    (55,'publication_propose', 'Publication - Propose a project', 2),
+    (56,'publication_approve', 'Publication - Approve or reject proposed publication projects', 2);
 
 
 INSERT INTO `user_perm_rel` (userID, permID)

--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -212,6 +212,8 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='issue_tracker_developer' AND m.Label='Issue Tracker';
 
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
+    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_release_view' AND m.Label='Data Release';
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_release_upload' AND m.Label='Data Release';
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_release_edit_file_access' AND m.Label='Data Release';

--- a/SQL/New_patches/2019-11-01-Add_data_release_permissions.sql
+++ b/SQL/New_patches/2019-11-01-Add_data_release_permissions.sql
@@ -1,0 +1,8 @@
+INSERT INTO permissions (code,description,categoryID) VALUES 
+('data_release_view','Data Release: View releases',(SELECT ID FROM permissions_category WHERE Description='Permission'));
+
+INSERT INTO LorisMenuPermissions (MenuID, PermID)
+    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_release_view' AND m.Label='Data Release';
+
+INSERT IGNORE INTO user_perm_rel
+SELECT upr.userID, p.permID FROM user_perm_rel upr JOIN permissions p WHERE upr.permID=1 AND p.code IN ('data_release_view');

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -27,6 +27,23 @@ namespace LORIS\data_release;
 class Data_Release extends \NDB_Menu_Filter
 {
     /**
+     * Check user permissions
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        // check user permissions
+        return (
+            $user->hasPermission('data_release_view')
+            || $user->hasPermission('data_release_upload')
+            || $user->hasPermission('data_release_edit_file_access')
+        );
+    }
+
+    /**
      * Setup variables
      *
      * @return void

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -36,10 +36,12 @@ class Data_Release extends \NDB_Menu_Filter
     function _hasAccess(\User $user) : bool
     {
         // check user permissions
-        return (
-            $user->hasPermission('data_release_view')
-            || $user->hasPermission('data_release_upload')
-            || $user->hasPermission('data_release_edit_file_access')
+        return $user->hasAnyPermission(
+            array(
+                'data_release_view',
+                'data_release_upload',
+                'data_release_edit_file_access'
+            )
         );
     }
 

--- a/raisinbread/RB_files/RB_LorisMenuPermissions.sql
+++ b/raisinbread/RB_files/RB_LorisMenuPermissions.sql
@@ -46,5 +46,6 @@ INSERT INTO `LorisMenuPermissions` (`MenuID`, `PermID`) VALUES (26,52);
 INSERT INTO `LorisMenuPermissions` (`MenuID`, `PermID`) VALUES (36,53);
 INSERT INTO `LorisMenuPermissions` (`MenuID`, `PermID`) VALUES (36,54);
 INSERT INTO `LorisMenuPermissions` (`MenuID`, `PermID`) VALUES (36,55);
+INSERT INTO `LorisMenuPermissions` (`MenuID`, `PermID`) VALUES (26,56);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -56,5 +56,6 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (53,'publication_view','Publication - Access to module',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (54,'publication_propose','Publication - Propose a project',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (55,'publication_approve','Publication - Approve or reject proposed publication projects',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (56,'data_release_view','Data Release: View releases',2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_user_perm_rel.sql
+++ b/raisinbread/RB_files/RB_user_perm_rel.sql
@@ -56,5 +56,6 @@ INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,52);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,53);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,54);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,55);
+INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,56);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes
This adds a new permission to the database to allow users view/download access to the data release module. the other 2 permissions that already exist give the user slightly more power, this one is the most basic access.


addresses https://github.com/aces/Loris/issues/5496 