### PR TITLE
[jsx/Card] Do not error out when no onClick is provided

### DIFF
--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -21,7 +21,9 @@ class Card extends Component {
   }
 
   handleClick(e) {
-    this.props.onClick(e);
+    if (this.props.onClick) {
+      this.props.onClick(e);
+    }
   }
 
   render() {


### PR DESCRIPTION
onClick is not a required and defaults to null. Add a guard
so that an error is not triggered when none is provided.