### PR TITLE
Replace straggling reference to zend with laminas

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -2,7 +2,7 @@
 /**
  * This file contains the entry point for a LORIS PSR15-based router.
  * The entrypoint constructs a ServerRequestInterface PSR7 object
- * (currently by using Zend Diactoros), adds generic LORIS middleware,
+ * (currently by using Laminas Diactoros), adds generic LORIS middleware,
  * and then delegates to a LORIS BaseRouter.
  *
  * The this entry point then prints the resulting value to the user.
@@ -32,7 +32,7 @@ $client->initialize();
 $middlewarechain = (new \LORIS\Middleware\ContentLength())
     ->withMiddleware(new \LORIS\Middleware\ResponseGenerator());
 
-$serverrequest = \Zend\Diactoros\ServerRequestFactory::fromGlobals();
+$serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();
 
 // Now that we've created the ServerRequest, handle it.
 $user = \User::singleton();

--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -142,7 +142,7 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
         return (new \LORIS\Http\Response())
             ->withHeader('Content-Type', 'application/x.raw')
             ->withHeader('Content-Disposition', "attachment; filename=${filename}")
-            ->withBody(new \Zend\Diactoros\CallbackStream($callback));
+            ->withBody(new \Laminas\Diactoros\CallbackStream($callback));
     }
 
     /**

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -14,7 +14,7 @@
 namespace LORIS\api\Test;
 
 use \PHPUnit\Framework\TestCase;
-use \Zend\Diactoros\ServerRequest;
+use \Laminas\Diactoros\ServerRequest;
 
 /**
  * PHPUnit class for API Login tests

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -56,7 +56,7 @@ class Module extends \Module
         $params    = $request->getQueryParams();
         $commentID = $params['commentID'] ?? null;
         if (empty($commentID)) {
-            return (new \Zend\Diactoros\Response())
+            return (new \Laminas\Diactoros\Response())
                 ->withBody(new \LORIS\Http\StringStream("Missing CommentID"))
                 ->withStatus(400);
         }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2729,7 +2729,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if ($request->getMethod() === "POST" && !isset($req['ClearInstrument'])) {
             $this->save();
         }
-        return (new \Zend\Diactoros\Response())
+        return (new \Laminas\Diactoros\Response())
             ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
     }
 

--- a/src/Http/Error.php
+++ b/src/Http/Error.php
@@ -31,7 +31,7 @@ use \Psr\Http\Message\ServerRequestInterface;
 class Error extends HtmlResponse
 {
     /**
-     * Takes the status code and and use the Zend\Response constructor to provide
+     * Takes the status code and and use the Laminas\Response constructor to provide
      * the approcriate reason phrase. It also add the appropriate body using
      * smarty templates based on status code.
      *

--- a/src/Http/StringStream.php
+++ b/src/Http/StringStream.php
@@ -286,7 +286,7 @@ class StringStream implements \Psr\Http\Message\StreamInterface, RequestHandlerI
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-            return (new \Zend\Diactoros\Response())
+            return (new \Laminas\Diactoros\Response())
                         ->withBody($this);
     }
 }

--- a/src/Router/ModuleFileRouter.php
+++ b/src/Router/ModuleFileRouter.php
@@ -84,7 +84,7 @@ class ModuleFileRouter implements RequestHandlerInterface
         if (is_file($fullpath)) {
             $resp = (new \LORIS\Http\Response)
                 ->withStatus(200)
-                ->withBody(new \Zend\Diactoros\Stream($fullpath));
+                ->withBody(new \Laminas\Diactoros\Stream($fullpath));
             if ($this->contenttype != "") {
                 $resp = $resp->withHeader("Content-Type", $this->contenttype);
             }


### PR DESCRIPTION
There were a few references to Zend (which was replaced by
Laminas in #5894) in our code base. For some reason, phan
didn't pick up on them until strict typing was enabled in #5923.

This fixes the references to zend and replaces them with laminas.