### PR TITLE
Add tool to remove condescending language from LORIS documentation

### DIFF
--- a/.alexignore
+++ b/.alexignore
@@ -1,0 +1,4 @@
+docs/deprecated_wiki/
+docs/wiki/_DELETED
+docs/wiki/_ARCHIVE
+docs/API/LorisRESTAPI_v0.0.3.md

--- a/.alexrc.yml
+++ b/.alexrc.yml
@@ -1,0 +1,3 @@
+allow:
+    - invalid
+    - special

--- a/.alexrc.yml
+++ b/.alexrc.yml
@@ -1,3 +1,4 @@
 allow:
     - invalid
     - special
+    - executed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ using the command `make checkstatic` and fix any resulting errors. Otherwise,
 would affect the data or custom code of a study - document this in your pull 
 request description and tag it with **Caveat for Existing Projects**. 
 This helps us to document our release notes.
-* In addition to the above guidelines, we use [Alex JS](https://github.com/get-alex/alex) 
-to help us create documentation that is friendly and accessible.
+* You can run the command `make checklanguage` to ensure that documentation
+you've contributed contains language that is friendly and accessible.
 
 If you're unsure about any of the above, feel free to ask us for
 clarification via the mailing list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ using the command `make checkstatic` and fix any resulting errors. Otherwise,
 would affect the data or custom code of a study - document this in your pull 
 request description and tag it with **Caveat for Existing Projects**. 
 This helps us to document our release notes.
+* In addition to the above guidelines, we use [Alex JS](https://github.com/get-alex/alex) 
+to help us create documentation that is friendly and accessible.
 
 If you're unsure about any of the above, feel free to ask us for
 clarification via the mailing list.

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,17 @@ clean:
 	rm -rf vendor
 
 # Perform static analysis checks
+#
+# The 'alex' tool scans documentation for condescending language.
+# Arguments:
+#     --quiet Shows only warnings and errors
+#     --why   Explains why something is problematic
+#     --diff  On Travis, only scans files changed
 checkstatic: phpdev
 	npm run lint:php
 	npm run lint:javascript
 	vendor/bin/phan
-	npx alex
+	npx alex --quiet --why --diff
 
 unittests: phpdev
 	vendor/bin/phpunit --configuration test/phpunit.xml

--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,17 @@ clean:
 	rm -rf vendor
 
 # Perform static analysis checks
-#
+checkstatic: phpdev
+	npm run lint:php
+	npm run lint:javascript
+	vendor/bin/phan
+
 # The 'alex' tool scans documentation for condescending language.
 # Arguments:
 #     --quiet Shows only warnings and errors
 #     --why   Explains why something is problematic
 #     --diff  On Travis, only scans files changed
-checkstatic: phpdev
-	npm run lint:php
-	npm run lint:javascript
-	vendor/bin/phan
+make checklanguage:
 	npx alex --quiet --why --diff
 
 unittests: phpdev

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ checkstatic: phpdev
 	npm run lint:php
 	npm run lint:javascript
 	vendor/bin/phan
+	npx alex
 
 unittests: phpdev
 	vendor/bin/phpunit --configuration test/phpunit.xml

--- a/README.Mac.md
+++ b/README.Mac.md
@@ -193,7 +193,7 @@ b. Create the file `ext-xdebug.ini` with this command:
 sudo touch /usr/local/etc/php/<your_php_version>/conf.d/ext-xdebug.ini
 ```
 
-c. Type the following into the `ext-xdebug.ini` file you just created (Note: replace the `zend_extension` path with the correct one on your machine):
+c. Type the following into the `ext-xdebug.ini` file you created (Note: replace the `zend_extension` path with the correct one on your machine):
 ```
 [xdebug]
 zend_extension="/usr/local/Cellar/php@7.2/7.2.14/pecl/20170718/xdebug.so"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 # LORIS Neuroimaging Platform
 
+<!--alex ignore easy-->
 LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web application that provides data- and project-management for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
 * Try the LORIS demo instance at https://demo.loris.ca.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 # LORIS Neuroimaging Platform
 
-<!--alex ignore easy-->
 LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web application that provides data- and project-management for neuroimaging research. LORIS makes it easy to manage large datasets including behavioural, clinical, neuroimaging and genetic data acquired over time or at different sites.
 
 * Try the LORIS demo instance at https://demo.loris.ca.

--- a/docs/API/InstrumentFormat.md
+++ b/docs/API/InstrumentFormat.md
@@ -167,7 +167,7 @@ as follows. It denotes a group of values of which the user must select one optio
                        to allow the user to explicitly not answer a question
                        but require that some answer is entered.
                        If false, it should not.
-                       This is done instead of simply adding the option to
+                       This is done instead of adding the option to
                        Values to ensure consistency with other PageElement types
                        such as date or text.
                        Default: true.

--- a/docs/API/LorisRESTAPI.md
+++ b/docs/API/LorisRESTAPI.md
@@ -33,8 +33,8 @@ DELETE is not supported on any resource defined in this API.
 # 1.1 Authentication
 
 If a user is logged in to Loris and can be authenticated using the standard session mechanism,
-no further authentication is required. Requests will be evaluated as requests from that user,
-so that standard Loris modules can simply use the API.
+no further authentication is required. Requests will be evaluated as requests from that user
+so that standard Loris modules are able to use the API.
 
 If a user is not logged in to Loris (for instance, in a third party app or a CORS application),
 they can be authenticated using [JSON Web Tokens](https://jwt.io).

--- a/docs/HelpStyleGuide.md
+++ b/docs/HelpStyleGuide.md
@@ -66,3 +66,6 @@ This means using more direct language and tone to get information across to the 
 * Break up large blocks of text. It's more visually pleasing and less intimidating.
 
 For more information, including research studies conducted, on the use and value of Plain Language, please see [this article](https://www.nngroup.com/articles/plain-language-experts/) and feel free to browse the rest of this website for further helpful details, tips, and tricks. 
+
+In addition to the above guidelines, we use [Alex JS](https://github.com/get-alex/alex)$
+to help us create documentation that is friendly and accessible.

--- a/docs/SQLModelingStandard.md
+++ b/docs/SQLModelingStandard.md
@@ -26,7 +26,7 @@ infrastructure will be re-designed to follow this guideline.*
   of the words in the name should reveal the concern of the table in a 
   broad-to-specific manner. 
   - *i.e. A table containing the consent information of a candidate would be 
-    named `candidate_consent`, candidate being the broader concern and just 
+    named `candidate_consent`, candidate being the broader concern and 
     `consent` is not sufficiently  informative to rule out user consents and 
     examiner consents. A table containing the consent types would be called 
     as such `consent_type`.*
@@ -76,7 +76,7 @@ infrastructure will be re-designed to follow this guideline.*
   be named like in `OriginCountryID` and `DestinationCountryID`.*
 - Both **primary key and foreign key** fields should end with **`ID`**
   in upper case.  
-- **Date** fields should not just be named “Date”. A
+- **Date** fields should not be named “Date”. A
   **qualifier** like “BoughtDate” or “DateAccepted” should be added as
   required.  
 - **No ENUM attributes** should be used in the default LORIS schema

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint-plugin-react": "^7.16.0",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.41.2",
-    "webpack-cli": "^3.3.0"
+    "webpack-cli": "^3.3.0",
+    "alex": ">=8.0.1"
   },
   "scripts": {
     "lint:javascript": "./test/run-js-linter.sh",


### PR DESCRIPTION
## Brief summary of changes

[How to remove condescending language from documentation](https://dev.to/meeshkan/how-to-remove-condescending-language-from-documentation-4a5p)

This post outlines why condescending documentation is a bad idea and recommends the `alex` tool to fix it.

This tool should be helpful as we go forward in creating our documentation on ReadTheDocs.

This PR:

* Adds the `alex` tool to devDependencies
* Creates configuration files for this tool
* Fixes detected occurrences
* Adds `alex` to our CI pipeline to prevent future issues.
