### PR TITLE
[User] Fix TypeError in password verification

### DIFF
--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -525,7 +525,7 @@ class User extends UserPermissions
     ): bool {
         return ! password_verify(
             $plaintextPassword,
-            $this->userInfo['Password_hash']
+            (string) $this->userInfo['Password_hash']
         );
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Fixes TypeError introduced by #5426.

> PHP Fatal error:  Uncaught TypeError: password_verify() expects parameter 2 to be string, null given

#### Testing instructions (if applicable)

1. Try to change your password via Edit User to the same password you have now. LORIS will crash
2. This fixes the crash.

#### Links to related tickets (GitHub, Redmine, ...)

* resolves #5601
