### PR TITLE
[Instrument Manager] Require 'superuser' permission for instrument upload

### DIFF
--- a/modules/instrument_manager/README.md
+++ b/modules/instrument_manager/README.md
@@ -37,7 +37,7 @@ following permissions:
 * `instrument_manager_read`
 * `instrument_manager_write`
 
-The write permission allows a user to upload new LORIS instrument. 
+Currently, only users with the `superuser` permission can install instruments.
 
 ## Configurations
 
@@ -51,6 +51,3 @@ patch respectively.)
 In order to automatically source the SQL patch and fully configure
 LINST instruments, the LORIS `quatUser` and `quatPassword` configuration
 must be set to a user which has the MySQL `CREATE TABLE` permission.
-(The name `quatUser` and `quatPassword` is an anachronism and should
-be renamed.)
-

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -79,8 +79,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     {
         return $user->hasAnyPermission(
             array(
-                'instrument_manager_read',
-                'instrument_manager_write',
+                'instrument_manager_read'
             )
         );
     }
@@ -116,7 +115,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     protected function handlePOST(ServerRequestInterface $request): ResponseInterface
     {
         // Ensure the user is allowed to upload.
-        if (! \User::singleton()->hasPermission('instrument_manager_write')) {
+        if (! \User::singleton()->hasPermission('superuser')) {
             return (new \LORIS\Http\Response())
                 ->withStatus(403, 'Forbidden')
                 ->withBody(

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -29,6 +29,11 @@ use \LORIS\Http\EmptyStream;
  */
 class Instrument_Manager extends \NDB_Menu_Filter
 {
+    const PERMISSIONS = array(
+        'instrument_manager_read',
+        'instrument_manager_write'
+    );
+    // Error messages
     const ALREADY_INSTALLED     = 'This instrument already exists in the ' .
                                   'test battery.';
     const CANNOT_WRITE_FILES    = 'Automatic installation of instruments is ' .
@@ -77,11 +82,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasAnyPermission(
-            array(
-                'instrument_manager_read'
-            )
-        );
+        return $user->hasAnyPermission(self::PERMISSIONS);
     }
 
     /**

--- a/modules/instrument_manager/test/TestPlan.md
+++ b/modules/instrument_manager/test/TestPlan.md
@@ -6,7 +6,7 @@
    [Automation Testing]
 3. Check that the warning text is accurate if the `project/instruments` or `project/tables_sql` directories are not writable by Apache. The select file/upload panel should only be there if it's writable.
    [Manual Testing]
-4. Take the sample .linst instrument file `test_all_fields.linst` in `docs/instruments` and upload it in Instrument Manager.
+4. Take the sample .linst instrument file `test_all_fields.linst` in `docs/instruments` and upload it in Instrument Manager. This must be done be a user with the `superuser` permission.
 Check that instrument gets installed properly. (New files should exist in `project/instruments/` & `project/tables_sql/`.) 
 Also check the paths in the code - eg uploaded instruments in the instruments directory with right permissions.
    [Manual Testing]

--- a/modules/instrument_manager/test/instrument_managerTest.php
+++ b/modules/instrument_manager/test/instrument_managerTest.php
@@ -2,7 +2,7 @@
 /**
  * Instrument_manager automated integration tests
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Test
  * @package  Loris
@@ -16,7 +16,7 @@ require_once __DIR__ .
 /**
  * Instrument_manager automated integration tests
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Test
  * @package  Loris


### PR DESCRIPTION
## Brief summary of changes

This feature should be restricted to superusers, as discussed in the LORIS meeting.

I did not remove the `instrument_manager_write` permission from the codebase as we may want to use it in the future when JSON instruments are ready.

Background: #5778
