### PR TITLE
Add PhanPossiblyUndeclaredVariable rule to Phan checks

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -39,7 +39,6 @@ return [
         "PhanTypeMismatchArgument",
         "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",
-        "PhanPossiblyUndeclaredVariable",
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -192,6 +192,7 @@ function getPathIDs(string $table): array
     if (! in_array($table, array('Config', 'ConfigSettings', true))) {
         throw new \LorisException('Table must be "Config" or "ConfigSettings"');
     }
+    $query = '';
     switch ($table) {
     case 'Config':
         /* Query adapated from:

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -112,18 +112,12 @@ class EditExaminer extends \NDB_Form
     {
         $DB = \Database::singleton();
 
+        // get the examinerID
+        $examinerID = $this->identifier;
         foreach ($values['certStatus'] as $testID => $certStatus) {
 
             $date_cert = $values['date_cert'][$testID];
             $comment   = trim($values['comment'][$testID]);
-
-            // get the examinerID - edit_examiner passes the ID through
-            // the identifier, training passes it as a value
-            if (!empty($values['examiner'])) {
-                $examinerID = $values['examiner'];
-            } else {
-                $examinerID = $this->identifier;
-            }
 
             // Get the certificationID if it exists
             $certID = $DB->pselectOne(
@@ -198,12 +192,15 @@ class EditExaminer extends \NDB_Form
                         'TID' => $testID,
                     )
                 );
-                if (!empty($oldVals)) {
-                    // since there is an ORDER BY in pselect
-                    // $oldVals[0] corresponds to the latest date
-                    $oldVal  = $oldVals[0]['new'] ?? null;
-                    $oldDate = $oldVals[0]['new_date'] ?? null;
+                if (empty($oldVals)) {
+                    throw new \LorisException(
+                        'Certification data could not be found'
+                    );
                 }
+                // since there is an ORDER BY in pselect
+                // $oldVals[0] corresponds to the latest date
+                $oldVal  = $oldVals[0]['new'] ?? null;
+                $oldDate = $oldVals[0]['new_date'] ?? null;
 
                 $oldCertification = $DB->pselectRow(
                     "SELECT pass, date_cert, comment

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -492,6 +492,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         ////////////////////Insert values into mri_upload//////////////////////
         ///////////////////////////////////////////////////////////////////////
         $date = date('Y-m-d H:i:s');
+
         ///////////////////////////////////////////////////////////////////////
         /////Get the pscid, candid and visit_label/////////////////////////////
         ///////////////////////////////////////////////////////////////////////
@@ -534,13 +535,13 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         if ($this->uploaded_file_path) {
             $this->removeTempDir();
         } else {
-                $this->uploaded_file_path = $this->getTempPath();
+            $this->uploaded_file_path = $this->getTempPath();
         }
         $values = array(
             'UploadedBy'               => $user_name,
             'UploadDate'               => $date,
             'UploadLocation'           => $this->uploaded_file_path,
-            'SessionID'                => $sessionid,
+            'SessionID'                => $sessionid ?? '',
             'PatientName'              => $pname,
             'IsPhantom'                => $IsPhantom,
             'TarchiveID'               => null,

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -232,6 +232,8 @@ function getUploadFields()
     $languageList    = Utility::getLanguageList();
     $startYear       = $config->getSetting('startYear');
     $endYear         = $config->getSetting('endYear');
+    $visit = '';
+    $pscid = '';
 
     // Build array of session data to be used in upload media dropdowns
     $sessionData = array();
@@ -252,7 +254,7 @@ function getUploadFields()
 
         // Populate instruments
         $visit = $record["Visit_label"];
-        $pscid =$record["PSCID"];
+        $pscid = $record["PSCID"];
 
         if (!isset($sessionData[$pscid]['instruments'][$visit])) {
             $sessionData[$pscid]['instruments'][$visit] = [];

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -232,8 +232,8 @@ function getUploadFields()
     $languageList    = Utility::getLanguageList();
     $startYear       = $config->getSetting('startYear');
     $endYear         = $config->getSetting('endYear');
-    $visit = '';
-    $pscid = '';
+    $visit           = '';
+    $pscid           = '';
 
     // Build array of session data to be used in upload media dropdowns
     $sessionData = array();

--- a/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
+++ b/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
@@ -99,6 +99,7 @@ class ServerProcessesMonitor
                   WHERE 1=1";
 
         // Build ID where clause if needed
+        $idInClause = '';
         if (!is_null($idsToMonitor)) {
             $idInClause = implode(',', $idsToMonitor);
             $query      = "$query AND id IN ($idInClause)";

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -107,6 +107,7 @@ class Statistics_Mri_Site extends Statistics_Site
                 $counter++;
             }
         }
+        $query = '';
         switch ($issue) {
         case 'Tarchive_Missing':
             $query = "SELECT DISTINCT f.CommentID as CommentID, 
@@ -178,7 +179,7 @@ class Statistics_Mri_Site extends Statistics_Site
 
         }
         if ($query) {
-                      $result = $DB->pselect($query, $this->query_vars);
+            $result = $DB->pselect($query, $this->query_vars);
         }
         return $result ?? [];
     }

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -203,6 +203,7 @@ class Stats_Demographic extends \NDB_Form
             if (!empty($subprojList)) {
                 $subprojectQuery ="AND s.SubprojectID IN ($subprojList)";
             }
+            $this->tpl_data['Subprojects'] = $subprojects;
         }
 
         //SITES
@@ -255,7 +256,6 @@ class Stats_Demographic extends \NDB_Form
 
         $this->tpl_data['Sites']       = $sites;
         $this->tpl_data['Projects']    = $projects;
-        $this->tpl_data['Subprojects'] = $subprojects;
         $this->tpl_data['Visits']      = $visits;
 
         /**

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -254,9 +254,9 @@ class Stats_Demographic extends \NDB_Form
             }
         }
 
-        $this->tpl_data['Sites']       = $sites;
-        $this->tpl_data['Projects']    = $projects;
-        $this->tpl_data['Visits']      = $visits;
+        $this->tpl_data['Sites']    = $sites;
+        $this->tpl_data['Projects'] = $projects;
+        $this->tpl_data['Visits']   = $visits;
 
         /**
          * REGISTERED CANDIDATES ROW

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -52,10 +52,6 @@ class Edit_User extends \NDB_Form
      */
     function _hasAccess(\User $editor) : bool
     {
-        if (!$this->isCreatingNewUser()) {
-            $user = \User::factory($this->identifier);
-        }
-
         if ($editor->hasPermission('user_accounts')) {
             if ($editor->hasPermission('user_accounts_multisite')) {
                 return true;
@@ -64,6 +60,7 @@ class Edit_User extends \NDB_Form
             if ($this->isCreatingNewUser()) {
                 return true;
             }
+            $user = \User::factory($this->identifier);
             return array_intersect(
                 $user->getData('CenterIDs'),
                 $editor->getData('CenterIDs')


### PR DESCRIPTION
## Brief summary of changes

This rule checks for a case where a variable may not be declared, for example if it is declared only within an if-statement, but the code below it uses it anyway.

e.g.

```php

if ($a === $b) {
    $c = 10;
}

echo $a . $c;
```

The code assumes `$c` exists but this may not always be the case.
