### PR TITLE
[Core] Raise minimum PHP requirement to 7.3

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -45,12 +45,6 @@ return [
 	"exclude_analysis_directory_list" => [
 		"vendor",
 	],
-    // Required to fix an issue with PHP 7.2, PHPCS, and TravisCI. This can be
-    // removed once PHP 7.3 or higher is the minimum required version for LORIS
-    // and support for 7.2 is dropped.
-    "exclude_file_list" => [
-        "vendor/squizlabs/php_codesniffer/src/Standards/PSR2/Tests/Methods/MethodDeclarationUnitTest.inc"
-    ],
     'autoload_internal_extension_signatures' => [
         // Xdebug stubs are bundled with Phan 0.10.1+/0.8.9+ for usage,
         // because Phan disables xdebug by default.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ language: php
 
 matrix:
   include:
-  - php: "7.2"
   - php: "7.3"
-  - php: "7.4snapshot"
-  allow_failures:
-  - php: "7.4snapshot"
+  - php: "7.4"
 
 services:
 - docker

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Deploy and log in with username *admin* and the password that's set up during de
 
  * Apache **2.4** or higher
  * MySQL >= 5.7 (or MariaDB >= 10.3) 
- * PHP <b>7.2</b> or higher
+ * PHP <b>7.3</b> or higher
  * [Composer](https://getcomposer.org/) <b>1.4</b> or higher
  * NodeJS <b>8.0</b> or higher
  * NPM

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
@@ -10,8 +10,8 @@ For further details on the install process, please see the LORIS GitHub Wiki Cen
 # System Requirements - Install dependencies
 
 Default dependencies installed by CentOS 7.x may not meet the version requirements for LORIS deployment or development:
-* MariaDB 10.3 is supported for LORIS 21.* 
-* PHP 7.2 is supported for LORIS 21.*
+* MariaDB 10.3 is supported for LORIS 23.* 
+* PHP 7.3 is supported for LORIS 23.*
 
 In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](./README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher
@@ -26,13 +26,13 @@ sudo yum install httpd
 sudo systemctl enable httpd
 sudo systemctl start httpd
 ```
-## PHP 7.2
+## PHP 7.3
 ```bash
 sudo yum install epel-release
 sudo yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
 sudo yum install yum-utils
 sudo yum update
-sudo yum --enablerepo=remi-php72 install php php-pdo php-pdo_mysql php72-php-fpm php72-php-gd php72-php-json php72-php-mbstring php72-php-mysqlnd php72-php-xml php72-php-xmlrpc php72-php-opcache php72-php-mysql
+sudo yum --enablerepo=remi-php73 install php php-pdo php-pdo_mysql php73-php-fpm php73-php-gd php73-php-json php73-php-mbstring php73-php-mysqlnd php73-php-xml php73-php-xmlrpc php73-php-opcache php73-php-mysql
 ```
 ## MariaDB
 

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -85,8 +85,7 @@ class Create_Timepoint extends \NDB_Form
         $user_list_of_projects = $user->getProjectIDs();
         if (count($user_list_of_projects) == 1) {
             //if there is only one project, autoselect first project from array of 1
-            //TODO: change this to array_key_first() when support is only PHP 7.3+
-            $project = \Project::getProjectFromID(array_pop($user_list_of_projects));
+            $project = array_key_first($user_list_of_projects);
         } else if (count($user_list_of_projects) > 1) {
             $project_id = intval($values['project']);
             $project    = \Project::getProjectFromID($project_id);

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -85,12 +85,11 @@ class Create_Timepoint extends \NDB_Form
         $user_list_of_projects = $user->getProjectIDs();
         if (count($user_list_of_projects) == 1) {
             //if there is only one project, autoselect first project from array of 1
-            $project_id = $user_list_of_projects[0];
+            $project = \Project::getProjectFromID(array_pop($user_list_of_projects));
         } else if (count($user_list_of_projects) > 1) {
             $project_id = intval($values['project']);
+            $project    = \Project::getProjectFromID($project_id);
         }
-
-        $project = \Project::getProjectFromID($project_id);
 
         assert(isset($site) && $site !== null);
         \TimePoint::createNew(

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -85,7 +85,7 @@ class Create_Timepoint extends \NDB_Form
         $user_list_of_projects = $user->getProjectIDs();
         if (count($user_list_of_projects) == 1) {
             //if there is only one project, autoselect first project from array of 1
-            $project_id = array_key_first($user_list_of_projects);
+            $project_id = $user_list_of_projects[0];
         } else if (count($user_list_of_projects) > 1) {
             $project_id = intval($values['project']);
         }

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -85,11 +85,12 @@ class Create_Timepoint extends \NDB_Form
         $user_list_of_projects = $user->getProjectIDs();
         if (count($user_list_of_projects) == 1) {
             //if there is only one project, autoselect first project from array of 1
-            $project = array_key_first($user_list_of_projects);
+            $project_id = array_key_first($user_list_of_projects);
         } else if (count($user_list_of_projects) > 1) {
             $project_id = intval($values['project']);
-            $project    = \Project::getProjectFromID($project_id);
         }
+
+        $project = \Project::getProjectFromID($project_id);
 
         assert(isset($site) && $site !== null);
         \TimePoint::createNew(

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -133,11 +133,7 @@ class NDB_Client
         );
         // start php session
         $sessionOptions = array('cookie_httponly' => true);
-        // TODO remove this if statement when 7.3 is the minimum required LORIS
-        // version. All session from then onward should have Same Site enabled.
-        if (PHP_MAJOR_VERSION === 7 && PHP_MINOR_VERSION >= 3) {
-            $sessionOptions['cookie_samesite'] = true;
-        }
+        $sessionOptions['cookie_samesite'] = true;
 
         // API Detect
         if (strpos(


### PR DESCRIPTION
## Brief summary of changes

PHP 7.2 is no longer receiving active support as of Nov. 30th, 2019. PHP 7.4 is being released at about the same time.

Typically we only support the last two releases of PHP. This PR brings the minimum requirement up to 7.3 from 7.2.

Detailed changes between these versions can be found here: https://www.php.net/manual/en/migration73.php

I'm adding the Security label because this upgrade will enable all LORIS instances to be fully protected from CSRF attacks via the SameSite cookie.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5063 
