### PR TITLE
[acknowledgements] public facing link broken - 500 error

### DIFF
--- a/htdocs/acknowledgements/acknowledgements.php
+++ b/htdocs/acknowledgements/acknowledgements.php
@@ -26,7 +26,6 @@ $publication_date = $_GET["date"];
 $columns = array(
     'full_name'     => 'Full Name',
     'citation_name' => 'Citation Name',
-    'title'         => 'Title',
     'affiliations'  => 'Affiliations',
     'degrees'       => 'Degrees',
     'roles'         => 'Roles',


### PR DESCRIPTION
## Brief summary of changes
 remove useless column

#### Testing instructions (if applicable)
Example public facing link:

`https://<YOUR-BASE-STUDY-URL>/acknowledgements/acknowledgements.php?date=2017-11-17`

Given the publication date of `2017-11-17`, this will limit the list to people
who started on or before `2017-11-17`.
This list is intended to be used in any publication(s), so keep in mind it will
be shared in the wild without authentication.

solve:
https://github.com/aces/Loris/issues/5885