### PR TITLE
[API] Add README for api module

### DIFF
--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -1,0 +1,38 @@
+# API
+
+## Purpose
+
+The api module is intended to provide a stable, versioned REST interface
+for interacting with the core LORIS functionality without requiring backend
+SQL access.
+
+## Intended Users
+
+The module has 2 intended users:
+1. Users (or creators) of LORIS data that are external to the LORIS core
+   software that must extract or import data from LORIS.
+2. Internal LORIS modules
+
+## Scope
+
+The API only provides information about concepts that are cross-module
+or data that is of general concern to users. 
+
+NOT in scope:
+
+- Data and functionality that is specific to a single module, and not of general
+  nature.
+- A graphical frontend
+
+## Permissions
+
+????
+
+## Configurations
+
+useEDC - This configuration setting determines whether the EDC is returned
+  or required for creating/retrieving candidates with the API.
+
+## Interactions with LORIS
+
+???

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -11,7 +11,7 @@ SQL access.
 The module has 2 intended users:
 1. Users (or creators) of LORIS data that are external to the LORIS core
    software that must extract or import data from LORIS.
-2. Internal LORIS modules
+2. Internal LORIS modules.
 
 ## Scope
 
@@ -22,7 +22,7 @@ NOT in scope:
 
 - Data and functionality that is specific to a single module, and not of general
   nature.
-- A graphical frontend
+- A graphical frontend for interacting with the API.
 
 ## Permissions
 

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -26,9 +26,17 @@ NOT in scope:
 
 ## Permissions
 
+The `api` module is a public module so that the `login` endpoint can be accessed,
+but otherwise all requests require a token (retrieved from the `login` endpoint)
+or the user accessing the API to be logged in to LORIS.
+
+The following permissions affect accessing data from the API:
 ????
 
 ## Configurations
+
+The following configuration settings affect the format of data returned from
+the API:
 
 useEDC - This configuration setting determines whether the EDC is returned
   or required for creating/retrieving candidates with the API.

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -4,7 +4,7 @@
 
 The api module is intended to provide a stable, versioned REST interface
 for interacting with the core LORIS functionality without requiring backend
-SQL access.
+database access.
 
 ## Intended Users
 

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -9,7 +9,7 @@ database access.
 ## Intended Users
 
 The module has 2 intended use cases:
-1. Users (or creators) of LORIS data that are external to the LORIS core
+1. Interactions with LORIS data coming from outside the LORIS core
    software that must extract or import data from LORIS.
 2. Internal LORIS modules which retrieve data from the API.
 

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -8,10 +8,10 @@ SQL access.
 
 ## Intended Users
 
-The module has 2 intended users:
+The module has 2 intended use cases:
 1. Users (or creators) of LORIS data that are external to the LORIS core
    software that must extract or import data from LORIS.
-2. Internal LORIS modules.
+2. Internal LORIS modules which retrieve data from the API.
 
 ## Scope
 
@@ -43,4 +43,8 @@ useEDC - This configuration setting determines whether the EDC is returned
 
 ## Interactions with LORIS
 
-???
+- A token retrieved from the login endpoint bypasses the normal cookie based
+  authentication of LORIS when provided in as "Authorization" bearer token. See
+  API documentation for details.
+
+- ??? (describe other interactions here)

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -10,7 +10,7 @@ database access.
 
 The module has 2 intended use cases:
 1. Interactions with LORIS data coming from outside the LORIS core
-   software that must extract or import data from LORIS.
+   software that extract or import data from LORIS.
 2. Internal LORIS modules which retrieve data from the API.
 
 ## Scope

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -31,7 +31,8 @@ but otherwise all requests require a token (retrieved from the `login` endpoint)
 or the user accessing the API to be logged in to LORIS.
 
 The following permissions affect accessing data from the API:
-????
+- The `data_entry` permission is required to access the candidates portion of
+  the API.
 
 ## Configurations
 
@@ -46,5 +47,3 @@ useEDC - This configuration setting determines whether the EDC is returned
 - A token retrieved from the login endpoint bypasses the normal cookie based
   authentication of LORIS when provided in as "Authorization" bearer token. See
   API documentation for details.
-
-- ??? (describe other interactions here)

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The api module is intended to provide a stable, versioned REST interface
+The API module is intended to provide a stable, versioned REST interface
 for interacting with the core LORIS functionality without requiring backend
 database access.
 


### PR DESCRIPTION
The API module is missing a README, because it didn't exist
as a module when it lived under htdocs and none was written
when it was migrated to a "real" LORIS module. This takes
a first pass at writing one to officially define its purpose.