### PR TITLE
[Core] Escape shell argument in Instrument class

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -399,7 +399,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if (file_exists($scorer)) {
             $output = array();
             exec(
-                $scorer . " " . escapeshellarg($this->getCommentID()),
+                escapeshellarg($scorer) . " " . escapeshellarg(
+                    $this->getCommentID()
+                ),
                 $output,
                 $retVal
             );


### PR DESCRIPTION
## Brief summary of changes

This argument should be escaped as it may be possible for a front-end user to supply malicious data via the test name.