### PR TITLE
[Phan] Enable dead code detection and solve some occurrences

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -27,11 +27,6 @@ return [
     //
     // When the module is refactored, this line should be deleted.
     "ignore_undeclared_variables_in_global_scope" => true,
-    // FIXME: We should add this.
-    "dead_code_detection" => false,
-    // FIXME: We should add this. Note that dead_code_detection also covers
-    // unused_variable_detection. It might be a good idea to enable this first.
-    "unused_variable_detection" => false,
     "suppress_issue_types" => [
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -27,7 +27,17 @@ return [
     //
     // When the module is refactored, this line should be deleted.
     "ignore_undeclared_variables_in_global_scope" => true,
+    // FIXME: We should add this.
+    "dead_code_detection" => false,
+    // FIXME: We should add this. Note that dead_code_detection also covers
+    // unused_variable_detection. It might be a good idea to enable this first.
+    "unused_variable_detection" => true,
     "suppress_issue_types" => [
+        "PhanUnusedVariable",
+        "PhanUnusedPublicMethodParameter",
+        "PhanUnusedPublicNoOverrideMethodParameter",
+        "PhanUnusedPrivateMethodParameter",
+        "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",
         "PhanUndeclaredClassMethod",

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -67,7 +67,7 @@ default:
 /**
  * Handles the updating of Candidate Info
  *
- * @param Database $db   database object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *
@@ -144,8 +144,7 @@ function editCandInfoFields($db)
 /**
  * Handles the updating of Proband Info
  *
- * @param Database $db   database object
- * @param User     $user user object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *
@@ -210,8 +209,7 @@ function editProbandInfoFields($db)
 /**
  * Handles the updating of Family Info
  *
- * @param Database $db   database object
- * @param User     $user user object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *
@@ -305,8 +303,7 @@ function editFamilyInfoFields($db)
 /**
  * Handles the deletion of a family member
  *
- * @param Database $db   database object
- * @param User     $user user object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *
@@ -336,7 +333,7 @@ function deleteFamilyMember($db)
 /**
  * Handles the updating of Participant Status
  *
- * @param Database $db   database object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *
@@ -389,7 +386,7 @@ function editParticipantStatusFields($db)
 /**
  * Handles the updating of Consent Status
  *
- * @param Database $db   database object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *
@@ -530,7 +527,7 @@ function editConsentStatusFields($db)
 /**
  * Handles the updating of candidate's date of birth.
  *
- * @param Database $db   database object
+ * @param Database $db database object
  *
  * @throws DatabaseException
  *

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -68,13 +68,12 @@ default:
  * Handles the updating of Candidate Info
  *
  * @param Database $db   database object
- * @param User     $user user object
  *
  * @throws DatabaseException
  *
  * @return void
  */
-function editCandInfoFields($db, $user)
+function editCandInfoFields($db)
 {
 
     $candID = $_POST['candID'];
@@ -152,7 +151,7 @@ function editCandInfoFields($db, $user)
  *
  * @return void
  */
-function editProbandInfoFields($db, $user)
+function editProbandInfoFields($db)
 {
     //Sanitizing the post data
     $sanitize = array_map('htmlentities', $_POST);
@@ -218,7 +217,7 @@ function editProbandInfoFields($db, $user)
  *
  * @return void
  */
-function editFamilyInfoFields($db, $user)
+function editFamilyInfoFields($db)
 {
     $candID = $_POST['candID'];
 
@@ -313,7 +312,7 @@ function editFamilyInfoFields($db, $user)
  *
  * @return void
  */
-function deleteFamilyMember($db, $user)
+function deleteFamilyMember($db)
 {
     $candID         = $_POST['candID'];
     $familyMemberID = $_POST['familyDCCID'];
@@ -338,13 +337,12 @@ function deleteFamilyMember($db, $user)
  * Handles the updating of Participant Status
  *
  * @param Database $db   database object
- * @param User     $user user object
  *
  * @throws DatabaseException
  *
  * @return void
  */
-function editParticipantStatusFields($db, $user)
+function editParticipantStatusFields($db)
 {
     $candID = $_POST['candID'];
 
@@ -392,13 +390,12 @@ function editParticipantStatusFields($db, $user)
  * Handles the updating of Consent Status
  *
  * @param Database $db   database object
- * @param User     $user user object
  *
  * @throws DatabaseException
  *
  * @return void
  */
-function editConsentStatusFields($db, $user)
+function editConsentStatusFields($db)
 {
     // Get CandID
     $candIDParam = $_POST['candID'];
@@ -534,13 +531,12 @@ function editConsentStatusFields($db, $user)
  * Handles the updating of candidate's date of birth.
  *
  * @param Database $db   database object
- * @param User     $user user object
  *
  * @throws DatabaseException
  *
  * @return void
  */
-function editCandidateDOB(\Database $db, \User $user): void
+function editCandidateDOB(\Database $db): void
 {
     $candID       = new CandID($_POST['candID']);
     $dob          = $_POST['dob'];

--- a/modules/genomic_browser/ajax/genomic_file_upload.php
+++ b/modules/genomic_browser/ajax/genomic_file_upload.php
@@ -381,7 +381,7 @@ function insertBetaValues(&$fileToUpload)
         $sample_label_prefix = date('U', strtotime($fileToUpload->date_inserted));
         array_walk(
             $headers,
-            function (&$item, $key, $prefix) {
+            function (&$item, $prefix) {
                 $item = $prefix . '_' . trim($item);
             },
             $sample_label_prefix

--- a/src/Data/ProvisionerInstance.php
+++ b/src/Data/ProvisionerInstance.php
@@ -126,7 +126,7 @@ abstract class ProvisionerInstance implements Provisioner
         // If it implements both Filter and Mapper, run the filter first so
         // that the mapping is less expensive.
         if ($this->modifier instanceof Filter) {
-            $callback = function ($current, $key, $iterator) use ($user) {
+            $callback = function ($current) use ($user) {
                 return $this->modifier->filter($user, $current);
             };
 

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -13,6 +13,13 @@
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+/**
+ * Phan has an issue with the FakeDatabase->trackChanges function. It appears
+ * that this function exists only to prevent an unnecessary call during unit
+ * tests so we don't need phan to bother us.
+ *
+ * @phan-file-suppress PhanUnusedProtectedMethodParameter
+ */
 class FakePDO extends PDO
 {
     public function __construct () {}


### PR DESCRIPTION
This enables Phan's ability to detect unused variables and dead code. As with default phan rules, some new rules have been suppressed and we will gradually enable these.

The following Phan rules are now checked and existing violations have been fixed:
* PhanUnusedProtectedMethodParameter
* PhanUnusedGlobalFunctionParameter
* PhanUnusedClosureParameter