### PR TITLE
[Core/Acknowledgments] Create generic way to check module permissions using integration tests

### DIFF
--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -28,7 +28,11 @@ namespace LORIS\acknowledgements;
 
 class Acknowledgements extends \NDB_Menu_Filter_Form
 {
-    public $skipTemplate = true;
+    public const PERMISSIONS = array(
+        'acknowledgements_view',
+        'acknowledgements_edit'
+    );
+    public $skipTemplate     = true;
 
     /**
      * Determine whether user should be granted access.
@@ -39,8 +43,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return ($user->hasPermission('acknowledgements_view')
-                ||$user->hasPermission('acknowledgements_edit'));
+        return $user->hasAnyPermission(self::PERMISSIONS);
     }
 
     /**

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -28,11 +28,7 @@ namespace LORIS\acknowledgements;
 
 class Acknowledgements extends \NDB_Menu_Filter_Form
 {
-    public const PERMISSIONS = array(
-        'acknowledgements_view',
-        'acknowledgements_edit'
-    );
-    public $skipTemplate     = true;
+    public $skipTemplate = true;
 
     /**
      * Determine whether user should be granted access.
@@ -43,7 +39,12 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasAnyPermission(self::PERMISSIONS);
+        return $user->hasAnyPermission(
+            [
+                'acknowledgements_view',
+                'acknowledgements_edit',
+            ]
+        );
     }
 
     /**

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -78,7 +78,8 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
     }
 
     /**
-     * {@inheritDoc}
+     * Ensures that the module loads if and only if the user has one of the
+     * module permissions codes.
      *
      * @return void
      */

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -83,9 +83,9 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function testPermissions(): void
+    public function testPermissions(): void
     {
-        $this->testPagePermissions(
+        $this->checkPagePermissions(
             '/acknowledgements/',
             array(
                 'acknowledgements_view',

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -76,36 +76,24 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
         $this->DB->delete("acknowledgements", array('full_name' => 'Test Test'));
         parent::tearDown();
     }
+
     /**
-     * Tests that, the homepage should have "Acknowledgements" on the page.
+     * {@inheritDoc}
      *
      * @return void
      */
-    function testPageLoads()
+    function testPermissions(): void
     {
-        $this->safeGet($this->url . "/acknowledgements/");
-        $bodyText = $this->webDriver
-            ->findElement(WebDriverBy::cssSelector("body"))->getText();
-        $this->assertContains("Acknowledgements", $bodyText);
-    }
-    /**
-     * Tests that, the homepage should have "You do not have access to this page."
-     * on the page without permission.
-     *
-     * @return void
-     */
-    function testPageLoadsWithoutPermissions()
-    {
-        $this->setupPermissions(array("violated_scans_view_allsites"));
-        $this->safeGet($this->url . "/acknowledgements/");
-        $bodyText = $this->webDriver
-            ->findElement(WebDriverBy::cssSelector("body"))->getText();
-        $this->assertContains(
-            "You do not have access to this page.",
-            $bodyText
+        $this->testPagePermissions(
+            '/acknowledgements/',
+            array(
+                'acknowledgements_view',
+                'acknowledgements_edit'
+            ),
+            "Acknowledgements"
         );
-        $this->resetPermissions();
     }
+
     /**
      * Tests that, after clicking the "filter" button, all of the
      * advanced filters appear on the page.

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -626,7 +626,7 @@ abstract class LorisIntegrationTest extends TestCase
      */
     private function _verifyPermission(string $needle, string $haystack): void
     {
-        assertContains($needle, $haystack);
+        $this->assertContains($needle, $haystack);
         $this->resetPermissions();
     }
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -559,5 +559,87 @@ abstract class LorisIntegrationTest extends TestCase
             );
         }
     }
+
+    /**
+     * Ensures that the module loads if and only if the user has the correct
+     * permissions.
+     *
+     * @param string   $path            The path to the module. Usually the same name as
+     *                                  the folder containing the module.
+     * @param string[] $permissionCodes An array of permission codes
+     *                                  corresponding to the module. Should
+     *                                  match the permission codes used in the
+     *                                  hasAccess() method of the module.
+     * @param string   $successMessage  Indicates that the module has
+     *                                  loaded successfully, i.e.
+     *                                  that the user has permission
+     *                                  to access the module. Usually
+     *                                  the name of the module, e.g.
+     *                                  "Data Release" for the
+     *                                  data_release module.
+     * @param string   $failureMessage  Indicates the user does not have
+     *                                  permission to view the module.
+     *                                  Defaults to the 403 message
+     *                                  served by
+     *                                  src/Middleware/AuthMiddleware.php.
+     *
+     * @return void
+     */
+    protected function testPagePermissions(
+        string $path,
+        array $permissionCodes,
+        string $successMessage,
+        string $failureMessage = 'You do not have access to this page'
+    ): void {
+        // Ensure a forbidden message is delivered when the user does not
+        // have any permissions set.
+        $this->_verifyPermission(
+            $failureMessage,
+            $this->_loadWithPermission($path)
+        );
+
+        // Validate that each permission code on its own is enough to load
+        // the module.
+        foreach ($permissionCodes as $code) {
+            $this->_verifyPermission(
+                $successMessage,
+                $this->_loadWithPermission($path, $code)
+            );
+        }
+    }
+
+    /**
+     * Asserts that a message appears in the HTML body of the page.
+     * Rests the permissions checked to cleanup before further tests.
+     *
+     * @param string $needle   This string should be in $haystack.
+     * @param string $haystack The HTML body of the page.
+     *
+     * @return void
+     */
+    function _verifyPermission(string $needle, string $haystack): void
+    {
+        assertContains($needle, $haystack);
+        $this->resetPermissions();
+    }
+
+    /**
+     * Helper function to set up and load a page with a given permisison code.
+     *
+     * @param string $path       The path to the module. Usually the same name as
+     *                           the folder containing the module.
+     * @param string $permission A valid permission code for the data_release
+     *                           module.
+     *
+     * @return string The body text of the page loaded.
+     */
+    function _loadWithPermission(string $path, string $permission = ''): string
+    {
+        $this->setupPermissions(array($permission));
+        $this->safeGet($this->url . $path);
+        return $this->safeFindElement(
+            WebDriverBy::cssSelector("body")
+        )->getText();
+    }
 }
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -617,7 +617,7 @@ abstract class LorisIntegrationTest extends TestCase
 
     /**
      * Asserts that a message appears in the HTML body of the page.
-     * Rests the permissions checked to cleanup before further tests.
+     * Resets the permissions checked to cleanup before further tests.
      *
      * @param string $needle   This string should be in $haystack.
      * @param string $haystack The HTML body of the page.
@@ -631,7 +631,7 @@ abstract class LorisIntegrationTest extends TestCase
     }
 
     /**
-     * Helper function to set up and load a page with a given permisison code.
+     * Helper function to set up and load a page with a given permission code.
      *
      * @param string $path       The path to the module. Usually the same name as
      *                           the folder containing the module.
@@ -649,4 +649,3 @@ abstract class LorisIntegrationTest extends TestCase
         )->getText();
     }
 }
-

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -162,8 +162,12 @@ abstract class LorisIntegrationTest extends TestCase
             )
         );
         */
-        $usernameEl = $this->webDriver->findElement(WebDriverBy::Name("username"));
-        $passwordEl = $this->webDriver->findElement(WebDriverBy::Name("password"));
+        $usernameEl = $this->webDriver->findElement(
+            WebDriverBy::Name("username")
+        );
+        $passwordEl = $this->webDriver->findElement(
+            WebDriverBy::Name("password")
+        );
 
         $usernameEl->sendKeys($username);
         $passwordEl->sendKeys($password);
@@ -176,7 +180,9 @@ abstract class LorisIntegrationTest extends TestCase
         // are run one will fail due to the login taking too long?
         $this->webDriver->wait(120, 1000)->until(
             WebDriverExpectedCondition::presenceOfElementLocated(
-                WebDriverBy::xpath("//div[@id='page'] | //input[@name='username']")
+                WebDriverBy::xpath(
+                    "//div[@id='page'] | //input[@name='username']"
+                )
             )
         );
     }
