### PR TITLE
[Consent] Add ParentID to `consent` for consent grouping

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -2059,13 +2059,26 @@ CREATE TABLE `feedback_mri_comments` (
 -- Consent tables
 -- ********************************
 
+CREATE TABLE `consent_group` (
+  `ConsentGroupID` integer unsigned NOT NULL AUTO_INCREMENT,
+  `Name` varchar(255) NOT NULL,
+  `Label` varchar(255) NOT NULL,
+  CONSTRAINT `PK_consent_group` PRIMARY KEY (`ConsentGroupID`),
+  CONSTRAINT `UK_consent_group_Name` UNIQUE KEY `Name` (`Name`),
+  CONSTRAINT `UK_consent_group_Label` UNIQUE KEY `Label` (`Label`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO `consent_group` (`ConsentGroupID`, `Name`, `Label`) VALUES ('1', 'main_consent', 'Main consent');
+
 CREATE TABLE `consent` (
   `ConsentID` integer unsigned NOT NULL AUTO_INCREMENT,
   `Name` varchar(255) NOT NULL,
   `Label` varchar(255) NOT NULL,
+  `ConsentGroupID` integer unsigned NOT NULL DEFAULT 1,
   CONSTRAINT `PK_consent` PRIMARY KEY (`ConsentID`),
   CONSTRAINT `UK_consent_Name` UNIQUE KEY `Name` (`Name`),
-  CONSTRAINT `UK_consent_Label` UNIQUE KEY `Label` (`Label`)
+  CONSTRAINT `UK_consent_Label` UNIQUE KEY `Label` (`Label`),
+  CONSTRAINT `FK_consent_ConsentGroupID` FOREIGN KEY (`ConsentGroupID`) REFERENCES `consent_group` (`ConsentGroupID`) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `candidate_consent_rel` (
@@ -2224,4 +2237,3 @@ CREATE TABLE `publication_users_edit_perm_rel` (
   CONSTRAINT `FK_publication_users_edit_perm_rel_PublicationID` FOREIGN KEY (`PublicationID`) REFERENCES `publication` (`PublicationID`),
   CONSTRAINT `FK_publication_users_edit_perm_rel_UserID` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET='utf8';
-

--- a/SQL/New_patches/2020-02-10-AddConsentGrouping.sql
+++ b/SQL/New_patches/2020-02-10-AddConsentGrouping.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `consent_group` (
+  `ConsentGroupID` integer unsigned NOT NULL AUTO_INCREMENT,
+  `Name` varchar(255) NOT NULL,
+  `Label` varchar(255) NOT NULL,
+  CONSTRAINT `PK_consent_group` PRIMARY KEY (`ConsentGroupID`),
+  CONSTRAINT `UK_consent_group_Name` UNIQUE KEY `Name` (`Name`),
+  CONSTRAINT `UK_consent_group_Label` UNIQUE KEY `Label` (`Label`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO `consent_group` (`ConsentGroupID`, `Name`, `Label`) VALUES ('1', 'main_consent', 'Main consent');
+
+ALTER TABLE `consent` ADD `ConsentGroupID` integer unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `consent` ADD CONSTRAINT `FK_consent_ConsentGroupID` FOREIGN KEY (`ConsentGroupID`) REFERENCES `consent_group` (`ConsentGroupID`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -422,12 +422,15 @@ function editConsentStatusFields(\Database $db)
 
         // Process posted data
         // Empty strings and type null are not passed (null is passed as a string)
-        $status     = ($_POST[$consentName] !== 'null') ?
-                        $_POST[$consentName] : null;
-        $date       = ($_POST[$consentName . '_date'] !== 'null') ?
-                        $_POST[$consentName . '_date'] : null;
-        $withdrawal = ($_POST[$consentName . '_withdrawal'] !== 'null') ?
-                        $_POST[$consentName . '_withdrawal'] : null;
+        $status     = (isset($_POST[$consentName]) &&
+                          $_POST[$consentName] !== 'null') ?
+                          $_POST[$consentName] : null;
+        $date       = (isset($_POST[$consentName . '_date']) &&
+                          $_POST[$consentName . '_date'] !== 'null') ?
+                          $_POST[$consentName . '_date'] : null;
+        $withdrawal = (isset($_POST[$consentName . '_withdrawal']) &&
+                          $_POST[$consentName . '_withdrawal'] !== 'null') ?
+                          $_POST[$consentName . '_withdrawal'] : null;
 
         $updateStatus  = [
             'CandidateID'   => $candID,

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -100,15 +100,16 @@ class Utility
     /**
      * Returns list of consents in the database
      *
-     * @return array An associative array of consents, with their names and labels.
-     *               The keys of the arrays are the IDs of the consents
+     * @return array An associative array of consents, with their names,
+     *               labels, and group ID. The keys of the arrays are the
+     *               IDs of the consents.
      */
     static function getConsentList(): array
     {
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $query = "SELECT ConsentID, Name, Label FROM consent";
+        $query = "SELECT ConsentID, Name, Label, ConsentGroupID FROM consent";
         $key   = "ConsentID";
 
         $result = $DB->pselectWithIndexKey($query, [], $key);

--- a/raisinbread/RB_files/RB_consent.sql
+++ b/raisinbread/RB_files/RB_consent.sql
@@ -1,8 +1,8 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `consent`;
 LOCK TABLES `consent` WRITE;
-INSERT INTO `consent` (`ConsentID`, `Name`, `Label`) VALUES (1,'study_consent','Consent to Study');
-INSERT INTO `consent` (`ConsentID`, `Name`, `Label`) VALUES (2,'raisin_consent','Consent to Raisin');
-INSERT INTO `consent` (`ConsentID`, `Name`, `Label`) VALUES (3,'bread_consent','Consent to Bread');
+INSERT INTO `consent` (`ConsentID`, `Name`, `Label`, `ConsentGroupID`) VALUES (1,'study_consent','Consent to Study', '1');
+INSERT INTO `consent` (`ConsentID`, `Name`, `Label`, `ConsentGroupID`) VALUES (2,'raisin_consent','Consent to Raisin', '2');
+INSERT INTO `consent` (`ConsentID`, `Name`, `Label`, `ConsentGroupID`) VALUES (3,'bread_consent','Consent to Bread', '2');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_consent_group.sql
+++ b/raisinbread/RB_files/RB_consent_group.sql
@@ -1,0 +1,7 @@
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE `consent_group`;
+LOCK TABLES `consent_group` WRITE;
+INSERT INTO `consent_group` (`ConsentGroupID`, `Name`, `Label`) VALUES (1,'study_consent_form','Study Information and Consent Form');
+INSERT INTO `consent_group` (`ConsentGroupID`, `Name`, `Label`) VALUES (2,'bakery_consent_form','Bakery Information and Consent Form');
+UNLOCK TABLES;
+SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

**PR 1 of 2**

This PR:
- adds ConsentGroupID to consent table (schema + patch)
- updates RB_consent.sql to have consent group IDs
- adds RB_consent_group.sql to have 2 groups
- update getConsentList() function in \Utility to query only ConsentGroupID as well
- fixes PHP notice of undefined index in formHandler.php

This PR keeps the Consent Status tab rendering the same. Only the back-end is affected in this PR. This feature is increasingly in demand from projects who would like to split up consents via e.g. consent forms. Front-end changes are in PR #6044 (to be rebased after this PR gets merged)

#### Testing instructions (if applicable)

1. On aces/main, test Consent Status tab of candidate_parameters module. See that you can fill in consent for a candidate for study_consent, raisin_consent, and bread_consent. If you don't see the Consent Status tab, turn on the _'useConsent'_ config.
2. Git checkout zaliqarosli/2020-02-10-AddParentIDToConsent
3. Source SQL/New_patches/2020-02-10-AddConsentGrouping.sql
4. Repeat the first step and ensure that nothing on the Consent Status tab has changed and that you can fill in consent the same as before