### PR TITLE
[NDB_BVL_Instrument] Data entry completion progress function

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1543,8 +1543,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $statusField = $field . '_status';
             // field shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
-            if ((($allData[$field] ?? null) === null)
-                || (($allData[$field] ?? "") === "")
+            if (((($allData[$field] ?? null) === null)
+                || (($allData[$field] ?? "") === ""))
                 && empty($allData[$statusField])
             ) {
                 $unanswered++;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1523,6 +1523,40 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         return null;
     }
 
+    /**
+     * Determines what percentage of the data entry has been completed, based on the
+     * number of fields in $_requiredElements having data
+     *
+     * @return int the data entry completion percentage
+     */
+    function determineDataEntryCompletionProgress(): int
+    {
+        // don't bother checking anything if the required elements array is empty
+        if (empty($this->_requiredElements)) {
+            return 100;
+        }
+        $allData       = $this->loadInstanceData($this);
+        $unanswered    = 0;
+        $totalElements = count($this->_requiredElements);
+        foreach ($this->_requiredElements as $field) {
+            // consider status field if not_answered chosen as an answer
+            $statusField = $field . '_status';
+            // field shouldn't be just empty() b/c 0 is a valid
+            // value for some required fields
+            if ((is_null($allData[$field]) || $allData[$field] === "")
+                && empty($allData[$statusField])
+            ) {
+                $unanswered++;
+            }
+        }
+        if ($unanswered == 0) {
+            return 100;
+        } else if ($unanswered == $totalElements) {
+            return 0;
+        }
+
+        return (int)round((($totalElements-$unanswered)/$totalElements)*100);
+    }
 
     /**
      * Determines what the data entry status flag should be set to
@@ -1538,9 +1572,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $allData = $this->loadInstanceData($this);
         foreach ($this->_requiredElements as $field) {
-            // this shouldn't be just empty() b/c 0 is a valid
+            // consider status field if not_answered chosen as an answer
+            $statusField = $field . '_status';
+            // field shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
-            if (is_null($allData[$field]) || $allData[$field] === "") {
+            if ((is_null($allData[$field]) || $allData[$field] === "")
+                && empty($allData[$statusField])
+            ) {
                 return 'Incomplete';
             }
         }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1543,7 +1543,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $statusField = $field . '_status';
             // field shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
-            if ((is_null($allData[$field]) || $allData[$field] === "")
+            if ((($allData[$field] ?? null) === null) || (($allData[$field] ?? "") === "")
                 && empty($allData[$statusField])
             ) {
                 $unanswered++;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1543,7 +1543,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $statusField = $field . '_status';
             // field shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
-            if ((($allData[$field] ?? null) === null) || (($allData[$field] ?? "") === "")
+            if ((($allData[$field] ?? null) === null)
+                || (($allData[$field] ?? "") === "")
                 && empty($allData[$statusField])
             ) {
                 $unanswered++;

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -415,8 +415,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 $addElements = true;
             }
 
-            $parsingPage       = 'top';
-            $firstSelectOfPage = true;
+            $parsingPage      = 'top';
+            $firstFieldOfPage = true;
 
             $Group = array(
                 'Name'      => null,
@@ -438,6 +438,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     || $fieldname == "Window_Difference"
                     || $fieldname == "Examiner"
                 ) {
+                    if ($firstFieldOfPage) {
+                        $this->_requiredElements[] = $fieldname;
+                        $firstFieldOfPage          = false;
+                    }
                     continue;
                 }
                 switch($type) {
@@ -457,7 +461,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     } else {
                         $addElements = false;
                     }
-                    $firstSelectOfPage = true;
+                    $firstFieldOfPage = true;
                     break;
                 case 'table':
                     $this->testName = trim($pieces[1]);
@@ -531,6 +535,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $this->addTextElement($pieces[1], $pieces[2]);
                         }
                     }
+                    if ($firstFieldOfPage) {
+                        $this->_requiredElements[] = $fieldname;
+                        $firstFieldOfPage          = false;
+                    }
                     $this->LinstQuestions[$pieces[1]] = array('type' => 'text');
                     break;
                 case 'textarea':
@@ -544,6 +552,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         } else {
                             $this->addTextAreaElement($pieces[1], $pieces[2]);
                         }
+                    }
+                    if ($firstFieldOfPage) {
+                        $this->_requiredElements[] = $fieldname;
+                        $firstFieldOfPage          = false;
                     }
                     $this->LinstQuestions[$pieces[1]] = array('type' => 'textarea');
                     break;
@@ -597,11 +609,19 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             );
                         }
                     }
+                    if ($firstFieldOfPage) {
+                        $this->_requiredElements[] = $fieldname;
+                        $firstFieldOfPage          = false;
+                    }
                     $this->LinstQuestions[$pieces[1]] = array('type' => 'date');
                     break;
                 case 'numeric':
                     if ($addElements) {
                         $this->addNumericElement($pieces[1], $pieces[2]);
+                    }
+                    if ($firstFieldOfPage) {
+                        $this->_requiredElements[] = $fieldname;
+                        $firstFieldOfPage          = false;
                     }
                     // FIXME: This variable is never populated.
                     $options = array();
@@ -675,9 +695,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
                         }
                     }
-                    if ($firstSelectOfPage) {
-                        $this->_requiredElements[] = $pieces[1];
-                        $firstSelectOfPage         = false;
+                    if ($firstFieldOfPage) {
+                        $this->_requiredElements[] = $fieldname;
+                        $firstFieldOfPage          = false;
                     }
                     $this->LinstQuestions[$pieces[1]] = array('type' => 'select');
                     break;


### PR DESCRIPTION
## Brief summary of changes

This PR adds a function that determines an instrument's completion progress based on how many of its required fields have been filled out. This new function evolved from the already existing `_determineDataEntryCompletionStatus` function.

This function is being used in the new candidate profile page as implemented by PR https://github.com/aces/Loris/pull/6121

#### Testing instructions (if applicable)
1. Test https://github.com/aces/Loris/pull/6121 to see if the function determineDataEntryCompletionProgress() is doing what it's intending to do.
2. On that branch, visit `https://$LORISURL/candidate_profile/$candID` and click on one of the timepoint boxes in the 'Behavioural Data' card to expand the instrument list for that timepoint with corresponding completion progress bar
3. Select a fresh blank instrument (completion progress 0%) and fill it out page by page. After every page, check the instrument's completion progress display to see that it matches e.g. if 2/5 pages have been filled out and saved, the completion progress is 40%.
4. At the same time, test the control panel workflow outlined in https://github.com/aces/Loris/pull/6129. The workflow should remain the exact same.
5. Fill out the whole instrument and mark the Data Entry as 'Complete'. Test that you are able to do this even if you set every field to 'Not Answered'.