### PR TITLE
[Data release] Edge case where version 0 always shows up checked

### DIFF
--- a/modules/data_release/templates/menu_data_release.tpl
+++ b/modules/data_release/templates/menu_data_release.tpl
@@ -132,7 +132,7 @@
                                     {foreach from = $data_release_versions item=vv key=kk}
                                       {*the [] brackets appended to the `name` attributes below are necessary
                                       to submit all checked permissions as an array rather then overwrite pervious values*}
-                                      {if in_array($vv, $elem)}
+                                      {if in_array($vv, $elem, true)}
                                         <input type='checkbox' name='permissions_{$k}[]' value='{$vv}' checked>{$vv}</input>
                                       {else}
                                         <input type='checkbox' name='permissions_{$k}[]' value='{$vv}'>{$vv}</input>


### PR DESCRIPTION
## Brief summary of changes

Fixes https://github.com/aces/Loris/issues/5708

Issue: when the version of the file is set to `0` the `in_array()` call will always return true because of cross-type checking. this eliminates the cross-type checking by adding the strict argument