### PR TITLE
[Test] Fix Docker scripts crashing when variables not set

### DIFF
--- a/Dockerfile.test.php7.debug
+++ b/Dockerfile.test.php7.debug
@@ -1,9 +1,9 @@
-FROM php:7.0
+FROM php:7.2
 
 RUN apt-get update && \
-    apt-get install -y mysql-client zlib1g-dev
+    apt-get install -y mariadb-client zlib1g-dev
 
-RUN yes | pecl install xdebug-2.4.1
+RUN yes | pecl install xdebug-2.8.0
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
 RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini
 RUN echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$DEBUG" == "true" ]
+if [ -v DEBUG ];
 then
     CONTAINER=integration-tests-debug
 else

--- a/test/dockerized-unit-tests.sh
+++ b/test/dockerized-unit-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$DEBUG" == "true" ]
+if [ -v DEBUG ];
 then
     CONTAINER=unit-tests-debug
 else

--- a/test/wait-for-services.sh
+++ b/test/wait-for-services.sh
@@ -11,7 +11,8 @@ while ! mysqladmin ping -h db -u SQLTestUser --password="TestPassword" --silent 
   sleep 1
 done
 
-if [ "$SELENIUM_REQUIRED" = true ]  ; then
+if [ -v SELENIUM_REQUIRED ]; 
+then
   echo "Waiting for Selenium..."
   until $(curl --output /dev/null --silent --head --fail http://selenium:4444/wd/hub); do
     sleep 1


### PR DESCRIPTION
## Brief summary of changes

A recent PR causes strict checking of variables in bash. We are doing some sneaky environment variable tricks relying on variables sometimes being set so this made our scripts crash.

They should now work as before.

#### Testing instructions (if applicable)

1. Running `npm run tests:unit` right now should cause an 'unbound variable error'
2. You should be able to run `npm run tests:unit` locally without that error (though the tests may fail for other reasons)

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5515 
