### PR TITLE
[Widgets] Update signature of getWidgets to include options

### DIFF
--- a/modules/bvl_feedback/php/module.class.inc
+++ b/modules/bvl_feedback/php/module.class.inc
@@ -51,12 +51,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user)
+    public function getWidgets(string $type, \User $user, array $options)
     {
         switch($type) {
         case 'dashboard':

--- a/modules/conflict_resolver/php/module.class.inc
+++ b/modules/conflict_resolver/php/module.class.inc
@@ -62,12 +62,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user) : array
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case 'usertasks':

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -72,7 +72,7 @@ class Dashboard extends \NDB_Form
         $this->mainwidgets  = [];
         foreach ($this->modules as $module) {
             if ($module->hasAccess($user)) {
-                $widgets = $module->getWidgets('dashboard', $user);
+                $widgets = $module->getWidgets('dashboard', $user, []);
                 foreach ($widgets as $widget) {
                     if (!($widget instanceof Widget)) {
                         continue;

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -39,12 +39,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user)
+    public function getWidgets(string $type, \User $user, array $options)
     {
         switch($type) {
         case 'dashboard':
@@ -142,7 +144,7 @@ class Module extends \Module
             if ($module->hasAccess($user)) {
                 $widgets = array_merge(
                     $widgets,
-                    $module->getWidgets('usertasks', $user)
+                    $module->getWidgets('usertasks', $user, [])
                 );
             }
         }

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -62,12 +62,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user)
+    public function getWidgets(string $type, \User $user, array $options)
     {
         switch($type) {
         case 'dashboard':

--- a/modules/imaging_browser/php/module.class.inc
+++ b/modules/imaging_browser/php/module.class.inc
@@ -69,12 +69,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user) : array
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case 'usertasks':

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -87,12 +87,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user) : array
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case "usertasks":

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -65,12 +65,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user) : array
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case 'usertasks':

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -65,12 +65,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user) : array
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case "usertasks":

--- a/modules/statistics/php/module.class.inc
+++ b/modules/statistics/php/module.class.inc
@@ -61,12 +61,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user)
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case 'dashboard':

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -78,12 +78,14 @@ class Module extends \Module
     /**
      * {@inheritDoc}
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user) : array
+    public function getWidgets(string $type, \User $user, array $options) : array
     {
         switch($type) {
         case "usertasks":

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -501,12 +501,14 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      * on $type, and the contract between the caller and callee is
      * implicit.
      *
-     * @param string $type The type of widgets to get
-     * @param \User  $user The user widgets are being retrieved for.
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
      *
      * @return \LORIS\GUI\Widget[]
      */
-    public function getWidgets(string $type, \User $user)
+    public function getWidgets(string $type, \User $user, array $options)
     {
         return [];
     }


### PR DESCRIPTION
This factors out the signature change from PR #6092 to simplify
the review process.

The signature of getWidgets if changed to include a weakly typed
'$options' parameter, which can be used to specify type-dependent
options.
