### PR TITLE
[Core] Fix TypeError/500 error when Certification settings not well-formatted

### DIFF
--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -149,7 +149,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         if ($this->instrumentExists($instrument)) {
             // An instrument with this name already exists in the test_names
             // table. Abort upload.
-            return new \LORIS\Http\Response\Conflict(self::ALREADY_INSTALLED);
+            return new \LORIS\Http\Response\JSON\Conflict(self::ALREADY_INSTALLED);
         }
 
         /* Although only .linst files should be uploaded to this module, and
@@ -171,7 +171,9 @@ class Instrument_Manager extends \NDB_Menu_Filter
                  * This should only happen for users on a system where automatic
                  * installation is disabled (ie. has no quatUser).
                  */
-                return new \LORIS\Http\Response\Conflict(self::FILE_ALREADY_EXISTS);
+                return new \LORIS\Http\Response\JSON\Conflict(
+                    self::FILE_ALREADY_EXISTS
+                );
             }
             return $response;
         }

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -208,7 +208,17 @@ class Instrument_Manager extends \NDB_Menu_Filter
         // silently. Otherwise, it will return the exit code and error
         // messsage from MySQL. This will be stored in $result and
         // logged via LorisException.
-        $table_name = \NDB_BVL_Instrument::factory($instrument, '', '')->table;
+        try {
+            $table_name = \NDB_BVL_Instrument::factory($instrument, '', '')->table;
+        } catch (\NotFound $e) {
+            return (new \LORIS\Http\Response\JSON\NotFound(
+                $e->getMessage()
+            ));
+        } catch (\Exception $e) {
+            return (new \LORIS\Http\Response\JSON\InternalServerError(
+                $e->getMessage()
+            ));
+        }
 
         $db_config = $this->factory->config()->getSetting('database');
         exec(

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -29,7 +29,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 {
     protected const ERROR_CERTIFICATION_BAD_FORMATTING
         = 'Certification settings are not formatted correctly in the '
-        . 'config file. Cannot continue';
+        . 'configuration file. Cannot continue.';
     /**
      * Determines whether this instrument should load data in
      * JSON format from the "Data" column of the flag table, or
@@ -180,6 +180,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @return object|null the new object of $instrument type
      * @access public
+     * @throws NotFound
+     * @throws Exception
      */
     static function factory(
         string $instrument,
@@ -222,7 +224,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 && ($guarantee_exists === true
                 && !file_exists($base."project/instruments/$class.class.inc"))
             ) {
-                throw new Exception("Instrument does not exist");
+                throw new NotFound("Instrument does not exist");
             }
             if (!class_exists($class)) {
                 include_once $base."project/instruments/$class.class.inc";
@@ -267,8 +269,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // check that user has access
         if ($access == false) {
             throw new Exception(
-                "You do not have access to this page.",
-                403
+                "You do not have access to this page."
             );
         }
 
@@ -886,6 +887,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * settings and don't need to parse the config file themselves.
      *
      * @return array
+     * @throws \ConfigurationException
      */
     function _getCertificationConfig(): array
     {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -269,7 +269,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // check that user has access
         if ($access == false) {
             throw new Exception(
-                "You do not have access to this page."
+                "You do not have access to this page.",
+                403
             );
         }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -27,6 +27,9 @@ use \Loris\StudyEntities\Candidate\CandID;
  */
 abstract class NDB_BVL_Instrument extends NDB_Page
 {
+    protected const ERROR_CERTIFICATION_BAD_FORMATTING
+        = 'Certification settings are not formatted correctly in the '
+        . 'config file. Cannot continue';
     /**
      * Determines whether this instrument should load data in
      * JSON format from the "Data" column of the flag table, or
@@ -894,6 +897,18 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $CertificationInstruments = array();
 
         if ($CertificationEnabled) {
+            // Throw exception if config file is formatted incorrectly.
+            if (!is_array(
+                $CertificationConfig['CertificationProjects']
+            )
+                || !is_array(
+                $CertificationConfig['CertificationInstruments']
+            )
+            ) {
+                throw new \ConfigurationException(
+                    self::ERROR_CERTIFICATION_BAD_FORMATTING
+                );
+            }
             foreach (
                 Utility::associativeToNumericArray(
                     $CertificationConfig['CertificationProjects']


### PR DESCRIPTION
# Brief summary of changes

Throws a configuration exception if the data in the config file is not formatted the way it's supposed to be.

Also fixes a namespacing issue in the Instrument Manager that was triggered in the same call stack. This caused a PHP Fatal Error.

#### Testing instructions (if applicable)

1. Enable `EnableCertification` in your config.xml file.
2. Leave the rest of the tags empty.
3. Try to upload the `test_all_fields.linst` instrument to the instrument manager. (`test/instruments/test_all_fields.linst`)
4. It won't work
5. Do the same on this PR.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5698 
