### PR TITLE
[stats] fixed only_full_group_by error in query

### DIFF
--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -182,8 +182,8 @@ class Charts extends \NDB_Page
             LEFT JOIN session s ON (s.ID=f.SessionID)
             JOIN parameter_type pt USING (ParameterTypeID)
             WHERE pt.Name='acquisition_date'
-            GROUP BY MONTH(pf.Value), YEAR(pf.Value), s.CenterID
-            ORDER BY YEAR(pf.Value), MONTH(pf.Value), s.CenterID",
+            GROUP BY datelabel, s.CenterID
+            ORDER BY datelabel, s.CenterID",
             array()
         );
 

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -182,8 +182,8 @@ class Charts extends \NDB_Page
             LEFT JOIN session s ON (s.ID=f.SessionID)
             JOIN parameter_type pt USING (ParameterTypeID)
             WHERE pt.Name='acquisition_date'
-            GROUP BY datelabel, s.CenterID
-            ORDER BY datelabel, s.CenterID",
+            GROUP BY MONTH(pf.Value), YEAR(pf.Value), s.CenterID, datelabel
+            ORDER BY YEAR(pf.Value), MONTH(pf.Value), s.CenterID",
             array()
         );
 


### PR DESCRIPTION
## Brief summary of changes
on MySQL 5.7 with SQL MODE `only_full_group_by` I get 500 errors on the dashboard for the query that was altered in this PR

#### Testing instructions (if applicable)

1. open error_log
2. make sure your SQL mode is properly set to `only_full_group_by`
2. access the dashboard.

**NOTE** Whomever this affects should verify that the results on the query are unchanged from this PR

