### PR TITLE
[Core] Remove 6 month password expiry

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -108,7 +108,7 @@ CREATE TABLE `users` (
 
 
 
-INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired);
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired)
 VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N',0);
 
 CREATE TABLE `user_psc_rel` (

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -94,7 +94,7 @@ CREATE TABLE `users` (
   `DBAccess` varchar(10) NOT NULL default '',
   `Active` enum('Y','N') NOT NULL default 'Y',
   `Password_hash` varchar(255) default NULL,
-  `Password_expiry` date NOT NULL default '1990-04-01',
+  `Password_expired` tinyint(1) NOT NULL default 0;
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   `language_preference` integer unsigned default NULL,
@@ -108,7 +108,7 @@ CREATE TABLE `users` (
 
 
 
-INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expiry)
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired)
 VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N','2016-03-30');
 
 CREATE TABLE `user_psc_rel` (

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -108,8 +108,8 @@ CREATE TABLE `users` (
 
 
 
-INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired)
-VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N',1);
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired);
+VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N',0);
 
 CREATE TABLE `user_psc_rel` (
   `UserID` int(10) unsigned NOT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -94,7 +94,7 @@ CREATE TABLE `users` (
   `DBAccess` varchar(10) NOT NULL default '',
   `Active` enum('Y','N') NOT NULL default 'Y',
   `Password_hash` varchar(255) default NULL,
-  `Password_expired` tinyint(1) NOT NULL default 0;
+  `Password_expired` tinyint(1) NOT NULL default 0,
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   `language_preference` integer unsigned default NULL,
@@ -109,7 +109,7 @@ CREATE TABLE `users` (
 
 
 INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired)
-VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N','2016-03-30');
+VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N',1);
 
 CREATE TABLE `user_psc_rel` (
   `UserID` int(10) unsigned NOT NULL,

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -94,7 +94,7 @@ CREATE TABLE `users` (
   `DBAccess` varchar(10) NOT NULL default '',
   `Active` enum('Y','N') NOT NULL default 'Y',
   `Password_hash` varchar(255) default NULL,
-  `Password_expired` tinyint(1) NOT NULL default 0,
+  `PasswordChangeRequired` tinyint(1) NOT NULL default 0,
   `Pending_approval` enum('Y','N') default 'Y',
   `Doc_Repo_Notifications` enum('Y','N') default 'N',
   `language_preference` integer unsigned default NULL,
@@ -108,7 +108,7 @@ CREATE TABLE `users` (
 
 
 
-INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,Password_expired)
+INSERT INTO `users` (ID,UserID,Real_name,First_name,Last_name,Email,Privilege,PSCPI,DBAccess,Active,Pending_approval,PasswordChangeRequired)
 VALUES (1,'admin','Admin account','Admin','account','admin@example.com',0,'N','','Y','N',0);
 
 CREATE TABLE `user_psc_rel` (

--- a/SQL/New_patches/2019-12-17-RemovePasswordExpiry.sql
+++ b/SQL/New_patches/2019-12-17-RemovePasswordExpiry.sql
@@ -1,2 +1,3 @@
-ALTER TABLE users DROP COLUMN Password_expiry;
 ALTER TABLE users ADD COLUMN Password_expired TINYINT(1) NOT NULL DEFAULT 0;
+UPDATE users SET Password_expired=1 WHERE Password_expiry < CURDATE();
+ALTER TABLE users DROP COLUMN Password_expiry;

--- a/SQL/New_patches/2019-12-17-RemovePasswordExpiry.sql
+++ b/SQL/New_patches/2019-12-17-RemovePasswordExpiry.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users DROP COLUMN Password_expiry;
+ALTER TABLE users ADD COLUMN Password_expired TINYINT(1) NOT NULL DEFAULT 0;

--- a/SQL/New_patches/2019-12-17-RemovePasswordExpiry.sql
+++ b/SQL/New_patches/2019-12-17-RemovePasswordExpiry.sql
@@ -1,3 +1,3 @@
-ALTER TABLE users ADD COLUMN Password_expired TINYINT(1) NOT NULL DEFAULT 0;
-UPDATE users SET Password_expired=1 WHERE Password_expiry < CURDATE();
+ALTER TABLE users ADD COLUMN PasswordChangeRequired TINYINT(1) NOT NULL DEFAULT 0;
+UPDATE users SET PasswordChangeRequired=1 WHERE Password_expiry < CURDATE();
 ALTER TABLE users DROP COLUMN Password_expiry;

--- a/htdocs/postdeploy.php
+++ b/htdocs/postdeploy.php
@@ -50,7 +50,7 @@ $pw = password_hash($password, PASSWORD_DEFAULT);
 
 $conn->query(
     "UPDATE users SET Password_hash=" . $conn->quote($pw) .
-    ", Password_expiry='2020-01-01', Pending_approval='N' WHERE ID=1"
+    ", Pending_approval='N' WHERE ID=1"
 );
 $RootDir = dirname(getcwd());
 $conn->query(

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -40,12 +40,12 @@ class DashboardTest extends LorisIntegrationTest
         //Insert a pending user
         $this->DB->insert(
             "users",
-            array(
+            [
                 'UserID'                 => 'testUser1',
                 'Email'                  => 'test@test.com',
                 'Password'               => 'AA1234567!',
                 'PasswordChangeRequired' => false
-            )
+            ]
         );
         $user_id = $this->DB->pselectOne(
             "SELECT ID FROM users WHERE UserID=:test_user_id",

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -41,9 +41,10 @@ class DashboardTest extends LorisIntegrationTest
         $this->DB->insert(
             "users",
             array(
-                'UserID'   => 'testUser1',
-                'Email'    => 'test@test.com',
-                'Password' => 'AA1234567!'
+                'UserID'           => 'testUser1',
+                'Email'            => 'test@test.com',
+                'Password'         => 'AA1234567!',
+                'Password_expired' => false
             )
         );
         $user_id = $this->DB->pselectOne(

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -44,7 +44,7 @@ class DashboardTest extends LorisIntegrationTest
                 'UserID'           => 'testUser1',
                 'Email'            => 'test@test.com',
                 'Password'         => 'AA1234567!',
-                'Password_expired' => false
+                'PasswordChangeRequired' => false
             )
         );
         $user_id = $this->DB->pselectOne(

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -41,9 +41,9 @@ class DashboardTest extends LorisIntegrationTest
         $this->DB->insert(
             "users",
             array(
-                'UserID'           => 'testUser1',
-                'Email'            => 'test@test.com',
-                'Password'         => 'AA1234567!',
+                'UserID'                 => 'testUser1',
+                'Email'                  => 'test@test.com',
+                'Password'               => 'AA1234567!',
                 'PasswordChangeRequired' => false
             )
         );

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -2,7 +2,7 @@
 /**
  * Dashboard automated integration tests
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Test
  * @package  Loris
@@ -17,7 +17,7 @@ require_once __DIR__ .
 /**
  * Dashboard module automated integration tests
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Test
  * @package  Loris
@@ -40,12 +40,11 @@ class DashboardTest extends LorisIntegrationTest
         //Insert a pending user
         $this->DB->insert(
             "users",
-            [
-                'UserID'          => 'testUser1',
-                'Email'           => 'test@test.com',
-                'Password'        => 'AA1234567!',
-                'Password_expiry' => '2020-01-06',
-            ]
+            array(
+                'UserID'   => 'testUser1',
+                'Email'    => 'test@test.com',
+                'Password' => 'AA1234567!'
+            )
         );
         $user_id = $this->DB->pselectOne(
             "SELECT ID FROM users WHERE UserID=:test_user_id",

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -72,8 +72,7 @@ class PasswordReset extends \NDB_Form
                 // reset the password in the database
                 // expire password so user must change it upon login
                 $user->updatePassword(
-                    new \Password($password),
-                    new \DateTime('1999-01-01')
+                    new \Password($password)
                 );
 
                 // send the user an email

--- a/modules/login/test/Reset_Password_Test_Plan.md
+++ b/modules/login/test/Reset_Password_Test_Plan.md
@@ -1,6 +1,6 @@
 # Reset Password Test Plan
 
-1. In the `users` table in the database, update the `Password_expiry` cell for a user you are testing to be a date in the past.
+1. In the `users` table in the database, set a user's `PasswordChangeRequired` value to `1`.
 2. Login as that user. You should see an update password page.
 3. Try using a very short password (e.g. "pass"). You should get an error.
 4. Try using a very weak password (e.g. "password"). You should get an error.

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -217,7 +217,7 @@ class Edit_User extends \NDB_Form
             ? array_keys($values['permID']) : [];
         $editorPermissions = $editor->getPermissionIDs() ?? [];
         $permIDs           = [];
-        $passwordExpired = false;
+        $passwordExpired   = false;
         // store the permission IDs
         if (!empty($values['permID'])) {
             // An editor can only grant permissions that they have already been

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -256,8 +256,8 @@ class Edit_User extends \NDB_Form
         unset($values['NA_UserID']);
         // generate new password
         if (!empty($values['NA_Password'])) {
-            $values['Password_hash']   = \Utility::randomString();
-            $values['Password_expiry'] = '1990-04-01';
+            $values['Password_hash']    = \Utility::randomString();
+            $values['Password_expired'] = true;
         }
         unset($values['NA_Password']);
         // If editing a user and nothing was specified in the password text field
@@ -493,17 +493,11 @@ class Edit_User extends \NDB_Form
         // and represents a plaintext password, not a hash.
         if (isset($values['Password_hash'])) {
 
-            // Set custom expiry date if the value is present.
-            // Otherwise, use null which will cause the expiry to be 6 months
-            // from the current date.
-            $expiry = isset($values['Password_expiry']) ?
-                new \DateTime($values['Password_expiry'])
-                : null;
             $user->updatePassword(
                 new \Password(
                     htmlspecialchars_decode($values['Password_hash'])
                 ),
-                $expiry
+                $values['Password_expired'] ?? false
             );
         }
 

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -257,8 +257,8 @@ class Edit_User extends \NDB_Form
         unset($values['NA_UserID']);
         // generate new password
         if (!empty($values['NA_Password'])) {
-            $values['Password_hash']    = \Utility::randomString();
-            $passwordExpired = true;
+            $values['Password_hash'] = \Utility::randomString();
+            $passwordExpired         = true;
         }
         unset($values['NA_Password']);
         // If editing a user and nothing was specified in the password text field

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -217,6 +217,7 @@ class Edit_User extends \NDB_Form
             ? array_keys($values['permID']) : [];
         $editorPermissions = $editor->getPermissionIDs() ?? [];
         $permIDs           = [];
+        $passwordExpired = false;
         // store the permission IDs
         if (!empty($values['permID'])) {
             // An editor can only grant permissions that they have already been
@@ -257,7 +258,7 @@ class Edit_User extends \NDB_Form
         // generate new password
         if (!empty($values['NA_Password'])) {
             $values['Password_hash']    = \Utility::randomString();
-            $values['Password_expired'] = true;
+            $passwordExpired = true;
         }
         unset($values['NA_Password']);
         // If editing a user and nothing was specified in the password text field
@@ -497,7 +498,7 @@ class Edit_User extends \NDB_Form
                 new \Password(
                     htmlspecialchars_decode($values['Password_hash'])
                 ),
-                $values['Password_expired'] ?? false
+                $passwordExpired
             );
         }
 

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -74,6 +74,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                 'PSCPI'            => 'N',
                 'Active'           => 'Y',
                 'Password_hash'    => $password,
+                'Password_expired' => false,
                 'Pending_approval' => 'N'
             ]
         );

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -64,18 +64,18 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $this->DB->insert(
             "users",
             [
-                'ID'               => 999995,
-                'UserID'           => 'UnitTesterTwo',
-                'Real_name'        => 'Unit Tester 2',
-                'First_name'       => 'Unit 2',
-                'Last_name'        => 'Tester 2',
-                'Email'            => 'tester2@example.com',
-                'Privilege'        => 0,
-                'PSCPI'            => 'N',
-                'Active'           => 'Y',
-                'Password_hash'    => $password,
+                'ID'                     => 999995,
+                'UserID'                 => 'UnitTesterTwo',
+                'Real_name'              => 'Unit Tester 2',
+                'First_name'             => 'Unit 2',
+                'Last_name'              => 'Tester 2',
+                'Email'                  => 'tester2@example.com',
+                'Privilege'              => 0,
+                'PSCPI'                  => 'N',
+                'Active'                 => 'Y',
+                'Password_hash'          => $password,
                 'PasswordChangeRequired' => false,
-                'Pending_approval' => 'N'
+                'Pending_approval'       => 'N'
             ]
         );
 

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -74,8 +74,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                 'PSCPI'            => 'N',
                 'Active'           => 'Y',
                 'Password_hash'    => $password,
-                'Password_expiry'  => '2099-12-31',
-                'Pending_approval' => 'N',
+                'Pending_approval' => 'N'
             ]
         );
 

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -74,7 +74,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                 'PSCPI'            => 'N',
                 'Active'           => 'Y',
                 'Password_hash'    => $password,
-                'Password_expired' => false,
+                'PasswordChangeRequired' => false,
                 'Pending_approval' => 'N'
             ]
         );

--- a/php/installer/Installer.class.inc
+++ b/php/installer/Installer.class.inc
@@ -540,7 +540,6 @@ class Installer
                UserID=:q_userID,
                Password_hash=:q_password,
                Active='Y',
-               Password_expiry=DATE_ADD(NOW(),INTERVAL 30 DAY)
              WHERE ID=1"
         );
         return $stmt->execute(

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -278,7 +278,7 @@ class SinglePointLogin
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
                         UserID,
-                        Password_expiry < NOW() as Expired,
+                        Password_expired as Expired,
                         Active,
                         Pending_approval,
                         Password_hash,

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -278,7 +278,7 @@ class SinglePointLogin
         // check users table to see if we have a valid user
         $query = "SELECT COUNT(*) AS User_count,
                         UserID,
-                        Password_expired as Expired,
+                        PasswordChangeRequired as Expired,
                         Active,
                         Pending_approval,
                         Password_hash,

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -498,10 +498,10 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         }
 
         $this->update(
-            array(
+            [
                 'Password_hash'          => $password,
                 'PasswordChangeRequired' => $expired ? 1 : 0
-            )
+            ]
         );
         $this->userInfo['Password_hash']          = (string) $password;
         $this->userInfo['PasswordChangeRequired'] = $expired;

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -500,11 +500,11 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         $this->update(
             array(
                 'Password_hash'    => $password,
-                'Password_expired' => $expired ? 1 : 0
+                'PasswordChangeRequired' => $expired ? 1 : 0
             )
         );
         $this->userInfo['Password_hash']    = (string) $password;
-        $this->userInfo['Password_expired'] = $expired;
+        $this->userInfo['PasswordChangeRequired'] = $expired;
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -499,11 +499,11 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
 
         $this->update(
             array(
-                'Password_hash'    => $password,
+                'Password_hash'          => $password,
                 'PasswordChangeRequired' => $expired ? 1 : 0
             )
         );
-        $this->userInfo['Password_hash']    = (string) $password;
+        $this->userInfo['Password_hash']          = (string) $password;
         $this->userInfo['PasswordChangeRequired'] = $expired;
     }
 

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -500,7 +500,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         $this->update(
             array(
                 'Password_hash'    => $password,
-                'Password_expired' => $expired
+                'Password_expired' => $expired ? 1 : 0
             )
         );
         $this->userInfo['Password_hash']    = (string) $password;

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -482,37 +482,29 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
      * database.
      *
      * @param \Password $password The plain text password to be hashed and saved.
-     * @param ?DateTime $expiry   When the password will expire. Can be set to a
-     *                            date in the past in order to create a one-time
-     *                            password.
+     * @param bool      $expired  Whether the password is expired. If so, a reset
+     *                            will be triggered on the user's next login.
      *
      * @return void
      */
     function updatePassword(
         \Password $password,
-        ?\DateTime $expiry = null
+        bool $expired = false
     ): void {
         if (password_verify($this->userInfo['Email'], (string) $password)) {
             throw new \InvalidArgumentException(
                 'Password cannot be set to email'
             );
         }
-        // Set default expiry date value to 6 months in the future.
-        $expiry = $expiry ?? new \DateTime(
-            date('Y-m-d', strtotime('+6 months'))
-        );
 
         $this->update(
-            [
-                'Password_hash'   => $password,
-                'Password_expiry' => $expiry->format(self::MYSQL_DATE_FORMAT),
-            ]
+            array(
+                'Password_hash'    => $password,
+                'Password_expired' => $expired
+            )
         );
-        // XXX This class should use DateTime objects instead of strings so
-        // that formatting doens't need to be specified and so that Date math
-        // is simpler and safer.
-        $this->userInfo['Password_hash']   = (string) $password;
-        $this->userInfo['Password_expiry'] = $expiry->format('Y-m-d');
+        $this->userInfo['Password_hash']    = (string) $password;
+        $this->userInfo['Password_expired'] = $expired;
     }
 
     /**

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -34,7 +34,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (34,38,'/data/uploads/')
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (35,40,'main.css');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (36,41,'25');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (37,44,'localhost');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (38,45,'http://localhost');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (39,48,'This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun.');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (40,51,'[a-zA-Z]{3}[0-9]{4}_[0-9]{6}_[vV][0-9]+');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (41,52,'(?i).');

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -34,6 +34,7 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (34,38,'/data/uploads/')
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (35,40,'main.css');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (36,41,'25');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (37,44,'localhost');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (38,45,'http://localhost');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (39,48,'This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun.');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (40,51,'[a-zA-Z]{3}[0-9]{4}_[0-9]{6}_[vV][0-9]+');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (41,52,'(?i).');

--- a/raisinbread/RB_files/RB_users.sql
+++ b/raisinbread/RB_files/RB_users.sql
@@ -1,6 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `users`;
 LOCK TABLES `users` WRITE;
-INSERT INTO `users` (`ID`, `UserID`, `Password`, `Real_name`, `First_name`, `Last_name`, `Degree`, `Position_title`, `Institution`, `Department`, `Address`, `City`, `State`, `Zip_code`, `Country`, `Phone`, `Fax`, `Email`, `Privilege`, `PSCPI`, `DBAccess`, `Active`, `Password_hash`, `Password_expired`, `Pending_approval`, `Doc_Repo_Notifications`, `language_preference`, `active_from`, `active_to`) VALUES (1,'admin',NULL,'Admin account','Admin','account',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'admin@example.com',0,'N','','Y','$2y$10$Rk0KgzjXv1c.6uix3/Wm4esr1CL3SH3Sfve/jSDn1cIBcjsXYC.4m',0,'N','N',NULL,NULL,NULL);
+INSERT INTO `users` (`ID`, `UserID`, `Password`, `Real_name`, `First_name`, `Last_name`, `Degree`, `Position_title`, `Institution`, `Department`, `Address`, `City`, `State`, `Zip_code`, `Country`, `Phone`, `Fax`, `Email`, `Privilege`, `PSCPI`, `DBAccess`, `Active`, `Password_hash`, `PasswordChangeRequired`, `Pending_approval`, `Doc_Repo_Notifications`, `language_preference`, `active_from`, `active_to`) VALUES (1,'admin',NULL,'Admin account','Admin','account',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'admin@example.com',0,'N','','Y','$2y$10$Rk0KgzjXv1c.6uix3/Wm4esr1CL3SH3Sfve/jSDn1cIBcjsXYC.4m',0,'N','N',NULL,NULL,NULL);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_users.sql
+++ b/raisinbread/RB_files/RB_users.sql
@@ -1,6 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `users`;
 LOCK TABLES `users` WRITE;
-INSERT INTO `users` (`ID`, `UserID`, `Password`, `Real_name`, `First_name`, `Last_name`, `Degree`, `Position_title`, `Institution`, `Department`, `Address`, `City`, `State`, `Zip_code`, `Country`, `Phone`, `Fax`, `Email`, `Privilege`, `PSCPI`, `DBAccess`, `Active`, `Password_hash`, `PasswordChangeRequired`, `Pending_approval`, `Doc_Repo_Notifications`, `language_preference`, `active_from`, `active_to`) VALUES (1,'admin',NULL,'Admin account','Admin','account',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'admin@example.com',0,'N','','Y','$2y$10$Rk0KgzjXv1c.6uix3/Wm4esr1CL3SH3Sfve/jSDn1cIBcjsXYC.4m',0,'N','N',NULL,NULL,NULL);
+INSERT INTO `users` (`ID`, `UserID`, `Password`, `Real_name`, `First_name`, `Last_name`, `Degree`, `Position_title`, `Institution`, `Department`, `Address`, `City`, `State`, `Zip_code`, `Country`, `Phone`, `Fax`, `Email`, `Privilege`, `PSCPI`, `DBAccess`, `Active`, `Password_hash`, `PasswordChangeRequired`, `Pending_approval`, `Doc_Repo_Notifications`, `language_preference`, `active_from`, `active_to`) VALUES (1,'admin',NULL,'Admin account','Admin','account',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'admin@example.com',0,'N','','Y','$2y$10$6pjQ.x5rPY7voNFs2w/eI.pzLL8H/9wPZ98nabvBOEwDBClhK0l1S',0,'N','N',NULL,NULL,NULL);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_users.sql
+++ b/raisinbread/RB_files/RB_users.sql
@@ -1,6 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `users`;
 LOCK TABLES `users` WRITE;
-INSERT INTO `users` (`ID`, `UserID`, `Password`, `Real_name`, `First_name`, `Last_name`, `Degree`, `Position_title`, `Institution`, `Department`, `Address`, `City`, `State`, `Zip_code`, `Country`, `Phone`, `Fax`, `Email`, `Privilege`, `PSCPI`, `DBAccess`, `Active`, `Password_hash`, `Password_expiry`, `Pending_approval`, `Doc_Repo_Notifications`, `language_preference`, `active_from`, `active_to`) VALUES (1,'admin',NULL,'Admin account','Admin','account',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'admin@example.com',0,'N','','Y','$2y$10$6pjQ.x5rPY7voNFs2w/eI.pzLL8H/9wPZ98nabvBOEwDBClhK0l1S','2100-01-01','N','N',NULL,NULL,NULL);
+INSERT INTO `users` (`ID`, `UserID`, `Password`, `Real_name`, `First_name`, `Last_name`, `Degree`, `Position_title`, `Institution`, `Department`, `Address`, `City`, `State`, `Zip_code`, `Country`, `Phone`, `Fax`, `Email`, `Privilege`, `PSCPI`, `DBAccess`, `Active`, `Password_hash`, `Password_expired`, `Pending_approval`, `Doc_Repo_Notifications`, `language_preference`, `active_from`, `active_to`) VALUES (1,'admin',NULL,'Admin account','Admin','account',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'admin@example.com',0,'N','','Y','$2y$10$Rk0KgzjXv1c.6uix3/Wm4esr1CL3SH3Sfve/jSDn1cIBcjsXYC.4m',0,'N','N',NULL,NULL,NULL);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -93,8 +93,7 @@ abstract class LorisIntegrationTest extends TestCase
                 'PSCPI'            => 'N',
                 'Active'           => 'Y',
                 'Password_hash'    => $password,
-                'Password_expiry'  => '2099-12-31',
-                'Pending_approval' => 'N',
+                'Pending_approval' => 'N'
             ]
         );
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -58,7 +58,7 @@ class UserTest extends TestCase
                 'DBAccess'               => '123',
                 'Active'                 => 'Y',
                 'Password_hash'          => null,
-                'Password_expired'        => false,
+                'Password_expired'        => 0,
                 'Pending_approval'       => 'Y',
                 'Doc_Repo_Notifications' => 'Y',
                 'language_preference'    => 2,
@@ -590,7 +590,7 @@ class UserTest extends TestCase
         //Re-populate the user object now that the password has been changed
         $this->_user = \User::factory(self::USERNAME);
 
-        $this->assertEquals(false, $this->_user->getData('Password_expired'));
+        $this->assertEquals(0, $this->_user->getData('Password_expired'));
         $this->assertNotEquals($oldHash, $this->_user->getData('Password_hash'));
     }
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -58,7 +58,7 @@ class UserTest extends TestCase
                 'DBAccess'               => '123',
                 'Active'                 => 'Y',
                 'Password_hash'          => null,
-                'Password_expiry'        => '2020-07-16',
+                'Password_expired'        => false,
                 'Pending_approval'       => 'Y',
                 'Doc_Repo_Notifications' => 'Y',
                 'language_preference'    => 2,
@@ -536,17 +536,17 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test that updatePassword updates the 'Password_hash' and 'Password_expiry'
-     * fields when both the new password and expiry date are specified
+     * Test that updatePassword updates the 'Password_hash' and 'Password_expired'
+     * fields when both the new password and expiration are specified
      *
      * @return void
      * @covers User::updatePassword
      */
-    public function testUpdatePasswordWithExpiryDate()
+    public function testUpdatePasswordWithExpiration()
     {
         $this->_user = \User::factory(self::USERNAME);
         $oldHash = $this->_user->getData('Password_hash');
-        $customDate = '2021-07-18';
+        $passwordExpired = true;
 
         // Cause usePwnedPasswordsAPI config option to return false.
         $this->_mockConfig->expects($this->any())
@@ -555,21 +555,20 @@ class UserTest extends TestCase
 
         $this->_user->updatePassword(
             new \Password(\Utility::randomString(16)), 
-            new DateTime($customDate)
+            $passwordExpired
         );
         //Re-populate the user object now that the password has been changed
         $this->_user = \User::factory(self::USERNAME);
 
-        $this->assertEquals($customDate, $this->_user->getData('Password_expiry'));
+        $this->assertEquals(true, $this->_user->getData('Password_expired'));
         // This checks that the hash has been updated. There is no way to predict
         // what the new hash will be, so simply check that it changed!
         $this->assertNotEquals($oldHash, $this->_user->getData('Password_hash'));
     }
 
     /**
-     * Test that updatePassword updates the 'Password_hash' and 'Password_expiry'
-     * fields when only the password is specified. The 'Password_expiry' should
-     * be updated to today's date plus 6 months if not specified!
+     * Test that updatePassword causes a new password to not be expired by
+     * default.
      *
      * @return void
      * @covers User::updatePassword
@@ -579,7 +578,6 @@ class UserTest extends TestCase
         $this->_user = \User::factory(self::USERNAME);
 
         $oldHash = $this->_user->getData('Password_hash');
-        $newDate = date('Y-m-d', strtotime('+6 months'));
 
         // Cause usePwnedPasswordsAPI config option to return false.
         $this->_mockConfig->expects($this->any())
@@ -592,7 +590,7 @@ class UserTest extends TestCase
         //Re-populate the user object now that the password has been changed
         $this->_user = \User::factory(self::USERNAME);
 
-        $this->assertEquals($newDate, $this->_user->getData('Password_expiry'));
+        $this->assertEquals(false, $this->_user->getData('Password_expired'));
         $this->assertNotEquals($oldHash, $this->_user->getData('Password_hash'));
     }
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -58,7 +58,7 @@ class UserTest extends TestCase
                 'DBAccess'               => '123',
                 'Active'                 => 'Y',
                 'Password_hash'          => null,
-                'Password_expired'        => 0,
+                'PasswordChangeRequired'        => 0,
                 'Pending_approval'       => 'Y',
                 'Doc_Repo_Notifications' => 'Y',
                 'language_preference'    => 2,
@@ -536,7 +536,7 @@ class UserTest extends TestCase
     }
 
     /**
-     * Test that updatePassword updates the 'Password_hash' and 'Password_expired'
+     * Test that updatePassword updates the 'Password_hash' and 'PasswordChangeRequired'
      * fields when both the new password and expiration are specified
      *
      * @return void
@@ -560,7 +560,7 @@ class UserTest extends TestCase
         //Re-populate the user object now that the password has been changed
         $this->_user = \User::factory(self::USERNAME);
 
-        $this->assertEquals(true, $this->_user->getData('Password_expired'));
+        $this->assertEquals(true, $this->_user->getData('PasswordChangeRequired'));
         // This checks that the hash has been updated. There is no way to predict
         // what the new hash will be, so simply check that it changed!
         $this->assertNotEquals($oldHash, $this->_user->getData('Password_hash'));
@@ -590,7 +590,7 @@ class UserTest extends TestCase
         //Re-populate the user object now that the password has been changed
         $this->_user = \User::factory(self::USERNAME);
 
-        $this->assertEquals(0, $this->_user->getData('Password_expired'));
+        $this->assertEquals(0, $this->_user->getData('PasswordChangeRequired'));
         $this->assertNotEquals($oldHash, $this->_user->getData('Password_hash'));
     }
 

--- a/tools/single_use/remove_logged_passwords.php
+++ b/tools/single_use/remove_logged_passwords.php
@@ -74,7 +74,7 @@ foreach($compromised as $username => $details) {
     // password reset
     $DB->update(
         'users', 
-        array('Password_expiry' => '1990-01-01'), 
+        array('Password_expired' => '1'), 
         array('UserID' => $username)
     );
 }

--- a/tools/single_use/remove_logged_passwords.php
+++ b/tools/single_use/remove_logged_passwords.php
@@ -74,7 +74,7 @@ foreach($compromised as $username => $details) {
     // password reset
     $DB->update(
         'users', 
-        array('Password_expired' => '1'), 
+        array('PasswordChangeRequired' => '1'), 
         array('UserID' => $username)
     );
 }


### PR DESCRIPTION
## Summary
This PR removes the Password_expiry date column and adds a PasswordExpired boolean column.

Passwords will no longer be required to reset after 6 months as this is not actually a security benefit (see discussion in linked issue) and because most projects were subverting this by setting passwords to have an infinite expiry time anyway.

Calling code and relevant tables are updated.

## Testing instructions (if applicable)

Follow the Test plan at modules/login/test/Reset_Password_Test_Plan.md

## Links to related tickets (GitHub, Redmine, ...)

Resolves #4458
Resolves #4208 