### PR TITLE
[jsx/Card] Allow Card component to add extra styles to object

### DIFF
--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -28,10 +28,13 @@ class Card extends Component {
     const cursorStyle = this.props.onClick ? {
       cursor: 'pointer',
     } : null;
-    const divStyling = {
+    let divStyling = {
       marginLeft: '5px',
       marginRight: '5px',
     };
+    if (this.props.style) {
+        divStyling = {...divStyling, ...this.props.style};
+    }
     return (
       <div style={divStyling}>
         <Panel


### PR DESCRIPTION
This allows the Card component to be provided with extra style
properties, which get merged into the parent div style attribute.
This can be used for specifying flexbox or CSS grid related properties
on a card.