### PR TITLE
[brainbrowser] fix multiple volumes display bug

### DIFF
--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -749,10 +749,10 @@ $(function() {
         minc_ids_arr = [minc_ids];
     }
 
-    let request;
+    let requests = [];
     for (i = 0; i < minc_ids_arr.length; i += 1) {
 
-      request = $.ajax({
+      let single_request = $.ajax({
         url: loris.BaseURL + "/brainbrowser/ajax/image.php",
         data: 'file_id=' + minc_ids_arr[i],
         method: 'GET',
@@ -796,6 +796,7 @@ $(function() {
           }
         }
       });
+      requests.push(single_request);
     }
 
     if (getQueryVariable("overlay") === "true") {
@@ -816,7 +817,7 @@ $(function() {
       $("#panel-size").change();
     }
 
-    //////////////////////////////
+    /////////////////////////////(
     // Load the default color map.
     //////////////////////////////
     viewer.loadDefaultColorMapFromURL(color_map_config.url, color_map_config.cursor_color);
@@ -836,7 +837,7 @@ $(function() {
     /////////////////////
     // Load the volumes.
     /////////////////////
-    request.then(function(filename) {
+    $.when.apply($, requests).then(function() {
       bboptions.volumes = minc_volumes;
       viewer.render();                // start the rendering
       viewer.loadVolumes(bboptions);  // load the volumes

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -2,14 +2,14 @@
 function getQueryVariable(variable) {
     "use strict";
     var query = window.location.search.substring(1),
-      vars = query.split("&"),
-      i,
-      pair;
+        vars = query.split("&"),
+        i,
+        pair;
     for (i = 0; i < vars.length; i += 1) {
-      pair = vars[i].split("=");
-      if (pair[0] === variable) {
-        return unescape(pair[1]);
-      }
+        pair = vars[i].split("=");
+        if (pair[0] === variable) {
+            return unescape(pair[1]);
+        }
     }
 }
 
@@ -553,9 +553,9 @@ $(function() {
                $('#filename-additional-info-'+vol_id).slideToggle("fast");
                var arrow = $(this).siblings('.arrow');
                if (arrow.hasClass('glyphicon-chevron-down')) {
-                     arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+                   arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
                } else {
-                     arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+                   arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
                }
 
        });
@@ -740,13 +740,13 @@ $(function() {
 
     minc_ids = getQueryVariable("minc_id");
     if (minc_ids[0] === '[') {
-    // An array was passed. Get rid of the brackets and then split on ","
-    minc_ids = minc_ids.substring(1, minc_ids.length - 1);
-    minc_ids_arr = minc_ids.split(",");
+        // An array was passed. Get rid of the brackets and then split on ","
+        minc_ids = minc_ids.substring(1, minc_ids.length - 1);
+        minc_ids_arr = minc_ids.split(",");
 
     } else {
-    // Only one passed
-    minc_ids_arr = [minc_ids];
+        // Only one passed
+        minc_ids_arr = [minc_ids];
     }
 
     function requestMINC(minc_id) {

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -817,7 +817,7 @@ $(function() {
       $("#panel-size").change();
     }
 
-    /////////////////////////////(
+    //////////////////////////////
     // Load the default color map.
     //////////////////////////////
     viewer.loadDefaultColorMapFromURL(color_map_config.url, color_map_config.cursor_color);

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -1,16 +1,16 @@
 /*global window, BrainBrowser, unescape, $*/
 function getQueryVariable(variable) {
-  "use strict";
-  var query = window.location.search.substring(1),
-    vars = query.split("&"),
-    i,
-    pair;
-  for (i = 0; i < vars.length; i += 1) {
-    pair = vars[i].split("=");
-    if (pair[0] === variable) {
-      return unescape(pair[1]);
+    "use strict";
+    var query = window.location.search.substring(1),
+      vars = query.split("&"),
+      i,
+      pair;
+    for (i = 0; i < vars.length; i += 1) {
+      pair = vars[i].split("=");
+      if (pair[0] === variable) {
+        return unescape(pair[1]);
+      }
     }
-  }
 }
 
 
@@ -29,7 +29,7 @@ $(function() {
     var loading_div = $("#loading");
 
     var link, minc_ids, minc_ids_arr, minc_volumes = [], i, minc_filenames = [] ,
-      bboptions = {};
+    bboptions = {};
 
     ///////////////////////////
     // Set up global UI hooks.
@@ -331,7 +331,7 @@ $(function() {
             value = volume.getVoxelMin();
           }
           value = Math.max(volume.getVoxelMin(),
-            Math.min(value, volume.getVoxelMax()));
+                           Math.min(value, volume.getVoxelMax()));
           this.value = value;
 
           // Update the slider.
@@ -350,7 +350,7 @@ $(function() {
             value = volume.getVoxelMax();
           }
           value = Math.max(volume.getVoxelMin(),
-            Math.min(value, volume.getVoxelMax()));
+                           Math.min(value, volume.getVoxelMax()));
           this.value = value;
 
           // Update the slider.
@@ -537,47 +537,47 @@ $(function() {
       });
 
       $.ajax({
-        dataType: "json",
-        data: 'file_id=' + minc_ids_arr[vol_id],
-        url: loris.BaseURL + '/brainbrowser/ajax/getImageName.php',
-        method: 'GET',
-        success: function(data) {
-          let fileName = $("#filename-" + vol_id);
-          fileName.html(data.filename);
-          fileName.data("title", data.filename);
-          fileName.tooltip();
-        }
+          dataType: "json",
+          data: 'file_id=' + minc_ids_arr[vol_id],
+          url: loris.BaseURL + '/brainbrowser/ajax/getImageName.php',
+          method: 'GET',
+          success: function(data) {
+              let fileName = $("#filename-" + vol_id);
+              fileName.html(data.filename);
+              fileName.data("title", data.filename);
+              fileName.tooltip();
+          }
       });
 
       $('#filename-'+vol_id).on("click", function() {
-        $('#filename-additional-info-'+vol_id).slideToggle("fast");
-        var arrow = $(this).siblings('.arrow');
-        if (arrow.hasClass('glyphicon-chevron-down')) {
-          arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
-        } else {
-          arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
-        }
+               $('#filename-additional-info-'+vol_id).slideToggle("fast");
+               var arrow = $(this).siblings('.arrow');
+               if (arrow.hasClass('glyphicon-chevron-down')) {
+                     arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+               } else {
+                     arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+               }
 
-      });
-      $('.filename-overlay').on("click", function() {
-        $('.filename-overlay-additional-info').slideToggle("fast");
-        var arrow = $(this).siblings('.arrow');
-        if (arrow.hasClass('glyphicon-chevron-down')) {
-          arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
-        } else {
-          arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
-        }
+       });
+       $('.filename-overlay').on("click", function() {
+               $('.filename-overlay-additional-info').slideToggle("fast");
+               var arrow = $(this).siblings('.arrow');
+               if (arrow.hasClass('glyphicon-chevron-down')) {
+                   arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+               } else {
+                   arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+               }
 
-      });
+       });
 
-      $('.arrow').on("click", function() {
-        $('#filename-additional-info-'+vol_id).slideToggle("fast");
-        if ($('.arrow').hasClass('glyphicon-chevron-down')) {
-          $('.arrow').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
-        } else {
-          $('.arrow').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
-        }
-      });
+        $('.arrow').on("click", function() {
+              $('#filename-additional-info-'+vol_id).slideToggle("fast");
+              if ($('.arrow').hasClass('glyphicon-chevron-down')) {
+                $('.arrow').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+              } else {
+                $('.arrow').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+              }
+            });
 
       // Contrast controls
       container.find(".contrast-div").each(function() {
@@ -726,9 +726,9 @@ $(function() {
       var fg_color = getContrastYIQ(bg_color);
 
       $("#intensity-value-" + vol_id)
-        .css("background-color", "#" + bg_color)
-        .css("color", fg_color)
-        .html(Math.floor(value));
+      .css("background-color", "#" + bg_color)
+      .css("color", fg_color)
+      .html(Math.floor(value));
 
       if (volume.header && volume.header.time) {
         $("#time-slider-" + vol_id).slider("option", "value", volume.current_time);
@@ -740,13 +740,13 @@ $(function() {
 
     minc_ids = getQueryVariable("minc_id");
     if (minc_ids[0] === '[') {
-      // An array was passed. Get rid of the brackets and then split on ","
-      minc_ids = minc_ids.substring(1, minc_ids.length - 1);
-      minc_ids_arr = minc_ids.split(",");
+    // An array was passed. Get rid of the brackets and then split on ","
+    minc_ids = minc_ids.substring(1, minc_ids.length - 1);
+    minc_ids_arr = minc_ids.split(",");
 
     } else {
-      // Only one passed
-      minc_ids_arr = [minc_ids];
+    // Only one passed
+    minc_ids_arr = [minc_ids];
     }
 
     function requestMINC(minc_id) {

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -844,7 +844,7 @@ $(function() {
     /////////////////////
     // Load the volumes.
     /////////////////////
-    Promise.all([...promises]).then(() => {
+    Promise.all(promises).then(() => {
       bboptions.volumes = minc_volumes;
       viewer.render();                // start the rendering
       viewer.loadVolumes(bboptions);  // load the volumes

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -784,12 +784,10 @@ $(function() {
               console.warn(msg);
               console.warn("\nNot supported file was " + filename);
               console.groupEnd();
-              console.log($("#loading").text());
             }
             resolve();
           },
           error: function (jqXHR, status, errorThrown) {
-            console.log('error');
             if (errorThrown === "Not Found") {
               let msg = "ERROR: file not found.";
               $("#loading").html(msg);

--- a/modules/brainbrowser/js/brainbrowser.loris.js
+++ b/modules/brainbrowser/js/brainbrowser.loris.js
@@ -1,16 +1,16 @@
 /*global window, BrainBrowser, unescape, $*/
 function getQueryVariable(variable) {
-    "use strict";
-    var query = window.location.search.substring(1),
-        vars = query.split("&"),
-        i,
-        pair;
-    for (i = 0; i < vars.length; i += 1) {
-        pair = vars[i].split("=");
-        if (pair[0] === variable) {
-            return unescape(pair[1]);
-        }
+  "use strict";
+  var query = window.location.search.substring(1),
+    vars = query.split("&"),
+    i,
+    pair;
+  for (i = 0; i < vars.length; i += 1) {
+    pair = vars[i].split("=");
+    if (pair[0] === variable) {
+      return unescape(pair[1]);
     }
+  }
 }
 
 
@@ -29,7 +29,7 @@ $(function() {
     var loading_div = $("#loading");
 
     var link, minc_ids, minc_ids_arr, minc_volumes = [], i, minc_filenames = [] ,
-    bboptions = {};
+      bboptions = {};
 
     ///////////////////////////
     // Set up global UI hooks.
@@ -331,7 +331,7 @@ $(function() {
             value = volume.getVoxelMin();
           }
           value = Math.max(volume.getVoxelMin(),
-                           Math.min(value, volume.getVoxelMax()));
+            Math.min(value, volume.getVoxelMax()));
           this.value = value;
 
           // Update the slider.
@@ -350,7 +350,7 @@ $(function() {
             value = volume.getVoxelMax();
           }
           value = Math.max(volume.getVoxelMin(),
-                           Math.min(value, volume.getVoxelMax()));
+            Math.min(value, volume.getVoxelMax()));
           this.value = value;
 
           // Update the slider.
@@ -537,47 +537,47 @@ $(function() {
       });
 
       $.ajax({
-          dataType: "json",
-          data: 'file_id=' + minc_ids_arr[vol_id],
-          url: loris.BaseURL + '/brainbrowser/ajax/getImageName.php',
-          method: 'GET',
-          success: function(data) {
-              let fileName = $("#filename-" + vol_id);
-              fileName.html(data.filename);
-              fileName.data("title", data.filename);
-              fileName.tooltip();
-          }
+        dataType: "json",
+        data: 'file_id=' + minc_ids_arr[vol_id],
+        url: loris.BaseURL + '/brainbrowser/ajax/getImageName.php',
+        method: 'GET',
+        success: function(data) {
+          let fileName = $("#filename-" + vol_id);
+          fileName.html(data.filename);
+          fileName.data("title", data.filename);
+          fileName.tooltip();
+        }
       });
 
       $('#filename-'+vol_id).on("click", function() {
-               $('#filename-additional-info-'+vol_id).slideToggle("fast");
-               var arrow = $(this).siblings('.arrow');
-               if (arrow.hasClass('glyphicon-chevron-down')) {
-                   arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
-               } else {
-                   arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
-               }
+        $('#filename-additional-info-'+vol_id).slideToggle("fast");
+        var arrow = $(this).siblings('.arrow');
+        if (arrow.hasClass('glyphicon-chevron-down')) {
+          arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+        } else {
+          arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+        }
 
-       });
-       $('.filename-overlay').on("click", function() {
-               $('.filename-overlay-additional-info').slideToggle("fast");
-               var arrow = $(this).siblings('.arrow');
-               if (arrow.hasClass('glyphicon-chevron-down')) {
-                   arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
-               } else {
-                   arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
-               }
+      });
+      $('.filename-overlay').on("click", function() {
+        $('.filename-overlay-additional-info').slideToggle("fast");
+        var arrow = $(this).siblings('.arrow');
+        if (arrow.hasClass('glyphicon-chevron-down')) {
+          arrow.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+        } else {
+          arrow.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+        }
 
-       });
+      });
 
-        $('.arrow').on("click", function() {
-              $('#filename-additional-info-'+vol_id).slideToggle("fast");
-              if ($('.arrow').hasClass('glyphicon-chevron-down')) {
-                $('.arrow').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
-              } else {
-                $('.arrow').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
-              }
-            });
+      $('.arrow').on("click", function() {
+        $('#filename-additional-info-'+vol_id).slideToggle("fast");
+        if ($('.arrow').hasClass('glyphicon-chevron-down')) {
+          $('.arrow').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+        } else {
+          $('.arrow').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+        }
+      });
 
       // Contrast controls
       container.find(".contrast-div").each(function() {
@@ -726,9 +726,9 @@ $(function() {
       var fg_color = getContrastYIQ(bg_color);
 
       $("#intensity-value-" + vol_id)
-      .css("background-color", "#" + bg_color)
-      .css("color", fg_color)
-      .html(Math.floor(value));
+        .css("background-color", "#" + bg_color)
+        .css("color", fg_color)
+        .html(Math.floor(value));
 
       if (volume.header && volume.header.time) {
         $("#time-slider-" + vol_id).slider("option", "value", volume.current_time);
@@ -740,72 +740,79 @@ $(function() {
 
     minc_ids = getQueryVariable("minc_id");
     if (minc_ids[0] === '[') {
-        // An array was passed. Get rid of the brackets and then split on ","
-        minc_ids = minc_ids.substring(1, minc_ids.length - 1);
-        minc_ids_arr = minc_ids.split(",");
+      // An array was passed. Get rid of the brackets and then split on ","
+      minc_ids = minc_ids.substring(1, minc_ids.length - 1);
+      minc_ids_arr = minc_ids.split(",");
 
     } else {
-        // Only one passed
-        minc_ids_arr = [minc_ids];
+      // Only one passed
+      minc_ids_arr = [minc_ids];
     }
 
-    let requests = [];
-    for (i = 0; i < minc_ids_arr.length; i += 1) {
-
-      let single_request = $.ajax({
-        url: loris.BaseURL + "/brainbrowser/ajax/image.php",
-        data: 'file_id=' + minc_ids_arr[i],
-        method: 'GET',
-        success: function (response, status, jqXHR) {
-          let type   = jqXHR.getResponseHeader('Content-Type');
-          let fileid = jqXHR.getResponseHeader('X-FileID');
-          if (type === "application/x-mnc") {
-            minc_volumes.push({
-              type: 'minc',
-              raw_data_url: loris.BaseURL + "/brainbrowser/ajax/image.php?file_id=" + fileid,
-              template: {
-                element_id: "volume-ui-template4d",
-                viewer_insert_class: "volume-viewer-display"
-              }
-            });
-          } else if (type === "application/x-nii") {
-            minc_volumes.push({
-              type: 'nifti1',
-              nii_url: loris.BaseURL + "/brainbrowser/ajax/image.php?file_id=" + fileid,
-              template: {
-                element_id: "volume-ui-template4d",
-                viewer_insert_class: "volume-viewer-display"
-              }
-            });
-          } else {
-            let msg = "WARNING: The volume viewer only supports MINC and" +
-                      " NIfTI file types.";
-            $("#loading").html(msg);
-            console.group('warning message');
+    function requestMINC(minc_id) {
+      return new Promise((resolve) => {
+        $.ajax({
+          url: loris.BaseURL + "/brainbrowser/ajax/image.php",
+          data: 'file_id=' + minc_id,
+          method: 'GET',
+          success: function (response, status, jqXHR) {
+            let type = jqXHR.getResponseHeader('Content-Type');
+            let fileid = jqXHR.getResponseHeader('X-FileID');
+            if (type === "application/x-mnc") {
+              minc_volumes.push({
+                type: 'minc',
+                raw_data_url: loris.BaseURL + "/brainbrowser/ajax/image.php?file_id=" + fileid,
+                template: {
+                  element_id: "volume-ui-template4d",
+                  viewer_insert_class: "volume-viewer-display"
+                }
+              });
+            } else if (type === "application/x-nii") {
+              minc_volumes.push({
+                type: 'nifti1',
+                nii_url: loris.BaseURL + "/brainbrowser/ajax/image.php?file_id=" + fileid,
+                template: {
+                  element_id: "volume-ui-template4d",
+                  viewer_insert_class: "volume-viewer-display"
+                }
+              });
+            } else {
+              let msg = "WARNING: The volume viewer only supports MINC and" +
+                " NIfTI file types.";
+              $("#loading").html(msg);
+              console.group('warning message');
               console.warn(msg);
               console.warn("\nNot supported file was " + filename);
-            console.groupEnd();
-            console.log($("#loading").text());
+              console.groupEnd();
+              console.log($("#loading").text());
+            }
+            resolve();
+          },
+          error: function (jqXHR, status, errorThrown) {
+            console.log('error');
+            if (errorThrown === "Not Found") {
+              let msg = "ERROR: file not found.";
+              $("#loading").html(msg);
+              console.error(msg);
+            }
+            resolve();
           }
-        },
-        error: function(jqXHR, status, errorThrown) {
-          if (errorThrown === "Not Found") {
-            let msg = "ERROR: file not found.";
-            $("#loading").html(msg);
-            console.error(msg);
-          }
-        }
+        });
       });
-      requests.push(single_request);
+    }
+
+    let promises = [];
+    for (i = 0; i < minc_ids_arr.length; i += 1) {
+      promises.push(requestMINC(minc_ids_arr[i]));
     }
 
     if (getQueryVariable("overlay") === "true") {
-        bboptions.overlay = {
-            template: {
-                element_id: "overlay-ui-template",
-                viewer_insert_class: "overlay-viewer-display"
-            }
+      bboptions.overlay = {
+        template: {
+          element_id: "overlay-ui-template",
+          viewer_insert_class: "overlay-viewer-display"
         }
+      }
     }
 
     var color_map_config = BrainBrowser.config.get("color_maps")[0];
@@ -837,7 +844,7 @@ $(function() {
     /////////////////////
     // Load the volumes.
     /////////////////////
-    $.when.apply($, requests).then(function() {
+    Promise.all([...promises]).then(() => {
       bboptions.volumes = minc_volumes;
       viewer.render();                // start the rendering
       viewer.loadVolumes(bboptions);  // load the volumes


### PR DESCRIPTION
## Brief summary of changes

When trying to load more than one volume in BB via the imaging browser, only the first volume got displayed. When we refreshed the page, then the second volume would be displayed and so on.

This fixes that bug and now all volumes are being displayed the first time the page is loaded.

#### Testing instructions (if applicable)

1. From the imaging browser page, select two volumes and click on either the "3D Only" or "3D + Overlay" button and verify that both volumes are being loaded. Note: the volumes might be slow to load given the size of the data being loaded in the browser...

#### Links to related tickets (GitHub, Redmine, ...)

* #5474 fixes the lack of clarity part of the issue (the slowness cannot really be fixed due to the size of the data being sent I guess...)
