### PR TITLE
Document how to upload larger files via front-end

### DIFF
--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
@@ -3,7 +3,7 @@
 In order for users to upload large files (> 2 MB), you'll need to configure
 Apache's `php.ini` configuration file. 
 
-Recommended sample values appropriate for compressed scans not exceeding 500M in size are: 
+Recommended sample values appropriate for compressed scans not exceeding 500MB in size are: 
 
 ```
 session.gc_maxlifetime = 10800  // After this number of seconds, stored data will be seen as 'garbage' and cleaned up by the garbage collection process.

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
@@ -1,6 +1,6 @@
 # Handling Large File Uploads
 
-In order to upload larger files (> 2 MB) for LORIS users, you'll need to configure
+In order for users to upload large files (> 2 MB), you'll need to configure
 Apache's `php.ini` configuration file. 
 
 Recommended sample values appropriate for compressed scans not exceeding 500M in size are: 

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
@@ -1,6 +1,6 @@
 # Handling Large File Uploads
 
-In order to upload larger files (> 2 MB) for LORUS users, you'll need to configure
+In order to upload larger files (> 2 MB) for LORIS users, you'll need to configure
 Apache's `php.ini` configuration file. 
 
 Recommended sample values appropriate for compressed scans not exceeding 500M in size are: 

--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md
@@ -1,0 +1,14 @@
+# Handling Large File Uploads
+
+In order to upload larger files (> 2 MB) for LORUS users, you'll need to configure
+Apache's `php.ini` configuration file. 
+
+Recommended sample values appropriate for compressed scans not exceeding 500M in size are: 
+
+```
+session.gc_maxlifetime = 10800  // After this number of seconds, stored data will be seen as 'garbage' and cleaned up by the garbage collection process.
+max_input_time = 10800          // Maximum amount of time each script may spend parsing request data (in seconds)
+max_execution_time = 10800      // Maximum execution time of each script (in seconds)
+upload_max_filesize = 1024M     // Maximum allowed size for uploaded files.
+post_max_size = 1024M           // Maximum size of POST data that PHP will accept.
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
             - 'Ubuntu Install': 'wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/Ubuntu/README.md'
             - 'CentOS Install': 'wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/CentOS/README.md'
         - Website Configuration: 'wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/README.md'
+            - 'Handling Large File Uploads': 'wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md'
     - Study Parameters Setup:
         - Study Variables: 
             - 'Introduction': 'wiki/01 - STUDY PARAMETERS SETUP/01 - Study Variables/00 - Introduction to Study Variables.md'

--- a/modules/genomic_browser/README.md
+++ b/modules/genomic_browser/README.md
@@ -33,4 +33,6 @@ uploading functionality to work.
 
 - For the methylation tab to work, the `genomic_cpg_annotation` table should be filled with data from the Illumina HumanMethylation450k probe annotations file. This file can be found at ftp://webdata2:webdata2@ussd-ftp.illumina.com/downloads/ProductFiles/HumanMethylation450/HumanMethylation450_15017482_v1-2.csv. Use the script `modules/genomic_browser/tools/HumanMethylation450k_annotations_to_sql.py` to transfer the csv file from Illumina's FTP to a mysql transaction file. (The process of loading the SQL file can take 5 to 10 minutes)
 - The `GenomicDataPath` configuration specifies where files are uploaded.
-- Large files may require changing php configuration values. These configurations are the same as the media module. See [media module README](../media/README.md) for details.
+
+To enable the Imaging Uploader to handle large files, please follow the
+instructons for [Handling Large File Uploads](../../docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md).

--- a/modules/imaging_uploader/README.md
+++ b/modules/imaging_uploader/README.md
@@ -69,17 +69,8 @@ The imaging uploader has the following configurations that affect its usage:
 
 #### Install Configurations
 
-To enable the Imaging Uploader to handle large files, please update the 
-`php.ini` apache configuration file. Recommended sample values appropriate for 
-compressed scans not exceeding 500M in size are: 
-
-```
-session.gc_maxlifetime = 10800  // After this number of seconds, stored data will be seen as 'garbage' and cleaned up by the garbage collection process.
-max_input_time = 10800          // Maximum amount of time each script may spend parsing request data (in seconds)
-max_execution_time = 10800      // Maximum execution time of each script (in seconds)
-upload_max_filesize = 1024M     // Maximum allowed size for uploaded files.
-post_max_size = 1024M           // Maximum size of POST data that PHP will accept.
-```
+To enable the Imaging Uploader to handle large files, please follow the
+instructons for [Handling Large File Uploads](../../docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/02 - Website Configuration/Handling Large File Uploads.md).
 
 #### <a name="database_config_link"></a> Database Configurations
 


### PR DESCRIPTION
## Brief summary of changes

Adds instructions to modifying Apache to allow for larger files to be uploaded via the front-end.

These will now be present on Read The Docs.

#### Link(s) to related issue(s)

* Resolves #5849
