### PR TITLE
Script to create VERSION file without git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: VERSION javascript
 
 # If anything changes, re-generate the VERSION file
 VERSION: .
-	git describe --tags --always > VERSION
+	tools/create-version-file.sh
 
 phpdev:
 	composer install

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: VERSION javascript
 
 # If anything changes, re-generate the VERSION file
 VERSION: .
-	tools/create-version-file.sh
+	tools/gen-version.sh
 
 phpdev:
 	composer install

--- a/tools/create-version-file.sh
+++ b/tools/create-version-file.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Creates the VERSION file in the LORIS root folder.
+set -euo pipefail
+
+# The name of the version file
+VERSION='VERSION'
+
+if [ -d '.git/' ]; then
+    git describe --tags --always > $VERSION
+else
+    echo 'Unknown' > $VERSION
+fi

--- a/tools/gen-version.sh
+++ b/tools/gen-version.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 # The name of the version file
 VERSION='VERSION'
 
-if [ -d '.git/' ]; then
+GIT_INSTALLED=$()
+
+if [ -d '.git/' ] && [ -n $(command -v git) ]; then
     git describe --tags --always > $VERSION
 else
     echo 'Unknown' > $VERSION

--- a/tools/gen-version.sh
+++ b/tools/gen-version.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 # The name of the version file
 VERSION='VERSION'
 
-
 if [ -d '.git/' ] && [ -n $(command -v git) ]; then
     git describe --tags --always > $VERSION
 else

--- a/tools/gen-version.sh
+++ b/tools/gen-version.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 # The name of the version file
 VERSION='VERSION'
 
-GIT_INSTALLED=$()
 
 if [ -d '.git/' ] && [ -n $(command -v git) ]; then
     git describe --tags --always > $VERSION


### PR DESCRIPTION
## Brief summary of changes

When a user runs `make` without git being installed, the script will crash because git was required to create the VERSION file.

This adds a small script to fix that problem.

#### Testing instructions (if applicable)

1. Checkout the branch. Delete your VERSION file if it exists.
2. Run `make VERSION`.
3. The VERSION file should contain information from git.
4. Run `mv .git/ .gitbkp/` to simulate a system without git.
5. Run `make VERSION`
6. The VERSION file should contain the string 'Unknown'
7. Run `mv .gitbkp/ .git/` to restore git.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5682 
