### PR TITLE
[Survey Accounts] Data Frameworkify the module

### DIFF
--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -41,7 +41,8 @@ class Survey_Accounts extends \DataFrameworkMenu
      *
      * @return bool
      */
-    public function useSiteFilter() : bool {
+    public function useSiteFilter() : bool
+    {
         return true;
     }
 
@@ -50,7 +51,8 @@ class Survey_Accounts extends \DataFrameworkMenu
      *
      * @return bool
      */
-    public function useProjectFilter() : bool {
+    public function useProjectFilter() : bool
+    {
         return true;
     }
 
@@ -59,7 +61,8 @@ class Survey_Accounts extends \DataFrameworkMenu
      *
      * @return array
      */
-    public function getFieldOptions() : array {
+    public function getFieldOptions() : array
+    {
         return [
             'visits'      => \Utility::getVisitList(),
             'instruments' => \Utility::getDirectInstruments(),
@@ -71,7 +74,8 @@ class Survey_Accounts extends \DataFrameworkMenu
      *
      * @return \LORIS\Data\Provisioner
      */
-    public function getBaseDataProvisioner() : \LORIS\Data\Provisioner {
+    public function getBaseDataProvisioner() : \LORIS\Data\Provisioner
+    {
         return new SurveyAccountsProvisioner();
     }
 

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -22,10 +22,8 @@ namespace LORIS\survey_accounts;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Survey_Accounts extends \NDB_Menu_Filter
+class Survey_Accounts extends \DataFrameworkMenu
 {
-    public $skipTemplate = true;
-
     /**
      * Determine if user has permission to access this page
      *
@@ -39,41 +37,48 @@ class Survey_Accounts extends \NDB_Menu_Filter
     }
 
     /**
-     * Setup internal class variables which are required by NDB_Meny_Filter
-     * for generating the query which the table data is based on
+     * {@inheritDoc}
      *
-     * @return void
+     * @return bool
      */
-    function _setupVariables()
-    {
-        // the base query
-        $query = " FROM participant_accounts p 
-            JOIN session s ON (p.SessionID=s.ID)
-            JOIN candidate c ON (c.CandID=s.CandID)
-            WHERE c.Active = 'Y'
-            AND   s.Active = 'Y'";
+    public function useSiteFilter() : bool {
+        return true;
+    }
 
-        // set the class variables
-        $this->columns      = array(
-            'c.PSCID AS PSCID',
-            's.Visit_label AS Visit',
-            'p.Email as Email',
-            'p.Test_name as SurveyName',
-            'p.OneTimePassword as URL',
-            'p.Status',
-        );
-        $this->query        = $query;
-        $this->order_by     = 'PSCID';
-        $this->fieldOptions = [
+    /**
+     * {@inheritDoc}
+     *
+     * @return bool
+     */
+    public function useProjectFilter() : bool {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function getFieldOptions() : array {
+        return [
             'visits'      => \Utility::getVisitList(),
             'instruments' => \Utility::getDirectInstruments(),
         ];
     }
 
     /**
-     * Gathers JS dependecies and merge them with the parent
+     * {@inheritDoc}
      *
-     * @return array of javascript to be inserted
+     * @return \LORIS\Data\Provisioner
+     */
+    public function getBaseDataProvisioner() : \LORIS\Data\Provisioner {
+        return new SurveyAccountsProvisioner();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
      */
     function getJSDependencies()
     {

--- a/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+/**
+ * This file implements a data provisioner to get all possible rows
+ * for the survey accounts menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Core
+ * @author     Dave MacFarlane <dave.macfarlane@mcin.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\survey_accounts;
+
+/**
+ * This class implements a data provisioner to get all possible rows
+ * for the survey accounts menu page.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Core
+ * @author     Dave MacFarlane <dave.macfarlane@mcin.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class SurveyAccountsProvisioner
+    extends \LORIS\Data\Provisioners\DBRowProvisioner
+{
+    /**
+     * Create a SurveyAccountsProvisioner, which gets rows for the
+     * survey accounts menu table.
+     */
+    function __construct()
+    {
+
+        parent::__construct(
+            "SELECT
+                c.PSCID AS PSCID,
+                s.Visit_label AS Visit,
+                p.Email as Email,
+                p.Test_name as SurveyName,
+                p.OneTimePassword as URL,
+                p.Status,
+                s.CenterID,
+                s.ProjectID
+             FROM participant_accounts p
+                JOIN session s ON (p.SessionID=s.ID)
+                JOIN candidate c ON (c.CandID=s.CandID)
+             WHERE c.Active = 'Y'
+                AND s.Active = 'Y'
+             ORDER BY PSCID",
+            []
+        );
+    }
+
+    /**
+     * Returns an instance of a SurveyAccountsRow object for a given
+     * table row.
+     *
+     * @param array $row The database row from the LORIS Database class.
+     *
+     * @return \LORIS\Data\DataInstance An instance representing this row.
+     */
+    public function getInstance($row) : \LORIS\Data\DataInstance
+    {
+        $cid = (int )$row['CenterID'];
+        $pid = (int )$row['ProjectID'];
+        return new SurveyAccountsRow($row, $cid, $pid);
+    }
+}

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+/**
+ * This class implements a data Instance which represents a single
+ * row in the survey accounts menu table.
+ *
+ * PHP Version 7
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Core
+ * @author     Dave MacFarlane <dave.macfarlane@mcin.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\survey_accounts;
+
+/**
+ * A SurveyAccountsRow represents a row in the survey accounts
+ * menu table.
+ *
+ * @category   Behavioural
+ * @package    Main
+ * @subpackage Core
+ * @author     Dave MacFarlane <dave.macfarlane@mcin.ca>
+ * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link       https://www.github.com/aces/Loris/
+ */
+class SurveyAccountsRow implements \LORIS\Data\DataInstance
+{
+    protected $DBRow;
+    protected $CenterID;
+    protected $ProjectID;
+
+    /**
+     * Create a new SurveyAccountsRow
+     *
+     * @param array   $row The row (in the same format as \Database::pselectRow
+     *                     returns
+     * @param integer $cid The centerID affiliated with this row.
+     * @param integer $pid The projectID affiliated with this row.
+     */
+    public function __construct(array $row, int $cid, int $pid)
+    {
+        $this->DBRow     = $row;
+        $this->CenterID  = $cid;
+        $this->ProjectID = $pid;
+    }
+
+    /**
+     * Implements \LORIS\Data\DataInstance interface for this row.
+     *
+     * @return string the row data.
+     */
+    public function toJSON() : string
+    {
+        return json_encode($this->DBRow);
+    }
+
+    /**
+     * Returns the CenterID for this row
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID(): int
+    {
+        return $this->CenterID;
+    }
+
+    /**
+     * Returns the ProjectID for this row
+     *
+     * @return integer The ProjectID
+     */
+    public function getProjectID(): int
+    {
+        return $this->ProjectID;
+    }
+}

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -61,7 +61,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $this->DB->insert(
             "Project",
             array(
-                'ProjectID' => '1',
+                'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
             )
         );
@@ -79,7 +79,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
                 'PSCID'                 => '8888',
-                'RegistrationProjectID' => '1',
+                'RegistrationProjectID' => '7777',
             )
         );
         $this->DB->insert(
@@ -87,8 +87,8 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'           => '111111',
                 'CandID'       => '999888',
-                'CenterID'     => '1',
-                'ProjectID'    => '1',
+                'CenterID'     => '55',
+                'ProjectID'    => '7777',
                 'UserID'       => '1',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
@@ -99,10 +99,10 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             "candidate",
             array(
                 'CandID'                => '999999',
-                'RegistrationCenterID'  => '1',
+                'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
                 'PSCID'                 => '8889',
-                'RegistrationProjectID' => '1',
+                'RegistrationProjectID' => '7777',
             )
         );
         $this->DB->insert(
@@ -110,8 +110,8 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'           => '111112',
                 'CandID'       => '999999',
-                'CenterID'     => '1',
-                'ProjectID'    => '1',
+                'CenterID'     => '55',
+                'ProjectID'    => '7777',
                 'UserID'       => '1',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
@@ -168,7 +168,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $this->DB->delete(
             "Project",
             array(
-                'ProjectID' => '1',
+                'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
             )
         );

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -61,7 +61,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $this->DB->insert(
             "Project",
             array(
-                'ProjectID' => '7777',
+                'ProjectID' => '1',
                 'Name'      => 'TESTinProject',
             )
         );
@@ -79,7 +79,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
                 'PSCID'                 => '8888',
-                'RegistrationProjectID' => '7777',
+                'RegistrationProjectID' => '1',
             )
         );
         $this->DB->insert(
@@ -87,8 +87,8 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'           => '111111',
                 'CandID'       => '999888',
-                'CenterID'     => '55',
-                'ProjectID'    => '7777',
+                'CenterID'     => '1',
+                'ProjectID'    => '1',
                 'UserID'       => '1',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
@@ -99,10 +99,10 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             "candidate",
             array(
                 'CandID'                => '999999',
-                'RegistrationCenterID'  => '55',
+                'RegistrationCenterID'  => '1',
                 'UserID'                => '1',
                 'PSCID'                 => '8889',
-                'RegistrationProjectID' => '7777',
+                'RegistrationProjectID' => '1',
             )
         );
         $this->DB->insert(
@@ -110,8 +110,8 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'           => '111112',
                 'CandID'       => '999999',
-                'CenterID'     => '55',
-                'ProjectID'    => '7777',
+                'CenterID'     => '1',
+                'ProjectID'    => '1',
                 'UserID'       => '1',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
@@ -168,7 +168,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $this->DB->delete(
             "Project",
             array(
-                'ProjectID' => '7777',
+                'ProjectID' => '1',
                 'Name'      => 'TESTinProject',
             )
         );

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -76,10 +76,10 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             "candidate",
             array(
                 'CandID'                => '999888',
-                'RegistrationCenterID'  => '55',
+                'RegistrationCenterID'  => '1',
                 'UserID'                => '1',
                 'PSCID'                 => '8888',
-                'RegistrationProjectID' => '7777',
+                'RegistrationProjectID' => '1',
             )
         );
         $this->DB->insert(
@@ -87,8 +87,8 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'           => '111111',
                 'CandID'       => '999888',
-                'CenterID'     => '55',
-                'ProjectID'    => '7777',
+                'CenterID'     => '1',
+                'ProjectID'    => '1',
                 'UserID'       => '1',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
@@ -110,8 +110,8 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'           => '111112',
                 'CandID'       => '999999',
-                'CenterID'     => '55',
-                'ProjectID'    => '7777',
+                'CenterID'     => '1',
+                'ProjectID'    => '1',
                 'UserID'       => '1',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',


### PR DESCRIPTION
This updates the survey accounts module to use the data framework. Functionality should remain identical to before, except that "Site" and "Project" permissions should now be enforced by the menu filter and users should not see rows from other project/site's sessions.