### PR TITLE
[Instruments] Handle NotFound exception causing LORIS to crash

### DIFF
--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -59,15 +59,21 @@ class Module extends \Module
         $params    = $request->getQueryParams();
         $commentID = $params['commentID'] ?? null;
         if (empty($commentID)) {
-            return (new \Laminas\Diactoros\Response())
-                ->withBody(new \LORIS\Http\StringStream("Missing CommentID"))
-                ->withStatus(400);
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                "Missing CommentID"
+            );
         }
-        $instrument = \NDB_BVL_Instrument::factory(
-            $instrumentName,
-            $commentID,
-            $page
-        );
+        try {
+            $instrument = \NDB_BVL_Instrument::factory(
+                $instrumentName,
+                $commentID,
+                $page
+            );
+        } catch (\NotFound $e) {
+            return new \LORIS\Http\Response\JSON\NotFound(
+                $e->getMessage()
+            );
+        }
 
         $request = $request->withAttribute('pageclass', $instrument);
 

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -69,15 +69,14 @@ class Module extends \Module
                 $commentID,
                 $page
             );
+            $request    = $request->withAttribute('pageclass', $instrument);
+
+            return $instrument->process($request, $instrument);
         } catch (\NotFound $e) {
             return new \LORIS\Http\Response\JSON\NotFound(
                 $e->getMessage()
             );
         }
-
-        $request = $request->withAttribute('pageclass', $instrument);
-
-        return $instrument->process($request, $instrument);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

When a candidate has an entry for an instrument in `instrument_list` but the instrument is not installed, a crash occurs if the user clicks on this entry. The back-end displays the error `PHP Fatal error:  Uncaught NotFound: Instrument does not exist ...`

This PR adds error handling to return the message `{"error":"Instrument does not exist"}` instead of a crash.

Further work should be done to provide SWAL error handling for this module.

#### Testing instructions (if applicable)

1. On a VM with raisinbread, go to `/instrument_list/?candID=300005&sessionID=5`.
2. Under "Behavioral Battery of Instruments" click Radiology review
3. If this instrument does not exist, LORIS will crash
4. On my branch you'll see instead a JSON response ``{"error":"Instrument does not exist"}``
