### PR TITLE
[acknowledgements] fix bug where users with edit permission only could not access the module

### DIFF
--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -39,7 +39,8 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return ($user->hasPermission('acknowledgements_view'));
+        return ($user->hasPermission('acknowledgements_view')
+                ||$user->hasPermission('acknowledgements_edit'));
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

Users with only `acknowledgements_edit` permission could not access the acknowledgements module. This fixes this issue.
