### PR TITLE
Add phan rule PhanUnusedPrivateMethodParameter

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -36,8 +36,6 @@ return [
         "PhanUnusedVariable",
         "PhanUnusedPublicMethodParameter",
         "PhanUnusedPublicNoOverrideMethodParameter",
-        "PhanUnusedPrivateMethodParameter",
-        "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",
         "PhanTypeMismatchArgument",

--- a/modules/api/php/endpoints/candidate/candidate.class.inc
+++ b/modules/api/php/endpoints/candidate/candidate.class.inc
@@ -125,11 +125,9 @@ class Candidate extends Endpoint implements \LORIS\Middleware\ETagCalculator
      * Returns an array representation of the requested candiate following
      * the API specifications.
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface
      */
-    private function _handleGET(ServerRequestInterface $request) : ResponseInterface
+    private function _handleGET() : ResponseInterface
     {
         // TODO :: User permission to acces this and subendpoints
         $array = (new \LORIS\api\Views\Candidate($this->_candidate))

--- a/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
@@ -115,11 +115,9 @@ class Dicom extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's response body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/archive.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/archive.class.inc
@@ -97,11 +97,9 @@ class Archive extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's response body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/channels.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/channels.class.inc
@@ -97,11 +97,9 @@ class Channels extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's response body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/electrodes.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/electrodes.class.inc
@@ -97,11 +97,9 @@ class Electrodes extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's response body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/events.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/events.class.inc
@@ -97,11 +97,9 @@ class Events extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's response body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/image/format/brainbrowser.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/brainbrowser.class.inc
@@ -101,11 +101,9 @@ class Brainbrowser extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's reponse body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -96,11 +96,9 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's reponse body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         $info = $this->_image->getFileInfo();
 

--- a/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
@@ -96,11 +96,9 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Creates a response with the thumbnail as body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         $info = $this->_image->getThumbnailFileInfo();
 

--- a/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
@@ -115,11 +115,9 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's reponse body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
@@ -113,11 +113,9 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Handles a GET request
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request) : ResponseInterface
+    private function _handleGET() : ResponseInterface
     {
         $body = (new \LORIS\api\Views\Visit\Flags(
             $this->_visit,

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -127,11 +127,9 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Handles a GET request
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request) : ResponseInterface
+    private function _handleGET() : ResponseInterface
     {
         $body = (new \LORIS\api\Views\Visit\Instrument(
             $this->_visit,

--- a/modules/api/php/endpoints/candidate/visit/instruments.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instruments.class.inc
@@ -142,11 +142,9 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's response body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/qc.class.inc
@@ -112,11 +112,9 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's reponse body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -147,11 +147,9 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Generates a response fitting the API specification for this endpoint.
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if ($this->_visit === null) {
             return new \LORIS\Http\Response\JSON\NotFound('Visit not found');

--- a/modules/api/php/endpoints/project/candidates.class.inc
+++ b/modules/api/php/endpoints/project/candidates.class.inc
@@ -106,11 +106,9 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array of this project's candidate's CandID
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/project/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/project/instrument/instrument.class.inc
@@ -104,11 +104,9 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's reponse body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/project/project.class.inc
+++ b/modules/api/php/endpoints/project/project.class.inc
@@ -133,11 +133,9 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
      * Generates a JSON representation of this project following the API
      * specification.
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/project/visits.class.inc
+++ b/modules/api/php/endpoints/project/visits.class.inc
@@ -105,11 +105,9 @@ class Visits extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Create an array representation of this endpoint's reponse body
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface The outgoing PSR7 response
      */
-    private function _handleGET(ServerRequestInterface $request): ResponseInterface
+    private function _handleGET(): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;

--- a/modules/api/php/endpoints/projects.class.inc
+++ b/modules/api/php/endpoints/projects.class.inc
@@ -120,11 +120,9 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * Returns a list of projects for this LORIS instance.
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
-     *
      * @return ResponseInterface
      */
-    private function _handleGET(ServerRequestInterface $request) : ResponseInterface
+    private function _handleGET() : ResponseInterface
     {
         if (!isset($this->_cache)) {
             // The projects list should be related to the user in the request

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -70,11 +70,9 @@ class View_Genomic_File extends \NDB_Form
     /**
      * Populates tpl form data using values from a Genomic_File object.
      *
-     * @param ?string $category type of data: raw,cleaned,gwas
-     *
      * @return void
      */
-    private function _setFileData(?string $category = null): void
+    private function _setFileData(): void
     {
         if (empty($this->genomic_file_id)) {
             $files = \Database::singleton()->pselect(

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -117,10 +117,10 @@ class Issue_TrackerTest extends LorisIntegrationTest
      */
     function testIssueTrackerFilter()
     {
-        $this->_testFilter('issueID', '999999');
-        $this->_testFilter('status', 'new');
-        $this->_testFilter('priority', 'low');
-        $this->_testFilter('reporter', 'TestUser');
+        $this->_testFilter('999999');
+        $this->_testFilter('new');
+        $this->_testFilter('low');
+        $this->_testFilter('TestUser');
     }
     /**
      * Tests that Issue Tracker filter

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -125,12 +125,14 @@ class Issue_TrackerTest extends LorisIntegrationTest
     /**
      * Tests that Issue Tracker filter
      *
-     * @param string $name  input the element name which we need test
+     * FIXME This test seems to just check the page source for a string and not
+     * actually use the menu filters.
+     *
      * @param string $value input the value that we expect
      *
      * @return void
      */
-    private function _testFilter($name,$value)
+    private function _testFilter(string $value)
     {
         $this->webDriver->get($this->url . "/issue_tracker/?format=json");
         $bodyText = $this->webDriver->getPageSource();

--- a/modules/server_processes_manager/php/serverprocesslauncher.class.inc
+++ b/modules/server_processes_manager/php/serverprocesslauncher.class.inc
@@ -111,18 +111,6 @@ class ServerProcessLauncher
     }
 
     /**
-     * Determines if a process should be allowed to be run or not.
-     *
-     * @param AbstractServerProcess $process process to consider.
-     *
-     * @return boolean true if the process is allowed to run, false otherwise.
-     */
-    private function _okToExecute(AbstractServerProcess $process)
-    {
-        return true;
-    }
-
-    /**
      * Launches the process passes as argument and records its information
      * in the database.
      *
@@ -134,10 +122,6 @@ class ServerProcessLauncher
      */
     private function _launch(AbstractServerProcess $process)
     {
-        if (!$this->_okToExecute($process)) {
-            return null;
-        }
-
         $process->execute();
 
         // Wait one second before checking the exit code: if the command is invalid

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -577,7 +577,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         );
         $centerMatch = !empty(
             array_intersect(
-                $this->getCenterIDs(), 
+                $this->getCenterIDs(),
                 $user->getCenterIDs()
             )
         );


### PR DESCRIPTION
## Brief summary of changes

Adds a rule to check when a function has a parameter in its signature that is never used.

#### Link(s) to related issue(s)

* #6027 must be merged first. This PR removes an exception introduced by that PR.