@@ -348,7 +354,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    function createSubproject($SubprojectID,$title)
+    function createSubproject($SubprojectID, $title)
     {
         $this->DB->insert(
             "subproject",
@@ -424,10 +430,11 @@ abstract class LorisIntegrationTest extends TestCase
     }
 
     /**
-     * Helper function to click on a element and wait for the new page to be loaded.
+     * Helper function to click on a element and wait for the new page to be 
+     * loaded.
      * When the DOM is reloaded, the elements of the previous page become stale.
-     * Selenium will raise an exception when a function (like getText) are called on
-     * those elements.
+     * Selenium will raise an exception when a function (like getText) are
+     * called on those elements.
      *
      * Note: If the page don't reload, this will produce an infinite loop.
      *
@@ -585,7 +592,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    protected function testPagePermissions(
+    public function checkPagePermissions(
         string $path,
         array $permissionCodes,
         string $successMessage,
@@ -617,7 +624,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    function _verifyPermission(string $needle, string $haystack): void
+    private function _verifyPermission(string $needle, string $haystack): void
     {
         assertContains($needle, $haystack);
         $this->resetPermissions();
@@ -633,7 +640,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return string The body text of the page loaded.
      */
-    function _loadWithPermission(string $path, string $permission = ''): string
+    private function _loadWithPermission(string $path, string $permission = ''): string
     {
         $this->setupPermissions(array($permission));
         $this->safeGet($this->url . $path);

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -430,7 +430,7 @@ abstract class LorisIntegrationTest extends TestCase
     }
 
     /**
-     * Helper function to click on a element and wait for the new page to be 
+     * Helper function to click on a element and wait for the new page to be
      * loaded.
      * When the DOM is reloaded, the elements of the previous page become stale.
      * Selenium will raise an exception when a function (like getText) are
@@ -571,8 +571,8 @@ abstract class LorisIntegrationTest extends TestCase
      * Ensures that the module loads if and only if the user has the correct
      * permissions.
      *
-     * @param string   $path            The path to the module. Usually the same name as
-     *                                  the folder containing the module.
+     * @param string   $path            The path to the module. Usually the same
+     *                                  name as the folder containing the module.
      * @param string[] $permissionCodes An array of permission codes
      *                                  corresponding to the module. Should
      *                                  match the permission codes used in the
@@ -640,8 +640,10 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return string The body text of the page loaded.
      */
-    private function _loadWithPermission(string $path, string $permission = ''): string
-    {
+    private function _loadWithPermission(
+        string $path,
+        string $permission = ''
+    ): string {
         $this->setupPermissions(array($permission));
         $this->safeGet($this->url . $path);
         return $this->safeFindElement(


### PR DESCRIPTION
## Brief summary of changes

#### Issue

We've had many issues reported lately where module `X` doesn't load when a user has only the `X_edit` permission without the `X_view` permission. 

In almost every case, it should be possible to at least view a module when you have any of its permissions.

This is trivial to check with integration tests, but many modules are lacking permission checking or they are out of date with respect to new permissions added to a module.

#### Solution
This PR aims to address both of these by creating a generic way to check module permissions using integration tests by adding new methods to the parent class that can validate permissions in a standard way.

All module integration tests going forward can use this idiom to simply and concisely validate that a module loads IFF the user has one of the permission codes for that module.

This should also reduce the size of individual integration tests by eliminating boilerplate.

The LorisIntegrationTest class now also conforms to our PHPCS config.

#### Links to related tickets (GitHub, Redmine, ...)

* This PR builds on the work of @cmadjar's PR #5584. A new permission code was added here but the integration tests didn't properly test the permissions. This is fixed by this PR.
