### PR TITLE
[DQT Importer] Issue where script breaks if scantype has a '-' character

### DIFF
--- a/tools/CouchDB_MRI_Importer.php
+++ b/tools/CouchDB_MRI_Importer.php
@@ -99,12 +99,12 @@ class CouchDBMRIImporter
             $Query .= ", (SELECT f.File FROM files f LEFT JOIN mri_scan_type msc
               ON (msc.ID= f.AcquisitionProtocolID)
               WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype' LIMIT 1)
-                    as Selected_$scantype, (SELECT fqc.QCStatus
+                    as `Selected_$scantype`, (SELECT fqc.QCStatus
                     FROM files f 
                     LEFT JOIN files_qcstatus fqc USING(FileID)
                     LEFT JOIN mri_scan_type msc ON(msc.ID= f.AcquisitionProtocolID)
               WHERE f.SessionID=s.ID AND msc.Scan_type='$scantype' LIMIT 1)
-                     as $scantype"."_QCStatus";
+                     as `$scantype"."_QCStatus`";
         }
         $Query .= " FROM session s JOIN candidate c USING (CandID)
             LEFT JOIN feedback_mri_comments fmric


### PR DESCRIPTION
## Brief summary of changes

adding backticks to make sure no errors are thrown if these are dashes in the scan type name
