### PR TITLE
Candidate parametrers fail to load

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -16,11 +16,11 @@ use \LORIS\StudyEntities\Candidate\CandID;
 
 $user = \NDB_Factory::singleton()->user();
 if (!$user->hasAnyPermission(
-      array(
+    array(
         'candidate_parameter_edit',
-        'candidate_parameter_view' 
-      )
+        'candidate_parameter_view'
     )
+)
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -15,8 +15,11 @@
 use \LORIS\StudyEntities\Candidate\CandID;
 
 $user = \NDB_Factory::singleton()->user();
-if (!$user->hasPermission('candidate_parameter_edit')
-    && !$user->hasPermission('candidate_parameter_view')
+if (!$user->hasAnyPermission(
+      array(
+        'candidate_parameter_edit',
+        'candidate_parameter_view' 
+      )
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -20,6 +20,7 @@ if (!$user->hasAnyPermission(
         'candidate_parameter_edit',
         'candidate_parameter_view' 
       )
+    )
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -15,7 +15,9 @@
 use \LORIS\StudyEntities\Candidate\CandID;
 
 $user = \NDB_Factory::singleton()->user();
-if (!$user->hasPermission('candidate_parameter_edit')) {
+if (!$user->hasPermission('candidate_parameter_edit')
+    && !$user->hasPermission('candidate_parameter_view')
+) {
     header("HTTP/1.1 403 Forbidden");
     exit;
 }


### PR DESCRIPTION
## Brief summary of changes

When you only have the `candidate_parameter_view` permission, you can access the candidate parameter page but when it loads, an error page is shown with text: `An error occurred when loading the form`.


Fixes #5791 