### PR TITLE
[Tools] Add option to specify tables to dump for RB on command line

### DIFF
--- a/tools/exporters/DB_dump_table_data.php
+++ b/tools/exporters/DB_dump_table_data.php
@@ -28,13 +28,19 @@ require_once __DIR__ . '/../generic_includes.php';
 $config = NDB_Config::singleton();
 $databaseInfo = $config->getSetting('database');
 
-// Get all tables in the database
-$tableNames = $DB->pselectCol("
+$tableNames = [];
+
+if ($argc < 2) {
+    // Get all tables in the database
+    $tableNames = $DB->pselectCol("
                       SELECT TABLE_NAME 
                       FROM INFORMATION_SCHEMA.TABLES
                       WHERE TABLE_SCHEMA =:dbn",
-    array("dbn"=>$databaseInfo['database'])
-);
+        array("dbn"=>$databaseInfo['database'])
+    );
+} else {
+    $tableNames = array_slice($argv, 1);
+}
 
 $adminUser = $databaseInfo["adminUser"];
 $adminPassword = $databaseInfo["adminPassword"];

--- a/tools/exporters/DB_dump_table_data.php
+++ b/tools/exporters/DB_dump_table_data.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php declare(strict_types=1);
 /**
  * This script generates data-only dumps for all tables in the currently active database.
@@ -30,16 +31,26 @@ $databaseInfo = $config->getSetting('database');
 
 $tableNames = [];
 
-if ($argc < 2) {
-    // Get all tables in the database
-    $tableNames = $DB->pselectCol("
+$allTables = $DB->pselectCol("
                       SELECT TABLE_NAME 
                       FROM INFORMATION_SCHEMA.TABLES
                       WHERE TABLE_SCHEMA =:dbn",
         array("dbn"=>$databaseInfo['database'])
     );
+if ($argc < 2) {
+    $tableNames = $allTables;
 } else {
     $tableNames = array_slice($argv, 1);
+    $hasErr = false;
+    foreach ($tableNames as $table) {
+        if (!in_array($table, $allTables, true)) {
+            fprintf(STDERR, "Invalid table $table\n");
+            $hasErr = true;
+        }
+    }
+    if ($hasErr) {
+        exit(1);
+    }
 }
 
 $adminUser = $databaseInfo["adminUser"];


### PR DESCRIPTION
This adds the ability to only dump certain tables by specifying them
as arguments on the command line to DB_dump_table_data.php.