### PR TITLE
[Core] Do not crash when there are Active invalid modules

### DIFF
--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -50,12 +50,16 @@ abstract class Module extends \LORIS\Router\PrefixRouter
             "SELECT Name FROM modules WHERE Active='Y'",
             []
         );
-        return array_map(
-            function ($name) {
-                return self::factory($name);
-            },
-            $mnames
-        );
+
+        $modules = [];
+        foreach ($mnames as $name) {
+            try {
+                $modules[] = self::factory($name);
+            } catch(\LorisModuleMissingException $e) {
+                error_log($e->getMessage() . " " . $e->getTraceAsString());
+            }
+        }
+        return $modules;
     }
 
     /**


### PR DESCRIPTION
When there is an active module installed in the module table
that does not exist LORIS crashes with an exception while trying
to build the menus. This catches the exception and logs it to the
error log instead of dying.

While the 'Active' invalid module indicates a configuration error
that should be fixed, it can often happen in development environments
when switching branches, so instead we just log it in the error log.
