### PR TITLE
[Core] Candidate createNew infinite loop

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -283,6 +283,7 @@ class Candidate
         $generator = new \CandIDGenerator();
         // declare the variable to avoid static analysis warnings
         $invalidID = false;
+        $attemptcount = 0;
         do {
             // Reset on each iteration
             $invalidID = false;
@@ -296,6 +297,12 @@ class Candidate
                 // with the same value has been inserted into the DB before this
                 // one.
                 $invalidID = true;
+                $attemptcount++;
+                if ($attemptcount > 2) {
+                    throw new LorisException(
+                        $e->getMessage()
+                    );
+                }
             }
         } while ($invalidID);
 


### PR DESCRIPTION
## Brief summary of changes
There is a retry mechanism in Candidate::createNew "in the case of a race condition where another CandID with the same value has been inserted into the DB before this one."

An infinite loop occurs when the insert statement fails for an other reason.

This adds a limit to the number of insert attempts 
#### Testing instructions (if applicable)

1. Set `userEDC` to false
2. Create a candidate with an invalid value for EDC (ex: an empty string)
3. A LorisException should be thrown after 3 attempts

