### PR TITLE
Add administrator contact email as a new config setting

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -263,4 +263,4 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, 'pd'    FROM ConfigSettings WHER
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'false'  FROM ConfigSettings WHERE Name="usePwnedPasswordsAPI";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'Y-m-d H:i:s'  FROM ConfigSettings WHERE Name="dateDisplayFormat";
 INSERT INTO Config (ConfigID, Value) SELECT ID, '/data/issue_tracker/' FROM ConfigSettings WHERE Name="IssueTrackerDataPath";
-INSERT INTO Config (ConfigID, Value) SELECT ID, 'loris-dev@bic.mni.mcgill.ca'  FROM ConfigSettings WHERE Name="adminContactEmail";
+INSERT INTO Config (ConfigID, Value) SELECT ID, ''  FROM ConfigSettings WHERE Name="adminContactEmail";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -62,6 +62,7 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'CSPAdditionalHeaders', 'Extensions to the Content-security policy allow only for self-hosted content', 1, 0, 'text', ID, 'Content-Security Extensions', 26 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'usePwnedPasswordsAPI', 'Whether to query the Have I Been Pwned password API on password changes to prevent the usage of common and breached passwords', 1, 0, 'boolean', ID, 'Enable "Pwned Password" check', 27 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dateDisplayFormat', 'The date format to use throughout LORIS for displaying date information - formats for date inputs are browser- and locale-dependent.', 1, 0, 'text', ID, 'Date display format', 28 FROM ConfigSettings WHERE Name="study";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'adminContactEmail', 'An email address that users can write to in order to report issues or ask question', 1, 0, 'text', ID, 'Administrator Email', 29 FROM ConfigSettings WHERE Name="study";
 
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, Label, OrderNumber) VALUES ('paths', 'Specify directories where LORIS-related files are stored or created. Take care when editing these fields as changing them incorrectly can cause certain modules to lose functionality.', 1, 0, 'Paths', 2);
@@ -262,3 +263,4 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, 'pd'    FROM ConfigSettings WHER
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'false'  FROM ConfigSettings WHERE Name="usePwnedPasswordsAPI";
 INSERT INTO Config (ConfigID, Value) SELECT ID, 'Y-m-d H:i:s'  FROM ConfigSettings WHERE Name="dateDisplayFormat";
 INSERT INTO Config (ConfigID, Value) SELECT ID, '/data/issue_tracker/' FROM ConfigSettings WHERE Name="IssueTrackerDataPath";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 'loris-dev@bic.mni.mcgill.ca'  FROM ConfigSettings WHERE Name="adminContactEmail";

--- a/SQL/New_patches/2020-02-25_Add-Admin-Contact-Email.sql
+++ b/SQL/New_patches/2020-02-25_Add-Admin-Contact-Email.sql
@@ -1,0 +1,2 @@
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'adminContactEmail', 'An email address that users can write to in order to report issues or ask question', 1, 0, 'text', ID, 'Administrator Email', 27 FROM ConfigSettings WHERE Name="study";
+INSERT INTO Config (ConfigID, Value) SELECT ID, 'loris-dev@bic.mni.mcgill.ca'  FROM ConfigSettings WHERE Name="adminContactEmail";

