### PR TITLE
[Password] Fix account lockout when special character present in password

### DIFF
--- a/php/libraries/Password.class.inc
+++ b/php/libraries/Password.class.inc
@@ -200,6 +200,11 @@ class Password
      */
     public final function __construct(string $value)
     {
+        // If a password contains a special character such as '&' or '<' then
+        // its possible that it has been encoded during transmission to the
+        // class.
+        $value = htmlspecialchars_decode($value);
+
         // Ensure proposed value is well-formed.
         $this->_validate($value);
         // Don't store the value in the object; instead use the hashed version

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -120,4 +120,42 @@ class PasswordTest extends TestCase
             password_verify(self::VALID_PASSWORD, (string) $password)
         );
     }
+
+    /**
+     * dataProvider for testAcceptsSpecialChars
+     *
+     * Provides strings containing special characters.
+     *
+     * @see https://www.php.net/manual/en/function.htmlspecialchars.php
+     */
+    public function specialValues(): array
+    {
+        return array(
+            // test single quote
+            ["password' AND 1=1; --"],
+            // test ampersand
+            ["Hot & Dangerous"],
+            // test double quote
+            ['unit tests are "useful"'],
+            // test less-than symbol
+            ['all you need is <3'],
+            // test greater-than symbol
+            ['> formatted quotation']
+        );
+    }
+
+
+    /**
+     * Ensures that the Password class HTML-decodes values given to it and
+     * creates a hash that can be used to authenticate users.
+     *
+     * @dataProvider specialValues
+     */
+    public function testAcceptsSpecialChars($specialText): void {
+        $encoded = htmlspecialchars($specialText);
+        $password = new \Password($encoded);
+        $hash = (string) $password;
+
+        $this->assertTrue(password_verify($specialText, $hash));
+    }
 }


### PR DESCRIPTION
## Brief summary of changes

Special characters can now be used in passwords. I forgot that they get automatically encoded upon submission to the codebase so passwords were never decoded before being hashed.

I added some unit tests to make sure everything is working fine.

#### Testing instructions (if applicable)

1. Checkout the branch, change your password to something containing a special character such as `&`, make sure you can login with that password.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5630 
* Extensive background reading about the history of why encoding happens https://github.com/aces/Loris/pull/4491#issuecomment-490567790
