### PR TITLE
[Data Table] Provide default table cell when getFormattedCell is not defined

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -435,6 +435,8 @@ class DataTable extends Component {
                     celldata,
                     row
                 );
+            } else {
+                cell = <td>{celldata}</td>;
             }
             if (cell !== null) {
                 // Note: Can't currently pass a key, need to update columnFormatter


### PR DESCRIPTION
When a getFormattedCell callback is not defined, the DataTable component
currently silently throws away all the cells in the table. Since it's not
a required prop, this is confusing.

This provides a default cell format when no cell formatter is defined.