### PR TITLE
[libraries/FeedbackMRI.class.inc] visit level feedback undefined

### DIFF
--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -334,10 +334,12 @@ class FeedbackMRI
         // build the output array and keep overall section at the end of the array
         $commentNames = array();
         $overallName  = array();
+        $overallType  = array();
         if (is_array($result)) {
             foreach ($result as $row) {
                 $CommentName = $row['CommentName'];
                 $CTID        = $row['CommentTypeID'];
+                $statusField = array();
                 // deal with CommentStatusField
                 if (!empty($row['CommentStatusField'])) {
                     $statusField = unserialize($row['CommentStatusField']);
@@ -355,9 +357,9 @@ class FeedbackMRI
                 } else {
                     // add a row to the output array
                     $commentNames[$CTID] = array(
-                        'name'   => stripslashes($CommentName),
-                        'field'  => $statusField['field'],
-                        'values' => $statusField['values'],
+                        'name'   => stripslashes($CommentName) ?? '',
+                        'field'  => $statusField['field'] ?? '',
+                        'values' => $statusField['values'] ?? '',
                     );
                 }
 


### PR DESCRIPTION
## Brief summary of changes

The error output log file was being polluted when clicking on the "Visit level Feedback" button. Inside the http://loris-url/imaging_browser/viewSession/?sessionID=1655# as an example.

Error output log:
```
[Tue Nov 12 15:37:11.232243 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP Notice:  Undefined variable: statusField in /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/FeedbackMRI.class.inc on line 359, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232587 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP Stack trace:, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232602 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP   1. {main}() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/feedback_mri_popup.php:0, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232675 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP   2. FeedbackMRI->getAllCommentTypes() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/feedback_mri_popup.php:113, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232889 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP Notice:  Undefined variable: statusField in /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/FeedbackMRI.class.inc on line 360, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232898 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP Stack trace:, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232906 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP   1. {main}() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/feedback_mri_popup.php:0, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232915 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP   2. FeedbackMRI->getAllCommentTypes() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/feedback_mri_popup.php:113, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232954 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP Notice:  Undefined variable: overallType in /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/FeedbackMRI.class.inc on line 367, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232961 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP Stack trace:, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.232998 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP   1. {main}() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/feedback_mri_popup.php:0, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
[Tue Nov 12 15:37:11.233050 2019] [php7:notice] [pid 33144] [client ::1:49177] PHP   2. FeedbackMRI->getAllCommentTypes() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/feedback_mri_popup.php:113, referer: http://localhost/imaging_browser/viewSession/?sessionID=1655
```

This PR resolves the undefined variables by initializing them and using ?? when necessary.

#### Testing instructions (if applicable)

1. Checkout PR.
2. Visit the viewSession of the imaging_browser and click on the "Visit level Feedback" button.
3. View your error logs.

