### PR TITLE
[Meta] Add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,9 +2,8 @@ LORIS is primarily developed at [McGill University](https://www.mcgill.ca/) with
 the [McGill Centre For Integrative Neuroscience](http://mcin.ca/). Contributors
 should comply with all relevant policies and codes of their respective organizations.
 
-However, as open source software we encourage contributions from other sources.
-When interacting within the LORIS community keep in mind that we are a diverse
-community incorporating people of many different backgrounds, and it is expected
-that everyone be treated with respect. When disagreements arise, it should be assumed
-that the other party is acting in good faith and shares the same goal of making LORIS
-the best software possible.
+As open source software we encourage contributions from other sources.  When interacting
+within the LORIS community keep in mind that we are a diverse community incorporating
+people of many different backgrounds, and it is expected that everyone be treated with
+respect. When disagreements arise, it should be assumed that the other party is acting
+in good faith and shares the same goal of making LORIS the best software possible.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+LORIS is primarily developed at [McGill University](https://www.mcgill.ca/) within
+the [McGill Centre For Integrative Neuroscience](http://mcin.ca/). Contributors
+should comply with all relevant policies and codes of their respective organizations.
+
+However, as open source software we encourage contributions from other sources.
+When interacting within the LORIS community keep in mind that we are a diverse
+community incorporating people of many different backgrounds, and it is expected
+that everyone be treated with respect. When disagreements arise, it should be assumed
+that the other party is acting in good faith and shares the same goal of making LORIS
+the best software possible.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,16 @@
-LORIS is primarily developed at [McGill University](https://www.mcgill.ca/) within
-the [McGill Centre For Integrative Neuroscience](http://mcin.ca/). Contributors
-should comply with all relevant policies and codes of their respective organizations.
+LORIS is primarily developed at [McGill University](https://www.mcgill.ca/) within the [McGill Centre For Integrative Neuroscience](http://mcin.ca/). As such, we are governed by the McGill Faculty of Medicine's [code of conduct](https://www.mcgill.ca/medicine/about/our-vision-mission-values/code-conduct).
 
-As open source software we encourage contributions from other sources.  When interacting
-within the LORIS community keep in mind that we are a diverse community incorporating
-people of many different backgrounds, and it is expected that everyone be treated with
-respect. When disagreements arise, it should be assumed that the other party is acting
-in good faith and shares the same goal of making LORIS the best software possible.
+The LORIS project also pushes certain philosophies such as:
+
+1) An environment of inclusion
+
+2) A respectful manner of discourse and disagreement
+
+3) A strong commitment to timely resolution of issues
+
+4) An open and free environment to voice opinions and suggestions
+
+5) Having the goal of transparency and clarity
+
+As open source software we encourage contributions from other sources, and as such we need to allow for heterogeneous ideas. When interacting within the LORIS community keep in mind that we are a diverse community incorporating people of many different backgrounds, and it is expected that everyone be treated with respect.
+


### PR DESCRIPTION
This adds a CODE_OF_CONDUCT.md file with the goal of being as
non-politicized as possible. It defers to MCIN and McGill University
codes and policies with a vague paragraph trying to include external
contributors, who might otherwise think that we don't accept external
contributions.

#### Testing instructions (if applicable)

1. Hire a lawyer and/or contact your local HR rep to ask if this code implies any legal or ethical issues that we should be aware of.

Resolves #5864