### PR TITLE
[api][docs] Correcting Version in title line from 0.0.0 0.0.3

### DIFF
--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -1,4 +1,4 @@
-# Loris API - v0.0.0-dev
+# Loris API - v0.0.3-dev
 ## 1.0 Overview
 
 This document specifies the Loris REST API.


### PR DESCRIPTION
This PR changes version number on the top line of api docs from `0.0.0` to 0.0.3`

Testing: 
Verify that the markdown looks good in the GitHub *and* in ReadTheDocs 

