### PR TITLE
[lorisform] undefined name warning for label element

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1238,8 +1238,10 @@ class LorisForm
             } else {
                 if ($el['type'] === 'file') {
                     $value = $_FILES[$el['name']]['name'];
-                } else {
+                } elseif (isset($el['name'])) {
                     $value = $this->getValue($el['name']);
+                } else { // If the form element is a static label
+                    $val = null;
                 }
 
                 if (isset($el['required'])

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1241,7 +1241,7 @@ class LorisForm
                 } elseif (isset($el['name'])) {
                     $value = $this->getValue($el['name']);
                 } else { // If the form element is a static label
-                    $val = null;
+                    $value = null;
                 }
 
                 if (isset($el['required'])


### PR DESCRIPTION
## Brief summary of changes
A instrument with
`$this->addLabel('<label>')` will always report PHP warning "Undefined index: name in LorisForm.class.inc on line 1242"

This happens because Loris form assumes that a name is mandatory, even for a label. I don't see the necessity here.

#### Testing instructions (if applicable)

1. Create an instrument, or a unit test case, put a label `$this->addLabel('<label>')` anyway in an instrument, check whether the PHP warning is in the log.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
N/A