### PR TITLE
Document composer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Deploy and log in with username *admin* and the password that's set up during de
  * Apache **2.4** or higher
  * MySQL >= 5.7 (or MariaDB >= 10.3) 
  * PHP <b>7.2</b> or higher
- * [Composer](https://getcomposer.org/)
+ * [Composer](https://getcomposer.org/) <b>1.4.2</b> or higher
  * NodeJS <b>8.0</b> or higher
  * NPM
  * make

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Deploy and log in with username *admin* and the password that's set up during de
  * Apache **2.4** or higher
  * MySQL >= 5.7 (or MariaDB >= 10.3) 
  * PHP <b>7.2</b> or higher
- * [Composer](https://getcomposer.org/) <b>1.4.2</b> or higher
+ * [Composer](https://getcomposer.org/) <b>1.4</b> or higher
  * NodeJS <b>8.0</b> or higher
  * NPM
  * make


### PR DESCRIPTION
## Brief summary of changes

Adds an explicit minimum version for composer based on discussion in #5845. 

There was some concern on the mailing list that an issue during the install was caused by an old composer version. It makes sense to be a little more specific about it in our documentation.

#### Links to related tickets (GitHub, Redmine, ...)

* Resolves #5845 
