### PR TITLE
[Survey Accounts] Fix long name

### DIFF
--- a/modules/survey_accounts/php/module.class.inc
+++ b/modules/survey_accounts/php/module.class.inc
@@ -53,6 +53,6 @@ class Module extends \Module
      */
     public function getLongName() : string
     {
-        return "Survey Module";
+        return "Survey Accounts";
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Survey Accounts is the proper name of the module but the long name and menu item were "Survey Module"

This change the module's long name to match the way we refer to it in our file structure and documentation. 
