### PR TITLE
[publication] Broken link in Breadcrumbs fix

### DIFF
--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -101,6 +101,23 @@ class View_Project extends \NDB_Form
     }
 
     /**
+     * Generate a breadcrumb trail for this page.
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        $label = ucwords(str_replace('_', ' ', $this->name));
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb($label, "/$this->name"),
+            new \LORIS\Breadcrumb(
+                'View Project',
+                "/publication/view_project?id=" . $_GET['id']
+            )
+        );
+    }
+
+    /**
      * Include additional JS files:
      *  1. editForm.js - reactified form to update media
      *


### PR DESCRIPTION
## Brief summary of changes

Solve the broken breadcrumbs for View Project while consulting a project.

#### Testing instructions (if applicable)

1. View publications module.
2. consult a project.
3. click on the View Project for breadcrumbs.

#### Links to related tickets (GitHub, Redmine, ...)

* https://github.com/aces/Loris/issues/5749