### PR TITLE
Array offsets: change curly brackets to square brackets 

### DIFF
--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -139,7 +139,7 @@ class Configuration extends \NDB_Form
             if ($setting['Disabled'] == 'No') {
                 $value = $this->DB->pselect(
                     "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
-                    array('ID' => $setting{'ID'})
+                    array('ID' => $setting['ID'])
                 );
                 if ($value) {
                     foreach ($value as $subvalue) {


### PR DESCRIPTION
## Brief summary of changes
This address the following error message
```
modules/configuration/php/configuration.class.inc:142 PhanCompatibleDimAlternativeSyntax Array and string offset access syntax with curly braces is deprecated in PHP 7.4. Use square brackets instead. Seen for $setting{'ID'}
```

fixes https://github.com/aces/Loris/issues/5626
