### PR TITLE
[User Accounts] Fix edge-case that gave a confusing error message

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -1085,7 +1085,14 @@ class Edit_User extends \NDB_Form
         //==================================
         //        Password validation
         //==================================
-        if ($values['Email'] === $values['Password_hash']) {
+
+        // Make sure the user is not using their email address as their password.
+        // Do not show this error if the password is an empty string: in this
+        // case, that means the email is empty also. It's more appropriate to
+        // display only the error 'You must enter an email'.
+        if ($values['Email'] === $values['Password_hash']
+            && $values['Password_hash'] !== ''
+        ) {
             $errors['Password_Group'] = self::PASSWORD_ERROR_IS_EMAIL;
         }
         if (!is_null($this->identifier)) {


### PR DESCRIPTION
## Brief summary of changes

When both the password and email fields were empty, an error was displayed saying "Your password cannot match your email address"

While technically accurate, this isn't actually helpful for a user, especially since our checkbox option "Generate new password" requires leaving the password field blank.

#### Testing instructions (if applicable)

1. Verify the confusing error message in the linked Issue.
2. On this branch, do the same thing. The password error won't appear.
3. Repeat 2. but uncheck 'Generate new password'. Ensure that the error message "Please specify password or click Generate new password" is displayed instead.

#### Link(s) to related issue(s)

* Resolves #5948 