### PR TITLE
[Core] Fix help text not loading for subpages

### DIFF
--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -3,7 +3,7 @@
  * This file retrieves content for specific help section
  * and returns a json object
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  Loris
@@ -13,50 +13,41 @@
  */
 
 try {
-    /**
-     * The link constructed from the front end sets the testName
-     * parameter, not the Module parameter.
-     */
-    if (isset($_REQUEST['testName'])) {
-        $mname = $_REQUEST['testName'];
-    }
-
-    $m = Module::factory($mname);
-} catch (Exception $e) {
-    $m = '';
-}
-if (!empty($m)) {
-    $page = !empty($_REQUEST['subtest']) ? $_REQUEST['subtest'] : $mname;
+    $moduleName  = $_REQUEST['testName'] ?? null;
+    $subpageName = $_REQUEST['subtest'] ?? null;
+    $m           = Module::factory($moduleName);
+    // Load help data. Try to load subpage first as its more specific and
+    // will only be present some of the time. Fallback to the module name if
+    // no subpage present.
     $help = array(
-        'content' => $m->getHelp($page),
+        'content' => $m->getHelp($subpageName ?? $moduleName),
         'format'  => 'markdown',
     );
     print json_encode($help);
     ob_end_flush();
-    exit(0);
-}
+    exit;
+} catch (Exception $e) {
 
-// Wasn't a module, so fall back on the old style of DB lookup.
-require_once "helpfile.class.inc";
+    // Wasn't a module, so fall back on the old style of DB lookup.
+    include_once "helpfile.class.inc";
 
-if (!empty($_REQUEST['testName'])) {
-    if (empty($_REQUEST['subtest'])) {
-        $helpID = \LORIS\help_editor\HelpFile::hashToID(md5($_REQUEST['testName']));
-    } else {
-        $helpID = \LORIS\help_editor\HelpFile::hashToID(md5($_REQUEST['subtest']));
+    if (!empty($moduleName)) {
+        $helpID = \LORIS\help_editor\HelpFile::hashToID(
+            md5($subpageName ?? $moduleName)
+        );
     }
-}
 
-$help_file       = \LORIS\help_editor\HelpFile::factory($helpID);
-$data            = $help_file->toArray();
-$data['content'] = trim($data['content']);
+    $help_file       = \LORIS\help_editor\HelpFile::factory($helpID);
+    $data            = $help_file->toArray();
+    $data['content'] = trim($data['content']);
 
-if (empty($data['updated'])) {
-    $data['updated'] = "-";
-    // if document was never updated should display date created
-    if (!empty($data['created'])) {
-        $data['updated'] = $data['created'];
+    if (empty($data['updated'])) {
+        $data['updated'] = "-";
+        // if document was never updated should display date created
+        if (!empty($data['created'])) {
+            $data['updated'] = $data['created'];
+        }
     }
+    print json_encode($data);
+    ob_end_flush();
 }
-print json_encode($data);
-ob_end_flush();

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -1,5 +1,4 @@
 <!-- Main table -->
-{* Olga: show3DViewer not tested *}
 {if $show3DViewer}
 {*<td nowrap="nowrap">the first opening td already opened in main.tpl *}<input type="button" name="button" value="3D Viewer" class="button" id = "dccid" name = "dccid" style = "background-color: #816e91" onclick="window.open('BrainBrowser/display.html?sessionID={$subject.sessionID}')" /></td>
 

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -47,7 +47,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         ob_start();
         // Set the page template variables
         // $user is set by the page base router
-        $user = $request->getAttribute("user");
+        $user     = $request->getAttribute("user");
         $tpl_data = array(
                      'test_name' => $this->PageName,
                      'subtest'   => $request->getAttribute('subtest') ?? '',

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -48,7 +48,6 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // Set the page template variables
         // $user is set by the page base router
         $user = $request->getAttribute("user");
-        //print_r($request);
         $tpl_data = array(
                      'test_name' => $this->PageName,
                      'subtest'   => $request->getAttribute('subtest') ?? '',

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -47,9 +47,11 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         ob_start();
         // Set the page template variables
         // $user is set by the page base router
-        $user     = $request->getAttribute("user");
+        $user = $request->getAttribute("user");
+        //print_r($request);
         $tpl_data = array(
                      'test_name' => $this->PageName,
+                     'subtest'   => $request->getAttribute('subtest') ?? '',
                     );
 
         // Basic page outline variables
@@ -88,6 +90,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         // I don't think anyone uses this. It's not really supported
         $tpl_data['css'] = $this->Config->getSetting('css');
+
+        $tpl_data['subtest'] = $request->getAttribute("pageclass")->page;
 
         $page = $request->getAttribute("pageclass");
         if (method_exists($page, 'getFeedbackPanel')

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -50,7 +50,6 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         $user     = $request->getAttribute("user");
         $tpl_data = array(
                      'test_name' => $this->PageName,
-                     'subtest'   => $request->getAttribute('subtest') ?? '',
                     );
 
         // Basic page outline variables


### PR DESCRIPTION
## Brief summary of changes

The `subtest` field was not being populated by the Middleware. As a result, the parameter was never passed to the back-end in order to load subpage help text. Instead the code would always fall back to loading the main help text for the module.

#### Testing instructions (if applicable)

Visit a module with a subpage. An example would be going to DICOM Archive and clicking "View Details". There should be specific help text for that module that is different from the help text for the main module.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5709 
