### PR TITLE
[Utility] Deprecate getAssociativeSiteList()

### DIFF
--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -198,7 +198,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $centerid = array_search(
             $data['Candidate']['Site'],
-            \Utility::getAssociativeSiteList()
+            \Utility::getSiteList()
         );
 
         $pscid = $data['Candidate']['PSCID'] ?? null;

--- a/modules/dashboard/ajax/get_recruitment_bar_data.php
+++ b/modules/dashboard/ajax/get_recruitment_bar_data.php
@@ -3,7 +3,7 @@
  * This file is used by the Dashboard to get the data for
  * the recruitment bar chart via AJAX
  *
- * PHP version 5
+ * PHP version 7
  *
  * @category Main
  * @package  Loris
@@ -17,7 +17,7 @@ ini_set('default_charset', 'utf-8');
 
 $DB            = Database::singleton();
 $sexData       = array();
-$list_of_sites = Utility::getAssociativeSiteList(true, false);
+$list_of_sites = Utility::getSiteList(true, false);
 
 foreach ($list_of_sites as $siteID => $siteName) {
     $sexData['labels'][] = $siteName;

--- a/modules/dashboard/ajax/get_recruitment_line_data.php
+++ b/modules/dashboard/ajax/get_recruitment_line_data.php
@@ -30,7 +30,7 @@ $recruitmentEndDate   = $DB->pselectOne(
 $recruitmentData['labels']
     = createChartLabels($recruitmentStartDate, $recruitmentEndDate);
 
-$list_of_sites = Utility::getAssociativeSiteList(true, false);
+$list_of_sites = Utility::getSiteList(true, false);
 
 foreach ($list_of_sites as $siteID => $siteName) {
     $recruitmentData['datasets'][] = array(

--- a/modules/dashboard/ajax/get_recruitment_pie_data.php
+++ b/modules/dashboard/ajax/get_recruitment_pie_data.php
@@ -17,7 +17,7 @@ ini_set('default_charset', 'utf-8');
 $DB = Database::singleton();
 
 $recruitmentBySiteData = array();
-$list_of_sites         = Utility::getAssociativeSiteList(true, false);
+$list_of_sites         = Utility::getSiteList(true, false);
 
 foreach ($list_of_sites as $siteID => $siteName) {
 

--- a/modules/dashboard/ajax/get_scan_line_data.php
+++ b/modules/dashboard/ajax/get_scan_line_data.php
@@ -42,7 +42,7 @@ $scanEndDate        = $DB->pselectOne(
 );
 $scanData['labels']
     = createLineChartLabels($scanStartDate, $scanEndDate);
-$list_of_sites      = Utility::getAssociativeSiteList(true, false);
+$list_of_sites      = Utility::getSiteList(true, false);
 foreach ($list_of_sites as $siteID => $siteName) {
     $scanData['datasets'][] = array(
         "name" => $siteName,

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -564,7 +564,7 @@ function getIssueFields()
     //get field options
     if ($user->hasPermission('access_all_profiles')) {
         // get the list of study sites - to be replaced by the Site object
-        $sites = Utility::getAssociativeSiteList();
+        $sites = Utility::getSiteList();
     } else {
         // allow only to view own site data
         $sites = $user->getStudySites();

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -163,6 +163,8 @@ class Utility
      *         Note that even though CenterID is numeric, the array
      *         should be interpreted as an associative array since the keys
      *         refer to the centerID, not the array index.
+     *
+     * @deprecated
      */
     static function getAssociativeSiteList(
         bool $study_site = true,

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -119,47 +119,13 @@ class Utility
     /**
      * Returns a list of sites in the database
      *
-     * @param bool $study_site If true only return sites that are
-     *                         study sites according to the psc
-     *                         table
-     *
-     * @return array an associative array("center ID" => "site name")
-     */
-    static function getSiteList(bool $study_site = true): array
-    {
-        $factory = NDB_Factory::singleton();
-        $DB      = $factory->database();
-
-        // get the list of study sites - to be replaced by the Site object
-        $query = "SELECT CenterID, Name FROM psc ";
-        if ($study_site) {
-            $query .= "WHERE Study_site='Y'";
-        }
-        $result = $DB->pselect($query, array());
-
-        // fix the array
-        $list = array();
-        foreach ($result as $row) {
-            $list[$row["CenterID"]] = $row["Name"];
-        }
-        natcasesort($list);
-        return $list;
-    }
-
-
-    /**
-     * Get the list of sites as an associative array
-     *
      * @param boolean $study_site if true only return study sites from psc
      *                            table
      * @param boolean $DCC        Whether the DCC should be included or not
      *
-     * @return array of the form CenterID => Site Name.
-     *         Note that even though CenterID is numeric, the array
-     *         should be interpreted as an associative array since the keys
-     *         refer to the centerID, not the array index.
+     * @return array an associative array("center ID" => "site name")
      */
-    static function getAssociativeSiteList(
+    static function getSiteList(
         bool $study_site = true,
         bool $DCC = true
     ): array {
@@ -183,6 +149,29 @@ class Utility
             $list[$row["CenterID"]] = $row["Name"];
         }
         return $list;
+    }
+
+
+    /**
+     * Get the list of sites as an associative array
+     *
+     * @param boolean $study_site if true only return study sites from psc
+     *                            table
+     * @param boolean $DCC        Whether the DCC should be included or not
+     *
+     * @return array of the form CenterID => Site Name.
+     *         Note that even though CenterID is numeric, the array
+     *         should be interpreted as an associative array since the keys
+     *         refer to the centerID, not the array index.
+     */
+    static function getAssociativeSiteList(
+        bool $study_site = true,
+        bool $DCC = true
+    ): array {
+        throw new \DeprecationException(
+            ' This function is deprecated. Please use \Utility::getSiteList()'
+            . ' instead.'
+        );
     }
 
     /**

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -168,7 +168,7 @@ class Utility
         bool $study_site = true,
         bool $DCC = true
     ): array {
-        throw new \DeprecationException(
+        throw new \DeprecatedException(
             ' This function is deprecated. Please use \Utility::getSiteList()'
             . ' instead.'
         );

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -403,10 +403,9 @@ class UtilityTest extends TestCase
      * TODO Potential edge cases: test with the study_site and DCC booleans as false
      *
      * @covers Utility::getSiteList()
-     * @covers Utility::getAssociativeSiteList
      * @return void
      */
-    public function testGetSiteListAndGetAssociativeSiteList()
+    public function testGetSiteList()
     {       
         $this->_dbMock->expects($this->any())
             ->method('pselect')
@@ -418,13 +417,6 @@ class UtilityTest extends TestCase
                 '1' => 'site1',
                 '2' => 'site2'),
             Utility::getSiteList()
-        );
-        
-        $this->assertEquals(
-            array(
-                '1' => 'site1',
-                '2' => 'site2'),
-            Utility::getAssociativeSiteList()
         );
     }
 


### PR DESCRIPTION
## Brief summary of changes

* Replaces contents of `getSiteList()` with `getAssociativeSiteList()` because that code optionally allows for the exclusion of DCC data.

* Changes `getAssociativeSiteList()` to `getSiteList()` in the codebase.

* `getAssociativeSiteList()` now throws a DeprecationException for any projects that may be using it.
