### PR TITLE
[webpack] Make module exports importable from LORIS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,96 +2,21 @@ const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
 const fs = require('fs');
 
-const config = [{
-  entry: {
-    './htdocs/js/components/DynamicDataTable.js': './jsx/DynamicDataTable.js',
-    './htdocs/js/components/PaginationLinks.js': './jsx/PaginationLinks.js',
-    './htdocs/js/components/StaticDataTable.js': './jsx/StaticDataTable.js',
-    './htdocs/js/components/MultiSelectDropdown.js': './jsx/MultiSelectDropdown.js',
-    './htdocs/js/components/Breadcrumbs.js': './jsx/Breadcrumbs.js',
-    './htdocs/js/components/Form.js': './jsx/Form.js',
-    './htdocs/js/components/Markdown.js': './jsx/Markdown.js',
-    './modules/media/js/mediaIndex.js': './modules/media/jsx/mediaIndex.js',
-    './modules/issue_tracker/js/issueTrackerIndex.js': './modules/issue_tracker/jsx/issueTrackerIndex.js',
-    './modules/issue_tracker/js/index.js': './modules/issue_tracker/jsx/index.js',
-    './modules/candidate_parameters/js/CandidateParameters.js': './modules/candidate_parameters/jsx/CandidateParameters.js',
-    './modules/configuration/js/SubprojectRelations.js': './modules/configuration/jsx/SubprojectRelations.js',
-    './modules/conflict_resolver/js/conflictResolverIndex.js': './modules/conflict_resolver/jsx/conflictResolverIndex.js',
-    './modules/conflict_resolver/js/resolvedConflictsIndex.js': './modules/conflict_resolver/jsx/resolvedConflictsIndex.js',
-    './modules/battery_manager/js/batteryManagerIndex.js': './modules/battery_manager/jsx/batteryManagerIndex.js',
-    './modules/bvl_feedback/js/react.behavioural_feedback_panel.js': './modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js',
-    './modules/behavioural_qc/js/behavioural_qc_module.js': './modules/behavioural_qc/jsx/behavioural_qc_module.js',
-    './modules/candidate_list/js/openProfileForm.js': './modules/candidate_list/jsx/openProfileForm.js',
-    './modules/candidate_list/js/onLoad.js': './modules/candidate_list/jsx/onLoad.js',
-    './modules/candidate_list/js/candidateListIndex.js': './modules/candidate_list/jsx/candidateListIndex.js',
-    './modules/datadict/js/dataDictIndex.js': './modules/datadict/jsx/dataDictIndex.js',
-    './modules/data_release/js/dataReleaseIndex.js': './modules/data_release/jsx/dataReleaseIndex.js',
-    './modules/data_release/js/uploadFileForm.js': './modules/data_release/jsx/uploadFileForm.js',
-    './modules/data_release/js/addPermissionForm.js': './modules/data_release/jsx/addPermissionForm.js',
-    './modules/dataquery/js/react.app.js': './modules/dataquery/jsx/react.app.js',
-    './modules/dataquery/js/react.fieldselector.js': './modules/dataquery/jsx/react.fieldselector.js',
-    './modules/dataquery/js/react.filterBuilder.js': './modules/dataquery/jsx/react.filterBuilder.js',
-    './modules/dataquery/js/react.paginator.js': './modules/dataquery/jsx/react.paginator.js',
-    './modules/dataquery/js/react.sidebar.js': './modules/dataquery/jsx/react.sidebar.js',
-    './modules/dataquery/js/react.tabs.js': './modules/dataquery/jsx/react.tabs.js',
-    './modules/dicom_archive/js/dicom_archive.js': './modules/dicom_archive/jsx/dicom_archive.js',
-    './modules/genomic_browser/js/FileUploadModal.js': './modules/genomic_browser/jsx/FileUploadModal.js',
-    './modules/electrophysiology_browser/js/electrophysiologyBrowserIndex.js': './modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js',
-    './modules/electrophysiology_browser/js/electrophysiologySessionView.js': './modules/electrophysiology_browser/jsx/electrophysiologySessionView.js',
-    './modules/electrophysiology_browser/js/components/electrophysiology_session_panels.js': './modules/electrophysiology_browser/jsx/components/electrophysiology_session_panels.js',
-    './modules/electrophysiology_browser/js/components/Sidebar.js': './modules/electrophysiology_browser/jsx/components/Sidebar.js',
-    './modules/electrophysiology_browser/js/components/SidebarContent.js': './modules/electrophysiology_browser/jsx/components/SidebarContent.js',
-    './modules/genomic_browser/js/profileColumnFormatter.js': './modules/genomic_browser/jsx/profileColumnFormatter.js',
-    './modules/imaging_browser/js/ImagePanel.js': './modules/imaging_browser/jsx/ImagePanel.js',
-    './modules/imaging_browser/js/imagingBrowserIndex.js': './modules/imaging_browser/jsx/imagingBrowserIndex.js',
-    './modules/instrument_builder/js/react.instrument_builder.js': './modules/instrument_builder/jsx/react.instrument_builder.js',
-    './modules/instrument_builder/js/react.questions.js': './modules/instrument_builder/jsx/react.questions.js',
-    './modules/instrument_manager/js/instrumentManagerIndex.js': './modules/instrument_manager/jsx/instrumentManagerIndex.js',
-    './modules/survey_accounts/js/surveyAccountsIndex.js': './modules/survey_accounts/jsx/surveyAccountsIndex.js',
-    './modules/mri_violations/js/mri_protocol_check_violations_columnFormatter.js': './modules/mri_violations/jsx/mri_protocol_check_violations_columnFormatter.js',
-    './modules/mri_violations/js/columnFormatter.js': './modules/mri_violations/jsx/columnFormatter.js',
-    './modules/mri_violations/js/columnFormatterUnresolved.js': './modules/mri_violations/jsx/columnFormatterUnresolved.js',
-    './modules/mri_violations/js/mri_protocol_violations_columnFormatter.js': './modules/mri_violations/jsx/mri_protocol_violations_columnFormatter.js',
-    './modules/user_accounts/js/userAccountsIndex.js': './modules/user_accounts/jsx/userAccountsIndex.js',
-    './modules/examiner/js/examinerIndex.js': './modules/examiner/jsx/examinerIndex.js',
-    './modules/help_editor/js/help_editor.js': './modules/help_editor/jsx/help_editor.js',
-    './modules/brainbrowser/js/Brainbrowser.js': './modules/brainbrowser/jsx/Brainbrowser.js',
-    './modules/imaging_uploader/js/index.js': './modules/imaging_uploader/jsx/index.js',
-    './modules/acknowledgements/js/acknowledgementsIndex.js': './modules/acknowledgements/jsx/acknowledgementsIndex.js',
-    './modules/new_profile/js/NewProfileIndex.js': './modules/new_profile/jsx/NewProfileIndex.js',
-    './modules/module_manager/js/modulemanager.js': './modules/module_manager/jsx/modulemanager.js',
-    './modules/imaging_qc/js/imagingQCIndex.js': './modules/imaging_qc/jsx/imagingQCIndex.js',
-    './modules/server_processes_manager/js/server_processes_managerIndex.js': './modules/server_processes_manager/jsx/server_processes_managerIndex.js',
-    './modules/document_repository/js/docIndex.js': './modules/document_repository/jsx/docIndex.js',
-    './modules/document_repository/js/editFormIndex.js': './modules/document_repository/jsx/editFormIndex.js',
-    './modules/publication/js/publicationIndex.js': './modules/publication/jsx/publicationIndex.js',
-    './modules/publication/js/viewProjectIndex.js': './modules/publication/jsx/viewProjectIndex.js',
-  },
-  output: {
-    path: __dirname + '/',
-    filename: '[name]',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(js|jsx)$/,
-        exclude: /node_modules/,
-        use: [
-          {
-            loader: 'babel-loader?cacheDirectory',
-          },
-          {
-            loader: 'eslint-loader',
-            options: {
-              cache: true,
-            },
-          },
-        ],
-        enforce: 'pre',
-      },
+const optimization = {
+    minimizer: [
+      new TerserPlugin({
+        cache: true,
+        parallel: true,
+        terserOptions: {
+          compress: false,
+          ecma: 6,
+          mangle: false,
+        },
+        sourceMap: true,
+      }),
     ],
-  },
-  resolve: {
+  };
+const resolve = {
     alias: {
       util: path.resolve(__dirname, './htdocs/js/util'),
       jsx: path.resolve(__dirname, './jsx'),
@@ -115,30 +40,119 @@ const config = [{
       Card: path.resolve(__dirname, './jsx/Card'),
     },
     extensions: ['*', '.js', '.jsx', '.json'],
-  },
-  externals: {
-    react: 'React',
-  },
-  node: {
-    fs: 'empty',
-  },
-  devtool: 'source-map',
-  plugins: [],
-  optimization: {
-    minimizer: [
-      new TerserPlugin({
-        cache: true,
-        parallel: true,
-        terserOptions: {
-          compress: false,
-          ecma: 6,
-          mangle: false,
-        },
-        sourceMap: true,
-      }),
+  };
+
+const mod = {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader?cacheDirectory',
+          },
+          {
+            loader: 'eslint-loader',
+            options: {
+              cache: true,
+            },
+          },
+        ],
+        enforce: 'pre',
+      },
     ],
-  },
-}];
+  };
+
+function lorisModule(mname, entries) {
+    let entObj = {};
+    for(let i = 0;i < entries.length; i++) {
+        entObj[entries[i]] = './modules/' + mname + '/jsx/' + entries[i] + '.js';
+    }
+    return {
+        entry: entObj,
+        output: {
+            path: path.resolve(__dirname, 'modules') + '/' + mname + '/js/',
+            filename: '[name].js',
+            library: [ 'lorisjs', mname ],
+            libraryTarget: 'window',
+        },
+        externals: {
+            react: 'React',
+        },
+        node: {
+            fs: 'empty',
+        },
+        devtool: 'source-map',
+        plugins: [],
+        optimization: optimization,
+        resolve: resolve,
+        module: mod
+    };
+}
+
+const config = [
+    // Core components
+    {
+        entry: {
+            './htdocs/js/components/DynamicDataTable.js': './jsx/DynamicDataTable.js',
+            './htdocs/js/components/PaginationLinks.js': './jsx/PaginationLinks.js',
+            './htdocs/js/components/StaticDataTable.js': './jsx/StaticDataTable.js',
+            './htdocs/js/components/MultiSelectDropdown.js': './jsx/MultiSelectDropdown.js',
+            './htdocs/js/components/Breadcrumbs.js': './jsx/Breadcrumbs.js',
+            './htdocs/js/components/Form.js': './jsx/Form.js',
+            './htdocs/js/components/Markdown.js': './jsx/Markdown.js',
+        },
+        output: {
+            path: __dirname + '/',
+            filename: '[name]',
+        },
+        externals: {
+            react: 'React',
+        },
+        node: {
+            fs: 'empty',
+        },
+        devtool: 'source-map',
+        plugins: [],
+        optimization: optimization,
+        resolve: resolve,
+        module: mod
+    },
+    // Modules 
+    lorisModule('media', ['mediaIndex']),
+    lorisModule('issue_tracker', ['issueTrackerIndex', 'index']),
+    lorisModule('publication', ['publicationIndex', 'viewProjectIndex']),
+    lorisModule('document_repository', ['docIndex', 'editFormIndex']),
+    lorisModule('candidate_parameters', [ 'CandidateParameters']),
+    lorisModule('configuration', [ 'SubprojectRelations']),
+    lorisModule('conflict_resolver', [ 'conflictResolverIndex', 'resolvedConflictsIndex' ]),
+    lorisModule('battery_manager', ['batteryManagerIndex']),
+    lorisModule('bvl_feedback', ['react.behavioural_feedback_panel']),
+    lorisModule('behavioural_qc', [ 'behavioural_qc_module']),
+    lorisModule('candidate_list', ['openProfileForm', 'onLoad', 'candidateListIndex']),
+    lorisModule('datadict', ['dataDictIndex']),
+    lorisModule('data_release', ['dataReleaseIndex', 'uploadFileForm', 'addPermissionForm']),
+    lorisModule('dataquery', [ 'react.app', 'react.fieldselector', 'react.filterBuilder', 'react.paginator', 'react.sidebar', 'react.tabs']),
+    lorisModule('dicom_archive', [ 'dicom_archive']),
+    lorisModule('genomic_browser', [ 'FileUploadModal' ]),
+    lorisModule('electrophysiology_browser', [ 'electrophysiologyBrowserIndex', 'electrophysiologySessionView', 'components/electrophysiology_session_panels', 'components/Sidebar', 'components/SidebarContent', ]),
+    lorisModule('genomic_browser', ['profileColumnFormatter']),
+    lorisModule('imaging_browser', [ 'ImagePanel', 'imagingBrowserIndex']),
+    lorisModule('instrument_builder', [ 'react.instrument_builder', 'react.questions' ]),
+    lorisModule('instrument_manager', [ 'instrumentManagerIndex' ]),
+    lorisModule('survey_accounts', [ 'surveyAccountsIndex' ]),
+    lorisModule('mri_violations', [ 'mri_protocol_check_violations_columnFormatter', 'columnFormatter', 'columnFormatterUnresolved', 'mri_protocol_violations_columnFormatter' ]),
+    lorisModule('user_accounts', [ 'userAccountsIndex' ]),
+    lorisModule('examiner', [ 'examinerIndex' ]),
+    lorisModule('help_editor', [ 'help_editor' ]),
+    lorisModule('brainbrowser', [ 'Brainbrowser' ]),
+    lorisModule('imaging_uploader', [ 'index' ]),
+    lorisModule('acknowledgements', [ 'acknowledgementsIndex' ]),
+    lorisModule('new_profile', [ 'NewProfileIndex' ]),
+    lorisModule('module_manager', [ 'modulemanager' ]),
+    lorisModule('imaging_qc', [ 'imagingQCIndex' ]),
+    lorisModule('server_processes_manager', [ 'server_processes_managerIndex' ]),
+];
 
 // Support project overrides
 if (fs.existsSync('./project/webpack-project.config.js')) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const optimization = {
         },
         sourceMap: true,
       }),
