### PR TITLE
[MRI Violations] Users with the 'edit' permission can now view the module without 'view' permission

### DIFF
--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -8,7 +8,7 @@
  * Inability to determine the scan type is logged in the mri_protocol_violations
  * table to which the NDB_Menu_Filter_mri_protocol_violations provides a frontend.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category MRI
  * @package  Main
@@ -38,7 +38,12 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('violated_scans_view_allsites');
+        return $user->hasAnyPermission(
+            array(
+                'violated_scans_view_allsites',
+                'violated_scans_edit'
+            )
+        );
     }
 
     /**

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -6,7 +6,7 @@
  * all the header information that was used for that purpose as well as
  * a table on top which shows what the valid protocols for this study are
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category MRI
  * @package  Main
@@ -20,7 +20,7 @@ namespace LORIS\mri_violations;
  *
  * @category MRI
  * @package  Main
- * @author   Zia Mohadesz <zia.mohades@gmail.com>
+ * @author   Zia Mohades <zia.mohades@gmail.com>
  * @license  Loris license
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
@@ -39,7 +39,12 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
     {
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
-        return ($user->hasPermission('violated_scans_view_allsites'));
+        return $user->hasAnyPermission(
+            array(
+                'violated_scans_view_allsites',
+                'violated_scans_edit'
+            )
+        );
     }
 
     /**

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -6,7 +6,7 @@
  * scan, etc) and link to the appropriate module to further investigate
  * why a scan was excluded by the imaging pipeline scripts.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category MRI
  * @package  Main
@@ -39,7 +39,12 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
     {
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
-        return ($user->hasPermission('violated_scans_view_allsites'));
+        return $user->hasAnyPermission(
+            array(
+                'violated_scans_view_allsites',
+                'violated_scans_edit'
+            )
+        );
     }
     /**
      * Process function
@@ -53,8 +58,8 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         if (!is_array($values) || count($values) ==0) {
             return true;
         }
-        $DB   =& \Database::singleton();
-        $user =& \User::singleton();
+        $DB   = \Database::singleton();
+        $user = \User::singleton();
         foreach ($values['resolvable'] AS $key=>$val) {
             $hash = $key;
             $row  = $DB->pselectRow(

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -5,7 +5,7 @@
  * Emailed site/pending,
  * Inserted, Rejected, Inserted with flag, Other.
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category MRI
  * @package  Main
@@ -38,7 +38,12 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
     {
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
-        return ($user->hasPermission('violated_scans_view_allsites'));
+        return $user->hasAnyPermission(
+            array(
+                'violated_scans_view_allsites',
+                'violated_scans_edit'
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

Fixes an issue where a user with Edit permissions but not View permissions couldn't see the module.

#### Testing instructions (if applicable)

1. A user with only the `mri_violations_edit` permission should now be able to view each table.

An automated test is added in #5546 to do this for us.

#### Links to related tickets (GitHub, Redmine, ...)

* Recent fix of a similar issue in cand_params #5373 
