### PR TITLE
Rename project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 project
-custom/
+custom/*
 smarty/templates_c
 .gitmodules
 project-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 project
+custom/
 smarty/templates_c
 .gitmodules
 project-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ changes in the following format: PR #1234***
 
 #### Core
 - Menus are now maintained by modules and no longer in the SQL database (PR #5839)
+- The custom directory containing the configuration file, module overrides, etc.
+has been renamed from `project/` to `custom/` in order to clarify the concept of
+a "Project" in LORIS (PR #5944)
 
 #### Modules 
 ##### module1

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Custom Directory.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Custom Directory.md
@@ -1,0 +1,38 @@
+# Custom Directory
+
+The `custom/` directory contains files that override the core functionality of
+LORIS. This can include custom modules and instruments that you can modify
+independently of the main source code of the LORIS repository.
+
+All files in this directory will be ignored by git and will not be committed
+to our repository if you push changes. The directory contains highly sensitive
+information (see below) and so these files should not be shared outside of your
+administrative team.
+
+## LORIS configuration file (config.xml)
+The file `custom/config.xml` will be created during the install process.
+It contains several important configuration settings for your LORIS instance,
+including credentials for the database. For this reason, this file must be kept
+private.
+
+## Module and Library Overrides
+
+You can modify existing LORIS modules by adding them to the `custom/` folder.
+If the path `custom/modules/` exists, LORIS module code can be placed here
+and should be usable in LORIS as long as it follows the format of other modules.
+
+For example if you wanted to make changes to the `data_release` module, you can
+copy the source code `modules/data_release/` to `custom/modules/data_release`.
+Any code in this directory will override (replace) the core LORIS module.
+
+The same can be done for new modules you create yourself.
+
+By placing custom code in this directory instead of modifying the source code
+directly, you will be able to track and manage your custom code independent
+of updates to the source code.
+
+The same can be done with LORIS core libraries by copying code from
+`php/libraries/` to `custom/libraries/`.
+
+## Instruments
+TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
             - 'Ubuntu Install': 'wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/Ubuntu/README.md'
             - 'CentOS Install': 'wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.md'
         - Website Configuration: 'wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/README.md'
+            - 'Custom Directory': 'wiki/00\ -\ SERVER\ INSTALL\ AND\ CONFIGURATION/02\ -\ Website\ Configuration/Custom\ Directory.md'
     - Study Parameters Setup:
         - Study Variables: 
             - 'Introduction': 'wiki/01 - STUDY PARAMETERS SETUP/01 - Study Variables/00 - Introduction to Study Variables.md'


### PR DESCRIPTION
## Brief summary of changes
We discussed renaming this file to disambiguate our use of the word project. Currently, when we say "project" it can refer to a bundle of overrides contained in a directory OR to the concept of a Project which has relationships to the idea of a Subproject, Site, TimePoint, etc and is represented by the `Project.class.inc` file.

### Discussion
I prefer the new name "Custom" for the directory. I think it encompasses the idea that:
1. This folder is the place to put things particular to a LORIS instance/study, such as module overrides, instruments, and configuration settings
2. This folder belongs ONLY to this particular LORIS instance; it should not be shared or committed to the repository. It belongs to the project admins; we shouldn't add things to it.

We can decide on a name together. At that point, I'll update the various references to `project/config.xml` in the source code and documentation. Until then, I'll leave this PR in draft mode.

#### Testing instructions (if applicable)
Rename your `project/` directory to `custom/`. LORIS should function as before without changes.

#### Link(s) to related issue(s)

* Resolves #5931 
