### PR TITLE
Add shellcheck to static analysis suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ checkstatic: phpdev
 	npm run lint:php
 	npm run lint:javascript
 	vendor/bin/phan
+	bash -c 'shopt -s globstar nullglob; GLOBIGNORE="vendor*:node_modules*"; shellcheck **/*.{sh,ksh,bash}'
 
 # The 'alex' tool scans documentation for condescending language.
 # Arguments:

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ clean:
 
 # Perform static analysis checks
 checkstatic: phpdev
+	npm run lint:shell
 	npm run lint:php
-	npm run lint:javascript
 	vendor/bin/phan
-	bash -c 'shopt -s globstar nullglob; GLOBIGNORE="vendor*:node_modules*"; shellcheck **/*.{sh,ksh,bash}'
+	npm run lint:javascript
 
 # The 'alex' tool scans documentation for condescending language.
 # Arguments:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lintfix:javascript": "eslint --fix --ext .js, jsx modules",
     "lint:php": "./test/run-php-linter.sh",
     "tests:static": "make checkstatic",
+    "lint:shell": "./test/run-shell-linter.sh",
     "tests:unit": "./test/dockerized-unit-tests.sh",
     "tests:unit:debug": "DEBUG=true ./test/dockerized-unit-tests.sh",
     "tests:integration": "./test/dockerized-integration-tests.sh",

--- a/test/run-shell-linter.sh
+++ b/test/run-shell-linter.sh
@@ -3,8 +3,33 @@ set -euo pipefail
 shopt -s globstar nullglob
 GLOBIGNORE="vendor*:node_modules*"
 
