### PR TITLE
[imaging browser] query construction bug

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -188,9 +188,9 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               GROUP_CONCAT(DISTINCT OutputType) as Links,
               s.ID as sessionID,
               GROUP_CONCAT(DISTINCT modality.Scan_type) as sequenceType,
-              $PendingNewquery as pending,
-              $modalities_subquery,
-              s.CenterID as CenterID,
+              $PendingNewquery as pending," .
+              ($modalities_subquery==''?'':"$modalities_subquery,") .
+              "s.CenterID as CenterID,
               c.Entity_type as entityType,
               s.ProjectID
             FROM psc AS p 


### PR DESCRIPTION
## Brief summary of changes
for a new installation, the `$modalities_subquery` might be empty, then the Query will be invalid, this causes some confusion for new users.

#### Testing instructions (if applicable)

1. click on the Imaging browser module link

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
Issue #6088 