### PR TITLE
[Statistics / Behavioural Statistics] Fix: Users with permissions different from 'access_all_profiles' were not able to see the 'breakdown per participant' page.

### DIFF
--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -89,10 +89,11 @@ class Statistics_Site extends \NDB_Menu
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
         } else {
-            if ($user->hasPermission('access_all_profiles')) {
+            $currentUser = \User::singleton();
+            if ($currentUser->hasPermission('access_all_profiles')) {
                 $list_of_sites = \Utility::getSiteList();
             } else {
-                $list_of_sites = \User::getStudySites();
+                $list_of_sites = $currentUser->getStudySites();
             }
             $sitesString = implode(",", array_keys($list_of_sites));
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -55,6 +55,20 @@ class Statistics_Site extends \NDB_Menu
                 'data_entry',
                 intval($_REQUEST['CenterID'])
             );
+        } else {
+
+            // If no CenterID is passed in the request, check if the user has the
+            // data_entry permission in all the sites/centers it have access to.
+            // TODO: There are no means of set permissions per site
+            // for a given user right now: (e.g.) The user X can have
+            // the permission data_entry on site Y but not on site Z.
+
+            $hasCenterPermission = true;
+            foreach ($user->getStudySites() as $key => $value) {
+                if (!$user->hasCenterPermission('data_entry', intval($key))) {
+                    $hasCenterPermission = false;
+                }
+            }
         }
 
         return $hasAccessToAllProfiles || $hasCenterPermission;
@@ -66,15 +80,27 @@ class Statistics_Site extends \NDB_Menu
      *
      * @param string $centerID  the value of centerID
      * @param string $projectID the value of projectID
+     * @param \User  $user      The user whose access is being checked
      *
      * @return void
      */
-    function _checkCriteria($centerID, $projectID)
+    function _checkCriteria($centerID, $projectID, \User $user)
     {
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
+        } else {
+            if ($user->hasPermission('access_all_profiles')) {
+                $list_of_sites = \Utility::getSiteList();
+            } else {
+                $list_of_sites = $user->getStudySites();
+            }
+            $sitesString = implode(",", array_keys($list_of_sites));
+
+            $this->query_criteria    .= " AND s.CenterID IN (:cids) ";
+            $this->query_vars['cids'] = $sitesString;
         }
+
         if (!empty($projectID)) {
             $this->query_criteria   .= " AND s.ProjectID =:pid ";
             $this->query_vars['pid'] = $projectID;

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -134,7 +134,7 @@ class Statistics_Site extends \NDB_Menu
                     }
                 }
             }
-            $sitesString = implode(",", array_keys($list_of_sites));
+            $sitesString = implode(",", array_keys($list_of_permitted_sites));
 
             $this->query_criteria    .= " AND s.CenterID IN (:cids) ";
             $this->query_vars['cids'] = $sitesString;

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -80,11 +80,10 @@ class Statistics_Site extends \NDB_Menu
      *
      * @param string $centerID  the value of centerID
      * @param string $projectID the value of projectID
-     * @param \User  $user      The user whose access is being checked
      *
      * @return void
      */
-    function _checkCriteria($centerID, $projectID, \User $user)
+    function _checkCriteria($centerID, $projectID)
     {
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
@@ -93,7 +92,7 @@ class Statistics_Site extends \NDB_Menu
             if ($user->hasPermission('access_all_profiles')) {
                 $list_of_sites = \Utility::getSiteList();
             } else {
-                $list_of_sites = $user->getStudySites();
+                $list_of_sites = \User::getStudySites();
             }
             $sitesString = implode(",", array_keys($list_of_sites));
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -122,7 +122,7 @@ class Statistics_Site extends \NDB_Menu
             $currentUser = \User::singleton();
 
             if ($currentUser->hasPermission('access_all_profiles')) {
-                $list_of_permitted_sites = \Utility::getSiteList();
+                $list_of_permitted_sites = array_keys(\Utility::getSiteList());
             } else {
                 foreach ($currentUser->getCenterIDs() as $centerID) {
                     if ($currentUser->hasCenterPermission(
@@ -134,7 +134,7 @@ class Statistics_Site extends \NDB_Menu
                     }
                 }
             }
-            $sitesString = implode(",", array_keys($list_of_permitted_sites));
+            $sitesString = implode(",", $list_of_permitted_sites);
 
             $this->query_criteria    .= " AND s.CenterID IN (:cids) ";
             $this->query_vars['cids'] = $sitesString;

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -47,26 +47,41 @@ class Statistics_Site extends \NDB_Menu
                 'data_entry',
             )
         );
