### PR TITLE
Add ReadTheDocs build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <img src="./htdocs/images/LORIS_logo.svg" width="35%">
 
 [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) 
-[![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
-
 [![Minimum PHP Version](https://img.shields.io/travis/php-v/aces/loris/master?color=787CB5)](https://php.net/)
+[![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
 
 # LORIS Neuroimaging Platform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img src="./htdocs/images/LORIS_logo.svg" width="35%">
 
 [![Build Status](https://travis-ci.org/aces/Loris.svg?branch=master)](https://travis-ci.org/aces/Loris) 
+[![Documentation Status](https://readthedocs.org/projects/acesloris/badge/?version=latest)](https://acesloris.readthedocs.io/en/latest/?badge=latest)
+
 [![Minimum PHP Version](https://img.shields.io/travis/php-v/aces/loris/master?color=787CB5)](https://php.net/)
 
 # LORIS Neuroimaging Platform


### PR DESCRIPTION
## Brief summary of changes

<img width="468" alt="Screen Shot 2020-02-10 at 10 23 43" src="https://user-images.githubusercontent.com/4022790/74162855-72973300-4bef-11ea-8d78-cf7f8eaefdac.png">


Adds a build badge representing the status of our ReadTheDocs build.

It's helpful to have -- by chance, I noticed our build was failing. This would be a much earlier warning sign.