### PR TITLE
[Candidate] Add get last visit subproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 ### Clean Up
 - *Add item here*
 ### Notes For Existing Projects
-- *Add item here*
+- New function Candidate::getSubjectForMostRecentVisit replaces Utility::getSubprojectIDUsingCandID, adding ability to determine which subproject a candidate belongs to given their most recent visit.
 ### Notes For Developers
 - *Add item here*
 

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -173,17 +173,13 @@ class Instrument_List extends \NDB_Menu_Filter
         $battery = new \NDB_BVL_Battery;
         $battery->selectBattery($this->timePoint->getSessionID());
 
-        $this->tpl_data['stage']        = \Utility::getStageUsingCandID(
-            $this->tpl_data['candID']
-        );
-        $this->tpl_data['subprojectID'] = \Utility::getSubprojectIDUsingCandID(
+        $this->tpl_data['stage'] = \Utility::getStageUsingCandID(
             $this->tpl_data['candID']
         );
 
         // get the list of instruments
         $listOfInstruments = $this->getBatteryInstrumentList(
-            $this->tpl_data['stage'],
-            $this->tpl_data['subprojectID']
+            $this->tpl_data['stage']
         );
 
         // display list of instruments
@@ -309,15 +305,14 @@ class Instrument_List extends \NDB_Menu_Filter
      * Gets an associative array of instruments which are members of the current
      * battery for instrument list module
      *
-     * @param string  $stage        Either 'visit' or 'screening' - determines
-     *                              whether to register only screening instruments
-     *                              or visit instruments
-     * @param integer $SubprojectID The SubprojectID of that we want the battery for.
+     * @param string $stage Either 'visit' or 'screening' - determines
+     *                      whether to register only screening instruments
+     *                      or visit instruments
      *
      * @return array an associative array containing Test_name,
      *         Full_name, Sub_group, CommentID
      */
-    function getBatteryInstrumentList($stage=null, $SubprojectID=null)
+    function getBatteryInstrumentList($stage=null)
     {
         $DB = \Database::singleton();
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -643,8 +643,35 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
 
         return $subprojList;
     }
+
     /**
-     * Returns first visit for a candidate based on Date_visit
+     * Returns the SubprojectID and subproject title of the candidate's last visit
+     * based on Date_visit
+     *
+     * @return array|null Array with values SubprojectID and title
+     *                    for the candidate's last visit or NULL if none exist
+     */
+    public function getSubprojectForMostRecentVisit(): ?array
+    {
+        $factory = NDB_Factory::singleton();
+        $db      = $factory->database();
+
+        $candID = $this->getCandID();
+        $query  = "SELECT SubprojectID, title FROM session
+          LEFT JOIN subproject USING (SubprojectID)
+          WHERE CandID=:cid AND Date_visit IS NOT NULL
+          ORDER BY Date_visit DESC LIMIT 1";
+        $where  = ['cid' => $candID];
+        $result = $db->pselect($query, $where);
+
+        if (empty($result)) {
+            return null;
+        }
+        return $result[0];
+    }
+
+    /**
+     * Returns first visit for a candidate based on VisitNo
      *
      * @return string The visit label for the candidate's first visit
      */

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -587,24 +587,6 @@ class Utility
     }
 
     /**
-     * Looks up visit stage using candidate ID.
-     *
-     * @param string $Cand_id candidate ID
-     *
-     * @return int
-     * @throws DatabaseException
-     */
-    static function getSubprojectIDUsingCandID(string $Cand_id): int
-    {
-        $factory = NDB_Factory::singleton();
-        $db      = $factory->database();
-
-        $query = "select DISTINCT SubprojectID from session where CandID = :CandID";
-        $stage = $db->pselect($query, ['CandID' => $Cand_id]);
-        return intval($stage[0]['SubprojectID']);
-    }
-
-    /**
      * Returns all the sourcefrom instruments from parameter_type
      *
      * @param string|null $instrument If specified, return fields from this

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -605,12 +605,12 @@ class CandidateTest extends TestCase
      */
     public function testGetSubprojectForMostRecentVisitReturnsMostRecentVisitLabel()
     {
-        $subproject = array(
-            array(
+        $subproject = [
+            [
                 'SubprojectID' => 1,
-                'title'        => 'testSubproject' 
-            )
-        );
+                'title'        => 'testSubproject'
+            ]
+        ];
 
         $this->_setUpTestDoublesForSelectCandidate();
         $this->_candidate->select($this->_candidateInfo['CandID']);
@@ -619,17 +619,17 @@ class CandidateTest extends TestCase
             ->method('pselect')
             ->with(
                 $this->stringContains(
-                   "SELECT SubprojectID, title"
+                    "SELECT SubprojectID, title"
                 )
             )
             ->willReturn(
                 $subproject
             );
 
-        $expectedSubproject = array(
+        $expectedSubproject = [
             'SubprojectID' => 1,
             'title'        => 'testSubproject'
-        );
+        ];
 
         $this->assertEquals(
             $expectedSubproject,
@@ -638,27 +638,31 @@ class CandidateTest extends TestCase
     }
 
     /**
-     * Test getSubprojectForMostRecentVisit returns null if there is no visit with a Date_visit
+     * Test getSubprojectForMostRecentVisit returns null if there is
+     * no visit with a Date_visit
      *
      * @covers Candidate::getSubprojectForMostRecentVisit
      * @return void
      */
     public function testGetSubprojectForMostRecentVisitReturnsNull()
     {
-        $subproject = array();
+        $subproject = [];
         $this->_setUpTestDoublesForSelectCandidate();
         $this->_candidate->select($this->_candidateInfo['CandID']);
-        
+
         $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->with(
                 $this->stringContains(
-                   "SELECT SubprojectID, title"
+                    "SELECT SubprojectID, title"
                 )
             )
             ->willReturn($subproject);
 
-        $this->assertEquals(null, $this->_candidate->getSubprojectForMostRecentVisit());
+        $this->assertEquals(
+            null,
+            $this->_candidate->getSubprojectForMostRecentVisit()
+        );
     }
 
     /**

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -598,6 +598,74 @@ class CandidateTest extends TestCase
     }
 
     /**
+     * Test getSubprojectForMostRecentVisit returns most recent visit's label
+     *
+     * @covers Candidate::getSubprojectForMostRecentVisit
+     * @return void
+     */
+    public function testGetSubprojectForMostRecentVisitReturnsMostRecentVisitLabel()
+    {
+        $subproject = array(
+            array(
+                'SubprojectID' => 1,
+                'title'        => 'testSubproject' 
+            )
+        );
+
+        $this->_setUpTestDoublesForSelectCandidate();
+
+        $this->_dbMock->expects($this->any())
+            ->method('pselect')
+            ->with(
+                $this->stringContains(
+                   "SELECT SubprojectID, title 
+                    FROM subproject 
+                    WHERE SubprojectID = :subprj"
+                )
+            )
+            ->willReturn(
+                $subproject
+            );
+
+        $expectedSubproject = array(
+            'SubprojectID' => 1,
+            'title'        => 'testSubproject'
+        );
+
+        $this->_candidate->select($this->_candidateInfo['CandID']);
+        $this->assertEquals(
+            $expectedSubproject,
+            $this->_candidate->getSubprojectForMostRecentVisit()
+        );
+    }
+
+    /**
+     * Test getSubprojectForMostRecentVisit returns null if there is no visit with a Date_visit
+     *
+     * @covers Candidate::getSubprojectForMostRecentVisit
+     * @return void
+     */
+    public function testGetSubprojectForMostRecentVisitReturnsNull()
+    {
+        $subproject = array();
+        $this->_setUpTestDoublesForSelectCandidate();
+        
+        $this->_dbMock->expects($this->any())
+            ->method('pselect')
+            ->with(
+                $this->stringContains(
+                   "SELECT SubprojectID, title 
+                    FROM subproject 
+                    WHERE SubprojectID = :subprj"
+                )
+            )
+            ->willReturn($subproject);
+
+        $this->_candidate->select($this->_candidateInfo['CandID']);
+        $this->assertEquals(null, $this->_candidate->getSubprojectForMostRecentVisit());
+    }
+
+    /**
      * Test getFirstVisit returns first visit's label
      *
      * @covers Candidate::getFirstVisit

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -613,14 +613,13 @@ class CandidateTest extends TestCase
         );
 
         $this->_setUpTestDoublesForSelectCandidate();
+        $this->_candidate->select($this->_candidateInfo['CandID']);
 
         $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->with(
                 $this->stringContains(
-                   "SELECT SubprojectID, title 
-                    FROM subproject 
-                    WHERE SubprojectID = :subprj"
+                   "SELECT SubprojectID, title"
                 )
             )
             ->willReturn(
@@ -632,7 +631,6 @@ class CandidateTest extends TestCase
             'title'        => 'testSubproject'
         );
 
-        $this->_candidate->select($this->_candidateInfo['CandID']);
         $this->assertEquals(
             $expectedSubproject,
             $this->_candidate->getSubprojectForMostRecentVisit()
@@ -649,19 +647,17 @@ class CandidateTest extends TestCase
     {
         $subproject = array();
         $this->_setUpTestDoublesForSelectCandidate();
+        $this->_candidate->select($this->_candidateInfo['CandID']);
         
         $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->with(
                 $this->stringContains(
-                   "SELECT SubprojectID, title 
-                    FROM subproject 
-                    WHERE SubprojectID = :subprj"
+                   "SELECT SubprojectID, title"
                 )
             )
             ->willReturn($subproject);
 
-        $this->_candidate->select($this->_candidateInfo['CandID']);
         $this->assertEquals(null, $this->_candidate->getSubprojectForMostRecentVisit());
     }
 

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -500,25 +500,6 @@ class UtilityTest extends TestCase
     }
 
     /**
-     * Test that getSubprojectIDUsingCandID() returns
-     * the correct SubprojectID given the CandID
-     *
-     * @covers Utility::getSubprojectIDUsingCandID
-     * @return void
-     */
-    public function testGetSubprojectIDUsingCandID()
-    {
-        $this->_dbMock->expects($this->any())
-            ->method('pselect')
-            ->willReturn($this->_sessionInfo);
-
-        $this->assertEquals(
-            '2',
-            Utility::getSubprojectIDUsingCandID('1')
-        );
-    }
-
-    /**
      * Test that getVisitList returns a list of visit labels
      * This is the simplest case of this function
      * TODO Potential edge cases: Set 'Active' to 'N'


### PR DESCRIPTION
## Brief summary of changes

This PR adds a new function called `getLastVisitSubproject` in the candidate class. This new function replaces the function `getSubprojectIDUsingCandID` in Utility class.

`getSubprojectIDUsingCandID` is only currently being called in one place, the instrument_list class. The returned value there however affects nothing. It is passed as an argument to the function `getBatteryInstrumentList` that then does nothing with the parameter

#### Testing instructions (if applicable)

1. Test instrument_list page on both master and this branch. Check that there are absolutely no changes.
2. Try to use getLastVisitSubproject and render the returned data somewhere on Loris and see the results