### PR TITLE
[User Accounts] Remove bad email validation in my preferences

### DIFF
--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -297,7 +297,6 @@ class My_Preferences extends \NDB_Form
 
         // email address rules
         $this->addRule('Email', 'Email address is required', 'required');
-        $this->addRule('Email', 'Your email address must be valid', 'email');
         $this->addRule(
             'Email',
             'Your email address must be less than 255 characters long',


### PR DESCRIPTION
## Brief summary of changes

There was some validation added in My Preferences that differed to Edit User. Both modules now use PHP's filter_var() function to check emails (not visible in GitHub diff).

#### Testing instructions (if applicable)

1. On 22.0-release, go to My Preferences and try changing your email to `nicolasbrossard.mni(test)@gmail.com`. You won't be able to.
2. On my branch, do the same. The email should work.
3. Try changing your email to an invalid value. Ensure that validation on emails still occurs.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5771 
