### PR TITLE
[Phan] Fix PhanTypeMismatchDimFetch errors

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -35,7 +35,6 @@ return [
     "suppress_issue_types" => [
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",
-        "PhanTypeMismatchDimFetch",
         "PhanUndeclaredClassMethod",
         "PhanTypeMismatchArgument",
         "PhanTypeMismatchProperty",

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -595,14 +595,19 @@ class NDB_Menu_Filter extends NDB_Menu
         $this->setTemplateVar('rowsPerPage', $rowsPerPage);
         $this->setTemplateVar('pageID', $pageID);
 
-        $this->setTemplateVar(
-            'filterfield',
-            $_GET['filter']['order']['field'] ?? ''
-        );
-        $this->setTemplateVar(
-            'filterfieldOrder',
-            $_GET['filter']['order']['fieldOrder'] ?? ''
-        );
+        if (is_array($_GET['filter']['order'])) {
+            $this->setTemplateVar(
+                'filterfield',
+                $_GET['filter']['order']['field'] ?? ''
+            );
+            $this->setTemplateVar(
+                'filterfieldOrder',
+                $_GET['filter']['order']['fieldOrder'] ?? ''
+            );
+        } else {
+            $this->setTemplateVar('filterfield', '');
+            $this->setTemplateVar('filterfieldOrder', '');
+        }
 
         // print out column headings
         $i = 0;

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -26,6 +26,8 @@ use PHPUnit\Framework\TestCase;
  */
 class LorisForms_Test extends TestCase
 {
+    protected $form;
+
     /**
      * Creates a new LorisForm to use for testing
      *

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -30,6 +30,9 @@ use \PHPUnit\Framework\TestCase;
  */
 class VisitTest extends TestCase
 {
+    protected $factory;
+    protected $DB;
+
     /**
      * Visit object use in tests
      *
@@ -187,5 +190,4 @@ class VisitTest extends TestCase
         parent::tearDown();
         $this->factory->reset();
     }
-
 }


### PR DESCRIPTION
$_GET['foo'] is usually a string, so we need to ensure
that it's an array places that it's submitted/treated as
an array.