### PR TITLE
Module to NullModule change due to libraries modification

### DIFF
--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -54,7 +54,7 @@ foreach ($files AS $file) {
     echo "Requiring file...\n";
     include_once $file;
     echo "Instantiating new object...\n";
-    $obj =new $className(new Module("", ""), "", "", "", "");
+    $obj =new $className(new NullModule("", ""), "", "", "", "");
     echo "Initializing instrument object...\n";
     $obj->setup(null, null);
 

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -54,7 +54,7 @@ foreach ($files AS $file) {
     echo "Requiring file...\n";
     include_once $file;
     echo "Instantiating new object...\n";
-    $obj =new $className(new NullModule("", ""), "", "", "", "");
+    $obj =new $className(new NullModule(), "", "", "", "");
     echo "Initializing instrument object...\n";
     $obj->setup(null, null);
 


### PR DESCRIPTION
## Brief summary of changes

With new update to Module or some related modules, the lorisform_parser is no longer working. See issue #5940, this PR is created according to the information provided by @driusan.

_To Reproduce_
Go to tools/, ls any instrument to feed lorisform_parser, the system will report

PHP Fatal error: Uncaught Error: Cannot instantiate abstract class Module in tools/lorisform_parser.php:57

#### Testing instructions (if applicable)

1. Go to tools/, ls any instrument to feed lorisform_parser

#### Link(s) to related issue(s)

Issue #5940

* Resolves #  (Reference the issue this fixes, if any.)