-    ],
+   ],
   };
 const resolve = {
     alias: {
@@ -57,23 +57,33 @@ const mod = {
               cache: true,
             },
           },
-        ],
+       ],
         enforce: 'pre',
       },
-    ],
+   ],
   };
 
+/**
+ * Creates a webpack config entry for a LORIS module named
+ * mname.
+ *
+ * @param {string} mname - The LORIS module name
+ * @param {array} entries - The webpack entry points for the module
+ *
+ * @return {object} - The webpack configuration
+ */
 function lorisModule(mname, entries) {
     let entObj = {};
-    for(let i = 0;i < entries.length; i++) {
-        entObj[entries[i]] = './modules/' + mname + '/jsx/' + entries[i] + '.js';
+    for (let i = 0; i < entries.length; i++) {
+        entObj[entries[i]] =
+            './modules/' + mname + '/jsx/' + entries[i] + '.js';
     }
     return {
         entry: entObj,
         output: {
             path: path.resolve(__dirname, 'modules') + '/' + mname + '/js/',
             filename: '[name].js',
-            library: [ 'lorisjs', mname ],
+            library: ['lorisjs', mname],
             libraryTarget: 'window',
         },
         externals: {
@@ -86,7 +96,7 @@ function lorisModule(mname, entries) {
         plugins: [],
         optimization: optimization,
         resolve: resolve,
-        module: mod
+        module: mod,
     };
 }
 
@@ -94,10 +104,14 @@ const config = [
     // Core components
     {
         entry: {
-            './htdocs/js/components/DynamicDataTable.js': './jsx/DynamicDataTable.js',
-            './htdocs/js/components/PaginationLinks.js': './jsx/PaginationLinks.js',
-            './htdocs/js/components/StaticDataTable.js': './jsx/StaticDataTable.js',
-            './htdocs/js/components/MultiSelectDropdown.js': './jsx/MultiSelectDropdown.js',
+            './htdocs/js/components/DynamicDataTable.js':
+                './jsx/DynamicDataTable.js',
+            './htdocs/js/components/PaginationLinks.js':
+                './jsx/PaginationLinks.js',
+            './htdocs/js/components/StaticDataTable.js':
+                './jsx/StaticDataTable.js',
+            './htdocs/js/components/MultiSelectDropdown.js':
+                './jsx/MultiSelectDropdown.js',
             './htdocs/js/components/Breadcrumbs.js': './jsx/Breadcrumbs.js',
             './htdocs/js/components/Form.js': './jsx/Form.js',
             './htdocs/js/components/Markdown.js': './jsx/Markdown.js',
@@ -116,42 +130,74 @@ const config = [
         plugins: [],
         optimization: optimization,
         resolve: resolve,
-        module: mod
+        module: mod,
     },
-    // Modules 
+    // Modules
     lorisModule('media', ['mediaIndex']),
     lorisModule('issue_tracker', ['issueTrackerIndex', 'index']),
     lorisModule('publication', ['publicationIndex', 'viewProjectIndex']),
     lorisModule('document_repository', ['docIndex', 'editFormIndex']),
-    lorisModule('candidate_parameters', [ 'CandidateParameters']),
-    lorisModule('configuration', [ 'SubprojectRelations']),
-    lorisModule('conflict_resolver', [ 'conflictResolverIndex', 'resolvedConflictsIndex' ]),
+    lorisModule('candidate_parameters', ['CandidateParameters']),
+    lorisModule('configuration', ['SubprojectRelations']),
+    lorisModule('conflict_resolver', [
+        'conflictResolverIndex',
+        'resolvedConflictsIndex',
+    ]),
     lorisModule('battery_manager', ['batteryManagerIndex']),
     lorisModule('bvl_feedback', ['react.behavioural_feedback_panel']),
-    lorisModule('behavioural_qc', [ 'behavioural_qc_module']),
-    lorisModule('candidate_list', ['openProfileForm', 'onLoad', 'candidateListIndex']),
+    lorisModule('behavioural_qc', ['behavioural_qc_module']),
+    lorisModule('candidate_list', [
+        'openProfileForm',
+        'onLoad',
+        'candidateListIndex',
+    ]),
     lorisModule('datadict', ['dataDictIndex']),
-    lorisModule('data_release', ['dataReleaseIndex', 'uploadFileForm', 'addPermissionForm']),
-    lorisModule('dataquery', [ 'react.app', 'react.fieldselector', 'react.filterBuilder', 'react.paginator', 'react.sidebar', 'react.tabs']),
-    lorisModule('dicom_archive', [ 'dicom_archive']),
-    lorisModule('genomic_browser', [ 'FileUploadModal' ]),
-    lorisModule('electrophysiology_browser', [ 'electrophysiologyBrowserIndex', 'electrophysiologySessionView', 'components/electrophysiology_session_panels', 'components/Sidebar', 'components/SidebarContent', ]),
+    lorisModule('data_release', [
+        'dataReleaseIndex',
+        'uploadFileForm',
+        'addPermissionForm',
+    ]),
+    lorisModule('dataquery', [
+        'react.app',
+        'react.fieldselector',
+        'react.filterBuilder',
+        'react.paginator',
+        'react.sidebar',
+        'react.tabs',
+    ]),
+    lorisModule('dicom_archive', ['dicom_archive']),
+    lorisModule('genomic_browser', ['FileUploadModal']),
+    lorisModule('electrophysiology_browser', [
+        'electrophysiologyBrowserIndex',
+        'electrophysiologySessionView',
+        'components/electrophysiology_session_panels',
+        'components/Sidebar',
+        'components/SidebarContent',
+    ]),
     lorisModule('genomic_browser', ['profileColumnFormatter']),
-    lorisModule('imaging_browser', [ 'ImagePanel', 'imagingBrowserIndex']),
-    lorisModule('instrument_builder', [ 'react.instrument_builder', 'react.questions' ]),
-    lorisModule('instrument_manager', [ 'instrumentManagerIndex' ]),
-    lorisModule('survey_accounts', [ 'surveyAccountsIndex' ]),
-    lorisModule('mri_violations', [ 'mri_protocol_check_violations_columnFormatter', 'columnFormatter', 'columnFormatterUnresolved', 'mri_protocol_violations_columnFormatter' ]),
-    lorisModule('user_accounts', [ 'userAccountsIndex' ]),
-    lorisModule('examiner', [ 'examinerIndex' ]),
-    lorisModule('help_editor', [ 'help_editor' ]),
-    lorisModule('brainbrowser', [ 'Brainbrowser' ]),
-    lorisModule('imaging_uploader', [ 'index' ]),
-    lorisModule('acknowledgements', [ 'acknowledgementsIndex' ]),
-    lorisModule('new_profile', [ 'NewProfileIndex' ]),
-    lorisModule('module_manager', [ 'modulemanager' ]),
-    lorisModule('imaging_qc', [ 'imagingQCIndex' ]),
-    lorisModule('server_processes_manager', [ 'server_processes_managerIndex' ]),
+    lorisModule('imaging_browser', ['ImagePanel', 'imagingBrowserIndex']),
+    lorisModule('instrument_builder', [
+        'react.instrument_builder',
+        'react.questions',
+    ]),
+    lorisModule('instrument_manager', ['instrumentManagerIndex']),
+    lorisModule('survey_accounts', ['surveyAccountsIndex']),
+    lorisModule('mri_violations', [
+        'mri_protocol_check_violations_columnFormatter',
+        'columnFormatter',
+        'columnFormatterUnresolved',
+        'mri_protocol_violations_columnFormatter',
+    ]),
+    lorisModule('user_accounts', ['userAccountsIndex']),
+    lorisModule('examiner', ['examinerIndex']),
+    lorisModule('help_editor', ['help_editor']),
+    lorisModule('brainbrowser', ['Brainbrowser']),
+    lorisModule('imaging_uploader', ['index']),
+    lorisModule('acknowledgements', ['acknowledgementsIndex']),
+    lorisModule('new_profile', ['NewProfileIndex']),
+    lorisModule('module_manager', ['modulemanager']),
+    lorisModule('imaging_qc', ['imagingQCIndex']),
+    lorisModule('server_processes_manager', ['server_processes_managerIndex']),
 ];
 
 // Support project overrides


### PR DESCRIPTION
Currently, there is no way to access a module's exported
components from plain javascript in LORIS. This refactors
the webpack config so that each module's exports can be
accessed in lorisjs.modulename.exportname. For instance,
if a LORIS module named "MyModule" defines as class as
`export class MyClass {}` it would be accessible as
`lorisjs.MyModule.MyClass`. Note that any exports done
via statements at the end of the file such as `export default MyClass;`
(separate from the named class definition) are accessed as
`lorisjs.MyModule.default`, not `lorisjs.MyModule.MyClass`. A
module may only have one default export, or it will be overridden
according to webpack's whims.

Everything in LORIS should work identically to before with the
exception that the exports are now available via plain javascript.