### PR TITLE
[feedback_mri_comments] Removed empty Overall drop down

### DIFF
--- a/smarty/templates/feedback_mri_popup.tpl
+++ b/smarty/templates/feedback_mri_popup.tpl
@@ -36,7 +36,7 @@
 
 {foreach from=$comment item=curr_comment}
 <h3>
-{if $curr_comment.select_name}
+{if $curr_comment.select_value_array}
 {* the assign is simply because i [jharlap] don't have time to figure out how to make this work otherwise *}
 {assign var="save_comment_status_field_name" value="saveCommentStatusField["|cat:$curr_comment.select_name|cat:"]"}
 {html_options name=$save_comment_status_field_name values=$curr_comment.select_value_array selected=$curr_comment.selected output=$curr_comment.select_value_array}

--- a/smarty/templates/feedback_mri_popup.tpl
+++ b/smarty/templates/feedback_mri_popup.tpl
@@ -36,7 +36,7 @@
 
 {foreach from=$comment item=curr_comment}
 <h3>
-{if $curr_comment.select_value_array}
+{if $curr_comment.select_value_array and $curr_comment.select_name}
 {* the assign is simply because i [jharlap] don't have time to figure out how to make this work otherwise *}
 {assign var="save_comment_status_field_name" value="saveCommentStatusField["|cat:$curr_comment.select_name|cat:"]"}
 {html_options name=$save_comment_status_field_name values=$curr_comment.select_value_array selected=$curr_comment.selected output=$curr_comment.select_value_array}


### PR DESCRIPTION
## Brief summary of changes

There should not be any drop down under the Overall MRI QC comments section like so:
![image](https://user-images.githubusercontent.com/1402456/69583379-c3ac6900-0fa8-11ea-92d9-059b073989bd.png)

On 22.0, there is an empty drop down for the overall section that should not be there:
![image](https://user-images.githubusercontent.com/1402456/69583419-daeb5680-0fa8-11ea-8120-f7dd7b7c3d7f.png)

This PR simply removes the empty drop down from the overall section of the MRI QC comments pop up page.

#### Testing instructions (if applicable)

1. Check that no drop down are displayed next to the Overall header in the MRI QC pop up
2. Check that the other drop downs are correctly populated and can be saved

#### Links to related tickets (GitHub, Redmine, ...)

* #5705