### PR TITLE
[docs] change link to new location in docs/wiki/00

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 * Try the LORIS demo instance at https://demo.loris.ca.
 
 This Readme covers installation of the LORIS <b>v22.*</b> release on <b>Ubuntu</b>.
-([CentOS Readme also available](./README.CentOS7.md)).
+([CentOS Readme also available](:./docs/wiki/00%20-%20SERVER%20INSTALL%20AND%20CONFIGURATION/01%20-%20LORIS%20Install/CentOS/README.CentOS7.md)).
 
 Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 * Try the LORIS demo instance at https://demo.loris.ca.
 
 This Readme covers installation of the LORIS <b>v22.*</b> release on <b>Ubuntu</b>.
-([CentOS Readme also available](:./docs/wiki/00%20-%20SERVER%20INSTALL%20AND%20CONFIGURATION/01%20-%20LORIS%20Install/CentOS/README.CentOS7.md)).
+([CentOS Readme also available](./docs/wiki/00%20-%20SERVER%20INSTALL%20AND%20CONFIGURATION/01%20-%20LORIS%20Install/CentOS/README.CentOS7.md)).
 
 Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.
 

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
@@ -13,7 +13,7 @@ Default dependencies installed by CentOS 7.x may not meet the version requiremen
 * MariaDB 10.3 is supported for LORIS 23.* 
 * PHP 7.3 is supported for LORIS 23.*
 
-In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](./README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
+In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](HTTPS://github.com/aces/Loris/blob/master/README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher
  * [Composer](https://getcomposer.org)
  * NodeJS 8.0 or higher
@@ -127,7 +127,7 @@ Finally, restart apache:
 sudo systemctl restart httpd
 sudo systemctl status httpd
 ```
-# Install LORIS
+d# Install LORIS
 
 For the purpose of following LORIS conventions and easy understanding of all LORIS documentation, we recommend the following account names: 
 
@@ -173,4 +173,4 @@ If there are any errors or you get a blank page, troubleshoot the errors in your
 **Next:** Follow the [**Setup Guide** in the LORIS wiki](https://github.com/aces/Loris/wiki/Setup) for all post-install steps and troubleshooting.  
 Config settings can be accessed via the front-end Config module under the Admin drop-down menu.
 
-Please see the main (Ubuntu) [LORIS Readme](./README.md) for info on our Community, Contributing, and who we are. 
+Please see the main (Ubuntu) [LORIS Readme](HTTPS://github.com/aces/Loris/blob/master/README.md) for info on our Community, Contributing, and who we are. 

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
@@ -173,4 +173,4 @@ If there are any errors or you get a blank page, troubleshoot the errors in your
 **Next:** Follow the [**Setup Guide** in the LORIS wiki](https://github.com/aces/Loris/wiki/Setup) for all post-install steps and troubleshooting.  
 Config settings can be accessed via the front-end Config module under the Admin drop-down menu.
 
-Please see the main (Ubuntu) [LORIS Readme](HTTPS://github.com/aces/Loris/blob/master/README.md) for info on our Community, Contributing, and who we are. 
+Please see the main (Ubuntu) [LORIS Readme](https://github.com/aces/Loris/blob/master/README.md) for info on our Community, Contributing, and who we are. 

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
@@ -127,7 +127,7 @@ Finally, restart apache:
 sudo systemctl restart httpd
 sudo systemctl status httpd
 ```
-d# Install LORIS
+# Install LORIS
 
 For the purpose of following LORIS conventions and easy understanding of all LORIS documentation, we recommend the following account names: 
 

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
@@ -13,7 +13,7 @@ Default dependencies installed by CentOS 7.x may not meet the version requiremen
 * MariaDB 10.3 is supported for LORIS 23.* 
 * PHP 7.3 is supported for LORIS 23.*
 
-In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](HTTPS://github.com/aces/Loris/blob/master/README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
+In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](https://github.com/aces/Loris/blob/master/README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher
  * [Composer](https://getcomposer.org)
  * NodeJS 8.0 or higher

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.CentOS7.md
@@ -13,7 +13,7 @@ Default dependencies installed by CentOS 7.x may not meet the version requiremen
 * MariaDB 10.3 is supported for LORIS 23.* 
 * PHP 7.3 is supported for LORIS 23.*
 
-In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](https://github.com/aces/Loris/blob/master/README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
+In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](../../../../../README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher
  * [Composer](https://getcomposer.org)
  * NodeJS 8.0 or higher
@@ -173,4 +173,4 @@ If there are any errors or you get a blank page, troubleshoot the errors in your
 **Next:** Follow the [**Setup Guide** in the LORIS wiki](https://github.com/aces/Loris/wiki/Setup) for all post-install steps and troubleshooting.  
 Config settings can be accessed via the front-end Config module under the Admin drop-down menu.
 
-Please see the main (Ubuntu) [LORIS Readme](https://github.com/aces/Loris/blob/master/README.md) for info on our Community, Contributing, and who we are. 
+Please see the main (Ubuntu) [LORIS Readme](../../../../../README.md) for info on our Community, Contributing, and who we are. 


### PR DESCRIPTION
## Brief summary of changes
change the link for the README.CentOS7.md file to the new docs/wiki directory.
and the link from that file to the README.md file

#### Testing instructions (if applicable)
Click on the link in the README.md file, you should get to the CentOS7 version.
From there, click on the link to the README.md file (2 location, near top and at bottom).