### PR TITLE
[Core] Raise minimum PHP requirement to 7.3

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -43,12 +43,6 @@ return [
 	"exclude_analysis_directory_list" => [
 		"vendor",
 	],
-    // Required to fix an issue with PHP 7.2, PHPCS, and TravisCI. This can be
-    // removed once PHP 7.3 or higher is the minimum required version for LORIS
-    // and support for 7.2 is dropped.
-    "exclude_file_list" => [
-        "vendor/squizlabs/php_codesniffer/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc"
-    ],
     'autoload_internal_extension_signatures' => [
         // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,
         // because Phan disables xdebug by default.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ language: php
 
 matrix:
   include:
-  - php: "7.2"
   - php: "7.3"
-  - php: "7.4snapshot"
-  allow_failures:
-  - php: "7.4snapshot"
+  - php: "7.4"
 
 services:
 - docker

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Deploy and log in with username *admin* and the password that's set up during de
 
  * Apache **2.4** or higher
  * MySQL >= 5.7 (or MariaDB >= 10.3) 
- * PHP <b>7.2</b> or higher
+ * PHP <b>7.3</b> or higher
  * [Composer](https://getcomposer.org/)
  * NodeJS <b>8.0</b> or higher
 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -85,8 +85,7 @@ class Create_Timepoint extends \NDB_Form
         $projects = \Utility::getProjectList();
         if (count($projects) == 1) {
             //if there is only one project, autoselect first project from array of 1
-            //TODO: change this to array_key_first() when support is only PHP 7.3+
-            $project = \Project::singleton(array_pop($projects));
+            $project = array_key_first($projects);
         } else if (count($projects) > 1) {
             $project_id = intval($values['project']);
             $project    = \Project::singleton($projects[$project_id]);

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -133,11 +133,7 @@ class NDB_Client
         );
         // start php session
         $sessionOptions = array('cookie_httponly' => true);
-        // TODO remove this if statement when 7.3 is the minimum required LORIS
-        // version. All session from then onward should have Same Site enabled.
-        if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
-            $sessionOptions['cookie_samesite'] = true;
-        }
+        $sessionOptions['cookie_samesite'] = true;
 
         // API Detect
         if (strpos(


### PR DESCRIPTION
## Brief summary of changes

PHP 7.2 is no longer receiving active support as of Nov. 30th, 2019. PHP 7.4 is being released at about the same time.

Typically we only support the last two releases of PHP. This PR brings the minimum requirement up to 7.3 from 7.2.

Detailed changes between these versions can be found here: https://www.php.net/manual/en/migration73.php

I'm adding the Security label because this upgrade will enable all LORIS instances to be fully protected from CSRF attacks via the SameSite cookie.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5063 
