### PR TITLE
[Dashboard/Recruitment -- view site breakdown] Restricting users to see statistics only from sites they have access to.

### DIFF
--- a/modules/dashboard/ajax/get_recruitment_bar_data.php
+++ b/modules/dashboard/ajax/get_recruitment_bar_data.php
@@ -17,7 +17,21 @@ ini_set('default_charset', 'utf-8');
 
 $DB            = Database::singleton();
 $sexData       = array();
-$list_of_sites = Utility::getAssociativeSiteList(true, false);
+$currentUser   = \User::singleton();
+$site          = array();
+$list_of_sites = array();
+
+
+//TODO: Create a permission specific to statistics
+if ($currentUser->hasPermission('access_all_profiles')) {
+    $list_of_sites = \Utility::getSiteList();
+} else {
+    $site_id_arr = $currentUser->getCenterIDs();
+    foreach ($site_id_arr as $key => $val) {
+        $site[$key]          = &Site::singleton($val);
+        $list_of_sites[$val] = $site[$key]->getCenterName();
+    }
+}
 
 foreach ($list_of_sites as $siteID => $siteName) {
     $sexData['labels'][] = $siteName;

--- a/modules/dashboard/ajax/get_recruitment_pie_data.php
+++ b/modules/dashboard/ajax/get_recruitment_pie_data.php
@@ -14,10 +14,23 @@
 
 ini_set('default_charset', 'utf-8');
 
-$DB = Database::singleton();
-
+$DB          = Database::singleton();
+$currentUser = \User::singleton();
 $recruitmentBySiteData = array();
-$list_of_sites         = Utility::getAssociativeSiteList(true, false);
+$site          = array();
+$list_of_sites = array();
+
+
+//TODO: Create a permission specific to statistics
+if ($currentUser->hasPermission('access_all_profiles')) {
+    $list_of_sites = \Utility::getSiteList();
+} else {
+    $site_id_arr = $currentUser->getCenterIDs();
+    foreach ($site_id_arr as $key => $val) {
+        $site[$key]          = &Site::singleton($val);
+        $list_of_sites[$val] = $site[$key]->getCenterName();
+    }
+}
 
 foreach ($list_of_sites as $siteID => $siteName) {
 


### PR DESCRIPTION
### Description of the issue
In **dashboard-> Recruitment-> View site breakdown** users were able to see statistics from sites they do not belong/have access

### Testing instructions

Now each user should be able to see the **view site breakdown** only for the sites it belong/have access

### Notes

This is a fix for 22.0.0, major design changes as creating a permission dedicated to statistics still pending.

**Notes relative to the code-set:**

**Note 1:** using the function `getSiteList() `pending to by refactored to act as `getAssociativeSiteList()` now shows stats from DCC for user having 'access_all_profiles' permission .

**Note 2:**  for the `/User `class we don’t have currently a similar function to `getSiteList()` but could be useful. In place, two of function are used in the current PR: `getCenterIDs()` and after creating the centrer from this ID then `getCenterName()`