### PR TITLE
Remove empty "Upgrading 17.0 to 17.1" document

### DIFF
--- a/docs/deprecated_wiki/Upgrading-17.0-to-17.1.md
+++ b/docs/deprecated_wiki/Upgrading-17.0-to-17.1.md
@@ -1,5 +1,0 @@
-# Work in Progress
-
-<!--
-> To future maintainers of this documentation, please fill in the upgrade instructions as necessary, when 17.1 has been released.
--->


### PR DESCRIPTION
We don't support this version of LORIS anymore so this document doe snot need to come forward with us into the new ReadTheDocs wiki.

There's also no content in it