### PR TITLE
Remove BaseURL config setting

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -87,7 +87,6 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('www', 'Web address settings', 1, 0, 'WWW', 4);
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'host', 'Host', 1, 0, 'text', ID, 'Host', 1 FROM ConfigSettings WHERE Name="www";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'url', 'Main URL where LORIS can be accessed', 1, 0, 'text', ID, 'Main LORIS URL', 2 FROM ConfigSettings WHERE Name="www";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'issue_tracker_url', 'The *new* bug/issue tracker url', 1, 0, 'text', ID, 'Issue tracker URL', 3 FROM ConfigSettings WHERE Name="www";
 
 

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -198,10 +198,6 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings W
 INSERT INTO Config (ConfigID, Value) SELECT ID, 25 FROM ConfigSettings WHERE Name="rowsPerPage";
 
 
-INSERT INTO Config (ConfigID, Value) SELECT ID, "localhost" FROM ConfigSettings WHERE Name="host";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "http://localhost/" FROM ConfigSettings WHERE Name="url";
-
-
 INSERT INTO Config (ConfigID, Value) SELECT ID, "This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun." FROM ConfigSettings WHERE Name="projectDescription";
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "." FROM ConfigSettings WHERE Name="patientIDRegex";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -197,6 +197,7 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "%MINCToolsPath%" FROM ConfigSet
 INSERT INTO Config (ConfigID, Value) SELECT ID, "main.css" FROM ConfigSettings WHERE Name="css";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 25 FROM ConfigSettings WHERE Name="rowsPerPage";
 
+INSERT INTO Config (ConfigID, Value) SELECT ID, "localhost" FROM ConfigSettings WHERE Name="host";
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun." FROM ConfigSettings WHERE Name="projectDescription";
 

--- a/SQL/Cleanup_patches/2020-02-05-NoHostConfig.sql
+++ b/SQL/Cleanup_patches/2020-02-05-NoHostConfig.sql
@@ -1,0 +1,4 @@
+-- Remove the 'url' configuration. The config is no longer used by LORIS, but overrides
+-- or custom project modules may depend on it.
+DELETE FROM Config WHERE ConfigID IN (Select ID FROM ConfigSettings WHERE Name='url');
+DELETE FROM ConfigSettings WHERE Name='url';

--- a/SQL/New_patches/2020-02-05-NoHostConfig.sql
+++ b/SQL/New_patches/2020-02-05-NoHostConfig.sql
@@ -1,2 +1,0 @@
-DELETE FROM Config WHERE ConfigID IN (Select ID FROM ConfigSettings WHERE Name='url');
-DELETE FROM ConfigSettings WHERE Name='url';

--- a/SQL/New_patches/2020-02-05-NoHostConfig.sql
+++ b/SQL/New_patches/2020-02-05-NoHostConfig.sql
@@ -1,0 +1,2 @@
+DELETE FROM Config WHERE ConfigID IN (Select ID FROM ConfigSettings WHERE Name IN ('host', 'url'));
+DELETE FROM ConfigSettings WHERE Name IN ('host', 'url');

--- a/SQL/New_patches/2020-02-05-NoHostConfig.sql
+++ b/SQL/New_patches/2020-02-05-NoHostConfig.sql
@@ -1,2 +1,2 @@
-DELETE FROM Config WHERE ConfigID IN (Select ID FROM ConfigSettings WHERE Name IN ('host', 'url'));
-DELETE FROM ConfigSettings WHERE Name IN ('host', 'url');
+DELETE FROM Config WHERE ConfigID IN (Select ID FROM ConfigSettings WHERE Name='url');
+DELETE FROM ConfigSettings WHERE Name='url';

