### PR TITLE
[Instrument] Breadcrumb does not match instrument_list link

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1187,7 +1187,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function _getQuickformDate(string $databaseValue)
     {
         throw new Exception(
-            "The function _getQuickformDate has been deprecated. 
+            "The function _getQuickformDate has been deprecated.
             Please contact LORIS developer mail list for support."
         );
     }
@@ -2697,7 +2697,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ),
             new \LORIS\Breadcrumb(
                 $this->getFullName(),
-                "/instruments/$instrument/?commentID=$this->commentID"
+                "/instruments/$instrument/".
+                "?commentID=$this->commentID&sessionID=$sessionid&candID=$candid"
             )
         );
     }


### PR DESCRIPTION
## Brief summary of changes
Breadcrumb element of any instrument was linking to `instruments/instr/?commentID=587630DCC0901053161524238782` instead of `instruments/instr/?commentID=587630DCC0901053161524238782&sessionID=1053&candID=587630` like the instrument list module does. 

#### Testing instructions (if applicable)

1. go on an instrument and click on it's breadcrumb with and without this PR
