### PR TITLE
[Candidate List] Fixed bug: Subproject column not displayed if value was null

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -125,7 +125,7 @@ class CandidateListIndex extends Component {
 
     if (column === 'Subproject') {
       // If user has multiple subprojects, join array into string
-      let result = (cell) ? <td>{cell.join(', ')}</td> : null;
+      let result = (cell) ? <td>{cell.join(', ')}</td> : <td></td>;
       return result;
     }
 


### PR DESCRIPTION
## Brief summary of changes
In the `formatColumn` function in Candidate List JSX Index file, if the subproject is `null` it now returns `<td></td>` instead of `null`. This is because if `null` is returned, the table data cell does not appear, and all the other rows of the table get shifted to the left.

## Resolves the following Issue
#5799 