### PR TITLE
[Dashboard/Study Progression -- View scans per site] Restricting users to see statistics only from sites they have access to.

### DIFF
--- a/modules/dashboard/ajax/get_scan_line_data.php
+++ b/modules/dashboard/ajax/get_scan_line_data.php
@@ -23,7 +23,21 @@ $client = new NDB_Client();
 $client->makeCommandLine();
 $client->initialize();
 
-$DB = Database::singleton();
+$DB            = Database::singleton();
+$currentUser   = \User::singleton();
+$site          = array();
+$list_of_sites = array();
+
+//TODO: Create a permission specific to statistics
+if ($currentUser->hasPermission('access_all_profiles')) {
+    $list_of_sites = \Utility::getSiteList();
+} else {
+    $site_id_arr = $currentUser->getCenterIDs();
+    foreach ($site_id_arr as $key => $val) {
+        $site[$key]          = &Site::singleton($val);
+        $list_of_sites[$val] = $site[$key]->getCenterName();
+    }
+}
 
 $scanData           = array();
 $scanStartDate      = $DB->pselectOne(
@@ -42,7 +56,6 @@ $scanEndDate        = $DB->pselectOne(
 );
 $scanData['labels']
     = createLineChartLabels($scanStartDate, $scanEndDate);
-$list_of_sites      = Utility::getAssociativeSiteList(true, false);
 foreach ($list_of_sites as $siteID => $siteName) {
     $scanData['datasets'][] = array(
         "name" => $siteName,


### PR DESCRIPTION
### Brief summary of changes

In **dashboard-> Study Progression-> View scans per site** users were able to see statistics from sites they do not belong/have access

#### Testing instructions

Now each user should be able to see the **view scans per site** only for the sites it belong/have access

#### Notes

This is a fix for 22.0.0, major design changes as creating a permission dedicated to statistics still pending.

#### Link(s) to related issue(s)

* Resolves #5847 