+        
+        $hasCenterPermission = false;
+                
+        // TODO: There are no means of set permissions per site
+        // for a given user right now: (e.g.) The user X can have
+        // the permission data_entry on site Y but not on site Z.
+        // Currently, hasCenterPermission() function is only checking
+        // if the user have a given center AND a given permission
+        // not if it have the permission for this specific center.
+        // This logic will be implemented in hasCenterPermission()
+        // in near versions when the permission framework allow it.
+        
         // If a CenterID is passed in the request, check if the user has the
         // data_entry permission at the site/center specified by CenterID.
-        $hasCenterPermission = false;
         if (!empty($_REQUEST['CenterID'])) {
             $hasCenterPermission = $user->hasCenterPermission(
                 'data_entry',
                 intval($_REQUEST['CenterID'])
             );
         } else {
+            
+            // For the short term the user we'll be granted access
+            // if at least have permission AND one of the centers
+            
+            // The filter _checkCriteria() (please see bellow)
+            // takes care of restricting access to sites the user belongs to.
+            // When logic reimplemented on hasCenterPermission(),
+            // _checkCriteria() will take care of retriving information
+            // only for those centers the user has the specific permission.
+            // (please see notes about hasCenterPermission() above)
 
-            // If no CenterID is passed in the request, check if the user has the
-            // data_entry permission in all the sites/centers it have access to.
-            // TODO: There are no means of set permissions per site
-            // for a given user right now: (e.g.) The user X can have
-            // the permission data_entry on site Y but not on site Z.
-
-            $hasCenterPermission = true;
-            foreach ($user->getStudySites() as $key => $value) {
-                if (!$user->hasCenterPermission('data_entry', intval($key))) {
-                    $hasCenterPermission = false;
+            foreach ($user->getCenterIDs() as $centerID) {
+                if ($user->hasCenterPermission('data_entry', intval($centerID))) {
+                    $hasCenterPermission = true;
+                    break;
                 }
             }
         }
@@ -83,17 +98,39 @@ class Statistics_Site extends \NDB_Menu
      *
      * @return void
      */
+    
+    // TODO: There are no means of set permissions per site
+    // for a given user right now: (e.g.) The user X can have
+    // the permission data_entry on site Y but not on site Z.
+    // Currently, hasCenterPermission() function is only checking
+    // if the user have a given center AND a given permission
+    // not if it have the permission for this specific center.
+    // This logic will be implemented in hasCenterPermission()
+    // in near versions when the permission framework allow it
+            
+    // The filter _checkCriteria() takes care of restricting
+    // the user access only to the sites it belongs to.
+    // When logic reimplemented on hasCenterPermission(),
+    // _checkCriteria() will take care of retriving information
+    // only for those centers the user has the specific permission.
+    
     function _checkCriteria($centerID, $projectID)
     {
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
         } else {
+            $list_of_permitted_sites = (array) null;
             $currentUser = \User::singleton();
+            
             if ($currentUser->hasPermission('access_all_profiles')) {
-                $list_of_sites = \Utility::getSiteList();
+                $list_of_permitted_sites = \Utility::getSiteList();
             } else {
-                $list_of_sites = $currentUser->getStudySites();
+                foreach ($currentUser->getCenterIDs() as $centerID) {
+                    if ($currentUser->hasCenterPermission('data_entry', intval($centerID))) {
+                        array_push($list_of_permitted_sites, $centerID);
+                    }
+                }
             }
             $sitesString = implode(",", array_keys($list_of_sites));
 

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -47,9 +47,9 @@ class Statistics_Site extends \NDB_Menu
                 'data_entry',
             )
         );
-        
+
         $hasCenterPermission = false;
-                
+
         // TODO: There are no means of set permissions per site
         // for a given user right now: (e.g.) The user X can have
         // the permission data_entry on site Y but not on site Z.
@@ -58,7 +58,7 @@ class Statistics_Site extends \NDB_Menu
         // not if it have the permission for this specific center.
         // This logic will be implemented in hasCenterPermission()
         // in near versions when the permission framework allow it.
-        
+
         // If a CenterID is passed in the request, check if the user has the
         // data_entry permission at the site/center specified by CenterID.
         if (!empty($_REQUEST['CenterID'])) {
@@ -67,10 +67,9 @@ class Statistics_Site extends \NDB_Menu
                 intval($_REQUEST['CenterID'])
             );
         } else {
-            
+
             // For the short term the user we'll be granted access
             // if at least have permission AND one of the centers
-            
             // The filter _checkCriteria() (please see bellow)
             // takes care of restricting access to sites the user belongs to.
             // When logic reimplemented on hasCenterPermission(),
@@ -98,31 +97,30 @@ class Statistics_Site extends \NDB_Menu
      *
      * @return void
      */
-    
-    // TODO: There are no means of set permissions per site
-    // for a given user right now: (e.g.) The user X can have
-    // the permission data_entry on site Y but not on site Z.
-    // Currently, hasCenterPermission() function is only checking
-    // if the user have a given center AND a given permission
-    // not if it have the permission for this specific center.
-    // This logic will be implemented in hasCenterPermission()
-    // in near versions when the permission framework allow it
-            
-    // The filter _checkCriteria() takes care of restricting
-    // the user access only to the sites it belongs to.
-    // When logic reimplemented on hasCenterPermission(),
-    // _checkCriteria() will take care of retriving information
-    // only for those centers the user has the specific permission.
-    
     function _checkCriteria($centerID, $projectID)
     {
+        // TODO: There are no means of set permissions per site
+        // for a given user right now: (e.g.) The user X can have
+        // the permission data_entry on site Y but not on site Z.
+        // Currently, hasCenterPermission() function is only checking
+        // if the user have a given center AND a given permission
+        // not if it have the permission for this specific center.
+        // This logic will be implemented in hasCenterPermission()
+        // in near versions when the permission framework allow it
+
+        // The filter _checkCriteria() takes care of restricting
+        // the user access only to the sites it belongs to.
+        // When logic reimplemented on hasCenterPermission(),
+        // _checkCriteria() will take care of retriving information
+        // only for those centers the user has the specific permission.
+
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
         } else {
             $list_of_permitted_sites = (array) null;
             $currentUser = \User::singleton();
-            
+
             if ($currentUser->hasPermission('access_all_profiles')) {
                 $list_of_permitted_sites = \Utility::getSiteList();
             } else {


### PR DESCRIPTION
### Description of the issue

Users with permissions different from 'access_all_profiles' were not able to see the 'breakdown per participant' page. An access restricted page were shown instead.

### Brief summary of changes
The "_hasAccess" function was modified to allow access the page in the case not only one CenterID is passed on the URL

The function "_checkCriteria" was modified for only retrieve data from the sites(centers) the user have access to. 

**Note:** In future developments the capacity of setting permissions per site per user could be desirable.  A note in rapport was included in the codeset. In this case the proposed function "_hasAccess" should be updated accordingly .

#### Testing instructions (if applicable)

A user with permission 'data_entry' should be now able to access the 'breakdown per participant' page for the sites it have access to.