### PR TITLE
Fix to PR 5591: Correctly calling 'pselect' function from class 'Database'

### DIFF
--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -134,10 +134,17 @@ class Statistics_Site extends \NDB_Menu
                     }
                 }
             }
-            $sitesString = implode(",", $list_of_permitted_sites);
 
-            $this->query_criteria    .= " AND s.CenterID IN (:cids) ";
-            $this->query_vars['cids'] = $sitesString;
+            $params    = array();
+            $centerIDs = array();
+            foreach ($list_of_permitted_sites as $key => $siteID) {
+                $params[]            = ":id$key";
+                $centerIDs["id$key"] = $siteID;
+            }
+
+            $this->query_criteria .=
+                " AND s.CenterID IN (" . implode(',', $params) . ")";
+            $this->query_vars     += $centerIDs;
         }
 
         if (!empty($projectID)) {


### PR DESCRIPTION
### Brief summary of changes

This fix an issue found during manual test in PR #5591 in which the `pselect` function from class `Database` was incorrectly called when using an IN clause in the SQL statement.

#### Testing instructions
Now all candidates for all the sites for a given user should be displayed when asked for the **breakdown per participant** in **Statistics -> Behavioural Statistics -> breakdown per participant (link)**

#### Link(s) to related issue(s)

* Resolves #5591 
