### PR TITLE
Update Coding Standards document and add to ReadTheDocs

### DIFF
--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -17,22 +17,16 @@ gg=G
 ```
 
 # PHP
-Ensure formatting meets Loris style guidelines by running phpcs with the LorisCS.xml
-  configuration file which accompanies these guidelines. You can run the tool
-  with the command 
-  ```bash
-  vendor/bin/phpcs --standard=docs/LorisCS.xml <file> [file2, file3, ...]
-  ```
-  for any files you've modified or added. For new modules, ensure that PHPCS has been
-  run on the module directory and add the module to `travis.yml`
+PHP code must pass our static analysis test suite. For details on the process,
+    please the [Automated Testing Guide](./wiki/99 - Developers/Automated Testing.md)
 
-  All new functions should use type hinting and return type declarations.
+All new functions should use type hinting and return type declarations.
 
-  All new classes should declare strict types by including the following line at
-  the top of the file:
-  ```php
-  <?php declare(strict_types=1);
-  ```
+All new classes should declare strict types by including the following line at
+the top of the file:
+```php
+<?php declare(strict_types=1);
+```
 
 # HTML
 - HTML should never be mixed with code. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - API: 'API/LorisRESTAPI.md'
     - Developers: 
         - 'Overview': 'wiki/99 - Developers/README.md'
+        - 'Coding Standards': 'CodingStandards.md'
         - 'SQL Dictionary': 'wiki/99 - Developers/SQL Dictionary.md'
         - 'Automated Testing': 'wiki/99 - Developers/Automated Testing.md'
         - 'Style Guide (for help text)': 'HelpStyleGuide.md'


### PR DESCRIPTION
The document was referring to an old process where we would manually test code with only PHPCS. Now it directs people to `make checkstatic` which automatically runs all of our analysis tools on all PHP source code.