### PR TITLE
First visit column of table test_battery not taken into account.

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -495,7 +495,7 @@ class NDB_BVL_Battery
             $query_firstVisit = "
                 SELECT DISTINCT Test_name
                 FROM test_battery
-                WHERE firstVisit=:FV AND SubprojectID=:subID";
+                WHERE firstVisit=:FV AND (SubprojectID IS NULL OR SubprojectID=:subID)";
             $where            = array(
                 'FV'    => 'Y',
                 'subID' => $SubprojectID,
@@ -511,7 +511,7 @@ class NDB_BVL_Battery
             $query_notfirstVisit = "
                 SELECT DISTINCT Test_name
                 FROM test_battery
-                WHERE firstVisit=:FV AND SubprojectID=:subID";
+                WHERE firstVisit=:FV AND (SubprojectID IS NULL OR SubprojectID=:subID)";
             $where = array(
                 'FV'    => 'N',
                 'subID' => $SubprojectID,

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -444,7 +444,11 @@ class NDB_BVL_Battery
                         (b.AgeMinDays<= :vAge AND b.AgeMaxDays >= :vAge)
                     )
                     AND b.Active='Y'
-                    AND (SubprojectID=:SubprojID OR SubprojectID IS NULL)";
+                    AND (
+                         SubprojectID=:SubprojID
+                            OR
+                         SubprojectID IS NULL
+                    )";
 
         if (!is_null($visit_label)) {
             $VisitBatteryExists = $DB->pselectOne(
@@ -495,7 +499,8 @@ class NDB_BVL_Battery
             $query_firstVisit = "
                 SELECT DISTINCT Test_name
                 FROM test_battery
-                WHERE firstVisit=:FV AND (SubprojectID IS NULL OR SubprojectID=:subID)";
+                WHERE firstVisit=:FV
+                AND (SubprojectID IS NULL OR SubprojectID=:subID)";
             $where            = array(
                 'FV'    => 'Y',
                 'subID' => $SubprojectID,
@@ -511,7 +516,8 @@ class NDB_BVL_Battery
             $query_notfirstVisit = "
                 SELECT DISTINCT Test_name
                 FROM test_battery
-                WHERE firstVisit=:FV AND (SubprojectID IS NULL OR SubprojectID=:subID)";
+                WHERE firstVisit=:FV 
+                AND (SubprojectID IS NULL OR SubprojectID=:subID)";
             $where = array(
                 'FV'    => 'N',
                 'subID' => $SubprojectID,


### PR DESCRIPTION
When creating a visit, the computation of the list of instruments that should be administered is incorrect: the `first_visit` column of table `test_battery` is not handled properly by the algorithm. 

This PR fixes #5569.
