### PR TITLE
Use module long name for Breadcrumb

### DIFF
--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -29,7 +29,9 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      * UI elements and locations
      * breadcrumb - 'MRI Violated Scans'
      */
-    private $_loadingUI = array('MRI Violated Scans' => '#bc2 > a:nth-child(2) > div');
+    private $_loadingUI = array(
+        'MRI Violated Scans' => '#bc2 > a:nth-child(2) > div'
+    );
     /**
      * Insert testing data
      *

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -27,9 +27,9 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
 {
     /**
      * UI elements and locations
-     * breadcrumb - 'Mri Violations'
+     * breadcrumb - 'MRI Violated Scans'
      */
-    private $_loadingUI = array('Mri Violations' => '#bc2 > a:nth-child(2) > div');
+    private $_loadingUI = array('MRI Violated Scans' => '#bc2 > a:nth-child(2) > div');
     /**
      * Insert testing data
      *

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -888,17 +888,19 @@ class NDB_Page implements RequestHandlerInterface
      */
     public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
     {
-        $label    = ucwords(str_replace('_', ' ', $this->name));
+        // If the page name is the same as the module directory name,
+        // there should only be 1 level of breadcrumb.
+        $pagename = ucwords(str_replace('_', ' ', $this->name));
         $sublabel = ucwords(str_replace('_', ' ', $this->page));
 
-        if ($label == $sublabel) {
+        if ($pagename == $sublabel) {
             return new \LORIS\BreadcrumbTrail(
-                new \LORIS\Breadcrumb($label, "/$this->name")
+                new \LORIS\Breadcrumb($this->Module->getLongName(), "/$this->name")
             );
         }
 
         return new \LORIS\BreadcrumbTrail(
-            new \LORIS\Breadcrumb($label, "/$this->name"),
+            new \LORIS\Breadcrumb($this->Module->getLongName(), "/$this->name"),
             new \LORIS\Breadcrumb($sublabel, "/$this->name/$this->page")
         );
     }


### PR DESCRIPTION
This updates the default breadcrumb for a page to
use the module's getLongName for the first level of
the breadcrumb, rather than the hack where it replaces
'_' with space in the URL.

Fixes #5856.