### PR TITLE
[Consent] Group consents + Improve UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 ### Modules
 #### Issue Tracker
 - Readability of comments and history was improved. (PR #6138)
+#### Candidate Parameters
+- Consent grouping added to SQL schema and Consent Status tab UI (PR #6042, PR #6044)
 ### Clean Up
 - *Add item here*
 ### Notes For Existing Projects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 #### Issue Tracker
 - Readability of comments and history was improved. (PR #6138)
 #### Candidate Parameters
-- Consent grouping added to SQL schema and Consent Status tab UI (PR #6042, PR #6044)
+- Consents may now be grouped in UI of consent tab (PR #6042, PR #6044)
 ### Clean Up
 - *Add item here*
 ### Notes For Existing Projects

--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -395,34 +395,36 @@ class ConsentStatus extends Component {
         const tabList = [];
         const tabPanes = Object.keys(this.state.Data.consentGroups).map(
           (consentID) => {
-            tabList.push({
-                id: consentID,
-                label: this.state.Data.consentGroups[consentID].Label,
-            });
-            return (
-                <TabPane key={consentID} TabId={consentID}>
-                    <FormElement
-                        name="consentStatus"
-                        onSubmit={this.handleSubmit}
-                        class="col-md-9"
-                    >
-                        <StaticElement
-                          label="PSCID"
-                          text={this.state.Data.pscid}
-                        />
-                        <StaticElement
-                          label="DCCID"
-                          text={this.state.Data.candID}
-                        />
-                        {this.state.Data.consentGroups[consentID].Children.map(
-                          (consentName) => {
-                            return this.renderConsent(consentName);
-                          }
-                        )}
-                        {updateButton}
-                    </FormElement>
-                </TabPane>
-            );
+            if (this.state.Data.consentGroups[consentID].Children) {
+              tabList.push({
+                  id: consentID,
+                  label: this.state.Data.consentGroups[consentID].Label,
+              });
+              return (
+                  <TabPane key={consentID} TabId={consentID}>
+                      <FormElement
+                          name="consentStatus"
+                          onSubmit={this.handleSubmit}
+                          class="col-md-9"
+                      >
+                          <StaticElement
+                            label="PSCID"
+                            text={this.state.Data.pscid}
+                          />
+                          <StaticElement
+                            label="DCCID"
+                            text={this.state.Data.candID}
+                          />
+                          {this.state.Data.consentGroups[consentID].Children
+                            .map((consentName) => {
+                              return this.renderConsent(consentName);
+                            }
+                          )}
+                          {updateButton}
+                      </FormElement>
+                  </TabPane>
+              );
+            }
           }
         );
         return (

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -98,6 +98,25 @@ class Utility
         return $age;
     }
     /**
+     * Returns list of consent groups in the database
+     *
+     * @return array An associative array of consent grouping,
+     *               with their names and labels. The keys of
+     *               the arrays are the IDs of the groups.
+     */
+    static function getConsentGroups(): array
+    {
+        $factory = NDB_Factory::singleton();
+        $DB      = $factory->database();
+
+        $query = "SELECT ConsentGroupID, Name, Label FROM consent_group";
+        $key   = "ConsentGroupID";
+
+        $result = $DB->pselectWithIndexKey($query, [], $key);
+
+        return $result;
+    }
+    /**
      * Returns list of consents in the database
      *
      * @return array An associative array of consents, with their names,


### PR DESCRIPTION
## Brief summary of changes

**PR 2 of 2.** This PR includes changes from https://github.com/aces/Loris/pull/6042 and will need to be rebased once #6042 has been merged.

This PR follows the first PR by rendering the grouping of consents and improves other aspects of the UI.

This PR:
- Adds vertical tabs for each parent consent and renders within that tab all the children consents
- For each consent rendering: adds a HeaderElement for the consent label, changes label for Yes/No select Element to 'Response', changes label for Date element to 'Date of Response'
- Hides Consent history by default
- Add Show/Hide Consent history toggling
- Cleans up the rendering of the history string

#### Testing instructions (if applicable)

1. Source all sql patches as instructed in PR #6042 
2. git checkout zaliqarosli/2020-02-10-AddParentToConsentUI
3. Run make
4. Got to Consent Status tab of candidate_parameters module and you will see the following changed display

<img width="1280" alt="Screenshot 2020-02-10 18 20 22" src="https://user-images.githubusercontent.com/17415878/74199405-0c7fcf80-4c32-11ea-9c6d-6150acd15145.png">

5. Play around with updating consent - the editing functionality should remain the same (other than 'Update' button getting disabled on form submission)
