### PR TITLE
Cleared two notices produced by feedback_mri_popup.php

### DIFF
--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -46,7 +46,9 @@ if (isset($_POST['fire_away']) && $_POST['fire_away']) {
     $comments->clearAllComments();
 
     // set selected predefined comments
-    $comments->setPredefinedComments($_POST['savecomments']['predefined']);
+    if (in_array('predefined', $_POST)) {
+        $comments->setPredefinedComments($_POST['savecomments']['predefined']);
+    }
 
     // save all textual comments but only if there is an entry [sebas]
     foreach (\Utility::asArray($_POST['savecomments']['text'])
@@ -58,7 +60,8 @@ if (isset($_POST['fire_away']) && $_POST['fire_away']) {
     }
 
     // save all comment status fields
-    if (is_array($_POST['saveCommentStatusField'])) {
+    if (in_array('saveCommentStatusField', $_POST)
+        && is_array($_POST['saveCommentStatusField'])) {
         foreach ($_POST['saveCommentStatusField'] as $status_field => $value) {
             $comments->setMRIValue($status_field, $value);
         }


### PR DESCRIPTION
## Brief summary of changes

When saving session-level imaging feedback, two notices were produced. These simple changes to the code get rid of those notices.

#### Testing instructions (if applicable)

1. Make sure you can still save image-level and session-level imaging feedback
