### PR TITLE
[Media] Added Project to Columns; Added Language to Edit File Form

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -53,9 +53,10 @@ function editFile()
     checkDateTaken($dateTaken);
 
     $updateValues = [
-        'date_taken' => $dateTaken,
-        'comments'   => $req['comments'],
-        'hide_file'  => $req['hideFile'] ? $req['hideFile'] : 0,
+        'date_taken'  => $dateTaken,
+        'comments'    => $req['comments'],
+        'language_id' => $req['language'],
+        'hide_file'   => $req['hideFile'] ? $req['hideFile'] : 0,
     ];
 
     try {

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -32,6 +32,7 @@ class MediaEditForm extends Component {
 
   componentDidMount() {
     let self = this;
+    console.log(this.props.DataURL);
     $.ajax(this.props.DataURL, {
       dataType: 'json',
       success: function(data) {
@@ -143,6 +144,13 @@ class MediaEditForm extends Component {
             onUserInput={this.setFormData}
             ref='comments'
             value={this.state.formData.comments}
+          />
+          <SelectElement
+            name='language'
+            label='Language'
+            options={this.state.Data.language}
+            onUserInput={this.setFormData}
+            value={this.state.formData.language}
           />
           <FileElement
             name='file'

--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -32,7 +32,6 @@ class MediaEditForm extends Component {
 
   componentDidMount() {
     let self = this;
-    console.log(this.props.DataURL);
     $.ajax(this.props.DataURL, {
       dataType: 'json',
       success: function(data) {

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -154,7 +154,11 @@ class MediaIndex extends Component {
         type: 'select',
         options: options.sites,
       }},
-      {label: 'Project', show: true},
+      {label: 'Project', show: true, filter: {
+        name: 'project',
+        type: 'select',
+        options: options.projects,
+      }},
       {label: 'Uploaded By', show: true, filter: {
         name: 'uploadedBy',
         type: 'text',

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -83,6 +83,9 @@ class MediaIndex extends Component {
     case 'Site':
       result = <td className={style}>{this.state.fieldOptions.sites[cell]}</td>;
       break;
+    case 'Project':
+      result = <td className={style}>{this.state.fieldOptions.projects[cell]}</td>;
+      break;
     case 'Edit Metadata':
       if (!this.props.hasPermission('media_write')) {
           return;
@@ -151,6 +154,7 @@ class MediaIndex extends Component {
         type: 'select',
         options: options.sites,
       }},
+      {label: 'Project', show: true},
       {label: 'Uploaded By', show: true, filter: {
         name: 'uploadedBy',
         type: 'text',

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -129,6 +129,7 @@ class Media extends \DataFrameworkMenu
             'fileTypes'     => $fileTypeList,
             'visits'        => $visitList,
             'sites'         => $siteList,
+            'projects'      => \Utility::getProjectList(),
             'instruments'   => $instrumentList,
             'languages'     => $languageList,
             'hidden'        => $hiddenOptions,


### PR DESCRIPTION
This PR Addresses Two Issues: 

#5581
I fixed the media datatable by adding Project to the column list and filter. Projects had been added to the query in MediaFileProvisioner, but was not added to the fields list which populates the Datatable. This was causing an issue where the values were not displayed right, and the edit file form was not accessible.

#5459
There was no field for 'Language' in the edit media form, and therefore there was no way to edit language. Language has now been added as a field and is editable.