### PR TITLE
[Install] Fix crash due to unbound variable access

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -176,6 +176,7 @@ echo "Ubuntu distribution detected."
         echo $yn | tee -a $LOGFILE > /dev/null
         case $yn in
             [Yy]* )
+                export projectname=""
                 while [ "$projectname" == "" ]; do
                         read -p "Please enter your Project name (if unsure, use LORIS) : " projectname
                         echo $projectname | tee -a $LOGFILE > /dev/null


### PR DESCRIPTION
## Brief summary of changes

Fixes a bug where the script would crash due to `$projectname` being accessed before it is initialized.

#### Testing instructions (if applicable)

1. Run the install script. 

#### Links to related tickets (GitHub, Redmine, ...)

* Fixes #5640
