### PR TITLE
Fix account lockout when special character present in password

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -88,7 +88,7 @@ class PasswordExpiry extends \NDB_Form
     {
         $this->_user = \User::factory($this->_username);
         $data        = $this->_user->getData();
-        $plaintext = htmlspecialchars_decode($values['password']);
+        $plaintext   = htmlspecialchars_decode($values['password']);
 
         try {
             $password = new \Password($plaintext);

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -88,15 +88,16 @@ class PasswordExpiry extends \NDB_Form
     {
         $this->_user = \User::factory($this->_username);
         $data        = $this->_user->getData();
+        $plaintext = htmlspecialchars_decode($values['password']);
 
         try {
-            $password = new \Password($_POST['password']);
+            $password = new \Password($plaintext);
         } catch (\InvalidArgumentException $e) {
             $this->tpl_data['error_message'] = $e->getMessage();
             return array('password' => $e->getMessage());
         }
 
-        if (!$this->_user->passwordChanged($_POST['password'])) {
+        if (!$this->_user->passwordChanged($plaintext)) {
             $this->tpl_data['error_message'] = 'You cannot keep the same password';
             return array('password' => 'You cannot keep the same password');
         }
@@ -114,7 +115,11 @@ class PasswordExpiry extends \NDB_Form
      */
     function _process($values)
     {
-        $this->_user->updatePassword(new \Password($values['password']));
+        $this->_user->updatePassword(
+            new \Password(
+                htmlspecialchars_decode($values['password'])
+            )
+        );
 
         // The password is no longer expired after updating it.
         unset($_SESSION['PasswordExpiredForUser']);

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -66,11 +66,11 @@ class PasswordReset extends \NDB_Form
         try {
             // check that the email is valid
             if ($user->isEmailValid()) {
-                  $config = \NDB_Config::singleton();
-                  // generate a new password
-                  $password = \Utility::randomString();
-                  // reset the password in the database
-                  // expire password so user must change it upon login
+                $config = \NDB_Config::singleton();
+                // generate a new password
+                $password = \Utility::randomString();
+                // reset the password in the database
+                // expire password so user must change it upon login
                 $user->updatePassword(
                     new \Password($password),
                     new \DateTime('1999-01-01')

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -489,21 +489,19 @@ class Edit_User extends \NDB_Form
 
         // Now set the password. Note that this field is named incorrectly
         // and represents a plaintext password, not a hash.
-        if (isset($values['Password_hash'], $values['Password_expiry'])) {
-            $decoded = htmlspecialchars_decode($values['Password_hash']);
-            // If both hash and expiry are set, use both values when resetting
-            // the password. This occurs when a new password is generated
-            // by the system.
-            $user->updatePassword(
-                new \Password($decoded),
+        if (isset($values['Password_hash'])) {
+
+            // Set custom expiry date if the value is present.
+            // Otherwise, use null which will cause the expiry to be 6 months
+            // from the current date.
+            $expiry = isset($values['Password_expiry']) ?
                 new \DateTime($values['Password_expiry'])
-            );
-        } else if (isset($values['Password_hash'])) {
-            // If just the Password_hash value is present, do not specify a
-            // custom expiry date. This will set the password to expire in
-            // 6 months from the current date (handled in updatePassword()).
+                : null;
             $user->updatePassword(
-                new \Password($decoded)
+                new \Password(
+                    htmlspecialchars_decode($decoded)
+                ),
+                $expiry
             );
         }
 
@@ -1109,8 +1107,8 @@ class Edit_User extends \NDB_Form
                 // The Password class is self-validating and will throw an
                 // InvalidArgumentException if the value passed to it is
                 // bad or the input is too weak to be a good password.
-                $decoded = htmlspecialchars_decode($plaintext)
-                $password            = new \Password($decoded);
+                $decoded  = htmlspecialchars_decode($plaintext);
+                $password = new \Password($decoded);
                 $isPasswordDifferent = \User::factory($this->identifier)
                     ->isPasswordDifferent($decoded);
                 if (! $isPasswordDifferent) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -499,7 +499,7 @@ class Edit_User extends \NDB_Form
                 : null;
             $user->updatePassword(
                 new \Password(
-                    htmlspecialchars_decode($decoded)
+                    htmlspecialchars_decode($values['Password_hash'])
                 ),
                 $expiry
             );

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -490,11 +490,12 @@ class Edit_User extends \NDB_Form
         // Now set the password. Note that this field is named incorrectly
         // and represents a plaintext password, not a hash.
         if (isset($values['Password_hash'], $values['Password_expiry'])) {
+            $decoded = htmlspecialchars_decode($values['Password_hash']);
             // If both hash and expiry are set, use both values when resetting
             // the password. This occurs when a new password is generated
             // by the system.
             $user->updatePassword(
-                new \Password($values['Password_hash']),
+                new \Password($decoded),
                 new \DateTime($values['Password_expiry'])
             );
         } else if (isset($values['Password_hash'])) {
@@ -502,7 +503,7 @@ class Edit_User extends \NDB_Form
             // custom expiry date. This will set the password to expire in
             // 6 months from the current date (handled in updatePassword()).
             $user->updatePassword(
-                new \Password($values['Password_hash'])
+                new \Password($decoded)
             );
         }
 
@@ -1108,9 +1109,10 @@ class Edit_User extends \NDB_Form
                 // The Password class is self-validating and will throw an
                 // InvalidArgumentException if the value passed to it is
                 // bad or the input is too weak to be a good password.
-                $password            = new \Password($plaintext);
+                $decoded = htmlspecialchars_decode($plaintext)
+                $password            = new \Password($decoded);
                 $isPasswordDifferent = \User::factory($this->identifier)
-                    ->isPasswordDifferent($plaintext);
+                    ->isPasswordDifferent($decoded);
                 if (! $isPasswordDifferent) {
                     $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;
                 }

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -200,7 +200,11 @@ class My_Preferences extends \NDB_Form
         // point in the code and represents a plaintext password, not a hash.
         // Validation for the password is performed in _validateMyPreferences()
         if (isset($values['Password_hash'])) {
-            $user->updatePassword(new \Password($values['Password_hash']));
+            $user->updatePassword(
+                new \Password(
+                    htmlspecialchars_decode($values['Password_hash'])
+                )
+            );
         }
 
         // send the user an email
@@ -415,10 +419,11 @@ class My_Preferences extends \NDB_Form
                 // bad or the input is too weak to be a good password.
                 //
                 // NOTE 'Password_hash' is actually plaintext, not a hash.
-                $password = new \Password($plaintext);
+                $decoded = htmlspecialchars_decode($plaintext);
+                $password = new \Password($decoded);
                 // New password must be different than current one
                 if (! \User::factory($this->identifier)->isPasswordDifferent(
-                    $values['Password_hash']
+                    $decoded
                 )
                 ) {
                     $errors['Password_Group'] = self::PASSWORD_ERROR_NO_CHANGE;

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -419,7 +419,7 @@ class My_Preferences extends \NDB_Form
                 // bad or the input is too weak to be a good password.
                 //
                 // NOTE 'Password_hash' is actually plaintext, not a hash.
-                $decoded = htmlspecialchars_decode($plaintext);
+                $decoded  = htmlspecialchars_decode($plaintext);
                 $password = new \Password($decoded);
                 // New password must be different than current one
                 if (! \User::factory($this->identifier)->isPasswordDifferent(


### PR DESCRIPTION
_Replaces #5642_

## Brief summary of changes

Special characters can now be used in passwords. I forgot that they get automatically encoded upon submission to the codebase so passwords were never decoded before being hashed.

#### Testing instructions (if applicable)

1. Checkout the branch, change your password to something containing a special character such as `&`, make sure you can login with that password.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5630 
* Extensive background reading about the history of why encoding happens https://github.com/aces/Loris/pull/4491#issuecomment-490567790