### PR TITLE
[install.sh] Script fails when not run in `tools/` directory

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -9,6 +9,12 @@
 
 set -euo pipefail
 
+# Script must be run from tools directory.
+if [[ "$PWD" != *'/tools'* ]]; then
+    echo "Please run this script from the tools directory."
+    exit 2
+fi
+
 # Must be run interactively.
 if ! test -t 0 -a -t 1 -a -t 2 ; then
     echo "This installation program should be run interactively."

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 # Script must be run from tools directory.
-if [[ ${PWD:(-6)} != *'/tools'* ]]; then
+if [[ "$PWD" != *'/tools' ]]; then
     echo "Please run this script from the tools directory."
     exit 1
 fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 # Script must be run from tools directory.
 if [[ "$PWD" != *'/tools'* ]]; then
     echo "Please run this script from the tools directory."
-    exit 2
+    exit 1
 fi
 
 # Must be run interactively.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 # Script must be run from tools directory.
-if [[ "$PWD" != *'/tools'* ]]; then
+if [[ ${PWD:(-6)} != *'/tools'* ]]; then
     echo "Please run this script from the tools directory."
     exit 1
 fi


### PR DESCRIPTION
## Brief summary of changes

Make the script fail when ran outside of the tools directory.

#### Testing instructions (if applicable)

1. Attempt to run the install.sh from outside the tools directory.

#### Links to related tickets (GitHub, Redmine, ...)

* https://github.com/aces/Loris/issues/5643
