### PR TITLE
Travis parallelization (performance boost)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,10 @@ jobs:
         - stage: "Tests"
           name: "Static Analysis"
           script: make checkstatic
-          php: "7.2"
           php: "7.3"
-          php: "7.4snapshot"
         - script: test/dockerized-unit-tests.sh
           name: "Unit Tests"
-          php: "7.2"
           php: "7.3"
-          php: "7.4snapshot"
         - script: test/dockerized-integration-tests.sh
           name: "Integration Tests"
-          php: "7.2"
           php: "7.3"
-          php: "7.4snapshot"
-  allow_failures:
-    - php: "7.4snapshot"
-  fast_finish: true
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ sudo: required
 
 language: php
 
+matrix:
+  include:
+  - php: "7.2"
+  - php: "7.3"
+  - php: "7.4snapshot"
+  allow_failures:
+  - php: "7.4snapshot"
+
 services:
 - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,8 @@ install:
 - make dev
 
 script: "npm run tests:$TEST_SUITE"
+
+# This should improve build time by caching composer files.
+cache:
+  directories:
+    - $HOME/.composer/cache/files

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ sudo: required
 language: php
 
 php: 
-- "7.2"
-- "7.3"
-- "nightly"
+- 7.2
+- 7.3
+- nightly
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: nightly
 
 services:
 - docker
@@ -23,20 +28,10 @@ before_script:
 jobs:
     include:
         - stage: "Tests"
+          php: 7.3
           name: "Static Analysis"
           script: make checkstatic
-          php: 
-            - "7.3"
-            - "nightly"
         - script: test/dockerized-unit-tests.sh
           name: "Unit Tests"
-          php: 
-            - "7.3"
-            - "nightly"
         - script: test/dockerized-integration-tests.sh
           name: "Integration Tests"
-          php: 
-            - "7.3"
-            - "nightly"
-    allow_failures:
-          php: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 7.3
   - "nightly"
 
+matrix:
+    - allow_failures:
+        - php: "nightly"
+
 env:
   - TEST_SUITE=static
   - TEST_SUITE=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ sudo: required
 language: php
 
 php: 
-  - 7.2
   - 7.3
-  - "7.4snapshot"
+  - 7.4
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: "7.4snapshot"
 
 env:
   - TEST_SUITE=static

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ sudo: required
 
 language: php
 
-matrix:
-  include:
-  - php: "7.2"
-  - php: "7.3"
-  - php: "7.4snapshot"
-  allow_failures:
-  - php: "7.4snapshot"
+php: "7.2"
+php: "7.3"
+php: "nightly"
 
 services:
 - docker
@@ -29,9 +25,14 @@ jobs:
           name: "Static Analysis"
           script: make checkstatic
           php: "7.3"
+          php: "nightly"
         - script: test/dockerized-unit-tests.sh
           name: "Unit Tests"
           php: "7.3"
+          php: "nightly"
         - script: test/dockerized-integration-tests.sh
           name: "Integration Tests"
           php: "7.3"
+          php: "nightly"
+    allow_failures:
+          php: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ sudo: required
 language: php
 
 php: 
-- 7.2
-- 7.3
-- nightly
+  - 7.2
+  - 7.3
+  - "nightly"
 
-matrix:
-    fast_finish: true
-    allow_failures:
-        - php: nightly
+env:
+  - TEST_SUITE=static
+  - TEST_SUITE=unit
+  - TEST_SUITE=integration
 
 services:
 - docker
@@ -22,16 +22,4 @@ install:
 - sudo apt-get install npm
 - make dev
 
-before_script:
-- sed -i "s/7.3/$TRAVIS_PHP_VERSION/g" Dockerfile.test.php7
-
-jobs:
-    include:
-        - stage: "Tests"
-          php: 7.3
-          name: "Static Analysis"
-          script: make checkstatic
-        - script: test/dockerized-unit-tests.sh
-          name: "Unit Tests"
-        - script: test/dockerized-integration-tests.sh
-          name: "Integration Tests"
+script: "npm run tests:$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ language: php
 php: 
   - 7.2
   - 7.3
-  - "nightly"
+  - "7.4snapshot"
 
 matrix:
-    - allow_failures:
-        - php: "nightly"
+    fast_finish: true
+    allow_failures:
+        - php: "7.4snapshot"
 
 env:
   - TEST_SUITE=static

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: required
 
 language: php
 
-php: "7.2"
-php: "7.3"
-php: "nightly"
+php: 
+- "7.2"
+- "7.3"
+- "nightly"
 
 services:
 - docker
