### PR TITLE
Fixed bug that prevented any consent status from being saved.

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -13,6 +13,9 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
+use \LORIS\StudyEntities\Candidate\CandID;
+
+
 $user = \User::singleton();
 if (!$user->hasPermission('candidate_parameter_edit')) {
     header("HTTP/1.1 403 Forbidden");
@@ -396,7 +399,7 @@ function editConsentStatusFields($db, $user)
     // Get CandID
     $candIDParam = $_POST['candID'];
     $candID      = (isset($candIDParam) && $candIDParam !== 'null') ?
-        $candIDParam : null;
+        new CandID($candIDParam) : null;
 
     $candidate   = \Candidate::singleton($candID);
     $currentUser = \User::singleton();

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -398,9 +398,11 @@ function editConsentStatusFields($db, $user)
 {
     // Get CandID
     $candIDParam = $_POST['candID'];
-    $candID      = (isset($candIDParam) && $candIDParam !== 'null') ?
-        new CandID($candIDParam) : null;
-
+    if (!isset($candIDParam) || $candIDParam === 'null') {
+        http_response_code(404);
+        die(json_encode(["error" => "Appointment does not exist."]));
+    }
+    $candID      = new CandID($candIDParam);
     $candidate   = \Candidate::singleton($candID);
     $currentUser = \User::singleton();
     $uid         = $currentUser->getUsername();

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -399,8 +399,8 @@ function editConsentStatusFields($db, $user)
     // Get CandID
     $candIDParam = $_POST['candID'];
     if (!isset($candIDParam) || $candIDParam === 'null') {
-        http_response_code(404);
-        die(json_encode(["error" => "Appointment does not exist."]));
+        http_response_code(400);
+        die(json_encode(["error" => "You must supply a CandID."]));
     }
     $candID      = new CandID($candIDParam);
     $candidate   = \Candidate::singleton($candID);


### PR DESCRIPTION
## Brief summary of changes

When accessing the candidate parameter page, there was a bug preventing you from saving any consent change you perform. This PR fixes that.

#### Links to related tickets (GitHub, Redmine, ...)

#5801 
