### PR TITLE
[JS] Fix eslint errors in Card and Panel classes

### DIFF
--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -15,15 +15,30 @@ import Panel from 'jsx/Panel';
  *
  */
 class Card extends Component {
+  /**
+   * Construct the React components
+   *
+   * @param {array} props - The React props
+   */
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
   }
 
+  /**
+   * Delegate clicks on the card to the onClick handler
+   *
+   * @param {Event} e - The event triggering the click
+   */
   handleClick(e) {
     this.props.onClick(e);
   }
 
+  /**
+   * Render the React component
+   *
+   * @return {object}
+   */
   render() {
     const cursorStyle = this.props.onClick ? {
       cursor: 'pointer',

--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -16,7 +16,7 @@ import Panel from 'jsx/Panel';
  */
 class Card extends Component {
   /**
-   * Construct the React components
+   * Construct the React component
    *
    * @param {array} props - The React props
    */

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -14,6 +14,11 @@ import PropTypes from 'prop-types';
  * Wraps children in a collapsible bootstrap panel
  */
 class Panel extends Component {
+  /**
+   * Construct the React component
+   *
+   * @param {array} props - The React props
+   */
   constructor(props) {
     super(props);
 
@@ -31,10 +36,18 @@ class Panel extends Component {
     this.toggleCollapsed = this.toggleCollapsed.bind(this);
   }
 
+  /**
+   * Toggle whether this Panel is displayed as collapsed
+   */
   toggleCollapsed() {
     this.setState({collapsed: !this.state.collapsed});
   }
 
+  /**
+   * Render the React component
+   *
+   * @return {object}
+   */
   render() {
     // Change arrow direction based on collapse status
     let glyphClass = (
@@ -61,7 +74,8 @@ class Panel extends Component {
       <div className="panel panel-primary">
         {panelHeading}
         <div id={this.props.id} className={this.panelClass} role="tabpanel">
-          <div className="panel-body" style={{...this.props.style, height: this.props.height}}>
+          <div className="panel-body"
+               style={{...this.props.style, height: this.props.height}}>
             {this.props.children}
           </div>
         </div>


### PR DESCRIPTION
This fixes the warnings from eslint in the Card and
Panel classes.

These had old warnings that were triggered while trying to validate that #6090 did not introduce any new errors.