### PR TITLE
Fix PhanTypeInvalidDimOffset, PhanNoopNew and remove incorrect comment from phan config

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -42,7 +42,6 @@ return [
         "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",
         "PhanPossiblyUndeclaredVariable",
-        "PhanNoopNew"
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -33,7 +33,6 @@ return [
     // unused_variable_detection. It might be a good idea to enable this first.
     "unused_variable_detection" => false,
     "suppress_issue_types" => [
-        "PhanTypeInvalidDimOffset",
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",
         "PhanTypeMismatchDimFetch",
@@ -47,11 +46,6 @@ return [
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [
-        /* This doesn't include php/installer, because there's
-           (intentionally) classes in the installer namespace
-           which redeclare classes from php/libraries, in order
-           to bootstrap the installer before the config/database
-           is set up */
         "php",
         "htdocs",
         "modules",

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -222,7 +222,9 @@ class ViewDetails extends \NDB_Form
             $this->tpl_data['archive']['PatientName'] = "INVALID - HIDDEN";
         }
 
-        if (!is_null($this->tpl_data['archive']['PatientID'])) {
+        if (isset($this->tpl_data['archive']['PatientID'])
+            && $this->tpl_data['archive']['PatientID'] !== null
+        ) {
             if (preg_match(
                 "/$pIDRegex/",
                 $this->tpl_data['archive']['PatientID']


### PR DESCRIPTION
There was only one error of type "PhanTypeInvalidDimOffset" detected (which was mostly just phan getting confused by the array being populated by a "SELECT *"), so this bandages over it by adding an isset. PhanNoopNew had no violations.