### PR TITLE
[Login] Fix issue where password could not be reset

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -97,7 +97,7 @@ class PasswordExpiry extends \NDB_Form
             return array('password' => $e->getMessage());
         }
 
-        if (!$this->_user->passwordChanged($plaintext)) {
+        if (!$this->_user->isPasswordDifferent($plaintext)) {
             $this->tpl_data['error_message'] = 'You cannot keep the same password';
             return array('password' => 'You cannot keep the same password');
         }


### PR DESCRIPTION
## Brief summary of changes

This file was not updated when the function `passwordChanged` was renamed to `isPasswordDifferent` which caused a PHP Fatal Error when trying to reset an expired password.

#### Testing instructions (if applicable)

1. On `22.0-release`, Manually expire a user's password.
2. Try logging in to the front-end.
3. Enter a new password
4. You should get a 403 error.
5. Do the same on my branch and everything should work normally.
