### PR TITLE
[bug] pageclass object null warning

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -132,24 +132,24 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // I don't think anyone uses this. It's not really supported
         $tpl_data['css'] = $this->Config->getSetting('css');
 
-        // Some page might call without pageclass
+        $page = null;
         if (!is_null($request->getAttribute("pageclass"))) {
             $tpl_data['subtest'] = $request->getAttribute("pageclass")->page;
-        }
 
-        $page = $request->getAttribute("pageclass");
-        if (method_exists($page, 'getFeedbackPanel')
-            && $user->hasPermission('bvl_feedback')
-            && $candID !== null
-        ) {
-            $tpl_data['feedback_panel'] = $page->getFeedbackPanel(
-                $candID,
-                $get['sessionID'] ?? null
-            );
+            $page = $request->getAttribute("pageclass");
+            if (method_exists($page, 'getFeedbackPanel')
+                && $user->hasPermission('bvl_feedback')
+                && $candID !== null
+                ) {
+                $tpl_data['feedback_panel'] = $page->getFeedbackPanel(
+                    $candID,
+                    $get['sessionID'] ?? null
+                );
 
-            $tpl_data['bvl_feedback'] = \NDB_BVL_Feedback::bvlFeedbackPossible(
-                $this->PageName
-            );
+                $tpl_data['bvl_feedback'] = \NDB_BVL_Feedback::bvlFeedbackPossible(
+                    $this->PageName
+                );
+            }
         }
 
         // This shouldn't exist. (And if it does, it shouldn't reference
@@ -241,20 +241,22 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
             return $undecorated;
         }
 
-        // This should be moved out of the middleware and into the modules that need it,
-        // but is currently required for backwards compatibility.
-        // This should also come after the above call to handle() in order for updated data
-        // on the controlPanel to be properly displayed.
-        if (method_exists($page, 'getControlPanel')) {
-            $tpl_data['control_panel'] = $page->getControlPanel();
-        }
+        if (!is_null($page)) {
+            // This should be moved out of the middleware and into the modules that need it,
+            // but is currently required for backwards compatibility.
+            // This should also come after the above call to handle() in order for updated data
+            // on the controlPanel to be properly displayed.
+            if (method_exists($page, 'getControlPanel')) {
+                $tpl_data['control_panel'] = $page->getControlPanel();
+            }
 
-        // This seems to only be used in imaging_browser, it can probably be
-        // moved to properly use OOP.
-        $tpl_data['FormAction'] = $page->FormAction ?? '';
+            // This seems to only be used in imaging_browser, it can probably be
+            // moved to properly use OOP.
+            $tpl_data['FormAction'] = $page->FormAction ?? '';
 
-        if ($page instanceof \NDB_Page) {
-            $tpl_data['breadcrumbs'] = $page->getBreadcrumbs();
+            if ($page instanceof \NDB_Page) {
+                $tpl_data['breadcrumbs'] = $page->getBreadcrumbs();
+            }
         }
 
         // Assign the console template variable as the very, very last thing.

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -132,7 +132,10 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // I don't think anyone uses this. It's not really supported
         $tpl_data['css'] = $this->Config->getSetting('css');
 
-        $tpl_data['subtest'] = $request->getAttribute("pageclass")->page;
+        // Some page might call without pageclass
+        if (!is_null($request->getAttribute("pageclass"))) {
+            $tpl_data['subtest'] = $request->getAttribute("pageclass")->page;
+        }
 
         $page = $request->getAttribute("pageclass");
         if (method_exists($page, 'getFeedbackPanel')


### PR DESCRIPTION
## Brief summary of changes

Each page loading of timepoint list, instrument list and instrument will trigger a warning "PHP Notice: Trying to get property 'page' of non-object in UserPageDecorationMiddleware.php", which is not pleasant to see when you are working with them every day. I assume that the problem comes from the Loris logic to process first without passing by timepoint module, if not having gone through then fail back to timepoint/instrument. I don't want to modify the logic. As a result, I just add a check to avoid the PHP warning.

#### Testing instructions (if applicable)

1. Load a timepoint list, instrument list and instrument page, then check web server log. The fix will avoid the warning.

#### Link(s) to related issue(s)

This is the recreation of the PR #5888, which I have wrongly pushed some other commits.

* Resolves #  (Reference the issue this fixes, if any.)