@@ -24,15 +25,18 @@ jobs:
         - stage: "Tests"
           name: "Static Analysis"
           script: make checkstatic
-          php: "7.3"
-          php: "nightly"
+          php: 
+            - "7.3"
+            - "nightly"
         - script: test/dockerized-unit-tests.sh
           name: "Unit Tests"
-          php: "7.3"
-          php: "nightly"
+          php: 
+            - "7.3"
+            - "nightly"
         - script: test/dockerized-integration-tests.sh
           name: "Integration Tests"
-          php: "7.3"
-          php: "nightly"
+          php: 
+            - "7.3"
+            - "nightly"
     allow_failures:
           php: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ sudo: required
 
 language: php
 
-matrix:
-  include:
-  - php: "7.3"
-  - php: "7.4"
-
 services:
 - docker
 
@@ -25,7 +20,20 @@ jobs:
         - stage: "Tests"
           name: "Static Analysis"
           script: make checkstatic
+          php: "7.2"
+          php: "7.3"
+          php: "7.4snapshot"
         - script: test/dockerized-unit-tests.sh
           name: "Unit Tests"
+          php: "7.2"
+          php: "7.3"
+          php: "7.4snapshot"
         - script: test/dockerized-integration-tests.sh
           name: "Integration Tests"
+          php: "7.2"
+          php: "7.3"
+          php: "7.4snapshot"
+  allow_failures:
+    - php: "7.4snapshot"
+  fast_finish: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 
-# any language should do it
 language: php
 
 matrix:
@@ -21,8 +20,12 @@ install:
 before_script:
 - sed -i "s/7.3/$TRAVIS_PHP_VERSION/g" Dockerfile.test.php7
 
-script:
-# Unable to initialize database, use the following code to debug. - docker-compose up --build
-# docker-compose up --build
-- make checkstatic
-- docker-compose run -e HEADLESS=true -T --rm integration-tests vendor/bin/phpunit --configuration test/phpunit.xml
+jobs:
+    include:
+        - stage: "Tests"
+          name: "Static Analysis"
+          script: make checkstatic
+        - script: test/dockerized-unit-tests.sh
+          name: "Unit Tests"
+        - script: test/dockerized-integration-tests.sh
+          name: "Integration Tests"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: clean dev all check checkstatic unittests test phpdev javascript
 
 all: VERSION javascript
-	composer install --no-dev --prefer-dist
+	composer install --no-dev
 
 # If anything changes, re-generate the VERSION file
 VERSION: .
 	tools/gen-version.sh
 
 phpdev:
-	composer install --prefer-dist
+	composer install
 
 javascript:
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: clean dev all check checkstatic unittests test phpdev javascript
 
 all: VERSION javascript
-	composer install --no-dev
+	composer install --no-dev --prefer-dist
 
 # If anything changes, re-generate the VERSION file
 VERSION: .
 	tools/gen-version.sh
 
 phpdev:
-	composer install
+	composer install --prefer-dist
 
 javascript:
 	npm install

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:javascript": "./test/run-js-linter.sh",
     "lintfix:javascript": "eslint --fix --ext .js, jsx modules",
     "lint:php": "./test/run-php-linter.sh",
+    "tests:static": "make checkstatic",
     "tests:unit": "./test/dockerized-unit-tests.sh",
     "tests:unit:debug": "DEBUG=true ./test/dockerized-unit-tests.sh",
     "tests:integration": "./test/dockerized-integration-tests.sh",

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -8,5 +8,4 @@ else
     CONTAINER=integration-tests
 fi
 
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*
+docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -8,4 +8,7 @@ else
     CONTAINER=integration-tests
 fi
 
+# Core integration tests
 docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
+# module integration tests
+docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -9,6 +9,4 @@ else
 fi
 
 # Core integration tests
-docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
-# module integration tests
-docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*
+docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml

--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -11,4 +11,4 @@ fi
 # Core integration tests
 docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
 # module integration tests
-docker-compose run -T --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*
+docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*


### PR DESCRIPTION
## Brief summary of changes

This PR uses caching + parallelization to reduce Travis testing time:

<img width="1052" alt="Screen Shot 2020-01-15 at 12 13 14" src="https://user-images.githubusercontent.com/4022790/72455250-71a9e780-3790-11ea-8682-b4085f2f3df7.png">

Travis will now also show an error status on GitHub as soon as any one of the jobs fails. However, other builds will still complete.
