### PR TITLE
[data_release/document_repository] Make upload directory configurable

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -75,8 +75,8 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_uploads', 'Path to uploaded publications', 1, 0, 'web_path', ID, 'Publications', 10 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_deletions', 'Path to deleted publications', 1, 0, 'web_path', ID, 'Deleted Publications', 11 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'web_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'documentRepositoryPath', 'Path to uploaded document repository files', 1, 0, 'text', ID, 'Document Repository Upload Path', 13 FROM ConfigSettings WHERE Name="paths";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dataReleasePath', 'Path to uploaded data release files', 1, 0, 'text', ID, 'Data release Upload Path', 14 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'documentRepositoryPath', 'Path to uploaded document repository files', 1, 0, 'web_path', ID, 'Document Repository Upload Path', 13 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dataReleasePath', 'Path to uploaded data release files', 1, 0, 'web_path', ID, 'Data release Upload Path', 14 FROM ConfigSettings WHERE Name="paths";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
@@ -192,8 +192,6 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSett
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/" FROM ConfigSettings WHERE Name="publication_uploads";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/to_be_deleted/" FROM ConfigSettings WHERE Name="publication_deletions";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="MINCToolsPath";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/document_repository_uploads/" FROM ConfigSettings WHERE Name="documentRepositoryPath";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/data_release_uploads/" FROM ConfigSettings WHERE Name="dataReleasePath";
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -75,6 +75,8 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_uploads', 'Path to uploaded publications', 1, 0, 'web_path', ID, 'Publications', 10 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'publication_deletions', 'Path to deleted publications', 1, 0, 'web_path', ID, 'Deleted Publications', 11 FROM ConfigSettings WHERE Name="paths";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'MINCToolsPath', 'Path to the MINC tools', 1, 0, 'web_path', ID, 'Path to the MINC tools', 12 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'documentRepositoryPath', 'Path to uploaded document repository files', 1, 0, 'text', ID, 'Document Repository Upload Path', 13 FROM ConfigSettings WHERE Name="paths";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dataReleasePath', 'Path to uploaded data release files', 1, 0, 'text', ID, 'Data release Upload Path', 14 FROM ConfigSettings WHERE Name="paths";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('gui', 'Settings related to the overall display of LORIS', 1, 0, 'GUI', 3);
@@ -190,6 +192,8 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/uploads/" FROM ConfigSett
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/" FROM ConfigSettings WHERE Name="publication_uploads";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/publication_uploads/to_be_deleted/" FROM ConfigSettings WHERE Name="publication_deletions";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSettings WHERE Name="MINCToolsPath";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/document_repository_uploads/" FROM ConfigSettings WHERE Name="documentRepositoryPath";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/data_release_uploads/" FROM ConfigSettings WHERE Name="dataReleasePath";
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";

--- a/SQL/New_patches/2019-11-29-Add_upload_directory_configuration.sql
+++ b/SQL/New_patches/2019-11-29-Add_upload_directory_configuration.sql
@@ -1,0 +1,9 @@
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'documentRepositoryPath', 'Path to uploaded document repository files', 1, 0, 'text', cs1.ID, 'Document Repository Upload Path', MAX(cs2.OrderNumber)+1 FROM ConfigSettings cs1 JOIN ConfigSettings cs2 WHERE cs1.Name="paths" AND cs2.parent=cs1.ID;
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dataReleasePath', 'Path to uploaded data release files', 1, 0, 'text', cs1.ID, 'Data Release Upload Path', MAX(cs2.OrderNumber)+1 FROM ConfigSettings cs1 JOIN ConfigSettings cs2 WHERE cs1.Name="paths" AND cs2.parent=cs1.ID;
+
+-- For backwards compatibility, check the previous base and default to same folder as previous setting
+SELECT Value INTO @base FROM Config c JOIN ConfigSettings cs ON cs.ID=c.ConfigID WHERE cs.Name="base";
+
+INSERT INTO Config (ConfigID, Value) SELECT ID, CONCAT(@base,"modules/document_repository/user_uploads/") FROM ConfigSettings WHERE Name="documentRepositoryPath";
+INSERT INTO Config (ConfigID, Value) SELECT ID, CONCAT(@base,"modules/data_release/user_uploads/") FROM ConfigSettings WHERE Name="dataReleasePath";
+

