### PR TITLE
[bug] sessionID is never passed to feedback_mri_popup.php

### DIFF
--- a/modules/imaging_browser/jsx/ImagePanel.js
+++ b/modules/imaging_browser/jsx/ImagePanel.js
@@ -510,7 +510,7 @@ class ImageQCCommentsButton extends Component {
     e.preventDefault();
     window.open(
       this.props.BaseURL + '/feedback_mri_popup.php?fileID=' +
-      this.props.FileID,
+      this.props.FileID + '&sessionID=' + this.props.sessionID,
       'feedback_mri',
       'width=500,height=800,toolbar=no,location=no,' +
       'status=yes,scrollbars=yes,resizable=yes'
@@ -588,6 +588,7 @@ class ImageDownloadButtons extends Component {
       <div className="row mri-second-row-panel col-xs-12">
         <ImageQCCommentsButton FileID={this.props.FileID}
                                BaseURL={this.props.BaseURL}
+                               sessionID={this.props.sessionID}
         />
         <DownloadButton FileName={this.props.Fullname}
                         Label="Download Minc"
@@ -663,6 +664,7 @@ class ImagePanelBody extends Component {
         <ImageDownloadButtons
           BaseURL={this.props.BaseURL}
           FileID={this.props.FileID}
+          sessionID={this.props.sessionID}
           Fullname={this.props.Fullname}
           XMLProtocol={this.props.XMLProtocol}
           XMLReport={this.props.XMLReport}
@@ -733,7 +735,7 @@ class ImagePanel extends Component {
           {this.state.BodyCollapsed ? '' :
             <ImagePanelBody
               BaseURL={this.props.BaseURL}
-
+              sessionID={this.props.sessionID}
               FileID={this.props.FileID}
               Filename={this.props.Filename}
               Checkpic={this.props.Checkpic}

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -102,6 +102,8 @@ class ViewSession extends \NDB_Form
             }
             $this->_setFilesData();
 
+            $this->tpl_data['sessionID'] = $this->sessionID;
+
             $this->tpl_data['headerTable'] = $this->getHeaderTable();
 
             $this->tpl_data['showFloatJIV'] = true;

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -20,8 +20,8 @@
           <script>
           ReactDOM.render(
                   RImagePanel({
-                      'BaseURL' : "{$baseurl}",
-
+                      'BaseURL'  : "{$baseurl}",
+                      'sessionID': "{$sessionID}",
                       'FileID'   : "{$files[file].FileID}",
                       'Filename' : "{$files[file].Filename}",
                       'QCStatus' : "{$files[file].QCStatus}",


### PR DESCRIPTION
## Brief summary of changes
I noticed that since Loris 19.1, the sessionID was never passed to feedback_mri_popup, which is required in the program. As a result, quite a lot comments data missed sessionID field. The fix would address this problem for the future but won't touch the existing data.

If necessary, this patch could be applied to the old version with necessary adjustment.

#### Testing instructions (if applicable)

1. Go to Image browser, click on "QC Comments" of any image file, check whether sessionID is passed or not.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
