### PR TITLE
[imaging_browser] Fix permissions of the view session page

### DIFF
--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -39,7 +39,8 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return ($user->hasPermission('acknowledgements_view'));
+        return ($user->hasPermission('acknowledgements_view')
+                ||$user->hasPermission('acknowledgements_edit'));
     }
 
     /**

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -57,15 +57,15 @@ class ViewSession extends \NDB_Form
         if ($candidate->getData('Entity_type') == 'Scanner') {
             return $user->hasPermission('imaging_browser_phantom_allsites')
                 || $user->hasCenterPermission(
-                    'imaging_browser_phantom_ownsite',
-                    \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
-                );
+                'imaging_browser_phantom_ownsite',
+                \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
+            );
         } elseif ($candidate->getData('Entity_type') == 'Human') {
             return $user->hasPermission('imaging_browser_view_allsites')
                 || $user->hasCenterPermission(
-                    'imaging_browser_view_site',
-                    \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
-                );
+                'imaging_browser_view_site',
+                \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
+            );
         }
 
         return false;

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -51,17 +51,24 @@ class ViewSession extends \NDB_Form
         /* User has access if they have an 'all site' permission or if they are
         * part of a study site and are permitted to view their own site.
          */
-        return $user->hasAnyPermission(
-            array(
-                'imaging_browser_view_allsites',
-                'imaging_browser_phantom_allsites',
-                'imaging_browser_phantom_ownsite',
-            )
-        )
-        || $user->hasCenterPermission(
-            'imaging_browser_view_site',
-            \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
-        );
+        $candid    = \TimePoint::singleton($_REQUEST['sessionID'])->getCandID();
+        $candidate = \Candidate::singleton($candid);
+
+        if ($candidate->getData('Entity_type') == 'Scanner') {
+            return $user->hasPermission('imaging_browser_phantom_allsites')
+                || $user->hasCenterPermission(
+                    'imaging_browser_phantom_ownsite',
+                    \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
+                );
+        } elseif ($candidate->getData('Entity_type') == 'Human') {
+            return $user->hasPermission('imaging_browser_view_allsites')
+                || $user->hasCenterPermission(
+                    'imaging_browser_view_site',
+                    \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
+                );
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

Users with phantom permissions could still view any view session page if given a link to that page. This PR fixes the permissions of the view session page of the imaging browser.

#### Testing instructions (if applicable)

1. Make sure that users with phantom permissions cannot view any view session page for a candidate

#### Links to related tickets (GitHub, Redmine, ...)

* #5586
