### PR TITLE
Remove PHPCS requirement for boilerplate comments

### DIFF
--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -9,7 +9,6 @@ define("DEBUG", false);
  * Throughout the class, all input arrays follow the same structure:
  * $array['column_name'] = 'value'.
  *
- * @author  Alex Zijdenbos <zijdenbos@example.com>
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class Database

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1,4 +1,6 @@
 <?php declare(strict_types=1);
+define("DEBUG", false);
+
 /**
  * Database abstraction layer presents a unified interface to database
  * connectivity.  Instantiate one object instance per database
@@ -10,8 +12,6 @@
  * @author  Alex Zijdenbos <zijdenbos@example.com>
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
-define("DEBUG", false);
-
 class Database
 {
     /**

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1,18 +1,5 @@
 <?php declare(strict_types=1);
 /**
- * This file represents an SQL database abstraction layer for use in Loris
- *
- * PHP Version 5
- *
- * @category Main
- * @package  Loris
- * @author   Alex Zijdenbos <zijdenbos@example.com>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris-Trunk/
- */
-define("DEBUG", false);
-
-/**
  * Database abstraction layer presents a unified interface to database
  * connectivity.  Instantiate one object instance per database
  * connection.
@@ -20,12 +7,11 @@ define("DEBUG", false);
  * Throughout the class, all input arrays follow the same structure:
  * $array['column_name'] = 'value'.
  *
- * @category Main
- * @package  Loris
- * @author   Alex Zijdenbos <zijdenbos@example.com>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris-Trunk/
+ * @author  Alex Zijdenbos <zijdenbos@example.com>
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
+define("DEBUG", false);
+
 class Database
 {
     /**

--- a/test/LorisCS.xml
+++ b/test/LorisCS.xml
@@ -4,11 +4,11 @@
 
     <!-- Include the PEAR standard -->
     <rule ref="PEAR">
-        <exclude name="PEAR.Commenting.ClassComment"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
-        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
+        <exclude name="PEAR.Commenting.FileComment"/>
+        <exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag"/>
+        <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag"/>
+        <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
+        <exclude name="PEAR.Commenting.ClassComment.MissingVersion"/>
     </rule>
 
     <!-- Pieces of other standards to include... -->

--- a/test/LorisCS.xml
+++ b/test/LorisCS.xml
@@ -9,6 +9,7 @@
         <exclude name="PEAR.Commenting.ClassComment.MissingPackageTag"/>
         <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
         <exclude name="PEAR.Commenting.ClassComment.MissingVersion"/>
+        <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag"/>
     </rule>
 
     <!-- Pieces of other standards to include... -->

--- a/test/LorisCS.xml
+++ b/test/LorisCS.xml
@@ -3,7 +3,13 @@
     <description>The coding standard for the Loris project</description>
 
     <!-- Include the PEAR standard -->
-    <rule ref="PEAR"/>
+    <rule ref="PEAR">
+        <exclude name="PEAR.Commenting.ClassComment"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
+    </rule>
 
     <!-- Pieces of other standards to include... -->
 


### PR DESCRIPTION
## Brief summary of changes

PHPCS no longer fails code if it does not have:

* A class comment
* A PHP version
* Link tag
* Package tag
* Category tag

PHPCS still requires a file comment, author, and licence. I chose to keep file comments over class comments so that there will still be some documentation required for PHP code without classes, such as tools/ and ajax/ scripts.