### PR TITLE
[API/Router] Move UnsupportedMediaType to the json folder

### DIFF
--- a/src/Http/Response/JSON/UnsupportedMediaType.php
+++ b/src/Http/Response/JSON/UnsupportedMediaType.php
@@ -14,7 +14,7 @@
  * @see https://www.php-fig.org/psr/psr-7/
  * @see https://www.php-fig.org/psr/psr-15/
  */
-namespace LORIS\Http\Response;
+namespace LORIS\Http\Response\JSON;
 
 use \LORIS\Http\Response\JsonResponse;
 


### PR DESCRIPTION
UnsupportedMediaType is a type of JSON response with a specific
HTTP response code. The API was instantiating it as if it was
in the LORIS\Http\Response\JSON namespace (as all the other
JSON specific response classes are) but the file was in
LORIS\Http\Response. This moves the file to the correct
namespace.