### PR TITLE
[Dashboard] Fix study progression performance

### DIFF
--- a/modules/dashboard/ajax/get_scan_line_data.php
+++ b/modules/dashboard/ajax/get_scan_line_data.php
@@ -25,15 +25,15 @@ $client->initialize();
 
 $DB = Database::singleton();
 
-$scanData           = array();
-$scanStartDate      = $DB->pselectOne(
+$scanData      = array();
+$scanStartDate = $DB->pselectOne(
     "SELECT MIN(pf.Value) 
      FROM parameter_file pf 
      JOIN parameter_type pt USING (ParameterTypeID) 
      WHERE pt.Name='acquisition_date'",
     array()
 );
-$scanEndDate        = $DB->pselectOne(
+$scanEndDate   = $DB->pselectOne(
     "SELECT MAX(pf.Value) 
      FROM parameter_file pf 
      JOIN parameter_type pt USING (ParameterTypeID) 
@@ -41,46 +41,75 @@ $scanEndDate        = $DB->pselectOne(
     array()
 );
 
-// Run a query to get all the data. Order matters to ensure that the labels are calculated
-// in the correct order.
-$data= $DB->pselect("SELECT s.CenterID, CONCAT(MONTH(pf.Value), '-', YEAR(pf.Value)) as datelabel, COUNT(distinct s.ID) as count
-        FROM files f
+// Run a query to get all the data. Order matters to ensure that the labels
+// are calculated in the correct order.
+$data = $DB->pselect(
+    "SELECT s.CenterID, 
+        CONCAT(MONTH(pf.Value), '-', YEAR(pf.Value)) as datelabel,
+        COUNT(distinct s.ID) as count
+    FROM files f
         LEFT JOIN parameter_file pf USING (FileID)
         LEFT JOIN session s ON (s.ID=f.SessionID)
         JOIN parameter_type pt USING (ParameterTypeID)
-        WHERE pt.Name='acquisition_date'
-        GROUP BY MONTH(pf.Value), YEAR(pf.Value), s.CenterID
-        ORDER BY YEAR(pf.Value), MONTH(pf.Value), s.CenterID",
-        array()
-    );
+    WHERE pt.Name='acquisition_date'
+    GROUP BY MONTH(pf.Value), YEAR(pf.Value), s.CenterID
+    ORDER BY YEAR(pf.Value), MONTH(pf.Value), s.CenterID",
+    array()
+);
 
 $scanData['labels'] = createLineChartLabels($data);
 
-$list_of_sites      = Utility::getSiteList(true, false);
+$list_of_sites = Utility::getSiteList(true, false);
 foreach ($list_of_sites as $siteID => $siteName) {
     $scanData['datasets'][] = array(
         "name" => $siteName,
-        "data" => getScanData2($data, $siteID, $scanData['labels'])
+        "data" => getScanData($data, $siteID, $scanData['labels'])
     );
 }
 
-function getScanData(array $data, int $siteID, array $labels) {
-    $sitedata = array_filter($data, function($row) use ($siteID) {
-        return $row['CenterID'] == $siteID;
-    });
+/**
+ * Massages the data passed into the format expected by C3.
+ * Extracts the data for $siteID from $data, and ensures
+ * that each label has a value in the correct index of the
+ * returned array. Labels not in $data for site are given
+ * a value of 0.
+ *
+ * @param array $data   The data to be extracted from
+ * @param int   $siteID The siteID to be extracted
+ * @param array $labels A list of labels that should appear
+ *                      in the result in the correct order.
+ *
+ * @return array The data for $siteID massaged into the correct form.
+ */
+function getScanData(array $data, int $siteID, array $labels)
+{
+    $sitedata   = array_filter(
+        $data,
+        function ($row) use ($siteID) {
+            return $row['CenterID'] == $siteID;
+        }
+    );
     $mappeddata = [];
     foreach ($sitedata as $row) {
         $mappeddata[$row['datelabel']] = $row['count'];
     }
 
     $data = [];
-    foreach($labels as $i => $label) {
+    foreach ($labels as $i => $label) {
         $data[$i] = $mappeddata[$label] ?? 0;
     }
     return $data;
 }
 
-function createLineChartLabels(array $data) {
+/**
+ * Extract all month labels that are in $data.
+ *
+ * @param array $data The data to extract labels from
+ *
+ * @return array An array of date labels that appear in the data.
+ */
+function createLineChartLabels(array $data)
+{
     // Order was determined by the SQL statement. This should
     // ensure that duplicates (for different sites) are stripped
     // out.

--- a/modules/dashboard/ajax/get_scan_line_data.php
+++ b/modules/dashboard/ajax/get_scan_line_data.php
@@ -68,14 +68,14 @@ foreach ($list_of_sites as $siteID => $siteName) {
 }
 
 /**
- * Massages the data passed into the format expected by C3.
- * Extracts the data for $siteID from $data, and ensures
- * that each label has a value in the correct index of the
- * returned array. Labels not in $data for site are given
- * a value of 0.
+ * Massages the data passed into the format expected by the
+ * C3 library. Extracts the data for $siteID from $data, and
+ * ensures that each label has a value in the correct index
+ * of the returned array. Labels not in $data for site are
+ * given a value of 0.
  *
- * @param array $data   The data to be extracted from
- * @param int   $siteID The siteID to be extracted
+ * @param array $data   The data to be extracted from.
+ * @param int   $siteID The siteID to be extracted.
  * @param array $labels A list of labels that should appear
  *                      in the result in the correct order.
  *


### PR DESCRIPTION
For long running studies the "study progression" widget on the
dashboard was doing an excessive number of queries on the database
(one per site per month of the study having been running) which
was causing the dashboard to take an excessive amount of time to
load.

This replaces it with a single query using a GROUP BY, and then
massages the data in PHP to the same format.

To test this compare the dashboard/ajax/get_scan_line_data.php results
before and after this change. The JSON returned should be identical, but the
performance should be faster (if there's a large enough amount of data
that the before was noticeably slow to load.).