### PR TITLE
[User Accounts] Fix hidden form field bug

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -812,22 +812,18 @@ class Edit_User extends \NDB_Form
                 )
             );
 
-            // A user should not be able to edit their own examiner approval
-            // status.
-            if (!$this->_isEditingOwnAccount()) {
-                $groupB[] = $this->createLabel(
-                    "Pending Approval:"
-                );
-                $groupB[] = $this->createSelect(
-                    "examiner_pending",
-                    "Pending Approval: ",
-                    array(
-                        null => "",
-                        'Y'  => 'Yes',
-                        'N'  => 'No',
-                    )
-                );
-            }
+            $groupB[] = $this->createLabel(
+                "Pending Approval:"
+            );
+            $groupB[] = $this->createSelect(
+                "examiner_pending",
+                "Pending Approval: ",
+                array(
+                    null => "",
+                    'Y'  => 'Yes',
+                    'N'  => 'No',
+                )
+            );
             $this->addGroup(
                 $groupA,
                 'examiner_sites',


### PR DESCRIPTION
## Brief summary of changes

This form was hidden when it should not have been. In a recent meeting it was decided that it's OK for a user with `User Management` to edit their own examiner status.

#### Testing instructions (if applicable)

1. Grant a user "User Management" and "Across all sites add and certify examiners"
2. Make sure that user can change their account details in `/user_accounts/edit_user/`

#### Link(s) to related issue(s)

* Resolves #6012 
