### PR TITLE
[added function] Group error message cell positioning

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2200,17 +2200,33 @@ class LorisForm
      * Sets an error for the given element to be displayed to the
      * user
      *
-     * @param string $el    The name of the element which has an error
-     * @param string $error The error to display with the element.
+     * @param string       $el    The name of the element which has an error.
+     * @param string|array $error The error to display with the element.
+     *                            string: the error message to show;
+     *                            array: an array of element to error message,
+     *                            multiple items in one section supported.
      *
      * @return void
      */
     function setElementError($el, $error)
     {
-        if (isset($this->form[$el]) && $this->form[$el]) {
-            $this->form[$el]["error"] = $error;
+        if (is_array($error)) {
+            $items = $this->form[$el];
+            foreach ($items['elements'] as $idx => $itm) {
+                foreach ($error as $key => $message) {
+                    if ($itm['name'] == $key) {
+                        $this->errors[$key] = $message;
+                        $this->form[$el]['elements'][$idx]["error"] = $message;
+                        break;
+                    }
+                }
+            }
+        } else {
+            if (isset($this->form[$el]) && $this->form[$el]) {
+                $this->form[$el]["error"] = $error;
+            }
+            $this->errors[$el] = $error;
         }
-        $this->errors[$el] = $error;
     }
 
     /**

--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -251,23 +251,44 @@
 				        <tr>
 				        {/if}
 							<td colspan="2">{$element.label}</td>
-							{foreach key=gkey item=gitem from=$element.elements}
-								{if $gitem.type == 'date'}
-									<td class="element form-inline">{$gitem.html}</td>
-								{elseif $gitem.type == 'checkbox'}
-									<td class="form-inline">{$gitem.html}</td>
-								{else}
-									<td class="element">{$gitem.html}</td>
-								{/if}
-							{/foreach}
+                            {assign var="itemError" value=""}
+                            {assign var="atLeastOneError" value=""}
+                            {foreach key=gkey item=gitem from=$element.elements}
+                                {if $gitem.error}
+                                    {assign var="itemError" value=" has-error"}
+                                    {assign var="atLeastOneError" value="1"}
+                                {else}
+                                    {assign var="itemError" value=""}
+                                {/if}
+                                {if $gitem.type == 'date'}
+                                    <td class="element form-inline{$itemError}">{$gitem.html}</td>
+                                {elseif $gitem.type == 'checkbox'}
+                                    <td class="form-inline{$itemError}">{$gitem.html}</td>
+                                {else}
+                                    <td class="element{$itemError}">{$gitem.html}</td>
+                                {/if}
+                            {/foreach}
 						</tr>
 						{if $element.error}
-							<tr>
-								<td colspan="2"></td>
-			                    <td colspan="{$element.elements|@count}" class="has-error">
-			                    	<font class="form-error">{$element.error}</font>
-			                    </td>
-			                </tr>
+                        <tr>
+                            <td colspan="2"></td>
+                            <td colspan="{$element.elements|@count}" class="has-error">
+                                <font class="form-error">{$element.error}</font>
+                            </td>
+                        </tr>
+                        {elseif $atLeastOneError}
+                        <tr>
+                            <td colspan="2"></td>
+                            {foreach key=gkey item=gitem from=$element.elements}
+                                {if $gitem.error}
+                                    <td class="has-error">
+                                        <font class="form-error">{$gitem.error}</font>
+                                    </td>
+                                {else}
+                                    <td/>
+                                {/if}
+                            {/foreach}
+                        </tr>
 						{/if}
 					{/if}
 				{/if}


### PR DESCRIPTION
## Brief summary of changes

When working with Loris Form, one can only position the error message to row level or to element level if this is a standalone element. 

If the items is in a big table, Loris doesn't support cell level error message positioning, though the table rendering is supported and the row level error message could somehow be supported. Because of the fact that here we have two interpretations for the same id (element vs table row), the idea is not quite clear because one needs to find the table row id instead of element id to be able to show positioning error message. this could create some confusion for new developers.

The modification here will add this capacity, with the following formats:

`$errors[<table id>] = ["<cell id>" => "<error message>"]`

or `$errors[<table id>] = ["<cell id 1>" => "<error message 1>", "<cell id 2>" => "<error message 2>"]`

I suppose that this could be an added capacity for form processing.

#### Testing instructions (if applicable)

1. Make a item like before, test error positioning capacity, in additional form validation instead of XIN rules.

2. Make a grouped item, with 1 and 2 items to verify the validation error message positioning capacity

#### Link(s) to related issue(s)

This is the recreation of the PR #5882