### PR TITLE
[login] TRIM inputs before inserting into users or examiners

### DIFF
--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -143,9 +143,9 @@ class RequestAccount extends \NDB_Form
     function _process($values)
     {
         $DB       = \Database::singleton();
-        $name     = htmlspecialchars($_REQUEST["firstname"], ENT_QUOTES);
-        $lastname = htmlspecialchars($_REQUEST["lastname"], ENT_QUOTES);
-        $from     = htmlspecialchars($_REQUEST["from"], ENT_QUOTES);
+        $name     = trim(htmlspecialchars($_REQUEST["firstname"], ENT_QUOTES));
+        $lastname = trim(htmlspecialchars($_REQUEST["lastname"], ENT_QUOTES));
+        $from     = trim(htmlspecialchars($_REQUEST["from"], ENT_QUOTES));
         $site     = $_REQUEST["site"];
         $fullname = $name." ".$lastname;
 


### PR DESCRIPTION
## Brief summary of changes
another issue on 21

user_accounts and examiner modules trim inputs before submission. request account does not do any trimming so entries like first/last name and emails get submitted with empty spaces around them.

This is particularly problematic for examiners where an examiner created with the incorrect `Real_name` value will cause a duplication of the examiner the first time the form is saved on user accounts because the name then gets trimmed and restored in it's correct format in the examiner table

result -> 500 error due to pselectrow returning more than one row