### PR TITLE
[Conflict Resolver] Restore help file and update

### DIFF
--- a/modules/conflict_resolver/help/conflict_resolver.md
+++ b/modules/conflict_resolver/help/conflict_resolver.md
@@ -1,8 +1,9 @@
 # Conflict Resolver
 
-The Conflict Resolver module enables studies to identify and resolve typos and discrepancies that arise between initial data entry and double data entry forms. Unresolved and Resolved conflicts are displayed on two separate tabs of the module.
-Unresolved conflicts are displayed by default upon accessing the module. Selection filters can be applied to search for a particular subject and/or instrument. Clicking "Show Data" after entering selection filter criteria, to display data results. Click the “Clear Form” button to reset all Selection Filters.  The Selection Filters panel can be hidden by clicking the upward arrow in the panel title bar.
-By default, unresolved data entry conflicts appear as “Unresolved” under the “Correct Answer” column, until a user manually resolves the data discrepancy.
-To resolve a conflict, click in the “Correct Answer” column dropdown select for a given data entry item. This dropdown-select will show two options: these are the data values that were entered in each of the initial and the double data entry forms. Select one of these options as the correct answer, after cross-checking against original data records (e.g. paper forms) for accuracy.
-To finalize this change and to successfully resolve the conflict, users must click “Save” located at the bottom of the results table.
-After refreshing the page, this newly resolved conflict will move to the Resolved Conflicts tab in the module.
+This module is designed to identify and resolve data conflicts in a study. LORIS uses double data entry, which means you may be asked to enter critical data twice in duplicate instrument forms. The Conflict Resolver will flag any discrepancies between the two entries (called *unresolved conflicts*) and allow you to fix—resolve—them easily. 
+
+Conflicts are displayed in a table with two separate tabs—resolved and unresolved conflicts. By default, the module displays the *Unresolved Conflicts* tab. You can narrow this list of results using any combination of filters in the *Selection Filters* section. 
+
+You can resolve all conflicts in the **Correct Answer** column of the resulting table. Click the drop-down to reveal two different responses—this is the conflict. These are two distinct values that were entered initially and during double data entry—they should be the same value. After cross-checking your data records for accuracy, select the correct response of the two. 
+
+You can continue resolving conflicts in this list. To save your changes, click **Save** below the table. All saved, resolved conflicts will now appear in the *Resolved Conflicts* tab of the table. 

--- a/modules/conflict_resolver/help/conflict_resolver.md
+++ b/modules/conflict_resolver/help/conflict_resolver.md
@@ -1,0 +1,8 @@
+# Conflict Resolver
+
+The Conflict Resolver module enables studies to identify and resolve typos and discrepancies that arise between initial data entry and double data entry forms. Unresolved and Resolved conflicts are displayed on two separate tabs of the module.
+Unresolved conflicts are displayed by default upon accessing the module. Selection filters can be applied to search for a particular subject and/or instrument. Clicking "Show Data" after entering selection filter criteria, to display data results. Click the “Clear Form” button to reset all Selection Filters.  The Selection Filters panel can be hidden by clicking the upward arrow in the panel title bar.
+By default, unresolved data entry conflicts appear as “Unresolved” under the “Correct Answer” column, until a user manually resolves the data discrepancy.
+To resolve a conflict, click in the “Correct Answer” column dropdown select for a given data entry item. This dropdown-select will show two options: these are the data values that were entered in each of the initial and the double data entry forms. Select one of these options as the correct answer, after cross-checking against original data records (e.g. paper forms) for accuracy.
+To finalize this change and to successfully resolve the conflict, users must click “Save” located at the bottom of the results table.
+After refreshing the page, this newly resolved conflict will move to the Resolved Conflicts tab in the module.

--- a/modules/conflict_resolver/help/conflict_resolver.md
+++ b/modules/conflict_resolver/help/conflict_resolver.md
@@ -1,6 +1,6 @@
 # Conflict Resolver
 
-This module is designed to identify and resolve data conflicts in a study. LORIS uses double data entry, which means you may be asked to enter critical data twice in duplicate instrument forms. The Conflict Resolver will flag any discrepancies between the two entries (called *unresolved conflicts*) and allow you to fix—resolve—them easily. 
+This module is designed to identify and resolve data conflicts in a study. LORIS uses double data entry, which means you may be asked to enter critical data twice in duplicate instrument forms. The Conflict Resolver will flag any discrepancies between the two entries (called *unresolved conflicts*) and allow you to fix or "resolve" them easily. 
 
 Conflicts are displayed in a table with two separate tabs—resolved and unresolved conflicts. By default, the module displays the *Unresolved Conflicts* tab. You can narrow this list of results using any combination of filters in the *Selection Filters* section. 
 


### PR DESCRIPTION
## Brief summary of changes

Restores the conflict resolver help file that was mistakenly deleted on the repo.

Also incorporates new changes from original PR.

#### Links to related tickets (GitHub, Redmine, ...)

* Replaces #5692 

issue: #5576
