### PR TITLE
[jsx/Panel] Make Panel title Bold

### DIFF
--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -79,7 +79,7 @@ class Panel extends Component {
           id={this.props.id}
           className={this.panelClass}
           role="tabpanel"
-          style={{height: 'calc(100% - 3em)', overflowX: 'auto'}}
+          style={{height: 'calc(100% - 3em)'}}
         >
           <div className="panel-body"
                style={{...this.props.style, height: this.props.height}}>

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -62,9 +62,9 @@ class Panel extends Component {
         onClick={this.toggleCollapsed}
         data-toggle="collapse"
         data-target={'#' + this.props.id}
-        style={{cursor: 'pointer', height: '3em'}}
+        style={{cursor: 'pointer', height: '3em', fontWeight: 'bold'}}
       >
-        <b>{this.props.title}</b>
+        {this.props.title}
         <span className={glyphClass}></span>
       </div>
     ) : '';

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -64,7 +64,7 @@ class Panel extends Component {
         data-target={'#' + this.props.id}
         style={{cursor: 'pointer', height: '3em'}}
       >
-        {this.props.title}
+        <b>{this.props.title}</b>
         <span className={glyphClass}></span>
       </div>
     ) : '';
@@ -79,7 +79,7 @@ class Panel extends Component {
           id={this.props.id}
           className={this.panelClass}
           role="tabpanel"
-          style={{height: 'calc(100% - 3em)'}}
+          style={{height: 'calc(100% - 3em)', overflowX: 'auto'}}
         >
           <div className="panel-body"
                style={{...this.props.style, height: this.props.height}}>
@@ -92,6 +92,7 @@ class Panel extends Component {
 }
 
 Panel.propTypes = {
+  initCollapsed: PropTypes.bool,
   id: PropTypes.string,
   height: PropTypes.string,
   title: PropTypes.string,
@@ -100,6 +101,7 @@ Panel.defaultProps = {
   initCollapsed: false,
   id: 'default-panel',
   height: '100%',
+  title: '',
 };
 
 export default Panel;


### PR DESCRIPTION
## Brief summary of changes

This PR does the following:
- makes title of Panel **bold** (let me know what you think about this. i find making it bold lets it stand out from other text on the page i.e. for if there are multiple Panels rendered such as in the new candidate profile module that has multiple cards)
- add missing proptypes and default proptype values (cleanup)

#### Testing instructions (if applicable)

1. run `npm run compile` , checkout Examiner module for now bold title 'Examiner' at the top of the Panel
