### PR TITLE
[Dashboard] Restricting users to see statistics only from sites they have access to.

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -286,22 +286,27 @@ class Charts extends \NDB_Page
             $list_of_sites = $currentUser->getSiteList(true, false);
         }
 
-        $listOfSitesString = implode(",", array_keys($list_of_sites));
-
-        $recruitmentData      = array();
+        $params            = array();
+        $centerIDs         = array();
+        $list_of_sites_ids = array_keys($list_of_sites);
+        foreach ($list_of_sites_ids as $key => $siteID) {
+            $params[]            = ":id$key";
+            $centerIDs["id$key"] = $siteID;
+        }
         $recruitmentStartDate = $DB->pselectOne(
             "SELECT MIN(Date_registered)
              FROM candidate
-             WHERE RegistrationCenterID IN (" . $listOfSitesString . ")",
-            array()
+             WHERE RegistrationCenterID IN (" . implode(',', $params) . ")",
+            $centerIDs
         );
         $recruitmentEndDate   = $DB->pselectOne(
             "SELECT MAX(Date_registered)
              FROM candidate
-             WHERE RegistrationCenterID IN (" . $listOfSitesString . ")",
-            array()
+             WHERE RegistrationCenterID IN (" . implode(',', $params) . ")",
+            $centerIDs
         );
 
+        $recruitmentData = array();
         if ($recruitmentStartDate !== null
             && $recruitmentEndDate !== null
         ) {

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -105,10 +105,16 @@ class Charts extends \NDB_Page
      */
     private function _handleSitePieData()
     {
-        $DB = \NDB_Factory::singleton()->database();
+        $DB          = \NDB_Factory::singleton()->database();
+        $currentUser = \NDB_Factory::singleton()->user();
 
         $recruitmentBySiteData = array();
-        $list_of_sites         = \Utility::getSiteList(true, false);
+
+        if ($currentUser->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList(true, false);
+        } else {
+            $list_of_sites = $currentUser->getSiteList(true, false);
+        }
 
         foreach ($list_of_sites as $siteID => $siteName) {
             $totalRecruitment = $DB->pselectOne(
@@ -136,9 +142,16 @@ class Charts extends \NDB_Page
      */
     private function _handleSiteSexBreakdown()
     {
-        $DB            = \NDB_Factory::singleton()->database();
-        $sexData       = array();
-        $list_of_sites = \Utility::getSiteList(true, false);
+        $DB          = \NDB_Factory::singleton()->database();
+        $currentUser = \NDB_Factory::singleton()->user();
+
+        $sexData = array();
+
+        if ($currentUser->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList(true, false);
+        } else {
+            $list_of_sites = $currentUser->getSiteList(true, false);
+        }
 
         foreach ($list_of_sites as $siteID => $siteName) {
             $sexData['labels'][] = $siteName;
@@ -202,8 +215,15 @@ class Charts extends \NDB_Page
         }
         $scanData['labels'] = array_keys($labels);
 
+        $currentUser = \NDB_Factory::singleton()->user();
+
+        if ($currentUser->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList(true, false);
+        } else {
+            $list_of_sites = $currentUser->getSiteList(true, false);
+        }
+
         // Massage the data into the appropriate format per site.
-        $list_of_sites = \Utility::getSiteList(true, false);
         foreach ($list_of_sites as $siteID => $siteName) {
             $scanData['datasets'][] = array(
                 "name" => $siteName,
@@ -257,15 +277,28 @@ class Charts extends \NDB_Page
      */
     private function _handleSiteLineData()
     {
-        $DB = \NDB_Factory::singleton()->database();
+        $DB          = \NDB_Factory::singleton()->database();
+        $currentUser = \NDB_Factory::singleton()->user();
+
+        if ($currentUser->hasPermission('access_all_profiles')) {
+            $list_of_sites = \Utility::getSiteList(true, false);
+        } else {
+            $list_of_sites = $currentUser->getSiteList(true, false);
+        }
+
+        $listOfSitesString = implode(",", array_keys($list_of_sites));
 
         $recruitmentData      = array();
         $recruitmentStartDate = $DB->pselectOne(
-            "SELECT MIN(Date_registered) FROM candidate",
+            "SELECT MIN(Date_registered)
+             FROM candidate
+             WHERE RegistrationCenterID IN (" . $listOfSitesString . ")",
             array()
         );
         $recruitmentEndDate   = $DB->pselectOne(
-            "SELECT MAX(Date_registered) FROM candidate",
+            "SELECT MAX(Date_registered)
+             FROM candidate
+             WHERE RegistrationCenterID IN (" . $listOfSitesString . ")",
             array()
         );
 
@@ -277,8 +310,6 @@ class Charts extends \NDB_Page
                 new \DateTimeImmutable($recruitmentEndDate)
             );
         }
-
-        $list_of_sites = \Utility::getSiteList(true, false);
 
         foreach ($list_of_sites as $siteID => $siteName) {
             $recruitmentData['datasets'][] = array(

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -363,6 +363,45 @@ class User extends UserPermissions
     }
 
     /**
+     * Returns a list with the user's sites
+     *
+     * @param boolean $study_site if true only return study sites
+     * @param boolean $DCC        Whether the DCC should be included or not
+     *
+     * @return array an associative array("center ID" => "site name")
+     */
+    function getSiteList(
+        bool $study_site = true,
+        bool $DCC = true
+    ): array {
+        $site_arr   = $this->getCenterIDs();
+        $user_sites = array();
+
+        if ($study_site) {
+            $site = array();
+            foreach ($site_arr as $key => $val) {
+                $site[$key] = &Site::singleton($val);
+                if ($site[$key]->isStudySite()) {
+                    $user_sites[$val] = $site[$key]->getCenterName();
+                }
+            }
+        } else {
+            $site = array();
+            foreach ($site_arr as $key => $val) {
+                $site[$key]       = &Site::singleton($val);
+                $user_sites[$val] = $site[$key]->getCenterName();
+            }
+        }
+
+        if (!$DCC) {
+            unset($user_sites["1"]);
+        }
+
+        natcasesort($user_sites);
+        return $user_sites;
+    }
+
+    /**
      * Checks if the user is in at least one study site
      *
      * @return boolean


### PR DESCRIPTION
### Brief summary of changes
Address #5889, #5861 and #5847 after the redesign proposed in #5896 

#### Testing instructions

Now each user should be able to see the dashboard statistics only for the sites it belong/have access to.

#### Link(s) to related issue(s)

* Resolves #5889,  #5861, #5847
