### PR TITLE
Parallelize Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 
-# any language should do it
 language: php
 
 matrix:
@@ -24,8 +23,12 @@ install:
 before_script:
 - sed -i "s/7.2/$TRAVIS_PHP_VERSION/g" Dockerfile.test.php7
 
-script:
-# Unable to initialize database, use the following code to debug. - docker-compose up --build
-# docker-compose up --build
-- make checkstatic
-- docker-compose run -e HEADLESS=true -T --rm integration-tests vendor/bin/phpunit --configuration test/phpunit.xml
+jobs:
+    include:
+        - stage: "Tests"
+          name: "Static Analysis"
+          script: make checkstatic
+        - script: test/dockerized-unit-tests.sh
+          name: "Unit Tests"
+        - script: test/dockerized-integration-tests.sh
+          name: "Integration Tests"

--- a/Dockerfile.test.php7.debug
+++ b/Dockerfile.test.php7.debug
@@ -1,9 +1,9 @@
-FROM php:7.0
+FROM php:7.2
 
 RUN apt-get update && \
-    apt-get install -y mysql-client zlib1g-dev
+    apt-get install -y mariadb-client zlib1g-dev
 
-RUN yes | pecl install xdebug-2.4.1
+RUN yes | pecl install xdebug-2.8.0
 RUN echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
 RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini
 RUN echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -8,5 +8,4 @@ else
     CONTAINER=integration-tests
 fi
 
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*
+docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$DEBUG" == "true" ]
+if [ -v DEBUG ];
 then
     CONTAINER=integration-tests-debug
 else

--- a/test/dockerized-unit-tests.sh
+++ b/test/dockerized-unit-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$DEBUG" == "true" ]
+if [ -v DEBUG ];
 then
     CONTAINER=unit-tests-debug
 else

--- a/test/wait-for-services.sh
+++ b/test/wait-for-services.sh
@@ -11,7 +11,8 @@ while ! mysqladmin ping -h db -u SQLTestUser --password="TestPassword" --silent 
   sleep 1
 done
 
-if [ "$SELENIUM_REQUIRED" = true ]  ; then
+if [ -v SELENIUM_REQUIRED ]; 
+then
   echo "Waiting for Selenium..."
   until $(curl --output /dev/null --silent --head --fail http://selenium:4444/wd/hub); do
     sleep 1


### PR DESCRIPTION
## Brief summary of changes

* Creates a test stage in Travis, "Testing" consisting of 3 parallel scripts
* These scripts test Static Analysis, Unit Tests, and Integration tests separately

This should allow for faster failure reports:
- _Let Static, Unit, and Integration tests be `X`, `Y`, `Z` respectively._
- _Let `t` be the time it takes to complete a build_
- Current build time is: `Xt + Yt + Zt`
- New build time is `MAX(Xt, Yt, Zt)` (realistically always `Zt` because integration tests always take a long time)

In concrete terms this will probably reduce the average test time from about 31 minutes closer to like 25 minutes.

This should also make parsing the build log easier since concerns are separated.

**Discussion point**

It's possible to configure Travis to fail early if `X` or `Y` fails which would improve our build time further to be `Xt` if X fails or `Yt` if `X` succeeds and `Y` fails.

In concrete terms this would change a failing test time to about 5 minutes from 31 (!).