### PR TITLE
Remove unnecessary (and potentially incorrect comment) and PHPMD rule

### DIFF
--- a/modules/behavioural_qc/php/behavioural_qc.class.inc
+++ b/modules/behavioural_qc/php/behavioural_qc.class.inc
@@ -492,9 +492,7 @@ class Behavioural_QC extends \NDB_Form
         $DB     = \NDB_Factory::singleton()->database();
         $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 
-        // Why is the first instrument skipped?
-        $numberOfInstruments = count($ddeInstruments);
-        for ($i = 0;$i < $numberOfInstruments; ++$i) {
+        for ($i = 0;$i < count($ddeInstruments); ++$i) {
             $ddeInstruments[$i] = \Database::singleton()->quote($ddeInstruments[$i]);
         }
 

--- a/test/LorisPHPMD.xml
+++ b/test/LorisPHPMD.xml
@@ -27,6 +27,7 @@
         <exclude name="GotoStatement" />
         <exclude name="NumberOfChildren" />
         <exclude name="DepthOfInheritance" />
+        <exclude name="CountInLoopExpression" />
         <exclude name="ExitExpression" />
     </rule>
 </ruleset>


### PR DESCRIPTION
This removes a comment that was mistakenly merged in #4404. It also
removes a design rule from the config that should never have been
added, but only got included because PHPMD's config file is based
on excluding rules that you don't want, and not including rules
that you want, and the rule was snuck in in a PHPMD upgrade.