-declare -a script_list=(
+declare -a excluded=(
+    'test/dockerized-integration-tests.sh'
+    'test/run-php-linter.sh'
+    'test/unittests.sh'
+    'test/run-shell-linter.sh'
+    'test/dockerized-unit-tests.sh'
+    'test/integration.sh'
+    'test/run-js-linter.sh'
+    'test/wait-for-services.sh'
+    'tools/gen-version.sh'
     'tools/install.sh'
+    'tools/create-project.sh'
+    'tools/deprecated/dump_all_tables_data_only.sh'
+    'tools/package_files.sh'
 )
 
-shellcheck "${script_list[@]/}" || exit $?;
+# Get all files ending with .sh that are not in the following folders:
+#   - vendor
+#   - node_modules
+#   - tools/deprecated
+#scripts=$(find . -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./vendor/*" -not -path "./tools/deprecated/*" -name '*.sh')
+#scripts=$(find . -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./vendor/*" -not -path "./tools/deprecated/*" -name '*.sh')
+
+scripts=()
+while IFS= read -d $'\0' -r file ; do
+    scripts=("${scripts[@]}" "$file")
+done < <(find . -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./vendor/*" -not -path "./tools/deprecated/*" -name '*.sh' -print0)
+
+echo "${scripts[@]}"
+shellcheck "${scripts[@]}"

--- a/test/run-shell-linter.sh
+++ b/test/run-shell-linter.sh
@@ -3,4 +3,8 @@ set -euo pipefail
 shopt -s globstar nullglob
 GLOBIGNORE="vendor*:node_modules*"
 
-shellcheck **/*.{sh,ksh,bash}
+declare -a script_list=(
+    'tools/install.sh'
+)
+
+shellcheck "${script_list[@]/}" || exit $?;

--- a/test/run-shell-linter.sh
+++ b/test/run-shell-linter.sh
@@ -7,7 +7,6 @@ declare -a excluded=(
     'test/dockerized-integration-tests.sh'
     'test/run-php-linter.sh'
     'test/unittests.sh'
-    'test/run-shell-linter.sh'
     'test/dockerized-unit-tests.sh'
     'test/integration.sh'
     'test/run-js-linter.sh'

--- a/test/run-shell-linter.sh
+++ b/test/run-shell-linter.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 shopt -s globstar nullglob
-GLOBIGNORE="vendor*:node_modules*"
+GLOBIGNORE="vendor*:node_modules*:.git*"
 
 declare -a excluded=(
     'test/dockerized-integration-tests.sh'
@@ -13,23 +13,23 @@ declare -a excluded=(
     'test/run-js-linter.sh'
     'test/wait-for-services.sh'
     'tools/gen-version.sh'
-    'tools/install.sh'
     'tools/create-project.sh'
     'tools/deprecated/dump_all_tables_data_only.sh'
     'tools/package_files.sh'
 )
 
-# Get all files ending with .sh that are not in the following folders:
-#   - vendor
-#   - node_modules
-#   - tools/deprecated
-#scripts=$(find . -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./vendor/*" -not -path "./tools/deprecated/*" -name '*.sh')
-#scripts=$(find . -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./vendor/*" -not -path "./tools/deprecated/*" -name '*.sh')
+#Build array of files
+files=(**/*.{sh,ksh,bash})
 
-scripts=()
-while IFS= read -d $'\0' -r file ; do
-    scripts=("${scripts[@]}" "$file")
-done < <(find . -not -path "./.git/*" -not -path "./node_modules/*" -not -path "./vendor/*" -not -path "./tools/deprecated/*" -name '*.sh' -print0)
+#Delete array elements present in exclude
+for exclude in "${excluded[@]}"; do
+  files=( "${files[@]/${exclude}}" )
+done
 
-echo "${scripts[@]}"
-shellcheck "${scripts[@]}"
+#Cleanup null array entries after delete
+for i in "${!files[@]}"; do
+  [[ -n "${files[$i]}" ]] || unset "files[$i]"
+done
+
+#Run shellcheck on files
+shellcheck "${files[@]}"

--- a/test/run-shell-linter.sh
+++ b/test/run-shell-linter.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s globstar nullglob
+GLOBIGNORE="vendor*:node_modules*"
+
+shellcheck **/*.{sh,ksh,bash}

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -24,17 +24,17 @@ fi
 # Create logs directory, if needed.
 mkdir -p logs
 
-START=`date "+%Y-%m-%dT%H:%M:%S"`
+START=$(date "+%Y-%m-%dT%H:%M:%S")
 LOGDIR="logs"
 LOGFILE="logs/install-$START.log"
 LOGPIPE=/tmp/pipe.$$
 mkfifo -m 700 $LOGPIPE
-trap "rm -f $LOGPIPE" EXIT
-tee -a <$LOGPIPE $LOGFILE &
+trap 'rm -f $LOGPIPE' EXIT
+tee -a <$LOGPIPE "$LOGFILE" &
 exec 1>$LOGPIPE 2>&1
 
-CWD=`pwd`
-RootDir=`dirname $CWD`
+CWD=$(pwd)
+RootDir=$(dirname "$CWD")
 
 if [ $UID == "0" ]; then
     echo "install.sh must not be run as root (but should be run as a user with sudo access.)"
@@ -47,8 +47,8 @@ if [ ! -w $LOGDIR ] ; then
         echo "The logs directory is not writable. You will not have an automatically generated report of your installation."
         echo "We recommend you verify your user permissions and then re-run this script."
         while true; do
-                read -p "Do you still want to continue? [yn] " yn
-		echo $yn | tee -a $LOGFILE > /dev/null
+                read -rp "Do you still want to continue? [yn] " yn
+		echo "$yn" | tee -a "$LOGFILE" > /dev/null
                 case $yn in
                         [Yy]* )
                                 break;;
@@ -77,7 +77,7 @@ if [ -f ../project/config.xml ]; then
 fi
 
 # Check that bash is being used
-if ! [ $BASH ] ; then
+if ! [ "$BASH" ] ; then
     echo "Please switch to a bash shell. Then re-run this script using the command: ./install.sh"
     exit 2
 fi
@@ -96,8 +96,8 @@ echo "More information on the complete installation and setup process is availab
 echo ""
 
 while true; do
-        read -p "Ready to continue? [yn] " yn
-	echo $yn | tee -a $LOGFILE > /dev/null
+        read -rp "Ready to continue? [yn] " yn
+	echo "$yn" | tee -a "$LOGFILE" > /dev/null
         case $yn in
             [Yy]* )
                 break;;
@@ -167,33 +167,33 @@ echo "Ubuntu distribution detected."
     # for CentOS, the log directory is called httpd
     logdirectory=/var/log/apache2
     while true; do
-        read -p "Would you like to automatically set up your apache configuration files? [yn] " yn
-        echo $yn | tee -a $LOGFILE > /dev/null
+        read -rp "Would you like to automatically set up your apache configuration files? [yn] " yn
+        echo "$yn" | tee -a "$LOGFILE" > /dev/null
         case $yn in
             [Yy]* )
                 while [ "$projectname" == "" ]; do
-                        read -p "Please enter your Project name (if unsure, use LORIS) : " projectname
-                        echo $projectname | tee -a $LOGFILE > /dev/null
+                        read -rp "Please enter your Project name (if unsure, use LORIS) : " projectname
+                        echo "$projectname" | tee -a "$LOGFILE" > /dev/null
                         case $projectname in
                                 "" )
-                                       read -p "Enter project name: " projectname
+                                       read -rp "Enter project name: " projectname
                                        continue;;
                                  * )
                                        break;;
                         esac
                 done;