--- a/modules/data_release/README.md
+++ b/modules/data_release/README.md
@@ -44,15 +44,8 @@ Note: At the moment, the only way to remove a user's permission to a specific
 
 ## Configurations
 
-- Data release uploads are stored under the
-  `modules/data_release/user_uploads directory`, which can easily be symlinked
-  to another location if necessary. Note that this directory needs to be
-  writable by your web server.
+- `dataReleasePath` designates the target location for release file uploads.
 
 ## Other notes:
 
-- Uploads are stored under the `modules/data_release/user_uploads` directory which 
-can easily be symlinked to another location if necessary, ensure that it can be written 
-to by your web server.
-- Remove permissions by deleting rows in the data_release_permissions table.
 - Upload date will automatically be added during file upload.

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -37,7 +37,7 @@ if ($_POST['action'] == 'upload'
         header("HTTP/1.1 500 Internal Server Error");
     } elseif (!is_writable($path)) {
         error_log(
-            "File upload failed. Default upload directory"
+            "File upload failed. Upload directory"
             . " does not appear to be writeable."
         );
         header("HTTP/1.1 500 Internal Server Error");
@@ -83,4 +83,3 @@ if ($_POST['action'] == 'upload'
     header("HTTP/1.1 400 Bad Request");
     echo "There was an error uploading the file";
 }
-

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -27,7 +27,7 @@ if ($_POST['action'] == 'upload'
     $settings = $factory->settings();
 
     $baseURL = $settings->getBaseURL();
-    $path    = $config->getSetting('dataReleasePath');
+    $path    = \Utility::appendForwardSlash($config->getSetting('dataReleasePath'));
 
     if (!file_exists($path)) {
         error_log(

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -14,7 +14,7 @@
 
 $DB     = \Database::singleton();
 $user   = \User::singleton();
-$config =\ NDB_Factory::singleton()->config();
+$config = \NDB_Factory::singleton()->config();
 
 if ($_POST['action'] == 'upload'
     && $user->hasPermission("data_release_upload")

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -12,8 +12,9 @@
  * @link     https://github.com/aces/Loris
  */
 
-$DB   = \Database::singleton();
-$user = \User::singleton();
+$DB     = \Database::singleton();
+$user   = \User::singleton();
+$config =\ NDB_Factory::singleton()->config();
 
 if ($_POST['action'] == 'upload'
     && $user->hasPermission("data_release_upload")
@@ -21,27 +22,27 @@ if ($_POST['action'] == 'upload'
     $fileName    = $_FILES["file"]["name"];
     $version     = $_POST['version'];
     $upload_date = date('Y-m-d');
-    $base_path   = __DIR__ . "/../user_uploads/";
 
     $factory  = NDB_Factory::singleton();
     $settings = $factory->settings();
 
     $baseURL = $settings->getBaseURL();
+    $path    = $config->getSetting('dataReleasePath');
 
-    if (!file_exists(__DIR__ . "/../user_uploads/")) {
+    if (!file_exists($path)) {
         error_log(
-            "ERROR: File upload failed. Default user_uploads"
+            "ERROR: File upload failed. Default upload"
             . " directory not found."
         );
         header("HTTP/1.1 500 Internal Server Error");
-    } elseif (!is_writable(__DIR__ . "/../user_uploads/")) {
+    } elseif (!is_writable($path)) {
         error_log(
-            "File upload failed. Default user_uploads directory"
+            "File upload failed. Default upload directory"
             . " does not appear to be writeable."
         );
         header("HTTP/1.1 500 Internal Server Error");
     } else {
-        $target_path = $base_path . $fileName;
+        $target_path = $path . $fileName;
         if (move_uploaded_file($_FILES["file"]["tmp_name"], $target_path)) {
             $DB->insert(
                 'data_release',

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -31,7 +31,7 @@ if ($_POST['action'] == 'upload'
 
     if (!file_exists($path)) {
         error_log(
-            "ERROR: File upload failed. Default upload"
+            "ERROR: File upload failed. Upload"
             . " directory not found."
         );
         header("HTTP/1.1 500 Internal Server Error");
@@ -83,5 +83,4 @@ if ($_POST['action'] == 'upload'
     header("HTTP/1.1 400 Bad Request");
     echo "There was an error uploading the file";
 }
-
 

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -12,9 +12,10 @@
  * @link     https://github.com/aces/Loris
  */
 
-$DB     = \Database::singleton();
-$user   = \User::singleton();
-$config = \NDB_Factory::singleton()->config();
+$factory = \NDB_Factory::singleton();
+$DB      = $factory->database();
+$user    = $factory->user();
+$config  = $factory->config();
 
 if ($_POST['action'] == 'upload'
     && $user->hasPermission("data_release_upload")
@@ -23,7 +24,6 @@ if ($_POST['action'] == 'upload'
     $version     = $_POST['version'];
     $upload_date = date('Y-m-d');
 
-    $factory  = NDB_Factory::singleton();
     $settings = $factory->settings();
 
     $baseURL = $settings->getBaseURL();

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -12,8 +12,11 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user   =& User::singleton();
-$config = \NDB_Factory::singleton()->config();
+
+$factory  = \NDB_Factory::singleton();
+$db     = $factory->database();
+$user   = $factory->user();
+$config = $factory->config();
 $path   = $config->getSetting('dataReleasePath');
 
 $File = $_GET['File'];
@@ -31,7 +34,6 @@ if (!file_exists($FullPath)) {
     header("HTTP/1.1 404 Not Found");
     exit(5);
 }
-$db         = \Database::singleton();
 $fileID     = $db->pselectOne(
     "SELECT ID FROM data_release WHERE "
     . "file_name=:fn",

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -12,7 +12,9 @@
  * @link     https://github.com/aces/Loris
  */
 
-$user =& User::singleton();
+$user   =& User::singleton();
+$config = \NDB_Factory::singleton()->config();
+$path   = $config->getSetting('dataReleasePath');
 
 $File = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by
@@ -23,13 +25,13 @@ if (strpos($File, "..") !== false) {
     header("HTTP/1.1 400 Bad Request");
     exit(4);
 }
-$FullPath = __DIR__ . "/../user_uploads/$File";
+$FullPath = $path . $File;
 if (!file_exists($FullPath)) {
     error_log("ERROR: File $FullPath does not exist");
     header("HTTP/1.1 404 Not Found");
     exit(5);
 }
-$db         =& Database::singleton();
+$db         = \Database::singleton();
 $fileID     = $db->pselectOne(
     "SELECT ID FROM data_release WHERE "
     . "file_name=:fn",

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -13,11 +13,11 @@
  */
 
 
-$factory  = \NDB_Factory::singleton();
-$db     = $factory->database();
-$user   = $factory->user();
-$config = $factory->config();
-$path   = $config->getSetting('dataReleasePath');
+$factory = \NDB_Factory::singleton();
+$db      = $factory->database();
+$user    = $factory->user();
+$config  = $factory->config();
+$path    = $config->getSetting('dataReleasePath');
 
 $File = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -17,7 +17,7 @@ $factory = \NDB_Factory::singleton();
 $db      = $factory->database();
 $user    = $factory->user();
 $config  = $factory->config();
-$path    = $config->getSetting('dataReleasePath');
+$path    = \Utility::appendForwardSlash($config->getSetting('dataReleasePath'));
 
 $File = $_GET['File'];
 // Make sure that the user isn't trying to break out of the $path by

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -173,16 +173,16 @@ class Files extends \NDB_Page
      */
     function deleteFile($rid): void
     {
-        $config = \NDB_Factory::singleton()->config();
-        $path   = $config->getSetting("documentRepositoryPath");
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+        $user    = $factory->user();
+        $config  = $factory->config();
+        $path    = $config->getSetting("documentRepositoryPath");
         // create Database object
-        $DB       = \Database::singleton();
-        $user     = \User::singleton();
         $Notifier = new \NDB_Notifier(
             "document_repository",
             "delete"
         );
-        $factory  = \NDB_Factory::singleton();
         $baseURL  = $factory->settings()->getBaseURL();
         $fileName = $DB->pselectOne(
             "SELECT File_name FROM document_repository

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -67,7 +67,7 @@ class Files extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $config =\ NDB_Factory::singleton()->config();
+        $config = \NDB_Factory::singleton()->config();
         $path   = $config->getSetting("documentRepositoryPath");
         switch ($request->getMethod()) {
         case "POST":
@@ -173,7 +173,7 @@ class Files extends \NDB_Page
      */
     function deleteFile($rid): void
     {
-        $config =\ NDB_Factory::singleton()->config();
+        $config = \NDB_Factory::singleton()->config();
         $path   = $config->getSetting("documentRepositoryPath");
         // create Database object
         $DB       = \Database::singleton();

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -67,6 +67,8 @@ class Files extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
+        $config =\ NDB_Factory::singleton()->config();
+        $path   = $config->getSetting("documentRepositoryPath");
         switch ($request->getMethod()) {
         case "POST":
             if ($this->uploadDocFile($request)) {
@@ -107,7 +109,7 @@ class Files extends \NDB_Page
             $name   = \User::singleton()->getUsername();
             $record = urldecode(basename($request->getUri()->getPath()));
             if (!is_numeric($record)) {
-                $file = __DIR__ . "/../user_uploads/$name/$record";
+                $file = $path. "$name/$record";
                 return (new \LORIS\Http\Response())
                     ->withHeader('Content-Type', 'application/octet-stream')
                     ->withHeader(
@@ -171,6 +173,8 @@ class Files extends \NDB_Page
      */
     function deleteFile($rid): void
     {
+        $config =\ NDB_Factory::singleton()->config();
+        $path   = $config->getSetting("documentRepositoryPath");
         // create Database object
         $DB       = \Database::singleton();
         $user     = \User::singleton();
@@ -205,7 +209,7 @@ class Files extends \NDB_Page
             $Notifier->notify($msg_data);
         }
 
-        $path = __DIR__ . "/../user_uploads/$dataDir";
+        $path = $path.$dataDir;
 
         if (file_exists($path)) {
             unlink($path);
@@ -349,6 +353,7 @@ class Files extends \NDB_Page
         $baseURL        = $factory->settings()->getBaseURL();
         $config         = $factory->config();
         $base           = $config->getSetting('base');
+        $path           = $config->getSetting("documentRepositoryPath");
         $name           = \User::singleton()->getUsername();
         $DB       = \Database::singleton();
         $category = $req['category']; // required
@@ -368,7 +373,7 @@ class Files extends \NDB_Page
         $fileSize     = $uploadedFile->getSize();
         $fileName     = $uploadedFile->getClientFileName();
         $fileType     = pathinfo($fileName, PATHINFO_EXTENSION);
-        $uploadPath   = "$base/modules/document_repository/user_uploads/$name/";
+        $uploadPath   = $path.$name."/";
         // $category is a string representation of an ID, and so should be at
         // least equal to zero.
         if (intval($category) < 0) {

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -68,7 +68,9 @@ class Files extends \NDB_Page
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $config = \NDB_Factory::singleton()->config();
-        $path   = $config->getSetting("documentRepositoryPath");
+        $path   = \Utility::appendForwardSlash(
+            $config->getSetting("documentRepositoryPath")
+        );
         switch ($request->getMethod()) {
         case "POST":
             if ($this->uploadDocFile($request)) {
@@ -177,7 +179,9 @@ class Files extends \NDB_Page
         $DB      = $factory->database();
         $user    = $factory->user();
         $config  = $factory->config();
-        $path    = $config->getSetting("documentRepositoryPath");
+        $path    = \Utility::appendForwardSlash(
+            $config->getSetting("documentRepositoryPath")
+        );
         // create Database object
         $Notifier = new \NDB_Notifier(
             "document_repository",
@@ -353,7 +357,9 @@ class Files extends \NDB_Page
         $baseURL        = $factory->settings()->getBaseURL();
         $config         = $factory->config();
         $base           = $config->getSetting('base');
-        $path           = $config->getSetting("documentRepositoryPath");
+        $path           = \Utility::appendForwardSlash(
+            $config->getSetting("documentRepositoryPath")
+        );
         $name           = \User::singleton()->getUsername();
         $DB       = \Database::singleton();
         $category = $req['category']; // required

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1005,5 +1005,17 @@ class Utility
 
         return $scan_types;
     }
+
+    /**
+     * Append a forward slash to a path if it doesn't already exist
+     *
+     * @param string $path path to which the slash should be appended
+     *
+     * @return string
+     */
+    static function appendForwardSlash(string $path) : string
+    {
+        return rtrim($path, '/\\') . '/';
+    }
 }
 

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -94,5 +94,7 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (97,70,'/data-raisinbrea
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (98,93,'V1');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (99,101,'');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (102,19,'false');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (103,102,'/var/www/loris/modules/document_repository/user_uploads/');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/var/www/loris/modules/data_release/user_uploads/');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -94,7 +94,7 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (97,70,'/data-raisinbrea
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (98,93,'V1');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (99,101,'');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (102,19,'false');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (103,102,'/var/www/loris/modules/document_repository/user_uploads/');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/var/www/loris/modules/data_release/user_uploads/');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (103,102,'/data/document_repository_uploads/');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/data/data_release_uploads/');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_ConfigSettings.sql
+++ b/raisinbread/RB_files/RB_ConfigSettings.sql
@@ -98,5 +98,7 @@ INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMult
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (99,'usePwnedPasswordsAPI','Whether to query the Have I Been Pwned password API on password changes to prevent the usage of common and breached passwords',1,0,'boolean',1,'Enable \"Pwned Password\" check',22);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (100,'EnvironmentFile','Name of the environment file that need to be sourced for the imaging pipeline',1,0,'text',69,'Name of the environment file',20);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (101,'MINCToolsPath','Path to the MINC tools',1,0,'web_path',26,'Path to the MINC tools',12);
+INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (102,'documentRepositoryPath','Path to uploaded document repository files',1,0,'text',26,'Document Repository Upload Path',13);
+INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (103,'dataReleasePath','Path to uploaded data release files',1,0,'text',26,'Data Release Upload Path',14);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/migration.md
+++ b/raisinbread/migration.md
@@ -55,5 +55,7 @@
 2019-11-25-Default_value_for_session_submitted.sql
 
 # NEW
+2019-10-09_move_MINCToolsPath_configuration_to_Config_tables.sql
+2019-11-29-Add_upload_directory_configuration.sql
 
 # CLEAN-UP

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -130,20 +130,12 @@ debian=("Debian" "Ubuntu")
 redhat=("Red" "CentOS" "Fedora" "Oracle")
 
 if [[ " ${debian[*]} " =~ " $os_distro " ]]; then
-    mkdir -p ../modules/document_repository/user_uploads
-    mkdir -p ../modules/data_release/user_uploads
-    sudo chown www-data.www-data ../modules/document_repository/user_uploads
-    sudo chown www-data.www-data ../modules/data_release/user_uploads
     sudo chown www-data.www-data ../smarty/templates_c
     # Make Apache the group for project directory, so that the web based install
     # can write the config.xml file.
     sudo chgrp www-data ../project
     sudo chmod 770 ../project
 elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
-    mkdir -p ../modules/document_repository/user_uploads
-    mkdir -p ../modules/data_release/user_uploads
-    sudo chown apache.apache ../modules/document_repository/user_uploads
-    sudo chown apache.apache ../modules/data_release/user_uploads
     sudo chown apache.apache ../smarty/templates_c
     # Make Apache the group for project directory, so that the web based install
     # can write the config.xml file.
@@ -152,8 +144,6 @@ elif [[ " ${redhat[*]} " =~ " $os_distro " ]]; then
 else
     echo "$os_distro Linux distribution detected. We currently do not support this. "
     echo "Please manually change subdirectory ownership and permissions to ensure the web server can read *and write* in the following: "
-    echo "../modules/data_release/user_uploads "
-    echo "../modules/document_repository/user_uploads "
     echo "../smarty/templates_c "
     echo ""
 fi

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -117,7 +117,6 @@ mkdir -p ../smarty/templates_c
 # Setting 770 permissions for templates_c
 chmod 770 ../smarty/templates_c
 
-# Changing group to 'www-data' or 'apache' to give permission to create directories in Document Repository module
 # Detecting distribution
 if ! os_distro=$(hostnamectl 2>/dev/null)
 then


### PR DESCRIPTION
## Brief summary of changes

This gives the option to the users to configure where the default upload directory of data_release and document_repository modules will be. this also removes the burden on LORIS to ensure these locations are readable/writeable and follows the standard established by the other modules uploading data to loris.

## testing
- before checking out the branch, make sure you are able to upload a file to doc repo and data release. If it is not the case, you should resolve the issue as it is not due to this change.
- check out this branch and ensure you are still able to upload and download files to the 2 modules (the sql patch for existing projects is designed to be backwards compatible)
- change the upload paths from the configuration module and make sure the new paths exist on your machine and are apache writable
- try uploading downloading other documents to both modules to ensure that the functionality is unaffected.

# Important note for release

Projects should be encouraged to move their files out of the old directories and into new directories somewhere else on their data mount/drive.

### Related

* Resolves #5062 