### PR TITLE
[Issue Tracker] Remove remaining references to LorisMenu table

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -435,13 +435,11 @@ function getComments($issueID)
     );
 
     //looping by reference so can edit in place
+    $modules = \Module::getActiveModulesIndexed($db);
     foreach ($unformattedComments as &$comment) {
         if ($comment['fieldChanged'] === 'module') {
-            $module = $db->pselectOne(
-                "SELECT Label FROM LorisMenu WHERE ID=:module",
-                array('module' => $comment['newValue'])
-            );
-            $comment['newValue'] = $module;
+            $mid = $comment['newValue'];
+            $comment['newValue'] = $modules[$mid]->getLongName();
             continue;
         } else if ($comment['fieldChanged'] === 'centerID') {
             $site = $db->pselectOne(
@@ -649,14 +647,11 @@ WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)",
         }
     }
 
-    $modules          = array();
-    $modules_expanded = $db->pselect(
-        "SELECT DISTINCT Label, ID FROM LorisMenu
-WHERE Parent IS NOT NULL ORDER BY Label ",
-        []
-    );
-    foreach ($modules_expanded as $m_row) {
-        $modules[$m_row['ID']] = $m_row['Label'];
+    $allmodules = \Module::getActiveModulesIndexed($db);
+
+    $modules = [];
+    foreach ($allmodules as $key => $m) {
+        $modules[$key] = $m->getLongName();
     }
 
     //Now get issue values

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -59,6 +59,30 @@ abstract class Module extends \LORIS\Router\PrefixRouter
     }
 
     /**
+     * Retrieve all active module descriptors from the given database, indexed
+     * by their primary key in the database.
+     *
+     * @param \Database $db an open connection to a database containing a 'modules'
+     *                      table
+     *
+     * @return \Module[]
+     */
+    static public function getActiveModulesIndexed(\Database $db): array
+    {
+        $mnames = $db->pselect(
+            "SELECT ID, Name FROM modules WHERE Active='Y'",
+            []
+        );
+
+        $rv = [];
+        foreach ($mnames as $row) {
+            $rv[$row['ID']] = self::factory($row['Name']);
+        }
+        return $rv;
+    }
+
+
+    /**
      * Returns a Module instance for the module named $name. The returned
      * value may be a subtype of the base LORIS module class and override
      * it's method.


### PR DESCRIPTION
Remove the remaining references to the LorisMenu table in the
issue tracker (in its ajax scripts) and update the code to
refer to the modules table instead.

Fixes #5938.