### PR TITLE
Add PHP minimum version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="./htdocs/images/LORIS_logo.svg" width="35%">
 
 [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) [![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
+[![Minimum PHP Version](https://img.shields.io/travis/php-v/aces/loris/22.0-release?color=787CB5)](https://php.net/)
 
 # LORIS Neuroimaging Platform
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="./htdocs/images/LORIS_logo.svg" width="35%">
 
-[![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) [![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
-[![Minimum PHP Version](https://img.shields.io/travis/php-v/aces/loris/22.0-release?color=787CB5)](https://php.net/)
+[![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) 
+[![Minimum PHP Version](https://img.shields.io/travis/php-v/aces/loris/master?color=787CB5)](https://php.net/)
 
 # LORIS Neuroimaging Platform
 


### PR DESCRIPTION

<img width="477" alt="Screen Shot 2020-01-13 at 16 53 16" src="https://user-images.githubusercontent.com/4022790/72295264-36d77080-3625-11ea-8578-87e1f7e26fac.png">


The badge version info gets pulled from our master branch on Travis so it's auto-updating.