### PR TITLE
[document_repository] Fix clicking on the 'Edit' Breadcrumb

### DIFF
--- a/modules/document_repository/php/edit.class.inc
+++ b/modules/document_repository/php/edit.class.inc
@@ -34,6 +34,24 @@ class Edit extends \NDB_Page
     {
         return $user->hasPermission('document_repository_view');
     }
+
+    /**
+     * Generate a breadcrumb trail for this page.
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        $label = ucwords(str_replace('_', ' ', $this->name));
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb($label, "/$this->name"),
+            new \LORIS\Breadcrumb(
+                'Edit',
+                "/" . $_GET['lorispath']
+            )
+        );
+    }
+
     /**
      * Include additional JS files:
      *  1. editForm.js - reactified form to update repository


### PR DESCRIPTION
## Brief summary of changes

Clicking on the 'Edit' breadcrumb in document repository used to give an error.

#### Testing instructions (if applicable)

1. Checkout PR
2. Visit Document Repository
3. Edit a file.
3. Click on BreadCrumb Edit

#### Links to related tickets (GitHub, Redmine, ...)

* https://github.com/aces/Loris/issues/5787
