### PR TITLE
Add basic linting to tools/ scripts

### DIFF
--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Run PHP -l on everything to ensure there's no syntax
 # errors.
-find docs modules htdocs php src -name '*.class.inc' -print0 -o -name '*.php' -print0 |xargs -0 -n1 php -l >/dev/null  
+find docs modules htdocs php src tools -name '*.class.inc' -print0 -o -name '*.php' -print0 |xargs -0 -n1 php -l >/dev/null  
 
 # Run PHPCS on all .php and .inc files in folders:
 # php/


### PR DESCRIPTION
Adds the `tools/` directly to the files analyzed by `php -l` (basic syntax checking).