--- a/SQL/New_patches/2020-02-25_Add-Admin-Contact-Email.sql
+++ b/SQL/New_patches/2020-02-25_Add-Admin-Contact-Email.sql
@@ -1,2 +1,2 @@
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'adminContactEmail', 'An email address that users can write to in order to report issues or ask question', 1, 0, 'text', ID, 'Administrator Email', 27 FROM ConfigSettings WHERE Name="study";
-INSERT INTO Config (ConfigID, Value) SELECT ID, 'loris-dev@bic.mni.mcgill.ca'  FROM ConfigSettings WHERE Name="adminContactEmail";
+INSERT INTO Config (ConfigID, Value) SELECT ID, ''  FROM ConfigSettings WHERE Name="adminContactEmail";

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -98,6 +98,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/data/data_rel
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (105,104,'YMd');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (106,105,'Y-m-d H:i:s');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (107,106,'/data/issue_tracker/');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (108,105,'');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (108,107,'');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -34,6 +34,7 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (34,38,'/data/uploads/')
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (35,40,'main.css');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (36,41,'25');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (37,44,'localhost');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (38,45,'http://localhost');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (39,48,'This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun.');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (40,51,'[a-zA-Z]{3}[0-9]{4}_[0-9]{6}_[vV][0-9]+');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (41,52,'(?i).');
@@ -98,5 +99,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/data/data_rel
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (105,104,'YMd');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (106,105,'Y-m-d H:i:s');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (107,106,'/data/issue_tracker/');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (108,105,'loris-dev@bic.mni.mcgill.ca');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_Config.sql
+++ b/raisinbread/RB_files/RB_Config.sql
@@ -34,7 +34,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (34,38,'/data/uploads/')
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (35,40,'main.css');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (36,41,'25');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (37,44,'localhost');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (38,45,'http://localhost');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (39,48,'This database provides an on-line mechanism to store both imaging and behavioral data collected from various locations. Within this framework, there are several tools that will make this process as efficient and simple as possible. For more detailed information regarding any aspect of the database, please click on the Help icon at the top right. Otherwise, feel free to contact us at the DCC. We strive to make data collection almost fun.');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (40,51,'[a-zA-Z]{3}[0-9]{4}_[0-9]{6}_[vV][0-9]+');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (41,52,'(?i).');
@@ -99,6 +98,6 @@ INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (104,103,'/data/data_rel
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (105,104,'YMd');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (106,105,'Y-m-d H:i:s');
 INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (107,106,'/data/issue_tracker/');
-INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (108,105,'loris-dev@bic.mni.mcgill.ca');
+INSERT INTO `Config` (`ID`, `ConfigID`, `Value`) VALUES (108,105,'');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_ConfigSettings.sql
+++ b/raisinbread/RB_files/RB_ConfigSettings.sql
@@ -102,6 +102,6 @@ INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMult
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (104,'dodFormat','Format of the Date of Death',1,0,'text',1,'DOD Format',10);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (105,'dateDisplayFormat','The date format to use throughout LORIS for displaying date information - formats for date inputs are browser- and locale-dependent.',1,0,'text',1,'Date display format',27);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (106,'IssueTrackerDataPath','Path to Issue Tracker data files',1,0,'web_path',26,'Issue Tracker Data Path',8);
-INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (105,'adminContactEmail','An email address that users can write to in order to report issues or ask question',1,0,'text',1,'Administrator Email',28);
+INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (107,'adminContactEmail','An email address that users can write to in order to report issues or ask question',1,0,'text',1,'Administrator Email',28);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_ConfigSettings.sql
+++ b/raisinbread/RB_files/RB_ConfigSettings.sql
@@ -102,5 +102,6 @@ INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMult
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (104,'dodFormat','Format of the Date of Death',1,0,'text',1,'DOD Format',10);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (105,'dateDisplayFormat','The date format to use throughout LORIS for displaying date information - formats for date inputs are browser- and locale-dependent.',1,0,'text',1,'Date display format',27);
 INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (106,'IssueTrackerDataPath','Path to Issue Tracker data files',1,0,'web_path',26,'Issue Tracker Data Path',8);
+INSERT INTO `ConfigSettings` (`ID`, `Name`, `Description`, `Visible`, `AllowMultiple`, `DataType`, `Parent`, `Label`, `OrderNumber`) VALUES (105,'adminContactEmail','An email address that users can write to in order to report issues or ask question',1,0,'text',1,'Administrator Email',28);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

Adds a new configuration setting for an admin "point of contact" email. The idea is to have an email that is monitored by a developer and/or project administrator for LORIS users to contact directly from within the software. 

An example of this would be when an Exception occurs in LORIS. The error page will provide a link for the user to email an admin when the error occurs. #6076 

Another example will be in the server configuration check script #5965. This script will send a test email to the admin to make sure that outgoing emails are working properly on the server.
