### PR TITLE
[User Accounts] Fix issue where users with multisite permission could not access the module

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -60,6 +60,7 @@ class Edit_User extends \NDB_Form
             return true;
         }
 
+        // Make sure that the editor and the user share site associations.
         if ($editor->hasPermission('user_accounts')) {
             if ($this->isCreatingNewUser()) {
                 return true;

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -52,20 +52,16 @@ class Edit_User extends \NDB_Form
      */
     function _hasAccess(\User $editor) : bool
     {
-        if (!$this->isCreatingNewUser()) {
-            $user = \User::factory($this->identifier);
-        }
-
         if ($editor->hasPermission('user_accounts_multisite')) {
             return true;
         }
 
-        // Make sure that the editor and the user share site associations.
         if ($editor->hasPermission('user_accounts')) {
             if ($this->isCreatingNewUser()) {
                 return true;
             }
             $user = \User::factory($this->identifier);
+            // Make sure that the editor and the user share site associations.
             return array_intersect(
                 $user->getData('CenterIDs'),
                 $editor->getData('CenterIDs')

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -2,7 +2,7 @@
 /**
  * The menu for user accounts
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  User_Account
@@ -15,7 +15,7 @@ namespace LORIS\user_accounts;
 /**
  * The menu for user accounts
  *
- * PHP Version 5
+ * PHP Version 7
  *
  * @category Main
  * @package  User_Account
@@ -26,6 +26,12 @@ namespace LORIS\user_accounts;
 
 class User_Accounts extends \DataFrameworkMenu
 {
+    const PERMISSIONS    = [
+        'user_accounts',
+        'user_accounts_multisite',
+    ];
+    public $skipTemplate = true;
+
     /**
      * Overloading this method to allow access to users account
      *
@@ -35,7 +41,7 @@ class User_Accounts extends \DataFrameworkMenu
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasPermission('user_accounts');
+        return $user->hasAnyPermission(self::PERMISSIONS);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

We've had this a few times before; a multisite permission was added to the module at some point but if a user has ONLY this permission (and not the site-specific permission), they cannot access the module.

In addition, the User Accounts module was not displayed in the LorisMenu dropdown.

#### Testing instructions (if applicable)

1. Modify a user's permission so that it has `user_accounts_multisite` but not `user_accounts`.
2. Confirm User Accounts does not show up in the Admin dropdown.
2. Try to go to the User Accounts module via URL. You can't!
3. Checkout my branch. You should be able to access the module via the dropdown.

#### Link(s) to related issue(s)

* Resolves #5951 
* Resolves #6657 