### PR TITLE
Fix "Undefined index: filter" errors in NDB_Menu_Filter

### DIFF
--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -595,9 +595,10 @@ class NDB_Menu_Filter extends NDB_Menu
         $this->setTemplateVar('rowsPerPage', $rowsPerPage);
         $this->setTemplateVar('pageID', $pageID);
 
-        if (isset($_GET['filter']) &&
-            is_array($_GET['filter']) &&
-            is_array($_GET['filter']['order'])) {
+        if (isset($_GET['filter'])
+            && is_array($_GET['filter'])
+            && is_array($_GET['filter']['order'])
+        ) {
             $this->setTemplateVar(
                 'filterfield',
                 $_GET['filter']['order']['field'] ?? ''

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -595,7 +595,9 @@ class NDB_Menu_Filter extends NDB_Menu
         $this->setTemplateVar('rowsPerPage', $rowsPerPage);
         $this->setTemplateVar('pageID', $pageID);
 
-        if (is_array($_GET['filter']['order'])) {
+        if (isset($_GET['filter']) &&
+            is_array($_GET['filter']) &&
+            is_array($_GET['filter']['order'])) {
             $this->setTemplateVar(
                 'filterfield',
                 $_GET['filter']['order']['field'] ?? ''


### PR DESCRIPTION
Fix errors of the type "Undefined index: filter" when accessing
some NDB_Menu_Filter pages. This prevents some modules from loading
because the notice results in the JSON returned by LORIS being
invalid.

(This PR is a duplicate of #6011 but with the requested changes
incorporated, since some modules currently can't be loaded without a
fix.)