### PR TITLE
[configurations] Allow for both 0/1 or true/false to be used

### DIFF
--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -1,9 +1,14 @@
 {function name=createRadio}
+  {*Use variable to make sure 1/0 values dont get converted to true/false accidentally, code sections expecting 1/0 or true/false can break otherwise*}
+  {$useZerosAndOnes=false}
+  {if $v eq "1" || $v eq "0"}
+    {$useZerosAndOnes=true}
+  {/if}
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="1" {if $v eq "1" || $v eq "true"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
+        <input type="radio" name="{$k}" {if $useZerosAndOnes} value="1"{else}value="true"{/if} {if $v eq "1" || $v eq "true"}checked{/if} {if $d eq "Yes"}disabled{/if}>Yes
     </label>
     <label class="radio-inline">
-        <input type="radio" name="{$k}" value="0" {if $v eq "0" || $v eq "false"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
+        <input type="radio" name="{$k}" {if $useZerosAndOnes} value="0"{else}value="false"{/if} {if $v eq "0" || $v eq "false"}checked{/if} {if $d eq "Yes"}disabled{/if}>No
     </label>
 {/function}
 

--- a/modules/configuration/test/TestPlan.md
+++ b/modules/configuration/test/TestPlan.md
@@ -17,8 +17,14 @@ for the project description in the dashboard settings, go to the dashboard to se
 the project description actually changed.
    >Some settings will break LORIS, like changing the base path, or Main project 
  URL, so be wary.
-  [Manual Test] 
-5. Go through each of the fields in the configuration module that have the 
+  [Manual Test]
+5. Boolean configurations in the database can be either set to `1/0` or `true/false`.
+   - make sure that changing the value from the module does not alter the type of 
+   boolean (`1/0` or `true/false`) in the database but only alters it's value. 
+   - manually change, in the database, the type of boolean (from `true/false` to `1/0`
+    for example) and make sure that updating the value from the front end subsequently 
+    only changes the value again without reverting the type to `true/false`.
+6. Go through each of the fields in the configuration module that have the 
 "Add field" button are configuration values that allow multiple entries. For each of 
 these fields:
    - try clicking the "Add field" button to see that this adds a new field to enter 
@@ -27,13 +33,13 @@ these fields:
    - try deleting a field with the 'X' button. Press save at the bottom of the page. 
    Refresh the page and check that the field was in fact deleted
   [Manual Test]
-6. Check that by setting 'Sandbox' in the config.xml to 1, the config tag names 
+7. Check that by setting 'Sandbox' in the config.xml to 1, the config tag names 
 appear in grey below their labels.
   [Automation Test]
-7. Check that the fields overridden in the config.xml appear greyed out in the config 
+8. Check that the fields overridden in the config.xml appear greyed out in the config 
 module and not editable.
   [Automation Test]
-8. Verify that Help section content and Developer's guide is complete, accurate and 
+9. Verify that Help section content and Developer's guide is complete, accurate and 
 up-to-date.
   [Automation Test]
  

--- a/modules/configuration/test/TestPlan.md
+++ b/modules/configuration/test/TestPlan.md
@@ -24,6 +24,7 @@ the project description actually changed.
    - manually change, in the database, the type of boolean (from `true/false` to `1/0`
     for example) and make sure that updating the value from the front end subsequently 
     only changes the value again without reverting the type to `true/false`.
+  [Manual Test]
 6. Go through each of the fields in the configuration module that have the 
 "Add field" button are configuration values that allow multiple entries. For each of 
 these fields:
@@ -41,7 +42,7 @@ module and not editable.
   [Automation Test]
 9. Verify that Help section content and Developer's guide is complete, accurate and 
 up-to-date.
-  [Automation Test]
+  [Manual Test]
  
 ## Subproject
 


### PR DESCRIPTION
## Brief summary of changes
This restores a behaviour from https://github.com/aces/Loris/pull/5592 while keeping the bugfix.

Previous behaviour was intentionally maintaining 1/0 values when previously saved value was 1/0 and true/false values when previously saved value was true/false. that is due to a lack of standard when coding with boolean values.

PR linked above converted all values to 1/0 automatically which is problematic because some code sections will be expecting a true or false to be returned from the `getSetting('something')` call.

#### Testing instructions (if applicable)

1. choose a boolean config of your choice
2. set it to either 1 or 0 from the database and make sure the module displays the correct homologous value on the front end
3. from the front end, change the value of the field and make sure the database stores the 0 1 homologous value of what was selected.
4. in the database change the value to true or false.
5. repeat steps 2 and 3 while making sure this time that the true/false values get persisted and not the 1/0
