### PR TITLE
[SQL] Add register_new_scanner Config setting for the imaging pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,9 @@ changes in the following format: PR #1234***
 - Menus are now maintained by modules and no longer in the SQL database (PR #5839)
 
 #### Modules 
-##### module1
+
+##### Configuration
+
+- Make sure to update your SQL database with the release patch and to select whether you want the 
+imaging pipeline to create a new scanner when an uploaded DICOM dataset was acquired on a new scanner.
+Note: 'Yes' was the default behaviour of the imaging pipeline, which is the default set in the release patch.

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -151,6 +151,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'reference_scan_type_for_defacing', 'Scan type to use as a reference for registration when defacing anatomical images (typically a T1W image)', 1, 0, 'scan_type', ID, 'Scan type to use as a reference for defacing (typically a T1W image)', 22 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'modalities_to_deface', 'Modalities for which defacing should be run and defaced image inserted in the database', 1, 1, 'scan_type', ID, 'Modalities on which to run the defacing pipeline', 23 FROM ConfigSettings WHERE Name="imaging_pipeline";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'default_bids_vl', 'Default visit label to use when no visit label set in the BIDS dataset', 1, 0, 'text', ID, 'Default visit label for BIDS dataset', 24 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'register_new_scanner', 'Determines whether new scanners should be created by the imaging pipeline', 1, 0, 'boolean', ID, 'Register new scanner', 25 FROM ConfigSettings WHERE Name="imaging_pipeline";
 
 --
 -- Filling Config table with default values
@@ -258,3 +259,5 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, 't1'    FROM ConfigSettings WHER
 INSERT INTO Config (ConfigID, Value) SELECT ID, 't2'    FROM ConfigSettings WHERE Name="modalities_to_deface";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'pd'    FROM ConfigSettings WHERE Name="modalities_to_deface";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'false'  FROM ConfigSettings WHERE Name="usePwnedPasswordsAPI";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 1 FROM ConfigSettings cs WHERE cs.Name="register_new_scanner";
+

--- a/SQL/New_patches/2020-01-24_add_register_new_scanner_to_config_module.sql
+++ b/SQL/New_patches/2020-01-24_add_register_new_scanner_to_config_module.sql
@@ -1,0 +1,2 @@
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'register_new_scanner', 'Determines whether new scanners should be created by the imaging pipeline', 1, 0, 'boolean', ID, 'Register new scanner', 25 FROM ConfigSettings WHERE Name="imaging_pipeline";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 1 FROM ConfigSettings cs WHERE cs.Name="register_new_scanner";

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -96,5 +96,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (99,101,'');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (102,19,'false');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (103,102,'/data/document_repository_uploads/');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/data/data_release_uploads/');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (105,104,'1');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_ConfigSettings.sql
+++ b/raisinbread/RB_files/RB_ConfigSettings.sql
@@ -100,5 +100,6 @@ INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMult
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (101,'MINCToolsPath','Path to the MINC tools',1,0,'web_path',26,'Path to the MINC tools',12);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (102,'documentRepositoryPath','Path to uploaded document repository files',1,0,'text',26,'Document Repository Upload Path',13);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (103,'dataReleasePath','Path to uploaded data release files',1,0,'text',26,'Data Release Upload Path',14);
+INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (104,'register_new_scanner','Determines whether new scanners should be created by the imaging pipeline',1,0,'boolean',69,'Register new scanner',25);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

This creates a config setting for the imaging backend pipeline to remove hardcoded configuration of 'new_scanner' in the backend script. This should be a config option instead of some hardcoded obscure code in the backend. 

#### Testing instructions 

1. Test that the SQL queries works

#### Caveat for Existing Projects

Make sure to update your SQL database with the release patch and to select whether you want the imaging pipeline to create a new scanner when an uploaded DICOM dataset was acquired on a new scanner. 
Note: 'Yes' was the default behaviour of the imaging pipeline, which is the default set in the release patch. 