### PR TITLE
Clarify documentation on password requirements

### DIFF
--- a/modules/login/templates/form_passwordexpiry.tpl
+++ b/modules/login/templates/form_passwordexpiry.tpl
@@ -7,8 +7,8 @@
       <p><b>Password Strength Rules</b></p>
       <ul>
         <li>The password must be at least 8 characters long.</li>
-        <li>The password and the user name must not be the same.</li>
         <li>The password and the email address must not be the same.</li>
+        <li>No special characters are required but your password must be sufficiently complex to be accepted.</li>
       </ul>
         <p><b>Please choose a unique password.</b></p>
         <p>We suggest using a password manager to generate one for you.</p>

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -41,6 +41,7 @@
       <ul>
         <li>The password must be at least 8 characters long.</li>
         <li>The password cannot be your username or email address.</li>
+        <li>No special characters are required but your password must be sufficiently complex to be accepted.</li>
       </ul>
         <p>Please choose a unique password.</p>
         <p>We suggest using a password manager to generate one for you.</p>

--- a/modules/user_accounts/templates/form_my_preferences.tpl
+++ b/modules/user_accounts/templates/form_my_preferences.tpl
@@ -4,6 +4,7 @@
       <ul>
         <li>The password must be at least 8 characters long.</li>
         <li>The password cannot be your username or email address.</li>
+        <li>No special characters are required but your password must be sufficiently complex to be accepted.</li>
       </ul>
         <p>Please choose a unique password.</p>
         <p>We suggest using a password manager to generate one for you.</p>


### PR DESCRIPTION
## Brief summary of changes

Adds a line to front-end explanation of password requirements to clarify what is expected from the users.

This is a small improvement but we need to add #5761 in order for this to be truly user-friendly.

#### Link(s) to related issue(s)

* There was some confusion about the password requirements resulting in issue #5962. This is meant to address that confusion.