-                if [ -f /etc/apache2/sites-available/$projectname ]; then
-                    echo "Apache appears to already be configured for $projectname. Aborting\n"
+                if [ -f /etc/apache2/sites-available/"$projectname" ]; then
+                    printf "Apache appears to already be configured for %s. Aborting\n" "$projectname"
                     exit 1
                 fi;
                 # Need to pipe to sudo tee because > is done as the logged in user, even if run through sudo
                 sed -e "s#%LORISROOT%#$RootDir#g" \
                     -e "s#%PROJECTNAME%#$projectname#g" \
       	            -e "s#%LOGDIRECTORY%#$logdirectory#g" \
-                    < ../docs/config/apache2-site | sudo tee /etc/apache2/sites-available/$projectname.conf > /dev/null
-                sudo ln -s /etc/apache2/sites-available/$projectname.conf /etc/apache2/sites-enabled/$projectname.conf
+                    < ../docs/config/apache2-site | sudo tee /etc/apache2/sites-available/"$projectname".conf > /dev/null
+                sudo ln -s /etc/apache2/sites-available/"$projectname".conf /etc/apache2/sites-enabled/"$projectname".conf
                 sudo a2dissite 000-default
-                sudo a2ensite $projectname.conf
+                sudo a2ensite "$projectname".conf
                 sudo a2enmod rewrite
                 sudo a2enmod headers
                 break;;
@@ -208,23 +208,23 @@ echo "CentOS distribution detected."
 # for CentOS, the log directory is called httpd
 logdirectory=/var/log/httpd
 while true; do
-    read -p "Would you like to automatically set up your apache configuration files? (In development for CentOS) [yn] " yn
-    echo $yn | tee -a $LOGFILE > /dev/null
+    read -rp "Would you like to automatically set up your apache configuration files? (In development for CentOS) [yn] " yn
+    echo "$yn" | tee -a "$LOGFILE" > /dev/null
     case $yn in
         [Yy]* )
             while [ "$projectname" == "" ]; do
-                      read -p "Please enter your Project name (if unsure, use LORIS) : " projectname
-                      echo $projectname | tee -a $LOGFILE > /dev/null
+                      read -rp "Please enter your Project name (if unsure, use LORIS) : " projectname
+                      echo "$projectname" | tee -a "$LOGFILE" > /dev/null
                       case $projectname in
                               "" )
-                                     read -p "Enter project name: " projectname
+                                     read -rp "Enter project name: " projectname
                                      continue;;
                                * )
                                      break;;
                       esac
             done;
-            if [ -f /etc/httpd/conf.d/$projectname ]; then
-                echo "Apache appears to already be configured for $projectname. Aborting\n"
+            if [ -f /etc/httpd/conf.d/"$projectname" ]; then
+                printf "Apache appears to already be configured for %s. Aborting\n" "$projectname"
                 exit 1
             fi;
 
@@ -232,7 +232,7 @@ while true; do
             sed -e "s#%LORISROOT%#$RootDir#g" \
                 -e "s#%PROJECTNAME%#$projectname#g" \
                 -e "s#%LOGDIRECTORY%#$logdirectory#g" \
-                < ../docs/config/apache2-site | sudo tee /etc/httpd/conf.d/$projectname.conf > /dev/null
+                < ../docs/config/apache2-site | sudo tee /etc/httpd/conf.d/"$projectname".conf > /dev/null
 
             sudo service httpd restart
             echo "You may need to manually uncomment the load rewrite module line of your apache configuration."


### PR DESCRIPTION
## Brief summary of changes

Building on the work of #5160, this adds `shellcheck` to our static analysis pipeline in the fashion of our PHP linters.

We can iterate on this to fix errors on a file-by-file basis. 

### Testing

Run the install script and make sure it works like it did before.