### PR TITLE
[left bar navigation] shrink left bar width size

### DIFF
--- a/htdocs/css/simple-sidebar.css
+++ b/htdocs/css/simple-sidebar.css
@@ -3,15 +3,15 @@
 }
 
 .wrapper {
-    padding-left: 250px;
+    padding-left: 200px;
     transition: all 0.4s ease 0s;
 }
 
 #sidebar-wrapper {
-    margin-left: -250px;
+    margin-left: -200px;
     margin-top: 50px;
-    left: 250px;
-    width: 250px;
+    left: 200px;
+    width: 200px;
     top: 0;
     background: #E4EBF2;
     border: 1px solid #C3D5DB;
@@ -37,7 +37,7 @@
 .sidebar-nav {
     position: absolute;
     top: 0;
-    width: 250px;
+    width: 200px;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -124,12 +124,12 @@
 
     .wrapper.active {
         position: relative;
-        left: 250px;
+        left: 200px;
     }
 
     .wrapper.active #sidebar-wrapper {
-        left: 250px;
-        width: 250px;
+        left: 200px;
+        width: 200px;
         transition: all 0.4s ease 0s;
     }
 


### PR DESCRIPTION
## Brief summary of changes
The left side bar occupies unnecessarily takes too much space for the most cases, especially when some instruments has big table which will needs more space, even 10 pixels count. In fact, even 250px will not show all the item titles for some instruments.
It is better that the bar is extensible, but for now a fixed value is fine for me.

#### Testing instructions (if applicable)

1. Check left side bar of the instrument under candidate profile, make sure that most items should be visible.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
