### PR TITLE
[Router] Remove unused routing logic from ModuleRouter

### DIFF
--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -100,7 +100,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $factory->setBaseURL($baseurl);
 
             $module  = \Module::factory($modulename);
-            $mr      = new ModuleRouter($module, $this->moduledir);
+            $mr      = new ModuleRouter($module);
             $request = $request->withURI($suburi);
             return $mr->handle($request);
         }
@@ -120,7 +120,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                     ->withAttribute("baseurl", rtrim($baseurl->__toString(), '/'))
                     ->withAttribute("CandID", $components[0]);
                     $module  = \Module::factory("timepoint_list");
-                    $mr      = new ModuleRouter($module, $this->moduledir);
+                    $mr      = new ModuleRouter($module);
                     return $mr->handle($request);
                 case 2:
                     // CandID/SessionID, inherited from htaccess
@@ -134,7 +134,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                         \TimePoint::singleton($components[1])
                     );
                         $module = \Module::factory("instrument_list");
-                        $mr     = new ModuleRouter($module, $this->moduledir);
+                        $mr     = new ModuleRouter($module);
                     return $mr->handle($request);
                 default:
                     // Fall through to 404. We don't have any routes that go farther

--- a/src/Router/ModuleRouter.php
+++ b/src/Router/ModuleRouter.php
@@ -16,6 +16,7 @@ namespace LORIS\Router;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Handles the base of a module's routing, adding authentication middleware
@@ -27,7 +28,7 @@ use \Psr\Http\Message\ResponseInterface;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class ModuleRouter extends PrefixRouter
+class ModuleRouter implements RequestHandlerInterface
 {
     /**
      * The module being accessed.
@@ -42,31 +43,9 @@ class ModuleRouter extends PrefixRouter
      * @param \Module $module    The module being accessed
      * @param string  $moduledir The base directory of $module.
      */
-    public function __construct(\Module $module, string $moduledir)
+    public function __construct(\Module $module)
     {
         $this->module = $module;
-
-        $arr = [
-                "/css/"    => new ModuleFileRouter(
-                    $module,
-                    $moduledir,
-                    "css",
-                    "text/css"
-                ),
-                "/js/"     => new ModuleFileRouter(
-                    $module,
-                    $moduledir,
-                    "js",
-                    "application/javascript"
-                ),
-                "/static/" => new ModuleFileRouter(
-                    $module,
-                    $moduledir,
-                    "static",
-                    ""
-                ),
-               ];
-        parent::__construct(new \ArrayIterator($arr));
     }
 
     /**


### PR DESCRIPTION
The module path and routes calculated by the ModuleRouter
are unused. In fact, the path passed to them is sometimes
wrong. The CSS, JS, and Static routes are handled by the
\Module class (where the path comes from the \Module::factory,
not the ModuleRouter). This removes the confusing dead
code.

#### Testing instructions (if applicable)

1. Test LORIS modules that have custom CSS, JS, or use the /static directory. In particular, project overrides for such modules should still work.