### PR TITLE
[Configuration] display radio buttons when boolean field does not have a default option

### DIFF
--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -1,19 +1,10 @@
 {function name=createRadio}
-    {if $v eq "1" || $v eq "0"}
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="1" {if $v eq "1"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
+        <input type="radio" name="{$k}" value="1" {if $v eq "1" || $v eq "true"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
     </label>
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="0" {if $v eq "0"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
+        <input type="radio" name="{$k}" value="0" {if $v eq "0" || $v eq "false"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
     </label>
-    {else if $v eq "true" || $v eq "false"}
-    <label class="radio-inline">
-        <input type="radio" name="{$k}" value="true" {if $v eq "true"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
-    </label>
-    <label class="radio-inline">
-        <input type="radio" name="{$k}" value="false" {if $v eq "false"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
-    </label>
-    {/if}
 {/function}
 
 {function name=createInstrument}
@@ -104,7 +95,9 @@
     {foreachelse}
         {if $node['AllowMultiple'] == 1}<div class="input-group entry">{/if}
         {assign var=id value={"add-"|cat:$node['ID']} }
-        {if $node['DataType'] eq 'instrument'}
+        {if $node['DataType'] eq 'boolean'}
+            {call createRadio k=$id d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'instrument'}
             {call createInstrument k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'scan_type'}
             {call createScanType k=$id d=$node['Disabled']}


### PR DESCRIPTION
## Brief summary of changes
This fixes the rendering of boolean fields in the configuration module. without this change a boolean field without a default option set (field defined in `ConfigSettings` but no entry in `Config` table) renders as a text entry in the configuration module. it should render as true/false radio buttons with non selected with this change.

#### Testing instructions (if applicable)

1. go to the configuration module
2. find any boolean field
3. delete the corresponding entry from the `Config` table in your database
4. make sure that the field still renders as radio buttons but non are selected.

#### Links to related tickets (GitHub, Redmine, ...)

* fixes https://github.com/aces/Loris/issues/5509
