### PR TITLE
[jsx/Markdown.js] Markdown feature bullets

### DIFF
--- a/jsx/Markdown.js
+++ b/jsx/Markdown.js
@@ -29,9 +29,39 @@ class Markdown extends Component {
       .replace(/&quot;/g, '"');
   }
 
+  bulletsHandler(lines) {
+    let bulletFlag = false;
+    const style = 'style="margin-left:0;"';
+    for (let i=0; i<lines.length; i++) {
+      let line = lines[i];
+      if ((line.trimStart()).length > 2
+        && (line.trimStart()).charAt(0) === '*'
+        && (line.trimStart()).charAt(1) === ' ') {
+        if (!bulletFlag) {
+          bulletFlag = true;
+          i === 0
+            ? lines.unshift('<ul ' + style + '>')
+            : lines.splice(i, 0, '<ul ' + style + '>');
+          lines[i+1] = '<li>' + lines[i+1].replace('<br>', '') + '</li>';
+          i += 1;
+        } else {
+          lines[i] = '<li>' + lines[i].replace('<br>', '') + '</li>';
+        }
+      } else if (bulletFlag) {
+        lines.splice(i, 0, '</ul>');
+        i += 1;
+        bulletFlag = false;
+      }
+    }
+    return lines.join('\n');
+  }
+
   render() {
     // Fix stupid-style newlines to be just \n.
     let fixedNewLines = this.props.content.replace(/\r\n/g, '\n');
+
+    // Fix bullets
+    fixedNewLines = this.bulletsHandler(fixedNewLines.split('\n'));
 
     // Fix excaped html
     fixedNewLines = this.htmlSpecialCharsDecode(fixedNewLines);


### PR DESCRIPTION
## Brief summary of changes

Adds Markdown "bullets" which is the equivalent to unordered html list. 

* First implementation of the bullets to the unordered html list (feature). I couldn't think of a way to do this with regex.
* I'm not happy with the first attempt because it only works with single list. Next implementation need to make the function recursive for lists within a list. Although I thought it would be good to send a PR for now. 

#### Testing instructions (if applicable)

1. Make a markdown file inside help for one of the modules with bullets.
2. View on the frontend.

#### Links to related tickets (GitHub, Redmine, ...)

* https://github.com/aces/Loris/issues/5259