### PR TITLE
[NDB_Config] Make field list explicit and remove unnecessary catch

### DIFF
--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -440,16 +440,15 @@ class NDB_Config
      */
     function getProjectSettings(int $ProjectID): ?array
     {
-        try {
-            $info = \NDB_Factory::singleton()
-                ->database()
-                ->pselectRow(
-                    "SELECT * FROM Project WHERE ProjectID=:sp",
-                    array('sp' => $ProjectID)
-                );
-        } catch (\DatabaseException $e) {
-            return null;
-        }
+        $info = \NDB_Factory::singleton()
+            ->database()
+            ->pselectRow(
+                "SELECT ProjectID, Name, Alias, recruitmentTarget
+                 FROM Project
+                 WHERE ProjectID=:sp",
+                array('sp' => $ProjectID)
+            );
+
         //Format the result into config.xml format.
         return is_null($info) ?
             null


### PR DESCRIPTION
This makes the field list in NDB_Config->getProjectSettings explicit
so that it crashes hard if a patch is missed rather than continuing
on and providing unrelated warnings later. It removes the try/catch
for the same reason (and because I couldn't figure out any reason it
was there in the first place. It looks like it was added in a commit to appease
phan, but phan is passing without it.)