### PR TITLE
Increase phan severity level

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -12,7 +12,7 @@ return [
     // The default severity level for phan is 5. After removing all the
     // suppressed rules, we should consider reducing this value to detect more
     // suspicious code.
-    "minimum_severity" => 5,
+    "minimum_severity" => 1,
     // FIXME: allow_missing_properties should be false, but there's
     // too many other things to fix first.
     "allow_missing_properties" => true,


### PR DESCRIPTION
## Brief summary of changes

Raises phan's severity level to 1 from 5 (0 is the most sensitive, 10 is the least).

Our codebase passes under the current rules under almost the highest severity.

This will raise the bar for new code going into LORIS. 