### PR TITLE
[Media] Resolving Issues from Testing

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -113,8 +113,7 @@ function uploadFile()
     $language   = isset($_POST['language']) ? $_POST['language'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES) || !isset($pscid) || !isset($visit) ||
-        !isset($instrument) || !isset($language)) {
+    if (!isset($_FILES, $pscid, $visit, $instrument, $language)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -108,13 +108,13 @@ function uploadFile()
     $pscid      = isset($_POST['pscid']) ? $_POST['pscid'] : null;
     $visit      = isset($_POST['visitLabel']) ? $_POST['visitLabel'] : null;
     $instrument = isset($_POST['instrument']) ? $_POST['instrument'] : null;
-    $site       = isset($_POST['forSite']) ? $_POST['forSite'] : null;
     $dateTaken  = isset($_POST['dateTaken']) ? $_POST['dateTaken'] : null;
     $comments   = isset($_POST['comments']) ? $_POST['comments'] : null;
     $language   = isset($_POST['language']) ? $_POST['language'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES) || !isset($pscid) || !isset($visit) || !isset($site)) {
+    if (!isset($_FILES) || !isset($pscid) || !isset($visit) ||
+        !isset($instrument) || !isset($language)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }
@@ -135,11 +135,10 @@ function uploadFile()
     $sessionID = $db->pselectOne(
         "SELECT s.ID as session_id FROM candidate c " .
         "LEFT JOIN session s USING(CandID) WHERE c.PSCID = :v_pscid AND " .
-        "s.Visit_label = :v_visit_label AND s.CenterID = :v_center_id",
+        "s.Visit_label = :v_visit_label",
         [
             'v_pscid'       => $pscid,
             'v_visit_label' => $visit,
-            'v_center_id'   => $site,
         ]
     );
 
@@ -209,7 +208,7 @@ function getUploadFields()
     $user   = \User::singleton();
     $config = \NDB_Config::singleton();
 
-    // Select only candidates that have had visit at user's sites
+    // Select only candidates that have had visit at user's ites
     $qparam       = array();
     $sessionQuery = "SELECT c.PSCID, s.Visit_label, s.CenterID, f.Test_name
                       FROM candidate c
@@ -230,7 +229,6 @@ function getUploadFields()
     $instrumentsList = toSelect($sessionRecords, "Test_name", null);
     $candidatesList  = toSelect($sessionRecords, "PSCID", null);
     $visitList       = Utility::getVisitList();
-    $siteList        = Utility::getSiteList(false);
     $languageList    = Utility::getLanguageList();
     $startYear       = $config->getSetting('startYear');
     $endYear         = $config->getSetting('endYear');
@@ -238,21 +236,6 @@ function getUploadFields()
     // Build array of session data to be used in upload media dropdowns
     $sessionData = array();
     foreach ($sessionRecords as $record) {
-
-        // Populate sites
-        if (!isset($sessionData[$record["PSCID"]]['sites'])) {
-            $sessionData[$record["PSCID"]]['sites'] = [];
-        }
-        if ($record["CenterID"] !== null && !in_array(
-            $record["CenterID"],
-            $sessionData[$record["PSCID"]]['sites'],
-            true
-        )
-        ) {
-            $sessionData[$record["PSCID"]]['sites'][$record["CenterID"]]
-                = $siteList[$record["CenterID"]];
-        }
-
         // Populate visits
         if (!isset($sessionData[$record["PSCID"]]['visits'])) {
             $sessionData[$record["PSCID"]]['visits'] = [];
@@ -326,7 +309,6 @@ function getUploadFields()
         'candidates'  => $candidatesList,
         'visits'      => $visitList,
         'instruments' => $instrumentsList,
-        'sites'       => $siteList,
         'mediaData'   => $mediaData,
         'mediaFiles'  => array_values(getFilesList()),
         'sessionData' => $sessionData,

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -113,7 +113,7 @@ function uploadFile()
     $language   = isset($_POST['language']) ? $_POST['language'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES, $pscid, $visit, $instrument, $language)) {
+    if (!isset($_FILES, $pscid, $visit, $language)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -208,7 +208,7 @@ function getUploadFields()
     $user   = \User::singleton();
     $config = \NDB_Config::singleton();
 
-    // Select only candidates that have had visit at user's ites
+    // Select only candidates that have had visit at user's sites
     $qparam       = array();
     $sessionQuery = "SELECT c.PSCID, s.Visit_label, s.CenterID, f.Test_name
                       FROM candidate c

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -113,7 +113,7 @@ function uploadFile()
     $language   = isset($_POST['language']) ? $_POST['language'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES, $pscid, $visit, $language)) {
+    if (!isset($_FILES, $pscid, $visit)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -37,7 +37,6 @@ class MediaEditForm extends Component {
       success: function(data) {
         let formData = {
           idMediaFile: data.mediaData.id,
-          forSite: data.mediaData.forSite,
           dateTaken: data.mediaData.dateTaken,
           comments: data.mediaData.comments,
           hideFile: data.mediaData.hideFile,
@@ -109,15 +108,6 @@ class MediaEditForm extends Component {
             required={true}
             disabled={true}
             value={this.state.mediaData.visitLabel}
-          />
-          <SelectElement
-            name='forSite'
-            label='Site'
-            options={this.state.Data.sites}
-            onUserInput={this.setFormData}
-            ref='forSite'
-            disabled={true}
-            value={this.state.mediaData.forSite}
           />
           <SelectElement
             name='instrument'

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -131,7 +131,7 @@ class MediaUploadForm extends Component {
               options={instruments}
               onUserInput={this.setFormData}
               ref='instrument'
-              required={true}
+              required={false}
               value={this.state.formData.instrument}
               disabled={this.state.formData.pscid == null}
             />

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -86,9 +86,6 @@ class MediaUploadForm extends Component {
     const visits = this.state.formData.pscid ?
       this.state.Data.sessionData[this.state.formData.pscid].visits :
       {};
-    const sites = this.state.formData.pscid ?
-      this.state.Data.sessionData[this.state.formData.pscid].sites :
-      {};
     const instruments = this.state.formData.pscid && this.state.formData.visitLabel ?
       this.state.Data.sessionData[this.state.formData.pscid].instruments[this.state.formData.visitLabel] :
       {};
@@ -128,18 +125,6 @@ class MediaUploadForm extends Component {
               value={this.state.formData.visitLabel}
               disabled={this.state.formData.pscid == null}
             />
-            <SearchableDropdown
-              name='forSite'
-              label='Site'
-              placeHolder='Search for site'
-              options={sites}
-              strictSearch={true}
-              onUserInput={this.setFormData}
-              ref='forSite'
-              required={true}
-              value={this.state.formData.forSite}
-              disabled={this.state.formData.pscid == null}
-            />
             <SelectElement
               name='instrument'
               label='Instrument'
@@ -172,7 +157,7 @@ class MediaUploadForm extends Component {
               options={this.state.Data.language}
               onUserInput={this.setFormData}
               ref='language'
-              required={false}
+              required={true}
               value={this.state.formData.language}
             />
             <FileElement

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -83,6 +83,15 @@ class MediaUploadForm extends Component {
       </span>
     );
 
+    const visits = this.state.formData.pscid ?
+      this.state.Data.sessionData[this.state.formData.pscid].visits :
+      {};
+    const sites = this.state.formData.pscid ?
+      this.state.Data.sessionData[this.state.formData.pscid].sites :
+      {};
+    const instruments = this.state.formData.pscid && this.state.formData.visitLabel ?
+      this.state.Data.sessionData[this.state.formData.pscid].instruments[this.state.formData.visitLabel] :
+      {};
     return (
       <div className='row'>
         <div className='col-md-8 col-lg-7'>
@@ -112,30 +121,34 @@ class MediaUploadForm extends Component {
             <SelectElement
               name='visitLabel'
               label='Visit Label'
-              options={this.state.Data.visits}
+              options={visits}
               onUserInput={this.setFormData}
               ref='visitLabel'
               required={true}
               value={this.state.formData.visitLabel}
+              disabled={this.state.formData.pscid == null}
             />
             <SearchableDropdown
               name='forSite'
               label='Site'
               placeHolder='Search for site'
-              options={this.state.Data.sites}
+              options={sites}
               strictSearch={true}
               onUserInput={this.setFormData}
               ref='forSite'
               required={true}
               value={this.state.formData.forSite}
+              disabled={this.state.formData.pscid == null}
             />
             <SelectElement
               name='instrument'
               label='Instrument'
-              options={this.state.Data.instruments}
+              options={instruments}
               onUserInput={this.setFormData}
               ref='instrument'
+              required={true}
               value={this.state.formData.instrument}
+              disabled={this.state.formData.pscid == null}
             />
             <DateElement
               name='dateTaken'
@@ -365,27 +378,6 @@ class MediaUploadForm extends Component {
    * @param {string} value - selected value for corresponding form element
    */
   setFormData(formElement, value) {
-    // Only display visits and sites available for the current pscid
-    let visitLabel = this.state.formData.visitLabel;
-    let pscid = this.state.formData.pscid;
-
-    if (formElement === 'pscid' && value !== '') {
-      this.state.Data.visits = this.state.Data.sessionData[value].visits;
-      this.state.Data.sites = this.state.Data.sessionData[value].sites;
-      if (visitLabel) {
-        this.state.Data.instruments =
-          this.state.Data.sessionData[value].instruments[visitLabel];
-      } else {
-        this.state.Data.instruments =
-          this.state.Data.sessionData[value].instruments.all;
-      }
-    }
-
-    if (formElement === 'visitLabel' && value !== '' && pscid) {
-      this.state.Data.instruments =
-        this.state.Data.sessionData[pscid].instruments[value];
-    }
-
     let formData = this.state.formData;
     formData[formElement] = value;
 

--- a/modules/media/jsx/uploadForm.js
+++ b/modules/media/jsx/uploadForm.js
@@ -157,7 +157,7 @@ class MediaUploadForm extends Component {
               options={this.state.Data.language}
               onUserInput={this.setFormData}
               ref='language'
-              required={true}
+              required={false}
               value={this.state.formData.language}
             />
             <FileElement


### PR DESCRIPTION
Addresses Issues From:
#5363 - Prevents Users from selecting a site, visit label, or instrument unless a pscid is selected.

This also removes the Site Field from the upload form and edit form in media. Site is redundant since visits are already associated with a site. This removes two unnecessary clicks for the user when uploading a file, and doesn't alter any data going to the database since the site was never saved anyways.
