### PR TITLE
[Menu] Do not show Data Query Tool menu item with data_dict_view permission

### DIFF
--- a/SQL/0000-00-02-Menus.sql
+++ b/SQL/0000-00-02-Menus.sql
@@ -140,11 +140,6 @@ INSERT INTO LorisMenuPermissions (MenuID, PermID)
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_entry' AND m.Label='Statistics';
 
-
-INSERT INTO LorisMenuPermissions (MenuID, PermID)
-    SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_dict_view' AND m.Label='Data Query Tool';
-
-
 INSERT INTO LorisMenuPermissions (MenuID, PermID)
     SELECT m.ID, p.PermID FROM permissions p CROSS JOIN LorisMenu m WHERE p.code='data_dict_view' AND m.Label='Data Dictionary';
 


### PR DESCRIPTION
The default schema incorrectly added a LorisMenuPermissions item for the
Data Query Tool if the user had the data_dict_view permission in the
default schema. This removes that line, as the correct permission
(according to the code) is the dataquery_view permission (which is
separately already included in the default schema. See line 209.)