--- a/modules/api/php/endpoints/login.class.inc
+++ b/modules/api/php/endpoints/login.class.inc
@@ -160,7 +160,8 @@ class Login extends Endpoint
     function getEncodedToken($user)
     {
         $factory = \NDB_Factory::singleton();
-        $config  = $factory->settings()->getBaseURL();
+        $config  = $factory->config();
+        $baseURL = $factory->settings()->getBaseURL();
 
         $token = array(
             // JWT related tokens to for the JWT library to validate

--- a/modules/api/php/endpoints/login.class.inc
+++ b/modules/api/php/endpoints/login.class.inc
@@ -160,10 +160,7 @@ class Login extends Endpoint
     function getEncodedToken($user)
     {
         $factory = \NDB_Factory::singleton();
-        $config  = $factory->config();
-
-        $www     = $config->getSetting("www");
-        $baseURL = $www['url'];
+        $config  = $factory->settings()->getBaseURL();
 
         $token = array(
             // JWT related tokens to for the JWT library to validate

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -75,14 +75,15 @@ class PasswordReset extends \NDB_Form
                     new \Password($password),
                     new \DateTime('1999-01-01')
                 );
-                  // send the user an email
-                  $msg_data          = array();
-                  $msg_data['study'] = $config->getSetting('title');
-                  $msg_data['url']   = $config->getSetting('url');
-                  $msg_data['realname'] = $user->getData('Real_name');
-                  $msg_data['password'] = $password;
-                  \Email::send($email, 'lost_password.tpl', $msg_data);
 
+                // send the user an email
+                $factory = \NDB_Factory::singleton();
+                $msg_data          = array();
+                $msg_data['study'] = $config->getSetting('title');
+                $msg_data['url']   = $factory->settings()->getBaseURL();
+                $msg_data['realname'] = $user->getData('Real_name');
+                $msg_data['password'] = $password;
+                \Email::send($email, 'lost_password.tpl', $msg_data);
             } else {
                 error_log(
                     $_SERVER['REMOTE_ADDR']

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -78,6 +78,7 @@ class PasswordReset extends \NDB_Form
 
                 // send the user an email
                 $factory = \NDB_Factory::singleton();
+
                 $msg_data          = array();
                 $msg_data['study'] = $config->getSetting('title');
                 $msg_data['url']   = $factory->settings()->getBaseURL();

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -439,7 +439,7 @@ function notify($pubID, $type) : void
         );
         throw new \LorisException('Invalid publication ID specified.');
     }
-    $url = $config->getSetting('url');
+    $url = \NDB_Factory::singleton()->settings()->getBaseURL();
 
     $emailData['Title']       = $data['Title'];
     $emailData['Date']        = $data['DateProposed'];

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -221,12 +221,12 @@ class AddSurvey extends \NDB_Form
         $this->tpl_data['success'] = true;
 
         if ($email) {
-            $config = \NDB_Config::singleton();
-            $www    = $config->getSetting("www");
+            $config  = \NDB_Config::singleton();
+            $baseURL = \NDB_Factory::singleton()->settings()->getBaseURL();
 
             $msg_data = array(
                 'study'     => $config->getSetting("title"),
-                'url'       => $www['url'] . '/survey.php?key=' .
+                'url'       => $baseURL . '/survey.php?key=' .
                                          urlencode($key),
                 'EmailForm' => $values['email_dialog'],
             );

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -571,7 +571,7 @@ class Edit_User extends \NDB_Form
         $baseURL = $factory->settings()->getBaseURL();
         // send the user an email
         if (!empty($send)) {
-            $config = $factory->singleton();
+            $config = $factory->config();
 
             // send the user an email
             $msg_data          = array();

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -566,14 +566,17 @@ class Edit_User extends \NDB_Form
                 $user->addPermissions($permIDs);
             }
         }
+
+        $factory = \NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
         // send the user an email
         if (!empty($send)) {
-            // create an instance of the config object
-            $config = \NDB_Config::singleton();
+            $config = $factory->singleton();
+
             // send the user an email
             $msg_data          = array();
             $msg_data['study'] = $config->getSetting('title');
-            $msg_data['url']   = $config->getSetting('url');
+            $msg_data['url']   = $baseURL;
             $msg_data['realname'] = $values['Real_name'];
             $msg_data['username'] = $user->getUsername();
             $msg_data['password'] = $values['Password_hash'];
@@ -584,7 +587,6 @@ class Edit_User extends \NDB_Form
         }
         $this->tpl_data['success'] = true;
         if ($this->isCreatingNewUser()) {
-            $baseURL        = $config->getSetting('url');
             $this->redirect = $baseURL
                 . "/user_accounts/edit_user/"
                 . $values['UserID'];

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -204,12 +204,13 @@ class My_Preferences extends \NDB_Form
         }
 
         // create an instance of the config object
-        $config = \NDB_Factory::singleton()->config();
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->config();
 
         // send the user an email
         $msg_data          = array();
         $msg_data['study'] = $config->getSetting('title');
-        $msg_data['url']   = $config->getSetting('url');
+        $msg_data['url']   = $factory->settings()->getBaseURL();
         $msg_data['realname'] = $values['Real_name'];
         $msg_data['username'] = $user->getUsername();
         $msg_data['password'] = $values['Password_hash'];

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -37,7 +37,7 @@ class NDB_Factory
     private static $_candidates = array();
     private static $_timepoints = array();
 
-    private $baseURL = "";
+    private $_baseURL = "";
     var $Testing; // Whether or not Mock objects should be returned instead of
                   // real ones
     //
@@ -99,7 +99,7 @@ class NDB_Factory
         self::$_candidates = array();
         self::$_timepoints = array();
 
-        $this->baseURL = "";
+        $this->_baseURL = "";
     }
 
     /**
@@ -373,8 +373,17 @@ class NDB_Factory
         return $couchDB;
     }
 
-    public function setBaseURL(string $baseURL) {
-        $this->baseURL = $baseURL;
+    /**
+     * Sets the baseURL that the settings object return by settings()
+     * should return when calling getBaseURL().
+     *
+     * @param string $baseURL The URL to be returned by the Settings object.
+     *
+     * @return void
+     */
+    public function setBaseURL(string $baseURL)
+    {
+        $this->_baseURL = $baseURL;
     }
     /**
      * Returns a singleton settings object

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -37,6 +37,7 @@ class NDB_Factory
     private static $_candidates = array();
     private static $_timepoints = array();
 
+    private $baseURL = "";
     var $Testing; // Whether or not Mock objects should be returned instead of
                   // real ones
     //
@@ -97,6 +98,8 @@ class NDB_Factory
 
         self::$_candidates = array();
         self::$_timepoints = array();
+
+        $this->baseURL = "";
     }
 
     /**
@@ -370,6 +373,9 @@ class NDB_Factory
         return $couchDB;
     }
 
+    public function setBaseURL(string $baseURL) {
+        $this->baseURL = $baseURL;
+    }
     /**
      * Returns a singleton settings object
      *
@@ -382,7 +388,7 @@ class NDB_Factory
         if (self::$_settings !== null) {
             return self::$_settings;
         }
-        self::$_settings = new Settings($this->config($configfile));
+        self::$_settings = new Settings($this->config($configfile), $this->baseURL);
         return self::$_settings;
     }
 

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -397,7 +397,7 @@ class NDB_Factory
         if (self::$_settings !== null) {
             return self::$_settings;
         }
-        self::$_settings = new Settings($this->config($configfile), $this->baseURL);
+        self::$_settings = new Settings($this->config($configfile), $this->_baseURL);
         return self::$_settings;
     }
 

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -124,7 +124,8 @@ abstract class NDB_Notifier_Abstract
         array $extra_tpl_data,
         bool $asAdmin
     ) {
-        $config = \NDB_Config::singleton();
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->config();
 
         $this->module         = $module_name;
         $this->operation      = $operation_type;
@@ -132,7 +133,7 @@ abstract class NDB_Notifier_Abstract
         $this->notifier       = \User::singleton();
         $this->_adminNotifier = $this->_getAdminUser();
         $this->tpl_data['study_logo'] = $config->getSetting('studylogo');
-        $this->tpl_data['baseurl']    = $config->getSetting('url');
+        $this->tpl_data['baseurl']    = $factory->settings()->getBaseURL();
         $this->tpl_data['study_name'] = $config->getSetting('title');
 
         if (!is_null($extra_tpl_data)) {

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -798,7 +798,7 @@ class NDB_Page implements RequestHandlerInterface
         $baseurl = $factory->settings()->getBaseURL();
         $config  = $factory->config();
 
-        $min     = ($config->getSetting("sandbox") === '1') ? '' : '.min';
+        $min = ($config->getSetting("sandbox") === '1') ? '' : '.min';
 
         // Currently jquery-ui is required for dialogs and datepickers to work.
         // In the future release, dialogs should be replaced with bootstrap dialogs

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -795,10 +795,9 @@ class NDB_Page implements RequestHandlerInterface
     function getJSDependencies()
     {
         $factory = NDB_Factory::singleton();
+        $baseurl = $factory->settings()->getBaseURL();
         $config  = $factory->config();
 
-        $www     = $config->getSetting('www');
-        $baseurl = $www['url'];
         $min     = ($config->getSetting("sandbox") === '1') ? '' : '.min';
 
         // Currently jquery-ui is required for dialogs and datepickers to work.
@@ -844,10 +843,7 @@ class NDB_Page implements RequestHandlerInterface
     function getCSSDependencies()
     {
         $factory = NDB_Factory::singleton();
-        $config  = $factory->config();
-
-        $www     = $config->getSetting('www');
-        $baseurl = $www['url'];
+        $baseurl = $factory->settings()->getBaseURL();
 
         $files = array(
             $baseurl . "/bootstrap/css/bootstrap.min.css",

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -42,7 +42,7 @@ class Settings
      * Settings constructor.
      *
      * @param NDB_Config $_config config object
-     * @param string     $baseurl The base URL of LORIS
+     * @param string     $baseURL The base URL of LORIS
      */
     public function __construct(NDB_Config $_config, string $baseURL='')
     {

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -44,7 +44,7 @@ class Settings
      * @param NDB_Config $_config config object
      * @param string     $baseurl The base URL of LORIS
      */
-    public function __construct(NDB_Config $_config, string $baseURL)
+    public function __construct(NDB_Config $_config, string $baseURL='')
     {
         $this->_config = $_config;
         $this->baseURL = $baseURL;

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -42,10 +42,12 @@ class Settings
      * Settings constructor.
      *
      * @param NDB_Config $_config config object
+     * @param string     $baseurl The base URL of LORIS
      */
-    public function __construct(NDB_Config $_config)
+    public function __construct(NDB_Config $_config, string $baseURL)
     {
         $this->_config = $_config;
+        $this->baseURL = $baseURL;
     }
 
     /**
@@ -56,12 +58,7 @@ class Settings
      */
     public function getBaseURL(): string
     {
-        $url = getenv("LORIS_BASEURL");
-        if (!empty($url)) {
-            return $url;
-        }
-        $www = $this->_config->getSetting('www');
-        return $www['url'];
+        return $this->baseURL;
     }
 
     /**

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -89,13 +89,17 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         ) {
             $uri    = $request->getURI();
             $suburi = $this->stripPrefix($modulename, $uri);
-            $module = \Module::factory($modulename);
 
             // Calculate the base path by stripping off the module from the original.
             $path    = $uri->getPath();
             $baseurl = substr($path, 0, strpos($path, $modulename));
             $baseurl = $uri->withPath($baseurl)->withQuery("");
             $request = $request->withAttribute("baseurl", $baseurl->__toString());
+
+            $factory = \NDB_Factory::singleton();
+            $factory->setBaseURL($baseurl);
+
+            $module = \Module::factory($modulename);
             $mr      = new ModuleRouter($module, $this->moduledir);
             $request = $request->withURI($suburi);
             return $mr->handle($request);
@@ -107,6 +111,9 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             // FIXME: This assumes the baseURL is under /
             $path    = $uri->getPath();
             $baseurl = $uri->withPath("/")->withQuery("");
+
+            $factory = \NDB_Factory::singleton();
+            $factory->setBaseURL($baseurl);
             switch (count($components)) {
                 case 1:
                     $request = $request

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -99,7 +99,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $factory = \NDB_Factory::singleton();
             $factory->setBaseURL($baseurl);
 
-            $module = \Module::factory($modulename);
+            $module  = \Module::factory($modulename);
             $mr      = new ModuleRouter($module, $this->moduledir);
             $request = $request->withURI($suburi);
             return $mr->handle($request);

--- a/test/unittests/SettingsTest.php
+++ b/test/unittests/SettingsTest.php
@@ -152,39 +152,6 @@ class SettingsTest extends TestCase
     }
 
     /**
-     * Test that getBaseURL() calls getSetting('www') on the config object 
-     * and returns the correct string if the 'LORIS_BASEURL' is empty
-     *
-     * @return void
-     * @covers Settings::getBaseURL
-     */
-    public function testGetBaseURL()
-    {
-        $this->_configMock->expects($this->any())
-            ->method('getSetting')
-            ->with($this->equalTo('www'))
-            ->willReturn(array('url' => 'test1.loris.ca'));
-
-        $this->assertEquals("test1.loris.ca", $this->_settings->getBaseURL());
-    }
-
-    /**
-     * Test that getBaseURL() returns the correct value from the 
-     * 'LORIS_BASEURL' environment variable if it is set
-     *
-     * @return void
-     * @covers Settings::getBaseURL
-     */
-    public function testGetBaseURLWithLorisBaseURL()
-    {
-        //putenv sets the environment variable:
-        putenv("LORIS_BASEURL=test2.loris.ca");
-        $this->assertEquals("test2.loris.ca", $this->_settings->getBaseURL());
-        //Unset the environment variable:
-        putenv("LORIS_BASEURL");
-    }
-
-    /**
      * Test dbName() returns correct database name
      *
      * @covers Settings::dbName


### PR DESCRIPTION
The \LORIS\BaseRouter was already calculating the BaseURL of the incoming request and adding it to the request object. Unfortunately, most places in LORIS are not using it. Most instances would need to be refactored to get access to it since they're often deeper in the code and using `\NDB_Factory->settings()->getBaseURL()` at places with no direct access to the PSR7 request instance. This updates the code to have the router to pass the calculated URL to the factory singleton instance which injects it into the Settings object.

There were a very straggling instances to the (even older) `$config->getSetting('www')['url']` style of getting the baseURL which had to be updated to use the factory.

Fixes #5395, #6007.

# Testing Instructions
1. Test LORIS. Everything should work as before.
2. Test LORIS via another hostname (ie. use the IP instead of the hostname or vice versa). Everything should still work.