### PR TITLE
Fix bad permission ordering in Raisinbread data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ changes in the following format: PR #1234***
  This allows projects to modify their instrument battery without requiring backend access.
  (https://github.com/aces/Loris/pull/4221)
  
-##### module1
+##### Electrophysiology Browser
+ - New module created to manage electrophysiology data within LORIS. (PR #5230)
 
 
 #### Clean Up

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -57,9 +57,9 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (55,'publication_approve','Publication - Approve or reject proposed publication projects',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (56,'data_release_view','Data Release: View releases',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (57,'candidate_dob_edit','Edit dates of birth',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (58,'battery_manager_view','View Battery Manager',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (59,'battery_manager_edit','Add, activate, and deactivate entries in Test Battery',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (60,'electrophysiology_browser_view_allsites','View all-sites Electrophysiology Browser pages',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (61,'electrophysiology_browser_view_site','View own site Electrophysiology Browser pages',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (58,'electrophysiology_browser_view_allsites','View all-sites Electrophysiology Browser pages',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (59,'electrophysiology_browser_view_site','View own site Electrophysiology Browser pages',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (60,'battery_manager_view','View Battery Manager',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (61,'battery_manager_edit','Add, activate, and deactivate entries in Test Battery',2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

Two new modules were recently added to LORIS. Raisinbread was updated but the permission codes were inverted which could cause issues with test data.

Compare with https://github.com/aces/Loris/blob/4d9c4c456d0c7f7a1dc4363c3c785298a9604cbc/SQL/0000-00-01-Permission.sql#L106-L109

Also updates the CHANGELOG with a sentence about the new Electrophysiology Browser module.