### PR TITLE
[UI] Fix width of select elements that have no label

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -478,7 +478,7 @@ class SelectElement extends Component {
     // element will take up the whole row.
     let label = null;
     let inputClass = 'col-sm-12';
-    if (this.props.label || this.props.label == '') {
+    if (this.props.label && this.props.label != '') {
       label = (
         <label className="col-sm-3 control-label" htmlFor={this.props.label}>
           {this.props.label}


### PR DESCRIPTION
Select elements that have no label are supposed to take the whole row,
but the logic in the if statement was incorrect and no label was resulting
in an empty 3 columns of the bootstrap grid.

This fixes the logic.