### PR TITLE
[imaging_qc] error log pollution fix

### DIFF
--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -368,9 +368,6 @@ class Imaging_QC extends \NDB_Menu_Filter
      */
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
-        $candid = $this->tpl_data['candID'];
-        $pscid  = $this->tpl_data['PSCID'];
-
         return new \LORIS\BreadcrumbTrail(
             new \LORIS\Breadcrumb(
                 'Imaging Quality Control',


### PR DESCRIPTION
## Brief summary of changes

Remove two unnecessary variables in getBreadcrumbs of the imaging_qc module.

Error logs (before):
```
[Wed Nov 13 12:19:55.111561 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP Notice:  Undefined index: candID in /Users/alizee/Development/GitHub/McGill/Loris/modules/imaging_qc/php/imaging_qc.class.inc on line 371, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111743 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP Stack trace:, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111752 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   1. {main}() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/index.php:0, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111822 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   2. LORIS\\Middleware\\ContentLength->process() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/index.php:47, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111839 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   3. LORIS\\Middleware\\ResponseGenerator->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/ContentLength.php:52, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111846 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   4. LORIS\\Router\\BaseRouter->handle() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/ResponseGenerator.php:50, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111852 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   5. LORIS\\Router\\ModuleRouter->handle() /Users/alizee/Development/GitHub/McGill/Loris/src/Router/BaseRouter.php:100, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111858 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   6. LORIS\\Middleware\\AuthMiddleware->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Router/ModuleRouter.php:96, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111863 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   7. LORIS\\Middleware\\ResponseGenerator->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/AuthMiddleware.php:63, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111868 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   8. LORIS\\imaging_qc\\Module->handle() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/ResponseGenerator.php:50, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111874 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   9. LORIS\\imaging_qc\\Imaging_QC->process() /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/Module.class.inc:342, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111879 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP  10. LORIS\\Middleware\\PageDecorationMiddleware->process() /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/NDB_Page.class.inc:695, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111884 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP  11. LORIS\\Middleware\\UserPageDecorationMiddleware->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/PageDecorationMiddleware.php:53, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.111902 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP  12. LORIS\\imaging_qc\\Imaging_QC->getBreadcrumbs() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/UserPageDecorationMiddleware.php:209, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112153 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP Notice:  Undefined index: PSCID in /Users/alizee/Development/GitHub/McGill/Loris/modules/imaging_qc/php/imaging_qc.class.inc on line 372, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112162 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP Stack trace:, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112167 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   1. {main}() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/index.php:0, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112187 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   2. LORIS\\Middleware\\ContentLength->process() /Users/alizee/Development/GitHub/McGill/Loris/htdocs/index.php:47, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112193 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   3. LORIS\\Middleware\\ResponseGenerator->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/ContentLength.php:52, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112198 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   4. LORIS\\Router\\BaseRouter->handle() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/ResponseGenerator.php:50, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112204 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   5. LORIS\\Router\\ModuleRouter->handle() /Users/alizee/Development/GitHub/McGill/Loris/src/Router/BaseRouter.php:100, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112210 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   6. LORIS\\Middleware\\AuthMiddleware->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Router/ModuleRouter.php:96, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112215 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   7. LORIS\\Middleware\\ResponseGenerator->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/AuthMiddleware.php:63, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112221 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   8. LORIS\\imaging_qc\\Module->handle() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/ResponseGenerator.php:50, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112226 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP   9. LORIS\\imaging_qc\\Imaging_QC->process() /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/Module.class.inc:342, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112231 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP  10. LORIS\\Middleware\\PageDecorationMiddleware->process() /Users/alizee/Development/GitHub/McGill/Loris/php/libraries/NDB_Page.class.inc:695, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112246 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP  11. LORIS\\Middleware\\UserPageDecorationMiddleware->process() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/PageDecorationMiddleware.php:53, referer: http://localhost/imaging_uploader/
[Wed Nov 13 12:19:55.112252 2019] [php7:notice] [pid 35053] [client ::1:50169] PHP  12. LORIS\\imaging_qc\\Imaging_QC->getBreadcrumbs() /Users/alizee/Development/GitHub/McGill/Loris/src/Middleware/UserPageDecorationMiddleware.php:209, referer: http://localhost/imaging_uploader/

```
