### PR TITLE
Get rid of long array syntax

### DIFF
--- a/htdocs/acknowledgements/acknowledgements.php
+++ b/htdocs/acknowledgements/acknowledgements.php
@@ -23,7 +23,7 @@ $db     = Database::singleton();
 
 $publication_date = $_GET["date"];
 
-$columns = array(
+$columns = [
     'full_name'     => 'Full Name',
     'citation_name' => 'Citation Name',
     'affiliations'  => 'Affiliations',
@@ -32,7 +32,7 @@ $columns = array(
     'start_date'    => 'Start Date',
     'end_date'      => 'End Date',
     'present'       => 'Present?',
-);
+];
 
 $keysAsString   = implode(', ', array_keys($columns));
 $valuesAsString = implode('","', array_values($columns));
@@ -43,7 +43,7 @@ $results = $db->pselect(
     " FROM acknowledgements
     WHERE start_date <= :publication_date
     ORDER BY ordering ASC",
-    array('publication_date' => $publication_date)
+    ['publication_date' => $publication_date]
 );
 echo "<html>";
 echo "<table border='1'>";

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -32,7 +32,7 @@ if (!$user->hasPermission('imaging_browser_qc')
     return;
 }
 
-$tpl_data = array();
+$tpl_data = [];
 $tpl_data['has_permission'] = $user->hasPermission('imaging_browser_qc');
 
 // instantiate feedback mri object
@@ -84,18 +84,18 @@ if ($comments->objectType == 'volume') {
                     AND f.AcquisitionProtocolID=st.ID
                     AND s.Active='Y'";
 
-    $qparams = array('FID' => $comments->fileID);
+    $qparams = ['FID' => $comments->fileID];
 } elseif ($comments->objectType == 'visit') {
     $query = "SELECT c.CandID, c.PSCID, s.Visit_label, s.SubprojectID
                 FROM session AS s, candidate AS c
               WHERE s.ID=:SID AND s.CandID=c.CandID AND s.Active='Y'";
 
-    $qparams = array('SID' => $comments->sessionID);
+    $qparams = ['SID' => $comments->sessionID];
 } else {
     $query = "SELECT c.CandID FROM session AS s, candidate AS c
                 WHERE s.ID=:SID AND s.CandID=c.CandID AND s.Active='Y'";
 
-    $qparams = array('SID' => $comments->sessionID);
+    $qparams = ['SID' => $comments->sessionID];
 }
 
 $result = $DB->pselect($query, $qparams);
@@ -115,7 +115,7 @@ $comment_types = $comments->getAllCommentTypes();
 // loop through the comment types
 $i = 0;
 foreach ($comment_types AS $comment_type_id => $comment_array) {
-    $tpl_data['comment'][$i] = array();
+    $tpl_data['comment'][$i] = [];
     $CommentTpl =& $tpl_data['comment'][$i];
 
     // print the status select field if it exists
@@ -142,14 +142,14 @@ foreach ($comment_types AS $comment_type_id => $comment_array) {
     foreach ($predefined_comments
         AS $predefined_comment_id => $predefined_comment_text
     ) {
-        $CommentTpl['predefined'][$j] = array();
+        $CommentTpl['predefined'][$j] = [];
         $PredefinedTpl =& $CommentTpl['predefined'][$j];
         // print a form element
         $PredefinedTpl['id'] = $predefined_comment_id;
         $PredefinedTpl['predefined_text'] = $predefined_comment_text['Comment'];
 
         // print the comment text
-        $Saved = $saved_comments[$comment_type_id] ?? array();
+        $Saved = $saved_comments[$comment_type_id] ?? [];
         if ($Saved['predefined'][$predefined_comment_id] ?? false) {
             $CommentTpl['predefined'][$j]['checked'] = true;
         }

--- a/htdocs/installdb.php
+++ b/htdocs/installdb.php
@@ -84,7 +84,7 @@ ini_set('default_charset', 'utf-8');
 // gzip handler.
 //ob_start('ob_gzhandler');
 ob_start();
-$tpl_data = array();
+$tpl_data = [];
 
 // Page 1: Help, prompt server, root username, root password
 // Page 2: 1. Connect with username/password

--- a/htdocs/mri/jiv/get_file.php
+++ b/htdocs/mri/jiv/get_file.php
@@ -42,11 +42,11 @@ $DownloadPath = $paths['DownloadPath'];
 $tarchivePath = $pipeline['tarchiveLibraryDir'];
 // Basic config validation
 if (!validConfigPaths(
-    array(
+    [
         $imagePath,
         $DownloadPath,
         $tarchivePath,
-    )
+    ]
 )
 ) {
     http_response_code(500);

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -79,16 +79,16 @@ class DirectDataEntryMainPage
         $this->TestName  = $DB->pselectOne(
             "SELECT Test_name FROM participant_accounts
             WHERE OneTimePassword=:key AND Status <> 'Complete'",
-            array('key' => $this->key)
+            ['key' => $this->key]
         );
         $this->CommentID = $DB->pselectOne(
             "SELECT CommentID FROM participant_accounts 
             WHERE OneTimePassword=:key AND Status <> 'Complete'",
-            array('key' => $this->key)
+            ['key' => $this->key]
         );
         $this->NumPages  = $DB->pselectOne(
             "SELECT COUNT(*) FROM instrument_subtests WHERE Test_name=:TN",
-            array('TN' => $this->TestName)
+            ['TN' => $this->TestName]
         );
 
         if (empty($this->TestName) && empty($this->CommentID)) {
@@ -107,29 +107,29 @@ class DirectDataEntryMainPage
                 "SELECT Subtest_name
                 FROM instrument_subtests
                 WHERE Test_name=:TN AND Order_number=:PN",
-                array(
+                [
                     'TN' => $this->TestName,
                     'PN' => $pageNum,
-                )
+                ]
             );
         }
 
         $totalPages        = $DB->pselectOne(
             "SELECT COUNT(*)+1 from instrument_subtests WHERE Test_name=:TN",
-            array('TN' => $this->TestName)
+            ['TN' => $this->TestName]
         );
         $this->NextPageNum = $this->getNextPageNum($pageNum);
         $this->PrevPageNum = $this->getPrevPageNum($pageNum);
 
         $this->CommentID = $this->getCommentID();
-        $this->tpl_data  = array(
+        $this->tpl_data  = [
             'nextpage'    => $this->NextPageNum,
             'prevpage'    => $this->PrevPageNum,
             'pageNum'     => $pageNum ? $pageNum + 1: 1,
             'totalPages'  => $totalPages,
             'key'         => $this->key,
             'study_title' => $config->getSetting('title'),
-        );
+        ];
     }
 
 
@@ -151,10 +151,10 @@ class DirectDataEntryMainPage
             \Database::singleton()->pselectOne(
                 "SELECT Order_number FROM instrument_subtests
                 WHERE Test_name=:TN AND Order_number=:PN",
-                array(
+                [
                     'TN' => $this->TestName,
                     'PN' => $nextPage,
-                )
+                ]
             )
         );
     }
@@ -185,17 +185,17 @@ class DirectDataEntryMainPage
                 "SELECT MAX(Order_number) 
                 FROM instrument_subtests 
                 WHERE Test_name=:TN",
-                array('TN' => $this->TestName)
+                ['TN' => $this->TestName]
             );
         }
         $prevPage = $currentPage-1;
         return $DB->pselectOne(
             "SELECT Order_number FROM instrument_subtests 
             WHERE Test_name=:TN AND Order_number=:PN",
-            array(
+            [
                 'TN' => $this->TestName,
                 'PN' => $prevPage,
-            )
+            ]
         );
     }
 
@@ -225,9 +225,9 @@ class DirectDataEntryMainPage
         return $DB->pselectOne(
             "SELECT CommentID FROM participant_accounts
             WHERE OneTimePassword=:key AND Status <> 'Complete'",
-            array(
+            [
                 'key' => $this->key,
-            )
+            ]
         );
     }
 
@@ -272,7 +272,7 @@ class DirectDataEntryMainPage
         $currentStatus = $DB->pselectOne(
             'SELECT Status FROM participant_accounts
             WHERE OneTimePassword=:key',
-            array('key' => $this->key)
+            ['key' => $this->key]
         );
 
         if ($currentStatus === 'Complete') {
@@ -283,8 +283,8 @@ class DirectDataEntryMainPage
 
         $DB->update(
             "participant_accounts",
-            array('Status' => $status),
-            array('OneTimePassword' => $this->key)
+            ['Status' => $status],
+            ['OneTimePassword' => $this->key]
         );
 
         return true;
@@ -305,11 +305,11 @@ class DirectDataEntryMainPage
         $DB = Database::singleton();
         $DB->update(
             "participant_accounts",
-            array(
+            [
                 'UserEaseRating' => $ease,
                 'UserComments'   => $comments,
-            ),
-            array('OneTimePassword' => $this->key)
+            ],
+            ['OneTimePassword' => $this->key]
         );
     }
 
@@ -371,22 +371,22 @@ class DirectDataEntryMainPage
             $this->updateStatus('Complete');
             $DB->update(
                 $this->TestName,
-                array(
+                [
                     'Date_taken' => date('Y-m-d'),
-                ),
-                array(
+                ],
+                [
                     'CommentID' => $this->CommentID,
-                )
+                ]
             );
             $DB->update(
                 'flag',
-                array(
+                [
                     'Data_entry'     => 'Complete',
                     'Administration' => 'All',
-                ),
-                array(
+                ],
+                [
                     'CommentID' => $this->CommentID,
-                )
+                ]
             );
 
         } else {

--- a/modules/acknowledgements/php/acknowledgements.class.inc
+++ b/modules/acknowledgements/php/acknowledgements.class.inc
@@ -56,7 +56,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      */
     function _validate($values): array
     {
-        $errors = array();
+        $errors = [];
 
         if ($values['addStartDate'] > $values['addEndDate']) {
             $errors['dates'] = "Start date cannot be greater than the end date.";
@@ -102,7 +102,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
             $roles        = is_array($values['addRoles']) ?
                 implode(', ', $values['addRoles']) :
                 $values['addRoles'];
-            $results      = array(
+            $results      = [
                 'ordering'      => $values['addOrdering'],
                 'full_name'     => $values['addFullName'],
                 'citation_name' => $values['addCitationName'],
@@ -112,7 +112,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
                 'start_date'    => $values['addStartDate'],
                 'end_date'      => $values['addEndDate'],
                 'present'       => $values['addPresent'],
-            );
+            ];
 
             $DB->insert('acknowledgements', $results);
             unset($values);
@@ -130,7 +130,7 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
      */
     function _setupVariables()
     {
-        $this->columns      = array(
+        $this->columns      = [
             'ordering',
             'full_name',
             'citation_name',
@@ -140,18 +140,18 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
             'start_date',
             'end_date',
             'present',
-        );
+        ];
         $this->query        = " FROM acknowledgements WHERE 1=1";
         $this->group_by     = '';
         $this->order_by     = "ordering ASC";
-        $this->validFilters = array(
+        $this->validFilters = [
             'full_name',
             'citation_name',
             'start_date',
             'end_date',
             'present',
-        );
-        $this->headers      = array(
+        ];
+        $this->headers      = [
             'ordering',
             'full_name',
             'citation_name',
@@ -161,14 +161,14 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
             'start_date',
             'end_date',
             'present',
-        );
-        $this->formToFilter = array(
+        ];
+        $this->formToFilter = [
             'full_name'     => 'full_name',
             'citation_name' => 'citation_name',
             'start_date'    => 'start_date',
             'end_date'      => 'end_date',
             'present'       => 'present',
-        );
+        ];
     }
 
     /**
@@ -182,12 +182,12 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
     {
         parent::setup();
 
-        $present = array(
+        $present = [
             'Yes' => 'Yes',
             'No'  => 'No',
-        );
+        ];
 
-        $this->fieldOptions = array('presents' => $present);
+        $this->fieldOptions = ['presents' => $present];
     }
 
     /**
@@ -225,9 +225,9 @@ class Acknowledgements extends \NDB_Menu_Filter_Form
 
         return array_merge(
             $baseDeps,
-            array(
+            [
                 $baseurl . '/acknowledgements/js/acknowledgementsIndex.js',
-            )
+            ]
         );
 
     }

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -1,10 +1,25 @@
 <?php
+/**
+ * AcknowledgementsIntegrationTest automated integration tests
+ *
+ * PHP Version 5
+ *
+ * @category Test
+ * @package  Loris
+ * @author   Wang Shen <wangshen.mcin@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
  require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
 /**
  * AcknowledgementsIntegrationTest
  *
- * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @category Test
+ * @package  Loris
+ * @author   Wang Shen <wangshen.mcin@gmail.com>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
  */
 class AcknowledgementsIntegrationTest extends LorisIntegrationTest
 {

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -1,32 +1,17 @@
 <?php
-/**
- * AcknowledgementsIntegrationTest automated integration tests
- *
- * PHP Version 5
- *
- * @category Test
- * @package  Loris
- * @author   Wang Shen <wangshen.mcin@gmail.com>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
- */
  require_once __DIR__
     . "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
 /**
  * AcknowledgementsIntegrationTest
  *
- * @category Test
- * @package  Loris
- * @author   Wang Shen <wangshen.mcin@gmail.com>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class AcknowledgementsIntegrationTest extends LorisIntegrationTest
 {
 
     // Initial array data
 
-    static $testData = array(
+    static $testData = [
         'ID'            => '999',
         'ordering'      => '999',
         'full_name'     => 'Demo Test',
@@ -37,8 +22,8 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
         'start_date'    => '2015-01-01',
         'end_date'      => '2016-01-01',
         'present'       => 'Yes',
-    );
-    static $newData  = array(
+    ];
+    static $newData  = [
         'ordering'      => '9999',
         'full_name'     => 'Test Test',
         'citation_name' => "Test's Citation",
@@ -48,7 +33,7 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
         'start_date'    => '2015-11-11',
         'end_date'      => '2016-11-11',
         'present'       => 'Yes',
-    );
+    ];
     /**
      * Insert testing data into the database
      * author: Wang Shen
@@ -72,8 +57,8 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
      */
     function tearDown()
     {
-        $this->DB->delete("acknowledgements", array('ID' => '999'));
-        $this->DB->delete("acknowledgements", array('full_name' => 'Test Test'));
+        $this->DB->delete("acknowledgements", ['ID' => '999']);
+        $this->DB->delete("acknowledgements", ['full_name' => 'Test Test']);
         parent::tearDown();
     }
 
@@ -87,10 +72,10 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
     {
         $this->checkPagePermissions(
             '/acknowledgements/',
-            array(
+            [
                 'acknowledgements_view',
                 'acknowledgements_edit'
-            ),
+            ],
             "Acknowledgements"
         );
     }

--- a/modules/api/php/endpoints/candidate/candidate.class.inc
+++ b/modules/api/php/endpoints/candidate/candidate.class.inc
@@ -51,7 +51,7 @@ class Candidate extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -62,10 +62,10 @@ class Candidate extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
@@ -68,7 +68,7 @@ class Dicom extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -79,7 +79,7 @@ class Dicom extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array('v0.0.3-dev');
+        return ['v0.0.3-dev'];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
@@ -57,7 +57,7 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -68,7 +68,7 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array('v0.0.3-dev');
+        return ['v0.0.3-dev'];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/image/format.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format.class.inc
@@ -49,7 +49,7 @@ class Format extends Endpoint
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -60,10 +60,10 @@ class Format extends Endpoint
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/image/format/brainbrowser.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/brainbrowser.class.inc
@@ -55,7 +55,7 @@ class Brainbrowser extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -66,10 +66,10 @@ class Brainbrowser extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -50,7 +50,7 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -61,10 +61,10 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**
@@ -158,11 +158,11 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         exec("minctoraw -v 2>&1", $output);
 
-        $signature = array(
+        $signature = [
             'minctoraw' => $output,
             'mtime'     => $info->getMTime(),
             'fullpath'  => $info->getPathname(),
-        );
+        ];
 
         return md5(json_encode($signature));
     }

--- a/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
@@ -50,7 +50,7 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -61,10 +61,10 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**
@@ -120,10 +120,10 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
         return new \LORIS\Http\Response(
             $body,
             200,
-            array(
+            [
                 'Content-Type'        => 'image/jpeg',
                 'Content-Disposition' => 'attachment; filename=' . $filename,
-            )
+            ]
         );
     }
 
@@ -142,11 +142,11 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
             return '';
         }
 
-        $signature = array(
+        $signature = [
             'filename' => $info->getFilename(),
             'size'     => $info->getSize(),
             'mtime'    => $info->getMTime(),
-        );
+        ];
 
         return md5(json_encode($signature));
     }

--- a/modules/api/php/endpoints/candidate/visit/image/headers.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/headers.class.inc
@@ -64,7 +64,7 @@ class Headers extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -75,10 +75,10 @@ class Headers extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -60,7 +60,7 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -71,10 +71,10 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**
@@ -198,11 +198,11 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $info = $image->getFileInfo();
 
-        $signature = array(
+        $signature = [
             'filename' => $this->_filename,
             'size'     => $info->getSize(),
             'mtime'    => $info->getMTime(),
-        );
+        ];
 
         return md5(json_encode($signature));
     }

--- a/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
@@ -64,10 +64,10 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array(
+        return [
             'GET',
             'PUT',
-        );
+        ];
     }
 
     /**
@@ -78,10 +78,10 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/images.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/images.class.inc
@@ -57,7 +57,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -68,10 +68,10 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
@@ -60,11 +60,11 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array(
+        return [
             'GET',
             'PUT',
             'PATCH',
-        );
+        ];
     }
 
     /**
@@ -75,10 +75,10 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -60,11 +60,11 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array(
+        return [
             'GET',
             'PUT',
             'PATCH',
-        );
+        ];
     }
 
     /**
@@ -75,10 +75,10 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/instruments.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instruments.class.inc
@@ -57,7 +57,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -68,10 +68,10 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/qc.class.inc
@@ -58,10 +58,10 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array(
+        return [
             'GET',
             'PUT',
-        );
+        ];
     }
 
     /**
@@ -72,10 +72,10 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**
@@ -143,11 +143,11 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         $data = json_decode((string) $request->getBody(), true);
 
-        $requiredfields = array(
+        $requiredfields = [
             'Meta',
             'SessionQC',
             'Pending',
-        );
+        ];
         $diff           = array_diff($requiredfields, array_keys($data));
         if (!empty($diff)) {
             return new \LORIS\Http\Response\JSON\BadRequest(
@@ -180,7 +180,7 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $ispending = $data['Pending'] ? 'Y' : 'N';
 
         try {
-            $this->_visit->setData(array('MRIQCStatus' => $qcstatus));
+            $this->_visit->setData(['MRIQCStatus' => $qcstatus]);
         } catch (\DatabaseException $e) {
             return new \LORIS\Http\Response\JSON\BadRequest(
                 'MRIQCStatus value not acceptable'
@@ -188,7 +188,7 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         try {
-            $this->_visit->setData(array('MRIQCPending' => $ispending));
+            $this->_visit->setData(['MRIQCPending' => $ispending]);
         } catch (\DatabaseException $e) {
             return new \LORIS\Http\Response\JSON\BadRequest(
                 'MRIQCPending value not acceptable'

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -61,10 +61,10 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array(
+        return [
             'GET',
             'PUT',
-        );
+        ];
     }
 
     /**
@@ -76,7 +76,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         // Removed 0.0.2 since session requires a project.
-        return array('v0.0.3-dev');
+        return ['v0.0.3-dev'];
     }
 
     /**
@@ -177,15 +177,15 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         $user      = $request->getAttribute('user');
         $data      = json_decode((string) $request->getBody(), true);
-        $visitinfo = $data ?? array();
+        $visitinfo = $data ?? [];
 
-        $requiredfields = array(
+        $requiredfields = [
             'CandID',
             'Visit',
             'Site',
             'Battery',
             'Project',
-        );
+        ];
         $diff           = array_diff($requiredfields, array_keys($visitinfo));
         if (!empty($diff)) {
             return new \LORIS\Http\Response\JSON\BadRequest(
@@ -238,7 +238,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
             $today    = date("Y-m-d");
 
             $timepoint->setData(
-                array(
+                [
                     'CenterID'        => $centerid,
                     'Visit_label'     => $visitinfo['Visit'],
                     'SubprojectID'    => $subprojectid,
@@ -249,7 +249,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
                     'Date_registered' => $today,
                     'Testdate'        => $today,
                     'ProjectID'       => $project->getId(),
-                )
+                ]
             );
 
             $link = '/' . $request->getUri()->getPath();

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -57,10 +57,10 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array(
+        return [
             'GET',
             'POST',
-        );
+        ];
     }
 
     /**
@@ -71,10 +71,10 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             "v0.0.2",
             "v0.0.3-dev",
-        );
+        ];
     }
 
     /**
@@ -147,7 +147,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $filter = new HasAnyPermissionOrUserSiteMatch(
-            array('access_all_profiles')
+            ['access_all_profiles']
         );
 
         $provisioner = (new \LORIS\api\Provisioners\CandidatesProvisioner())
@@ -158,7 +158,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
             ->toArray($request->getAttribute('user'));
 
         $this->_cache = new \LORIS\Http\Response\JsonResponse(
-            array('Candidates' => $candidates)
+            ['Candidates' => $candidates]
         );
 
         return $this->_cache;

--- a/modules/api/php/endpoints/login.class.inc
+++ b/modules/api/php/endpoints/login.class.inc
@@ -65,7 +65,7 @@ class Login extends Endpoint
      */
     protected function allowedMethods() : array
     {
-        return array('POST');
+        return ['POST'];
     }
 
     /**
@@ -79,10 +79,10 @@ class Login extends Endpoint
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**
@@ -117,7 +117,7 @@ class Login extends Endpoint
                 $token = $this->getEncodedToken($user);
                 if (!empty($token)) {
                     return new \LORIS\Http\Response\JsonResponse(
-                        array('token' => $token)
+                        ['token' => $token]
                     );
                 } else {
                     return new \LORIS\Http\Response\JSON\InternalServerError(
@@ -163,7 +163,7 @@ class Login extends Endpoint
         $config  = $factory->config();
         $baseURL = $factory->settings()->getBaseURL();
 
-        $token = array(
+        $token = [
             // JWT related tokens to for the JWT library to validate
             "iss"  => $baseURL,
             "aud"  => $baseURL,
@@ -174,7 +174,7 @@ class Login extends Endpoint
             "exp"  => time() + 86400,
             // Additional payload data
             "user" => $user,
-        );
+        ];
 
         $key = $config->getSetting("JWTKey");
         if (!self::isKeyStrong($key)) {

--- a/modules/api/php/endpoints/project/candidates.class.inc
+++ b/modules/api/php/endpoints/project/candidates.class.inc
@@ -55,7 +55,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -66,10 +66,10 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/project/images.class.inc
+++ b/modules/api/php/endpoints/project/images.class.inc
@@ -55,7 +55,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -66,7 +66,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array("v0.0.3-dev");
+        return ["v0.0.3-dev"];
     }
 
     /**
@@ -133,7 +133,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
             ->toArray($request->getAttribute('user'));
 
         $this->_cache = new \LORIS\Http\Response\JsonResponse(
-            array('Images' => $images)
+            ['Images' => $images]
         );
 
         return $this->_cache;

--- a/modules/api/php/endpoints/project/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/project/instrument/instrument.class.inc
@@ -56,7 +56,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -67,10 +67,10 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/project/instruments.class.inc
+++ b/modules/api/php/endpoints/project/instruments.class.inc
@@ -55,7 +55,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -66,10 +66,10 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/project/project.class.inc
+++ b/modules/api/php/endpoints/project/project.class.inc
@@ -55,7 +55,7 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -66,10 +66,10 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/project/visits.class.inc
+++ b/modules/api/php/endpoints/project/visits.class.inc
@@ -55,7 +55,7 @@ class Visits extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -66,10 +66,10 @@ class Visits extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/endpoints/projects.class.inc
+++ b/modules/api/php/endpoints/projects.class.inc
@@ -51,7 +51,7 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function allowedMethods() : array
     {
-        return array('GET');
+        return ['GET'];
     }
 
     /**
@@ -62,10 +62,10 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array(
+        return [
             'v0.0.2',
             'v0.0.3-dev',
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -55,7 +55,7 @@ class CandidatesRow implements \LORIS\Data\DataInstance
      */
     public function toJSON() : string
     {
-        $obj = array(
+        $obj = [
             'CandID'  => $this->_candid,
             'Project' => $this->_projectname,
             'PSCID'   => $this->_pscid,
@@ -63,7 +63,7 @@ class CandidatesRow implements \LORIS\Data\DataInstance
             'EDC'     => $this->_edc,
             'DoB'     => $this->_dob,
             'Sex'     => $this->_sex,
-        );
+        ];
 
         return json_encode($obj);
     }

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -63,7 +63,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
      */
     public function toJSON() : string
     {
-        $obj = array(
+        $obj = [
             'Candidate'  => $this->_candid,
             'PSCID'      => $this->_pscid,
             'Visit'      => $this->_visitlabel,
@@ -74,7 +74,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
             'ScanType'   => $this->_scantype,
             'QC_status'  => $this->_qcstatus,
             'Selected'   => $this->_selected,
-        );
+        ];
 
         $filename = basename($obj['File']);
         $candid   = $obj['Candidate'];

--- a/modules/api/php/models/projectinstrumentsrow.class.inc
+++ b/modules/api/php/models/projectinstrumentsrow.class.inc
@@ -104,11 +104,11 @@ class ProjectInstrumentsRow implements \LORIS\Data\DataInstance
      */
     private function _toArray() : array
     {
-        return array(
+        return [
             'shortname' => $this->_shortname,
             'fullname'  => $this->_fullname,
             'subgroup'  => $this->_subgroupname,
             'ddeenable' => $this->_isDDE,
-        );
+        ];
     }
 }

--- a/modules/api/php/provisioners/candidatesprovisioner.class.inc
+++ b/modules/api/php/provisioners/candidatesprovisioner.class.inc
@@ -55,7 +55,7 @@ class CandidatesProvisioner extends DBRowProvisioner
                ON (c.RegistrationProjectID = p.ProjectID)
              WHERE c.Active=\'Y\'
             ',
-            array()
+            []
         );
     }
 

--- a/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
@@ -74,10 +74,10 @@ class ProjectImagesRowProvisioner extends DBRowProvisioner
                f.InsertTime > :v_time
              ORDER BY f.InsertTime ASC
             ',
-            array(
+            [
                 'v_projectname' => $project->getName(),
                 'v_time'        => $since->getTimestamp(),
-            )
+            ]
         );
     }
 

--- a/modules/api/php/provisioners/projectinstrumentsrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectinstrumentsrowprovisioner.class.inc
@@ -48,7 +48,7 @@ class ProjectInstrumentsRowProvisioner extends DBRowProvisioner
              LEFT JOIN test_subgroups sg
                ON (tn.Sub_group=sg.ID)
             ',
-            array()
+            []
         );
     }
 

--- a/modules/api/php/provisioners/visitdicomsrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/visitdicomsrowprovisioner.class.inc
@@ -51,9 +51,9 @@ class VisitDicomsRowProvisioner extends DBRowProvisioner
                s.Active=\'Y\' AND
                s.ID = :v_sessionid
             ',
-            array(
+            [
                 'v_sessionid' => $timepoint->getSessionID(),
-            )
+            ]
         );
     }
 

--- a/modules/api/php/views/candidate.class.inc
+++ b/modules/api/php/views/candidate.class.inc
@@ -43,7 +43,7 @@ class Candidate
      */
     public function toArray(): array
     {
-        $meta = array(
+        $meta = [
             'CandID'  => $this->_candidate->getCandID(),
             'Project' => $this->_candidate->getProjectTitle(),
             'PSCID'   => $this->_candidate->getPSCID(),
@@ -51,13 +51,13 @@ class Candidate
             'EDC'     => $this->_candidate->getCandidateEDC(),
             'DoB'     => $this->_candidate->getCandidateDoB(),
             'Sex'     => $this->_candidate->getCandidateSex(),
-        );
+        ];
 
         $visits = array_values($this->_candidate->getListOfVisitLabels());
 
-        return array(
+        return [
             'Meta'   => $meta,
             'Visits' => $visits,
-        );
+        ];
     }
 }

--- a/modules/api/php/views/project.class.inc
+++ b/modules/api/php/views/project.class.inc
@@ -49,14 +49,14 @@ class Project
      */
     public function toArray(): array
     {
-        $meta = array('Project' => $this->_project->getName());
+        $meta = ['Project' => $this->_project->getName()];
 
-        return array(
+        return [
             'Meta'        => $meta,
             'Candidates'  => $this->_project->getCandidateIds(),
             'Instruments' => array_keys(\Utility::getAllInstruments()),
             'Visits'      => $this->_getVisits(),
-        );
+        ];
     }
 
     /**
@@ -67,12 +67,12 @@ class Project
      */
     public function toCandidateArray(): array
     {
-        $meta = array('Project' => $this->_project->getName());
+        $meta = ['Project' => $this->_project->getName()];
 
-        return array(
+        return [
             'Meta'       => $meta,
             'Candidates' => $this->_project->getCandidateIds(),
-        );
+        ];
     }
 
     /**
@@ -83,12 +83,12 @@ class Project
      */
     public function toVisitArray(): array
     {
-        $meta = array('Project' => $this->_project->getName());
+        $meta = ['Project' => $this->_project->getName()];
 
-        return array(
+        return [
             'Meta'   => $meta,
             'Visits' => $this->_getVisits(),
-        );
+        ];
     }
 
     /**

--- a/modules/api/php/views/project/instruments.class.inc
+++ b/modules/api/php/views/project/instruments.class.inc
@@ -58,23 +58,23 @@ class Instruments
      */
     public function toArray(): array
     {
-        $meta = array('Project' => $this->_project->getName());
+        $meta = ['Project' => $this->_project->getName()];
 
-        $instruments = array();
+        $instruments = [];
 
         foreach ($this->_instruments as $instrument) {
             $shortname = $instrument->getShortname();
-            $item      = array(
+            $item      = [
                 'Fullname'               => $instrument->getFullname(),
                 'Subgroup'               => $instrument->getSubgroupname(),
                 'DoubleDataEntryEnabled' => $instrument->isDDE(),
-            );
+            ];
             $instruments[$shortname] = $item;
         }
 
-        return array(
+        return [
             'Meta'        => $meta,
             'Instruments' => $instruments,
-        );
+        ];
     }
 }

--- a/modules/api/php/views/projects.class.inc
+++ b/modules/api/php/views/projects.class.inc
@@ -52,20 +52,20 @@ class Projects
 
         $type = $PSCID['generation'] == 'sequential' ? 'auto' : 'prompt';
 
-        $settings = array(
+        $settings = [
             "useEDC" => $useEDC,
-            "PSCID"  => array(
+            "PSCID"  => [
                 "Type"  => $type,
                 "Regex" => $PSCIDFormat,
-            ),
-        );
+            ],
+        ];
 
-        $projects = array();
+        $projects = [];
         foreach ($this->_projects as $project) {
             // All projects have the same settings.
             $project_name            = $project->getName();
             $projects[$project_name] = $settings;
         }
-        return array('Projects' => $projects);
+        return ['Projects' => $projects];
     }
 }

--- a/modules/api/php/views/visit.class.inc
+++ b/modules/api/php/views/visit.class.inc
@@ -42,46 +42,46 @@ class Visit
      */
     public function toArray(): array
     {
-        $meta = array(
+        $meta = [
             'CandID'  => $this->_timepoint->getCandID(),
             'Visit'   => $this->_timepoint->getVisitLabel(),
             'Site'    => $this->_timepoint->getPSC(),
             'Battery' => $this->_timepoint->getData('SubprojectTitle'),
             'Project' => $this->_timepoint->getProject(),
-        );
+        ];
 
-        $stages = array();
+        $stages = [];
 
         if ($this->_timepoint->getDateOfScreening() !== null) {
-            $screening = array(
+            $screening = [
                 'Date'   => $this->_timepoint->getDateOfScreening(),
                 'Status' => $this->_timepoint->getScreeningStatus(),
-            );
+            ];
 
             $stages['Screening'] = $screening;
         }
 
         if ($this->_timepoint->getDateOfVisit() !== null) {
-            $visit = array(
+            $visit = [
                 'Date'   => $this->_timepoint->getDateOfVisit(),
                 'Status' => $this->_timepoint->getVisitStatus(),
-            );
+            ];
 
             $stages['Visit'] = $visit;
         }
 
         if ($this->_timepoint->getDateOfApproval() !== null) {
-            $approval = array(
+            $approval = [
                 'Date'   => $this->_timepoint->getDateOfapproval(),
                 'Status' => $this->_timepoint->getApprovalStatus(),
-            );
+            ];
 
             $stages['Screening'] = $approval;
         }
 
-        return array(
+        return [
             'Meta'   => $meta,
             'Stages' => $stages,
-        );
+        ];
     }
 }

--- a/modules/api/php/views/visit/dicoms.class.inc
+++ b/modules/api/php/views/visit/dicoms.class.inc
@@ -51,16 +51,16 @@ class Dicoms
      */
     private static function _formatDicomTars(DicomTarDTO $dicom): array
     {
-        return array(
+        return [
             'Tarname'    => $dicom->getTarname(),
             'SeriesInfo' => array_map(
-                array(
+                [
                     'self',
                     '_formatSeries'
-                ),
+                ],
                 $dicom->getSeries()
             ),
-        );
+        ];
     }
 
     /**
@@ -73,7 +73,7 @@ class Dicoms
      */
     private static function _formatSeries(DicomSeriesDTO $series): array
     {
-        return array(
+        return [
             'SeriesDescription' => $series->getSeriesDescription(),
             'SeriesNumber'      => $series->getSeriesNumber(),
             'EchoTime'          => $series->getEchotime(),
@@ -82,7 +82,7 @@ class Dicoms
             'SliceThickness'    => $series->getSlicethickness(),
             'Modality'          => $series->getModality(),
             'SeriesUID'         => $series->getSeriesuid(),
-        );
+        ];
     }
 
     /**
@@ -92,20 +92,20 @@ class Dicoms
      */
     public function toArray(): array
     {
-        $meta = array(
+        $meta = [
             'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
-        );
+        ];
 
         $dicomtars = array_map(
             'self::_formatDicomTars',
             $this->_dicoms
         );
 
-        return array(
+        return [
             'Meta'      => $meta,
             'DicomTars' => $dicomtars,
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/flags.class.inc
+++ b/modules/api/php/views/visit/flags.class.inc
@@ -57,19 +57,19 @@ class Flags
 
         $isDDE = strpos($instrumentdata['CommentID'], 'DDE_') === 0;
 
-        $meta = array(
+        $meta = [
             'Candidate'  => $this->_timepoint->getCandID(),
             'Visit'      => $this->_timepoint->getVisitLabel(),
             'DDE'        => $isDDE,
             'Instrument' => $instrumentname,
-        );
+        ];
 
         $flags = $this->_instrument->getFlags()->toArray();
 
-        return array(
+        return [
             'Meta'  => $meta,
             'Flags' => $flags,
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/image/format/brainbrowser.class.inc
+++ b/modules/api/php/views/visit/image/format/brainbrowser.class.inc
@@ -47,12 +47,12 @@ class Brainbrowser
     {
         $order = $this->_image->getHeader("image:dimorder");
 
-        $responsearray = array(
+        $responsearray = [
             'order'  => $order,
             'xspace' => $this->_getDimension('xspace'),
             'yspace' => $this->_getDimension('yspace'),
             'zspace' => $this->_getDimension('zspace'),
-        );
+        ];
 
         if (count(explode(',', $order)) == 4) {
             $responsearray['time'] = $this->_getDimension('time');
@@ -70,11 +70,11 @@ class Brainbrowser
      */
     private function _getDimension(string $dim): array
     {
-        return array(
+        return [
             'space_length' => $this->_image->getHeader("$dim:length"),
             'start'        => $this->_image->getHeader("$dim:start"),
             'step'         => $this->_image->getHeader("$dim:step"),
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/image/headers/full.class.inc
+++ b/modules/api/php/views/visit/image/headers/full.class.inc
@@ -68,10 +68,10 @@ class Full
         unset($headers['check_pic_filename']);
         unset($headers['jiv_path']);
 
-        return  array(
+        return  [
             'Meta'    => $this->_formatMeta(),
             'Headers' => $headers,
-        );
+        ];
     }
 
     /**
@@ -85,11 +85,11 @@ class Full
         $visitlabel = $this->_visit->getVisitLabel();
         $filename   = $this->_image->getFileInfo()->getFilename();
 
-        return array(
+        return [
             'CandID' => $candid,
             'Visit'  => $visitlabel,
             'File'   => $filename,
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/image/headers/specific.class.inc
+++ b/modules/api/php/views/visit/image/headers/specific.class.inc
@@ -70,10 +70,10 @@ class Specific
      */
     public function toArray(): array
     {
-        return  array(
+        return  [
             'Meta'  => $this->_formatMeta(),
             'Value' => $this->_image->getHeader($this->_headername),
-        );
+        ];
     }
 
     /**
@@ -87,12 +87,12 @@ class Specific
         $visitlabel = $this->_visit->getVisitLabel();
         $filename   = $this->_image->getFileInfo()->getFilename();
 
-        return array(
+        return [
             'CandID' => $candid,
             'Visit'  => $visitlabel,
             'File'   => $filename,
             'Header' => $this->_headername,
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/image/headers/summary.class.inc
+++ b/modules/api/php/views/visit/image/headers/summary.class.inc
@@ -58,13 +58,13 @@ class Summary
      */
     public function toArray(): array
     {
-        return  array(
+        return  [
             'Meta'        => $this->_formatMeta(),
             'Physical'    => $this->_formatPhysical(),
             'Description' => $this->_formatDescription(),
             'Dimensions'  => $this->_formatDimensions(),
             'ScannerInfo' => $this->_formatScannerInfo(),
-        );
+        ];
     }
 
     /**
@@ -78,11 +78,11 @@ class Summary
         $visitlabel = $this->_visit->getVisitLabel();
         $filename   = $this->_image->getFileInfo()->getFilename();
 
-        return array(
+        return [
             'CandID' => $candid,
             'Visit'  => $visitlabel,
             'File'   => $filename,
-        );
+        ];
     }
 
     /**
@@ -97,12 +97,12 @@ class Summary
         $ti = $this->_image->getHeader('acquisition:inversion_time');
         $st = $this->_image->getHeader('acquisition:slice_thickness');
 
-        return array(
+        return [
             'TE'             => $te,
             'TR'             => $tr,
             'TI'             => $ti,
             'SliceThickness' => $st,
-        );
+        ];
     }
 
     /**
@@ -115,10 +115,10 @@ class Summary
         $sn = $this->_image->getHeader('acquisition:protocol');
         $sd = $this->_image->getHeader('acquisition:series_description');
 
-        return array(
+        return [
             'SeriesName'        => $sn,
             'SeriesDescription' => $sd,
-        );
+        ];
     }
 
     /**
@@ -129,11 +129,11 @@ class Summary
     private function _formatDimensions(): array
     {
 
-        $dimensions = array(
+        $dimensions = [
             'XSpace' => $this->_getDimension('xspace'),
             'YSpace' => $this->_getDimension('yspace'),
             'ZSpace' => $this->_getDimension('zspace'),
-        );
+        ];
 
         $order = $this->_image->getHeader("image:dimorder");
         if (count(explode(',', $order)) == 4) {
@@ -152,10 +152,10 @@ class Summary
      */
     private function _getDimension(string $dim): array
     {
-        return array(
+        return [
             'Length'   => $this->_image->getHeader("$dim:length"),
             'StepSize' => $this->_image->getHeader("$dim:step"),
-        );
+        ];
     }
 
     /**
@@ -171,13 +171,13 @@ class Summary
         $serialnumber    = $this->_image->getHeader('study:serial_no');
         $fieldstrength   = $this->_image->getHeader('study:field_value');
 
-        return array(
+        return [
             'Manufacturer'    => $manufacturer,
             'Model'           => $model,
             'SoftwareVersion' => $softwareversion,
             'SerialNumber'    => $serialnumber,
             'FieldStrength'   => $fieldstrength,
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/image/qc.class.inc
+++ b/modules/api/php/views/visit/image/qc.class.inc
@@ -48,11 +48,11 @@ class Qc
      */
     public function toArray(): array
     {
-        $meta = array(
+        $meta = [
             'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
             'File'   => $this->_image->getFileInfo()->getFilename(),
-        );
+        ];
 
         $imageqcstatus = $this->_image->getQcStatus();
 
@@ -61,23 +61,23 @@ class Qc
 
         $caveats = array_map(
             function ($caveat) {
-                return array(
+                return [
                     'Severity'   => $caveat->getSeverity(),
                     'Header'     => $caveat->getHeader(),
                     'Value'      => $caveat->getValue(),
                     'ValidRange' => $caveat->getValidRange(),
                     'ValidRegex' => $caveat->getValidRegex(),
-                );
+                ];
             },
             $this->_image->getCaveats()
         );
 
-        return array(
+        return [
             'Meta'     => $meta,
             'QC'       => $qc,
             'Selected' => $selected,
             'Caveats'  => $caveats,
-        );
+        ];
     }
 }
 

--- a/modules/api/php/views/visit/images.class.inc
+++ b/modules/api/php/views/visit/images.class.inc
@@ -47,25 +47,25 @@ class Images
      */
     public function toArray(): array
     {
-        $meta = array(
+        $meta = [
             'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
-        );
+        ];
 
         $imagesdata = array_map(
             function ($image) {
-                return array(
+                return [
                     'OutputType'      => $image->getOutputType(),
                     'Filename'        => $image->getFilename(),
                     'AcquisitionType' => $image->getAcquisitionprotocol(),
-                );
+                ];
             },
             $this->_images
         );
 
-        return array(
+        return [
             'Meta'  => $meta,
             'Files' => $imagesdata,
-        );
+        ];
     }
 }

--- a/modules/api/php/views/visit/instrument.class.inc
+++ b/modules/api/php/views/visit/instrument.class.inc
@@ -57,17 +57,17 @@ class Instrument
 
         $isDDE = strpos($instrumentdata['CommentID'], 'DDE_') === 0;
 
-        $meta = array(
+        $meta = [
             'Candidate'  => $this->_timepoint->getCandID(),
             'Visit'      => $this->_timepoint->getVisitLabel(),
             'DDE'        => $isDDE,
             'Instrument' => $instrumentname,
-        );
+        ];
 
-        $instrument = array($instrumentname => $instrumentdata);
+        $instrument = [$instrumentname => $instrumentdata];
 
         return array_merge(
-            array('Meta' => $meta),
+            ['Meta' => $meta],
             $instrument
         );
     }

--- a/modules/api/php/views/visit/instruments.class.inc
+++ b/modules/api/php/views/visit/instruments.class.inc
@@ -43,14 +43,19 @@ class Instruments
      */
     public function toArray(): array
     {
+<<<<<<< HEAD
         $meta = array(
             'CandID' => $this->_timepoint->getCandID(),
+=======
+        $meta = [
+            'CandID' => (string) $this->_timepoint->getCandID(),
+>>>>>>> e60320c89... Remove all long arrays
             'Visit'  => $this->_timepoint->getVisitLabel(),
-        );
+        ];
 
-        return array(
+        return [
             'Meta'        => $meta,
             'Instruments' => $this->_timepoint->getInstrumentNames(),
-        );
+        ];
     }
 }

--- a/modules/api/php/views/visit/instruments.class.inc
+++ b/modules/api/php/views/visit/instruments.class.inc
@@ -43,13 +43,8 @@ class Instruments
      */
     public function toArray(): array
     {
-<<<<<<< HEAD
-        $meta = array(
-            'CandID' => $this->_timepoint->getCandID(),
-=======
         $meta = [
-            'CandID' => (string) $this->_timepoint->getCandID(),
->>>>>>> e60320c89... Remove all long arrays
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
         ];
 

--- a/modules/api/php/views/visit/qc.class.inc
+++ b/modules/api/php/views/visit/qc.class.inc
@@ -48,18 +48,23 @@ class Qc
      */
     public function toArray(): array
     {
+<<<<<<< HEAD
         $meta = array(
             'CandID' => $this->_timepoint->getCandID(),
+=======
+        $meta = [
+            'CandID' => (string) $this->_timepoint->getCandID(),
+>>>>>>> e60320c89... Remove all long arrays
             'Visit'  => $this->_timepoint->getVisitLabel(),
-        );
+        ];
 
         $sessionqc = $this->_qc->getQC();
         $ispending = $this->_qc->getQCPending();
 
-        return array(
+        return [
             'Meta'      => $meta,
             'SessionQC' => $sessionqc,
             'Pending'   => $ispending === 'N' ? false : true,
-        );
+        ];
     }
 }

--- a/modules/api/php/views/visit/qc.class.inc
+++ b/modules/api/php/views/visit/qc.class.inc
@@ -48,13 +48,8 @@ class Qc
      */
     public function toArray(): array
     {
-<<<<<<< HEAD
-        $meta = array(
-            'CandID' => $this->_timepoint->getCandID(),
-=======
         $meta = [
-            'CandID' => (string) $this->_timepoint->getCandID(),
->>>>>>> e60320c89... Remove all long arrays
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
         ];
 

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -91,7 +91,7 @@ class LoginTest extends TestCase
             ->willReturn('jwt_token');
 
         $request = $this->_request
-            ->withAttribute('pathparts', array('login'))
+            ->withAttribute('pathparts', ['login'])
             ->withAttribute('LORIS-API-Version', 'v0.0.3-dev')
             ->withAttribute('user', new \LORIS\AnonymousUser())
             ->withMethod('POST')
@@ -109,7 +109,7 @@ class LoginTest extends TestCase
         );
 
         $this->assertEquals(
-            array('token' => 'jwt_token'),
+            ['token' => 'jwt_token'],
             json_decode((string) $response->getBody(), true)
         );
     }

--- a/modules/battery_manager/php/battery_manager.class.inc
+++ b/modules/battery_manager/php/battery_manager.class.inc
@@ -82,9 +82,9 @@ class Battery_Manager extends \NDB_Page
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/battery_manager/js/batteryManagerIndex.js",
-            )
+            ]
         );
     }
 }

--- a/modules/battery_manager/php/test.class.inc
+++ b/modules/battery_manager/php/test.class.inc
@@ -68,7 +68,7 @@ class Test implements \LORIS\Data\DataInstance
      */
     public function toSQL() : array
     {
-        return array(
+        return [
             'ID'           => $this->row['id']              ?? null,
             'Test_name'    => $this->row['testName']        ?? null,
             'AgeMinDays'   => $this->row['ageMinDays']      ?? null,
@@ -80,6 +80,6 @@ class Test implements \LORIS\Data\DataInstance
             'firstVisit'   => $this->row['firstVisit']      ?? null,
             'instr_order'  => $this->row['instrumentOrder'] ?? null,
             'Active'       => $this->row['active']          ?? null,
-        );
+        ];
     }
 }

--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -192,7 +192,7 @@ class TestEndpoint implements RequestHandlerInterface
                          firstVisit
                   FROM test_battery";
         // Select duplicate entry from Test Battery
-        $entries = $this->db->pselect($query, array());
+        $entries = $this->db->pselect($query, []);
 
         $testArray = $test->toSQL();
         foreach ($entries as $entry) {

--- a/modules/battery_manager/php/testoptionsendpoint.class.inc
+++ b/modules/battery_manager/php/testoptionsendpoint.class.inc
@@ -58,7 +58,7 @@ class TestOptionsEndpoint extends \NDB_Page
      */
     private function _getOptions() : array
     {
-        return array(
+        return [
             'instruments' => \Utility::getAllInstruments(),
             'stages'      => $this->_getStageList(),
             'subprojects' => \Utility::getSubprojectList(null),
@@ -66,7 +66,7 @@ class TestOptionsEndpoint extends \NDB_Page
             'sites'       => \Utility::getSiteList(false),
             'firstVisit'  => $this->_getYesNoList(),
             'active'      => $this->_getYesNoList(),
-        );
+        ];
     }
 
     /**
@@ -76,14 +76,14 @@ class TestOptionsEndpoint extends \NDB_Page
      */
     private function _getStageList() : array
     {
-        return array(
+        return [
             "Not Started"   => 'Not Started',
             "Screening"     => 'Screening',
             "Visit"         => 'Visit',
             "Approval"      => "Approval",
             "Subject"       => "Subject",
             "Recycling Bin" => "Recycling Bin",
-        );
+        ];
     }
 
     /**
@@ -93,10 +93,10 @@ class TestOptionsEndpoint extends \NDB_Page
      */
     private function _getYesNoList() : array
     {
-        return array(
+        return [
             'Y' => 'Yes',
             'N' => 'No',
-        );
+        ];
     }
 }
 

--- a/modules/battery_manager/php/testprovisioner.class.inc
+++ b/modules/battery_manager/php/testprovisioner.class.inc
@@ -52,7 +52,7 @@ class TestProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
           LEFT JOIN subproject s USING (SubprojectID)
           LEFT JOIN psc p USING (CenterID)
         ORDER BY t.Test_name",
-            array()
+            []
         );
     }
 

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -36,7 +36,7 @@ class BatteryManagerTest extends LorisIntegrationTest
      */
     function testLoadsWithPermissionRead()
     {
-        $this->setupPermissions(array("battery_manager_view"));
+        $this->setupPermissions(["battery_manager_view"]);
         $this->safeGet($this->url . "/battery_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -52,7 +52,7 @@ class BatteryManagerTest extends LorisIntegrationTest
      */
     function testDoesNotLoadWithoutPermission()
     {
-        $this->setupPermissions(array());
+        $this->setupPermissions([]);
         $this->safeGet($this->url . "/battery_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/behavioural_qc/ajax/GetCandidates.php
+++ b/modules/behavioural_qc/ajax/GetCandidates.php
@@ -25,7 +25,7 @@ if (!$user->hasPermission('quality_control')) {
 }
 
 $db          =& Database::singleton();
-$searchArray = array();
+$searchArray = [];
 
     $query = "SELECT DISTINCT ses.candID FROM session AS ses
                 JOIN test_battery AS tst
@@ -46,7 +46,7 @@ if (isset($_REQUEST['instrument']) && !empty($_REQUEST['instrument'])
 
 $result = $db->pselect($query, $searchArray);
 
-$flattened_result = array();
+$flattened_result = [];
 
 if ($result == null) {
     $flattened_result[0] = "Not found";
@@ -56,7 +56,7 @@ if ($result == null) {
     }
 }
 
-$response = array();
+$response = [];
 $response["suggestions"] = $flattened_result;
 print json_encode($response);
 

--- a/modules/behavioural_qc/ajax/GetInstruments.php
+++ b/modules/behavioural_qc/ajax/GetInstruments.php
@@ -34,7 +34,7 @@ header("content-type:application/json");
 require_once "Utility.class.inc";
 
 //Array containing the JSON information to return.
-$flattened_result = array();
+$flattened_result = [];
 //gets the given visit_label and returns the instrument
 
 //If all visits are selected return all visits

--- a/modules/behavioural_qc/php/behavioural_qc.class.inc
+++ b/modules/behavioural_qc/php/behavioural_qc.class.inc
@@ -78,7 +78,7 @@ class Behavioural_QC extends \NDB_Form
             $candID = $sanitize['candidate'];
         } elseif (isset($sanitize['PSCID']) && !empty($sanitize['PSCID'])) {
             $query   = "SELECT CandID FROM candidate WHERE PSCID = :PID";
-            $qparams = (array('PID' => $sanitize['PSCID']));
+            $qparams = (['PID' => $sanitize['PSCID']]);
             $candID  = $DB->pselectOne($query, $qparams);
         }
 
@@ -96,19 +96,19 @@ class Behavioural_QC extends \NDB_Form
          */
         $visit_array   =\Utility::getExistingVisitLabels();
         $visit_array   = array_combine($visit_array, $visit_array);
-        $list_of_sites = array();
+        $list_of_sites = [];
         $this->tpl_data['visitLabels'] = $visit_array;
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites      = \Utility::getSiteList();
-            $default_site_array =array('All Sites' => 'All Sites');
+            $default_site_array =['All Sites' => 'All Sites'];
             if (is_array($list_of_sites)) {
                 $list_of_sites = $default_site_array + $list_of_sites;
             }
         } else {
             // allow only to view own study site data
             $list_of_sites      = $user->getStudySites();
-            $default_site_array =array('All User Sites' => 'All User Sites');
+            $default_site_array =['All User Sites' => 'All User Sites'];
             $list_of_sites      = $default_site_array + $list_of_sites;
         }
         $this->tpl_data['siteList'] = $list_of_sites;
@@ -209,7 +209,7 @@ class Behavioural_QC extends \NDB_Form
     ) {
 
         $DB      =& \Database::singleton();
-        $qparams = array();
+        $qparams = [];
 
         $select = "SELECT fb.FeedbackID, fb.CandID, fb.SessionID,
                       fb.CommentID, fb.Feedback_level, f.Test_name, fb.FieldName,
@@ -262,7 +262,7 @@ class Behavioural_QC extends \NDB_Form
 
             $query = $select . $where;
 
-            $results = array();
+            $results = [];
             foreach ($field_names as $field) {
                 $qparams['FN'] = $field["SourceField"];
                 $result        = $DB->pselect($query, $qparams);
@@ -342,10 +342,10 @@ class Behavioural_QC extends \NDB_Form
     ) {
 
         global $DB;
-        $conflicts = array();
+        $conflicts = [];
         //if test_name exists and candidate is not set
 
-        $qparams = array();
+        $qparams = [];
 
         if ($DB->ColumnExists($test_name, 'Test_name_display')) {
             $query = "SELECT DISTINCT s.CandID,ca.PSCID, c.FieldName,
@@ -427,7 +427,7 @@ class Behavioural_QC extends \NDB_Form
         //Do for each instrument....one shot....
         //And then extract the specific info through template..
         global $DB;
-        $conflicts = array();
+        $conflicts = [];
         if ($DB->ColumnExists($test_name, 'Test_name_display')) {
 
             $query = "SELECT DISTINCT s.CandID, ca.PSCID, c.FieldName,
@@ -463,10 +463,10 @@ class Behavioural_QC extends \NDB_Form
         }
         $conflicts = $DB->pselect(
             $query,
-            array(
+            [
                 'TN' => $test_name,
                 'FN' => $field_name,
-            )
+            ]
         );
         return $conflicts;
     }
@@ -519,7 +519,7 @@ class Behavioural_QC extends \NDB_Form
                 AND (f.commentid NOT LIKE 'DDE_%')
             ";
         }
-        $qparams = array();
+        $qparams = [];
 
         //filter for testname
         if (($test_name !=null)&&($test_name!='All Instruments')) {
@@ -594,7 +594,7 @@ class Behavioural_QC extends \NDB_Form
             JOIN psc ON (s.CenterID = psc.CenterID)	";
         }
 
-        $qparams = array();
+        $qparams = [];
 
         $where =" WHERE s.Active='Y'
             AND c.Active='Y'
@@ -674,7 +674,7 @@ class Behavioural_QC extends \NDB_Form
             AND f.Data_entry = 'Complete'
             AND psc.Centerid!= '1'
             AND c.Entity_type != 'Scanner'";
-        $qparams = array();
+        $qparams = [];
 
         if (($visit_label !=null)&&($visit_label!='All Visits')) {
             $where        .= " AND s.Visit_label = :VL";
@@ -772,7 +772,7 @@ class Behavioural_QC extends \NDB_Form
                     " WHERE Test_name_display=:display";
                 $test_name    = $DB->pselectOne(
                     $sqlSelectOne,
-                    array('display' => $full_name)
+                    ['display' => $full_name]
                 );
             } else {
                 $test_name = \Utility::getTestNameUsingFullName($full_name);
@@ -797,7 +797,7 @@ class Behavioural_QC extends \NDB_Form
         if ($DB->ColumnExists('test_battery', 'Test_name_display')) {
             $sqlSelect  = "SELECT distinct Test_name_display".
                 " from test_battery where Visit_label =:vl";
-            $test_names = $DB->pselect($sqlSelect, array('vl' => $visit_label));
+            $test_names = $DB->pselect($sqlSelect, ['vl' => $visit_label]);
         } else {
             $test_names = $DB->pselect(
                 "SELECT DISTINCT t.Full_name as Test_name_display 
@@ -811,7 +811,7 @@ class Behavioural_QC extends \NDB_Form
                         AND psc.CenterID != '1'
                         AND c.Entity_type != 'Scanner'
                         ORDER BY t.Full_name ",
-                array('vl' => $visit_label)
+                ['vl' => $visit_label]
             );
         }
 
@@ -831,9 +831,9 @@ class Behavioural_QC extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/behavioural_qc/js/behavioural_qc.js",
-            )
+            ]
         );
     }
 

--- a/modules/behavioural_qc/test/behavioural_qcTest.php
+++ b/modules/behavioural_qc/test/behavioural_qcTest.php
@@ -46,7 +46,7 @@ class Behavioural_QCTest extends LorisIntegrationTest
       */
     function testBehaviouralQCWithoutPermission()
     {
-         $this->setupPermissions(array());
+         $this->setupPermissions([]);
          $this->safeGet($this->url . "/behavioural_qc/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
@@ -64,7 +64,7 @@ class Behavioural_QCTest extends LorisIntegrationTest
      */
     function testBehaviouralQCPermission()
     {
-         $this->setupPermissions(array("quality_control"));
+         $this->setupPermissions(["quality_control"]);
          $this->safeGet($this->url . "/behavioural_qc/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/brainbrowser/ajax/getImageName.php
+++ b/modules/brainbrowser/ajax/getImageName.php
@@ -18,14 +18,14 @@ require_once "Utility.class.inc";
 $DB = Database::singleton();
 
 $query = "select File from files where FileID = :FileID";
-$file  = $DB->pselectOne($query, array('FileID' => $_REQUEST['file_id']));
+$file  = $DB->pselectOne($query, ['FileID' => $_REQUEST['file_id']]);
 $file  = substr($file, strrpos($file, '/') + 1);
 
 // create a JSON object with the file information
-$result = array(
+$result = [
     'filename' => $file,
     'fileid'   => $_REQUEST['file_id'],
-);
+];
 
 echo json_encode($result);
 

--- a/modules/brainbrowser/ajax/image.php
+++ b/modules/brainbrowser/ajax/image.php
@@ -32,16 +32,16 @@ if (strpos($_REQUEST['file_id'], 'l') !== false) {
     }
 
     if (!empty($query)) {
-        $image_file = $DB->pselectOne($query, array('LogID' => $id));
+        $image_file = $DB->pselectOne($query, ['LogID' => $id]);
         $image_path = getFileLocation() . $image_file;
     }
 } else {
     $query      = "select File from files where FileID = :FileID";
     $image_file = $DB->pselectOne(
         $query,
-        array(
+        [
             'FileID' => $_REQUEST['file_id'],
-        )
+        ]
     );
     $image_path = getFileLocation() . $image_file;
 }

--- a/modules/brainbrowser/php/brainbrowser.class.inc
+++ b/modules/brainbrowser/php/brainbrowser.class.inc
@@ -37,11 +37,11 @@ class Brainbrowser extends \NDB_Page
         * part of a study site and are permitted to view their own site.
          */
         return $user->hasAnyPermission(
-            array(
+            [
                 'imaging_browser_view_allsites',
                 'imaging_browser_phantom_allsites',
                 'imaging_browser_phantom_ownsite',
-            )
+            ]
         )
         || (
             $user->hasStudySite()
@@ -63,14 +63,14 @@ class Brainbrowser extends \NDB_Page
         $deps = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/brainbrowser/js/Brainbrowser.js",
                 $baseURL . "/brainbrowser/js/jquery.mousewheel.min.js",
                 $baseURL . "/brainbrowser/js/three.min.js",
                 $baseURL . "/brainbrowser/js/brainbrowser.volume-viewer.min.js",
                 $baseURL . "/brainbrowser/js/brainbrowser.config.js",
                 $baseURL . "/brainbrowser/js/brainbrowser.loris.js",
-            )
+            ]
         );
     }
 

--- a/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/close_bvl_feedback_thread.php
@@ -22,14 +22,14 @@ try {
 } catch (\DomainException $e) {
     header("HTTP/1.1 400 Bad Request");
     header("Content-Type: application/json");
-    print json_encode(array('error' => 'invalid candID'));
+    print json_encode(['error' => 'invalid candID']);
     exit;
 }
 
 if (!isset($_POST['feedbackID'])) {
     header("HTTP/1.1 400 Bad Request");
     header("Content-Type: application/json");
-    print json_encode(array('error' => 'Missing FeedbackID'));
+    print json_encode(['error' => 'Missing FeedbackID']);
     exit;
 }
 
@@ -46,7 +46,7 @@ try {
     header("HTTP/1.1 404 Not Found");
     header("Content-Type: application/json");
     print json_encode(
-        array('error' => 'The requested feedback thread can`t be found')
+        ['error' => 'The requested feedback thread can`t be found']
     );
     exit;
 }
@@ -55,7 +55,7 @@ if ($closethreadcount === 0) {
     header("HTTP/1.1 500 Internal Server Error");
     header("Content-Type: application/json");
     print json_encode(
-        array('error' => 'No feedback thread updated')
+        ['error' => 'No feedback thread updated']
     );
     exit;
 }

--- a/modules/bvl_feedback/ajax/new_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/new_bvl_feedback.php
@@ -17,7 +17,7 @@ ini_set('default_charset', 'utf-8');
 require_once "bvl_panel_ajax.php";
 
 //Creating a new array to pass the set values into the DB.
-$newThreadValues = array();
+$newThreadValues = [];
 
 //For profile level feedback
 if (isset($_POST['comment']) && isset($_POST['candID'])

--- a/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
@@ -19,7 +19,7 @@ if (! \Utility::valueIsPositiveInteger($feedbackID)) {
     header("HTTP/1.1 400 Bad Request");
     header("Content-Type: application/json");
     print json_encode(
-        array('error' => 'feedbackId missing or invalid')
+        ['error' => 'feedbackId missing or invalid']
     );
     exit;
 }
@@ -33,7 +33,7 @@ if ($openedthreadcount === 0) {
     header("HTTP/1.1 500 Internal Server Error");
     header("Content-Type: application/json");
     print json_encode(
-        array('error' => 'No feedback thread updated')
+        ['error' => 'No feedback thread updated']
     );
     exit;
 }

--- a/modules/bvl_feedback/ajax/thread_comment_bvl_feedback.php
+++ b/modules/bvl_feedback/ajax/thread_comment_bvl_feedback.php
@@ -19,7 +19,7 @@ require "bvl_panel_ajax.php";
 $user     =& User::singleton();
 $username = $user->getUsername();
 
-$newEntryValues = array();
+$newEntryValues = [];
 
 if (isset($_POST['comment']) && isset($_POST['feedbackID'])) {
     $newEntryValues = $feedbackThread->createEntry(

--- a/modules/bvl_feedback/php/module.class.inc
+++ b/modules/bvl_feedback/php/module.class.inc
@@ -76,9 +76,9 @@ class Module extends \Module
                 JOIN feedback_bvl_type fbt USING (Feedback_type)
                 WHERE fbth.Status='opened' AND fbth.Active='Y'
                 ORDER BY Testdate DESC LIMIT 4",
-                array()
+                []
             );
-            $frontend_feedback = array();
+            $frontend_feedback = [];
             foreach ($bvl_feedback as $row) {
                 if (new \DateTime($row['Testdate']) > $last_login) {
                     $row['new'] = true;
@@ -99,7 +99,7 @@ class Module extends \Module
                 case 'instrument':
                     $instrument = $DB->pselectOne(
                         "SELECT Test_name from flag WHERE CommentID=:cid",
-                        array('cid' => $row['CommentID'])
+                        ['cid' => $row['CommentID']]
                     );
                     if (!empty($instrument)) {
                         $url = '/instruments/'. $instrument

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -86,21 +86,21 @@ class Candidate_List extends \DataFrameworkMenu
         } else {
             $list_of_sites = $user->getStudySites();
         }
-        $site_options = array();
+        $site_options = [];
         foreach ($list_of_sites as $id => $name) {
             $site_options[$name] = $name;
         }
 
         // get the list of projects
         $list_of_projects = \Utility::getProjectList();
-        $project_options  = array();
+        $project_options  = [];
         foreach ($list_of_projects as $id => $name) {
             $project_options[$name] = $name;
         }
 
         // get the list of subprojects
         $list_of_subprojects = \Utility::getSubprojectList();
-        $subproject_options  = array();
+        $subproject_options  = [];
         foreach ($list_of_subprojects as $id => $name) {
             $subproject_options[$name] = $name;
         }
@@ -108,7 +108,7 @@ class Candidate_List extends \DataFrameworkMenu
         // get the list participant status options
         $list_of_participant_status
             = \Candidate::getParticipantStatusOptions();
-        $participant_status_options = array();
+        $participant_status_options = [];
         foreach ($list_of_participant_status as $id => $name) {
             $participant_status_options[$name] = $name;
         }
@@ -136,9 +136,9 @@ class Candidate_List extends \DataFrameworkMenu
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/candidate_list/js/candidateListIndex.js",
-            )
+            ]
         );
     }
 

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -75,7 +75,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
                 GROUP BY c.CandID, psc.Name, c.PSCID, c.Sex
                 ORDER BY c.PSCID ASC
             ",
-            array()
+            []
         );
     }
 

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -69,7 +69,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
      */
     function testPageLoadsWithoutPermissionsAccessAllProfiles()
     {
-        $this->setupPermissions(array("access_all_profiles"));
+        $this->setupPermissions(["access_all_profiles"]);
         $this->safeGet($this->url . "/candidate_list/");
         $bodyText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector("body"))->getText();
@@ -239,7 +239,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
      */
     function testDataEntryAndOpenProfile()
     {
-        $this->setupPermissions(array("data_entry"));
+        $this->setupPermissions(["data_entry"]);
         $this->safeGet($this->url . "/candidate_list/");
         //click open profile button
         $btn = self::$openProfile;

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -106,7 +106,7 @@ function editCandInfoFields($db, $user)
 
     $db->update('candidate', $updateValues, ['CandID' => $candID]);
 
-    foreach (array_keys($_POST ?? array()) as $field) {
+    foreach (array_keys($_POST ?? []) as $field) {
         if (!empty($_POST[$field])) {
             if (substr($field, 0, 4) === 'PTID') {
                 $ptid = substr($field, 4);
@@ -520,10 +520,10 @@ function editConsentStatusFields($db, $user)
                 $db->update(
                     'candidate_consent_rel',
                     $updateStatus,
-                    array(
+                    [
                         'CandidateID' => $candID,
                         'ConsentID'   => $consentID,
-                    )
+                    ]
                 );
             } else {
                 $db->insert('candidate_consent_rel', $updateStatus);
@@ -556,8 +556,8 @@ function editCandidateDOB(\Database $db, \User $user): void
         }
         $db->update(
             'candidate',
-            array('DoB' => $strippedDate ?? $dob),
-            array('CandID' => $candID->__toString())
+            ['DoB' => $strippedDate ?? $dob],
+            ['CandID' => $candID->__toString()]
         );
     }
 }
@@ -593,8 +593,8 @@ function editCandidateDOD(\Database $db, \User $user): void
         }
         $db->update(
             'candidate',
-            array('DoD' => $strippedDate ?? $dodString),
-            array('CandID' => $candID->__toString())
+            ['DoD' => $strippedDate ?? $dodString],
+            ['CandID' => $candID->__toString()]
         );
     }
 }

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -16,10 +16,10 @@ use \LORIS\StudyEntities\Candidate\CandID;
 
 $user = \NDB_Factory::singleton()->user();
 if (!$user->hasAnyPermission(
-    array(
+    [
         'candidate_parameter_edit',
         'candidate_parameter_view'
-    )
+    ]
 )
 ) {
     header("HTTP/1.1 403 Forbidden");
@@ -75,7 +75,7 @@ function getCandInfoFields()
     $caveat_options = [];
     $options        = $db->pselect(
         "SELECT ID, Description FROM caveat_options",
-        array()
+        []
     );
     foreach ($options as $row) {
         $caveat_options[$row['ID']] = $row['Description'];
@@ -84,22 +84,22 @@ function getCandInfoFields()
     // get pscid
     $pscid = $db->pselectOne(
         'SELECT PSCID FROM candidate WHERE CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $flag = $db->pselectOne(
         'SELECT flagged_caveatemptor FROM candidate WHERE CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $reason = $db->pselectOne(
         'SELECT flagged_reason FROM candidate WHERE CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $other = $db->pselectOne(
         'SELECT flagged_other FROM candidate WHERE CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $extra_parameters = $db->pselect(
@@ -110,13 +110,13 @@ function getCandInfoFields()
         JOIN parameter_type_category ptc USING (ParameterTypeCategoryID)
         WHERE ptc.Name='Candidate Parameters'
         ORDER BY pt.ParameterTypeID, pt.name ASC",
-        array()
+        []
     );
 
     $fields = $db->pselect(
         "SELECT CONCAT('PTID', ParameterTypeID) AS ParameterTypeID, Value 
         FROM parameter_candidate WHERE CandID=:cid",
-        array('cid' => $candID)
+        ['cid' => $candID]
     );
 
     $parameter_values = [];
@@ -154,17 +154,17 @@ function getProbandInfoFields()
     // get pscid
     $pscid = $db->pselectOne(
         'SELECT PSCID FROM candidate where CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $sex = $db->pselectOne(
         'SELECT ProbandSex FROM candidate where CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $dob = $db->pselectOne(
         'SELECT ProbandDoB FROM candidate where CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $extra_parameters = $db->pselect(
@@ -175,13 +175,13 @@ function getProbandInfoFields()
         JOIN parameter_type_category ptc USING (ParameterTypeCategoryID)
         WHERE ptc.Name='Candidate Parameters Proband'
         ORDER BY pt.ParameterTypeID, pt.name ASC",
-        array()
+        []
     );
 
     $fields = $db->pselect(
         "SELECT CONCAT('PTID', ParameterTypeID) AS ParameterTypeID, Value 
          FROM parameter_candidate WHERE CandID=:cid",
-        array('cid' => $candID)
+        ['cid' => $candID]
     );
 
     $parameter_values = [];
@@ -193,7 +193,7 @@ function getProbandInfoFields()
     $ageDifference = "Could not calculate age";
     $candidateDOB  = $db->pselectOne(
         "SELECT DoB FROM candidate WHERE CandID=:CandidateID",
-        array('CandidateID' => $candID)
+        ['CandidateID' => $candID]
     );
     if (!empty($candidateDOB) && !empty($dob)) {
         $age = \Utility::calculateAge($dob, $candidateDOB);
@@ -234,29 +234,29 @@ function getFamilyInfoFields()
     // get pscid
     $pscid = $db->pselectOne(
         'SELECT PSCID FROM candidate where CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $candidatesList = $db->pselect(
         "SELECT CandID FROM candidate ORDER BY CandID",
-        array()
+        []
     );
 
     $siblingsList = $db->pselect(
         "SELECT f1.CandID 
         FROM family f1 JOIN family f2
         ON f1.FamilyID=f2.FamilyID WHERE f2.CandId=:candid GROUP BY f1.CandID",
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
-    $siblings = array();
+    $siblings = [];
     foreach ($siblingsList as $key => $siblingArray) {
         foreach ($siblingArray as $ID) {
             array_push($siblings, $ID);
         }
     }
 
-    $candidates = array();
+    $candidates = [];
     // Remove own ID and sibling IDs from list of possible family members
     foreach ($candidatesList as $key => $candidate) {
         foreach ($candidate as $ID) {
@@ -273,10 +273,10 @@ function getFamilyInfoFields()
         FROM family f1 JOIN family f2 ON f1.FamilyID=f2.FamilyID
         WHERE f2.CandID = :candid AND f1.CandID <> :candid2 
           ORDER BY f1.CandID",
-        array(
+        [
             'candid'  => $candID,
             'candid2' => $candID,
-        )
+        ]
     );
 
     $result = [
@@ -306,34 +306,34 @@ function getParticipantStatusFields()
     // get pscid
     $pscid = $db->pselectOne(
         'SELECT PSCID FROM candidate where CandID = :candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
 
     $statusOptions = \Candidate::getParticipantStatusOptions();
-    $reasonOptions = array();
+    $reasonOptions = [];
 
     $req      = $db->pselect(
         'SELECT ID from participant_status_options where Required=1',
-        array()
+        []
     );
-    $required = array();
+    $required = [];
     foreach ($req as $k=>$row) {
         $required[$k] = $row['ID'];
     }
     $parentIDs   = $db->pselect(
         'SELECT distinct(parentID) from participant_status_options',
-        array()
+        []
     );
-    $parentIDMap = array();
+    $parentIDMap = [];
     foreach ($parentIDs as $ID) {
-        $reasonOptions = array();
+        $reasonOptions = [];
         foreach ($ID as $parentID) {
             if ($parentID != null) {
                 $options = $db->pselect(
                     "SELECT ID, Description 
                     FROM participant_status_options 
                     WHERE parentID=:pid",
-                    array('pid' => $parentID)
+                    ['pid' => $parentID]
                 );
                 foreach ($options as $option) {
                     $reasonOptions[$option['ID']] = $option['Description'];
@@ -391,7 +391,7 @@ function getParticipantStatusHistory(CandID $candID)
               WHERE ID=psh.participant_subOptions) 
               AS suboption,  reason_specify 
             FROM participant_status_history psh WHERE CandID=:cid",
-        array('cid' => $candID)
+        ['cid' => $candID]
     );
 
     return $unformattedComments;
@@ -473,7 +473,7 @@ function getConsentStatusHistory($pscid)
          FROM candidate_consent_history 
          WHERE PSCID=:pscid 
          ORDER BY EntryDate ASC",
-        array('pscid' => $pscid)
+        ['pscid' => $pscid]
     );
 
     $formattedHistory = [];
@@ -510,7 +510,7 @@ function getDOBFields(): array
     // Get PSCID
     $candidateData = $db->pselectRow(
         'SELECT PSCID,DoB FROM candidate where CandID =:candid',
-        array('candid' => $candID->__toString())
+        ['candid' => $candID->__toString()]
     );
     $pscid         = $candidateData['PSCID'] ?? null;
     $dob           = $candidateData['DoB'] ?? null;
@@ -534,7 +534,7 @@ function getDODFields(): array
 
     $candidateData = $db->pselectRow(
         'SELECT PSCID,DoD, DoB FROM candidate where CandID =:candid',
-        array('candid' => $candID)
+        ['candid' => $candID]
     );
     $result        = [
         'pscid'  => $candidateData['PSCID'],

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -41,10 +41,10 @@ class Candidate_Parameters extends \NDB_Form
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'candidate_parameter_view',
                 'candidate_parameter_edit',
-            )
+            ]
         );
     }
 
@@ -70,9 +70,9 @@ class Candidate_Parameters extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/candidate_parameters/js/CandidateParameters.js",
-            )
+            ]
         );
     }
 

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -116,7 +116,7 @@ class Candidate_Profile extends \NDB_Page
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . '/js/components/CSSGrid.js')
+            [$baseURL . '/js/components/CSSGrid.js']
         );
     }
 

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -37,7 +37,7 @@ foreach ($_POST as $key => $value) {
         // Config table with ID == $key.
         if ($value == "") {
             // A blank value is the same as deleting.
-            $DB->delete('Config', array('ID' => $key));
+            $DB->delete('Config', ['ID' => $key]);
         } else {
             if (! noDuplicateInDropdown($key, $value)) {
                 // Don't alter the table if the same key was passed twice.
@@ -62,8 +62,8 @@ foreach ($_POST as $key => $value) {
             // Update the config setting to the new value.
             $DB->update(
                 'Config',
-                array('Value' => $value),
-                array('ID' => $key)
+                ['Value' => $value],
+                ['ID' => $key]
             );
         }
     } else {
@@ -106,16 +106,16 @@ foreach ($_POST as $key => $value) {
             // Add the new setting
             $DB->insert(
                 'Config',
-                array(
+                [
                     'ConfigID' => $ConfigSettingsID, // FK to ConfigSettings.
                     'Value'    => $value,
-                )
+                ]
             );
         } elseif ($action == 'remove') {
             // Delete an entry from the Config table.
             $DB->delete(
                 'Config',
-                array('ID' => $removeID)
+                ['ID' => $removeID]
             );
         } else {
             displayError(400, 'Invalid action');
@@ -137,10 +137,10 @@ function isDuplicate($key, $value): bool
     $DB      = $factory->database();
     $result  = $DB->pselectOne(
         "SELECT COUNT(*) FROM Config WHERE ConfigID =:ConfigID AND Value =:Value",
-        array(
+        [
             'ConfigID' => $key,
             'Value'    => $value,
-        )
+        ]
     );
     return intval($result) > 0;
 }
@@ -159,15 +159,15 @@ function noDuplicateInDropdown($id,$value)
        // ConfigID can be found in the Config table by searching new id.
     $ConfigID = $DB->pselectOne(
         "SELECT ConfigID FROM Config WHERE ID =:ID",
-        array('ID' => $id)
+        ['ID' => $id]
     );
        // IDBefore means that row ID contains the same configID and value pair.
     $IDBefore = $DB->pselectOne(
         "SELECT ID FROM Config WHERE ConfigID =:ConfigID AND Value =:Value",
-        array(
+        [
             'ConfigID' => $ConfigID,
             'Value'    => $value,
-        )
+        ]
     );
        //If the new "id" equals "IDBefore" in Config table means
        //it can be updated in the table. Otherwise, it means Dropdown menu has
@@ -189,7 +189,7 @@ function noDuplicateInDropdown($id,$value)
  */
 function getPathIDs(string $table): array
 {
-    if (! in_array($table, array('Config', 'ConfigSettings', true))) {
+    if (! in_array($table, ['Config', 'ConfigSettings', true])) {
         throw new \LorisException('Table must be "Config" or "ConfigSettings"');
     }
     $query = '';
@@ -208,7 +208,7 @@ function getPathIDs(string $table): array
             . "WHERE DataType = 'web_path';";
         break;
     }
-    return \Database::singleton()->pselectCol($query, array());
+    return \Database::singleton()->pselectCol($query, []);
 }
 
 /**

--- a/modules/configuration/ajax/updateProject.php
+++ b/modules/configuration/ajax/updateProject.php
@@ -31,7 +31,7 @@ $projectAlias  = $_POST['Alias'] ?? '';
 $recTarget     = empty($_POST['recruitmentTarget'])
     ? null : $_POST['recruitmentTarget'];
 $projectID     = $_POST['ProjectID'] ?? null;
-$subprojectIDs = $_POST['SubprojectIDs'] ?? array();
+$subprojectIDs = $_POST['SubprojectIDs'] ?? [];
 
 $project = null;
 
@@ -40,7 +40,7 @@ if ($projectID == 'new') {
     // Give Conflict response if this project already exists.
     if (in_array($_POST['Name'], $ProjectList, true)) {
         http_response_code(409);
-        echo json_encode(array('error' => 'Conflict'));
+        echo json_encode(['error' => 'Conflict']);
         exit;
     }
 
@@ -70,6 +70,6 @@ if (!empty($subprojectIDs)) {
 }
 
 http_response_code(200);
-echo json_encode(array('ok' => 'Success'));
+echo json_encode(['ok' => 'Success']);
 exit;
 

--- a/modules/configuration/ajax/updateSubproject.php
+++ b/modules/configuration/ajax/updateSubproject.php
@@ -33,12 +33,12 @@ if ($_POST['subprojectID'] === 'new') {
     if (!in_array($_POST['title'], $SubprojectList) && !empty($_POST['title'])) {
         $db->insert(
             "subproject",
-            array(
+            [
                 "title"             => $_POST['title'],
                 "useEDC"            => $_POST['useEDC'],
                 "WindowDifference"  => $_POST['WindowDifference'],
                 "RecruitmentTarget" => $recTarget,
-            )
+            ]
         );
     } else {
         header("HTTP/1.1 409 Conflict");
@@ -48,13 +48,13 @@ if ($_POST['subprojectID'] === 'new') {
 } else {
     $db->update(
         "subproject",
-        array(
+        [
             "title"             => $_POST['title'],
             "useEDC"            => $_POST['useEDC'],
             "WindowDifference"  => $_POST['WindowDifference'],
             "RecruitmentTarget" => $recTarget,
-        ),
-        array("SubprojectID" => $_POST['subprojectID'])
+        ],
+        ["SubprojectID" => $_POST['subprojectID']]
     );
 }
 header("HTTP/1.1 200 OK");

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -53,9 +53,9 @@ class Configuration extends \NDB_Form
         $scans      = $DB->pselect(
             "SELECT Scan_type
              FROM mri_scan_type",
-            array()
+            []
         );
-        $scan_types = array('' => '');
+        $scan_types = ['' => ''];
         foreach ($scans as $type) {
             $val = $type['Scan_type'];
             $scan_types[$val] = $val;
@@ -69,11 +69,11 @@ class Configuration extends \NDB_Form
         $this->tpl_data['instruments']     = $instruments;
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
         $this->tpl_data['scan_types']      = $scan_types;
-        $this->tpl_data['lookup_center']   = array(
+        $this->tpl_data['lookup_center']   = [
             ''            => '',
             'PatientID'   => 'PatientID',
             'PatientName' => 'PatientName',
-        );
+        ];
     }
 
     /**
@@ -90,7 +90,7 @@ class Configuration extends \NDB_Form
             "SELECT Label, Name 
              FROM ConfigSettings 
              WHERE Parent IS NULL AND Visible=1 ORDER BY OrderNumber",
-            array()
+            []
         );
 
         return $parentConfigItems;
@@ -111,7 +111,7 @@ class Configuration extends \NDB_Form
         // Get the names and meta-information for the config settings in the database
         $configs = $this->DB->pselect(
             "SELECT * FROM ConfigSettings WHERE Visible=1 ORDER BY OrderNumber",
-            array()
+            []
         );
 
         // Check whether any setting is overwritten in the config.xml
@@ -139,7 +139,7 @@ class Configuration extends \NDB_Form
             if ($setting['Disabled'] == 'No') {
                 $value = $this->DB->pselect(
                     "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
-                    array('ID' => $setting['ID'])
+                    ['ID' => $setting['ID']]
                 );
                 if ($value) {
                     foreach ($value as $subvalue) {
@@ -150,9 +150,9 @@ class Configuration extends \NDB_Form
         }
 
         // build a tree from configs array
-        $tree = array();
+        $tree = [];
         foreach ($configs as &$node) {
-            $node['Children']  = array();
+            $node['Children']  = [];
             $tree[$node['ID']] = &$node;
 
         }
@@ -176,9 +176,9 @@ class Configuration extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/configuration/js/configuration_helper.js",
-            )
+            ]
         );
     }
 

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -52,7 +52,7 @@ class Project extends \NDB_Form
         $config         = $factory->config();
         $projectList    = \Utility::getProjectList();
         $subprojectList = \Utility::getSubprojectList();
-        $projects       = array();
+        $projects       = [];
         foreach (array_keys($projectList) as $ProjectID) {
             $projects[$ProjectID] = $config->getProjectSettings($ProjectID);
             $projects[$ProjectID]['projectSubprojects']

--- a/modules/configuration/php/subproject.class.inc
+++ b/modules/configuration/php/subproject.class.inc
@@ -50,7 +50,7 @@ class Subproject extends \NDB_Form
         $config  = $factory->config();
 
         $subprojectList = \Utility::getSubprojectList();
-        $subprojects    = array();
+        $subprojects    = [];
         foreach (array_keys($subprojectList) as $subprojectID) {
             $subprojects[$subprojectID]
                 = $config->getSubprojectSettings(intval($subprojectID));
@@ -58,15 +58,15 @@ class Subproject extends \NDB_Form
         $this->tpl_data['subprojects'] = $subprojects;
 
         $this->tpl_data['useEDCOptions']
-            = array(
+            = [
                 '1' => 'Yes',
                 '0' => 'No',
-            );
+            ];
 
         $this->tpl_data['WindowDifferenceOptions']
-            = array(
+            = [
                 'battery' => 'Closest Test Battery',
                 'optimal' => 'Optimal Visit Window for Visit Label',
-            );
+            ];
     }
 }

--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -50,7 +50,7 @@ class ConfigurationTest extends LorisIntegrationTest
     {
         $this->DB->delete(
             "subproject",
-            array('title' => 'Test Test Test')
+            ['title' => 'Test Test Test']
         );
         parent::tearDown();
     }
@@ -79,7 +79,7 @@ class ConfigurationTest extends LorisIntegrationTest
      */
     public function testConfigPermission()
     {
-         $this->setupPermissions(array("config"));
+         $this->setupPermissions(["config"]);
          $this->safeGet($this->url . "/configuration/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -94,7 +94,7 @@ class ConfigurationTest extends LorisIntegrationTest
      */
     public function testConfigWithoutPermission()
     {
-         $this->setupPermissions(array());
+         $this->setupPermissions([]);
          $this->safeGet($this->url . "/configuration/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/configuration/tools/import_projects.php
+++ b/modules/configuration/tools/import_projects.php
@@ -53,12 +53,12 @@ if ((isset($argv[$optionpos]) && $argv[$optionpos] === "-s")
         if (isset($row['options']) && isset($row['options']['WindowDifference'])) {
             $windowDiff = $row['options']['WindowDifference'];
         }
-        $ins = array(
+        $ins = [
             'SubprojectID'     => $row['id'],
             'title'            => $row['title'],
             'useEDC'           => 0,
             'WindowDifference' => $windowDiff,
-        );
+        ];
         if ($row['options']['useEDC'] === '1'
             || $row['options']['useEDC'] === 'true'
         ) {
@@ -81,11 +81,11 @@ if ((isset($argv[$optionpos]) && $argv[$optionpos] === "-p")
     }
     $db = $factory->database();
     foreach ($projects['project'] as $row) {
-        $insert = array(
+        $insert = [
             'ProjectID'         => $row['id'],
             'Name'              => $row['title'],
             'recruitmentTarget' => $row['recruitmentTarget'],
-        );
+        ];
         $insert = Utility::nullifyEmpty($insert, 'recruitmentTarget');
         $db->insert('Project', $insert);
     }

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -74,19 +74,19 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                     JOIN candidate c ON (c.CandID=s.CandID)
                     WHERE MD5(CONCAT_WS(':',TableName, ExtraKeyColumn, ExtraKey1,
                         ExtraKey2, FieldName, CommentId1, CommentId2)) = :hash",
-                    array('hash' => $hash)
+                    ['hash' => $hash]
                 );
                 if (!empty($row)) {
                     // insert into conflicts_resolved
                     $user1         = $DB->pselectOne(
                         "SELECT UserID FROM flag WHERE CommentID=:CID",
-                        array('CID' => $row['CommentId1'])
+                        ['CID' => $row['CommentId1']]
                     );
                     $user2         = $DB->pselectOne(
                         "SELECT UserID FROM flag WHERE CommentID=:CID",
-                        array('CID' => $row['CommentId2'])
+                        ['CID' => $row['CommentId2']]
                     );
-                    $resolutionLog = array(
+                    $resolutionLog = [
                         'UserID'         => $user->getUsername(),
                         'User1'          => $user1,
                         'User2'          => $user2,
@@ -101,18 +101,18 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                         'OldValue2'      => $row['Value2'],
                         'NewValue'       => $val,
                         'ConflictID'     => $row['ConflictID'],
-                    );
+                    ];
 
                     $DB->insert('conflicts_resolved', $resolutionLog);
 
                     // update the source tables
-                    $setArray    = array(
+                    $setArray    = [
                         $row['FieldName'] => (
                                     $val == '1' ? $row['Value1'] : $row['Value2']
                                     ),
-                    );
-                    $whereArray1 = array('CommentID' => $row['CommentId1']);
-                    $whereArray2 = array('CommentID' => $row['CommentId2']);
+                    ];
+                    $whereArray1 = ['CommentID' => $row['CommentId1']];
+                    $whereArray2 = ['CommentID' => $row['CommentId2']];
                     if ($row['ExtraKeyColumn'] != null) {
                         $whereArray1[$row['ExtraKeyColumn']] = $row['ExtraKey1'];
                         $whereArray2[$row['ExtraKeyColumn']] = $row['ExtraKey2'];
@@ -141,7 +141,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                         //calculate candidate age if Date_taken was changed
                         if ($row['FieldName'] == 'Date_taken') {
                             $Instrument->_saveValues(
-                                array('Date_taken' => $setArray['Date_taken'])
+                                ['Date_taken' => $setArray['Date_taken']]
                             );
                         }
 
@@ -163,7 +163,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                         //calculate candidate age if Date_taken was changed
                         if ($row['FieldName'] == 'Date_taken') {
                             $Instrument->_saveValues(
-                                array('Date_taken' => $setArray['Date_taken'])
+                                ['Date_taken' => $setArray['Date_taken']]
                             );
                         }
                         $Instrument->score();
@@ -183,17 +183,17 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     function _setupVariables()
     {
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'conflicts_unresolved.TableName as instrument',
             'session.CandID as candID',
             'candidate.PSCID as pscid',
             'session.Visit_label as visit_label',
             'Project.Name as Project',
-        );
+        ];
 
         $this->columns = array_merge(
             $this->columns,
-            array(
+            [
                 'conflicts_unresolved.FieldName as question',
                 '"" as Correct_Answer',
                 'conflicts_unresolved.Value1 as Value1',
@@ -212,7 +212,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
              )
              as Hash",
                 '(SELECT name FROM psc WHERE CenterID=session.CenterID) as site',
-            )
+            ]
         );
 
         $this->query = " FROM conflicts_unresolved
@@ -231,7 +231,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
 
         $this->group_by = '';
         $this->order_by = 'conflicts_unresolved.TableName, session.Visit_label';
-        $this->headers  = array(
+        $this->headers  = [
             'Instrument',
             'CandID',
             'PSCID',
@@ -243,7 +243,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
             'Value2',
             'Hash',
             'Site',
-        );
+        ];
     }
 
     /**
@@ -262,7 +262,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
 
         // Get visits
         $visits = \Utility::getVisitList();
-        $visits = array_merge(array('' => 'All'), $visits);
+        $visits = array_merge(['' => 'All'], $visits);
 
         // Get sites
         if ($user->hasPermission('access_all_profiles')) {
@@ -273,7 +273,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                 $sites[$site] = $site;
             }
             if (is_array($sites)) {
-                $sites = array('' => 'All') + $sites;
+                $sites = ['' => 'All'] + $sites;
             }
         } else {
             // allow only to view own site data
@@ -282,13 +282,13 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                 unset($sites[$key]);
                 $sites[$site] = $site;
             }
-            $sites = array('' => 'All User Sites') + $sites;
+            $sites = ['' => 'All User Sites'] + $sites;
         }
 
-        $labelOptions = array(
+        $labelOptions = [
             'addEmptyOption'   => true,
             'emptyOptionValue' => '',
-        );
+        ];
 
         // Add form elements
         $this->addSelect('site', 'For Site:', $sites);
@@ -297,23 +297,23 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
         $this->addBasicText(
             'candID',
             'CandID:',
-            array(
+            [
                 'size'      => 9,
                 'maxlength' => 6,
-            )
+            ]
         );
         $this->addBasicText(
             'pSCID',
             'PSCID:',
-            array(
+            [
                 'size'      => 9,
                 'maxlength' => 7,
-            )
+            ]
         );
         $this->addBasicText('question', 'Question:');
 
         // Project list, if applicable
-        $list_of_projects = array();
+        $list_of_projects = [];
         $projectList      = \Utility::getProjectList();
         foreach ($projectList as $key => $value) {
             $list_of_projects[$value] = $value;
@@ -359,7 +359,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                         'SELECT full_name 
                          FROM examiners 
                          WHERE examinerID=:eid',
-                        array('eid' => $r['Value1'])
+                        ['eid' => $r['Value1']]
                     );
                 }
                 if (!empty($r['Value2'])) {
@@ -367,7 +367,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                         'SELECT full_name 
                          FROM examiners 
                          WHERE examinerID=:eid',
-                        array('eid' => $r['Value2'])
+                        ['eid' => $r['Value2']]
                     );
                 }
                 $result[$k] = $r;
@@ -402,15 +402,15 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
     function toArray()
     {
         $unanonymized = parent::toArray();
-        $data         = array();
+        $data         = [];
 
         foreach ($unanonymized['Data'] as &$row) {
             $data[] = $row;
         }
-        return array(
+        return [
             'Headers' => $unanonymized['Headers'],
             'Data'    => $data,
-        );
+        ];
     }
 
     /**
@@ -425,9 +425,9 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . '/conflict_resolver/js/conflictResolverIndex.js',
-            )
+            ]
         );
     }
 }

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -50,7 +50,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        $this->columns = array(
+        $this->columns = [
             'conflicts_resolved.TableName as instrument',
             'session.CandID as candID',
             'candidate.PSCID as pscid',
@@ -64,7 +64,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
             'session.CenterID as CenterID',
             '(SELECT name FROM psc WHERE CenterID=session.CenterID)'
                           .' as site',
-        );
+        ];
 
         $this->query = " FROM conflicts_resolved
             LEFT JOIN flag ON (conflicts_resolved.CommentId1=flag.CommentID)
@@ -83,7 +83,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
         $this->group_by = '';
         $this->order_by = 'conflicts_resolved.TableName, session.Visit_label';
 
-        $this->headers = array(
+        $this->headers = [
             'Instrument',
             'CandID',
             'PSCID',
@@ -96,7 +96,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
             'Old Value2',
             'CenterID',
             'Site',
-        );
+        ];
     }
 
     /**
@@ -115,7 +115,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
 
         // Get visits
         $visits = \Utility::getVisitList();
-        $visits = array_merge(array('' => 'All'), $visits);
+        $visits = array_merge(['' => 'All'], $visits);
 
         // Get sites
         if ($user->hasPermission('access_all_profiles')) {
@@ -126,7 +126,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
                 $sites[$site] = $site;
             }
             if (is_array($sites)) {
-                $sites = array('' => 'All') + $sites;
+                $sites = ['' => 'All'] + $sites;
             }
         } else {
             // allow only to view own site data
@@ -135,13 +135,13 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
                 unset($sites[$key]);
                 $sites[$site] = $site;
             }
-            $sites = array('' => 'All User Sites') + $sites;
+            $sites = ['' => 'All User Sites'] + $sites;
         }
 
-        $labelOptions = array(
+        $labelOptions = [
             'addEmptyOption'   => true,
             'emptyOptionValue' => '',
-        );
+        ];
 
         // Add form elements
         $this->addSelect('site', 'For Site:', $sites);
@@ -150,24 +150,24 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
         $this->addBasicText(
             'candID',
             'CandID:',
-            array(
+            [
                 'size'      => 9,
                 'maxlength' => 6,
-            )
+            ]
         );
         $this->addBasicText(
             'pSCID',
             'PSCID:',
-            array(
+            [
                 'size'      => 9,
                 'maxlength' => 7,
-            )
+            ]
         );
         $this->addBasicText('question', 'Question:');
         $this->addBasicText('resolutionTimestamp', 'Resolution Timestamp:');
 
         // Project list, if applicable
-        $list_of_projects = array();
+        $list_of_projects = [];
         $projectList      = \Utility::getProjectList();
         foreach ($projectList as $key => $value) {
             $list_of_projects[$value] = $value;
@@ -213,7 +213,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
                         'SELECT full_name 
                          FROM examiners 
                          WHERE examinerID=:eid',
-                        array('eid' => $r['correct_answer'])
+                        ['eid' => $r['correct_answer']]
                     );
                 }
                 $result[$k] = $r;
@@ -248,15 +248,15 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
     function toArray()
     {
         $unanonymized = parent::toArray();
-        $data         = array();
+        $data         = [];
 
         foreach ($unanonymized['Data'] as &$row) {
             $data[] = $row;
         }
-        return array(
+        return [
             'Headers' => $unanonymized['Headers'],
             'Data'    => $data,
-        );
+        ];
     }
 
     /**
@@ -271,9 +271,9 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . '/conflict_resolver/js/resolvedConflictsIndex.js',
-            )
+            ]
         );
     }
 }

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -54,7 +54,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
         $this->setUpConfigSetting("useProjects", "true");
         $this->DB->insert(
             "conflicts_resolved",
-            array(
+            [
                 'ResolvedID'          => '999999',
                 'UserID'              => 'demo',
                 'ResolutionTimestamp' => '2015-11-03 16:21:49',
@@ -69,11 +69,11 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
                 'OldValue1'           => 'Mother',
                 'OldValue2'           => 'Father',
                 'NewValue'            => 'NULL',
-            )
+            ]
         );
         $this->DB->insert(
             "conflicts_unresolved",
-            array(
+            [
                 'TableName'      => 'TestTestTest',
                 'ExtraKeyColumn' => 'Test',
                 'ExtraKey1'      => 'Null',
@@ -83,7 +83,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
                 'Value1'         => 'no',
                 'CommentId2'     => 'DDE_963443000111271151398976899',
                 'Value2'         => 'no',
-            )
+            ]
         );
     }
      /**
@@ -96,10 +96,10 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
     {
         parent::tearDown();
         $this->restoreConfigSetting("useProjects");
-        $this->DB->delete("conflicts_resolved", array('ResolvedID' => '999999'));
+        $this->DB->delete("conflicts_resolved", ['ResolvedID' => '999999']);
         $this->DB->delete(
             "conflicts_unresolved",
-            array('TableName' => 'TestTestTest')
+            ['TableName' => 'TestTestTest']
         );
     }
 
@@ -110,7 +110,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
       */
     function testConflictResolverPermission()
     {
-         $this->setupPermissions(array("conflict_resolver"));
+         $this->setupPermissions(["conflict_resolver"]);
          $this->safeGet($this->url . "/conflict_resolver/");
         $bodyText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector("body"))->getText();
@@ -133,7 +133,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
       */
     function testConflictResolverResolvedConflictsPermission()
     {
-         $this->setupPermissions(array("conflict_resolver"));
+         $this->setupPermissions(["conflict_resolver"]);
         $this->safeGet(
             $this->url
              . "/conflict_resolver/resolved_conflicts/"
@@ -152,7 +152,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
       */
     function testConflictResolverWithoutPermission()
     {
-         $this->setupPermissions(array());
+         $this->setupPermissions([]);
          $this->safeGet($this->url . "/conflict_resolver/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -142,7 +142,7 @@ class Create_Timepoint extends \NDB_Form
             for this study. If you are an administrator, please use the 
             Configuration module to add new subprojects.";
         }
-        $sp_labelOptions = array(null => '');
+        $sp_labelOptions = [null => ''];
         $subprojList     = null;
         //List of valid subprojects for a given project
         $subprojList = $candidate->getValidSubprojects();
@@ -158,12 +158,12 @@ class Create_Timepoint extends \NDB_Form
             }
         }
 
-        $attributes = array(
+        $attributes = [
             "onchange" => "location.href='?test_name=create_timepoint" .
                 "&candID=" . $this->identifier .
                 "&identifier=" . $this->identifier .
                 "&subprojectID='+this[this.selectedIndex].value;",
-        );
+        ];
         $this->addSelect(
             'subprojectID',
             'Subproject',
@@ -171,7 +171,7 @@ class Create_Timepoint extends \NDB_Form
             $attributes
         );
         $this->addRule('subprojectID', 'A Subproject ID is required', 'required');
-        $this->_setDefaults(array("subprojectID" => $this->subprojectID));
+        $this->_setDefaults(["subprojectID" => $this->subprojectID]);
 
         // visit label
         $visitLabelSettings  = $config->getSetting('visitLabel');
@@ -193,7 +193,7 @@ class Create_Timepoint extends \NDB_Form
                         "longer supported in Loris."
                     );
                 }
-                $labelOptions = array('' => null);
+                $labelOptions = ['' => null];
                 $items        = \Utility::associativeToNumericArray(
                     $visitLabel['labelSet']['item']
                 );
@@ -246,7 +246,7 @@ class Create_Timepoint extends \NDB_Form
                 $user_list_of_projects = $user->getProjectIDs();
                 if (count($user_list_of_projects) > 1) {
                     $this->tpl_data['projectAdded'] = true;
-                    $projectOptions = array(null => '');
+                    $projectOptions = [null => ''];
                     foreach ($user_list_of_projects as $key => $projectID) {
                         $project = \Project::getProjectFromID($projectID);
                         $projectOptions[$projectID] = $project->getName();
@@ -269,7 +269,7 @@ class Create_Timepoint extends \NDB_Form
             the config.xml file.";
         }
 
-        $this->form->addFormRule(array(&$this, '_validate'));
+        $this->form->addFormRule([&$this, '_validate']);
 
     }
 
@@ -285,7 +285,7 @@ class Create_Timepoint extends \NDB_Form
     {
         $user = \User::singleton();
 
-        $errors = array();
+        $errors = [];
 
         // validate site entered
         $site = $val['psc'] ?? '';

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -134,7 +134,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
      */
     public function testCreateTimepointPermission()
     {
-        $this->setupPermissions(array("data_entry"));
+        $this->setupPermissions(["data_entry"]);
         $this->safeGet(
             $this->url . "/create_timepoint/?candID=900000&identifier=900000"
         );

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -159,9 +159,9 @@ class Dashboard extends \NDB_Form
 
         return array_merge(
             $baseDeps,
-            array(
+            [
                 $baseurl . '/dashboard/js/dashboard-helper.js',
-            ),
+            ],
             $this->widgetjs,
         );
     }

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -83,11 +83,11 @@ class Module extends \Module
         $dashboard_links = $config->getExternalLinks('dashboard');
         $links           = [];
         foreach ($dashboard_links as $text => $url) {
-            $links[] = array(
+            $links[] = [
                 'url'        => $url,
                 'label'      => $text,
                 'WindowName' => md5($url),
-            );
+            ];
         }
 
         $footer = "";

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -40,51 +40,51 @@ class DashboardTest extends LorisIntegrationTest
         //Insert a pending user
         $this->DB->insert(
             "users",
-            array(
+            [
                 'UserID'          => 'testUser1',
                 'Email'           => 'test@test.com',
                 'Password'        => 'AA1234567!',
                 'Password_expiry' => '2020-01-06',
-            )
+            ]
         );
         $user_id = $this->DB->pselectOne(
             "SELECT ID FROM users WHERE UserID=:test_user_id",
-            array("test_user_id" => 'testUser1')
+            ["test_user_id" => 'testUser1']
         );
         $this->DB->insert(
             "user_psc_rel",
-            array(
+            [
                 'UserID'   => $user_id,
                 'CenterID' => '1',
-            )
+            ]
         );
         //Insert two violation scan
         $this->DB->insert(
             "psc",
-            array(
+            [
                 'CenterID'  => '55',
                 'Name'      => 'TESTinPSC',
                 'Alias'     => 'tst',
                 'MRI_alias' => 'test',
-            )
+            ]
         );
         $this->DB->insert(
             "subproject",
-            array(
+            [
                 'SubprojectID' => '55',
                 'title'        => 'TESTinSubproject',
-            )
+            ]
         );
         $this->DB->insert(
             "Project",
-            array(
+            [
                 'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
-            )
+            ]
         );
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '999888',
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
@@ -92,11 +92,11 @@ class DashboardTest extends LorisIntegrationTest
                 'RegistrationProjectID' => '7777',
                 'Entity_type'           => 'Human',
                 'Active'                => 'Y',
-            )
+            ]
         );
         $this->DB->insert(
             "session",
-            array(
+            [
                 'ID'           => '222222',
                 'CandID'       => '999888',
                 'CenterID'     => '55',
@@ -105,11 +105,11 @@ class DashboardTest extends LorisIntegrationTest
                 'MRIQCStatus'  => '',
                 'SubprojectID' => '55',
                 'Active'       => 'Y',
-            )
+            ]
         );
         $this->DB->insert(
             "mri_protocol_violated_scans",
-            array(
+            [
                 'ID'                 => '1001',
                 'CandID'             => '999888',
                 'PatientName'        => '[Test]PatientName',
@@ -117,11 +117,11 @@ class DashboardTest extends LorisIntegrationTest
                 'minc_location'      => 'assembly/test/test/mri/test/test.mnc',
                 'series_description' => 'Test Series Description',
                 'SeriesUID'          => '5555',
-            )
+            ]
         );
         $this->DB->insert(
             "mri_protocol_violated_scans",
-            array(
+            [
                 'ID'                 => '1002',
                 'CandID'             => '999888',
                 'PatientName'        => '[Test]PatientName',
@@ -129,57 +129,57 @@ class DashboardTest extends LorisIntegrationTest
                 'minc_location'      => 'assembly/test2/test2/mri/test2/test2.mnc',
                 'series_description' => 'Test Series Description',
                 'SeriesUID'          => '5556',
-            )
+            ]
         );
         $this->DB->insert(
             "violations_resolved",
-            array(
+            [
                 'ExtID'     => '1001',
                 'hash'      => 'this is not a null value',
                 'TypeTable' => 'mri_protocol_violated_scans',
                 'Resolved'  => 'other',
-            )
+            ]
         );
         $this->DB->insert(
             "violations_resolved",
-            array(
+            [
                 'ExtID'     => '1002',
                 'hash'      => 'this is not a null value',
                 'TypeTable' => 'MRICandidateErrors',
                 'Resolved'  => 'unresolved',
-            )
+            ]
         );
         $this->DB->insert(
             "MRICandidateErrors",
-            array(
+            [
                 'ID'          => '1002',
                 'PatientName' => '[Test]PatientName',
                 'MincFile'    => 'assembly/test2/test2/mri/test2/test2.mnc',
                 'SeriesUID'   => '5556',
-            )
+            ]
         );
         //Insert an incomplete form data
         $this->DB->insert(
             "test_names",
-            array(
+            [
                 'ID'        => '111',
                 'Test_name' => 'TestName11111111111',
-            )
+            ]
         );
         $this->DB->insert(
             "flag",
-            array(
+            [
                 'ID'         => '111111',
                 'SessionID'  => '222222',
                 'Test_name'  => 'TestName11111111111',
                 'CommentID'  => 'commentID111',
                 'Data_entry' => 'In Progress',
-            )
+            ]
         );
         //Insert a demo data into conflicts_unresolved
         $this->DB->insert(
             "conflicts_unresolved",
-            array(
+            [
                 'TableName'      => 'TestTestTest',
                 'ExtraKeyColumn' => 'Test',
                 'ExtraKey1'      => 'Null',
@@ -189,27 +189,27 @@ class DashboardTest extends LorisIntegrationTest
                 'Value1'         => 'no',
                 'CommentId2'     => 'DDE_963443000111271151398976899',
                 'Value2'         => 'no',
-            )
+            ]
         );
         $this->DB->insert(
             "files",
-            array(
+            [
                 'FileID'       => '1111112',
                 'SessionID'    => '222222',
                 'SourceFileID' => '1111112',
-            )
+            ]
         );
 
         $this->DB->insert(
             "files_qcstatus",
-            array(
+            [
                 'FileID'   => '1111112',
                 'FileQCID' => '2222221',
-            )
+            ]
         );
         $this->DB->insert(
             "conflicts_resolved",
-            array(
+            [
                 'ResolvedID'          => '999999',
                 'UserID'              => 'demo',
                 'ResolutionTimestamp' => '2015-11-03 16:21:49',
@@ -224,11 +224,11 @@ class DashboardTest extends LorisIntegrationTest
                 'OldValue1'           => 'Mother',
                 'OldValue2'           => 'Father',
                 'NewValue'            => 'NULL',
-            )
+            ]
         );
         $this->DB->insert(
             "conflicts_unresolved",
-            array(
+            [
                 'TableName'      => 'TestTestTest',
                 'ExtraKeyColumn' => 'Test',
                 'ExtraKey1'      => 'Null',
@@ -238,33 +238,33 @@ class DashboardTest extends LorisIntegrationTest
                 'Value1'         => 'no',
                 'CommentId2'     => 'DDE_963443000111271151398976899',
                 'Value2'         => 'no',
-            )
+            ]
         );
         $this->DB->insert(
             "issues",
-            array(
+            [
                 'issueID'  => '999999',
                 'assignee' => 'UnitTester',
                 'status'   => 'new',
                 'priority' => 'low',
                 'reporter' => 'UnitTester',
-            )
+            ]
         );
         $this->DB->insert(
             "users",
-            array(
+            [
                 'ID'     => '9999991',
                 'UserID' => 'Tester1',
-            )
+            ]
         );
         $this->DB->insert(
             "document_repository",
-            array(
+            [
                 'record_id'  => '9999997',
                 'visitLabel' => null,
                 'Date_taken' => '2016-07-27 18:00:10',
                 'File_name'  => 'test.jpg',
-            )
+            ]
         );
     }
     /**
@@ -277,114 +277,114 @@ class DashboardTest extends LorisIntegrationTest
         $this->DB->run('SET foreign_key_checks =0');
         $this->DB->delete(
             "document_repository",
-            array('record_id' => '9999997')
+            ['record_id' => '9999997']
         );
         $this->DB->delete(
             "users",
-            array('ID' => '9999991')
+            ['ID' => '9999991']
         );
         $this->DB->delete(
             "issues",
-            array('issueID' => '999999')
+            ['issueID' => '999999']
         );
         $this->DB->delete(
             "conflicts_resolved",
-            array('ResolvedID' => '999999')
+            ['ResolvedID' => '999999']
         );
         $this->DB->delete(
             "conflicts_unresolved",
-            array('TableName' => 'TestTestTest')
+            ['TableName' => 'TestTestTest']
         );
         $this->DB->delete(
             "files_qcstatus",
-            array('FileID' => '1111112')
+            ['FileID' => '1111112']
         );
         $this->DB->delete(
             "files",
-            array('FileID' => '1111112')
+            ['FileID' => '1111112']
         );
 
         $this->DB->delete(
             "users",
-            array('UserID' => 'testUser1')
+            ['UserID' => 'testUser1']
         );
         $this->DB->delete(
             "session",
-            array('ID' => '222222')
+            ['ID' => '222222']
         );
         $this->DB->delete(
             "candidate",
-            array(
+            [
                 'CandID'               => '999888',
                 'RegistrationCenterID' => '55',
-            )
+            ]
         );
         $this->DB->delete(
             "mri_protocol_violated_scans",
-            array(
+            [
                 'ID'     => '1001',
                 'CandID' => '999888',
-            )
+            ]
         );
         $this->DB->delete(
             "mri_protocol_violated_scans",
-            array(
+            [
                 'ID'     => '1002',
                 'CandID' => '999888',
-            )
+            ]
         );
         $this->DB->delete(
             "violations_resolved",
-            array(
+            [
                 'ExtID'     => '1001',
                 'TypeTable' => 'mri_protocol_violated_scans',
-            )
+            ]
         );
         $this->DB->delete(
             "MRICandidateErrors",
-            array('ID' => '1002')
+            ['ID' => '1002']
         );
         $this->DB->delete(
             "violations_resolved",
-            array(
+            [
                 'ExtID'     => '1002',
                 'TypeTable' => 'mri_protocol_violated_scans',
-            )
+            ]
         );
         $this->DB->delete(
             "psc",
-            array(
+            [
                 'CenterID' => '55',
                 'Name'     => 'TESTinPSC',
-            )
+            ]
         );
         $this->DB->delete(
             "subproject",
-            array('SubprojectID' => '55')
+            ['SubprojectID' => '55']
         );
         $this->DB->delete(
             "Project",
-            array(
+            [
                 'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
-            )
+            ]
         );
         $this->DB->delete(
             "flag",
-            array('CommentID' => 'commentID111')
+            ['CommentID' => 'commentID111']
         );
         $this->DB->delete(
             "test_names",
-            array('ID' => '111')
+            ['ID' => '111']
         );
         $this->DB->delete(
             "conflicts_unresolved",
-            array('TableName' => 'TestTestTest')
+            ['TableName' => 'TestTestTest']
         );
         $this->DB->update(
             "Config",
-            array("Value" => null),
-            array("ConfigID" => 48)
+            ["Value" => null],
+            ["ConfigID" => 48]
         );
         $this->DB->run('SET foreign_key_checks =1');
         parent::tearDown();
@@ -458,10 +458,10 @@ class DashboardTest extends LorisIntegrationTest
     {
 
         $this->setupPermissions(
-            array(
+            [
                 "imaging_browser_qc",
                 "imaging_browser_view_allsites",
-            )
+            ]
         );
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
@@ -486,10 +486,10 @@ class DashboardTest extends LorisIntegrationTest
     {
 
         $this->setupPermissions(
-            array(
+            [
                 "conflict_resolver",
                 "access_all_profiles",
-            )
+            ]
         );
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
@@ -509,7 +509,7 @@ class DashboardTest extends LorisIntegrationTest
     public function testIssues()
     {
         $this->setupPermissions(
-            array("issue_tracker_developer")
+            ["issue_tracker_developer"]
         );
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
@@ -537,10 +537,10 @@ class DashboardTest extends LorisIntegrationTest
     public function testIncompleteForm()
     {
         $this->setupPermissions(
-            array(
+            [
                 "data_entry",
                 "access_all_profiles",
-            )
+            ]
         );
         $this->safeGet($this->url . '/dashboard/');
         $bodyText = $this->webDriver->getPageSource();
@@ -563,10 +563,10 @@ class DashboardTest extends LorisIntegrationTest
     {
 
         $this->setupPermissions(
-            array(
+            [
                 "user_accounts_multisite",
                 "user_accounts",
-            )
+            ]
         );
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
@@ -591,10 +591,10 @@ class DashboardTest extends LorisIntegrationTest
     {
 
         $this->setupPermissions(
-            array(
+            [
                 "document_repository_delete",
                 "document_repository_view",
-            )
+            ]
         );
         $this->safeGet($this->url . '/dashboard/');
         $bodyText = $this->webDriver->getPageSource();

--- a/modules/data_release/ajax/AddPermission.php
+++ b/modules/data_release/ajax/AddPermission.php
@@ -46,10 +46,10 @@ if ($_GET['action'] == 'addpermission') {
         $data_release_id = $_POST['data_release_id'];
         $DB->insertIgnore(
             'data_release_permissions',
-            array(
+            [
                 'userid'          => $userid,
                 'data_release_id' => $data_release_id,
-            )
+            ]
         );
 
     } elseif (empty($_POST['data_release_id'])
@@ -63,15 +63,15 @@ if ($_GET['action'] == 'addpermission') {
                   ? "version IS NULL OR version=:drv" : "version=:drv";
         $IDs    = $DB->pselectCol(
             $query,
-            array(':drv' => $data_release_version)
+            [':drv' => $data_release_version]
         );
         foreach ($IDs as $ID) {
             $DB->insertIgnore(
                 'data_release_permissions',
-                array(
+                [
                     'userid'          => $userid,
                     'data_release_id' => $ID,
-                )
+                ]
             );
         }
     }
@@ -103,7 +103,7 @@ if ($_GET['action'] == 'addpermission') {
     $vFiles         = $data_release->getVersionedFiles($DB);
     $prePermissions = $data_release->getUserVersionPermissions($vFiles, $DB);
 
-    $postPermissions = array();
+    $postPermissions = [];
     foreach ($_POST as $key => $value) {
         $new_value = json_decode($value, true);
         if ($new_value['permission']) {
@@ -120,7 +120,7 @@ if ($_GET['action'] == 'addpermission') {
     foreach ($prePermissions as $user => $oldVersions) {
         // query to get user ID
         $query  = "SELECT ID FROM users WHERE UserID LIKE :userid";
-        $params = array('userid' => $user);
+        $params = ['userid' => $user];
         // PHP replaces dots "." characters by underscores "_" in variables.
         // to be able to compare below, do the same thing
         $userNoDot = str_replace(".", "_", $user);
@@ -135,10 +135,10 @@ if ($_GET['action'] == 'addpermission') {
                     foreach ($vFiles[$version] as $fileID => $fileName) {
                         $DB->replace(
                             'data_release_permissions',
-                            array(
+                            [
                                 'userid'          => $userid,
                                 'data_release_id' => $fileID,
-                            )
+                            ]
                         );
                     }
                 }
@@ -160,10 +160,10 @@ if ($_GET['action'] == 'addpermission') {
                     foreach ($vFiles[$version] as $fileID => $fileName) {
                         $DB->replace(
                             'data_release_permissions',
-                            array(
+                            [
                                 'userid'          => $userid,
                                 'data_release_id' => $fileID,
-                            )
+                            ]
                         );
                     }
                 }
@@ -172,10 +172,10 @@ if ($_GET['action'] == 'addpermission') {
                     foreach ($vFiles[$version] as $fileID => $fileName) {
                         $DB->delete(
                             'data_release_permissions',
-                            array(
+                            [
                                 'userid'          => $userid,
                                 'data_release_id' => $fileID,
-                            )
+                            ]
                         );
                     }
                 }
@@ -188,10 +188,10 @@ if ($_GET['action'] == 'addpermission') {
                     foreach ($vFiles[$version] as $fileID => $fileName) {
                         $DB->delete(
                             'data_release_permissions',
-                            array(
+                            [
                                 'userid'          => $userid,
                                 'data_release_id' => $fileID,
-                            )
+                            ]
                         );
                     }
                 }

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -45,16 +45,16 @@ if ($_GET['action'] == 'upload') {
             // insert the file into the data_release table
             $DB->insert(
                 'data_release',
-                array(
+                [
                     'file_name'   => $fileName,
                     'version'     => $version,
                     'upload_date' => $upload_date,
-                )
+                ]
             );
             // get the ID of the user who uploaded the file
             $user_ID = $DB->pselectOne(
                 "SELECT ID FROM users WHERE userid=:UserID",
-                array('UserID' => $user->getUsername())
+                ['UserID' => $user->getUsername()]
             );
             // get the ID of the file inserted in the data_release table
             $version_where = $version ? "version=:version" : "version IS :version";
@@ -67,19 +67,19 @@ if ($_GET['action'] == 'upload') {
                file_name=:file_name 
                AND $version_where
                AND upload_date=:upload_date",
-                array(
+                [
                     'file_name'   => $fileName,
                     'version'     => $version,
                     'upload_date' => $upload_date,
-                )
+                ]
             );
             // add permission to the user for the uploaded data_release file
             $DB->insert(
                 'data_release_permissions',
-                array(
+                [
                     'userid'          => $user_ID,
                     'data_release_id' => $ID,
-                )
+                ]
             );
         }
         header("Location: {$baseURL}/data_release/?uploadSuccess=true");
@@ -89,10 +89,10 @@ if ($_GET['action'] == 'upload') {
 } elseif ($_GET['action'] == 'getData') {
     $filesList = $DB->pselect(
         "SELECT id, file_name FROM data_release",
-        array()
+        []
     );
 
-    $dataReleaseFiles = array();
+    $dataReleaseFiles = [];
     foreach ($filesList as $row) {
         $dataReleaseFiles[$row['id']] = $row['file_name'];
     }

--- a/modules/data_release/ajax/GetFile.php
+++ b/modules/data_release/ajax/GetFile.php
@@ -37,21 +37,21 @@ if (!file_exists($FullPath)) {
 $fileID     = $db->pselectOne(
     "SELECT ID FROM data_release WHERE "
     . "file_name=:fn",
-    array('fn' => $File)
+    ['fn' => $File]
 );
 $uid        = $db->pselectOne(
     "SELECT ID FROM users WHERE "
     . "UserID=:userid",
-    array('userid' => $user->getUsername())
+    ['userid' => $user->getUsername()]
 );
 $permission = $db->pselectOne(
     "SELECT 'X' 
           FROM data_release_permissions 
           WHERE userid=:uid AND data_release_id=:fileID",
-    array(
+    [
         'uid'    => $uid,
         'fileID' => $fileID,
-    )
+    ]
 );
 if (empty($permission)) {
     header("HTTP/1.1 403 Forbidden");

--- a/modules/data_release/php/data_release.class.inc
+++ b/modules/data_release/php/data_release.class.inc
@@ -40,11 +40,11 @@ class Data_Release extends \NDB_Menu_Filter
     {
         // check user permissions
         return $user->hasAnyPermission(
-            array(
+            [
                 'data_release_view',
                 'data_release_upload',
                 'data_release_edit_file_access'
-            )
+            ]
         );
     }
 
@@ -59,11 +59,11 @@ class Data_Release extends \NDB_Menu_Filter
         $DB   = \Database::singleton();
 
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'file_name AS fileName',
             'version',
             'upload_date AS uploadDate',
-        );
+        ];
         $this->query   = " FROM data_release dr";
 
         if (!$user->hasPermission("superuser")) {
@@ -95,8 +95,8 @@ class Data_Release extends \NDB_Menu_Filter
         // Get list of data release versions and filenames
         $vFiles = $this->getVersionedFiles($DB);
 
-        $filenames_options = array();
-        $versions_options  = array();
+        $filenames_options = [];
+        $versions_options  = [];
 
         foreach ($vFiles as $versionName => $filesArray) {
             foreach ($filesArray as $fileID => $fileName) {
@@ -128,7 +128,7 @@ class Data_Release extends \NDB_Menu_Filter
     {
         $userids = $DB->pselectColWithIndexKey(
             "SELECT ID, UserID FROM users",
-            array(),
+            [],
             "ID"
         );
 
@@ -151,10 +151,10 @@ class Data_Release extends \NDB_Menu_Filter
         $versionedFiles = $DB->pselect(
             "SELECT id, file_name, version 
                   FROM data_release",
-            array()
+            []
         );
 
-        $vFFormatted = array();
+        $vFFormatted = [];
         foreach ($versionedFiles as $row) {
             $version = $row['version'] === null || $row['version'] === ''
                 ? 'Unversioned': $row['version'];
@@ -187,13 +187,13 @@ class Data_Release extends \NDB_Menu_Filter
              FROM users u
                 LEFT JOIN data_release_permissions drp ON (u.ID=drp.userid) 
                 LEFT JOIN data_release dr ON (drp.data_release_id=dr.id)",
-            array()
+            []
         );
 
         //in order to have a checked box a user must have permission to see all
         //files belonging to a release version
         //array to hold checked checkboxes in the manage permissions menu
-        $uFAFormatted = array();
+        $uFAFormatted = [];
         foreach ($userFileAccess as $row) {
             $userID          = $row['UserID'];
             $version         = $row['version'] ?? null;
@@ -214,22 +214,22 @@ class Data_Release extends \NDB_Menu_Filter
                         = $releaseFileName;
                 }
             } else {
-                $uFAFormatted[$userID] = array();
+                $uFAFormatted[$userID] = [];
             }
         }
 
         //now we can compare the $uFAFormatted to $vFiles (versioned files array)
         //to identify which checkboxes should be checked
-        $version_permissions = array();
+        $version_permissions = [];
         foreach ($uFAFormatted as $userID=>$userVersions) {
             if (empty($userVersions)) {
-                $version_permissions[$userID] = array();
+                $version_permissions[$userID] = [];
             }
             foreach ($userVersions as $versionName=>$versionFiles) {
                 if (empty(array_diff($vFiles[$versionName], $versionFiles))) {
                     $version_permissions[$userID][] = $versionName;
                 } else {
-                    $version_permissions[$userID] = array();
+                    $version_permissions[$userID] = [];
                 }
             }
         }
@@ -248,9 +248,9 @@ class Data_Release extends \NDB_Menu_Filter
         $baseurl = $factory->settings()->getBaseURL();
         return array_merge(
             parent::getJSDependencies(),
-            array(
+            [
                 $baseurl . "/data_release/js/dataReleaseIndex.js",
-            )
+            ]
         );
     }
 }

--- a/modules/data_release/test/data_releaseTest.php
+++ b/modules/data_release/test/data_releaseTest.php
@@ -75,7 +75,7 @@ class DataReleaseIntegrationTest extends LorisIntegrationTest
      */
     function _loadWithPermission(string $permission): string
     {
-        $this->setupPermissions(array($permission));
+        $this->setupPermissions([$permission]);
         $this->safeGet($this->url . "/data_release/");
         return $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/datadict/ajax/UpdateDataDict.php
+++ b/modules/datadict/ajax/UpdateDataDict.php
@@ -40,7 +40,7 @@ if ($user->hasPermission('data_dict_edit')) { //if user has edit permission
 
     $native_description = $DB->pselectOne(
         "SELECT Description FROM parameter_type WHERE Name = :v_name",
-        array("v_name" => $name)
+        ["v_name" => $name]
     );
 
     if ($description != $native_description) {
@@ -49,15 +49,15 @@ if ($user->hasPermission('data_dict_edit')) { //if user has edit permission
         }
         $DB->replace(
             'parameter_type_override',
-            array(
+            [
                 'Description' => $description,
                 'Name'        => $name,
-            )
+            ]
         );
     } else {
         $DB->delete(
             'parameter_type_override',
-            array('Name' => $name)
+            ['Name' => $name]
         );
     }
 }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -59,9 +59,9 @@ class Datadict extends \DataFrameworkMenu
      */
     public function getFieldOptions() : array
     {
-        return array(
+        return [
             'sourceFrom' => \Utility::getAllInstruments(),
-        );
+        ];
     }
 
     /**
@@ -87,9 +87,9 @@ class Datadict extends \DataFrameworkMenu
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/datadict/js/dataDictIndex.js",
-            )
+            ]
         );
     }
 

--- a/modules/datadict/php/datadictrowprovisioner.class.inc
+++ b/modules/datadict/php/datadictrowprovisioner.class.inc
@@ -51,7 +51,7 @@ class DataDictRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             LEFT JOIN parameter_type_override pto USING (Name)
             WHERE pt.Queryable=1
             ",
-            array()
+            []
         );
     }
 

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -32,14 +32,14 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
      * Table headers
      */
     private $_loadingUI
-        =  array(
+        =  [
             'Data Dictionary'    => '#bc2 > a:nth-child(2) > div',
             'Source From'        => '#dynamictable > thead > tr > th:nth-child(2)',
             'Name'               => '#dynamictable > thead > tr > th:nth-child(3)',
             'Source Field'       => '#dynamictable > thead > tr > th:nth-child(4)',
             'Description'        => '#dynamictable > thead > tr > th:nth-child(5)',
             'Description Status' => '#dynamictable > thead > tr > th:nth-child(6)',
-        );
+        ];
 
     /**
      * Inserting testing data
@@ -51,7 +51,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
         parent::setUp();
         $this->DB->insert(
             "parameter_type",
-            array(
+            [
                 'Name'        => 'TestParameterNotRealMAGICNUMBER335',
                 'Type'        => 'varchar(255)',
                 'Description' => 'I am a fake description used only for testing'.
@@ -60,7 +60,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
                 'SourceField' => 'imaginary',
                 'Queryable'   => true,
                 'IsFile'      => 0,
-            )
+            ]
         );
     }
     /**
@@ -73,7 +73,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
         parent::tearDown();
         $this->DB->delete(
             'parameter_type',
-            array('Name' => 'TestParameterNotRealMAGICNUMBER335')
+            ['Name' => 'TestParameterNotRealMAGICNUMBER335']
         );
     }
     /**

--- a/modules/dataquery/ajax/datadictionary.php
+++ b/modules/dataquery/ajax/datadictionary.php
@@ -30,18 +30,18 @@ $cdb         = \NDB_Factory::singleton()->couchDB(
     $couchConfig['adminpass']
 );
 
-$results = array();
+$results = [];
 if (isset($_REQUEST['category']) && $_REQUEST['category']) {
     $category = urlencode($_REQUEST['category']);
 
     $results = $cdb->queryView(
         "DQG-2.0",
         "datadictionary",
-        array(
+        [
             "reduce"   => "false",
             "startkey" => "[\"$category\"]",
             "endkey"   => "[\"$category\", \"ZZZZZZZZ\"]",
-        )
+        ]
     );
 } else if (isset($_REQUEST['key']) && $_REQUEST['key']) {
     $key = explode('%2C', urlencode($_REQUEST['key']));
@@ -49,10 +49,10 @@ if (isset($_REQUEST['category']) && $_REQUEST['category']) {
     $results = $cdb->queryView(
         "DQG-2.0",
         "datadictionary",
-        array(
+        [
             "reduce" => "false",
             "key"    => "[\"$key[0]\",\"$key[1]\"]",
-        )
+        ]
     );
 }
 

--- a/modules/dataquery/ajax/getAllSessions.php
+++ b/modules/dataquery/ajax/getAllSessions.php
@@ -31,10 +31,10 @@ $cdb            = \NDB_Factory::singleton()->couchDB(
 $results        = $cdb->queryView(
     "DQG-2.0",
     "sessions",
-    array(
+    [
         "reduce" => "true",
         "group"  => "true",
-    )
+    ]
 );
 $sessionResults = array_map(
     function ($element) {

--- a/modules/dataquery/ajax/queryContains.php
+++ b/modules/dataquery/ajax/queryContains.php
@@ -34,11 +34,11 @@ $value          = $_REQUEST['value'];
 $results        = $cdb->queryView(
     "DQG-2.0",
     "search",
-    array(
+    [
         "reduce"   => "false",
         "startkey" => "[\"$category\", \"$fieldName\"]",
         "endkey"   => "[\"$category\", \"$fieldName\", {} ]",
-    )
+    ]
 );
 $sessionResults = array_filter(
     $results,

--- a/modules/dataquery/ajax/queryEqual.php
+++ b/modules/dataquery/ajax/queryEqual.php
@@ -39,10 +39,10 @@ if (!is_numeric($value) && $value !== "null") {
 $results = $cdb->queryView(
     "DQG-2.0",
     "search",
-    array(
+    [
         "reduce" => "false",
         "key"    => "[\"$category\", \"$fieldName\", $value]",
-    )
+    ]
 );
 
 $sessionResults = array_map(

--- a/modules/dataquery/ajax/queryGreaterThanEqual.php
+++ b/modules/dataquery/ajax/queryGreaterThanEqual.php
@@ -37,11 +37,11 @@ $value       = is_numeric($value) ? $value : "\"$value\"";
 $results = $cdb->queryView(
     "DQG-2.0",
     "search",
-    array(
+    [
         "reduce"   => "false",
         "startkey" => "[\"$category\", \"$fieldName\", $value]",
         "endkey"   => "[\"$category\", \"$fieldName\", {}]",
-    )
+    ]
 );
 
 $sessionResults = array_map(

--- a/modules/dataquery/ajax/queryLessThanEqual.php
+++ b/modules/dataquery/ajax/queryLessThanEqual.php
@@ -36,11 +36,11 @@ $value       = is_numeric($value) ? $value : "\"$value\"";
 $results = $cdb->queryView(
     "DQG-2.0",
     "search",
-    array(
+    [
         "reduce"   => "false",
         "startkey" => "[\"$category\", \"$fieldName\"]",
         "endkey"   => "[\"$category\", \"$fieldName\", $value]",
-    )
+    ]
 );
 
 $sessionResults = array_map(

--- a/modules/dataquery/ajax/queryNotEqual.php
+++ b/modules/dataquery/ajax/queryNotEqual.php
@@ -38,14 +38,14 @@ $value       = $_REQUEST['value'];
 $results = $cdb->queryView(
     "DQG-2.0",
     "search",
-    array(
+    [
         "reduce"   => "false",
         "startkey" => "[\"$category\", \"$fieldName\"]",
         "endkey"   => "[\"$category\", \"$fieldName\", {}]",
-    )
+    ]
 );
 // TODO: Rewrite this using array_filter and array_map.
-$sessionResults = array();
+$sessionResults = [];
 foreach ($results as $row) {
     if ($row['key'][2] == $value) {
         continue;

--- a/modules/dataquery/ajax/queryStartsWith.php
+++ b/modules/dataquery/ajax/queryStartsWith.php
@@ -34,7 +34,7 @@ $value          = $_REQUEST['value'];
 $results        = $cdb->queryView(
     "DQG-2.0",
     "search",
-    array(
+    [
         "reduce"   => "false",
         "startkey" => "[\"$category\", \"$fieldName\", \"$value\"]",
         "endkey"   => "[\"$category\", \"$fieldName\", \"$value"
@@ -43,7 +43,7 @@ $results        = $cdb->queryView(
                           //  unicode character
                           . mb_convert_encoding('&#x9999;', 'UTF-8', 'HTML-ENTITIES')
                           . "\"]",
-    )
+    ]
 );
 $sessionResults = array_map(
     function ($element) {

--- a/modules/dataquery/ajax/retrieveCategoryDocs.php
+++ b/modules/dataquery/ajax/retrieveCategoryDocs.php
@@ -35,18 +35,18 @@ $category    = $_REQUEST['DocType'];
 $sessions    = json_decode($_REQUEST['Sessions']);
 $keys        = array_map(
     function ($row) use ($category) {
-        return array_merge(array($category), $row);
+        return array_merge([$category], $row);
     },
     $sessions
 );
 $results     = $cdb->queryView(
     "DQG-2.0",
     "instruments",
-    array(
+    [
         "reduce"       => "false",
         "include_docs" => "true",
         "keys"         => $keys,
-    ),
+    ],
     true
 );
 $keys        = null;

--- a/modules/dataquery/ajax/saveQuery.php
+++ b/modules/dataquery/ajax/saveQuery.php
@@ -51,15 +51,15 @@ if ($_REQUEST['OverwriteQuery'] === "false") {
     }
 }
 
-$baseDocument = array(
+$baseDocument = [
     '_id'        => $qid,
-    'Meta'       => array(
+    'Meta'       => [
         'DocType' => 'SavedQuery',
         'user'    => $user->getUserName(),
-    ),
-    'Fields'     => array(),
-    'Conditions' => array(),
-);
+    ],
+    'Fields'     => [],
+    'Conditions' => [],
+];
 if (isset($_REQUEST['QueryName'])) {
     $baseDocument['Meta']['name'] = $_REQUEST['QueryName'];
 }
@@ -74,7 +74,7 @@ $cond   = $_REQUEST['Filters'];
 $baseDocument['Conditions'] = $cond;
 $baseDocument['Fields']     = $fields;
 
-$query = array();
+$query = [];
 if ($_REQUEST['OverwriteQuery'] === "true") {
     unset($baseDocument['_id']);
     $cdb->replaceDoc($qid, $baseDocument);

--- a/modules/dataquery/php/dataquery.class.inc
+++ b/modules/dataquery/php/dataquery.class.inc
@@ -81,24 +81,24 @@ class Dataquery extends \NDB_Form
         $update = $couch->queryView(
             "DQG-2.0",
             "runlog",
-            array(
+            [
                 "reduce"     => "false",
                 "limit"      => "1",
                 "descending" => "true",
-            )
+            ]
         );
         $this->tpl_data['updatetime'] = $update[0]['key'];
 
         $categories = $couch->queryView(
             "DQG-2.0",
             "datadictionary",
-            array(
+            [
                 "reduce"      => "true",
                 "group_level" => "1",
-            )
+            ]
         );
 
-        $cat_tpl = array();
+        $cat_tpl = [];
         foreach ($categories as $row) {
             if ($row['value']) {
                 $cat_tpl[$row['key'][0]] = $row['value'];
@@ -111,19 +111,19 @@ class Dataquery extends \NDB_Form
         $usersaved = $couch->queryView(
             "DQG-2.0",
             "savedqueries",
-            array(
+            [
                 "key"    => "\"$username\"",
                 "reduce" => "false",
-            )
+            ]
         );
 
         $globalsaved = $couch->queryView(
             "DQG-2.0",
             "savedqueries",
-            array(
+            [
                 "key"    => "\"global\"",
                 "reduce" => "false",
-            )
+            ]
         );
 
         $IDMapCallback = function ($row) {
@@ -133,17 +133,17 @@ class Dataquery extends \NDB_Form
         $usersavedNames   = array_map($IDMapCallback, $usersaved);
         $globalsavedNames = array_map($IDMapCallback, $globalsaved);
 
-        $this->tpl_data['savedqueries'] = array(
+        $this->tpl_data['savedqueries'] = [
             'user'   => $usersavedNames,
             'shared' => $globalsavedNames,
-        );
+        ];
         $sessionResults           = $couch->queryView(
             "DQG-2.0",
             "sessions",
-            array(
+            [
                 "reduce" => "true",
                 "group"  => "true",
-            )
+            ]
         );
         $this->tpl_data['visits'] = \Utility::getExistingVisitLabels();
 
@@ -170,7 +170,7 @@ class Dataquery extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/dataquery/js/arrayintersect.js",
                 $baseURL . "/dataquery/js/react.fieldselector.js",
                 $baseURL . "/dataquery/js/react.filterBuilder.js",
@@ -183,7 +183,7 @@ class Dataquery extends \NDB_Form
                 $baseURL . '/js/components/PaginationLinks.js',
                 $baseURL . "/js/jszip/jszip.min.js",
                 $baseURL . "/js/components/MultiSelectDropdown.js",
-            )
+            ]
         );
     }
 
@@ -200,9 +200,9 @@ class Dataquery extends \NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/dataquery/css/dataquery.css",
-            )
+            ]
         );
     }
 }

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -105,9 +105,9 @@ class Dicom_Archive extends \DataFrameworkMenu
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/dicom_archive/js/dicom_archive.js",
-            )
+            ]
         );
     }
 }

--- a/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverowprovisioner.class.inc
@@ -56,7 +56,7 @@ class DicomArchiveRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvision
                   LEFT JOIN candidate c ON (c.CandID=s.CandID)
                   LEFT JOIN psc ON (psc.CenterID=s.CenterID)
             WHERE COALESCE(c.Active, 'Y')='Y' AND COALESCE(s.Active, 'Y')='Y'",
-            array()
+            []
         );
     }
 

--- a/modules/dicom_archive/php/module.class.inc
+++ b/modules/dicom_archive/php/module.class.inc
@@ -86,12 +86,12 @@ class Module extends \Module
          * before continuing.
          */
         $config        = \NDB_Config::singleton()->getSetting("imaging_modules");
-        $configOptions = array(
+        $configOptions = [
             'patientNameRegex',
             'LegoPhantomRegex',
             'LivingPhantomRegex',
             'patientIDRegex',
-        );
+        ];
         $configError   = 'Configuration settings missing for DICOM anonymization. ' .
             'Please ensure that the following settings are configured to ' .
             'be valid regular expressions: ';

--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -94,7 +94,7 @@ class ViewDetails extends \NDB_Form
             $query        = "SELECT * FROM $table WHERE TarchiveID =:ID";
             $tarchiveData = $this->DB->pselectRow(
                 $query,
-                array('ID' => $tarchiveID)
+                ['ID' => $tarchiveID]
             );
             break;
         case "tarchive_series":
@@ -102,10 +102,10 @@ class ViewDetails extends \NDB_Form
                 ORDER BY :OField";
             $tarchiveData = $this->DB->pselect(
                 $query,
-                array(
+                [
                     'ID'     => $tarchiveID,
                     "OField" => $order,
-                )
+                ]
             );
 
             if ($this->_setProtocols()) {
@@ -131,15 +131,15 @@ class ViewDetails extends \NDB_Form
                 ORDER BY :OField";
             $tarchiveData = $this->DB->pselect(
                 $query,
-                array(
+                [
                     'ID'     => $tarchiveID,
                     'OField' => $order,
-                )
+                ]
             );
             break;
         }
 
-        return $tarchiveData ?? array();
+        return $tarchiveData ?? [];
     }
     /**
      * Validates PatientName and PatientID,
@@ -186,7 +186,7 @@ class ViewDetails extends \NDB_Form
                    . ")";
         $isPhantom = $db->pselectRow(
             $query,
-            array('tid' => $this->tpl_data['archive']['TarchiveID'])
+            ['tid' => $this->tpl_data['archive']['TarchiveID']]
         )['IsPhantom'] ?? null;
 
         if ($isPhantom === 'Y') {
@@ -250,7 +250,7 @@ class ViewDetails extends \NDB_Form
             $query           = "SELECT Scan_type, TR_min, TR_max, TE_min, TE_max,
                 TI_min, TI_max, slice_thickness_min, slice_thickness_max FROM
                 mri_protocol";
-            $this->protocols = $this->DB->pselect($query, array());
+            $this->protocols = $this->DB->pselect($query, []);
             return true;
         } catch(\LorisException $e) {
             return false;
@@ -327,7 +327,7 @@ class ViewDetails extends \NDB_Form
     {
         try {
             $query = "SELECT Scan_type FROM mri_scan_type WHERE ID=:ID";
-            $array = $this->DB->pselectRow($query, array('ID' => $id));
+            $array = $this->DB->pselectRow($query, ['ID' => $id]);
             return $array['Scan_type'] ?? 'Unknown';
         } catch (\LorisException $e) {
             return "Unknown";
@@ -362,9 +362,9 @@ class ViewDetails extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/dicom_archive/js/view_details_link.js",
-            )
+            ]
         );
     }
 

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -78,7 +78,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
      */
     function testDicomArchivePermission()
     {
-        $this->setupPermissions(array("dicom_archive_view_allsites"));
+        $this->setupPermissions(["dicom_archive_view_allsites"]);
         $this->safeGet($this->url . "/dicom_archive/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -43,10 +43,10 @@ class DocTree extends \NDB_Page
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'document_repository_view',
                 'document_repository_delete',
-            )
+            ]
         );
     }
 
@@ -81,7 +81,7 @@ class DocTree extends \NDB_Page
     {
         return \Database::singleton()->pselect(
             "SELECT * FROM document_repository_categories",
-            array()
+            []
         );
     }
     /**
@@ -119,7 +119,7 @@ class DocTree extends \NDB_Page
      */
     public function getParents($data, $id)
     {
-        $arr = array();
+        $arr = [];
         foreach ($data as $v) {
             if ($v['id'] == $id) {
                 $arr[] = $v;
@@ -143,8 +143,8 @@ class DocTree extends \NDB_Page
      */
     public function fileTree($id)
     {
-        $result           = array();
-        $allsubcategories = array();
+        $result           = [];
+        $allsubcategories = [];
         $db = \NDB_Factory::singleton()->database();
 
         $tree = $this->getTreeData();
@@ -153,13 +153,13 @@ class DocTree extends \NDB_Page
         $currentcategory    = $db->pselect(
             "SELECT id,category_name,comments
              FROM document_repository_categories WHERE id=:id",
-            array('id' => $id)
+            ['id' => $id]
         );
-        $allsubcategories[] = array('id' => $id);
+        $allsubcategories[] = ['id' => $id];
         foreach ($pids as $pid) {
             $category           = $db->pselectRow(
                 "SELECT id FROM document_repository_categories WHERE id=:pid",
-                array('pid' => $pid)
+                ['pid' => $pid]
             );
             $allsubcategories[] = $category;
         }
@@ -167,7 +167,7 @@ class DocTree extends \NDB_Page
         $subcategories    = $db->pselect(
             "SELECT id,category_name,comments 
              FROM document_repository_categories WHERE parent_id=:id",
-            array('id' => $id)
+            ['id' => $id]
         );
         $parentcategories =   $this->getParents($tree, $id);
         $result['allsubcategories'] = $allsubcategories;

--- a/modules/document_repository/php/document_repository.class.inc
+++ b/modules/document_repository/php/document_repository.class.inc
@@ -37,10 +37,10 @@ class Document_Repository extends \NDB_Menu_Filter_Form
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'document_repository_view',
                 'document_repository_delete',
-            )
+            ]
         );
     }
     /**
@@ -55,16 +55,16 @@ class Document_Repository extends \NDB_Menu_Filter_Form
         $db    = \Database::singleton();
         $query = $db->pselect(
             "SELECT * FROM document_repository_categories",
-            array()
+            []
         );
         //categories
-        $categoriesList = array();
+        $categoriesList = [];
         foreach ($query as $value) {
                $arr = $this->parseCategory($value);
                $categoriesList[$arr['id']] =$arr['name'];
         }
         //site
-        $siteList = array();
+        $siteList = [];
 
         // allow to view all sites data through filter
         if ($user->hasPermission('access_all_profiles')) {
@@ -87,7 +87,7 @@ class Document_Repository extends \NDB_Menu_Filter_Form
         //instrument
         $instruments     = $db->pselectCol(
             "SELECT Test_name FROM test_names ORDER BY Test_name",
-            array()
+            []
         );
         $instrumentsList = array_combine($instruments, $instruments);
 
@@ -100,12 +100,12 @@ class Document_Repository extends \NDB_Menu_Filter_Form
         foreach ($fileTypeQuery as $filetype) {
             $fileTypeList[$filetype['File_type']] = $filetype['File_type'];
         }
-        $this->fieldOptions = array(
+        $this->fieldOptions = [
             'fileCategories' => $categoriesList,
             'sites'          => $siteList,
             'instruments'    => $instrumentsList,
             'fileTypes'      => $fileTypeList,
-        );
+        ];
         return;
     }
     /**
@@ -127,7 +127,7 @@ class Document_Repository extends \NDB_Menu_Filter_Form
                 $parent_id = $value['parent_id'];
                 $query     = "SELECT * FROM document_repository_categories".
                             " where id=$parent_id";
-                $value     = $DB->pselectRow($query, array());
+                $value     = $DB->pselectRow($query, []);
                 if (is_null($value)) {
                     throw new \LorisException(
                         'Could not find data for specified parent ID. '
@@ -137,10 +137,10 @@ class Document_Repository extends \NDB_Menu_Filter_Form
                 $categoryName = $value['category_name'] . ">" . $categoryName;
             }
         } while ($value['parent_id'] != 0);
-         return array(
+         return [
              "name" => $categoryName,
              "id"   => $id,
-         );
+         ];
     }
 
     /**
@@ -225,9 +225,9 @@ class Document_Repository extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/document_repository/js/docIndex.js",
-            )
+            ]
         );
     }
 

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -47,10 +47,10 @@ class Files extends \NDB_Page
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'document_repository_view',
                 'document_repository_delete',
-            )
+            ]
         );
     }
 
@@ -190,20 +190,20 @@ class Files extends \NDB_Page
         $fileName = $DB->pselectOne(
             "SELECT File_name FROM document_repository
              WHERE record_id =:identifier",
-            array(':identifier' => $rid)
+            [':identifier' => $rid]
         );
         $dataDir  = $DB->pselectOne(
             "SELECT Data_dir FROM document_repository WHERE record_id =:identifier",
-            array(':identifier' => $rid)
+            [':identifier' => $rid]
         );
 
         //if user has document repository delete permission
         if ($user->hasPermission('document_repository_delete')) {
-            $DB->delete("document_repository", array("record_id" => $rid));
-            $msg_data = array(
+            $DB->delete("document_repository", ["record_id" => $rid]);
+            $msg_data = [
                 'deleteDocument' => $baseURL. "/document_repository/",
                 'document'       => $fileName,
-            );
+            ];
             $Notifier->notify($msg_data);
         }
 
@@ -225,10 +225,10 @@ class Files extends \NDB_Page
         $db    = \Database::singleton();
         $query = $db->pselect(
             "SELECT * FROM document_repository_categories",
-            array()
+            []
         );
         //categories
-        $categoriesList = array();
+        $categoriesList = [];
         foreach ($query as $value) {
              $arr = $this->parseCategory($value);
              $categoriesList[$arr['id']] =$arr['name'];
@@ -238,7 +238,7 @@ class Files extends \NDB_Page
         //instrument
         $instruments     = $db->pselectCol(
             "SELECT Test_name FROM test_names ORDER BY Test_name",
-            array()
+            []
         );
         $instrumentsList = array_combine($instruments, $instruments);
         //docFile
@@ -254,15 +254,15 @@ class Files extends \NDB_Page
                 "version " .
                 "FROM document_repository " .
                 " WHERE record_id = :record_id";
-        $where   = array('record_id' => $id);
+        $where   = ['record_id' => $id];
         $docData = $db->pselectRow($query, $where);
 
-        $result = array(
+        $result = [
             'categories'  => $categoriesList,
             'sites'       => $siteList,
             'instruments' => $instrumentsList,
             'docData'     => $docData,
-        );
+        ];
 
         return $result;
     }
@@ -286,7 +286,7 @@ class Files extends \NDB_Page
                 $parent_id = $value['parent_id'];
                 $query     = "SELECT * FROM document_repository_categories".
                             " WHERE id=:parent_id";
-                $where     = array('parent_id' => $parent_id);
+                $where     = ['parent_id' => $parent_id];
                 $value     = $DB->pselectRow($query, $where);
                 if (is_null($value)) {
                     throw new \LorisException(
@@ -297,10 +297,10 @@ class Files extends \NDB_Page
                 $categoryName = $value['category_name'] . ">" . $categoryName;
             }
         } while ($value['parent_id'] != 0);
-        return array(
+        return [
             "name" => $categoryName,
             "id"   => $id,
-        );
+        ];
     }
 
     /**
@@ -332,7 +332,7 @@ class Files extends \NDB_Page
 
         $site       = $DB->pselectOne(
             "SELECT CenterID FROM psc WHERE Name=:name",
-            array('name' => $site)
+            ['name' => $site]
         );
         $instrument = !empty($req['instrument']) ? $req['instrument'] : null;
         $pscid      = !empty($req['pscid'])      ? $req['pscid']      : null;
@@ -374,7 +374,7 @@ class Files extends \NDB_Page
 
                 $DB->insert(
                     'document_repository',
-                    array(
+                    [
                         'File_category' => $category,
                         'For_site'      => $site,
                         'comments'      => $comments,
@@ -387,12 +387,12 @@ class Files extends \NDB_Page
                         'PSCID'         => $pscid,
                         'visitLabel'    => $visit,
                         'File_type'     => $fileType,
-                    )
+                    ]
                 );
-                $msg_data = array(
+                $msg_data = [
                     'newDocument' => $baseURL . "/document_repository/",
                     'document'    => $fileName,
-                );
+                ];
                 $uploadNotifier->notify($msg_data);
                 $uploadOK = true;
         }
@@ -411,7 +411,7 @@ class Files extends \NDB_Page
         $fileCount =  $DB->pselectOne(
             "SELECT COUNT(*) FROM document_repository
              WHERE File_Name=:name",
-            array('name' => $filename)
+            ['name' => $filename]
         );
         if ((int)$fileCount > 0) {
             return true;

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -82,7 +82,7 @@ class Module extends \Module
             $docs         = $DB->pselect(
                 "SELECT File_name, Date_uploaded, Data_dir FROM document_repository
                  ORDER BY Date_uploaded DESC LIMIT 4",
-                array()
+                []
             );
             $numberOfDocs = sizeof($docs);
             for ($i=0; $i < $numberOfDocs; $i++) {

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -37,10 +37,10 @@ class UploadCategory extends \NDB_Page
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'document_repository_view',
                 'document_repository_delete',
-            )
+            ]
         );
     }
 
@@ -88,11 +88,11 @@ class UploadCategory extends \NDB_Page
         // todo check duplicate name category
         $DB->insert(
             "document_repository_categories",
-            array(
+            [
                 "category_name" => $category_name,
                 "parent_id"     => $parent_id,
                 "comments"      => $comments,
-            )
+            ]
         );
     }
 }

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -55,7 +55,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
       */
     public function testSuperUserPermission()
     {
-         $this->setupPermissions(array("superuser"));
+         $this->setupPermissions(["superuser"]);
          $this->safeGet($this->url . "/document_repository/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
@@ -75,7 +75,7 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
     {
         // create user object
         $user          = \NDB_Factory::singleton()->user();
-        $list_of_sites = array();
+        $list_of_sites = [];
 
         // grep the sites available to the user
         if ($user->hasPermission('electrophysiology_browser_view_allsites')) {
@@ -95,17 +95,17 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
         }
 
         // get list of projects
-        $list_of_projects = array();
+        $list_of_projects = [];
         $projectList      = \Utility::getProjectList();
         foreach ($projectList as $key => $project) {
             unset($projectList[$key]);
             $list_of_projects[$project] = $project;
         }
 
-        return array(
+        return [
             'sites'    => $list_of_sites,
             'projects' => $list_of_projects,
-        );
+        ];
 
     }
 
@@ -134,10 +134,10 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
         $baseURL = $factory->settings()->getBaseURL();
         return array_merge(
             parent::getJSDependencies(),
-            array(
+            [
                 $baseURL
                 . '/electrophysiology_browser/js/electrophysiologyBrowserIndex.js',
-            )
+            ]
         );
     }
 

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
@@ -64,7 +64,7 @@ class ElectrophysiologyBrowserRowProvisioner
                 SELECT type FROM ImagingFileTypes WHERE Description LIKE '%(EEG)'
               )
             GROUP BY SessionID",
-            array()
+            []
         );
     }
 

--- a/modules/electrophysiology_browser/php/models/ElectrophysioFile.class.inc
+++ b/modules/electrophysiology_browser/php/models/ElectrophysioFile.class.inc
@@ -24,8 +24,8 @@ namespace LORIS\electrophysiology_browser\Models;
  */
 class ElectrophysioFile implements \LORIS\Data\DataInstance
 {
-    private $_fileData   = array();
-    private $_parameters = array();
+    private $_fileData   = [];
+    private $_parameters = [];
 
     /**
      * Construct a BIDSFile
@@ -49,7 +49,7 @@ class ElectrophysioFile implements \LORIS\Data\DataInstance
                        FilePath  
                      FROM physiological_file 
                      WHERE PhysiologicalFileID=:PFID";
-        $params   = array('PFID' => $physiologicalFileID);
+        $params   = ['PFID' => $physiologicalFileID];
         $fileData = $db->pselectRow($query, $params);
 
         foreach ($fileData AS $key=>$value) {

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -109,7 +109,7 @@ class Sessions extends \NDB_Page
 
         if ($request->getMethod() != 'GET') {
             return (new \LORIS\Http\Response\JSON\MethodNotAllowed(
-                array('GET')
+                ['GET']
             ));
         }
 
@@ -155,9 +155,9 @@ class Sessions extends \NDB_Page
                 AND pf.FileType IN ("bdf", "cnt", "edf", "set", "vhdr", "vsm") 
               ORDER BY pf.SessionID';
 
-        $response = array();
+        $response = [];
 
-        $sessions            = $db->pselect($query, array());
+        $sessions            = $db->pselect($query, []);
         $sessions            = array_column($sessions, 'SessionID');
         $response['patient'] = $this->getSubjectData($outputType);
         $response['database']    = array_values(
@@ -181,7 +181,7 @@ class Sessions extends \NDB_Page
      */
     function getSubjectData($outputType)
     {
-        $subjectData = array();
+        $subjectData = [];
         $candidate   = \NDB_Factory::singleton()->candidate(
             $this->timepoint->getCandID()
         );
@@ -213,8 +213,8 @@ class Sessions extends \NDB_Page
     {
         $db = \NDB_Factory::singleton()->database();
 
-        $fileCollection = array();
-        $params         = array();
+        $fileCollection = [];
+        $params         = [];
         $params['SID']  = $sessionID;
         $query          = 'SELECT 
                          pf.PhysiologicalFileID, 
@@ -236,7 +236,7 @@ class Sessions extends \NDB_Page
         $physiologicalFiles = $db->pselect($query, $params);
 
         foreach ($physiologicalFiles as $file) {
-            $fileSummary         = array();
+            $fileSummary         = [];
             $physiologicalFileID = $file['PhysiologicalFileID'];
             $physiologicalFile   = $file['FilePath'];
             $physioFileObj       = new ElectrophysioFile(
@@ -269,22 +269,22 @@ class Sessions extends \NDB_Page
             $ecgChannelCount = $physioFileObj->getParameter('ECGChannelCount');
             $emgChannelCount = $physioFileObj->getParameter('EMGChannelCount');
 
-            $fileSummary['task']['channel'][] = array(
+            $fileSummary['task']['channel'][] = [
                 'name'  => 'EEG Channel Count',
                 'value' => $eegChannelCount,
-            );
-            $fileSummary['task']['channel'][] = array(
+            ];
+            $fileSummary['task']['channel'][] = [
                 'name'  => 'EOG Channel Count',
                 'value' => $eogChannelCount,
-            );
-            $fileSummary['task']['channel'][] = array(
+            ];
+            $fileSummary['task']['channel'][] = [
                 'name'  => 'ECG Channel Count',
                 'value' => $ecgChannelCount,
-            );
-            $fileSummary['task']['channel'][] = array(
+            ];
+            $fileSummary['task']['channel'][] = [
                 'name'  => 'EMG Channel Count',
                 'value' => $emgChannelCount,
-            );
+            ];
 
             // get the task reference
 
@@ -377,13 +377,13 @@ class Sessions extends \NDB_Page
     {
         $db = \NDB_Factory::singleton()->database();
 
-        $params          = array();
+        $params          = [];
         $params['PFID']  = $physioFileID;
-        $downloadLinks   = array();
-        $downloadLinks[] = array(
+        $downloadLinks   = [];
+        $downloadLinks[] = [
             'type' => 'physiological_file',
             'file' => $physioFile,
-        );
+        ];
 
         $queries = [
             'physiological_electrode'  => 'physiological_electrode_file',
@@ -401,15 +401,15 @@ class Sessions extends \NDB_Page
                               PhysiologicalFileID=:PFID";
             $query_statement = $db->pselectRow($query_statement, $params);
             if (isset($query_statement['FileType'])) {
-                $downloadLinks[] = array(
+                $downloadLinks[] = [
                     'type' => $query_statement['FileType'],
                     'file' => $query_statement['FilePath'],
-                );
+                ];
             } else {
-                $downloadLinks[] = array(
+                $downloadLinks[] = [
                     'type' => $query_value,
                     'file' => '',
-                );
+                ];
             }
         }
 
@@ -424,15 +424,15 @@ class Sessions extends \NDB_Page
                    AND PhysiologicalFileID=:PFID";
         $queryFDT = $db->pselectRow($queryFDT, $params);
         if (isset($queryFDT['FileType'])) {
-            $downloadLinks[] = array(
+            $downloadLinks[] = [
                 'type' => $queryFDT['FileType'],
                 'file' => $queryFDT['FilePath'],
-            );
+            ];
         } else {
-            $downloadLinks[] = array(
+            $downloadLinks[] = [
                 'type' => 'physiological_fdt_file',
                 'file' => '',
-            );
+            ];
         }
 
         return $downloadLinks;
@@ -450,10 +450,10 @@ class Sessions extends \NDB_Page
         $baseurl = $factory->settings()->getBaseURL();
         $depends = array_merge(
             $depends,
-            array(
+            [
                 $baseurl
                 . '/electrophysiology_browser/js/electrophysiologySessionView.js',
-            )
+            ]
         );
         return $depends;
     }

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -52,9 +52,9 @@ class EditExaminer extends \NDB_Form
                  FROM examiners e
                   LEFT JOIN examiners_psc_rel epr ON (e.examinerID=epr.examinerID)
                  WHERE e.examinerID=:EID",
-                array('EID' => $this->identifier)
+                ['EID' => $this->identifier]
             );
-            $centerIDs =array();
+            $centerIDs =[];
             foreach ($cids as $row) {
                 $centerIDs[] = $row['centerID'];
             }
@@ -87,11 +87,11 @@ class EditExaminer extends \NDB_Form
             "SELECT testID, pass, date_cert, comment
              FROM certification
              WHERE examinerID=:EID",
-            array('EID' => $this->identifier)
+            ['EID' => $this->identifier]
         );
 
         // set the form defaults for the page
-        $defaults = array();
+        $defaults = [];
         foreach ($result as $row) {
             $defaults['date_cert[' . $row['testID'] . ']']       = $row['date_cert'];
             $defaults['certStatus['      . $row['testID'] . ']'] = $row['pass'];
@@ -124,10 +124,10 @@ class EditExaminer extends \NDB_Form
                 "SELECT certID
                  FROM certification
                  WHERE examinerID=:EID AND testID=:TID",
-                array(
+                [
                     'EID' => $examinerID,
                     'TID' => $testID,
-                )
+                ]
             );
             // FIXME $visit_label should be set properly. This declaration
             // was only added to appease phan.
@@ -136,12 +136,12 @@ class EditExaminer extends \NDB_Form
              // if certification for new instrument for the examiner
             if (empty($certID) && !empty($certStatus)) {
                 // insert a new certification entry
-                $data = array(
+                $data = [
                     'examinerID' => $examinerID,
                     'testID'     => $testID,
                     'pass'       => $certStatus,
                     'comment'    => $comment,
-                );
+                ];
                 if ($date_cert != "") {
                     $data['date_cert'] = $date_cert;
                 }
@@ -154,13 +154,13 @@ class EditExaminer extends \NDB_Form
                     "SELECT certID
                      FROM certification
                      WHERE examinerID =:EID and testID=:TID",
-                    array(
+                    [
                         'EID' => $examinerID,
                         'TID' => $testID,
-                    )
+                    ]
                 );
                 // Add a new entry to the certification history table
-                $data = array(
+                $data = [
                     'col'         => 'pass',
                     'new'         => $certStatus,
                     'primaryVals' => $certID,
@@ -169,7 +169,7 @@ class EditExaminer extends \NDB_Form
                     'changeDate'  => date("Y-m-d H:i:s"),
                     'userID'      => $_SESSION['State']->getUsername(),
                     'type'        => 'I',
-                );
+                ];
                 if ($date_cert != "") {
                     $data['new_date'] = $date_cert;
                 }
@@ -187,10 +187,10 @@ class EditExaminer extends \NDB_Form
                      LEFT JOIN certification c ON (c.certID=ch.primaryVals)
                      WHERE c.examinerID=:EID AND ch.testID=:TID
                      ORDER BY changeDate DESC LIMIT 1",
-                    array(
+                    [
                         'EID' => $examinerID,
                         'TID' => $testID,
-                    )
+                    ]
                 );
                 if (empty($oldVals)) {
                     throw new \LorisException(
@@ -206,10 +206,10 @@ class EditExaminer extends \NDB_Form
                     "SELECT pass, date_cert, comment
                      FROM certification
                      WHERE examinerID=:EID AND testID=:TID",
-                    array(
+                    [
                         'EID' => $examinerID,
                         'TID' => $testID,
-                    )
+                    ]
                 );
 
                 if (!empty($oldCertification)) {
@@ -220,25 +220,25 @@ class EditExaminer extends \NDB_Form
                         || $oldCertification['date_cert'] != $date_cert
                     ) {
                         // Update the certification entry
-                        $data = array(
+                        $data = [
                             'pass'    => $certStatus,
                             'comment' => $comment,
-                        );
+                        ];
                         if ($date_cert != "") {
                             $data['date_cert'] = $date_cert;
                         }
                         $DB->update(
                             'certification',
                             $data,
-                            array(
+                            [
                                 'examinerID' => $examinerID,
                                 'testID'     => $testID,
-                            )
+                            ]
                         );
 
                         // Add a new entry to the certification history table
                         if ($oldDate != $date_cert || $oldVal != $certStatus) {
-                            $data = array(
+                            $data = [
                                 'col'         => 'pass',
                                 'old'         => $oldVal,
                                 'new'         => $certStatus,
@@ -248,7 +248,7 @@ class EditExaminer extends \NDB_Form
                                 'changeDate'  => date("Y-m-d H:i:s"),
                                 'userID'      => $_SESSION['State']->getUsername(),
                                 'type'        => 'U',
-                            );
+                            ];
                             if ($oldDate != "") {
                                 $data['old_date'] = $oldDate;
                             }
@@ -288,33 +288,33 @@ class EditExaminer extends \NDB_Form
              LEFT JOIN certification c ON (c.certID=ch.primaryVals)
              WHERE c.examinerID=:EID
              ORDER BY changeDate DESC",
-            array('EID' => $this->identifier)
+            ['EID' => $this->identifier]
         );
 
         $this->tpl_data['certification_history'] = $certification_history;
 
         $config = \NDB_Config::singleton();
 
-        $dateOptions   = array(
+        $dateOptions   = [
             'language'       => 'en',
             'format'         => 'YMd',
             'addEmptyOption' => true,
             'minYear'        => $config->getSetting('startYear'),
             'maxYear'        => $config->getSetting('endYear'),
-        );
-        $statusOptions = array(
+        ];
+        $statusOptions = [
             null            => 'N/A',
             'not_certified' => 'Not Certified',
             'in_training'   => 'In Training',
             'certified'     => 'Certified',
-        );
+        ];
 
         // Get the list of certification instruments
         $instruments = $this->getCertificationInstruments();
         $this->tpl_data['instruments'] = $instruments;
 
         // Create the form elements for each certification instrument
-        $group = array();
+        $group = [];
         foreach ($instruments as $key => $value) {
             $group[] = $this->createSelect(
                 'certStatus['.$key.']',
@@ -335,10 +335,10 @@ class EditExaminer extends \NDB_Form
                 $value,
                 $value,
                 '',
-                array(
+                [
                     'prefix_wrapper'  => '<div class="col-md-3">',
                     'postfix_wrapper' => '</div>',
-                )
+                ]
             );
             unset($group);
         }
@@ -351,7 +351,7 @@ class EditExaminer extends \NDB_Form
             "SELECT e.full_name
               FROM examiners e
               WHERE e.examinerID=:EID",
-            array('EID' => $this->identifier)
+            ['EID' => $this->identifier]
         );
         if (is_null($row)) {
             throw new \LorisException(
@@ -364,7 +364,7 @@ class EditExaminer extends \NDB_Form
 
         $this->tpl_data['examiner_name'] = $row['full_name'];
 
-        $this->form->addFormRule(array(&$this, '_validateEditExaminer'));
+        $this->form->addFormRule([&$this, '_validateEditExaminer']);
     }
 
 
@@ -378,7 +378,7 @@ class EditExaminer extends \NDB_Form
     function _validateEditExaminer($values)
     {
         $DB     = \Database::singleton();
-        $errors = array();
+        $errors = [];
 
         // check that there is both a status and a date (neither can be null)
         foreach ($values['certStatus'] as $instrumentID => $certificationStatus) {
@@ -400,7 +400,7 @@ class EditExaminer extends \NDB_Form
             "SELECT c.testID
               FROM certification c
               WHERE c.examinerID=:EID",
-            array('EID' => $this->identifier)
+            ['EID' => $this->identifier]
         );
         foreach ($rows as $row) {
             if ($values['certStatus'][$row['testID']] == "") {
@@ -427,11 +427,11 @@ class EditExaminer extends \NDB_Form
         $certificationInstruments = $certificationConfig['CertificationInstruments'];
 
         if (!isset($certificationInstruments['test'])) {
-            return array();
+            return [];
         }
         $certificationInstruments['test']
             = \Utility::associativeToNumericArray($certificationInstruments['test']);
-        $instruments = array();
+        $instruments = [];
 
         foreach ($certificationInstruments['test'] as $certificationInstrument) {
             $testName = $certificationInstrument['@']['value'];
@@ -439,7 +439,7 @@ class EditExaminer extends \NDB_Form
                 "SELECT ID
                  FROM test_names
                  WHERE Test_name =:testName",
-                array('testName' => $testName)
+                ['testName' => $testName]
             );
             $instruments[$testID] = $certificationInstrument['#'];
         }

--- a/modules/examiner/php/examiner.class.inc
+++ b/modules/examiner/php/examiner.class.inc
@@ -39,10 +39,10 @@ class Examiner extends \NDB_Menu_Filter_Form
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'examiner_view',
                 'examiner_multisite',
-            )
+            ]
         );
     }
 
@@ -87,35 +87,35 @@ class Examiner extends \NDB_Menu_Filter_Form
         }
 
         // set the class variables
-        $this->columns      = array(
+        $this->columns      = [
             'e.full_name as Examiner',
             'e.examinerID as ID',
             'psc.Name as Site',
             'e.radiologist as Radiologist',
             "GROUP_CONCAT(tn.full_name SEPARATOR ', ') as
                                 Certification",
-        );
+        ];
         $this->group_by     = "e.full_name,psc.Name,e.examinerID";
         $this->query        = $query;
         $this->order_by     = 'e.full_name';
-        $this->headers      = array(
+        $this->headers      = [
             'Examiner',
             'ID',
             'Site',
             'Radiologist',
             'Certification',
-        );
-        $this->validFilters = array(
+        ];
+        $this->validFilters = [
             'e.full_name',
             'epr.centerID',
             'COALESCE(e.radiologist, 0)',
-        );
+        ];
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'examiner'    => 'e.full_name',
             'site'        => 'epr.centerID',
             'radiologist' => 'COALESCE(e.radiologist, 0)',
-        );
+        ];
     }
 
     /**
@@ -146,17 +146,17 @@ class Examiner extends \NDB_Menu_Filter_Form
         }
 
         // Radiologist options
-        $radiologist = array(
+        $radiologist = [
             '1' => 'Yes',
             '0' => 'No',
-        );
+        ];
 
-        $this->fieldOptions = array(
+        $this->fieldOptions = [
             'sites'        => $sites,
             'radiologists' => $radiologist,
-        );
+        ];
 
-        $this->form->addFormRule(array(&$this, '_validateAddExaminer'));
+        $this->form->addFormRule([&$this, '_validateAddExaminer']);
     }
 
     /**
@@ -221,13 +221,13 @@ class Examiner extends \NDB_Menu_Filter_Form
             "SELECT examinerID
              FROM examiners
              WHERE full_name=:fullName",
-            array('fullName' => $fullName)
+            ['fullName' => $fullName]
         );
 
         //Check if examiner is already a loris user, if so add foreign key
         $isUser = $DB->pselectOne(
             "SELECT ID FROM users WHERE Real_name=:fullName",
-            array('fullName' => $fullName)
+            ['fullName' => $fullName]
         );
 
         $user_id = null;
@@ -237,26 +237,26 @@ class Examiner extends \NDB_Menu_Filter_Form
         if (empty($examinerID)) {
             $DB->insert(
                 'examiners',
-                array(
+                [
                     'full_name'   => $fullName,
                     'radiologist' => $radiologist,
                     'userID'      => $user_id,
-                )
+                ]
             );
         } else {
             $DB->update(
                 'examiners',
-                array('radiologist' => $radiologist),
-                array('examinerID' => $examinerID)
+                ['radiologist' => $radiologist],
+                ['examinerID' => $examinerID]
             );
         }
 
         $DB->insert(
             'examiners_psc_rel',
-            array(
+            [
                 'examinerID' => $this->getExaminerID($fullName),
                 'centerID'   => $siteID,
-            )
+            ]
         );
 
         header("Location: {$baseurl}/examiner/", true, 303);
@@ -279,10 +279,10 @@ class Examiner extends \NDB_Menu_Filter_Form
              FROM examiners e
                   LEFT JOIN examiners_psc_rel epr ON (e.examinerID=epr.examinerID)
              WHERE e.full_name=:fullName AND epr.centerID=:siteID",
-            array(
+            [
                 'fullName' => $fullName,
                 'siteID'   => $siteID,
-            )
+            ]
         );
 
         if (empty($examinerID)) {
@@ -306,7 +306,7 @@ class Examiner extends \NDB_Menu_Filter_Form
             "SELECT examinerID
              FROM examiners
              WHERE full_name=:fullName",
-            array('fullName' => $fullName)
+            ['fullName' => $fullName]
         );
 
         //returned as a string
@@ -327,7 +327,7 @@ class Examiner extends \NDB_Menu_Filter_Form
             "SELECT CenterID
              FROM psc
              WHERE Name=:siteName",
-            array('siteName' => $siteName)
+            ['siteName' => $siteName]
         );
         //returned as a string
         return $siteID;
@@ -362,9 +362,9 @@ class Examiner extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/examiner/js/examinerIndex.js",
-            )
+            ]
         );
     }
 }

--- a/modules/examiner/test/ExaminerTest.php
+++ b/modules/examiner/test/ExaminerTest.php
@@ -37,14 +37,14 @@ class ExaminerTest extends LorisIntegrationTest
      * Table headers
      */
     private $_loadingUI
-        =  array(
+        =  [
             'Examiner'         => '#bc2 > a:nth-child(2) > div',
             'Selection Filter' => '#lorisworkspace > div.row > '.
                                   'div.col-sm-12.col-md-7 > div > div.panel-heading',
             'Add Examiner'     => '#lorisworkspace > div > div:nth-child(1) > '.
                                   'div > div:nth-child(1)',
             'Add'              => '#examiner > div:nth-child(3) > div > button',
-        );
+        ];
 
     /**
      * Insert testing data
@@ -64,12 +64,12 @@ class ExaminerTest extends LorisIntegrationTest
     {
         $this->DB->delete(
             "examiners",
-            array('full_name' => 'Test_Examiner')
+            ['full_name' => 'Test_Examiner']
         );
 
         $this->DB->delete(
             "psc",
-            array('Name' => 'TEST_Site')
+            ['Name' => 'TEST_Site']
         );
          parent::tearDown();
     }
@@ -81,7 +81,7 @@ class ExaminerTest extends LorisIntegrationTest
      */
     function testResultTableLoadsWithPermission()
     {
-        $this->setupPermissions(array("examiner_view"));
+        $this->setupPermissions(["examiner_view"]);
         $this->safeGet($this->url . "/examiner/?format=json");
 
         // Check the table column headers
@@ -102,7 +102,7 @@ class ExaminerTest extends LorisIntegrationTest
      */
     function testExaminerDoesNotLoadWithoutPermission()
     {
-        $this->setupPermissions(array());
+        $this->setupPermissions([]);
         $this->safeGet($this->url . "/examiner/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -118,7 +118,7 @@ class ExaminerTest extends LorisIntegrationTest
      */
     function testExaminerDoesLoadWithoutSuperuser()
     {
-        $this->setupPermissions(array('superuser'));
+        $this->setupPermissions(['superuser']);
         $this->safeGet($this->url . "/examiner/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/genomic_browser/ajax/genomic_file_upload.php
+++ b/modules/genomic_browser/ajax/genomic_file_upload.php
@@ -40,7 +40,7 @@ header('Content-Type: application/json; charset=UTF-8');
 $bytes = $_FILES["fileData"]['size'];
 
 $fileToUpload
-    = (object) array(
+    = (object) [
         'file_type'         => $_FILES["fileData"]["type"],
         'file_name'         => $_FILES["fileData"]["name"],
         'tmp_name'          => $_FILES["fileData"]["tmp_name"],
@@ -49,7 +49,7 @@ $fileToUpload
         'genomic_file_type' => empty($_POST['fileType']) ?
                     null : str_replace('_', ' ', $_POST['fileType']),
         'description'       => $_POST['description'],
-    );
+    ];
 
 setFullPath($fileToUpload);
 
@@ -71,12 +71,12 @@ case 'Other':
 default:
     die(
         json_encode(
-            array(
+            [
                 'message'  => "Unsupported filetype: " .
                                $fileToUpload->genomic_file_type,
                 'progress' => 100,
                 'error'    => true,
-            )
+            ]
         )
     );
 }
@@ -99,11 +99,11 @@ function validateRequest()
     ) {
         die(
             json_encode(
-                array(
+                [
                     'message'  => 'Validation failed : Missing inputs',
                     'progress' => 100,
                     'error'    => true,
-                )
+                ]
             )
         );
         // This require some more work
@@ -137,12 +137,12 @@ function setFullPath(&$fileToUpload)
         if ($collision_count > $collision_max) {
             die(
                 json_encode(
-                    array(
+                    [
                         'message'  => 'That file already exists, '
                         . 'could not generate a non-colliding name',
                         'progress' => 100,
                         'error'    => true,
-                    )
+                    ]
                 )
             );
         }
@@ -196,11 +196,11 @@ function moveFileToFS(&$fileToUpload)
         //       Further debugging needed
         die(
             json_encode(
-                array(
+                [
                     'message'  => "File copy failed",
                     'progress' => 100,
                     'error'    => true,
-                )
+                ]
             )
         );
     }
@@ -217,7 +217,7 @@ function moveFileToFS(&$fileToUpload)
 function registerFile(&$fileToUpload)
 {
     $DB     = \Database::singleton();
-    $values = array(
+    $values = [
         'FileName'         => $fileToUpload->full_path,
         'Description'      => $fileToUpload->description,
         'FileType'         => $fileToUpload->file_type,
@@ -225,7 +225,7 @@ function registerFile(&$fileToUpload)
         'FileSize'         => $fileToUpload->size,
         'Date_inserted'    => date("Y-m-d h:i:s", time()),
         'InsertedByUserID' => $fileToUpload->inserted_by,
-    );
+    ];
     try {
         $DB->replace('genomic_files', $values);
         //TODO :: This should select using date_insert and
@@ -233,7 +233,7 @@ function registerFile(&$fileToUpload)
         $last_id = $DB->pselectOne(
             'SELECT MAX(GenomicFileID) AS last_id
            FROM genomic_files',
-            array()
+            []
         );
         $fileToUpload->GenomicFileID = $last_id;
 
@@ -245,12 +245,12 @@ function registerFile(&$fileToUpload)
         //      Currently, it generates unnecessary PHP warnings
         die(
             json_encode(
-                array(
+                [
                     'message'  => 'File registration failed. Is the '
                                     .' description empty?',
                     'progress' => 100,
                     'error'    => true,
-                )
+                ]
             )
         );
     }
@@ -316,13 +316,13 @@ function createSampleCandidateRelations(&$fileToUpload)
     try {
         foreach ($headers as $pscid) {
             $stmt->execute(
-                array(
+                [
                     "sample_label" => $pscid,
                     "pscid"        => explode(
                         '_',
                         $pscid
                     )[1],
-                )
+                ]
             );
         }
         // Report number on relation created (candidate founded)
@@ -331,11 +331,11 @@ function createSampleCandidateRelations(&$fileToUpload)
         endWithFailure();
         die(
             json_encode(
-                array(
+                [
                     'message'  => "Can't insert into the database.",
                     'progress' => 100,
                     'error'    => true,
-                )
+                ]
             )
         );
     }
@@ -409,11 +409,11 @@ function insertBetaValues(&$fileToUpload)
                 array_shift($values);
                 foreach ($values as $key => $value) {
                     $success = $stmt->execute(
-                        array(
+                        [
                             "sample_label" => $headers[$key],
                             "cpg_name"     => $probe_id,
                             "beta_value"   => $value,
-                        )
+                        ]
                     );
                     if (!$success) {
                         throw new DatabaseException("Failed to insert row");
@@ -423,11 +423,11 @@ function insertBetaValues(&$fileToUpload)
                 endWithFailure();
                 die(
                     json_encode(
-                        array(
+                        [
                             'message'  => 'Insertion failed',
                             'progress' => 100,
                             'error'    => true,
-                        )
+                        ]
                     )
                 );
             }
@@ -437,11 +437,11 @@ function insertBetaValues(&$fileToUpload)
         endWithFailure();
         die(
             json_encode(
-                array(
+                [
                     'message'  => 'Beta value file can`t be opened',
                     'progress' => 100,
                     'error'    => true,
-                )
+                ]
             )
         );
     }
@@ -487,10 +487,10 @@ function createCandidateFileRelations(&$fileToUpload)
             foreach ($headers as $pscid) {
                 $pscid   = trim($pscid);
                 $success = $stmt->execute(
-                    array(
+                    [
                         "pscid"           => $pscid,
                         "genomic_file_id" => $fileToUpload->GenomicFileID,
-                    )
+                    ]
                 );
                 if (!$success) {
                     throw new DatabaseException("Failed to insert row");
@@ -500,11 +500,11 @@ function createCandidateFileRelations(&$fileToUpload)
             endWithFailure();
             die(
                 json_encode(
-                    array(
+                    [
                         'message'  => 'File registration failed',
                         'progress' => 100,
                         'error'    => true,
-                    )
+                    ]
                 )
             );
         }
@@ -512,11 +512,11 @@ function createCandidateFileRelations(&$fileToUpload)
         endWithFailure();
         die(
             json_encode(
-                array(
+                [
                     'message'  => 'Beta value file can`t be opened',
                     'progress' => 100,
                     'error'    => true,
-                )
+                ]
             )
         );
     }
@@ -551,10 +551,10 @@ function insertMethylationData(&$fileToUpload)
  */
 function reportProgress($progress, $message)
 {
-    $response = array(
+    $response = [
         'message'  => $message,
         'progress' => $progress,
-    );
+    ];
     echo json_encode($response);
     sleep(1);
 }
@@ -574,7 +574,7 @@ function candidateExists($pscid)
 
     $CandID = $DB->pselectOne(
         "SELECT CandID from candidate WHERE PSCID = :pscid",
-        array("pscid" => $pscid)
+        ["pscid" => $pscid]
     );
 
     return !empty($CandID);

--- a/modules/genomic_browser/ajax/get_genomic_file.php
+++ b/modules/genomic_browser/ajax/get_genomic_file.php
@@ -39,7 +39,7 @@ $results = $DB->pselect(
          genomic_files 
      WHERE 
          GenomicFileID = :v_file_id',
-    array('v_file_id' => $_GET['GenomicFileID'])
+    ['v_file_id' => $_GET['GenomicFileID']]
 );
 
 if (count($results) < 1) {

--- a/modules/genomic_browser/ajax/get_genomic_file_type.php
+++ b/modules/genomic_browser/ajax/get_genomic_file_type.php
@@ -23,7 +23,7 @@ $DB     =& Database::singleton();
 $result = $DB->pselect(
     'SELECT analysis_modality as genomicFileType
        FROM genomic_analysis_modality_enum',
-    array()
+    []
 );
 header('Content-Type: application/json; charset=UTF-8');
 echo json_encode($result);

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -62,7 +62,7 @@ class CNV_Browser extends \NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'psc.Name AS PSC',
             'LPAD(candidate.CandID, 6, "0") AS DCCID',
             'candidate.PSCID',
@@ -94,7 +94,7 @@ class CNV_Browser extends \NDB_Menu_Filter
             'CNV.Markers as Markers',
             'CNV.ValidationMethod as Validation_Method',
             'genotyping_platform.Name as Platform',
-        );
+        ];
 
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
@@ -103,7 +103,7 @@ class CNV_Browser extends \NDB_Menu_Filter
                 function ($header) {
                         return ucwords(str_replace('_', ' ', $header));
                 },
-                array(
+                [
                     'PSC',
                     'DCCID',
                     'Subproject',
@@ -120,7 +120,7 @@ class CNV_Browser extends \NDB_Menu_Filter
                     'Array_Report',
                     'Markers',
                     'Validation_Method',
-                )
+                ]
             )
         );
 
@@ -146,7 +146,7 @@ class CNV_Browser extends \NDB_Menu_Filter
 
         $this->limit = 10000;
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'candidate.RegistrationCenterID',
             'candidate.CandID',
             'candidate.PSCID',
@@ -171,9 +171,9 @@ class CNV_Browser extends \NDB_Menu_Filter
             'CNV.OfficialSymbol',
             'CNV.OfficialName',
             'genotyping_platform.Name',
-        );
+        ];
 
-        $ftf = array(
+        $ftf = [
             'centerID'           => 'candidate.RegistrationCenterID',
             'DCCID'              => 'candidate.CandID',
             'PSCID'              => 'candidate.PSCID',
@@ -197,7 +197,7 @@ class CNV_Browser extends \NDB_Menu_Filter
             'Gene_Symbol'        => 'CNV.OfficialSymbol',
             'Gene_Name'          => 'CNV.OfficialName',
             'Platform'           => 'genotyping_platform.Name',
-        );
+        ];
         $this->formToFilter = $ftf;
     }
 
@@ -221,12 +221,12 @@ class CNV_Browser extends \NDB_Menu_Filter
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = \Utility::getSiteList();
             if (is_array($list_of_sites)) {
-                $list_of_sites = array('' => 'Any') + $list_of_sites;
+                $list_of_sites = ['' => 'Any'] + $list_of_sites;
             }
         } else {
             // allow only to view own site data
             $list_of_sites = $user->getStudySites();
-            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
+            $list_of_sites = ['' => 'All User Sites'] + $list_of_sites;
         }
 
         // SubprojectID
@@ -240,63 +240,63 @@ class CNV_Browser extends \NDB_Menu_Filter
         $this->addSelect(
             'sex',
             'Sex:',
-            array(
+            [
                 ''       => 'All',
                 'Male'   => 'Male',
                 'Female' => 'Female',
                 'Other'  => 'Other',
-            )
+            ]
         );
         $this->addSelect(
             'SubprojectID',
             'Subproject:',
-            array('' => 'Any') + $list_of_subprojects
+            ['' => 'Any'] + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', ['maxlength' => 10]);
 
-        $show_results_options = array(
+        $show_results_options = [
             'brief' => 'Summary fields',
             'full'  => 'All fields',
-        );
+        ];
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
 
         // CNV
 
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             '37' => 'GRCh37',
-        );
+        ];
         $this->addSelect('Assembly', 'Build:', $Base_options);
 
-        $CNV_Type_options = array(
+        $CNV_Type_options = [
             null      => 'All',
             'gain'    => 'gain',
             'loss'    => 'loss',
             'unknown' => 'Unknown',
-        );
+        ];
         $this->addSelect('CNV_Type', 'Type:', $CNV_Type_options);
         $this->addBasicText('Copy_Num_Change', 'Copy Number Change:');
         $this->addBasicText('CNV_Description', 'Description:');
         $this->addBasicText('Event_Name', 'Event Name:');
 
-        $Common_CNV_options = array(
+        $Common_CNV_options = [
             null => 'Any',
             'Y'  => 'Yes',
             'N'  => 'No',
-        );
+        ];
         $this->addSelect('Common_CNV', 'Common:', $Common_CNV_options);
-        $Characteristics_options = array(
+        $Characteristics_options = [
             null         => 'Any',
             'Benign'     => 'Benign',
             'Pathogenic' => 'Pathogenic',
             'Unknown'    => 'Unknown',
-        );
+        ];
         $this->addSelect(
             'Characteristics',
             'Characteristics:',
             $Characteristics_options
         );
-        $Inheritance_options = array(
+        $Inheritance_options = [
             null           => 'Any',
             'de novo'      => 'de novo',
             'maternal'     => 'maternal',
@@ -304,16 +304,16 @@ class CNV_Browser extends \NDB_Menu_Filter
             'unclassified' => 'unclassified',
             'unknown'      => 'unknown',
             'NA'           => 'NA',
-        );
+        ];
         $this->addSelect('Inheritance', 'Inheritance:', $Inheritance_options);
 
         $this->addBasicText('Chromosome', 'Chromosome:');
 
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             'F'  => 'Forward',
             'R'  => 'Reverse',
-        );
+        ];
         $this->addSelect('Strand', 'Strand:', $Base_options);
 
         $this->addBasicText('genomic_range', 'Genomic Range:');
@@ -322,22 +322,22 @@ class CNV_Browser extends \NDB_Menu_Filter
         $DB = \Database::singleton();
         $platform_results = $DB->pselect(
             "SELECT distinct Name FROM genotyping_platform",
-            array()
+            []
         );
 
-        $platform_options = array('' => 'Any');
+        $platform_options = ['' => 'Any'];
         foreach ($platform_results as $result) {
             $name = $result['Name'];
             $platform_options[$name] = $name;
         }
         $this->addSelect('Platform', 'Platform:', $platform_options);
-        $Array_Report_options = array(
+        $Array_Report_options = [
             null        => 'Any',
             'Abnormal'  => 'Abnormal',
             'Normal'    => 'Normal',
             'Pending'   => 'Pending',
             'Uncertain' => 'Uncertain',
-        );
+        ];
         $this->addSelect('Array_Report', 'Array Report:', $Array_Report_options);
         $this->addBasicText('Markers', 'Markers:');
         $this->addBasicText('Validation_Method', 'Validation Method:');
@@ -414,10 +414,10 @@ class CNV_Browser extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/genomic_browser/js/genomic_browser.js",
                 $baseURL . "/genomic_browser/js/cnvColumnFormatter.js",
-            )
+            ]
         );
     }
 

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -65,7 +65,7 @@ class CpG_Browser extends \NDB_Menu_Filter
     {
         // set the class variables
         $this->_displayBrief = !(isset($_REQUEST['format']));
-        $this->columns       = array(
+        $this->columns       = [
             'psc.Name AS PSC',
             'LPAD(candidate.CandID, 6, "0") AS DCCID',
             'candidate.PSCID',
@@ -99,7 +99,7 @@ class CpG_Browser extends \NDB_Menu_Filter
             'gca.reg_feature_group as Reg_Feature_Grp',
             'gca.dhs as DHS',
             'platform.Name as Platform',
-        );
+        ];
 
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
@@ -108,7 +108,7 @@ class CpG_Browser extends \NDB_Menu_Filter
                 function ($header) {
                         return ucwords(str_replace('_', ' ', $header));
                 },
-                array(
+                [
                     'PSC',
                     'DCCID',
                     'Subproject',
@@ -135,7 +135,7 @@ class CpG_Browser extends \NDB_Menu_Filter
                     'Reg_Feature_Grp',
                     'DHS',
                     'Platform',
-                )
+                ]
             )
         );
 
@@ -169,7 +169,7 @@ class CpG_Browser extends \NDB_Menu_Filter
 
         $this->limit = 10000;
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'candidate.RegistrationCenterID',
             'candidate.CandID',
             'candidate.PSCID',
@@ -199,9 +199,9 @@ class CpG_Browser extends \NDB_Menu_Filter
             'gca.reg_feature_group',
             'gca.dhs',
             'platform.Name',
-        );
+        ];
 
-        $ftf = array(
+        $ftf = [
             'centerID'           => 'candidate.RegistrationCenterID',
             'DCCID'              => 'candidate.CandID',
             'PSCID'              => 'candidate.PSCID',
@@ -232,16 +232,16 @@ class CpG_Browser extends \NDB_Menu_Filter
             'Reg_Feature_Loc'    => 'gca.reg_feature_loc',
             'Reg_Feature_Grp'    => 'gca.reg_feature_group',
             'DHS'                => 'gca.dhs',
-        );
+        ];
         $this->formToFilter = $ftf;
 
-        $this->EqualityFilters = array(
+        $this->EqualityFilters = [
             'candidate.Sex',
             'cpg.cpg_name',
             'gca.genome_build',
             'gca.design_type',
             'gca.Strand',
-        );
+        ];
     }
 
     /**
@@ -264,12 +264,12 @@ class CpG_Browser extends \NDB_Menu_Filter
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = \Utility::getSiteList();
             if (is_array($list_of_sites)) {
-                $list_of_sites = array('' => 'Any') + $list_of_sites;
+                $list_of_sites = ['' => 'Any'] + $list_of_sites;
             }
         } else {
             // allow only to view own site data
             $list_of_sites = $user->getStudySites();
-            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
+            $list_of_sites = ['' => 'All User Sites'] + $list_of_sites;
         }
 
         // SubprojectID
@@ -285,25 +285,25 @@ class CpG_Browser extends \NDB_Menu_Filter
         $this->addSelect(
             'sex',
             'Sex:',
-            array(
+            [
                 ''       => 'All',
                 'Male'   => 'Male',
                 'Female' => 'Female',
                 'Other'  => 'Other'
-            )
+            ]
         );
         $this->addSelect(
             'SubprojectID',
             'Subproject:',
-            array('' => 'Any') + $list_of_subprojects
+            ['' => 'Any'] + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', ['maxlength' => 10]);
 
         $show_results_options
-            = array(
+            = [
                 'brief' => 'Summary fields',
                 'full'  => 'All fields',
-            );
+            ];
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
 
         // ------------------------------------------------------------
@@ -312,16 +312,16 @@ class CpG_Browser extends \NDB_Menu_Filter
 
         $this->addBasicText('Gene_Symbol', 'Gene:');
         $this->addBasicText('genomic_range', 'Genomic Range:');
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             '37' => 'GRCh37',
-        );
+        ];
         $this->addSelect('Assembly', 'Build:', $Base_options);
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             'F'  => 'Forward',
             'R'  => 'Reverse',
-        );
+        ];
         $this->addSelect('Strand', 'Strand:', $Base_options);
 
         // ------------------------------------------------------------
@@ -345,7 +345,7 @@ class CpG_Browser extends \NDB_Menu_Filter
         $this->addSelect('Platform', 'Platform:', $Base_options);
 
         // Gene_Grp
-        $Base_options = array(
+        $Base_options = [
             null      => 'Any',
             '1stExon' => '1st Exon',
             '3`UTR'   => '3`UTR',
@@ -353,38 +353,38 @@ class CpG_Browser extends \NDB_Menu_Filter
             'Body'    => 'Body',
             'TSS1500' => 'TSS1500',
             'TSS200'  => 'TSS200',
-        );
+        ];
         $this->addSelect('Gene_Grp', 'Position:', $Base_options);
 
         // Design
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             'I'  => 'I',
             'II' => 'II',
-        );
+        ];
         $this->addSelect('Design', 'Infinium design:', $Base_options);
 
         // Color
-        $Base_options = array(
+        $Base_options = [
             null  => 'Any',
             'Grn' => 'Green',
             'Red' => 'Red',
-        );
+        ];
         $this->addSelect('Color', 'Color:', $Base_options);
 
         // Enhancer
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             '1'  => 'Yes',
-        );
+        ];
         $this->addSelect('Enhancer', 'Enhancer:', $Base_options);
 
         // SNP_10
-        $Base_options = array(
+        $Base_options = [
             null   => 'Any',
             'NULL' => 'No',
             '_'    => 'Yes',
-        );
+        ];
         $this->addSelect('SNP_10', 'SNP:', $Base_options);
 
         // Reg_Feature_Grp
@@ -395,27 +395,27 @@ class CpG_Browser extends \NDB_Menu_Filter
         $this->addSelect('Reg_Feature_Grp', 'Regulatory feat.:', $Base_options);
 
         // Fantom_Prom
-        $Base_options = array(
+        $Base_options = [
             null       => 'Any',
             'NULL'     => 'No',
             'NOT_NULL' => 'Yes',
-        );
+        ];
         $this->addSelect('Fantom_Prom', 'Promoter:', $Base_options);
 
         // HMM_Island
-        $Base_options = array(
+        $Base_options = [
             null       => 'Any',
             'NULL'     => 'No',
             'NOT_NULL' => 'Yes',
-        );
+        ];
         $this->addSelect('HMM_Island', 'HMM Island:', $Base_options);
 
         // DHS
-        $Base_options = array(
+        $Base_options = [
             null   => 'Any',
             '1'    => 'Yes',
             'NULL' => 'No',
-        );
+        ];
         $this->addSelect('DHS', 'DHS:', $Base_options);
 
         // DMR
@@ -502,10 +502,10 @@ class CpG_Browser extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/genomic_browser/js/genomic_browser.js",
                 $baseURL . "/genomic_browser/js/cpgColumnFormatter.js",
-            )
+            ]
         );
     }
 
@@ -524,7 +524,7 @@ class CpG_Browser extends \NDB_Menu_Filter
         $DB      = \Database::singleton();
         $results = $DB->pselect(
             "SELECT DISTINCT $column FROM $table ",
-            array()
+            []
         );
         return array_reduce(
             $results,
@@ -535,7 +535,7 @@ class CpG_Browser extends \NDB_Menu_Filter
                 }
                 return $carry;
             },
-            array(null => 'Any')
+            [null => 'Any']
         );
 
     }

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -93,7 +93,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
             where candid = candidate.candid
           ) THEN 'Y' ELSE 'N' END
         ";
-        $this->columns = array(
+        $this->columns = [
             'psc.Name AS PSC',
             'LPAD(candidate.CandID, 6, "0") AS DCCID',
             'candidate.PSCID',
@@ -105,7 +105,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
             "$snp_subquery as SNP",
             "$cnv_subquery as CNV",
             "$cpg_subquery as CPG",
-        );
+        ];
 
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
@@ -114,12 +114,12 @@ class Genomic_Browser extends \NDB_Menu_Filter
                 function ($header) {
                         return ucwords(str_replace('_', ' ', $header));
                 },
-                array(
+                [
                     'PSC',
                     'DCCID',
                     'externalID',
                     'DoB',
-                )
+                ]
             )
         );
 
@@ -142,7 +142,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
 
         $this->order_by = 'psc.Name, candidate.CandID DESC';
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'candidate.RegistrationCenterID',
             'candidate.CandID',
             'candidate.PSCID',
@@ -155,16 +155,16 @@ class Genomic_Browser extends \NDB_Menu_Filter
             'CNV',
             'SNP',
             'CPG',
-        );
+        ];
 
-        $this->validHavingFilters = array(
+        $this->validHavingFilters = [
             'File',
             'CNV',
             'SNP',
             'CPG',
-        );
+        ];
 
-        $ftf = array(
+        $ftf = [
             'centerID'           => 'candidate.RegistrationCenterID',
             'DCCID'              => 'candidate.CandID',
             'PSCID'              => 'candidate.PSCID',
@@ -176,7 +176,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
             'SNP'                => 'SNP',
             'CNV'                => 'CNV',
             'CPG'                => 'CPG',
-        );
+        ];
 
         $this->formToFilter = $ftf;
 
@@ -202,11 +202,11 @@ class Genomic_Browser extends \NDB_Menu_Filter
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = \Utility::getSiteList();
             if (is_array($list_of_sites)) {
-                $list_of_sites = array('' => 'Any') + $list_of_sites;
+                $list_of_sites = ['' => 'Any'] + $list_of_sites;
             }
         } else {
             $list_of_sites = $user->getStudySites();
-            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
+            $list_of_sites = ['' => 'All User Sites'] + $list_of_sites;
         }
 
         // SubprojectID
@@ -220,34 +220,34 @@ class Genomic_Browser extends \NDB_Menu_Filter
         $this->addSelect(
             'sex',
             'Sex:',
-            array(
+            [
                 ''       => 'All',
                 'Male'   => 'Male',
                 'Female' => 'Female',
                 'Other'  => 'Other'
-            )
+            ]
         );
         $this->addSelect(
             'SubprojectID',
             'Subproject:',
-            array('' => 'Any') + $list_of_subprojects
+            ['' => 'Any'] + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', ['maxlength' => 10]);
 
-        $any_options = array(
+        $any_options = [
             ''  => null,
             'Y' => 'Yes',
             'N' => 'No',
-        );
+        ];
         $this->addSelect('File', 'Files:', $any_options);
         $this->addSelect('SNP', 'SNPs found:', $any_options);
         $this->addSelect('CNV', 'CNVs found:', $any_options);
         $this->addSelect('CPG', 'CPGs found:', $any_options);
 
-        $show_results_options = array(
+        $show_results_options = [
             'brief' => 'Summary fields',
             'full'  => 'All fields',
-        );
+        ];
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
     }
 
@@ -304,10 +304,10 @@ class Genomic_Browser extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/genomic_browser/js/genomic_browser.js",
                 $baseURL . "/genomic_browser/js/profileColumnFormatter.js",
-            )
+            ]
         );
     }
 }

--- a/modules/genomic_browser/php/genomic_file.class.inc
+++ b/modules/genomic_browser/php/genomic_file.class.inc
@@ -22,9 +22,9 @@ namespace LORIS\genomic_browser;
  */
 class Genomic_File
 {
-    var $fileData   = array();
-    var $parameters = array();
-    var $QCData     = array();
+    var $fileData   = [];
+    var $parameters = [];
+    var $QCData     = [];
 
     /**
      * Construct a GenomicFile
@@ -36,7 +36,7 @@ class Genomic_File
     function __construct(int $fileID)
     {
         $db     =& \Database::singleton();
-        $params = array('FID' => $fileID);
+        $params = ['FID' => $fileID];
 
         $query    = "SELECT * FROM genomic_files WHERE GenomicFileID=:FID";
         $fileData = $db->pselectRow($query, $params);

--- a/modules/genomic_browser/php/genomic_file_uploader.class.inc
+++ b/modules/genomic_browser/php/genomic_file_uploader.class.inc
@@ -40,10 +40,10 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'genomic_browser_view_allsites',
                 'genomic_browser_view_site',
-            )
+            ]
         );
     }
 
@@ -56,7 +56,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'GenomicFileID',
             'FileName',
             'Description',
@@ -65,7 +65,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
             'InsertedByUserID',
             'Caveat',
             'Notes',
-        );
+        ];
 
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
@@ -74,13 +74,13 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
                 function ($header) {
                         return ucwords(str_replace('_', ' ', $header));
                 },
-                array()
+                []
             )
         );
 
         $this->query = " FROM genomic_files WHERE 1=1 ";
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'GenomicFileID',
             'FileName',
             'Description',
@@ -89,21 +89,21 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
             'InsertedByUserID',
             'Caveat',
             'Notes',
-        );
+        ];
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'file_name'         => 'FileName',
             'description'       => 'Description',
             'genomic_file_type' => 'FileType',
             'date_inserted'     => 'Date_inserted',
             'caveat'            => 'Caveat',
             'notes'             => 'Notes',
-        );
+        ];
 
-        $this->EqualityFilters = array(
+        $this->EqualityFilters = [
             'FileType',
             'Caveat',
-        );
+        ];
 
     }
 
@@ -158,11 +158,11 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/genomic_browser/js/genomic_browser.js",
                 $baseURL . "/genomic_browser/js/genomic_file_uploader.js",
                 $baseURL . "/genomic_browser/js/FileUploadModal.js",
-            )
+            ]
         );
     }
 
@@ -181,7 +181,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
         $DB      = \Database::singleton();
         $results = $DB->pselect(
             "SELECT DISTINCT $column FROM $table ",
-            array()
+            []
         );
         return array_reduce(
             $results,
@@ -192,7 +192,7 @@ class Genomic_File_Uploader extends \NDB_Menu_Filter
                 }
                 return $carry;
             },
-            array(null => 'Any')
+            [null => 'Any']
         );
 
     }

--- a/modules/genomic_browser/php/gwas_browser.class.inc
+++ b/modules/genomic_browser/php/gwas_browser.class.inc
@@ -56,7 +56,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'GWAS.rsID AS SNP_ID',
             'SNP.Chromosome AS Chromosome',
             'SNP.StartLoc AS Position_BP',
@@ -66,7 +66,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
             'GWAS.Estimate AS Estimate',
             'GWAS.StdErr AS StdErr',
             'GWAS.Pvalue AS Pvalue',
-        );
+        ];
 
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
@@ -75,7 +75,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
                 function ($header) {
                         return ucwords(str_replace('_', ' ', $header));
                 },
-                array()
+                []
             )
         );
 
@@ -84,7 +84,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
             JOIN SNP ON (GWAS.SNPID = SNP.SNPID)";
 
         $this->order_by     = 'SNP.Chromosome, GWAS.Pvalue DESC';
-        $this->validFilters = array(
+        $this->validFilters = [
             'GWAS.rsID',
             'SNP.Chromosome',
             'SNP.StartLoc',
@@ -94,9 +94,9 @@ class GWAS_Browser extends \NDB_Menu_Filter
             'GWAS.Estimate',
             'GWAS.StdErr',
             'GWAS.Pvalue',
-        );
+        ];
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'SNP_ID'       => 'GWAS.rsID',
             'Chromosome'   => 'SNP.Chromosome',
             'BP_Position'  => 'SNP.StartLoc',
@@ -106,7 +106,7 @@ class GWAS_Browser extends \NDB_Menu_Filter
             'Estimate'     => 'GWAS.Estimate',
             'StdErr'       => 'GWAS.StdErr',
             'Pvalue'       => 'GWAS.Pvalue',
-        );
+        ];
 
     }
 
@@ -122,10 +122,10 @@ class GWAS_Browser extends \NDB_Menu_Filter
         parent::setup();
 
         // add form elements
-        $show_results_options = array(
+        $show_results_options = [
             'brief' => 'Summary fields',
             'full'  => 'All fields',
-        );
+        ];
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
 
         $this->addBasicText('SNP_ID', 'SNP ID:');
@@ -133,13 +133,13 @@ class GWAS_Browser extends \NDB_Menu_Filter
         $this->addBasicText('BP_Position', 'BP Position:');
         $this->addBasicText('MAF', 'MAF:');
 
-        $alleleArray = array(
+        $alleleArray = [
             ''  => 'Any',
             'A' => 'A',
             'C' => 'C',
             'T' => 'T',
             'G' => 'G',
-        );
+        ];
         $this->addSelect('Minor_Allele', 'Minor Allele:', $alleleArray);
         $this->addSelect('Major_Allele', 'Major Allele:', $alleleArray);
 
@@ -201,10 +201,10 @@ class GWAS_Browser extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/genomic_browser/js/genomic_browser.js",
                 $baseURL . "/genomic_browser/js/gwasColumnFormatter.js",
-            )
+            ]
         );
     }
 

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -63,7 +63,7 @@ class SNP_Browser extends \NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'psc.Name AS PSC',
             'LPAD(candidate.CandID, 6, "0") AS DCCID',
             'candidate.PSCID',
@@ -94,7 +94,7 @@ class SNP_Browser extends \NDB_Menu_Filter
             'SNP.Damaging as Damaging',
             'SNP_candidate_rel.GenotypeQuality as Genotype_Quality',
             'SNP.ExonicFunction as Exonic_Function',
-        );
+        ];
 
         // This variable will be used by the columnFormatter javascript
         // to set the default hidden columns in the data table.
@@ -103,7 +103,7 @@ class SNP_Browser extends \NDB_Menu_Filter
                 function ($header) {
                         return ucwords(str_replace('_', ' ', $header));
                 },
-                array(
+                [
                     'PSC',
                     'DCCID',
                     'Subproject',
@@ -124,7 +124,7 @@ class SNP_Browser extends \NDB_Menu_Filter
                     'Validation_Method',
                     'Validated',
                     'Genotype_Quality',
-                )
+                ]
             )
         );
 
@@ -154,7 +154,7 @@ class SNP_Browser extends \NDB_Menu_Filter
 
         $this->limit = 10000;
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'candidate.RegistrationCenterID',
             'candidate.CandID',
             'candidate.PSCID',
@@ -188,9 +188,9 @@ class SNP_Browser extends \NDB_Menu_Filter
             'SNP.OfficialName',
             'genotyping_platform.Name',
             'genomic_range',
-        );
+        ];
 
-        $ftf = array(
+        $ftf = [
             'centerID'            => 'candidate.RegistrationCenterID',
             'DCCID'               => 'candidate.CandID',
             'PSCID'               => 'candidate.PSCID',
@@ -219,7 +219,7 @@ class SNP_Browser extends \NDB_Menu_Filter
             'Gene_Symbol'         => 'SNP.OfficalSymbol',
             'genomic_range'       => 'genomic_range',
             'Platform'            => 'genotyping_platform.Name',
-        );
+        ];
 
         $this->formToFilter = $ftf;
     }
@@ -244,12 +244,12 @@ class SNP_Browser extends \NDB_Menu_Filter
             // get the list of study sites - to be replaced by the Site object
             $list_of_sites = \Utility::getSiteList();
             if (is_array($list_of_sites)) {
-                $list_of_sites = array('' => 'Any') + $list_of_sites;
+                $list_of_sites = ['' => 'Any'] + $list_of_sites;
             }
         } else {
             // allow only to view own site data
             $list_of_sites = $user->getStudySites();
-            $list_of_sites = array('' => 'All User Sites') + $list_of_sites;
+            $list_of_sites = ['' => 'All User Sites'] + $list_of_sites;
         }
 
         // SubprojectID
@@ -263,45 +263,45 @@ class SNP_Browser extends \NDB_Menu_Filter
         $this->addSelect(
             'sex',
             'Sex:',
-            array(
+            [
                 ''       => 'All',
                 'Male'   => 'Male',
                 'Female' => 'Female',
                 'Other'  => 'Other',
-            )
+            ]
         );
         $this->addSelect(
             'SubprojectID',
             'Subproject:',
-            array('' => 'Any') + $list_of_subprojects
+            ['' => 'Any'] + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', ['maxlength' => 10]);
 
-        $show_results_options = array(
+        $show_results_options = [
             'brief' => 'Summary fields',
             'full'  => 'All fields',
-        );
+        ];
         $this->addSelect('Show_Brief_Results', 'Display:', $show_results_options);
 
         // SNP
 
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             '37' => 'GRCh37',
-        );
+        ];
         $this->addSelect('Assembly', 'Build:', $Base_options);
 
         $this->addBasicText('rsID', 'rsID:');
         $this->addBasicText('SNP_Name', 'Name:');
         $this->addBasicText('SNP_Description', 'Description:');
         $this->addBasicText('SNP_External_Source', 'External Source:');
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             'A'  => 'A',
             'C'  => 'C',
             'T'  => 'T',
             'G'  => 'G',
-        );
+        ];
         $this->addSelect('Allele_A', 'Allele A:', $Base_options);
         $this->addSelect('Allele_B', 'Allele B:', $Base_options);
         $this->addSelect('Reference_Base', 'Reference Base:', $Base_options);
@@ -310,41 +310,41 @@ class SNP_Browser extends \NDB_Menu_Filter
         $this->addSelect(
             'Validated',
             'Validated:',
-            array(
+            [
                 null => 'Any',
                 '0'  => '0',
                 '1'  => '1',
-            )
+            ]
         );
         $this->addSelect(
             'Function_Prediction',
             'Function Prediction:',
-            array(
+            [
                 null          => 'Any',
                 'exonic'      => 'exonic',
                 'ncRNAexonic' => 'ncRNAexonic',
                 'splicing'    => 'splicing',
                 'UTR3'        => 'UTR3',
                 'UTR5'        => 'UTR5',
-            )
+            ]
         );
         $this->addSelect(
             'Damaging',
             'Damaging:',
-            array(
+            [
                 null => 'Any',
                 'D'  => 'D',
                 'NA' => 'NA',
-            )
+            ]
         );
         $this->addBasicText('Genotype_Quality', 'Genotype Quality:');
         $this->addBasicText('Exonic_Function', 'Exonic Function:');
 
-        $Base_options = array(
+        $Base_options = [
             null => 'Any',
             'F'  => 'Forward',
             'R'  => 'Reverse',
-        );
+        ];
         $this->addSelect('Strand', 'Strand:', $Base_options);
 
         $this->addBasicText('genomic_range', 'Genomic Range:');
@@ -355,22 +355,22 @@ class SNP_Browser extends \NDB_Menu_Filter
         $platform_results
             = $DB->pselect(
                 "SELECT distinct Name FROM genotyping_platform ",
-                array()
+                []
             );
 
-        $platform_options = array('' => 'Any');
+        $platform_options = ['' => 'Any'];
         foreach ($platform_results as $result ) {
             $name = $result['Name'];
             $platform_options[$name] = $name;
         }
         $this->addSelect('Platform', 'Platform:', $platform_options);
-        $Array_Report_options = array(
+        $Array_Report_options = [
             null        => 'Any',
             'Abnormal'  => 'Abnormal',
             'Normal'    => 'Normal',
             'Pending'   => 'Pending',
             'Uncertain' => 'Uncertain',
-        );
+        ];
         $this->addSelect('Array_Report', 'Array Report:', $Array_Report_options);
         $this->addBasicText('Markers', 'Markers:');
         $this->addBasicText('Validation_Method', 'Validation Method:');
@@ -449,10 +449,10 @@ class SNP_Browser extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/genomic_browser/js/genomic_browser.js",
                 $baseURL . "/genomic_browser/js/snpColumnFormatter.js",
-            )
+            ]
         );
     }
 

--- a/modules/genomic_browser/php/view_genomic_file.class.inc
+++ b/modules/genomic_browser/php/view_genomic_file.class.inc
@@ -80,14 +80,14 @@ class View_Genomic_File extends \NDB_Form
             $files = \Database::singleton()->pselect(
                 "SELECT g.GenomicFileID
                 FROM genomic_candidate_files_rel g WHERE g.CandID=:cid ",
-                array('cid' => $this->candID)
+                ['cid' => $this->candID]
             );
         } else {
-            $files = array(
-                array('GenomicFileID' => $this->genomic_file_id),
-            );
+            $files = [
+                ['GenomicFileID' => $this->genomic_file_id],
+            ];
         }
-        $this->tpl_data['files'] = array();
+        $this->tpl_data['files'] = [];
         foreach ($files as $fileRow) {
             $FileObj = new Genomic_File(intval($fileRow['GenomicFileID']));
 
@@ -100,7 +100,7 @@ class View_Genomic_File extends \NDB_Form
             $paramQCDate           = $FileObj->getParameter('QCLastChangeTime');
 
             // load $file array
-            $file = array(
+            $file = [
                 'FileID'           => $fileRow['GenomicFileID'],
                 'Filename'         => $paramFilename,
                 'FullFilename'     => $FileObj->getParameter('FileName'),
@@ -124,7 +124,7 @@ class View_Genomic_File extends \NDB_Form
                 'Selected'         => $FileObj->getParameter('Selected'),
                 'QCStatus'         => $FileObj->getParameter('QCStatus'),
                 'QCDate'           => $paramQCDate,
-            );
+            ];
 
             $this->tpl_data['files'][] = $file;
         }

--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -27,7 +27,7 @@ require_once __DIR__
 class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
 {
     // expect UIs for Profiles Tab
-    private $_loadingProfilesUI = array(
+    private $_loadingProfilesUI = [
         'Profiles'          => '#onLoad > strong',
         'Candidate Filters' => '#lorisworkspace>div>'.
                                            'div:nth-child(2)>div>div>form>div:nth'.
@@ -46,17 +46,17 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
         'SNP'               => '#dynamictable > thead',
         'CNV'               => '#dynamictable > thead',
         'CPG'               => '#dynamictable > thead',
-    );
+    ];
     // expect UIs for GWAS Tab
-    private $_loadingGWASUI = array(
+    private $_loadingGWASUI = [
         'Gwas Browser' => '#bc2 > a:nth-child(3) > div',
         'GWAS Filters' => '#lorisworkspace > div > '.
                                            'div:nth-child(2) > div >div > form >'.
                                            'div>div>div.form-group.col-sm-8>div> '.
                                            'div.panel-heading',
-    );
+    ];
     // expect UIs for SNP Tab
-    private $_loadingSNPUI = array(
+    private $_loadingSNPUI = [
         'SNP Filters'         => '#lorisworkspace > div >'.
                                            'div:nth-child(2) > div > div'.
                                            '> form > div > div:nth-child(2) >'.
@@ -74,9 +74,9 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
         'Function Prediction' => '#dynamictable > thead',
         'Damaging'            => '#dynamictable > thead',
         'Exonic Function'     => '#dynamictable > thead',
-    );
+    ];
     // expect UIs for Methylation Tab
-    private $_MethylationUI = array(
+    private $_MethylationUI = [
         'Candidate Filters'     => '#lorisworkspace > div >'.
                                            ' div:nth-child(2) > div> div > form >'.
                                            ' div>div:nth-child(1)>div.form-group.'.
@@ -90,12 +90,12 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
                                            ' > form > div > div:nth-child(2) >'.
                                            ' div.form-group.col-sm-8 >'.
                                            ' div > div.panel-heading',
-    );
+    ];
     // expect UIs for Files Tab
-    private $_FilesUI = array(
+    private $_FilesUI = [
         'Genomic File Filters' => '#genomic_upload > div >'.
                              ' div.col-sm-10.col-md-8 > div > div.panel-heading',
-    );
+    ];
     /**
      * Tests that, when loading the genomic_browser module, the
      * breadcrumb is 'Genomic browser' or an error is given according
@@ -105,7 +105,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
      */
     function testGenomicBrowserWithoutPermission()
     {
-         $this->setupPermissions(array());
+         $this->setupPermissions([]);
          $this->safeGet($this->url . "/genomic_browser/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -123,10 +123,10 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
     function testGenomicBrowserWithPermission()
     {
         $this->setupPermissions(
-            array(
+            [
                 "genomic_browser_view_allsites",
                 "genomic_browser_view_site",
-            )
+            ]
         );
          $this->safeGet($this->url . "/genomic_browser/");
         $bodyText = $this->webDriver->findElement(

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -19,10 +19,10 @@ try {
     // Load help data. Try to load subpage first as its more specific and
     // will only be present some of the time. Fallback to the module name if
     // no subpage present.
-    $help = array(
+    $help = [
         'content' => $m->getHelp($subpageName ?? $moduleName),
         'format'  => 'markdown',
-    );
+    ];
     print json_encode($help);
     ob_end_flush();
     exit;

--- a/modules/help_editor/ajax/process.php
+++ b/modules/help_editor/ajax/process.php
@@ -33,14 +33,14 @@ if (!empty($_POST['helpID'])
     $help_file = HelpFile::factory($helpID);
     // update the help file
     $help_file->update(
-        array(
+        [
             'topic'   => $_POST['title'],
             'content' => $_POST['content'],
             'updated' => date(
                 'Y-m-d h:i:s',
                 time()
             ),
-        )
+        ]
     );
 } else {
     //content does not exist insert the help file
@@ -50,7 +50,7 @@ if (!empty($_POST['helpID'])
     ) {
         //create parent help section first
         $parentID = HelpFile::insert(
-            array(
+            [
                 'hash'    => md5($_POST['section']),
                 'topic'   => "",
                 'content' => "Under construction",
@@ -58,7 +58,7 @@ if (!empty($_POST['helpID'])
                     'Y-m-d h:i:s',
                     time()
                 ),
-            )
+            ]
         );
          // check errors
     }
@@ -69,7 +69,7 @@ if (!empty($_POST['helpID'])
 
         // insert the help file
         $helpID = HelpFile::insert(
-            array(
+            [
                 'parentID' => $_POST['parentID'],
                 'hash'     => md5($_POST['subsection']),
                 'topic'    => $_POST['title'],
@@ -78,7 +78,7 @@ if (!empty($_POST['helpID'])
                     'Y-m-d h:i:s',
                     time()
                 ),
-            )
+            ]
         );
 
     } else if (!empty($_POST['section'])
@@ -86,7 +86,7 @@ if (!empty($_POST['helpID'])
     ) {
         //default case
         $helpID = HelpFile::insert(
-            array(
+            [
                 'hash'    => md5($_POST['section']),
                 'topic'   => $_POST['title'],
                 'content' => $_POST['content'],
@@ -94,7 +94,7 @@ if (!empty($_POST['helpID'])
                     'Y-m-d h:i:s',
                     time()
                 ),
-            )
+            ]
         );
     }
 }

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -46,7 +46,7 @@ class Edit_Help_Content extends \NDB_Form
     function _getDefaults()
     {
         //Get the default values
-        $defaults = array();
+        $defaults = [];
 
         // Sanitize user input
         $safeSection    = $_REQUEST['section'] ?
@@ -54,7 +54,7 @@ class Edit_Help_Content extends \NDB_Form
         $safeSubsection = $_REQUEST['subsection'] ?
             htmlspecialchars($_REQUEST['subsection']) : '';
 
-        $defaults = array();
+        $defaults = [];
 
         if (isset($_REQUEST['helpID'])) {
             $helpID = htmlspecialchars($_REQUEST['helpID']);
@@ -128,10 +128,10 @@ class Edit_Help_Content extends \NDB_Form
         $this->addBasicTextArea(
             'content',
             'Content',
-            array(
+            [
                 'cols' => 140,
                 'rows' => 30,
-            )
+            ]
         );
 
     }
@@ -149,9 +149,9 @@ class Edit_Help_Content extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/help_editor/js/help_editor_helper.js",
-            )
+            ]
         );
     }
 }

--- a/modules/help_editor/php/help_editor.class.inc
+++ b/modules/help_editor/php/help_editor.class.inc
@@ -82,7 +82,7 @@ class Help_Editor extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/help_editor/js/help_editor.js")
+            [$baseURL . "/help_editor/js/help_editor.js"]
         );
     }
 }

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -65,7 +65,7 @@ class HelpFile
             "SELECT helpID, parentID, hash, topic,
              content,
              created, updated FROM help WHERE helpID = :HID",
-            array('HID' => $helpID)
+            ['HID' => $helpID]
         );
         // set the help file
         $obj->data = $result;
@@ -104,7 +104,7 @@ class HelpFile
     {
         // update the help file
         \NDB_Factory::singleton()->database()
-            ->update('help', $set, array('helpID' => $this->helpID));
+            ->update('help', $set, ['helpID' => $this->helpID]);
 
         return true;
     }
@@ -121,7 +121,7 @@ class HelpFile
 
         $result = $DB->pselectOne(
             "SELECT COUNT(*) FROM help WHERE parentID = :HID",
-            array('HID' => $this->helpID)
+            ['HID' => $this->helpID]
         );
         return ($result > 0);
     }
@@ -143,13 +143,13 @@ class HelpFile
         // see if it has a child
         $hasChild = $this->hasChild();
 
-        $childIDs = array();
+        $childIDs = [];
 
         // get its children
         if ($hasChild) {
             $result = $DB->pselect(
                 "SELECT helpID FROM help WHERE parentID = :HID",
-                array('HID' => $this->helpID)
+                ['HID' => $this->helpID]
             );
             // add the children to the array
             $childIDs = $result;
@@ -189,7 +189,7 @@ class HelpFile
         // see if it has a child
         $hasChild = $this->hasChild();
 
-        $childData = array();
+        $childData = [];
 
         // get its children
         if ($hasChild) {
@@ -197,7 +197,7 @@ class HelpFile
                 "SELECT helpID, topic, $level as level
                 FROM help
                 WHERE parentID = :HID",
-                array('HID' => $this->helpID)
+                ['HID' => $this->helpID]
             );
 
             // add the children to the array
@@ -232,7 +232,7 @@ class HelpFile
      */
     function parentIDs($stopat = 1, $level = 1)
     {
-        $parentIDs = array();
+        $parentIDs = [];
 
         if ($this->data['parentID'] > 0) {
             // add the parent to the array
@@ -267,14 +267,14 @@ class HelpFile
         // create DB object
         $DB = \Database::singleton();
 
-        $parentData = array();
+        $parentData = [];
 
         if ($this->data['parentID'] > 0) {
             $parentData = $DB->pselectRow(
                 "SELECT helpID, topic, $level as level
                  FROM help
                  WHERE helpID = :HID",
-                array('HID' => $this->data['parentID'])
+                ['HID' => $this->data['parentID']]
             );
 
             // check if we're done recursing
@@ -289,7 +289,7 @@ class HelpFile
             }
         }
 
-        return $parentData ?? array();
+        return $parentData ?? [];
     }
 
     /**
@@ -322,7 +322,7 @@ class HelpFile
 
         $helpID = $DB->pselectOne(
             "SELECT helpID FROM help WHERE hash = :HID",
-            array('HID' => $hash)
+            ['HID' => $hash]
         );
 
         return $helpID;

--- a/modules/help_editor/php/helprowprovisioner.class.inc
+++ b/modules/help_editor/php/helprowprovisioner.class.inc
@@ -49,7 +49,7 @@ class HelpRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
              WHERE helpChild.hash IS NOT NULL
              AND helpChild.topic IS NOT NULL
              ORDER BY helpChild.helpID",
-            array()
+            []
         );
     }
 

--- a/modules/help_editor/test/help_editorTest.php
+++ b/modules/help_editor/test/help_editorTest.php
@@ -39,14 +39,14 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         $window->maximize();
         $this->DB->insert(
             "help",
-            array(
+            [
                 'helpID'   => '999999',
                 'parentID' => '-1',
                 'hash'     => $md5String,
                 'topic'    => 'Test Topic',
                 'content'  => 'This is a test content.',
                 'created'  => '2013-04-05 00:00:00',
-            )
+            ]
         );
     }
     /**
@@ -57,7 +57,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
     function tearDown()
     {
         parent::tearDown();
-        $this->DB->delete("help", array('helpID' => '999999'));
+        $this->DB->delete("help", ['helpID' => '999999']);
     }
 
     /**
@@ -104,7 +104,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
      */
     function testHelpEditorPermission()
     {
-         $this->setupPermissions(array("context_help"));
+         $this->setupPermissions(["context_help"]);
          $this->safeGet($this->url . "/help_editor/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
@@ -119,7 +119,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
      */
     function testHelpEditorWithoutPermission()
     {
-         $this->setupPermissions(array());
+         $this->setupPermissions([]);
          $this->safeGet($this->url . "/help_editor/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/imaging_browser/ajax/setSortedRows.php
+++ b/modules/imaging_browser/ajax/setSortedRows.php
@@ -16,11 +16,11 @@
  * part of a study site and are permitted to view their own site.
  */
 $canAccess = \User::singleton()->hasAnyPermission(
-    array(
+    [
         'imaging_browser_view_allsites',
         'imaging_browser_phantom_allsites',
         'imaging_browser_phantom_ownsite',
-    )
+    ]
 )
 || ($user->hasStudySite()
 && $user->hasPermission('imaging_browser_view_site'));

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -43,11 +43,11 @@ class Imaging_Browser extends \DataFrameworkMenu
         * part of a study site and are permitted to view their own site.
          */
         return $user->hasAnyPermission(
-            array(
+            [
                 'imaging_browser_view_allsites',
                 'imaging_browser_phantom_allsites',
                 'imaging_browser_phantom_ownsite',
-            )
+            ]
         )
             || (
                 $user->hasStudySite()
@@ -85,7 +85,7 @@ class Imaging_Browser extends \DataFrameworkMenu
     {
         // create user object
         $user     = \User::singleton();
-        $siteList = array();
+        $siteList = [];
 
         // get list of sites available for the user
         if ($user->hasPermission('imaging_browser_view_allsites')
@@ -109,7 +109,7 @@ class Imaging_Browser extends \DataFrameworkMenu
         }
 
         // get list of projects
-        $list_of_projects = array();
+        $list_of_projects = [];
         $projectList      = \Utility::getProjectList();
         foreach ($projectList as $key => $project) {
             unset($projectList[$key]);
@@ -117,16 +117,16 @@ class Imaging_Browser extends \DataFrameworkMenu
         }
 
         // get visit QC status options
-        $visitQCStatus = array(
+        $visitQCStatus = [
             'Pass' => 'Pass',
             'Fail' => 'Fail',
-        );
+        ];
 
         // get Pending/New options
-        $pending = array(
+        $pending = [
             'P' => 'Pending',
             'N' => 'New',
-        );
+        ];
 
         // get list of scan types
         $all_scan_types = \Utility::getScanTypeList();
@@ -216,9 +216,9 @@ class Imaging_Browser extends \DataFrameworkMenu
         $baseurl = $factory->settings()->getBaseURL();
         return array_merge(
             parent::getJSDependencies(),
-            array(
+            [
                 $baseurl . "/imaging_browser/js/imagingBrowserIndex.js",
-            )
+            ]
         );
     }
 }

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -66,28 +66,28 @@ class Imaging_Session_ControlPanel
         $config    = \NDB_Config::singleton();
         $timePoint = \TimePoint::singleton($_REQUEST['sessionID']);
 
-        $subjectData = array(
+        $subjectData = [
             'sessionID' => $_REQUEST['sessionID'],
             'candid'    => $timePoint->getCandID(),
-        );
+        ];
 
         $linkedInstruments
             = $config->getSetting('ImagingBrowserLinkedInstruments');
         if (!is_array($linkedInstruments)) {
-            $linkedInstruments = array();
+            $linkedInstruments = [];
         }
 
-        $links = array();
+        $links = [];
         foreach ($linkedInstruments as $v) {
             $qresult = $DB->pselectRow(
                 "SELECT f.CommentID, tn.Full_name FROM flag f
             JOIN test_names tn ON f.Test_name = tn.Test_name 
             WHERE f.Test_name = :tname AND f.SessionID = :v_sessions_id
             AND f.CommentID NOT LIKE 'DDE_%'",
-                array(
+                [
                     'tname'         => $v,
                     'v_sessions_id' => $this->sessionID,
-                )
+                ]
             );
             if (is_null($qresult)) {
                 throw new \LorisException(
@@ -95,11 +95,11 @@ class Imaging_Session_ControlPanel
                     . 'test name and session ID'
                 );
             }
-            $links[] = array(
+            $links[] = [
                 "FEName"    => $qresult['Full_name'],
                 "BEName"    => $v,
                 "CommentID" => $qresult['CommentID'],
-            );
+            ];
         }
         $subjectData['links'] = (empty($links)) ? "" : $links;
 
@@ -110,7 +110,7 @@ class Imaging_Session_ControlPanel
         * therefore it should NEVER consist of data that can be supplied in
         * any way by any user.
          */
-        $params     = array();
+        $params     = [];
         $ID         = 'NULL';
         $EntityType = $candidate->getData('Entity_type');
         if ($EntityType == 'Scanner') {
@@ -131,7 +131,7 @@ class Imaging_Session_ControlPanel
             $params
         );
 
-        $tarIDToTarLoc = array();
+        $tarIDToTarLoc = [];
         foreach ($qresult as $v) {
             $tarchiveID = $v['TarchiveID'];
             $tarIDToTarLoc[$tarchiveID]['ArchiveLocation'] = $v['ArchiveLocation'];
@@ -153,19 +153,19 @@ class Imaging_Session_ControlPanel
         $subjectData['issue_tracker_url']    = $issue_tracker_url;
 
         $subjectData['has_permission']  = $this->_hasAccess();
-        $subjectData['status_options']  = array(
+        $subjectData['status_options']  = [
             'Unrated' => '',
             'Pass'    => 'Pass',
             'Fail'    => 'Fail',
-        );
-        $subjectData['pending_options'] = array(
+        ];
+        $subjectData['pending_options'] = [
             'Y' => 'Yes',
             'N' => 'No',
-        );
-        $subjectData['caveat_options']  = array(
+        ];
+        $subjectData['caveat_options']  = [
             'true'  => 'True',
             'false' => 'False',
-        );
+        ];
 
         $qcstatus = $timePoint->getImagingQC();
 

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -103,10 +103,10 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // =====================================================
         // Create Pending Fail and Pending New subquery
         // =====================================================
-        $case_desc     = array();
-        $qc            = array();
-        $pass          = array();
-        $coalesce_desc = array();
+        $case_desc     = [];
+        $qc            = [];
+        $pass          = [];
+        $coalesce_desc = [];
 
         foreach ($scan_id_types as $id => $type) {
             $pass[$id]          = $type . 'pass';
@@ -210,7 +210,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label
             ",
-            array()
+            []
         );
     }
 

--- a/modules/imaging_browser/php/mrinavigation.class.inc
+++ b/modules/imaging_browser/php/mrinavigation.class.inc
@@ -28,7 +28,7 @@ namespace LORIS\imaging_browser;
 class MRINavigation
 {
 
-    public $urlParams = array();
+    public $urlParams = [];
 
     /**
      *  Gets the session
@@ -44,7 +44,7 @@ class MRINavigation
             ->getProperty('mriSessionsListed');
 
         if (!is_array($this->FilteredSessionList)) {
-            $this->FilteredSessionList = array();
+            $this->FilteredSessionList = [];
         }
         $this->currentListIndex = array_search(
             $this->sessionID,

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -111,22 +111,22 @@ class ViewSession extends \NDB_Form
                 JOIN session s 
                 ON (s.ID=f.SessionID) 
                 WHERE s.ID=:sid AND FileType='obj'",
-                array('sid' => $this->sessionID)
+                ['sid' => $this->sessionID]
             );
             if (!empty($file)) {
                 $this->tpl_data['show3DViewer'] = true;
             }
 
-            $this->tpl_data['status_options']    = array(
+            $this->tpl_data['status_options']    = [
                 ''     => '&nbsp;',
                 'Pass' => 'Pass',
                 'Fail' => 'Fail',
-            );
-            $this->tpl_data['caveat_options']    = array(
+            ];
+            $this->tpl_data['caveat_options']    = [
                 ''    => '&nbsp;',
                 true  => 'True',
                 false => 'False',
-            );
+            ];
             $this->tpl_data['has_permission']    = ($this->_hasAccess($user)) ?
                                                  true : false;
             $this->tpl_data['has_qc_permission'] = ($this->_hasQCPerm()) ?
@@ -150,7 +150,7 @@ class ViewSession extends \NDB_Form
         if (!empty($_REQUEST['selectedOnly'])) {
             $extra_where_string .= " AND COALESCE(sel.Selected,'') <> ''";
         }
-        $args = array('SID' => $this->sessionID);
+        $args = ['SID' => $this->sessionID];
         // To better support QC for CIVET output a couple of
         // additional conditions have been put in...
         if (!empty($_REQUEST['outputType'])) {
@@ -181,7 +181,7 @@ class ViewSession extends \NDB_Form
                      files.File",
             $args
         );
-        $this->tpl_data['files'] = array();
+        $this->tpl_data['files'] = [];
         foreach ($files as $fileRow) {
             $FileObj = new \MRIFile($fileRow['FileID']);
             if (empty($scannerID)) {
@@ -191,7 +191,7 @@ class ViewSession extends \NDB_Form
                              " Serial_number) FROM mri_scanner WHERE ID=:ScanID";
                     $this->scanner = $this->DB->pselectOne(
                         $query,
-                        array('ScanID' => $scannerID)
+                        ['ScanID' => $scannerID]
                     );
                 }
             }
@@ -292,7 +292,7 @@ class ViewSession extends \NDB_Form
                 (int)$FileObj->getParameter('AcquisitionProtocolID')
             );
 
-            $file = array(
+            $file = [
                 'FileID'                => $FileID,
                 'Filename'              => $Filename,
                 'CheckPic'              => $CheckPic,
@@ -336,7 +336,7 @@ class ViewSession extends \NDB_Form
                 'XMLprotocol'           => $XMLprotocol,
                 'NrrdFile'              => $NrrdFile,
                 'OtherTimepoints'       => $OtherTimepoints,
-            );
+            ];
             $this->tpl_data['files'][] = $file;
         }
     }
@@ -350,7 +350,7 @@ class ViewSession extends \NDB_Form
      */
     function _getRejected(\MRIFile $file, string $type): ?string
     {
-        $array     = array();
+        $array     = [];
         $parameter = 'processing:' . $type . '_rejected';
         if (preg_match(
             "/(Directions)([^\(]+)(\(\d+\))/",
@@ -377,7 +377,7 @@ class ViewSession extends \NDB_Form
      */
     function _getDate(\MRIFile $file, string $type)
     {
-        $array = array();
+        $array = [];
         if (preg_match(
             "/(\d{4})-?(\d{2})-?(\d{2})/",
             $file->getParameter($type) ?? '',
@@ -410,13 +410,13 @@ class ViewSession extends \NDB_Form
                 if ($curStatus == 'unrated') {
                     $curStatus ='';
                 }
-                $updateSet = array(
+                $updateSet = [
                     'QCStatus'         => $curStatus,
                     'QCLastChangeTime' => time(),
-                );
+                ];
 
                 // set first change time, if it's null only
-                $params          = array('FID' => $curFileID);
+                $params          = ['FID' => $curFileID];
                 $firstChangeTime = $this->DB->pselectOne(
                     "SELECT QCFirstChangeTime 
                     FROM files_qcstatus 
@@ -434,7 +434,7 @@ class ViewSession extends \NDB_Form
                     $params
                 );
                 $updateSet   = \Utility::nullifyEmpty($updateSet, 'QCStatus');
-                $updateWhere = array();
+                $updateWhere = [];
                 if (!empty($QCExists)) {
                     $updateWhere['FileID'] = $curFileID;
                     $this->DB->update(
@@ -465,12 +465,12 @@ class ViewSession extends \NDB_Form
                 }
                 $this->DB->update(
                     "files",
-                    array('Caveat' => $curCaveat),
-                    array('FileID' => $curFileID)
+                    ['Caveat' => $curCaveat],
+                    ['FileID' => $curFileID]
                 );
 
                 if ($curCaveat == true) {
-                    $insertSet = array();
+                    $insertSet = [];
                     $file      = new \MRIFile($curFileID);
                     $insertSet['SeriesUID']   = $file->getParameter(
                         'series_instance_uid'
@@ -506,8 +506,8 @@ class ViewSession extends \NDB_Form
         // update selected's
         if (is_array($_POST['selectedvol'])) {
             foreach ($_POST['selectedvol'] AS $curFileID => $curSelected) {
-                $params      = array('FID' => $curFileID);
-                $updateWhere = array('FileID' => $curFileID);
+                $params      = ['FID' => $curFileID];
+                $updateWhere = ['FileID' => $curFileID];
 
                 if ($curSelected == 'Unselected') {
                     if ($this->DB->pselectOne(
@@ -527,10 +527,10 @@ class ViewSession extends \NDB_Form
                         $params
                     ) > 0
                     ) {
-                        $updateSet = array(
+                        $updateSet = [
                             'Selected'         => $curSelected,
                             'QCLastChangeTime' => time(),
-                        );
+                        ];
                         $updateSet = \Utility::nullifyEmpty($updateSet, 'Selected');
                         $this->DB->update(
                             'files_qcstatus',
@@ -538,11 +538,11 @@ class ViewSession extends \NDB_Form
                             $updateWhere
                         );
                     } else {
-                        $insertSet = array(
+                        $insertSet = [
                             'FileID'            => $curFileID,
                             'Selected'          => $curSelected,
                             'QCFirstChangeTime' => time(),
-                        );
+                        ];
                         $insertSet = \Utility::nullifyEmpty($insertSet, 'Selected');
                         $this->DB->insert('files_qcstatus', $insertSet);
                     }
@@ -558,7 +558,7 @@ class ViewSession extends \NDB_Form
     function _updateVisitStatus()
     {
         if (!empty($_POST['visit_status'])) {
-            $params           = array('SID' => $this->sessionID);
+            $params           = ['SID' => $this->sessionID];
             $old_visit_status = $this->DB->pselectOne(
                 "SELECT MRIQCStatus 
                 FROM session 
@@ -578,12 +578,12 @@ class ViewSession extends \NDB_Form
                 $params
             );
 
-            $updateSet       = array(
+            $updateSet       = [
                 'MRIQCPending'        => $_POST['visit_pending'],
                 'MRIQCStatus'         => $_POST['visit_status'],
                 'MRICaveat'           => $_POST['visit_caveat'],
                 'MRIQCLastChangeTime' => date("Y-m-d H:i:s"),
-            );
+            ];
             $firstChangeTime = $this->DB->pselectOne(
                 "SELECT MRIQCFirstChangeTime 
                 FROM session 
@@ -598,7 +598,7 @@ class ViewSession extends \NDB_Form
             $this->DB->update(
                 'session',
                 $updateSet,
-                array('ID' => $this->sessionID)
+                ['ID' => $this->sessionID]
             );
             // spool a message to the mri qc status rss channel
             if (($_POST['visit_status'] != $old_visit_status)
@@ -650,13 +650,13 @@ class ViewSession extends \NDB_Form
             "WHERE AcquisitionProtocolID =:initialFileAcquisitionID ".
             "AND SessionID in (SELECT s2.ID FROM session s1 RIGHT JOIN session s2 ".
             "ON s1.CandID = s2.CandID WHERE s1.ID =:initialFileID)",
-            array(
+            [
                 'initialFileAcquisitionID' => $initialFileAcquisitionID,
                 'initialFileID'            => $initialFileID,
-            )
+            ]
         );
 
-        $fileIDS = array();
+        $fileIDS = [];
         foreach ($selectResults as $selectResult) {
             $fileIDS[] = $selectResult['FileID'];
         }
@@ -677,7 +677,7 @@ class ViewSession extends \NDB_Form
         $selected = $this->DB->pselectOne(
             "SELECT Selected FROM files_qcstatus ".
             "WHERE FileID =:FileID",
-            array('FileID' => $FileID)
+            ['FileID' => $FileID]
         );
         return $selected;
     }
@@ -689,7 +689,7 @@ class ViewSession extends \NDB_Form
      */
     function getHeaderTable()
     {
-        $tpl_data            = array();
+        $tpl_data            = [];
         $tpl_data['subject'] = $this->getSubjectData();
 
         if (!empty($_REQUEST['outputType'])) {
@@ -715,7 +715,7 @@ class ViewSession extends \NDB_Form
     {
         $timePoint = \TimePoint::singleton($_REQUEST['sessionID']);
 
-        $subjectData = array();
+        $subjectData = [];
         $subjectData['sessionID']       = $_REQUEST['sessionID'];
         $subjectData['SubprojectID']    = $timePoint->getSubprojectID();
         $subjectData['SubprojectTitle'] = $timePoint->getData('SubprojectTitle');
@@ -725,7 +725,7 @@ class ViewSession extends \NDB_Form
         $qcstatus = $this->DB->pselectRow(
             "SELECT MRIQCStatus, MRIQCPending, MRICaveat 
             FROM session WHERE ID=:SID",
-            array('SID' => $_REQUEST['sessionID'])
+            ['SID' => $_REQUEST['sessionID']]
         );
         if (is_null($qcstatus)) {
             throw new \LorisException(
@@ -748,7 +748,7 @@ class ViewSession extends \NDB_Form
         // This doesn't work.
         //Need to find the proper way to get the TarchiveID.
         //It should be per file, not per candidate. --Dave
-        $params     = array();
+        $params     = [];
         $EntityType = $candidate->getData('Entity_type');
         if ($EntityType == 'Scanner') {
             $ID = ":PPSCID";
@@ -791,10 +791,10 @@ class ViewSession extends \NDB_Form
         $baseurl = $factory->settings()->getBaseURL();
         $depends = array_merge(
             $depends,
-            array(
+            [
                 $baseurl . "/imaging_browser/js/jiv_and_imaging_browser.js",
                 $baseurl . "/imaging_browser/js/ImagePanel.js",
-            )
+            ]
         );
         return $depends;
     }

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -43,64 +43,64 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         // Create tests-specific data
         $this->DB->insert(
             "psc",
-            array(
+            [
                 'CenterID'  => '253',
                 'Name'      => 'Test Site AOL',
                 'Alias'     => 'AOL',
                 'MRI_alias' => 'Y',
-            )
+            ]
         );
 
         $this->DB->insert(
             "psc",
-            array(
+            [
                 'CenterID'  => '254',
                 'Name'      => 'Test Site BOL',
                 'Alias'     => 'BOL',
                 'MRI_alias' => 'Y',
-            )
+            ]
         );
 
         // Create test-specific data
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '000001',
                 'PSCID'                 => 'DCC0001',
                 'RegistrationCenterID'  => 1,
                 'RegistrationProjectID' => 1,
                 'Active'                => 'Y',
                 'Entity_type'           => 'Human',
-            )
+            ]
         );
 
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '000002',
                 'PSCID'                 => 'AOL0002',
                 'RegistrationCenterID'  => 253,
                 'RegistrationProjectID' => 1,
                 'Active'                => 'Y',
                 'Entity_type'           => 'Human',
-            )
+            ]
         );
 
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => 000003,
                 'PSCID'                 => 'BOL0003',
                 'RegistrationCenterID'  => 254,
                 'RegistrationProjectID' => 1,
                 'Active'                => 'Y',
                 'Entity_type'           => 'Human',
-            )
+            ]
         );
 
         $this->DB->insert(
             'session',
-            array(
+            [
                 'ID'            => 999997,
                 'CandID'        => 000001,
                 'Visit_label'   => 'Test0',
@@ -109,12 +109,12 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 'Scan_done'     => 'Y',
                 'Current_stage' => 'Visit',
                 'Visit'         => 'In Progress',
-            )
+            ]
         );
 
         $this->DB->insert(
             'session',
-            array(
+            [
                 'ID'            => 999998,
                 'CandID'        => 000002,
                 'Visit_label'   => 'Test1',
@@ -123,12 +123,12 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 'Scan_done'     => 'Y',
                 'Current_stage' => 'Visit',
                 'Visit'         => 'In Progress',
-            )
+            ]
         );
 
         $this->DB->insert(
             'session',
-            array(
+            [
                 'ID'            => 999999,
                 'CandID'        => 000003,
                 'Visit_label'   => 'Test2',
@@ -137,39 +137,39 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 'Scan_done'     => 'Y',
                 'Current_stage' => 'Visit',
                 'Visit'         => 'In Progress',
-            )
+            ]
         );
 
         // Add imaging data
 
         $this->DB->insert(
             'mri_processing_protocol',
-            array(
+            [
                 'ProcessProtocolID' => 1111,
                 'ProtocolFile'      => 'None1',
                 'FileType'          => null,
                 'Tool'              => 'None1',
                 'InsertTime'        => 0,
                 'md5sum'            => null,
-            )
+            ]
         );
 
         $this->DB->insert(
             'mri_processing_protocol',
-            array(
+            [
                 'ProcessProtocolID' => 2222,
                 'ProtocolFile'      => 'None2',
                 'FileType'          => null,
                 'Tool'              => 'None2',
                 'InsertTime'        => 0,
                 'md5sum'            => null,
-            )
+            ]
         );
 
         // create the tarchive entries
         $this->DB->insert(
             'tarchive',
-            array(
+            [
                 'TarchiveID'             => 263,
                 'DicomArchiveID'         => '1.3.12.2.1107.5.2.32.35442.30000012' .
                '100912542610900000004',
@@ -190,12 +190,12 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 'AcquisitionMetadata'    => 'metadata',
                 'SessionID'              => 999998,
                 'PendingTransfer'        => 1,
-            )
+            ]
         );
 
         $this->DB->insert(
             'tarchive',
-            array(
+            [
                 'TarchiveID'             => 264,
                 'DicomArchiveID'         => '1.3.12.2.1107.5.2.32.35442.30000012' .
                '100912542610900000001',
@@ -216,7 +216,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 'AcquisitionMetadata'    => 'metadata',
                 'SessionID'              => 999999,
                 'PendingTransfer'        => 1,
-            )
+            ]
         );
 
         // @codingStandardsIgnoreStart

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -58,10 +58,10 @@ class Imaging_QC extends \NDB_Menu_Filter
 
         $all_scan_types_2d = $db->pselect(
             "SELECT ID, Scan_type FROM mri_scan_type mri",
-            array()
+            []
         );
 
-        $all_scan_types = array();
+        $all_scan_types = [];
         foreach ($all_scan_types_2d as $row) {
             $type = $row['Scan_type'];
             $all_scan_types[$row['ID']] = $type;
@@ -184,7 +184,7 @@ class Imaging_QC extends \NDB_Menu_Filter
         $this->skipTemplate = true;
         $user      = \User::singleton();
         $db        = \Database::singleton();
-        $siteList  = array();
+        $siteList  = [];
         $visitList = \Utility::getVisitList();
         // allow to view all sites data through filter
         if ($user->hasPermission('imaging_browser_qc')) {
@@ -208,30 +208,30 @@ class Imaging_QC extends \NDB_Menu_Filter
         $scan_types = $this->_getScanTypes();
 
         $projectList  = \Utility::getProjectList();
-        $projectList2 = array();
+        $projectList2 = [];
         foreach ($projectList as $key => $value) {
             $projectList2[$value] = $value;
         }
         $subprojectList  = \Utility::getSubprojectList();
-        $subprojectList2 = array();
+        $subprojectList2 = [];
         foreach ($subprojectList as $key => $value) {
             $subprojectList2[$value] = $value;
         }
         //print_r($subprojectList2);
-        $uploaderList = array();
+        $uploaderList = [];
         $uploaders    = $db -> pselect(
             "SELECT UploadedBy FROM mri_upload GROUP BY UploadedBy",
-            array()
+            []
         );
         foreach ($uploaders as $up) {
             $uploaderList[$up['UploadedBy']] = $up['UploadedBy'];
         }
 
-        $scan_location = array(
+        $scan_location = [
             "In Imaging Browser"    => "Found in Imaging Browser",
             "In MRI Violated Scans" => "Found in MRI Violated Scans",
             "Missing"               => "Missing",
-        );
+        ];
 
         $this->fieldOptions
             = [
@@ -239,36 +239,36 @@ class Imaging_QC extends \NDB_Menu_Filter
                 'project'          => $projectList2,
                 'subproject'       => $subprojectList2,
                 'scanType'         => $scan_types,
-                'mRIParameterForm' => array(
+                'mRIParameterForm' => [
                     "Incomplete" => "Incomplete",
                     "Complete"   => "Complete",
-                ),
-                'scanDoneInMRIPF'  => array(
+                ],
+                'scanDoneInMRIPF'  => [
                     "Yes" => "Yes",
                     "No"  => "No",
-                ),
-                'tarchive'         => array(
+                ],
+                'tarchive'         => [
                     "In DICOM" => "In DICOM Archives",
                     "Missing"  => "Missing",
-                ),
+                ],
                 'scanLocation'     => $scan_location,
-                'qCStatus'         => array(
+                'qCStatus'         => [
                     "Pass" => "Pass",
                     "Fail" => "Fail",
-                ),
+                ],
                 'uploadedBy'       => $uploaderList,
-                'selected'         => array(
+                'selected'         => [
                     "True"  => "True",
                     "False" => "False",
-                ),
+                ],
                 'visitLabel'       => $visitList,
             ];
 
         $scan_types = $this->_getScanTypes();
-        $scans_done = array();
-        $acq_IDs    = array();
+        $scans_done = [];
+        $acq_IDs    = [];
         foreach ($scan_types as $scan_type) {
-            $query_params        = array('scan_type' => $scan_type);
+            $query_params        = ['scan_type' => $scan_type];
             $acq_IDs[$scan_type] = $db->pselectOne(
                 "SELECT ID FROM mri_scan_type WHERE Scan_type=:scan_type",
                 $query_params
@@ -355,9 +355,9 @@ class Imaging_QC extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/imaging_qc/js/imagingQCIndex.js",
-            )
+            ]
         );
     }
 

--- a/modules/imaging_uploader/ajax/getUploadSummary.php
+++ b/modules/imaging_uploader/ajax/getUploadSummary.php
@@ -39,7 +39,7 @@ $query = "SELECT Inserting, InsertionComplete
 
 $row       = $DB->pselectRow(
     $query,
-    array('uploadId' => $uploadId)
+    ['uploadId' => $uploadId]
 );
 $inserting = $row['Inserting'] ?? '';
 $insertionComplete = $row['InsertionComplete'] ?? '';
@@ -57,16 +57,16 @@ if ($summary) {
 
 $notifications = $DB->pselect(
     $query,
-    array('processId' => $uploadId)
+    ['processId' => $uploadId]
 );
 
 // Return JSON object encapsulating the response
 echo json_encode(
-    array(
+    [
         'inserting'         => $inserting,
         'insertionComplete' => $insertionComplete,
         'notifications'     => $notifications ?? '',
-    )
+    ]
 );
 
 /**

--- a/modules/imaging_uploader/php/imaging_uploader.class.inc
+++ b/modules/imaging_uploader/php/imaging_uploader.class.inc
@@ -62,7 +62,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             . "IF(Inserting=1, 'In Progress...', "
             . "IF(InsertionComplete=0, 'Failure', 'Success'))) as Progress";
         // set the class variables
-        $this->columns      = array(
+        $this->columns      = [
             'UploadID AS Upload_ID',
             $progressSelectPart,
             's.CandID',
@@ -76,25 +76,25 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             'number_of_mincInserted AS Number_of_MINC_Inserted',
             'ta.PatientName',
             's.ID AS SessionID',
-        );
-        $this->validFilters = array(
+        ];
+        $this->validFilters = [
             's.CandID',
             'c.PSCID',
             's.Visit_label',
             'mu.IsPhantom',
-        );
+        ];
         $this->query        = " FROM mri_upload mu LEFT JOIN session".
                               " s ON (s.ID = mu.SessionID)".
                               " LEFT JOIN candidate c ON (c.CandID = s.CandID)".
                               " LEFT JOIN tarchive ta ON".
                               " (mu.TarchiveID = ta.TarchiveID)".
                               " WHERE 1=1 ";
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'CandID'      => 's.CandID',
             'PSCID'       => 'c.PSCID',
             'Visit_label' => 's.Visit_label',
             'IsPhantom'   => 'mu.IsPhantom',
-        );
+        ];
     }
      /**
       * Sets up the menu filter items for the imaging uploader
@@ -125,13 +125,13 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             $error_message   = "Please make sure files are not larger than " .
                                 $upload_max_size;
             http_response_code(400);
-            $errors = array(
-                'IsPhantom'  => array(),
-                'candID'     => array(),
-                'pSCID'      => array(),
-                'visitLabel' => array(),
-                'mriFile'    => array($error_message),
-            );
+            $errors = [
+                'IsPhantom'  => [],
+                'candID'     => [],
+                'pSCID'      => [],
+                'visitLabel' => [],
+                'mriFile'    => [$error_message],
+            ];
             header('Content-Type: application/json; charset=UTF-8');
             exit(json_encode(['errors' => $errors]));
         }
@@ -153,8 +153,8 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             $db = \Database::singleton();
             $db->update(
                 'notification_spool',
-                array('Active' => 'N'),
-                array('ProcessID' => $this->mri_upload_id)
+                ['Active' => 'N'],
+                ['ProcessID' => $this->mri_upload_id]
             );
 
             // Save file succeeded. All that's left to do is launch the MRI
@@ -175,17 +175,17 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                     );
                     $db->update(
                         'mri_upload',
-                        array('Inserting' => 1),
-                        array('UploadID' => $this->mri_upload_id)
+                        ['Inserting' => 1],
+                        ['UploadID' => $this->mri_upload_id]
                     );
                 } catch (\Exception $e) {
                     $notificationTypeID = $db->pselectOne(
                         "SELECT NotificationTypeID
                          FROM notification_types
                          WHERE Type = :type",
-                        array('type' => 'mri upload handler emergency')
+                        ['type' => 'mri upload handler emergency']
                     );
-                    $values = array(
+                    $values = [
                         'NotificationTypeID' => $notificationTypeID,
                         'Message'            => 'MRI pipeline could not be '
                                               . 'started: ' . $e->getMessage() . "\n"
@@ -195,12 +195,12 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                         'ProcessID'          => $this->mri_upload_id,
                         'Error'              => 'Y',
                         'Verbose'            => 'N',
-                    );
+                    ];
                     $db->insert('notification_spool', $values);
                     $db->update(
                         'mri_upload',
-                        array('Inserting' => 0),
-                        array('UploadID' => $this->mri_upload_id)
+                        ['Inserting' => 0],
+                        ['UploadID' => $this->mri_upload_id]
                     );
                     return false;
                 }
@@ -247,7 +247,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             $this
         );
         //set the the IDs to the handler functions.
-        $file->setHandlerArgs(array("values" => $values));
+        $file->setHandlerArgs(["values" => $values]);
         //proccesses them (including verify, move, and import steps)
         $file->processFiles();
         return true;
@@ -277,13 +277,13 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $temp_file = $file->fileInfo['tmp_name'];
         $db        = \Database::singleton();
         // creates associative array to store error messages for each form element
-        $errors = array(
-            'IsPhantom'  => array(),
-            'candID'     => array(),
-            'pSCID'      => array(),
-            'visitLabel' => array(),
-            'mriFile'    => array(),
-        );
+        $errors = [
+            'IsPhantom'  => [],
+            'candID'     => [],
+            'pSCID'      => [],
+            'visitLabel' => [],
+            'mriFile'    => [],
+        ];
         // creates empty string variable to store error message for wrong file name
         $file_name_error = "";
         $config          = \NDB_Config::singleton();
@@ -412,7 +412,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                 IF (InsertionComplete=0 AND 
                 (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID 
                 FROM mri_upload WHERE UploadLocation LIKE :ul",
-            array('ul' => "%$file_name")
+            ['ul' => "%$file_name"]
         );
 
         $uploadPath = $config->getSetting('MRIUploadIncomingPath') . $file_name;
@@ -511,10 +511,10 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                 $sessionid   = $db->pselectOne(
                     "SELECT ID FROM  session WHERE CandID = :cid
                      AND Visit_label =:vlabel",
-                    array(
+                    [
                         'cid'    => $candid,
                         'vlabel' => $visit_label,
-                    )
+                    ]
                 );
             }
         }
@@ -537,7 +537,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         } else {
             $this->uploaded_file_path = $this->getTempPath();
         }
-        $values = array(
+        $values = [
             'UploadedBy'               => $user_name,
             'UploadDate'               => $date,
             'UploadLocation'           => $this->uploaded_file_path,
@@ -551,7 +551,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
             'IsTarchiveValidated'      => 0,
             'number_of_mincInserted'   => null,
             'number_of_mincCreated'    => null,
-        );
+        ];
         if ($updateFile) {
             // Only overwrite file if it failed MRI pipeline. Need to use
             // wildcard for files that were uploaded to a random temp path.
@@ -561,10 +561,10 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
                 IF (InsertionComplete=0 AND 
                 (ISNULL(Inserting) OR Inserting=0), UploadID, NULL) as UploadID 
                 FROM mri_upload WHERE UploadLocation LIKE :ul",
-                array('ul' => "%$fileName")
+                ['ul' => "%$fileName"]
             );
             if (!empty($id)) {
-                $db->update('mri_upload', $values, array('UploadID' => $id));
+                $db->update('mri_upload', $values, ['UploadID' => $id]);
                 $this->mri_upload_id = $id;
                 return true;
             }
@@ -685,7 +685,7 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
      */
     function _getFileList($data)
     {
-        $files = array();
+        $files = [];
         foreach ($data as $row) {
             $uploadStatus = $row[1];
             $filePath     = $row[5];
@@ -728,10 +728,10 @@ class Imaging_Uploader extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/imaging_uploader/js/index.js",
                 $baseURL . "/imaging_uploader/js/imaging_uploader_helper.js",
-            )
+            ]
         );
     }
     /**

--- a/modules/imaging_uploader/test/imaging_uploaderTest.php
+++ b/modules/imaging_uploader/test/imaging_uploaderTest.php
@@ -26,100 +26,100 @@ require_once __DIR__ .
 class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
 {
     // expect UIs for Browse Tab
-    private $_loadingBrowseUI = array(
-        array(
+    private $_loadingBrowseUI = [
+        [
             "label"    => "CandID",
             "selector" => "#imaging_filter>div",
-        ),
-        array(
+        ],
+        [
             "label"    => "PSCID",
             "selector" => "#imaging_filter>div",
-        ),
-        array(
+        ],
+        [
             "label"    => "Visit Label",
             "selector" => "#imaging_filter>div",
-        ),
-        array(
+        ],
+        [
             "label"    => "Logs to display",
             "selector" => "#log_panel>div>form>div",
-        ),
+        ],
                                  // expected_headers
-        array(
+        [
             "label"    => "No.",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "UploadID",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "Progress",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "CandID",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "PSCID",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "Visit Label",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "UploadLocation",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "UploadDate",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "UploadedBy",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "Tarchive Info",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "Number Of MincCreated",
             "selector" => "#dynamictable > thead",
-        ),
-        array(
+        ],
+        [
             "label"    => "Number Of MincInserted",
             "selector" => "#dynamictable > thead",
-        ),
-    );
+        ],
+    ];
     // expect UIs for Upload Tab
-    private $_loadingUploadUI = array(
-        array(
+    private $_loadingUploadUI = [
+        [
             "label"    => "Upload an imaging scan",
             "selector" => "#upload",
-        ),
-        array(
+        ],
+        [
             "label"    => "Phantom Scans",
             "selector" => "#upload",
-        ),
-        array(
+        ],
+        [
             "label"    => "CandID",
             "selector" => "#upload",
-        ),
-        array(
+        ],
+        [
             "label"    => "PSCID",
             "selector" => "#upload",
-        ),
-        array(
+        ],
+        [
             "label"    => "Visit Label",
             "selector" => "#upload",
-        ),
-        array(
+        ],
+        [
             "label"    => "File to Upload",
             "selector" => "#upload",
-        ),
-    );
+        ],
+    ];
 
     /**
      * Tests that, when loading the Imaging_uploader module, some
@@ -143,7 +143,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
      */
     function testImagingUploaderLoadWithoutPermission()
     {
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->safeGet($this->url . '/imaging_uploader/');
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -158,7 +158,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
      */
     function testImagingUploaderLoadWithPermission()
     {
-        $this->setupPermissions(array("imaging_uploader"));
+        $this->setupPermissions(["imaging_uploader"]);
         $this->safeGet($this->url . '/imaging_uploader/');
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/instrument_builder/php/instrument_builder.class.inc
+++ b/modules/instrument_builder/php/instrument_builder.class.inc
@@ -73,12 +73,12 @@ class Instrument_Builder extends \NDB_Form
         $depends = parent::getJSDependencies();
         return array_merge(
             $depends,
-            array(
+            [
                 $baseurl . "/instrument_builder/js/instrument_builder.instrument.js",
                 $baseurl . "/instrument_builder/js/instrument_builder.rules.js",
                 $baseurl . "/instrument_builder/js/react.questions.js",
                 $baseurl . "/instrument_builder/js/react.instrument_builder.js",
-            )
+            ]
         );
     }
 }

--- a/modules/instrument_builder/test/instrument_builderTest.php
+++ b/modules/instrument_builder/test/instrument_builderTest.php
@@ -49,7 +49,7 @@ class InstrumentBuilderTestIntegrationTest extends LorisIntegrationTest
      */
     function testInstrumentBuilderDoespageLoadWithPermission()
     {
-        $this->setupPermissions(array("instrument_builder"));
+        $this->setupPermissions(["instrument_builder"]);
         $this->safeGet($this->url . "/instrument_builder/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
@@ -64,7 +64,7 @@ class InstrumentBuilderTestIntegrationTest extends LorisIntegrationTest
      */
     function testInstrumentBuilderDoespageLoadWithoutPermission()
     {
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->safeGet($this->url . "/instrument_builder/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -341,7 +341,7 @@ class Instrument_List extends \NDB_Menu_Filter
             	JOIN test_names t ON (f.Test_name=t.Test_name)
             	JOIN test_subgroups ts ON (ts.ID = t.Sub_group)
             	LEFT JOIN session s ON (s.ID=f.SessionID) ";
-        $qparams = array('SID' => $this->timePoint->getSessionID());
+        $qparams = ['SID' => $this->timePoint->getSessionID()];
 
         if (!is_null($stage)) {
             $query .= "
@@ -385,9 +385,9 @@ class Instrument_List extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/instrument_list/js/instrument_list_helper.js",
-            )
+            ]
         );
     }
 

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -104,9 +104,9 @@ class Instrument_List_ControlPanel extends \TimePoint
             && in_array($currentStage, $this->_dynamicStageOptions)
         ) {
             $this->setData(
-                array(
+                [
                     $currentStage => $_REQUEST['setStageUpdate'],
-                )
+                ]
             );
             return;
         }
@@ -114,16 +114,16 @@ class Instrument_List_ControlPanel extends \TimePoint
         // submit to dcc (a.k.a., finalize)
         if (isset($_REQUEST['setSubmitted']) && $_REQUEST['setSubmitted'] == 'Y'
             && $this->_hasAccessSendToDCC()
-            && in_array($currentStage, array('Visit', 'Screening'))
+            && in_array($currentStage, ['Visit', 'Screening'])
             && $currentStatus != 'In Progress'
         ) {
             $config = \NDB_Config::singleton();
 
             // Send to DCC - set Submitted to Y
             $this->setData(
-                array(
+                [
                     'Submitted' => $_REQUEST['setSubmitted'],
-                )
+                ]
             );
             // move to next stage (approval or the bin)
             if ($currentStatus == 'Pass') {
@@ -172,27 +172,27 @@ class Instrument_List_ControlPanel extends \TimePoint
         $condition2 = $this->_hasAccessSendToDCC();
         $condition3 = !in_array(
             $currentStage,
-            array(
+            [
                 null,
                 'Not Started',
                 'Visit',
                 'Screening',
-            )
+            ]
         );
         // un-submit to dcc
         if ($condition1 && $condition2 && $condition3) {
 
             $this->setData(
-                array('Submitted' => $submitted)
+                ['Submitted' => $submitted]
             );
 
                 // revert from approval (or the bin)
             if ($currentStage == 'Approval') {
                 $this->setData(
-                    array(
+                    [
                         'Approval'      => null,
                         'Date_approval' => null,
-                    )
+                    ]
                 );
             }
                 $previousStage = $this->_determinePreviousStage();
@@ -242,9 +242,9 @@ class Instrument_List_ControlPanel extends \TimePoint
             // update the value of 'BVLQCStatus' to what is
             // in the request.
             $this->setData(
-                array(
+                [
                     'BVLQCStatus' => $_REQUEST['setBVLQCStatus'],
-                )
+                ]
             );
             return;
         } else if (isset($_REQUEST['setBVLQCStatus'])
@@ -258,7 +258,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             // update the value of 'BVLQCStatus' to null.
             // Otherwise, do nothing.
             $this->setData(
-                array('BVLQCStatus' => null)
+                ['BVLQCStatus' => null]
             );
             return;
         }
@@ -269,9 +269,9 @@ class Instrument_List_ControlPanel extends \TimePoint
             // update the value of 'BVLQCType' to what is
             // in the request.
             $this->setData(
-                array(
+                [
                     'BVLQCType' => $_REQUEST['setBVLQCType'],
-                )
+                ]
             );
             return;
         } else if (isset($_REQUEST['setBVLQCType'])
@@ -285,7 +285,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             // update the value of 'BVLQVType' to null.
             // Otherwise, do nothing.
             $this->setData(
-                array('BVLQCType' => null)
+                ['BVLQCType' => null]
             );
             return;
         }
@@ -616,10 +616,10 @@ class Instrument_List_ControlPanel extends \TimePoint
         }
         if (!in_array(
             $this->getData('Current_stage'),
-            array(
+            [
                 'Screening',
                 'Visit',
-            )
+            ]
         )
         ) {
             $returnStr = "This stage is not a Screening or Visit stage.".
@@ -628,10 +628,10 @@ class Instrument_List_ControlPanel extends \TimePoint
         }
         if (in_array(
             $this->getData($this->getData('Current_stage')),
-            array(
+            [
                 null,
                 'In Progress',
-            )
+            ]
         )
         ) {
             $returnStr = "The status of this stage is either".
@@ -714,17 +714,17 @@ class Instrument_List_ControlPanel extends \TimePoint
             && $this->getData('Submitted')=='N'
             && in_array(
                 $this->getData('Current_stage'),
-                array(
+                [
                     'Screening',
                     'Visit',
-                )
+                ]
             )
             && !in_array(
                 $this->getData($this->getData('Current_stage')),
-                array(
+                [
                     null,
                     'In Progress',
-                )
+                ]
             )
             && ($config->getSetting("useScanDone")==="false"
             || ($this->getData('Current_stage') == 'Screening'

--- a/modules/instrument_list/test/instrument_listTest.php
+++ b/modules/instrument_list/test/instrument_listTest.php
@@ -34,11 +34,11 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
      * Table headers
      */
     private $_loadingUI
-        =  array(
+        =  [
             'Access Profile'  => '#bc2 > a:nth-child(2) > div',
             '300001 / MTL001' => '#bc2 > a:nth-child(3) > div',
             'TimePoint V1'    => '#bc2 > a:nth-child(4) > div',
-        );
+        ];
     /**
      * Tests that, when loading the Instrument list module, some
      * text appears in the body.
@@ -64,7 +64,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
      */
     function testInstrumentListDoespageLoadWithPermission()
     {
-        $this->setupPermissions(array("access_all_profiles"));
+        $this->setupPermissions(["access_all_profiles"]);
         $this->webDriver->get(
             $this->url .
             "/instrument_list/?candID=300001&sessionID=1"
@@ -82,7 +82,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
      */
     function testInstrumentListDoespageLoadWithoutPermission()
     {
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->webDriver->get(
             $this->url .
             "/instrument_list/?candID=300001&sessionID=1"

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -29,10 +29,10 @@ use \LORIS\Http\EmptyStream;
  */
 class Instrument_Manager extends \NDB_Menu_Filter
 {
-    const PERMISSIONS = array(
+    const PERMISSIONS = [
         'instrument_manager_read',
         'instrument_manager_write'
-    );
+    ];
     // Error messages
     const ALREADY_INSTALLED     = 'This instrument already exists in the ' .
                                   'test battery.';
@@ -122,7 +122,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode(
-                            array('error' => 'Forbidden')
+                            ['error' => 'Forbidden']
                         )
                     )
                 );
@@ -134,7 +134,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode(
-                            array('error' => self::CANNOT_WRITE_FILES)
+                            ['error' => self::CANNOT_WRITE_FILES]
                         )
                     )
                 );
@@ -163,7 +163,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
 
         $response = $uploader->handle($request);
 
-        if (!in_array($response->getStatusCode(), array(200, 201), true)) {
+        if (!in_array($response->getStatusCode(), [200, 201], true)) {
             if ($response->getStatusCode() == 409) {
                 /* Don't update the file if it already exists on the back-end.
                  * Instead, inform users that an administrator must install it
@@ -196,7 +196,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode(
-                            array('message' => self::UPLOAD_NO_INSTALL)
+                            ['message' => self::UPLOAD_NO_INSTALL]
                         )
                     )
                 );
@@ -247,7 +247,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode(
-                            array('error' => self::UPLOAD_INSTALL_FAILED)
+                            ['error' => self::UPLOAD_INSTALL_FAILED]
                         )
                     )
                 );
@@ -265,17 +265,17 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
-        $this->headers      = array(
+        $this->headers      = [
             'Instrument',
             'Instrument_Type',
             'Table_Installed',
             'Table_Valid',
             'Pages_Valid',
-        );
-        $this->columns      = array('Test_name as Instrument');
+        ];
+        $this->columns      = ['Test_name as Instrument'];
         $this->query        = " FROM test_names";
-        $this->validFilters = array();
-        $this->formToFilter = array();
+        $this->validFilters = [];
+        $this->formToFilter = [];
     }
 
     /**
@@ -309,18 +309,18 @@ class Instrument_Manager extends \NDB_Menu_Filter
             $this->headers
         );
 
-        $MappedData = array();
+        $MappedData = [];
         foreach ($data as $row) {
             $MappedData[] = array_values($row);
         }
 
-        return array(
+        return [
             'Headers'      => $headers,
             'Data'         => $MappedData,
             'fieldOptions' => $this->fieldOptions,
             'writable'     => $this->canWriteFiles(),
             'caninstall'   => $this->isQuatUserConfigured(),
-        );
+        ];
     }
 
     /**
@@ -409,10 +409,10 @@ class Instrument_Manager extends \NDB_Menu_Filter
            WHERE TABLE_SCHEMA=:dbname AND
            TABLE_NAME=:tablename
           ',
-            array(
+            [
                 'dbname'    => $this->factory->settings()->dbName(),
                 'tablename' => $instrument,
-            )
+            ]
         );
         return ($exists > 0) ? 'Exists' : 'Missing';
     }
@@ -428,7 +428,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     {
         $count = $this->factory->database()->pselectOne(
             'SELECT count(*) FROM test_names WHERE Test_name=:v_instrument',
-            array(':v_instrument' => $instrument)
+            [':v_instrument' => $instrument]
         );
         return $count > 0;
     }
@@ -453,12 +453,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
                         " AND DATA_TYPE=:typename";
         $exists       = $db->pselectOne(
             $sqlSelectOne,
-            array(
+            [
                 'dbname'     => $this->factory->settings()->dbName(),
                 'columnname' => $columnname,
                 'tablename'  => $tablename,
                 'typename'   => $type,
-            )
+            ]
         );
         if (!$exists) {
             return "Column $columnname invalid";
@@ -523,13 +523,13 @@ class Instrument_Manager extends \NDB_Menu_Filter
                                 " AND DATA_TYPE='enum'";
                 $db_enum      = $db->pselectOne(
                     $sqlSelectOne,
-                    array(
+                    [
                         'dbname'     => $this->factory->settings()->dbName(),
                         'columnname' => $name,
                         'tablename'  => $instname,
-                    )
+                    ]
                 );
-                $options      = array();
+                $options      = [];
                 foreach ($enums as $enum) {
                     $enum_split = explode("=>", $enum);
                     $key        = $enum_split[0];
@@ -574,10 +574,10 @@ class Instrument_Manager extends \NDB_Menu_Filter
             case 'page':
                 $exists = $db->pselectOne(
                     $sqlSelectOne,
-                    array(
+                    [
                         'testname' => $instname,
                         'testdesc' => trim($pieces[2]),
-                    )
+                    ]
                 );
                 if ($exists <= 0) {
                     return "Missing page '" . trim($pieces[2]) . "'";
@@ -651,9 +651,9 @@ class Instrument_Manager extends \NDB_Menu_Filter
         $baseURL = $this->factory->settings()->getBaseURL();
         return array_merge(
             $depends,
-            array(
+            [
                 $baseURL . '/instrument_manager/js/instrumentManagerIndex.js',
-            )
+            ]
         );
     }
 }

--- a/modules/instrument_manager/test/instrument_managerTest.php
+++ b/modules/instrument_manager/test/instrument_managerTest.php
@@ -50,7 +50,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
     function testInstrumentManagerDoespageLoadWithpermission()
     {
         // Check read permission, 'instrument_manager_read'
-        $this->setupPermissions(array('instrument_manager_read'));
+        $this->setupPermissions(['instrument_manager_read']);
         $this->safeGet($this->url . "/instrument_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -59,7 +59,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
         $this->resetPermissions();
 
         // Check write permission, 'instrument_manager_write'
-        $this->setupPermissions(array('instrument_manager_write'));
+        $this->setupPermissions(['instrument_manager_write']);
         $this->safeGet($this->url . "/instrument_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -75,7 +75,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
      */
     function testInstrumentManagerDoespageLoadWithoutpermission()
     {
-        $this->setupPermissions(array());
+        $this->setupPermissions([]);
         $this->safeGet($this->url . "/instrument_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -42,7 +42,7 @@ class Module extends \Module
             return $resp;
         }
 
-        $pathComponents = array();
+        $pathComponents = [];
 
         // Breakdown path information from the request.
         preg_match(

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -53,9 +53,9 @@ function editIssue()
     $db   =& Database::singleton();
     $user =& User::singleton();
 
-    $issueValues    = array();
-    $validateValues = array();
-    $fields         = array(
+    $issueValues    = [];
+    $validateValues = [];
+    $fields         = [
         'assignee',
         'status',
         'priority',
@@ -63,12 +63,12 @@ function editIssue()
         'title',
         'category',
         'module',
-    );
-    $fieldsToValidateFirst = array(
+    ];
+    $fieldsToValidateFirst = [
         'PSCID',
         'visitLabel',
         'centerID',
-    );
+    ];
 
     foreach ($fields as $field) {
         // The default is a string "null" because if the front end submits
@@ -129,10 +129,10 @@ function editIssue()
 
     // Adding new assignee to watching
     if (isset($issueValues['assignee'])) {
-        $nowWatching = array(
+        $nowWatching = [
             'userID'  => $issueValues['assignee'],
             'issueID' => $issueID,
-        );
+        ];
         $db->replace('issues_watching', $nowWatching);
 
         //sending email
@@ -165,18 +165,18 @@ function editIssue()
 
     // Add editor to the watching table unless they don't want to be added.
     if (isset($_POST['watching']) &&  $_POST['watching'] == 'Yes') {
-        $nowWatching = array(
+        $nowWatching = [
             'userID'  => $user->getData('UserID'),
             'issueID' => $issueID,
-        );
+        ];
         $db->replace('issues_watching', $nowWatching);
     } else if (isset($_POST['watching']) && $_POST['watching'] == 'No') {
         $db->delete(
             'issues_watching',
-            array(
+            [
                 'issueID' => $issueID,
                 'userID'  => $user->getData('UserID'),
-            )
+            ]
         );
     }
     return ['issueID' => $issueID];
@@ -217,10 +217,10 @@ function validateInput($values)
             WHERE
                 PSCID = :psc_id
         ",
-            array(
+            [
                 "center_id" => $result['centerID'],
                 "psc_id"    => $result['PSCID'],
-            )
+            ]
         );
         if (!$validCenter) {
             $validCenter = $db->pselectOne(
@@ -240,10 +240,10 @@ function validateInput($values)
                             c.PSCID = :psc_id
                     )
             ",
-                array(
+                [
                     "center_id" => $result['centerID'],
                     "psc_id"    => $result['PSCID'],
-                )
+                ]
             );
         }
         if (!$validCenter) {
@@ -370,11 +370,11 @@ function updateComments($comment, $issueID)
     $db   =& Database::singleton();
 
     if (isset($comment) && $comment != "null") {
-        $commentValues = array(
+        $commentValues = [
             'issueComment' => $comment,
             'addedBy'      => $user->getData('UserID'),
             'issueID'      => $issueID,
-        );
+        ];
         $db->insert('issues_comments', $commentValues);
     }
 }
@@ -394,11 +394,11 @@ function updateCommentHistory($issueCommentID, $newCommentValue)
     $user =& User::singleton();
     $db   =& Database::singleton();
 
-    $changedValue = array(
+    $changedValue = [
         'issueCommentID' => $issueCommentID,
         'newValue'       => $newCommentValue,
         'editedBy'       => $user->getData('UserID'),
-    );
+    ];
 
     $db->insert('issues_comments_history', $changedValue);
 }
@@ -418,10 +418,10 @@ function getWatching($issueID)
 
     $watching = $db->pselect(
         "SELECT userID from issues_watching WHERE issueID=:issueID",
-        array('issueID' => $issueID)
+        ['issueID' => $issueID]
     );
 
-    $whoIsWatching = array();
+    $whoIsWatching = [];
     foreach ($watching as $watcher) {
         $whoIsWatching[] = $watcher['userID'];
     }
@@ -446,7 +446,7 @@ function getComments($issueID)
         "UNION " .
         "SELECT issueComment, 'comment', dateAdded, addedBy " .
         "FROM issues_comments where issueID=:issueID ",
-        array('issueID' => $issueID)
+        ['issueID' => $issueID]
     );
 
     //looping by reference so can edit in place
@@ -459,7 +459,7 @@ function getComments($issueID)
         } else if ($comment['fieldChanged'] === 'centerID') {
             $site = $db->pselectOne(
                 "SELECT Name FROM psc WHERE CenterID=:centerID",
-                array('centerID' => $comment['newValue'])
+                ['centerID' => $comment['newValue']]
             );
             $comment['newValue']     = $site;
             $comment['fieldChanged'] = 'site';
@@ -467,7 +467,7 @@ function getComments($issueID)
         } else if ($comment['fieldChanged'] === 'candID') {
             $PSCID = $db->pselectOne(
                 "SELECT PSCID FROM candidate WHERE CandID=:candID",
-                array('candID' => $comment['newValue'])
+                ['candID' => $comment['newValue']]
             );
             $comment['newValue']     = $PSCID;
             $comment['fieldChanged'] = 'PSCID';
@@ -475,7 +475,7 @@ function getComments($issueID)
         } else if ($comment['fieldChanged'] === 'sessionID') {
             $visitLabel          = $db->pselectOne(
                 "SELECT Visit_label FROM session WHERE ID=:sessionID",
-                array('sessionID' => $comment['newValue'])
+                ['sessionID' => $comment['newValue']]
             );
             $comment['newValue'] = $visitLabel;
             $comment['fieldChanged'] = 'Visit Label';
@@ -505,10 +505,10 @@ function emailUser($issueID, $changed_assignee)
     $title = $db->pSelectOne(
         "SELECT title FROM issues
         WHERE issueID=:issueID",
-        array('issueID' => $issueID)
+        ['issueID' => $issueID]
     );
 
-    $msg_data            = array();
+    $msg_data            = [];
     $msg_data['url']     = $baseurl .
         "/issue_tracker/issue/" . $issueID;
     $msg_data['issueID'] = $issueID;
@@ -520,10 +520,10 @@ function emailUser($issueID, $changed_assignee)
             "SELECT u.Email as Email, u.First_name as firstname " .
             "FROM users u WHERE u.UserID=:assignee
             AND u.UserID<>:currentUser",
-            array(
+            [
                 'assignee'    => $changed_assignee,
                 'currentUser' => $user->getUserName(),
-            )
+            ]
         );
 
         if (isset($issueChangeEmailsAssignee[0])) {
@@ -543,11 +543,11 @@ function emailUser($issueID, $changed_assignee)
         "SELECT u.Email as Email, u.First_name as firstname " .
         "FROM users u INNER JOIN issues_watching w ON (w.userID = u.userID) WHERE ".
         "w.issueID=:issueID AND u.UserID<>:uid AND u.UserID<>:assignee",
-        array(
+        [
             'issueID'  => $issueID,
             'uid'      => $user->getUsername(),
             'assignee' => $changed_assignee,
-        )
+        ]
     );
 
     $msg_data['url']         = $baseurl .
@@ -572,7 +572,7 @@ function getIssueFields()
 
     $db    =& Database::singleton();
     $user  =& User::singleton();
-    $sites = array();
+    $sites = [];
 
     //get field options
     if ($user->hasPermission('access_all_profiles')) {
@@ -584,26 +584,26 @@ function getIssueFields()
     }
 
     //not yet ideal permissions
-    $assignees = array();
+    $assignees = [];
     if ($user->hasPermission('access_all_profiles')) {
         $assignee_expanded = $db->pselect(
             "SELECT Real_name, UserID FROM users",
-            array()
+            []
         );
     } else {
         $CenterID = implode(',', $user->getCenterIDs());
         $DCCID    = $db->pselectOne(
             "SELECT CenterID from psc where Name='DCC'",
-            array()
+            []
         );
         $assignee_expanded = $db->pselect(
             "SELECT DISTINCT u.Real_name, u.UserID FROM users u
              LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
 WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)",
-            array(
+            [
                 'CenterID' => $CenterID,
                 'DCC'      => $DCCID,
-            )
+            ]
         );
     }
 
@@ -611,10 +611,10 @@ WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)",
         $assignees[$a_row['UserID']] = $a_row['Real_name'];
     }
 
-    $otherWatchers = array();
+    $otherWatchers = [];
     $potential_watchers_expanded = $db->pselect(
         "SELECT Real_name, UserID FROM users",
-        array()
+        []
     );
     foreach ($potential_watchers_expanded as $w_row) {
         if ($w_row['UserID'] != $user->getData('UserID')) {
@@ -624,31 +624,31 @@ WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)",
 
     //can't set to closed if not developer.
     if ($user->hasPermission('issue_tracker_developer')) {
-        $statuses = array(
+        $statuses = [
             'new'          => 'New',
             'acknowledged' => 'Acknowledged',
             'assigned'     => 'Assigned',
             'feedback'     => 'Feedback',
             'resolved'     => 'Resolved',
             'closed'       => 'Closed',
-        );
+        ];
     } else {
-        $statuses = array(
+        $statuses = [
             'new'          => 'New',
             'acknowledged' => 'Acknowledged',
             'assigned'     => 'Assigned',
             'feedback'     => 'Feedback',
             'resolved'     => 'Resolved',
-        );
+        ];
     }
 
-    $priorities = array(
+    $priorities = [
         'low'       => 'Low',
         'normal'    => 'Normal',
         'high'      => 'High',
         'urgent'    => 'Urgent',
         'immediate' => 'Immediate',
-    );
+    ];
 
     $unorgCategories = $db->pselect(
         "SELECT categoryName FROM issues_categories",
@@ -681,7 +681,7 @@ WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)",
             "SELECT issueComment
 FROM issues_comments WHERE issueID=:i
 ORDER BY dateAdded LIMIT 1",
-            array('i' => $issueID)
+            ['i' => $issueID]
         );
 
         $provisioner = (new AttachmentProvisioner($issueID));
@@ -692,10 +692,10 @@ ORDER BY dateAdded LIMIT 1",
         $isWatching = $db->pselectOne(
             "SELECT userID, issueID FROM issues_watching
             WHERE issueID=:issueID AND userID=:userID",
-            array(
+            [
                 'issueID' => $issueID,
                 'userID'  => $user->getData('UserID'),
-            )
+            ]
         );
         if ($isWatching === null) {
             $issueData['watching'] = "No";
@@ -756,7 +756,7 @@ function getIssueData($issueID=null)
             "LEFT JOIN session s ON (i.sessionID=s.ID) " .
             "WHERE issueID=:issueID",
             ['issueID' => $issueID]
-        ) ?? array();
+        ) ?? [];
     }
 
     return [

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -120,10 +120,10 @@ function editIssue()
         $attachment->setupUploading(
             $user,
             $_FILES,
-            array(
+            [
                 'fileDescription' => '',
                 'issueID'         => $issueID,
-            )
+            ]
         );
     }
 

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -65,7 +65,7 @@ class Attachment extends \NDB_Page implements ETagCalculator
                         issues_attachments
                     WHERE
                         ID = :ID';
-        $result  = $DB->pselectRow($query, array('ID' => $ID));
+        $result  = $DB->pselectRow($query, ['ID' => $ID]);
 
         $config = \NDB_Config::singleton();
         $attachment_data_dir = rtrim(
@@ -137,11 +137,11 @@ class Attachment extends \NDB_Page implements ETagCalculator
             $DB      = $factory->database();
             $DB->update(
                 'issues_attachments',
-                array('deleted' => 1),
-                array('ID' => $ID)
+                ['deleted' => 1],
+                ['ID' => $ID]
             );
             return new \LORIS\Http\Response\JsonResponse(
-                array('success' => true)
+                ['success' => true]
             );
         }
         return new \LORIS\Http\Response\JSON\Forbidden(
@@ -175,7 +175,7 @@ class Attachment extends \NDB_Page implements ETagCalculator
                         AND USER = :user;';
         $result   = $DB->pselectOne(
             $query,
-            array('ID' => $ID, 'user' => $username)
+            ['ID' => $ID, 'user' => $username]
         );
         // Check if User shouldn't be able to Delete.
         if (empty($result)
@@ -211,11 +211,11 @@ class Attachment extends \NDB_Page implements ETagCalculator
      */
     protected function allowedMethods(): array
     {
-        return array(
+        return [
             'GET',
             'POST',
             'DELETE'
-        );
+        ];
     }
 
     /**
@@ -229,10 +229,10 @@ class Attachment extends \NDB_Page implements ETagCalculator
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'issue_tracker_reporter',
                 'issue_tracker_developer'
-            )
+            ]
         );
     }
 

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -42,10 +42,10 @@ class Issue extends \NDB_Form
         if ((empty($issueID)
             || !isset($issueID))
             && !$user->hasAnyPermission(
-                array(
+                [
                     'issue_tracker_reporter',
                     'issue_tracker_developer',
-                )
+                ]
             )
         ) {
             header("HTTP/1.1 403 Forbidden");
@@ -102,7 +102,7 @@ class Issue extends \NDB_Form
         }
         $issueData = \Database::singleton()->pselectRow(
             "SELECT centerID FROM issues WHERE issueID=:issueID",
-            array('issueID' => $issueID)
+            ['issueID' => $issueID]
         );
         return (is_null($issueData)
             || in_array($issueData['centerID'], $user->getData('CenterIDs'))
@@ -121,7 +121,7 @@ class Issue extends \NDB_Form
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $results = array();
+        $results = [];
         preg_match(
             '#/issue/([0-9]+|new)$#',
             $request->getURI()->getPath(),

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -40,10 +40,10 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'issue_tracker_reporter',
                 'issue_tracker_developer',
-            )
+            ]
         );
     }
 
@@ -79,7 +79,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         $db   = \Database::singleton();
 
         //sites
-        $sites = array();
+        $sites = [];
         if ($user->hasPermission('access_all_profiles')) {
             $sites = \Utility::getSiteList();
         } else {
@@ -88,28 +88,28 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         }
 
         //reporters
-        $reporters         = array();
+        $reporters         = [];
         $reporter_expanded = $db->pselect(
             "SELECT u.UserID,
                     u.Real_name
              FROM issues i
              INNER JOIN users u
                ON(i.assignee=u.UserID)",
-            array()
+            []
         );
         foreach ($reporter_expanded as $r_row) {
             $reporters[$r_row['UserID']] = $r_row['Real_name'];
         }
 
         //assignees
-        $assignees         = array();
+        $assignees         = [];
         $assignee_expanded = $db->pselect(
             "SELECT u.UserID,
                     u.Real_name
              FROM issues i
              INNER JOIN users u
                ON(i.assignee=u.UserID)",
-            array()
+            []
         );
         foreach ($assignee_expanded as $a_row) {
             $assignees[$a_row['UserID']] = $a_row['Real_name'];
@@ -117,28 +117,28 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
 
         $modules = \Module::getActiveModules($db);
 
-        $priorities = array(
+        $priorities = [
             'normal'    => 'Normal',
             'high'      => 'High',
             'urgent'    => 'Urgent',
             'immediate' => 'Immediate',
-        );
+        ];
 
-        $statuses = array(
+        $statuses = [
             'new'          => 'New',
             'acknowledged' => 'Acknowledged',
             'feedback'     => 'Feedback',
             'assigned'     => 'Assigned',
             'resolved'     => 'Resolved',
             'closed'       => 'Closed',
-        );
+        ];
 
         $unorgCategories = $db -> pselect(
             "SELECT categoryName
              FROM issues_categories",
             []
         );
-        $categories      = array();
+        $categories      = [];
         foreach ($unorgCategories as $r_row) {
             $categoryName = $r_row['categoryName'];
             if ($categoryName) {
@@ -185,7 +185,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         $baseurl = $factory->settings()->getBaseURL();
         return array_merge(
             parent::getJSDependencies(),
-            array($baseurl . "/issue_tracker/js/issueTrackerIndex.js")
+            [$baseurl . "/issue_tracker/js/issueTrackerIndex.js"]
         );
     }
 }

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -68,7 +68,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
               ON (i.issueID = ic.issueID)
             GROUP BY i.issueID, w.userID
             ORDER BY i.issueID DESC",
-            array('username' => $userID)
+            ['username' => $userID]
         );
     }
 

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -35,7 +35,7 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
     public function toJSON(): string
     {
         return json_encode(
-            array(
+            [
                 'ID'          => $this->ID,
                 'issueID'     => $this->issueID,
                 'file_hash'   => $this->file_hash,
@@ -46,7 +46,7 @@ class AttachmentDTO implements \LORIS\Data\DataInstance
                 'description' => $this->description,
                 'file_size'   => $this->file_size,
                 'mime_type'   => $this->mime_type,
-            )
+            ]
         );
     }
 }

--- a/modules/issue_tracker/php/provisioners/attachmentprovisioner.class.inc
+++ b/modules/issue_tracker/php/provisioners/attachmentprovisioner.class.inc
@@ -51,7 +51,7 @@ class AttachmentProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             ORDER BY
                 date_added
             ",
-            array('issueID' => $issueID),
+            ['issueID' => $issueID],
             '\LORIS\issue_tracker\Models\AttachmentDTO'
         );
     }

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -63,17 +63,17 @@ class UploadHelper
         if (!isset($files['file']['tmp_name'])
             || empty($files['file']['tmp_name'])
         ) {
-            return array(
+            return [
                 'error' =>
                     'The server is not configured to receive a file this large.'
-            );
+            ];
         }
         $this->_user   = $user;
         $this->_bytes  = $files['file']['size'];
         $this->_values = $values;
 
         $this->_fileToUpload
-            = (object) array(
+            = (object) [
                 'file'        => $files['file']['name'],
                 'file_hash'   => $this->generateHash($files['file']['tmp_name']),
                 'mime_type'   => $this->getFileMimeType($files['file']['name']),
@@ -81,7 +81,7 @@ class UploadHelper
                 'size'        => $this->_bytes,
                 'inserted_by' => $this->_user->getData('UserID'),
                 'description' => $this->_values['fileDescription'] ?? '',
-            );
+            ];
 
         $this->setFullPath($this->_fileToUpload);
 
@@ -90,7 +90,7 @@ class UploadHelper
         $this->registerFile($this->_fileToUpload);
         $this->endWithSuccess();
 
-        return array('success' => true);
+        return ['success' => true];
     }
 
     /**
@@ -137,7 +137,7 @@ class UploadHelper
     function registerFile(Object &$fileToUpload) : void
     {
         $DB     = \NDB_Factory::singleton()->database();
-        $values = array(
+        $values = [
             'issueID'     => $this->_values['issueID'],
             'file_hash'   => $fileToUpload->file_hash,
             'date_added'  => date('Y-m-d h:i:s', time()),
@@ -147,7 +147,7 @@ class UploadHelper
             'description' => $fileToUpload->description,
             'file_size'   => $fileToUpload->size,
             'mime_type'   => $fileToUpload->mime_type
-        );
+        ];
         try {
             $DB->insert('issues_attachments', $values);
             // Move file from tmp to issue_tracker attachment directory.
@@ -171,7 +171,7 @@ class UploadHelper
      */
     function getFileMimeType(string $file) : string
     {
-        $known_mime_types = array(
+        $known_mime_types = [
             'htm'  => 'text/html',
             'csv'  => 'text/csv',
             'exe'  => 'application/octet-stream',
@@ -187,7 +187,7 @@ class UploadHelper
             'html' => 'text/html',
             'png'  => 'image/png',
             'jpeg' => 'image/jpg',
-        );
+        ];
         if (strpos($file, '.') !== false) {
             $file_extension = strtolower(substr(strrchr($file, '.'), 1));
             if (array_key_exists($file_extension, $known_mime_types)) {

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -39,30 +39,30 @@ class Issue_TrackerTest extends LorisIntegrationTest
         parent::setUp();
         $this->DB->insert(
             "psc",
-            array(
+            [
                 'CenterID'  => '55',
                 'Name'      => 'TESTinPSC',
                 'Alias'     => 'tst',
                 'MRI_alias' => 'test',
-            )
+            ]
         );
         $this->DB->insert(
             "users",
-            array(
+            [
                 'ID'     => '999998',
                 'UserID' => 'TestUser',
-            )
+            ]
         );
         $this->DB->insert(
             "issues",
-            array(
+            [
                 'issueID'  => '999999',
                 'title'    => 'Test Issue',
                 'status'   => 'new',
                 'priority' => 'low',
                 'reporter' => 'TestUser',
                 'centerID' => '55',
-            )
+            ]
         );
     }
 
@@ -74,9 +74,9 @@ class Issue_TrackerTest extends LorisIntegrationTest
     function tearDown()
     {
         parent::tearDown();
-        $this->DB->delete("issues", array('issueID' => '999999'));
-        $this->DB->delete("users", array('ID' => '999998'));
-        $this->DB->delete("psc", array('CenterID' => '55'));
+        $this->DB->delete("issues", ['issueID' => '999999']);
+        $this->DB->delete("users", ['ID' => '999998']);
+        $this->DB->delete("psc", ['CenterID' => '55']);
     }
 
     /**
@@ -101,7 +101,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
      */
     function testIssueTrackerDoespageLoadWithPermission()
     {
-        $this->setupPermissions(array("issue_tracker_reporter"));
+        $this->setupPermissions(["issue_tracker_reporter"]);
         $this->safeGet($this->url . "/issue_tracker/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/login/php/login.class.inc
+++ b/modules/login/php/login.class.inc
@@ -44,11 +44,11 @@ class Login extends \NDB_Page
         $study_links = $config->getExternalLinks('Studylinks');
         foreach ($study_links as $label => $url) {
             $WindowName = md5($url);
-            $this->tpl_data['studylinks'][] = array(
+            $this->tpl_data['studylinks'][] = [
                 'url'        => $url,
                 'label'      => $label,
                 'windowName' => $WindowName,
-            );
+            ];
         }
 
         $this->tpl_data['study_description'] = html_entity_decode(

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -71,7 +71,7 @@ class PasswordExpiry extends \NDB_Form
         // be named "password" and why there's a hidden element named "login"
         // in the smarty template.)
         $this->tpl_data['username'] = $this->_username;
-        $this->form->addFormRule(array(&$this, '_validate'));
+        $this->form->addFormRule([&$this, '_validate']);
     }
 
 
@@ -93,15 +93,15 @@ class PasswordExpiry extends \NDB_Form
             new \Password($plaintext);
         } catch (\InvalidArgumentException $e) {
             $this->tpl_data['error_message'] = $e->getMessage();
-            return array('password' => $e->getMessage());
+            return ['password' => $e->getMessage()];
         }
 
         if (!$this->_user->isPasswordDifferent($plaintext)) {
             $this->tpl_data['error_message'] = 'You cannot keep the same password';
-            return array('password' => 'You cannot keep the same password');
+            return ['password' => 'You cannot keep the same password'];
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -34,7 +34,7 @@ class PasswordReset extends \NDB_Form
     function setup()
     {
         $this->tpl_data['page_title'] = 'Reset Password';
-        $this->addBasicText("username", "", array("required" => true));
+        $this->addBasicText("username", "", ["required" => true]);
 
     }
 
@@ -79,7 +79,7 @@ class PasswordReset extends \NDB_Form
                 // send the user an email
                 $factory = \NDB_Factory::singleton();
 
-                $msg_data          = array();
+                $msg_data          = [];
                 $msg_data['study'] = $config->getSetting('title');
                 $msg_data['url']   = $factory->settings()->getBaseURL();
                 $msg_data['realname'] = $user->getData('Real_name');

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -37,26 +37,26 @@ class RequestAccount extends \NDB_Form
         $this->addBasicText(
             "firstname",
             "First name",
-            array(
+            [
                 "placeholder" => "First Name",
                 "required"    => true,
-            )
+            ]
         );
         $this->addBasicText(
             "lastname",
             "Last name",
-            array(
+            [
                 "placeholder" => "Last Name",
                 "required"    => true,
-            )
+            ]
         );
         $this->addBasicText(
             "from",
             "Email address",
-            array(
+            [
                 "placeholder" => "Email address",
                 "required"    => true,
-            )
+            ]
         );
 
         //merging array using + sign to avoid reindexing of keys which
@@ -64,13 +64,13 @@ class RequestAccount extends \NDB_Form
         $this->addSelect(
             "site",
             "Site",
-            array("" => "Choose your site:") + \Utility::getSiteList(),
-            array("required" => true)
+            ["" => "Choose your site:"] + \Utility::getSiteList(),
+            ["required" => true]
         );
-        $this->addCheckbox("examiner", "Examiner role", array());
-        $this->addCheckbox("radiologist", "Radiologist", array());
+        $this->addCheckbox("examiner", "Examiner role", []);
+        $this->addCheckbox("radiologist", "Radiologist", []);
 
-        $this->form->addFormRule(array(&$this, '_validate'));
+        $this->form->addFormRule([&$this, '_validate']);
     }
 
     /**
@@ -82,7 +82,7 @@ class RequestAccount extends \NDB_Form
      */
     function _validate($values): array
     {
-        $errors = array();
+        $errors = [];
         // FIXME: These error checks are direct ports from when the request
         // account page was a standalone php script (with the ridiculous
         // "name must be at least 3 characters" check removed, because some
@@ -140,19 +140,19 @@ class RequestAccount extends \NDB_Form
         $site     = $_REQUEST["site"];
         $fullname = $name." ".$lastname;
 
-        $vals = array(
+        $vals = [
             'UserID'           => $from,
             'Real_name'        => $fullname,
             'First_name'       => $name,
             'Last_name'        => $lastname,
             'Pending_approval' => 'Y',
             'Email'            => $from,
-        );
+        ];
 
         // check email address' uniqueness
         $result = $DB->pselectOne(
             "SELECT COUNT(*) FROM users WHERE Email=:VEmail OR UserID=:VEmail",
-            array('VEmail' => $from)
+            ['VEmail' => $from]
         );
 
         $user_id = null;
@@ -165,10 +165,10 @@ class RequestAccount extends \NDB_Form
 
             $DB->insert(
                 'user_psc_rel',
-                array(
+                [
                     'UserID'   => $user_id,
                     'CenterID' => $site,
-                )
+                ]
             );
 
             $examinerCheck    = $_REQUEST['examiner'] ?? 'off';
@@ -184,35 +184,35 @@ class RequestAccount extends \NDB_Form
                     "SELECT e.examinerID
                  FROM examiners e
                  WHERE e.full_name=:fn",
-                    array("fn" => $fullname)
+                    ["fn" => $fullname]
                 );
 
                 // If examiner not in table add him
                 if (empty($examinerID)) {
                     $DB->insert(
                         'examiners',
-                        array(
+                        [
                             'full_name'   => $fullname,
                             'radiologist' => $rad,
                             'userID'      => $user_id,
-                        )
+                        ]
                     );
                     $examinerID = $DB->getLastInsertID();
                     $DB->insert(
                         'examiners_psc_rel',
-                        array(
+                        [
                             'examinerID'       => $examinerID,
                             'centerID'         => $site,
                             'active'           => 'Y',
                             'pending_approval' => 'Y',
-                        )
+                        ]
                     );
                 }
             }
         }
 
         // Verify reCAPTCHA
-        $err = array();
+        $err = [];
         if (isset($values['g-recaptcha-response']) && isset($reCAPTCHAPrivate)) {
             $recaptcha = new \ReCaptcha\ReCaptcha($reCAPTCHAPrivate);
             $resp      = $recaptcha->verify(

--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -32,7 +32,7 @@ $filePath = $path . $file;
 $downloadNotifier = new NDB_Notifier(
     "media",
     "download",
-    array("file" => $file)
+    ["file" => $file]
 );
 
 if (!file_exists($filePath)) {

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -171,7 +171,7 @@ function uploadFile()
         try {
             // Insert or override db record if file_name already exists
             $db->insertOnDuplicateUpdate('media', $query);
-            $uploadNotifier->notify(array("file" => $fileName));
+            $uploadNotifier->notify(["file" => $fileName]);
         } catch (DatabaseException $e) {
             showMediaError("Could not upload the file. Please try again!", 500);
         }
@@ -209,7 +209,7 @@ function getUploadFields()
     $config = \NDB_Config::singleton();
 
     // Select only candidates that have had visit at user's sites
-    $qparam       = array();
+    $qparam       = [];
     $sessionQuery = "SELECT c.PSCID, s.Visit_label, s.CenterID, f.Test_name
                       FROM candidate c
                       LEFT JOIN session s USING (CandID)
@@ -236,7 +236,7 @@ function getUploadFields()
     $pscid           = '';
 
     // Build array of session data to be used in upload media dropdowns
-    $sessionData = array();
+    $sessionData = [];
     foreach ($sessionRecords as $record) {
         // Populate visits
         if (!isset($sessionData[$record["PSCID"]]['visits'])) {
@@ -353,7 +353,7 @@ function showMediaError($message, $code)
  */
 function toSelect($options, $item, $item2)
 {
-    $selectOptions = array();
+    $selectOptions = [];
 
     $optionsValue = $item;
     if (isset($item2)) {
@@ -378,7 +378,7 @@ function getFilesList()
     $db       =& Database::singleton();
     $fileList = $db->pselect("SELECT id, file_name FROM media", []);
 
-    $mediaFiles = array();
+    $mediaFiles = [];
     foreach ($fileList as $row) {
         $mediaFiles[$row['id']] = $row['file_name'];
     }

--- a/modules/media/php/edit.class.inc
+++ b/modules/media/php/edit.class.inc
@@ -45,7 +45,7 @@ class Edit extends \NDB_Form
         if (isset($idMediaFile)) {
             $result = $db->pselectRow(
                 "SELECT id FROM media WHERE id = :mid",
-                array('mid' => $idMediaFile)
+                ['mid' => $idMediaFile]
             );
             if (empty($result)) {
                 header('Location: ' . $baseURL . '/media/');

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -39,10 +39,10 @@ class Media extends \DataFrameworkMenu
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'media_read',
                 'media_write',
-            )
+            ]
         );
     }
 
@@ -78,7 +78,7 @@ class Media extends \DataFrameworkMenu
         $user = \User::singleton();
         $db   = \Database::singleton();
 
-        $siteList  = array();
+        $siteList  = [];
         $visitList = \Utility::getVisitList();
 
         // allow to view all sites data through filter
@@ -95,7 +95,7 @@ class Media extends \DataFrameworkMenu
             }
         }
 
-        $instrumentList   = array();
+        $instrumentList   = [];
         $instrumentsQuery = $db->pselect(
             "SELECT Test_name, Full_name FROM test_names ORDER BY Test_name",
             []
@@ -104,7 +104,7 @@ class Media extends \DataFrameworkMenu
             $instrumentList[$instrument['Full_name']] = $instrument['Full_name'];
         }
 
-        $fileTypeList  = array();
+        $fileTypeList  = [];
         $fileTypeQuery = $db->pselect("SELECT file_type FROM media", []);
         foreach ($fileTypeQuery as $filetype) {
             $fileTypeList[$filetype['file_type']] = $filetype['file_type'];
@@ -112,20 +112,20 @@ class Media extends \DataFrameworkMenu
 
         //Language selector
         $languages    = \Utility::getLanguageList();
-        $languageList = array();
+        $languageList = [];
         foreach ($languages as $language) {
             $languageList[$language] = $language;
         }
 
-        $hiddenOptions = array();
+        $hiddenOptions = [];
         if (\User::singleton()->hasPermission('superuser')) {
-            $hiddenOptions = array(
+            $hiddenOptions = [
                 0 => 'Visible only',
                 1 => 'Hidden only',
-            );
+            ];
         }
 
-        return array(
+        return [
             'fileTypes'     => $fileTypeList,
             'visits'        => $visitList,
             'sites'         => $siteList,
@@ -134,7 +134,7 @@ class Media extends \DataFrameworkMenu
             'languages'     => $languageList,
             'hidden'        => $hiddenOptions,
             'maxUploadSize' => \Utility::getMaxUploadSize(),
-        );
+        ];
     }
 
     /**
@@ -188,9 +188,9 @@ class Media extends \DataFrameworkMenu
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/media/js/mediaIndex.js",
-            )
+            ]
         );
     }
 }

--- a/modules/media/php/mediafileprovisioner.class.inc
+++ b/modules/media/php/mediafileprovisioner.class.inc
@@ -59,7 +59,7 @@ class MediaFileProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
              INNER JOIN candidate c ON c.CandID=s.CandID
              LEFT JOIN language l USING (language_id)
              WHERE s.Active='Y' and c.Active='Y'",
-            array()
+            []
         );
     }
 

--- a/modules/media/test/MediaTest.php
+++ b/modules/media/test/MediaTest.php
@@ -54,7 +54,7 @@ class MediaTest extends LorisIntegrationTest
      */
     function testLoadsWithPermissionRead()
     {
-        $this->setupPermissions(array("media_read"));
+        $this->setupPermissions(["media_read"]);
         $this->safeGet($this->url . "/media/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -70,7 +70,7 @@ class MediaTest extends LorisIntegrationTest
      */
     function testDoesNotLoadWithoutPermission()
     {
-        $this->setupPermissions(array());
+        $this->setupPermissions([]);
         $this->safeGet($this->url . "/media/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -79,9 +79,9 @@ class Module_Manager extends \DataFrameworkMenu
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/module_manager/js/modulemanager.js",
-            )
+            ]
         );
     }
 }

--- a/modules/module_manager/php/modulemanagerprovisioner.class.inc
+++ b/modules/module_manager/php/modulemanagerprovisioner.class.inc
@@ -38,7 +38,7 @@ class ModuleManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     {
         parent::__construct(
             "SELECT name, active FROM modules",
-            array()
+            []
         );
     }
 

--- a/modules/module_manager/php/modules.class.inc
+++ b/modules/module_manager/php/modules.class.inc
@@ -71,7 +71,7 @@ class Modules extends \NDB_Page
             return $this->_handlePatch($request);
         default:
             return new \LORIS\Http\Response\JSON\MethodNotAllowed(
-                array('PATCH')
+                ['PATCH']
             );
         }
     }

--- a/modules/module_manager/test/module_managerTest.php
+++ b/modules/module_manager/test/module_managerTest.php
@@ -32,7 +32,7 @@ class ModuleManagerTest extends LorisIntegrationTest
      */
     function testLoadPageWithoutPermission()
     {
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->safeGet($this->url . "/module_manager/");
 
         // Test that the Imaging menu appears in the first row
@@ -55,7 +55,7 @@ class ModuleManagerTest extends LorisIntegrationTest
     function testLoadPageWithPermission()
     {
         // View permission
-        $this->setupPermissions(array("module_manager_view"));
+        $this->setupPermissions(["module_manager_view"]);
         $this->safeGet($this->url . "/module_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -67,7 +67,7 @@ class ModuleManagerTest extends LorisIntegrationTest
         $this->resetPermissions();
 
         // Edit permission
-        $this->setupPermissions(array("module_manager_edit"));
+        $this->setupPermissions(["module_manager_edit"]);
         $this->safeGet($this->url . "/module_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -79,7 +79,7 @@ class ModuleManagerTest extends LorisIntegrationTest
         $this->resetPermissions();
 
         // Both
-        $this->setupPermissions(array("module_manager_view", "module_manager_edit"));
+        $this->setupPermissions(["module_manager_view", "module_manager_edit"]);
         $this->safeGet($this->url . "/module_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/mri_violations/ajax/UpdateMRIProtocol.php
+++ b/modules/mri_violations/ajax/UpdateMRIProtocol.php
@@ -27,7 +27,7 @@ $client = new \NDB_Client();
 $client->initialize();
 list($row,$row_id,$column,$column_id) = explode("_", $_REQUEST['field_id']);
 $value       = $_REQUEST['field_value'];
-$table_desc  = $DB->pselect("DESC mri_protocol", array());
+$table_desc  = $DB->pselect("DESC mri_protocol", []);
 $column_name = $table_desc[$column_id]['Field'];
 
 // create user object
@@ -36,8 +36,8 @@ $user =& \User::singleton();
 if ($user->hasPermission('violated_scans_edit')) {
     $DB->update(
         'mri_protocol',
-        array($column_name => $value),
-        array('ID' => $row_id)
+        [$column_name => $value],
+        ['ID' => $row_id]
     );
 }
 

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -39,10 +39,10 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
     function _hasAccess(\User $user) : bool
     {
         return $user->hasAnyPermission(
-            array(
+            [
                 'violated_scans_view_allsites',
                 'violated_scans_edit'
-            )
+            ]
         );
     }
 
@@ -55,7 +55,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
     {
         $this->query    = " FROM mri_violations_log l LEFT JOIN mri_scan_type m
                          ON m.ID=l.Scan_type WHERE 1=1 ";
-        $this->columns  = array(
+        $this->columns  = [
             'l.PatientName',
             'l.CandID',
             'l.Visit_label',
@@ -67,9 +67,9 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
             'l.ValidRegex',
             'l.SeriesUID',
             'l.TarchiveID as TarchiveID',
-        );
+        ];
         $this->order_by = 'PatientName';
-        $this->headers  = array(
+        $this->headers  = [
             'PatientName',
             'CandID',
             'Visit_label',
@@ -81,20 +81,20 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
             'ValidRegex',
             'SeriesUID',
             'TarchiveID',
-        );
+        ];
         $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
-        $this->validFilters = array(
+        $this->validFilters = [
             'l.TarchiveID',
             'l.SeriesUID',
             'l.PatientName',
             'l.CandID',
-        );
-        $this->formToFilter = array(
+        ];
+        $this->formToFilter = [
             'TarchiveID'  => 'l.TarchiveID',
             'SeriesUID'   => 'l.SeriesUID',
             'PatientName' => 'l.PatientName',
             'CandID'      => 'l.CandID',
-        );
+        ];
         $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
     }
 
@@ -112,34 +112,34 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         $this->addBasicText(
             'TarchiveID',
             'Tarchive ID:',
-            array(
+            [
                 "size"      => 9,
                 "maxlength" => 20,
-            )
+            ]
         );
         $this->addBasicText(
             'PatientName',
             'PatientName:',
-            array(
+            [
                 "size"      => 20,
                 "maxlength" => 64,
-            )
+            ]
         );
         $this->addBasicText(
             'CandID',
             'CandID:',
-            array(
+            [
                 "size"      => 20,
                 "maxlength" => 6,
-            )
+            ]
         );
         $this->addBasicText(
             'SeriesUID',
             'DICOM Series UID:',
-            array(
+            [
                 "size"      => 20,
                 "maxlength" => 64,
-            )
+            ]
         );
 
     }
@@ -171,10 +171,10 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
                 if ($key == 'Severity') {
                     $this->tpl_data['items'][$x]['severity'] = $val;
                 }
-                $row           = array(
+                $row           = [
                     'value' => $val,
                     'name'  => $key,
-                );
+                ];
                 $row['CandID'] = isset($item['CandID']) ? $item['CandID'] : '';
                 $row['CommentID'] = isset($item['CommentID'])
                     ? $item['CommentID']
@@ -203,10 +203,10 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
                            "mri_protocol_check_violations_columnFormatter.js";
         return array_merge(
             $depends,
-            array(
+            [
                 $baseurl . $columnFormatter,
                 $baseurl . "/mri_violations/js/mri_protocol_check_violations.js",
-            )
+            ]
         );
     }
 }

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -40,10 +40,10 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return $user->hasAnyPermission(
-            array(
+            [
                 'violated_scans_view_allsites',
                 'violated_scans_edit'
-            )
+            ]
         );
     }
 
@@ -55,7 +55,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
     function _setupVariables()
     {
         // set the class variables
-        $this->columns      = array(
+        $this->columns      = [
             'mpv.CandID',
             'mpv.PSCID',
             'mpv.time_run',
@@ -75,16 +75,16 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
             'mpv.time_range',
             'mpv.SeriesUID',
             'tarchive.TarchiveID',
-        );
-        $this->validFilters = array(
+        ];
+        $this->validFilters = [
             'mpv.CandID',
             'mpv.PSCID',
             'mpv.PatientName',
             'mpv.SeriesUID',
             'mpv.series_description',
             'mpv.time_run',
-        );
-        $this->headers      = array(
+        ];
+        $this->headers      = [
             'CandID',
             'PSCID',
             'Time_Run',
@@ -104,19 +104,19 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
             'Time',
             'SeriesUID',
             'TarchiveID',
-        );
+        ];
         $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
         $this->query        = " FROM mri_protocol_violated_scans mpv
                  LEFT JOIN tarchive ON
                 (mpv.PatientName = tarchive.PatientName) WHERE 1=1";
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'CandID'            => 'mpv.CandID',
             'PSCID'             => 'mpv.PSCID',
             'PatientName'       => 'mpv.PatientName',
             'SeriesUID'         => 'mpv.SeriesUID',
             'SeriesDescription' => 'mpv.series_description',
             'TimeRun'           => 'mpv.time_run',
-        );
+        ];
         $this->tpl_data['mri_protocol_data']   = $this->getMRIProtocolData();
         $this->tpl_data['mri_protocol_header']
             = array_keys($this->tpl_data['mri_protocol_data'][0]);
@@ -136,13 +136,13 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
         $minYear     = $config->getSetting('startYear')
             - $config->getSetting('ageMax');
         $maxYear     = $config->getSetting('endYear');
-        $dateOptions = array(
+        $dateOptions = [
             'language'       => 'en',
             'format'         => 'YMd',
             'addEmptyOption' => true,
             'minYear'        => $minYear,
             'maxYear'        => $maxYear,
-        );
+        ];
 
         $this->addBasicText('CandID', 'DCC-ID:');
         $this->addBasicText('PSCID', 'PSC-ID:');
@@ -175,7 +175,7 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
             FROM mri_protocol as p
             LEFT JOIN mri_scan_type as s
             ON p.Scan_type=s.ID",
-            array()
+            []
         );
         return $mri_protocols;
     }
@@ -191,10 +191,10 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL .
                "/mri_violations/js/mri_protocol_violations_columnFormatter.js",
-            )
+            ]
         );
     }
 }

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -40,10 +40,10 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return $user->hasAnyPermission(
-            array(
+            [
                 'violated_scans_view_allsites',
                 'violated_scans_edit'
-            )
+            ]
         );
     }
     /**
@@ -65,7 +65,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             $row  = $DB->pselectRow(
                 "SELECT * FROM violations_resolved
                     WHERE hash = :hash",
-                array('hash' => $hash)
+                ['hash' => $hash]
             );
 
             //if row is found it means that resolve status was previously assigned,
@@ -79,11 +79,11 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                             break;
                         } else {
                             // user input doesn't match DB, so we update the DB
-                            $setArray   = array(
+                            $setArray   = [
                                 'Resolved'   => (string)$val,
                                 'ChangeDate' => date("Y-m-d H:i:s"),
-                            );
-                            $whereArray = array('hash' => $hash);
+                            ];
+                            $whereArray = ['hash' => $hash];
                             $DB->update(
                                 'violations_resolved',
                                 $setArray,
@@ -99,7 +99,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                 if ($val=='unresolved') {
                     continue;
                 }
-                $newlyResolved         = array();
+                $newlyResolved         = [];
                 $newlyResolved['hash'] = $key;
                 $newlyResolved['Resolved']   = (string)$val;
                 $newlyResolved['User']       = $user->getUsername();
@@ -113,7 +113,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                               ':',minc_location,PatientName,SeriesUID,time_run)
                                    )
                     )",
-                    array('hash' => $key)
+                    ['hash' => $key]
                 );
                 if (!empty($ID_mri_protocol_violated_scans)) {
                     $newlyResolved['TypeTable'] = 'mri_protocol_violated_scans';
@@ -127,7 +127,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                                     ':',MincFile,PatientName,SeriesUID,TimeRun)
                                    )
                     )",
-                    array('hash' => $key)
+                    ['hash' => $key]
                 );
 
                 if (!empty($ID_mri_violations_log)) {
@@ -143,7 +143,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                                     ':',MincFile,PatientName,SeriesUID,TimeRun)
                                    )
                     )",
-                    array('hash' => $key)
+                    ['hash' => $key]
                 );
 
                 if (!empty($ID_MRICandidateErrors)) {
@@ -165,7 +165,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
     function _setupVariables()
     {
         // set the class variables
-        $this->columns = array(
+        $this->columns = [
             'v.PatientName',
             'pjct.Name as Project',
             'subpjct.title as Subproject',
@@ -178,9 +178,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             'v.hash',
             'v.join_id',
             'v.Resolved',
-        );
+        ];
 
-        $this->headers = array(
+        $this->headers = [
             'PatientName',
             'Project',
             'Subproject',
@@ -193,7 +193,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             'Hash',
             'JoinID',
             'Resolution_status',
-        );
+        ];
 
         $this->tpl_data['hiddenHeaders'] = json_encode(
             [
@@ -303,7 +303,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             WHERE 1=1";
         $this->order_by = 'v.TimeRun DESC';
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'PatientName' => 'v.PatientName',
             'Project'     => 'v.Project',
             'Subproject'  => 'v.Subproject',
@@ -313,9 +313,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             'Description' => 'v.Series_Description',
             'SeriesUID'   => 'v.SeriesUID',
             'Site'        => 'v.Site',
-        );
+        ];
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'v.PatientName',
             'v.Project',
             'v.Subproject',
@@ -325,7 +325,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             'v.Series_Description',
             'v.SeriesUID',
             'v.Site',
-        );
+        ];
 
         $this->EqualityFilters[] = 'v.Site';
     }
@@ -347,13 +347,13 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         $minYear = $config->getSetting('startYear') - $config->getSetting('ageMax');
         $maxYear = $config->getSetting('endYear');
 
-        $dateOptions = array(
+        $dateOptions = [
             'language'       => 'en',
             'format'         => 'YMd',
             'addEmptyOption' => true,
             'minYear'        => $minYear,
             'maxYear'        => $maxYear,
-        );
+        ];
 
         $problemOptions = ['' => 'Any'];
 
@@ -365,7 +365,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             FROM mri_protocol_violated_scans
             UNION
             SELECT DISTINCT 'Protocol Violation' FROM mri_violations_log",
-            array()
+            []
         );
         foreach ($problemTypes as $problem) {
             $problemOptions[$problem['Reason']] = $problem['Reason'];
@@ -379,7 +379,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         $this->addSelect("ProblemType", "Type of problem", $problemOptions);
 
         // project
-        $list_of_projects = array('' => 'Any') + \Utility::getProjectList();
+        $list_of_projects = ['' => 'Any'] + \Utility::getProjectList();
         $this->addSelect(
             'Project',
             'Project',
@@ -387,7 +387,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         );
 
         // Subproject
-        $list_of_subprojects = array('' => 'Any') +
+        $list_of_subprojects = ['' => 'Any'] +
             \Utility::getSubprojectList();
         $this->addSelect(
             'Subproject',
@@ -400,12 +400,12 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             // get the list of study sites - to be replaced by the Site object
             $sites = \Utility::getSiteList();
             if (is_array($sites)) {
-                $sites = array('' => 'All') + $sites;
+                $sites = ['' => 'All'] + $sites;
             }
         } else {
             // allow only to view own site data
             $sites = $user->getStudySites();
-            $sites = array('' => 'All User Sites') + $sites;
+            $sites = ['' => 'All User Sites'] + $sites;
         }
         $this->addSelect('Site', 'Site', $sites);
     }
@@ -423,9 +423,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseurl . "/mri_violations/js/columnFormatterUnresolved.js",
-            )
+            ]
         );
     }
 
@@ -441,7 +441,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/mri_violations/css/mri_violations.css")
+            [$baseURL . "/mri_violations/css/mri_violations.css"]
         );
     }
 }

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -39,10 +39,10 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         $this->tpl_data['violated_scans_modifications']
             = $user->hasPermission('violated_scans_edit');
         return $user->hasAnyPermission(
-            array(
+            [
                 'violated_scans_view_allsites',
                 'violated_scans_edit'
-            )
+            ]
         );
     }
 
@@ -65,7 +65,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             $hash = $key;
             $row  = $DB->pselectRow(
                 "SELECT * FROM violations_resolved WHERE hash = :hash",
-                array('hash' => $hash)
+                ['hash' => $hash]
             );
             //if row is found, check value and update if needed
             if (!empty($row)) {
@@ -77,8 +77,8 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                             break;
                         } else { // user input doesn't match DB,
                                  // so we update the DB
-                            $setArray   = array('Resolved' => (string)$val2);
-                            $whereArray = array('hash' => $hash);
+                            $setArray   = ['Resolved' => (string)$val2];
+                            $whereArray = ['hash' => $hash];
                             $DB->update(
                                 'violations_resolved',
                                 $setArray,
@@ -93,7 +93,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 if ($val==0) {
                     continue;
                 }
-                $newlyResolved         = array();
+                $newlyResolved         = [];
                 $newlyResolved['hash'] = $key;
                 $newlyResolved['Resolved']   = (string)$val;
                 $newlyResolved['User']       = $user->getUsername();
@@ -107,7 +107,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                                 "SeriesUID,time_run)))";
                 $ID_mri_protocol_violated_scans = $DB->pselectOne(
                     $sqlSelectOne,
-                    array('hash' => $key)
+                    ['hash' => $key]
                 );
                 if (!empty($ID_mri_protocol_violated_scans)) {
                     $newlyResolved['TypeTable'] = 'mri_protocol_violated_scans';
@@ -120,7 +120,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                                 "MincFile,PatientName,SeriesUID,TimeRun)))";
                 $ID_mri_violations_log = $DB->pselectOne(
                     $sqlSelectOne,
-                    array('hash' => $key)
+                    ['hash' => $key]
                 );
                 if (!empty($ID_mri_violations_log)) {
                     $newlyResolved['TypeTable'] = 'mri_violations_log';
@@ -134,7 +134,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                                 "MincFile,PatientName,SeriesUID,TimeRun)))";
                 $ID_MRICandidateErrors = $DB->pselectOne(
                     $sqlSelectOne,
-                    array('hash' => $key)
+                    ['hash' => $key]
                 );
                 if (!empty($ID_MRICandidateErrors)) {
                     $newlyResolved['TypeTable'] = 'MRICandidateErrors';
@@ -154,7 +154,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
      */
     function _setupVariables()
     {
-        $this->columns = array(
+        $this->columns = [
             'v.Resolved as Resolution_status',
             'pjct.Name as Project',
             'subpjct.title as Subproject',
@@ -168,8 +168,8 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             'v.hash as Hash',
             'v.join_id as JoinID',
             'v.Site as SiteID',
-        );
-        $this->headers = array(
+        ];
+        $this->headers = [
             'Resolution_status',
             'Project',
             'Subproject',
@@ -183,7 +183,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             'Hash',
             'JoinID',
             'SiteID',
-        );
+        ];
 
         $this->tpl_data['hiddenHeaders'] = json_encode(
             [
@@ -279,7 +279,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             WHERE 1=1";
         $this->order_by = 'v.TimeRun DESC';
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'PatientName' => 'v.PatientName',
             'Site'        => 'v.Site',
             'TimeRun'     => 'v.TimeRun',
@@ -290,8 +290,8 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             'Description' => 'v.Series_Description',
             'SeriesUID'   => 'v.SeriesUID',
             'Resolved'    => 'v.Resolved',
-        );
-        $this->validFilters = array(
+        ];
+        $this->validFilters = [
             'v.PatientName',
             'v.Site',
             'v.TimeRun',
@@ -302,7 +302,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             'v.Series_Description',
             'v.SeriesUID',
             'v.Resolved',
-        );
+        ];
         return;
     }
 
@@ -322,13 +322,13 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         $minYear     = $config->getSetting('startYear')
             - $config->getSetting('ageMax');
         $maxYear     = $config->getSetting('endYear');
-        $dateOptions = array(
+        $dateOptions = [
             'language'       => 'en',
             'format'         => 'YMd',
             'addEmptyOption' => true,
             'minYear'        => $minYear,
             'maxYear'        => $maxYear,
-        );
+        ];
         $this->addBasicText('PatientName', 'Patient Name');
         $this->addBasicText('Description', 'Series Description or Scan Type');
         $this->addBasicDate('TimeRun', 'Time Run', $dateOptions);
@@ -338,18 +338,18 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         $this->addSelect(
             "ProblemType",
             "Type of problem",
-            array(
+            [
                 ''                             => 'Any',
                 $notMatchString                => 'Candidate Mismatch',
                 'Could not identify scan type' => 'Could not identify scan type',
                 'Protocol Violation'           => 'MRI Protocol Check violation',
-            )
+            ]
         );
         // violation resolved
         $this->addSelect(
             'Resolved',
             'Violation resolved',
-            array(
+            [
                 ''              => 'Any',
                 'reran'         => 'Reran',
                 'emailed'       => 'Emailed site/pending',
@@ -357,14 +357,14 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 'rejected'      => 'Rejected',
                 'inserted_flag' => 'Inserted with flag',
                 'other'         => 'Other',
-            )
+            ]
         );
         // project
         $list_of_projects = \Utility::getProjectList();
         $this->addSelect(
             'Project',
             'Project',
-            array('' => 'All') + $list_of_projects
+            ['' => 'All'] + $list_of_projects
         );
 
         // Subproject
@@ -372,7 +372,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         $this->addSelect(
             'Subproject',
             'Subproject',
-            array('' => 'All') + $list_of_subprojects
+            ['' => 'All'] + $list_of_subprojects
         );
 
         // Get sites
@@ -380,12 +380,12 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             // get the list of study sites - to be replaced by the Site object
             $sites = \Utility::getSiteList();
             if (is_array($sites)) {
-                $sites = array('' => 'All') + $sites;
+                $sites = ['' => 'All'] + $sites;
             }
         } else {
             // allow only to view own site data
             $sites = $user->getStudySites();
-            $sites = array('' => 'All User Sites') + $sites;
+            $sites = ['' => 'All User Sites'] + $sites;
         }
         $this->addSelect('Site', 'Site', $sites);
 
@@ -402,7 +402,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/mri_violations/js/columnFormatter.js")
+            [$baseURL . "/mri_violations/js/columnFormatter.js"]
         );
     }
 }

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -29,9 +29,9 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      * UI elements and locations
      * breadcrumb - 'MRI Violated Scans'
      */
-    private $_loadingUI = array(
+    private $_loadingUI = [
         'MRI Violated Scans' => '#bc2 > a:nth-child(2) > div'
-    );
+    ];
     /**
      * Insert testing data
      *
@@ -42,50 +42,50 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         parent::setUp();
         $this->DB->insert(
             "Project",
-            array(
+            [
                 'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
-            )
+            ]
         );
         $this->DB->insert(
             "psc",
-            array(
+            [
                 'CenterID'  => '55',
                 'Name'      => 'TESTinPSC',
                 'Alias'     => 'ttt',
                 'MRI_alias' => 'test',
-            )
+            ]
         );
         $this->DB->insert(
             "subproject",
-            array(
+            [
                 'SubprojectID' => '55',
                 'title'        => 'TESTinSubproject',
-            )
+            ]
         );
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '999888',
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
                 'PSCID'                 => '8888',
                 'RegistrationProjectID' => '7777',
-            )
+            ]
         );
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '999777',
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '2',
                 'PSCID'                 => '6666',
                 'RegistrationProjectID' => '7777',
-            )
+            ]
         );
         $this->DB->insert(
             "session",
-            array(
+            [
                 'ID'           => '9888',
                 'CandID'       => '999888',
                 'CenterID'     => '55',
@@ -94,11 +94,11 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
                 'Visit_label'  => 'Test1',
-            )
+            ]
         );
         $this->DB->insert(
             "session",
-            array(
+            [
                 'ID'           => '9777',
                 'CandID'       => '999777',
                 'CenterID'     => '55',
@@ -107,13 +107,13 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
                 'Visit_label'  => 'Test1',
-            )
+            ]
         );
 
         // create the tarchive entries
         $this->DB->insert(
             'tarchive',
-            array(
+            [
                 'TarchiveID'             => '263',
                 'DicomArchiveID'         => '1.3.12.2.1107.5.2.32.35442.30000012' .
               '100912542610900000004',
@@ -134,11 +134,11 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'AcquisitionMetadata'    => 'metadata',
                 'SessionID'              => '9888',
                 'PendingTransfer'        => '1',
-            )
+            ]
         );
         $this->DB->insert(
             'tarchive',
-            array(
+            [
                 'TarchiveID'             => '264',
                 'DicomArchiveID'         => '1.3.12.2.1107.5.2.32.35442.30000012' .
                '100912542610900000004',
@@ -159,12 +159,12 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'AcquisitionMetadata'    => 'metadata',
                 'SessionID'              => '9777',
                 'PendingTransfer'        => '1',
-            )
+            ]
         );
 
         $this->DB->insert(
             "mri_protocol_violated_scans",
-            array(
+            [
                 'ID'                 => '1001',
                 'CandID'             => '999888',
                 'PatientName'        => '[Test]PatientName_Test1',
@@ -173,11 +173,11 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'series_description' => 'Test Description',
                 'SeriesUID'          => '5555',
                 'TarchiveID'         => '263',
-            )
+            ]
         );
         $this->DB->insert(
             "mri_protocol_violated_scans",
-            array(
+            [
                 'ID'                 => '1002',
                 'CandID'             => '999777',
                 'PatientName'        => '[name]test_Test1',
@@ -186,16 +186,16 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'series_description' => 'Test Series Description',
                 'SeriesUID'          => '5556',
                 'TarchiveID'         => '264',
-            )
+            ]
         );
         $this->DB->insert(
             "violations_resolved",
-            array(
+            [
                 'ExtID'     => '1001',
                 'hash'      => '123456',
                 'TypeTable' => 'mri_protocol_violated_scans',
                 'Resolved'  => 'other',
-            )
+            ]
         );
 
     }
@@ -209,76 +209,76 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
 
         $this->DB->delete(
             "mri_protocol_violated_scans",
-            array('ID' => '1001')
+            ['ID' => '1001']
         );
         $this->DB->delete(
             "mri_protocol_violated_scans",
-            array('ID' => '1002')
+            ['ID' => '1002']
         );
         $this->DB->delete(
             "tarchive",
-            array('TarchiveID' => '263')
+            ['TarchiveID' => '263']
         );
         $this->DB->delete(
             "tarchive",
-            array('TarchiveID' => '264')
+            ['TarchiveID' => '264']
         );
         $this->DB->delete(
             "session",
-            array(
+            [
                 'CandID'   => '999888',
                 'CenterID' => '55',
-            )
+            ]
         );
         $this->DB->delete(
             "session",
-            array(
+            [
                 'CandID'   => '999777',
                 'CenterID' => '55',
-            )
+            ]
         );
         $this->DB->delete(
             "candidate",
-            array(
+            [
                 'CandID'               => '999888',
                 'RegistrationCenterID' => '55',
-            )
+            ]
         );
         $this->DB->delete(
             "candidate",
-            array(
+            [
                 'CandID'               => '999777',
                 'RegistrationCenterID' => '55',
-            )
+            ]
         );
         $this->DB->delete(
             "violations_resolved",
-            array(
+            [
                 'ExtID'     => '1001',
                 'TypeTable' => 'mri_protocol_violated_scans',
-            )
+            ]
         );
         $this->DB->delete(
             "violations_resolved",
-            array('ExtID' => '1002')
+            ['ExtID' => '1002']
         );
         $this->DB->delete(
             "subproject",
-            array('SubprojectID' => '55')
+            ['SubprojectID' => '55']
         );
         $this->DB->delete(
             "psc",
-            array(
+            [
                 'CenterID' => '55',
                 'Name'     => 'TESTinPSC',
-            )
+            ]
         );
         $this->DB->delete(
             "Project",
-            array(
+            [
                 'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
-            )
+            ]
         );
         parent::tearDown();
     }
@@ -332,7 +332,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      */
     function testModuleLoadsWithAllSitesPermission()
     {
-        $this->setupPermissions(array("violated_scans_view_allsites"));
+        $this->setupPermissions(["violated_scans_view_allsites"]);
         $this->safeGet($this->url . "/mri_violations/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
@@ -352,7 +352,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      */
     function testModuleLoadsWithEditPermission()
     {
-        $this->setupPermissions(array("violated_scans_edit"));
+        $this->setupPermissions(["violated_scans_edit"]);
         $this->safeGet($this->url . "/mri_violations/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
@@ -371,7 +371,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      */
     function testModuleDoesNotLoadWithoutPermission()
     {
-         $this->setupPermissions(array(""));
+         $this->setupPermissions([""]);
          $this->safeGet($this->url . "/mri_violations/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -123,10 +123,10 @@ class New_Profile extends \NDB_Form
                         )
                     );
             }
-            $result = array(
+            $result = [
                 'candID' => $this->_candID,
                 'pscid'  => $this->_pscid,
-            );
+            ];
             return (new \LORIS\Http\Response())
                 ->withHeader("Content-Type", "application/json")
                 ->withStatus(201)
@@ -160,11 +160,11 @@ class New_Profile extends \NDB_Form
         $ageMin    = $config->getSetting('ageMin');
         $dobFormat = $config->getSetting('dobFormat');
         $edc       = $config->getSetting('useEDC');
-        $sex       = array(
+        $sex       = [
             'male'   => 'Male',
             'female' => 'Female',
             'other'  => 'Other',
-        );
+        ];
         $pscidSet  = "false";
         $minYear   = (isset($startYear, $ageMax)) ? $startYear - $ageMax : null;
         $maxYear   = (isset($endYear, $ageMin)) ? $endYear - $ageMin : null;
@@ -172,12 +172,12 @@ class New_Profile extends \NDB_Form
         // Get sites for the select dropdown
         $user_list_of_sites = $user->getData('CenterIDs');
         $num_sites          = count($user_list_of_sites);
-        $psc_labelOptions   = array();
+        $psc_labelOptions   = [];
         if ($num_sites > 1) {
             foreach ($user_list_of_sites as $siteID) {
                 $center = $DB->pselectRow(
                     "SELECT CenterID as ID, Name FROM psc WHERE CenterID =:cid",
-                    array('cid' => $siteID)
+                    ['cid' => $siteID]
                 );
                 if (!is_null($center)) {
                     $psc_labelOptions[$siteID] = $center['Name'];
@@ -187,7 +187,7 @@ class New_Profile extends \NDB_Form
         $site = $psc_labelOptions;
 
         // Get projects for the select dropdown
-        $projList = array();
+        $projList = [];
         $projects = \Utility::getProjectList();
         foreach ($projects as $projectID => $projectName) {
             $projList[$projectID] = $projectName;
@@ -200,7 +200,7 @@ class New_Profile extends \NDB_Form
             $pscidSet = "true";
         }
 
-        $this->fieldOptions = array(
+        $this->fieldOptions = [
             'minYear'   => $minYear,
             'maxYear'   => $maxYear,
             'dobFormat' => $dobFormat,
@@ -209,9 +209,9 @@ class New_Profile extends \NDB_Form
             'pscidSet'  => $pscidSet,
             'site'      => $site,
             'project'   => $project,
-        );
+        ];
 
-        $this->form->addFormRule(array(&$this, '_validateNewCandidate'));
+        $this->form->addFormRule([&$this, '_validateNewCandidate']);
     }
 
     /**
@@ -224,7 +224,7 @@ class New_Profile extends \NDB_Form
     function _validateNewCandidate($values): array
     {
         $this->_error = null;
-        $errors       = array();
+        $errors       = [];
         $config       = \NDB_Config::singleton();
         $user         = \User::singleton();
         $db           = \Database::singleton();
@@ -303,7 +303,7 @@ class New_Profile extends \NDB_Form
                 $errors['pscid'] = 'PSCID does not match the required structure';
             } elseif ($db->pselectOne(
                 "SELECT count(PSCID) FROM candidate WHERE PSCID=:V_PSCID",
-                array('V_PSCID' => $values['pscid'])
+                ['V_PSCID' => $values['pscid']]
             ) > 0
             ) {
                 $errors['pscid'] = 'PSCID has already been registered';

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -80,26 +80,26 @@ class Next_Stage extends \NDB_Form
 
         // set the date for the new stage
         $timePoint->setData(
-            array(
+            [
                 "Date_".$newStage => $values['date1'],
-            )
+            ]
         );
 
         // set SubprojectID if applicable
         if (isset($values['SubprojectID'])) {
             $timePoint->setData(
-                array(
+                [
                     'SubprojectID' => $values['SubprojectID'],
-                )
+                ]
             );
         }
 
         // set scan done if applicable
         if (isset($values['scan_done'])) {
             $timePoint->setData(
-                array(
+                [
                     'Scan_done' => $values['scan_done'],
-                )
+                ]
             );
         }
 
@@ -151,13 +151,13 @@ class Next_Stage extends \NDB_Form
         $timePoint =& \TimePoint::singleton($this->identifier);
         $config    =& \NDB_Config::singleton();
 
-        $dateOptions = array(
+        $dateOptions = [
             'language'       => 'en',
             'format'         => 'YMd',
             'addEmptyOption' => true,
             'minYear'        => $config->getSetting('startYear'),
             'maxYear'        => $config->getSetting('endYear'),
-        );
+        ];
 
         $this->addHidden('candID', $timePoint->getData('CandID'));
         $this->addHidden('sessionID', $timePoint->getData('SessionID'));
@@ -170,11 +170,11 @@ class Next_Stage extends \NDB_Form
             $this->addSelect(
                 'scan_done',
                 'Scan Done',
-                array(
+                [
                     null => null,
                     'Y'  => 'Yes',
                     'N'  => 'No',
-                )
+                ]
             );
             $this->addRule('scan_done', 'Scan done is required', 'required');
         }
@@ -201,16 +201,16 @@ class Next_Stage extends \NDB_Form
             $this->addSelect(
                 'SubprojectID',
                 'Objective',
-                array('' => '') + $list_of_objectives
+                ['' => ''] + $list_of_objectives
             );
             $this->addRule('SubprojectID', 'Required', 'required');
         }
 
         // add date rules
         $this->addRule('date1', 'Date is required', 'required');
-        $this->addRule(array('date1', 'date2'), 'Date fields must match', 'compare');
+        $this->addRule(['date1', 'date2'], 'Date fields must match', 'compare');
 
-        $this->form->addFormRule(array(&$this, '_validate'));
+        $this->form->addFormRule([&$this, '_validate']);
     }
     /**
      * Validate function
@@ -224,7 +224,7 @@ class Next_Stage extends \NDB_Form
         $config    = \NDB_Factory::singleton()->config();
         $timePoint = \NDB_Factory::singleton()->timepoint($this->identifier);
 
-        $errors = array();
+        $errors = [];
         /* Check that dates are present. Return early as there is no point
          * doing further processing otherwise.
          */

--- a/modules/next_stage/test/next_stageTest.php
+++ b/modules/next_stage/test/next_stageTest.php
@@ -51,7 +51,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
      */
     function testNextStageDoesPageLoadWithPermission()
     {
-        $this->setupPermissions(array("data_entry"));
+        $this->setupPermissions(["data_entry"]);
         $this->safeGet(
             $this->url .
             "/next_stage/?candID=900000&sessionID=999999&identifier=999999"
@@ -70,7 +70,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
      */
     function testNextStageDoesNotPageLoadWithoutPermission()
     {
-        $this->setupPermissions(array());
+        $this->setupPermissions([]);
         $this->webDriver->get(
             $this->url .
             "/next_stage/?candID=900000&sessionID=999999&identifier=999999"
@@ -98,7 +98,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->changeStudySite();
 
         // Check to make sure page doesn't load without permission
-        $this->setupPermissions(array());
+        $this->setupPermissions([]);
         $this->webDriver->get(
             $this->url .
             "/next_stage/?candID=900000&sessionID=999999&identifier=999999"
@@ -113,7 +113,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->resetPermissions();
 
         // Check to make sure page doesn't load with permission
-        $this->setupPermissions(array("data_entry"));
+        $this->setupPermissions(["data_entry"]);
         $this->webDriver->get(
             $this->url .
             "/next_stage/?candID=900000&sessionID=999999&identifier=999999"

--- a/modules/publication/ajax/FileDelete.php
+++ b/modules/publication/ajax/FileDelete.php
@@ -20,9 +20,9 @@ $config   = \NDB_Config::singleton();
 $query      = "SELECT PublicationID, Filename ".
     "FROM publication_upload ".
     "WHERE PublicationUploadID=:upid";
-$uploadData = $db->pselectRow($query, array('upid' => $uploadID));
+$uploadData = $db->pselectRow($query, ['upid' => $uploadID]);
 
-$message = array('message' => null);
+$message = ['message' => null];
 
 if (empty($uploadData)) {
     http_response_code(400);
@@ -34,7 +34,7 @@ if (userCanDelete($uploadData, $db, $user)) {
 
     $db->delete(
         'publication_upload',
-        array('PublicationUploadID' => $uploadID)
+        ['PublicationUploadID' => $uploadID]
     );
 
     $src  = $config->getSetting('publication_uploads') . $uploadData['Filename'];
@@ -62,14 +62,14 @@ function userCanDelete($uploadData, $db, $user) : bool
     $retVal   = false;
     $origUser = $db->pselectOne(
         'SELECT UserID FROM publication WHERE PublicationID=:pid',
-        array('pid' => $uploadData['PublicationID'])
+        ['pid' => $uploadData['PublicationID']]
     );
 
     $editors = $db->pselectCol(
         'SELECT UserID 
         FROM publication_users_edit_perm_rel 
         WHERE PublicationID=:pid',
-        array('pid' => $uploadData['PublicationID'])
+        ['pid' => $uploadData['PublicationID']]
     );
 
     // Allow user to delete if they are original uploader

--- a/modules/publication/ajax/FileDownload.php
+++ b/modules/publication/ajax/FileDownload.php
@@ -12,7 +12,7 @@
  */
 
 $user    = \User::singleton();
-$message = array('message' => null);
+$message = ['message' => null];
 
 if (userCanDownload($user)) {
     // Make sure that the user isn't trying to break out of the $path

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -16,7 +16,7 @@ if (isset($_REQUEST['action'])) {
     $db      = \Database::singleton();
     $user    = \User::singleton();
     $action  = $_REQUEST['action'];
-    $message = array('message' => null);
+    $message = ['message' => null];
 
     if ($action === 'getData') {
         if (userCanGetData($db, $user)) {
@@ -51,17 +51,17 @@ if (isset($_REQUEST['action'])) {
  */
 function getData($db) : array
 {
-    $data   = array();
+    $data   = [];
     $titles = $db->pselectCol(
         'SELECT Title FROM publication',
-        array()
+        []
     );
 
     // for selecting behavioral variables of interest
     $bvlVOIs = $db->pselect(
         "SELECT pt.Name, pt.SourceFrom FROM parameter_type pt ".
         "JOIN test_names tn ON tn.Test_name=pt.SourceFrom ORDER BY pt.SourceFrom",
-        array()
+        []
     );
 
     // merge variables and test names into one array
@@ -72,7 +72,7 @@ function getData($db) : array
     sort($bvlVOIs);
 
     // sets keys and values to be equal
-    $allVOIs = array();
+    $allVOIs = [];
     $allVOIs['Behavioral'] = array_combine($bvlVOIs, $bvlVOIs);
 
     // imaging VoIs -- filter out non-human readable DICOM tags
@@ -83,7 +83,7 @@ function getData($db) : array
          JOIN parameter_type_category ptc 
          ON ptc.ParameterTypeCategoryID=ptcr.ParameterTypeCategoryID 
          WHERE ptc.Name='MRI Variables'",
-        array()
+        []
     );
 
     sort($imgVOIs);
@@ -95,19 +95,19 @@ function getData($db) : array
         "SELECT ID, Real_name FROM users ".
         "WHERE Active='Y' AND Pending_approval='N' ".
         "ORDER BY Real_name",
-        array(),
+        [],
         'ID'
     );
 
     $kws = $db->pselectCol(
         'SELECT Label FROM publication_keyword',
-        array()
+        []
     );
     $kws = array_combine($kws, $kws);
 
     $collabs = $db->pselectCol(
         'SELECT Name FROM publication_collaborator',
-        array()
+        []
     );
     $collabs = array_combine($collabs, $collabs);
 
@@ -140,7 +140,7 @@ function getProjectData($db, $user, $id) : array
         'WHERE p.PublicationID=:pid ';
     $result = $db->pselectRow(
         $query,
-        array('pid' => $id)
+        ['pid' => $id]
     );
 
     if (!$result) {
@@ -156,7 +156,7 @@ function getProjectData($db, $user, $id) : array
             'SELECT pu.UserID as ID '.
             'FROM publication_users_edit_perm_rel pu '.
             'WHERE PublicationID=:p',
-            array('p' => $id)
+            ['p' => $id]
         );
 
         $userCanEdit = (
@@ -170,7 +170,7 @@ function getProjectData($db, $user, $id) : array
         $description    = htmlspecialchars_decode($result['Description']);
         $rejectedReason = htmlspecialchars_decode($result['RejectedReason']);
 
-        $pubData = array(
+        $pubData = [
             'title'                 => $title,
             'description'           => $description,
             'leadInvestigator'      => $result['LeadInvestigator'],
@@ -185,7 +185,7 @@ function getProjectData($db, $user, $id) : array
             'userCanEdit'           => $userCanEdit,
             'statusOpts'            => getStatusOptions(),
             'uploadTypes'           => getUploadTypes(),
-        );
+        ];
 
         // if user can edit, retrieve getData() options to allow modifications
         if ($userCanEdit) {
@@ -211,7 +211,7 @@ function getVOIs($id) : array
         'LEFT JOIN publication_parameter_type_rel pptr '.
         'ON pptr.ParameterTypeID=pt.ParameterTypeID '.
         'WHERE pptr.PublicationID=:pid',
-        array('pid' => $id)
+        ['pid' => $id]
     );
     $testNames = $db->pselectCol(
         'SELECT Test_name '.
@@ -219,7 +219,7 @@ function getVOIs($id) : array
         'LEFT JOIN test_names tn '.
         'ON tn.ID=ptnr.TestNameID '.
         'WHERE PublicationID=:pid',
-        array('pid' => $id)
+        ['pid' => $id]
     );
     $vois      =  array_merge($testNames, $fields);
     return $vois;
@@ -239,7 +239,7 @@ function getKeywords($id) : array
         'LEFT JOIN publication_keyword_rel pkr '.
         'ON pkr.PublicationKeywordID=pk.PublicationKeywordID '.
         'WHERE pkr.PublicationID=:pid',
-        array('pid' => $id)
+        ['pid' => $id]
     );
 
     return $kws;
@@ -261,7 +261,7 @@ function getCollaborators($id) : array
         'LEFT JOIN publication_collaborator_rel pcr '.
         'ON pc.PublicationCollaboratorID=pcr.PublicationCollaboratorID '.
         'WHERE pcr.PublicationID=:pid',
-        array('pid' => $id)
+        ['pid' => $id]
     );
 
     return $collaborators;
@@ -280,7 +280,7 @@ function getFiles($id) : array
 
     $files = $db->pselect(
         'SELECT * FROM publication_upload WHERE PublicationID=:pid',
-        array('pid' => $id)
+        ['pid' => $id]
     );
 
     foreach ($files as $key => $f) {
@@ -301,10 +301,10 @@ function getStatusOptions() : array
     $db        = \Database::singleton();
     $rawStatus = $db->pselect(
         'SELECT * FROM publication_status',
-        array()
+        []
     );
 
-    $statusOpts = array();
+    $statusOpts = [];
     foreach ($rawStatus as $rs) {
         $statusOpts[$rs['PublicationStatusID']] = $rs['Label'];
     }
@@ -323,7 +323,7 @@ function getUploadTypes() : array
 
     return $db->pselectColWithIndexKey(
         'SELECT PublicationUploadTypeID, Label FROM publication_upload_type',
-        array(),
+        [],
         'PublicationUploadTypeID'
     );
 }
@@ -346,14 +346,14 @@ function userCanGetData($db, $user, $pubID = null) : bool
 
     $origUser = $db->pselectOne(
         'SELECT UserID FROM publication WHERE PublicationID=:p',
-        array('p' => $pubID)
+        ['p' => $pubID]
     );
 
     $userIDs = $db->pselectCol(
         'SELECT pu.UserID as ID '.
         'FROM publication_users_edit_perm_rel pu '.
         'WHERE PublicationID=:p',
-        array('p' => $pubID)
+        ['p' => $pubID]
     );
 
     $userCanEdit = (

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -42,7 +42,7 @@ class Publication extends \NDB_Menu_Filter_Form
         $nProjects = $db->pselectOne(
             'SELECT COUNT(*) FROM publication_users_edit_perm_rel '.
             'WHERE UserID=:uid',
-            array('uid' => $user->getId())
+            ['uid' => $user->getId()]
         );
         return ($user->hasPermission('publication_view')
             || $user->hasPermission('publication_propose')
@@ -97,7 +97,7 @@ class Publication extends \NDB_Menu_Filter_Form
 
         $query .= " GROUP BY p.PublicationID ";
 
-        $this->columns = array(
+        $this->columns = [
             'p.Title',
             'pcli.Name as LeadInvestigator',
             'p.DateProposed',
@@ -112,10 +112,10 @@ class Publication extends \NDB_Menu_Filter_Form
                           )',
             'GROUP_CONCAT(DISTINCT pk.Label)', // Keywords
             'p.PublicationID',
-        );
+        ];
 
         $this->query   = $query;
-        $this->headers = array(
+        $this->headers = [
             'Title',
             'Lead Investigator',
             'Date Proposed',
@@ -125,25 +125,25 @@ class Publication extends \NDB_Menu_Filter_Form
             'Variables Of Interest',
             'Keywords',
             'Publication ID',
-        );
+        ];
 
-        $this->validFilters = array(
+        $this->validFilters = [
             'p.Title',
             'p.ApprovalStatus',
             'pc.Name',
             'pk.Label',
             'pcli.Name', // Lead Investigator's name
             'pt.Name',
-        );
+        ];
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'titleOrDescription'  => 'p.Title',
             'approvalStatus'      => 'ps.Label',
             'collaborators'       => 'pc.Name',
             'keywords'            => 'pk.Label',
             'variablesOfInterest' => 'pt.Name',
             'leadInvestigator'    => 'pcli.Name',
-        );
+        ];
     }
 
     /**
@@ -158,10 +158,10 @@ class Publication extends \NDB_Menu_Filter_Form
         $db        = \Database::singleton();
         $rawStatus = $db->pselectCol(
             'SELECT Label FROM publication_status',
-            array()
+            []
         );
 
-        $statusOptions = array();
+        $statusOptions = [];
         foreach ($rawStatus as $rs) {
             $statusOptions[$rs] = $rs;
         }
@@ -212,7 +212,7 @@ class Publication extends \NDB_Menu_Filter_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . '/publication/js/publicationIndex.js')
+            [$baseURL . '/publication/js/publicationIndex.js']
         );
     }
 
@@ -229,7 +229,7 @@ class Publication extends \NDB_Menu_Filter_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . '/publication/css/publication.css')
+            [$baseURL . '/publication/css/publication.css']
         );
     }
 

--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -43,10 +43,10 @@ class View_Project extends \NDB_Form
         $nProjects = $db->pselectOne(
             'SELECT COUNT(*) FROM publication_users_edit_perm_rel '.
             'WHERE UserID=:uid AND PublicationID=:pid',
-            array(
+            [
                 'uid' => $user->getId(),
                 'pid' => $pubID,
-            )
+            ]
         );
         return ($user->hasPermission('publication_view')
             || $user->hasPermission('publication_propose')
@@ -73,9 +73,9 @@ class View_Project extends \NDB_Form
         if (isset($pubID)) {
             $result = $db->pselectRow(
                 "SELECT PublicationID FROM publication WHERE PublicationID = :pid",
-                array('pid' => $pubID)
+                ['pid' => $pubID]
             );
-            if (count($result ?? array()) < 1) {
+            if (count($result ?? []) < 1) {
                 header('Location: ' . $baseURL . '/publication/');
             }
         } else {
@@ -94,7 +94,7 @@ class View_Project extends \NDB_Form
         $deps = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array()
+            []
         );
     }
 
@@ -128,7 +128,7 @@ class View_Project extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/publication/js/viewProjectIndex.js")
+            [$baseURL . "/publication/js/viewProjectIndex.js"]
         );
     }
 

--- a/modules/server_processes_manager/php/abstractserverprocess.class.inc
+++ b/modules/server_processes_manager/php/abstractserverprocess.class.inc
@@ -459,12 +459,12 @@ abstract class AbstractServerProcess
         //--------------------------------------------------------------------------
         // Update object and database values to reflect what was computed previously
         //--------------------------------------------------------------------------
-        $setValues   = array(
+        $setValues   = [
             'exit_text' => $exitText,
             'exit_code' => $exitCode,
             'end_time'  => $endTime,
-        );
-        $whereValues = array('id' => $this->getId());
+        ];
+        $whereValues = ['id' => $this->getId()];
 
         try {
             $this->getDatabaseProvider()->getDatabase()->update(

--- a/modules/server_processes_manager/php/defaultprocessmonitor.class.inc
+++ b/modules/server_processes_manager/php/defaultprocessmonitor.class.inc
@@ -49,7 +49,7 @@ class DefaultProcessMonitor implements IProcessMonitor
         }
 
         // Get the list of running processes
-        $runningProcesses = array();
+        $runningProcesses = [];
         foreach ($psOutput as $psInfo) {
             if (preg_match('^(0-9]+)', $psInfo, $pid)) {
                 $runningProcesses[] = $pid[1];

--- a/modules/server_processes_manager/php/process.class.inc
+++ b/modules/server_processes_manager/php/process.class.inc
@@ -178,7 +178,7 @@ class Process
         }
 
         $runningPids = $this->getProcessMonitor()->getRunningProcesses(
-            array($this->getPid())
+            [$this->getPid()]
         );
 
         return count($runningPids) == 1;

--- a/modules/server_processes_manager/php/server_processes_manager.class.inc
+++ b/modules/server_processes_manager/php/server_processes_manager.class.inc
@@ -55,7 +55,7 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
         $serverProcessesMonitor->getProcessesState();
 
         // Columns displayed in the result table
-        $this->columns = array(
+        $this->columns = [
             'pid',
             'type',
             'stdout_file',
@@ -66,23 +66,23 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
             'start_time',
             'end_time',
             'exit_text',
-        );
+        ];
 
         // Allow to sort on pid, type and userid
-        $this->validFilters = array(
+        $this->validFilters = [
             'pid',
             'type',
             'userid',
-        );
+        ];
 
         $this->query = " FROM server_processes 
                          WHERE 1=1";
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'pid'    => 'pid',
             'type'   => 'type',
             'userid' => 'userid',
-        );
+        ];
 
     }
 
@@ -98,10 +98,10 @@ class Server_Processes_Manager extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL .
              "/server_processes_manager/js/server_processes_managerIndex.js",
-            )
+            ]
         );
     }
 

--- a/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
+++ b/modules/server_processes_manager/php/serverprocessesmonitor.class.inc
@@ -106,7 +106,7 @@ class ServerProcessesMonitor
         }
 
         // Build userid where clause if needed
-        $params = array();
+        $params = [];
         if (!is_null($userid)) {
             $query = "$query AND userid =:requestUserid";
             $params['requestUserid'] = $userid;
@@ -139,7 +139,7 @@ class ServerProcessesMonitor
         // retrieved from the database
         //---------------------------------------------------
         $serverProcessFactory = new ServerProcessFactory();
-        $savedProcesses       = array();
+        $savedProcesses       = [];
         foreach ($rows as $row) {
             $savedProcesses[$row['id']] = $serverProcessFactory->getServerProcess(
                 $row['id'],
@@ -165,7 +165,7 @@ class ServerProcessesMonitor
         // consider only those whose ids were passed as argument.
         $idsToMonitor = is_null($idsToMonitor)
             ? array_keys($savedProcesses) : $idsToMonitor;
-        $processState = array();
+        $processState = [];
 
         // Compute process state for each process to monitor
         foreach ($idsToMonitor as $id) {
@@ -200,7 +200,7 @@ class ServerProcessesMonitor
             }
 
             // Add current process state to state array
-            $processState[] = array(
+            $processState[] = [
                 'ID'        => is_null($matchingProcess) ? null :
                                              $matchingProcess->getId(),
                 'PID'       => is_null($matchingProcess) ? null :
@@ -209,7 +209,7 @@ class ServerProcessesMonitor
                 'PROGRESS'  => $progress,
                 'EXIT_CODE' => $exitCode,
                 'END_TIME'  => $endTime,
-            );
+            ];
         }
 
         return $processState;

--- a/modules/server_processes_manager/php/serverprocesslauncher.class.inc
+++ b/modules/server_processes_manager/php/serverprocesslauncher.class.inc
@@ -96,7 +96,7 @@ class ServerProcessLauncher
 
         $db->insert(
             'server_processes',
-            array(
+            [
                 'pid'            => $process->getPid(),
                 'type'           => $process->getType(),
                 'stdout_file'    => $process->getStdoutFile(),
@@ -104,7 +104,7 @@ class ServerProcessLauncher
                 'exit_code_file' => $process->getExitCodeFile(),
                 'userid'         => $process->getUserId(),
                 'start_time'     => $process->getStartTime(),
-            )
+            ]
         );
 
         return $db->lastInsertID;

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -41,7 +41,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      * Table headers
      */
     private $_loadingUI
-        =  array(
+        =  [
             'Server Processes Manager' => '#bc2 > a:nth-child(2) > div',
             //table headers
             'No.'                      => '#dynamictable > thead > tr',
@@ -54,7 +54,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             'User ID'                  => '#dynamictable > thead > tr',
             'Start Time'               => '#dynamictable > thead > tr',
             'End Time'                 => '#dynamictable > thead > tr',
-        );
+        ];
     /**
      * Tests that the page does not load if config setting mriCodePath has
      * not been set.
@@ -64,7 +64,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
     function testDoesNotLoadWithoutMRICodePath()
     {
         $this->setupConfigSetting('mriCodePath', null);
-        $this->setupPermissions(array("server_processes_manager"));
+        $this->setupPermissions(["server_processes_manager"]);
         $this->safeGet($this->url . "/server_processes_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -83,7 +83,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
     {
         // This function sets mriCodePath for all future functions
         $this->setupConfigSetting('mriCodePath', self::MRI_CODE_PATH);
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->safeGet($this->url . "/server_processes_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
@@ -99,7 +99,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
      */
     function testDoesNotLoadWithPermission()
     {
-        $this->setupPermissions(array("server_processes_manager"));
+        $this->setupPermissions(["server_processes_manager"]);
         $this->safeGet($this->url . "/server_processes_manager/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/statistics/php/charts.class.inc
+++ b/modules/statistics/php/charts.class.inc
@@ -107,7 +107,7 @@ class Charts extends \NDB_Page
     {
         $DB = \NDB_Factory::singleton()->database();
 
-        $recruitmentBySiteData = array();
+        $recruitmentBySiteData = [];
         $list_of_sites         = \Utility::getSiteList(true, false);
 
         foreach ($list_of_sites as $siteID => $siteName) {
@@ -118,13 +118,13 @@ class Charts extends \NDB_Page
                 c.RegistrationCenterID=:Site AND
                 c.Active='Y' AND
                 c.Entity_type='Human'",
-                array('Site' => $siteID)
+                ['Site' => $siteID]
             );
 
-            $recruitmentBySiteData[] = array(
+            $recruitmentBySiteData[] = [
                 "label" => $siteName,
                 "total" => $totalRecruitment,
-            );
+            ];
         }
         return new \LORIS\Http\Response\JsonResponse($recruitmentBySiteData);
     }
@@ -137,7 +137,7 @@ class Charts extends \NDB_Page
     private function _handleSiteSexBreakdown()
     {
         $DB            = \NDB_Factory::singleton()->database();
-        $sexData       = array();
+        $sexData       = [];
         $list_of_sites = \Utility::getSiteList(true, false);
 
         foreach ($list_of_sites as $siteID => $siteName) {
@@ -148,14 +148,14 @@ class Charts extends \NDB_Page
                 WHERE c.RegistrationCenterID=:Site
                     AND c.Sex='female' AND c.Active='Y'
                     AND c.Entity_type='Human'",
-                array('Site' => $siteID)
+                ['Site' => $siteID]
             );
             $sexData['datasets']['male'][]   = $DB->pselectOne(
                 "SELECT COUNT(c.CandID)
                 FROM candidate c
                 WHERE c.RegistrationCenterID=:Site AND c.Sex='male' AND c.Active='Y'
                 AND c.Entity_type='Human'",
-                array('Site' => $siteID)
+                ['Site' => $siteID]
             );
         }
         return (new \LORIS\Http\Response\JsonResponse($sexData));
@@ -170,7 +170,7 @@ class Charts extends \NDB_Page
     {
         $DB = \NDB_Factory::singleton()->database();
 
-        $scanData = array();
+        $scanData = [];
         // Run a query to get all the data. Order matters to ensure that the
         // labels are calculated in the correct order.
         $data = $DB->pselect(
@@ -184,7 +184,7 @@ class Charts extends \NDB_Page
             WHERE pt.Name='acquisition_date'
             GROUP BY MONTH(pf.Value), YEAR(pf.Value), s.CenterID, datelabel
             ORDER BY YEAR(pf.Value), MONTH(pf.Value), s.CenterID",
-            array()
+            []
         );
 
         // Create the labels.
@@ -205,14 +205,14 @@ class Charts extends \NDB_Page
         // Massage the data into the appropriate format per site.
         $list_of_sites = \Utility::getSiteList(true, false);
         foreach ($list_of_sites as $siteID => $siteName) {
-            $scanData['datasets'][] = array(
+            $scanData['datasets'][] = [
                 "name" => $siteName,
                 "data" => $this->_getScansPerMonthData(
                     $data,
                     $siteID,
                     $scanData['labels']
                 )
-            );
+            ];
         }
         return (new \LORIS\Http\Response\JsonResponse($scanData));
     }
@@ -262,14 +262,14 @@ class Charts extends \NDB_Page
     {
         $DB = \NDB_Factory::singleton()->database();
 
-        $recruitmentData      = array();
+        $recruitmentData      = [];
         $recruitmentStartDate = $DB->pselectOne(
             "SELECT MIN(Date_registered) FROM candidate",
-            array()
+            []
         );
         $recruitmentEndDate   = $DB->pselectOne(
             "SELECT MAX(Date_registered) FROM candidate",
-            array()
+            []
         );
 
         if ($recruitmentStartDate !== null
@@ -284,13 +284,13 @@ class Charts extends \NDB_Page
         $list_of_sites = \Utility::getSiteList(true, false);
 
         foreach ($list_of_sites as $siteID => $siteName) {
-            $recruitmentData['datasets'][] = array(
+            $recruitmentData['datasets'][] = [
                 "name" => $siteName,
                 "data" => $this->_getSiteLineRecruitmentData(
                     $siteID,
                     $recruitmentData['labels']
                 ),
-            );
+            ];
         }
         return new \LORIS\Http\Response\JsonResponse($recruitmentData);
     }
@@ -334,7 +334,7 @@ class Charts extends \NDB_Page
     private function _getSiteLineRecruitmentData($siteID, $labels)
     {
         $DB   = \NDB_Factory::singleton()->database();
-        $data = array();
+        $data = [];
 
         foreach ($labels as $label) {
             $month  = (strlen($label) == 6)
@@ -347,11 +347,11 @@ class Charts extends \NDB_Page
                 AND MONTH(c.Date_registered)=:Month
                 AND YEAR(c.Date_registered)=:Year
                 AND c.Entity_type='Human'",
-                array(
+                [
                     'Site'  => $siteID,
                     'Month' => $month,
                     'Year'  => $year,
-                )
+                ]
             );
         }
         return $data;

--- a/modules/statistics/php/module.class.inc
+++ b/modules/statistics/php/module.class.inc
@@ -197,7 +197,7 @@ class Module extends \Module
             "SELECT COUNT(*) FROM candidate c
              WHERE c.Active='Y' AND c.Entity_type='Human'
              AND c.RegistrationCenterID <> 1",
-            array()
+            []
         );
         return $totalRecruitment;
     }
@@ -274,7 +274,7 @@ class Module extends \Module
             FROM candidate c
             WHERE c.Sex=:sex AND c.Active='Y' AND c.Entity_type='Human'
             AND c.RegistrationCenterID <> 1",
-            array('sex' => $sex)
+            ['sex' => $sex]
         );
     }
 
@@ -296,10 +296,10 @@ class Module extends \Module
             FROM candidate c
             WHERE c.Sex=:sex AND c.Active='Y' AND c.RegistrationProjectID=:PID
             AND c.Entity_type='Human' AND c.RegistrationCenterID <> 1",
-            array(
+            [
                 'sex' => $sex,
                 'PID' => $projectID,
-            )
+            ]
         );
     }
 
@@ -322,7 +322,7 @@ class Module extends \Module
               AND c.RegistrationProjectID=:PID
               AND c.Entity_type='Human'
               AND c.RegistrationCenterID <> 1",
-            array('PID' => $projectID)
+            ['PID' => $projectID]
         );
     }
 }

--- a/modules/statistics/php/statistics.class.inc
+++ b/modules/statistics/php/statistics.class.inc
@@ -51,7 +51,7 @@ class Statistics extends \NDB_Form
             "SELECT ModuleName, SubModuleName, Description
                  FROM StatisticsTabs
                  ORDER BY OrderNo",
-            array()
+            []
         );
 
     }
@@ -69,9 +69,9 @@ class Statistics extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/statistics/js/statistics.js",
-            )
+            ]
         );
     }
     /**
@@ -86,7 +86,7 @@ class Statistics extends \NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/statistics/css/statistics.css")
+            [$baseURL . "/statistics/css/statistics.css"]
         );
     }
 }

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -27,7 +27,7 @@ class Statistics_DD_Site extends statistics_site
 {
 
     var $query_criteria = '';
-    var $query_vars     = array();
+    var $query_vars     = [];
 
     /**
      * CheckCriteria function
@@ -78,10 +78,10 @@ class Statistics_DD_Site extends statistics_site
 
         $this->instruments = array_filter(
             $this->instruments,
-            array(
+            [
                 &$this,
                 'notexcluded',
-            )
+            ]
         );
     }
 

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -26,7 +26,7 @@ namespace LORIS\statistics;
 class Statistics_Mri_Site extends Statistics_Site
 {
     var $query_criteria = '';
-    var $query_vars     = array();
+    var $query_vars     = [];
 
     /**
      * CheckCriteria function
@@ -94,7 +94,7 @@ class Statistics_Mri_Site extends Statistics_Site
         $this->_checkCriteria($centerID, $projectID);
         $DB =& \Database::singleton();
 
-        $scan_types = $DB->pselect("SELECT Scan_type from mri_scan_type", array());
+        $scan_types = $DB->pselect("SELECT Scan_type from mri_scan_type", []);
         $where      = "WHERE (";
         $counter    = 1;
         foreach ($scan_types as $index=>$scan) {
@@ -191,16 +191,16 @@ class Statistics_Mri_Site extends Statistics_Site
      */
     function setup()
     {
-        $this->issues = array(
+        $this->issues = [
             "Tarchive_Missing",
             "Files_Missing",
             "PF_Missing",
-        );
+        ];
 
         $DB     =& \Database::singleton();
         $sqlRow = "SELECT CenterID as ID,".
                   " PSCArea as Name FROM psc WHERE CenterID=:cid";
-        $center = $DB->pselectRow($sqlRow, array('cid' => $_REQUEST['CenterID']));
+        $center = $DB->pselectRow($sqlRow, ['cid' => $_REQUEST['CenterID']]);
         if (is_null($center)) {
             throw new \LorisException('Invalid CenterID specified');
         }
@@ -210,10 +210,10 @@ class Statistics_Mri_Site extends Statistics_Site
         // that we can iterate over it to display later, and leave blank
         // cells for ones that are missing for a given issue in the
         // template
-        $visits    = array();
+        $visits    = [];
         $projectID = $_REQUEST['ProjectID'] ?? '';
 
-        $data = array();
+        $data = [];
         foreach ($this->issues as $issue) {
             // FIXME The function _completeCount() seems to be unfinished and
             // always returns null.
@@ -226,19 +226,19 @@ class Statistics_Mri_Site extends Statistics_Site
                 if (!in_array($row['Visit_label'], $visits)) {
                     $visits[] = $row['Visit_label'];
                 }
-                $results[$row['Visit_label']][] = array(
+                $results[$row['Visit_label']][] = [
                     'test_url'  => $test_url,
                     'CandID'    => $row['CandID'],
                     'SessionID' => $row['SessionID'],
                     'CommentID' => $row['CommentID'],
                     'PSCID'     => $row['PSCID'],
-                );
+                ];
             }
-            $data[] = array(
+            $data[] = [
                 'name'        => $this->_getIssueName($issue),
                 'count'       => $complete_count,
                 'incompletes' => $results,
-            );
+            ];
         }
 
         $this->tpl_data["data"]     = $data;
@@ -260,7 +260,7 @@ class Statistics_Mri_Site extends Statistics_Site
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/statistics/css/statistics.css")
+            [$baseURL . "/statistics/css/statistics.css"]
         );
     }
 }

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -26,10 +26,10 @@ namespace LORIS\statistics;
 class Statistics_Site extends \NDB_Menu
 {
 
-    var $instruments    = array();
-    var $issues         = array();
+    var $instruments    = [];
+    var $issues         = [];
     var $query_criteria = '';
-    var $query_vars     = array();
+    var $query_vars     = [];
 
     /**
      * Checking user's permission
@@ -42,10 +42,10 @@ class Statistics_Site extends \NDB_Menu
     {
         //TODO: Create a permission specific to statistics
         $hasAccessToAllProfiles = $user->hasAllPermissions(
-            array(
+            [
                 'access_all_profiles',
                 'data_entry',
-            )
+            ]
         );
 
         $hasCenterPermission = false;
@@ -248,7 +248,7 @@ class Statistics_Site extends \NDB_Menu
         if (!empty($_REQUEST['CenterID'])) {
             $center   = $DB->pselectRow(
                 $sqlRow,
-                array('cid' => $_REQUEST['CenterID'])
+                ['cid' => $_REQUEST['CenterID']]
             );
             $centerID = $center['ID'] ?? '';
             $name     = $center['Name'] ?? '';
@@ -265,10 +265,10 @@ class Statistics_Site extends \NDB_Menu
         // that we can iterate over it to display later, and leave blank
         // cells for ones that are missing for a given instrument in the
         // template
-        $visits = array();
+        $visits = [];
 
         $this->_setInstrumentName();
-        $data = array();
+        $data = [];
         foreach ($this->instruments as $instrument=>$label) {
 
             if ($DB->tableExists($instrument)) {
@@ -290,20 +290,20 @@ class Statistics_Site extends \NDB_Menu
                     if (!in_array($row['Visit_label'], $visits)) {
                         $visits[] = $row['Visit_label'];
                     }
-                    $arrayVar = array(
+                    $arrayVar = [
                         'test_url'  => $test_url,
                         'CandID'    => $row['CandID'],
                         'SessionID' => $row['SessionID'],
                         'CommentID' => $row['CommentID'],
                         'PSCID'     => $row['PSCID'],
-                    );
+                    ];
                     $results[$row['Visit_label']][] = $arrayVar;
                 }
-                $data[] = array(
+                $data[] = [
                     'name'        => $label,
                     'count'       => $complete_count,
                     'incompletes' => $results,
-                );
+                ];
             }
         }
 
@@ -326,7 +326,7 @@ class Statistics_Site extends \NDB_Menu
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/statistics/css/statistics.css")
+            [$baseURL . "/statistics/css/statistics.css"]
         );
     }
 }

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -135,8 +135,8 @@ class Statistics_Site extends \NDB_Menu
                 }
             }
 
-            $params    = array();
-            $centerIDs = array();
+            $params    = [];
+            $centerIDs = [];
             foreach ($list_of_permitted_sites as $key => $siteID) {
                 $params[]            = ":id$key";
                 $centerIDs["id$key"] = $siteID;

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -84,7 +84,7 @@ class Stats_Behavioural extends \NDB_Form
               WHERE CenterID <> '1'
                     AND Study_site = 'Y'
 	            AND CenterID IN (" . $sitesString . ")",
-            array()
+            []
         );
 
         $this->tpl_data['Centers'] = $centers;
@@ -98,10 +98,10 @@ class Stats_Behavioural extends \NDB_Form
             if (isset($_REQUEST['site'])
                 && $_REQUEST['site'] == $row['NumericID']
             ) {
-                $this->tpl_data['CurrentSite'] = array(
+                $this->tpl_data['CurrentSite'] = [
                     'ID'   => $row['NumericID'],
                     'Name' => $row['LongName'],
-                );
+                ];
             }
 
         }
@@ -110,10 +110,10 @@ class Stats_Behavioural extends \NDB_Form
         ) {
             $currentProject = htmlspecialchars($_REQUEST['BehaviouralProject']);
             $this->tpl_data['CurrentProject']
-                = array(
+                = [
                     'ID'   => $currentProject,
                     'Name' => $projects[$currentProject],
-                );
+                ];
             $Param_Project       ='AND (s.ProjectID IS NULL 
                                    OR c.RegistrationProjectID=:pid)';
             $this->params['pid'] = htmlspecialchars($_REQUEST['BehaviouralProject']);
@@ -154,7 +154,7 @@ class Stats_Behavioural extends \NDB_Form
                     $suproject_query
                     $Param_Project
                 GROUP by s.ID, s.CenterID, VLabel, f.Data_Entry",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         foreach ($result as $row) {
@@ -227,7 +227,7 @@ class Stats_Behavioural extends \NDB_Form
                     $suproject_query
                     $Param_Project
                 GROUP BY s.CenterID, VLabel, f.Data_Entry",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         foreach ($result as $row) {
@@ -294,9 +294,9 @@ class Stats_Behavioural extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/statistics/js/form_stats_behavioural.js",
-            )
+            ]
         );
     }
 
@@ -312,7 +312,7 @@ class Stats_Behavioural extends \NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/statistics/css/statistics.css")
+            [$baseURL . "/statistics/css/statistics.css"]
         );
     }
 }

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -98,7 +98,7 @@ class Stats_Demographic extends \NDB_Form
         // This line replaces the empty $projectID string with null
         // `$projectID ?? null` would retain empty strings.
         $projectID = empty($projectID) ? null : $projectID;
-        $tpl_data  = array();
+        $tpl_data  = [];
         $tpl_data['test_name']  = isset($_REQUEST['test_name']) ?
             htmlspecialchars($_REQUEST['test_name']) : '';
         $tpl_data['Subsection'] = $subsection;
@@ -113,20 +113,20 @@ class Stats_Demographic extends \NDB_Form
         $tpl_data['DropdownName']     = $dropdownName;
         $tpl_data['DropdownOptions']  = $dropdownOpt;
         $tpl_data['DropdownSelected'] = $dropdownSelected;
-        $tpl_data['Centers']          = $centers ?? array();
+        $tpl_data['Centers']          = $centers ?? [];
         foreach ($data as $row) {
             $subproj = $row['SubprojectID'];
             $vl      = $row['VLabel'];
             $subcat  = $row['Subcat'];
             $center  = $row['CenterID'];
 
-            if (in_array($vl, $visits ?? array())
+            if (in_array($vl, $visits ?? [])
                 && in_array($subcat, $subcats)
                 && $this->_inCenter($center, $centers)
             ) {
                 $C = 'C' . $center;
                 // Ensure $tpl_data['data'] is not null before continuing
-                $tpl_data['data'] = $tpl_data['data'] ?? array();
+                $tpl_data['data'] = $tpl_data['data'] ?? [];
                 $tpl_data['data'][$subproj][$vl][$subcat] += $row['val'];
                 $tpl_data['data'][$subproj][$vl]['total'] += $row['val'];
                 $tpl_data['data'][$subproj][$subcat]      += $row['val'];
@@ -174,7 +174,7 @@ class Stats_Demographic extends \NDB_Form
         $this->tpl_data['showTable'] = true;
 
         //PROJECTS
-        $projects     = array();
+        $projects     = [];
         $projects[''] = 'All Projects';
         foreach (\Utility::getProjectList() as $key => $value) {
             $projects[$key] = $value;
@@ -186,10 +186,10 @@ class Stats_Demographic extends \NDB_Form
         if (!empty($demographicProject)) {
             $demographicProject = htmlspecialchars($demographicProject);
             $this->tpl_data['CurrentProject']
-                = array(
+                = [
                     'ID'   => $demographicProject,
                     'Name' => $projects[$demographicProject] ?? '',
-                );
+                ];
             $paramProject        ='AND (s.ProjectID IS NULL OR s.ProjectID=:pid) ';
             $this->params['pid'] = $demographicProject;
         }
@@ -236,20 +236,20 @@ class Stats_Demographic extends \NDB_Form
             WHERE CenterID <> '1'
 		    AND Study_site = 'Y'
 	            AND CenterID IN (" . $sitesString . ")",
-            array()
+            []
         );
 
-        $sites     = array();
+        $sites     = [];
         $sites[''] ='All sites';
 
         if (!empty($centers)) {
             foreach ($centers as $row) {
                 $sites[$row['NumericID']] = $row['ShortName'];
                 if ($demographicSite == $row['NumericID']) {
-                    $this->tpl_data['CurrentSite'] = array(
+                    $this->tpl_data['CurrentSite'] = [
                         'ID'   => $row['NumericID'],
                         'Name' => $row['LongName'],
-                    );
+                    ];
                 }
             }
         }
@@ -276,7 +276,7 @@ class Stats_Demographic extends \NDB_Form
                           $paramProject
                           $paramSite
                       GROUP BY s.subprojectid",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         $this->tpl_data['registered']['total'] = 0;
@@ -306,7 +306,7 @@ class Stats_Demographic extends \NDB_Form
                           $paramProject
                           $paramSite
                       GROUP BY s.subprojectid",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         $this->tpl_data['ps_active']['total'] = 0;
@@ -335,7 +335,7 @@ class Stats_Demographic extends \NDB_Form
                           $paramProject
                           $paramSite
                       GROUP BY s.subprojectid",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         $this->tpl_data['ps_inactive']['total'] = 0;
@@ -363,7 +363,7 @@ class Stats_Demographic extends \NDB_Form
                           $paramProject
                           $paramSite
                       GROUP BY s.subprojectid",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         $this->tpl_data['sex_male']['total'] = 0;
@@ -395,7 +395,7 @@ class Stats_Demographic extends \NDB_Form
                           $paramProject
                           $paramSite
                       GROUP BY s.subprojectid",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         $this->tpl_data['sex_female']['total'] = 0;
@@ -429,7 +429,7 @@ class Stats_Demographic extends \NDB_Form
                           $paramSite) 
                                 as res
               GROUP BY rowid",
-            $this->params ?? array()
+            $this->params ?? []
         );
 
         foreach ($result as $row) {
@@ -443,17 +443,17 @@ class Stats_Demographic extends \NDB_Form
         //START BIG TABLE
         $instrumentList = \Utility::getAllInstruments();
         $instDropdown   = array_merge(
-            array( '' => 'Recruit Breakdown by Sex'),
+            [ '' => 'Recruit Breakdown by Sex'],
             $instrumentList
         );
         $this->tpl_data['all_instruments'] = $instrumentList;
         $demographicInstrument = $_REQUEST['DemographicInstrument'] ?? '';
         if (!empty($demographicInstrument)) {
             $demographicInstrument = htmlspecialchars($demographicInstrument);
-            $subcategories         = array(
+            $subcategories         = [
                 'Complete',
                 'Incomplete',
-            );
+            ];
             $result = $db->pselect(
                 "SELECT count(*) as val,
                         f.Data_entry as Subcat,
@@ -494,7 +494,7 @@ class Stats_Demographic extends \NDB_Form
                     AND (f.Data_entry IS NULL OR f.Data_entry <> 'Complete')
                 GROUP BY c.RegistrationCenterID, SubprojectID, VLabel, Subcat
                 ",
-                $this->params ?? array()
+                $this->params ?? []
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
                 'Breakdown of Registered Candidates',
@@ -512,10 +512,10 @@ class Stats_Demographic extends \NDB_Form
                 $demographicProject
             );
         } else {
-            $subcategories = array(
+            $subcategories = [
                 'Male',
                 'Female',
-            );
+            ];
             $result        = $db->pselect(
                 "SELECT s.CenterID as CenterID,
                         s.SubprojectID as SubprojectID,
@@ -532,7 +532,7 @@ class Stats_Demographic extends \NDB_Form
                 AND COALESCE(s.Screening,'') NOT IN ('Failure', 'Withdrawal')
                 AND COALESCE(s.Visit,'') NOT IN ('Failure', 'Withdrawal')
                 GROUP BY s.CenterID, SubprojectID, VLabel, Subcat",
-                array()
+                []
             );
             $this->tpl_data['RecruitsTable'] = $this->renderStatsTable(
                 'Breakdown of Registered Candidates',
@@ -564,10 +564,10 @@ class Stats_Demographic extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . '/statistics/js/table_statistics.js',
                 $baseURL . '/statistics/js/form_stats_demographic.js',
-            )
+            ]
         );
     }
     /**
@@ -582,7 +582,7 @@ class Stats_Demographic extends \NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . '/statistics/css/statistics.css')
+            [$baseURL . '/statistics/css/statistics.css']
         );
     }
 

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -90,7 +90,7 @@ class Stats_MRI extends \NDB_Form
         $renderTable=true
     ): string {
 
-        $tpl_data = array();
+        $tpl_data = [];
         // Sanitize test name if present. Otherwise use empty string.
         $tpl_data['test_name']  = isset($_REQUEST['test_name'])
             ? htmlspecialchars($_REQUEST['test_name'])
@@ -220,13 +220,13 @@ class Stats_MRI extends \NDB_Form
         $DB      = $factory->database();
         $user    = $factory->user();
 
-        $bigTable_params = array();
-        $this->params    = array();
+        $bigTable_params = [];
+        $this->params    = [];
 
         $this->tpl_data['showTable'] = true;
 
         //PROJECTS
-        $projects     = array();
+        $projects     = [];
         $projects[''] = 'All Projects';
         foreach (\Utility::getProjectList() as $key => $value) {
             $projects[$key] = $value;
@@ -235,10 +235,10 @@ class Stats_MRI extends \NDB_Form
         if ($_REQUEST['MRIProject'] ?? '') {
             $currentProject = htmlspecialchars($_REQUEST['MRIProject']);
             $this->tpl_data['CurrentProject']
-                = array(
+                = [
                     'ID'   => $currentProject,
                     'Name' => $projects[$currentProject],
-                );
+                ];
             $sqlVar        = 'AND (s.ProjectID IS NULL OR s.ProjectID=:pid) ';
             $Param_Project =$sqlVar;
             $this->params['pid']    = htmlspecialchars($_REQUEST['MRIProject']);
@@ -280,19 +280,19 @@ class Stats_MRI extends \NDB_Form
               WHERE CenterID <> '1'
                 AND Study_site = 'Y'
 	        AND CenterID IN (" . $sitesString . ")",
-            array()
+            []
         );
-        $sites     = array();
+        $sites     = [];
         $sites[''] ="All sites";
         foreach ($centers as $row) {
             $sites[$row['NumericID']] = $row['ShortName'];
             if (isset($_REQUEST['MRIsite'])
                 && $_REQUEST['MRIsite'] == $row['NumericID']
             ) {
-                $this->tpl_data['CurrentSite'] = array(
+                $this->tpl_data['CurrentSite'] = [
                     'ID'   => $row['NumericID'],
                     'Name' => $row['LongName'],
-                );
+                ];
             }
         }
 
@@ -301,20 +301,20 @@ class Stats_MRI extends \NDB_Form
             "SELECT mst.ID, mst.Scan_type
               FROM mri_scan_type mst
                 JOIN mri_protocol mp ON (mst.ID=mp.Scan_type)",
-            array()
+            []
         );
 
-        $scan_types = array();
+        $scan_types = [];
         foreach ($Scan_type_results as $row) {
             $scan_types[$row['ID']] = $row['Scan_type'];
         }
 
-        $scans_selected = array();
+        $scans_selected = [];
         if ($_REQUEST['Scans'] ?? '') {
             $scans_selected_input = explode(",", $_REQUEST['Scans']);
         }
         if (empty($scans_selected_input)) {
-            $scans_selected = $scan_types ?? array();
+            $scans_selected = $scan_types ?? [];
         } else {
             foreach ($scans_selected_input as $key => $scid) {
                 $scans_selected[$scid] =$scan_types[$scid];
@@ -323,7 +323,7 @@ class Stats_MRI extends \NDB_Form
 
         $Visits = \Utility::getExistingVisitLabels($currentProject);
         $this->tpl_data['scan_types']     = $scan_types;
-        $this->tpl_data['Scans_sel_box']  = array_keys($scans_selected ?? array());
+        $this->tpl_data['Scans_sel_box']  = array_keys($scans_selected ?? []);
         $this->tpl_data['Scans_selected'] = $scans_selected;
         $this->tpl_data['Sites']          = $sites;
         $this->tpl_data['Projects']       = $projects;
@@ -337,11 +337,11 @@ class Stats_MRI extends \NDB_Form
             $this->tpl_data['mri_table_exists'] = false;
             return;
         }
-        $MRISubcategories = array(
+        $MRISubcategories = [
             'Complete',
             'Partial Run',
             'No Scan',
-        );
+        ];
 
         //Check if a specific scan is requested otherwise display first
         //available scan
@@ -362,7 +362,7 @@ class Stats_MRI extends \NDB_Form
 
         // Check if the mri_parameter_form contains the necessary columns before
         // running the query
-        $result         = array();
+        $result         = [];
         $scanDoneExists = false;
         if ($DB->columnExists('mri_parameter_form', $MRI_Type . "_Scan_Done")) {
             $scanDoneExists = true;
@@ -413,9 +413,9 @@ class Stats_MRI extends \NDB_Form
 
         //considers the naming convention of
         // mri_parameter_form is "scanType_scan_done"
-        $Scan_data_results =array();
+        $Scan_data_results =[];
         foreach ($scans_selected as $key => $scan) {
-            $scan_params = array_merge(array('scan' => $scan), $this->params);
+            $scan_params = array_merge(['scan' => $scan], $this->params);
 
             //INSERT COUNT TOTAL
             $Scan_data_results[$key]['insert_count']['total'] = $DB->pselectOne(
@@ -588,7 +588,7 @@ class Stats_MRI extends \NDB_Form
      */
     function initializeStatsArray(array $subcategories): array
     {
-        $to_ret = array('total' => 0);
+        $to_ret = ['total' => 0];
         // Initialize all values to 0.
         foreach ($subcategories as $subcat) {
             $to_ret[$subcat] = 0;
@@ -609,10 +609,10 @@ class Stats_MRI extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/statistics/js/table_statistics.js",
                 $baseURL . "/statistics/js/form_stats_MRI.js",
-            )
+            ]
         );
     }
     /**
@@ -627,7 +627,7 @@ class Stats_MRI extends \NDB_Form
         $deps    = parent::getCSSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/statistics/css/statistics.css")
+            [$baseURL . "/statistics/css/statistics.css"]
         );
     }
 

--- a/modules/statistics/test/Statistics_Test.php
+++ b/modules/statistics/test/Statistics_Test.php
@@ -49,7 +49,7 @@ class StatisticsTest extends LorisIntegrationTest
      */
     function testLoadPageWithoutPermission()
     {
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->safeGet($this->url . "/statistics/");
 
         // Test that the Imaging menu appears in the first row
@@ -71,7 +71,7 @@ class StatisticsTest extends LorisIntegrationTest
      */
     function testLoadPageWithPermission()
     {
-        $this->setupPermissions(array("data_entry"));
+        $this->setupPermissions(["data_entry"]);
         $this->safeGet($this->url . "/statistics/");
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")

--- a/modules/survey_accounts/ajax/GetEmailContent.php
+++ b/modules/survey_accounts/ajax/GetEmailContent.php
@@ -34,7 +34,7 @@ $DB = Database::singleton();
 
 $result = $DB->pselectOne(
     "SELECT DefaultEmail FROM participant_emails WHERE Test_name=:TN",
-    array('TN' => $_REQUEST['test_name'])
+    ['TN' => $_REQUEST['test_name']]
 );
 if (empty($result)) {
     print "";

--- a/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
+++ b/modules/survey_accounts/ajax/ValidateEmailSubmitInput.php
@@ -36,15 +36,15 @@ $numCandidates = $db->pselectOne(
     "SELECT COUNT(*) FROM candidate 
             WHERE PSCID=:v_PSCID 
             AND CandID=:v_CandID AND Active='Y'",
-    array(
+    [
         'v_PSCID'  => $_REQUEST['pscid'],
         'v_CandID' => $_REQUEST['dccid'],
-    )
+    ]
 );
 $error_msg     = "PSCID and DCC ID do not match or candidate does not exist.";
 if ($numCandidates != 1) {
     echo json_encode(
-        array('error_msg' => $error_msg)
+        ['error_msg' => $error_msg]
     );
     exit;
 }
@@ -54,25 +54,25 @@ $numSessions = $db->pselectOne(
             WHERE CandID=:v_CandID 
             AND UPPER(Visit_label)=UPPER(:v_VL) 
             AND Active='Y'",
-    array(
+    [
         'v_CandID' => $_REQUEST['dccid'],
         'v_VL'     => $_REQUEST['VL'],
-    )
+    ]
 );
 
 if ($numSessions != 1) {
     echo json_encode(
-        array(
+        [
             'error_msg' => "Visit ". $_REQUEST['VL'].
                              " does not exist for given candidate",
-        )
+        ]
     );
     exit;
 }
 
 if (empty($_REQUEST['TN'])) {
     echo json_encode(
-        array('error_msg' => 'Please choose an instrument')
+        ['error_msg' => 'Please choose an instrument']
     );
     exit;
 }
@@ -83,18 +83,18 @@ $instrument_list = $db->pselect(
              WHERE s.CandID=:v_CandID  
              AND UPPER(s.Visit_label)=UPPER(:v_VL) 
              AND s.Active='Y'",
-    array(
+    [
         'v_CandID' => $_REQUEST['dccid'],
         'v_VL'     => $_REQUEST['VL'],
-    )
+    ]
 );
 foreach ($instrument_list as $instrument) {
     if ($_REQUEST['TN'] == $instrument['Test_name']) {
         echo json_encode(
-            array(
+            [
                 'error_msg' => "Instrument ". $_REQUEST['TN'].
                 " already exists for given candidate for visit ". $_REQUEST['VL'],
-            )
+            ]
         );
         exit;
     }
@@ -103,7 +103,7 @@ foreach ($instrument_list as $instrument) {
 if (!empty($_REQUEST['Email']) ) {
     if (!filter_var($_REQUEST['Email'], FILTER_VALIDATE_EMAIL) ) {
         echo json_encode(
-            array('error_msg' => 'The email address is not valid.')
+            ['error_msg' => 'The email address is not valid.']
         );
         exit;
     }

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -45,7 +45,7 @@ class AddSurvey extends \NDB_Form
      */
     function _getDefaults()
     {
-        $defaults = array();
+        $defaults = [];
         return $defaults;
     }
 
@@ -65,16 +65,16 @@ class AddSurvey extends \NDB_Form
             "SELECT COUNT(*) FROM candidate 
             WHERE PSCID=:v_PSCID 
             AND CandID=:v_CandID AND Active='Y'",
-            array(
+            [
                 'v_PSCID'  => $values['PSCID'],
                 'v_CandID' => $values['CandID'],
-            )
+            ]
         );
         $error         = "PSCID and DCC ID do not match "
                 ."or candidate does not exist.";
         if ($numCandidates != 1) {
             return
-              array('CandID' => $error);
+              ['CandID' => $error];
         }
 
         $numSessions = $db->pselectOne(
@@ -82,18 +82,18 @@ class AddSurvey extends \NDB_Form
             WHERE CandID=:v_CandID 
             AND UPPER(Visit_label)=UPPER(:v_VL) 
             AND Active='Y'",
-            array(
+            [
                 'v_CandID' => $values['CandID'],
                 'v_VL'     => $values['VL'],
-            )
+            ]
         );
 
         if ($numSessions != 1) {
-            return array(
+            return [
                 'VL' => "Visit ".
                             $values['VL'].
                             " does not exist for given candidate",
-            );
+            ];
         }
 
         $instrument_list = $db->pselect(
@@ -102,10 +102,10 @@ class AddSurvey extends \NDB_Form
              WHERE s.CandID=:v_CandID  
              AND UPPER(s.Visit_label)=UPPER(:v_VL) 
              AND s.Active='Y'",
-            array(
+            [
                 'v_CandID' => $values['CandID'],
                 'v_VL'     => $values['VL'],
-            )
+            ]
         );
         $reminder        = " already exists for given candidate for visit ";
         foreach ($instrument_list as $instrument) {
@@ -113,31 +113,31 @@ class AddSurvey extends \NDB_Form
                 $instrument_instance = \NDB_BVL_Instrument::factory(
                     $instrument['Test_name']
                 );
-                return array(
+                return [
                     'Test_name' => "Instrument ".
                         $instrument_instance->getFullName().
                         $reminder. $values['VL'],
-                );
+                ];
             }
         }
 
         if (!empty($values['Email']) ) {
             if (!filter_var($values['Email'], FILTER_VALIDATE_EMAIL) ) {
-                return array('Email' => 'The email address is not valid.');
+                return ['Email' => 'The email address is not valid.'];
             }
         }
         if (!empty($values['Email']) && !empty($values['Email2'])) {
             if ($values['Email'] != $values['Email2']) {
-                return array('Email2' => 'The email addresses do not match.');
+                return ['Email2' => 'The email addresses do not match.'];
             }
         }
 
         if (!empty($values['Email']) && empty($values['Email2'])) {
-            return array('Email2' => 'Please confirm the email address.');
+            return ['Email2' => 'Please confirm the email address.'];
         }
 
         if (empty($values['Test_name'])) {
-            return array('Test_name' => 'Please choose an instrument.');
+            return ['Test_name' => 'Please choose an instrument.'];
         }
         if ($_REQUEST['fire_away'] !== 'Create survey') {
             if (!filter_var(
@@ -145,12 +145,12 @@ class AddSurvey extends \NDB_Form
                 FILTER_VALIDATE_EMAIL
             )
             ) {
-                return array('Email' => 'Email is not valid.');
+                return ['Email' => 'Email is not valid.'];
 
             }
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -168,19 +168,19 @@ class AddSurvey extends \NDB_Form
         $SessionID = $db->pselectOne(
             "SELECT ID FROM session".
             " WHERE CandID=:v_CandID AND Visit_label=:v_VL",
-            array(
+            [
                 'v_CandID' => $values['CandID'],
                 'v_VL'     => $values['VL'],
-            )
+            ]
         );
 
         $InstrumentExists = $db->pselectOne(
             "SELECT 'x' FROM participant_accounts
             WHERE Test_name=:TN AND SessionID=:SID",
-            array(
+            [
                 'TN'  => $values['Test_name'],
                 'SID' => $SessionID,
-            )
+            ]
         );
         if ($InstrumentExists == 'x') {
             return;
@@ -205,14 +205,14 @@ class AddSurvey extends \NDB_Form
         try {
             $db->insert(
                 "participant_accounts",
-                array(
+                [
                     'SessionID'       => $SessionID,
                     'Test_name'       => $values['Test_name'],
                     'Email'           => $values['Email'],
                     'Status'          => $status,
                     'OneTimePassword' => $key,
                     'CommentID'       => $commentID,
-                )
+                ]
             );
         } catch(\DatabaseException $e) {
             error_log($e->getMessage());
@@ -224,12 +224,12 @@ class AddSurvey extends \NDB_Form
             $config  = \NDB_Config::singleton();
             $baseURL = \NDB_Factory::singleton()->settings()->getBaseURL();
 
-            $msg_data = array(
+            $msg_data = [
                 'study'     => $config->getSetting("title"),
                 'url'       => $baseURL . '/survey.php?key=' .
                                          urlencode($key),
                 'EmailForm' => $values['email_dialog'],
-            );
+            ];
             \Email::send($values['Email'], 'new_survey.tpl', $msg_data);
         }
     }
@@ -264,14 +264,14 @@ class AddSurvey extends \NDB_Form
             "Test_name",
             "Instrument",
             array_merge(
-                array('' => ''),
+                ['' => ''],
                 \Utility::getDirectInstruments()
             )
         );
         $this->addBasicText("Email", "Email address");
         $this->addBasicText("Email2", "Confirm Email address");
 
-        $this->form->addFormRule(array(&$this, '_validateAddSurvey'));
+        $this->form->addFormRule([&$this, '_validateAddSurvey']);
     }
 
     /**
@@ -286,9 +286,9 @@ class AddSurvey extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/survey_accounts/js/survey_accounts_helper.js",
-            )
+            ]
         );
     }
 }

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -54,14 +54,14 @@ class Survey_Accounts extends \NDB_Menu_Filter
             AND   s.Active = 'Y'";
 
         // set the class variables
-        $this->columns      = array(
+        $this->columns      = [
             'c.PSCID AS PSCID',
             's.Visit_label AS Visit',
             'p.Email as Email',
             'p.Test_name as SurveyName',
             'p.OneTimePassword as URL',
             'p.Status',
-        );
+        ];
         $this->query        = $query;
         $this->order_by     = 'PSCID';
         $this->fieldOptions = [
@@ -82,9 +82,9 @@ class Survey_Accounts extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array(
+            [
                 $baseURL . "/survey_accounts/js/surveyAccountsIndex.js",
-            )
+            ]
         );
     }
 }

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -51,40 +51,40 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         parent::setUp();
         $this->DB->insert(
             "psc",
-            array(
+            [
                 'CenterID'  => '55',
                 'Name'      => 'TESTinPSC',
                 'Alias'     => 'tst',
                 'MRI_alias' => 'test',
-            )
+            ]
         );
         $this->DB->insert(
             "Project",
-            array(
+            [
                 'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
-            )
+            ]
         );
         $this->DB->insert(
             "subproject",
-            array(
+            [
                 'SubprojectID' => '55',
                 'title'        => 'TESTinSubproject',
-            )
+            ]
         );
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '999888',
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
                 'PSCID'                 => '8888',
                 'RegistrationProjectID' => '7777',
-            )
+            ]
         );
         $this->DB->insert(
             "session",
-            array(
+            [
                 'ID'           => '111111',
                 'CandID'       => '999888',
                 'CenterID'     => '55',
@@ -93,21 +93,21 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
                 'Visit'        => 'In Progress',
-            )
+            ]
         );
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '999999',
                 'RegistrationCenterID'  => '55',
                 'UserID'                => '1',
                 'PSCID'                 => '8889',
                 'RegistrationProjectID' => '7777',
-            )
+            ]
         );
         $this->DB->insert(
             "session",
-            array(
+            [
                 'ID'           => '111112',
                 'CandID'       => '999999',
                 'CenterID'     => '55',
@@ -116,17 +116,17 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
                 'Visit'        => 'In Progress',
-            )
+            ]
         );
         $this->DB->insert(
             "participant_accounts",
-            array(
+            [
                 'SessionID'       => '111111',
                 'Email'           => 'TestTestTest@example.com',
                 'Test_name'       => 'Test',
                 'Status'          => 'In Progress',
                 'OneTimePassword' => 'Test',
-            )
+            ]
         );
     }
 
@@ -139,38 +139,38 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
     {
         $this->DB->delete(
             "participant_accounts",
-            array('SessionID' => '111111')
+            ['SessionID' => '111111']
         );
         $this->DB->delete(
             "session",
-            array('CandID' => '999888')
+            ['CandID' => '999888']
         );
         $this->DB->delete(
             "candidate",
-            array('CandID' => '999888')
+            ['CandID' => '999888']
         );
         $this->DB->delete(
             "session",
-            array('CandID' => '999999')
+            ['CandID' => '999999']
         );
         $this->DB->delete(
             "candidate",
-            array('CandID' => '999999')
+            ['CandID' => '999999']
         );
         $this->DB->delete(
             "subproject",
-            array('SubprojectID' => '55')
+            ['SubprojectID' => '55']
         );
         $this->DB->delete(
             "psc",
-            array('CenterID' => '55')
+            ['CenterID' => '55']
         );
         $this->DB->delete(
             "Project",
-            array(
+            [
                 'ProjectID' => '7777',
                 'Name'      => 'TESTinProject',
-            )
+            ]
         );
         parent::tearDown();
     }
@@ -182,7 +182,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
      */
     function testSurveyAccountsDoespageLoad()
     {
-        $this->setupPermissions(array("user_accounts"));
+        $this->setupPermissions(["user_accounts"]);
         $this->safeGet($this->url . "/survey_accounts/");
         $bodyText
             = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
@@ -198,7 +198,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
      */
     function testSurveyAccountsWithoutPermission()
     {
-        $this->setupPermissions(array(""));
+        $this->setupPermissions([""]);
         $this->safeGet($this->url . "/survey_accounts/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -144,12 +144,12 @@ class Timepoint_List extends \NDB_Menu
 
                 if (!in_array(
                     $timePoint->getCurrentStage(),
-                    array(
+                    [
                         null,
                         'Not Started',
                         'Visit',
                         'Screening',
-                    )
+                    ]
                 )
                 ) {
                     // for static stages, don't bother showing current status

--- a/modules/timepoint_list/test/timepoint_listTest.php
+++ b/modules/timepoint_list/test/timepoint_listTest.php
@@ -27,7 +27,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
      * Contents (columns) of the session table displayed when accessing
      * the time point list page for candidate TST0001.
      */
-    private static $_TST0001_SESSION = array(
+    private static $_TST0001_SESSION = [
         'Test',
         '',
         'DCC',
@@ -39,7 +39,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
         '',
         '',
         '',
-    );
+    ];
 
     /**
      * Candidate ID for candidate TST0001.
@@ -88,7 +88,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
             $elements      = $actualSessions[$i]->findElements(
                 WebDriverBy::xpath('.//td')
             );
-            $actualSession = array();
+            $actualSession = [];
             foreach ($elements as $e) {
                 $actualSession[] = $e->getText();
             }
@@ -110,7 +110,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
         // Candidate TST0002
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '900001',
                 'PSCID'                 => 'TST0002',
                 'RegistrationCenterID'  => 1,
@@ -118,41 +118,41 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
                 'Active'                => 'Y',
                 'UserID'                => 1,
                 'Entity_type'           => 'Human',
-            )
+            ]
         );
 
         // Session for candidate TST0002: should not be listed on the page
         $this->DB->insert(
             'session',
-            array(
+            [
                 'ID'          => '999998',
                 'CandID'      => '900001',
                 'Visit_label' => 'Test',
                 'CenterID'    => 1,
                 'ProjectID'   => 1,
-            )
+            ]
         );
 
         // Inactive session for candidate TST0001: should not appear
         // on the page
         $this->DB->insert(
             'session',
-            array(
+            [
                 'ID'          => '999997',
                 'CandID'      => self::$_TST0001_CANDID,
                 'Visit_label' => 'Test2',
                 'CenterID'    => 1,
                 'ProjectID'   => 1,
                 'Active'      => 'N',
-            )
+            ]
         );
         $this->safeGet(
             $this->url . "/" .  self::$_TST0001_CANDID . "/"
         );
-        $this->_validateSessionTableContents(array(self::$_TST0001_SESSION));
-        $this->DB->delete('session', array('ID' => '999997'));
-        $this->DB->delete('session', array('ID' => '999998'));
-        $this->DB->delete('candidate', array('CandID' => 900001));
+        $this->_validateSessionTableContents([self::$_TST0001_SESSION]);
+        $this->DB->delete('session', ['ID' => '999997']);
+        $this->DB->delete('session', ['ID' => '999998']);
+        $this->DB->delete('candidate', ['CandID' => 900001]);
     }
 }
 

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -58,6 +58,6 @@ if (!Edit_User::canRejectAccount($rejectee)) {
     );
 }
 
-(\Database::singleton())->delete('users', array("UserID" => $username));
+(\Database::singleton())->delete('users', ["UserID" => $username]);
 header("HTTP/1.1 204 No Content");
 

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -79,7 +79,7 @@ class Edit_User extends \NDB_Form
      */
     function _getDefaults()
     {
-        $defaults = array();
+        $defaults = [];
 
         if (!$this->isCreatingNewUser()) {
             $user = \User::factory($this->identifier);
@@ -97,7 +97,7 @@ class Edit_User extends \NDB_Form
             }
 
             // An array of each field that requires front-end sanitization
-            $fieldsThatAreStrings = array(
+            $fieldsThatAreStrings = [
                 'UserID',
                 'First_name',
                 'Last_name',
@@ -111,7 +111,7 @@ class Edit_User extends \NDB_Form
                 'Zip_code',
                 'Country',
                 'Fax',
-            );
+            ];
             // Prevent Javascript injection on all fields
             foreach ($fieldsThatAreStrings as $fieldName) {
                 // this check prevents PHP Notices
@@ -184,8 +184,8 @@ class Edit_User extends \NDB_Form
         $config = \NDB_Config::singleton();
         $DB     = \Database::singleton();
         //The arrays that contain the edited permissions
-        $permissionsRemoved = array();
-        $permissionsAdded   = array();
+        $permissionsRemoved = [];
+        $permissionsAdded   = [];
         $editor = \User::singleton();
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
@@ -209,9 +209,9 @@ class Edit_User extends \NDB_Form
         // 2) Certain old permissions that the editor is not permitted to alter
         // In addition, old permissions should be removed if the editor has
         // removed them and the editor has permissions to remove them.
-        $newPermissions    = array_keys($values['permID']) ?? array();
-        $editorPermissions = $editor->getPermissionIDs() ?? array();
-        $permIDs           = array();
+        $newPermissions    = array_keys($values['permID']) ?? [];
+        $editorPermissions = $editor->getPermissionIDs() ?? [];
+        $permIDs           = [];
         // store the permission IDs
         if (!empty($values['permID'])) {
             // An editor can only grant permissions that they have already been
@@ -265,14 +265,14 @@ class Edit_User extends \NDB_Form
         $uid           = $user->getData('ID');
         $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
-            $DB->delete('user_psc_rel', array("UserID" => $uid));
+            $DB->delete('user_psc_rel', ["UserID" => $uid]);
             foreach ($us_curr_sites as $site) {
                 $DB->insert(
                     'user_psc_rel',
-                    array(
+                    [
                         "UserID"   => $uid,
                         "CenterID" => $site,
-                    )
+                    ]
                 );
             }
         }
@@ -282,14 +282,14 @@ class Edit_User extends \NDB_Form
         // START PROJECT UPDATE
         $us_curr_projects = $values['ProjectIDs'];
         if (!$this->isCreatingNewUser()) {
-            $DB->delete('user_project_rel', array("UserID" => $uid));
+            $DB->delete('user_project_rel', ["UserID" => $uid]);
             foreach ($us_curr_projects as $project) {
                 $DB->insert(
                     'user_project_rel',
-                    array(
+                    [
                         "UserID"    => $uid,
                         "ProjectID" => $project,
-                    )
+                    ]
                 );
             }
         }
@@ -299,8 +299,8 @@ class Edit_User extends \NDB_Form
         // EXAMINER UPDATE
         if ($editor->hasPermission('examiner_multisite')) {
             // get all fields that are related to examiners
-            $ex_curr_sites  = array();
-            $ex_prev_sites  = array();
+            $ex_curr_sites  = [];
+            $ex_prev_sites  = [];
             $ex_radiologist = 'N';
             $ex_pending     = 'Y';
 
@@ -324,9 +324,9 @@ class Edit_User extends \NDB_Form
                 "SELECT e.examinerID
              FROM examiners e
              WHERE e.full_name=:fn",
-                array(
+                [
                     "fn" => $values['Real_name'],
-                )
+                ]
             );
 
             // START EXAMINER UPDATE
@@ -340,17 +340,17 @@ class Edit_User extends \NDB_Form
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
                 $DB->insert(
                     'examiners',
-                    array(
+                    [
                         'full_name'   => $values['Real_name'],
                         'radiologist' => $ex_radiologist,
                         'userID'      => $uid,
-                    )
+                    ]
                 );
                 $examinerID = $DB->pselectOne(
                     "SELECT examinerID
                             FROM examiners
                             WHERE full_name=:fullName",
-                    array('fullName' => $values['Real_name'])
+                    ['fullName' => $values['Real_name']]
                 );
             } elseif (!empty($examinerID)
                 && ((!empty($ex_radiologist)
@@ -364,13 +364,13 @@ class Edit_User extends \NDB_Form
                 $ex_radiologist = $ex_radiologist === 'Y' ? 1 : 0;
                 $DB->update(
                     'examiners',
-                    array(
+                    [
                         'radiologist' => $ex_radiologist,
                         'userID'      => $uid,
-                    ),
-                    array(
+                    ],
+                    [
                         "full_name" => $values['Real_name'],
-                    )
+                    ]
                 );
                 $examinerID = $examinerID[0]['examinerID'];
 
@@ -379,7 +379,7 @@ class Edit_User extends \NDB_Form
                     "SELECT centerID
                             FROM examiners_psc_rel epr
                             WHERE examinerID=:eid",
-                    array("eid" => $examinerID)
+                    ["eid" => $examinerID]
                 );
 
                 //get sites where user is already an examiner at for compare
@@ -394,34 +394,34 @@ class Edit_User extends \NDB_Form
                     "SELECT epr.centerID
                            FROM examiners_psc_rel epr 
                            WHERE epr.examinerID=:eid AND epr.centerID=:cid",
-                    array(
+                    [
                         "eid" => $examinerID,
                         "cid" => $v,
-                    )
+                    ]
                 );
 
                 // examiner was not previously added, add and set to active
                 if (empty($result)) {
                     $DB->insert(
                         'examiners_psc_rel',
-                        array(
+                        [
                             'examinerID'       => $examinerID,
                             'centerID'         => $v,
                             'active'           => 'Y',
                             'pending_approval' => $ex_pending,
-                        )
+                        ]
                     );
                 } else {
                     $DB->update(
                         'examiners_psc_rel',
-                        array(
+                        [
                             'active'           => 'Y',
                             'pending_approval' => $ex_pending,
-                        ),
-                        array(
+                        ],
+                        [
                             'examinerID' => $examinerID,
                             'centerID'   => $v,
-                        )
+                        ]
                     );
                 }
                 unset($values[$k]);
@@ -432,11 +432,11 @@ class Edit_User extends \NDB_Form
             foreach ($ex_inactive as $cid) {
                 $DB->update(
                     'examiners_psc_rel',
-                    array("active" => 'N'),
-                    array(
+                    ["active" => 'N'],
+                    [
                         'examinerID' => $examinerID,
                         'centerID'   => $cid,
-                    )
+                    ]
                 );
             }
         }
@@ -445,7 +445,7 @@ class Edit_User extends \NDB_Form
         //END EXAMINER UPDATE
 
         // make the set
-        $set = array();
+        $set = [];
         foreach ($values as $key => $value) {
             // Password updates are handled separately
             if (!empty($value) && $key != 'Password_hash') {
@@ -463,19 +463,19 @@ class Edit_User extends \NDB_Form
             foreach ($us_curr_sites as $site) {
                 $DB->insert(
                     'user_psc_rel',
-                    array(
+                    [
                         "UserID"   => $uid,
                         "CenterID" => $site,
-                    )
+                    ]
                 );
             }
             foreach ($us_curr_projects as $project) {
                 $DB->insert(
                     'user_project_rel',
-                    array(
+                    [
                         "UserID"    => $uid,
                         "ProjectID" => $project,
-                    )
+                    ]
                 );
             }
         } else {
@@ -541,7 +541,7 @@ class Edit_User extends \NDB_Form
                 foreach ($supervisorEmails as $email => $checkValue) {
                     if (!empty($permissionsAdded) || !empty($permissionsRemoved)) {
                         if ($checkValue == 'on') {
-                            $msg_data = array();
+                            $msg_data = [];
                             $msg_data['current_user'] = $editor->getFullname();
                             $msg_data['study']        = $config->getSetting('title');
                             $msg_data['realname']     = $values['Real_name'];
@@ -571,7 +571,7 @@ class Edit_User extends \NDB_Form
             $config = $factory->config();
 
             // send the user an email
-            $msg_data          = array();
+            $msg_data          = [];
             $msg_data['study'] = $config->getSetting('title');
             $msg_data['url']   = $baseURL;
             $msg_data['realname'] = $values['Real_name'];
@@ -633,7 +633,7 @@ class Edit_User extends \NDB_Form
         //------------------------------------------------------------
 
         // it is a new user
-        $group = array();
+        $group = [];
         if ($this->identifier == '') {
             // user name
             $group[] = $this->createText('UserID', 'User name');
@@ -657,7 +657,7 @@ class Edit_User extends \NDB_Form
         }
 
         // password
-        $group   = array();
+        $group   = [];
         $group[] = $this->createPassword('Password_hash');
         $group[] = $this->createCheckbox('NA_Password', 'Generate new password');
         $this->addGroup(
@@ -680,12 +680,12 @@ class Edit_User extends \NDB_Form
         $this->addBasicText(
             'First_name',
             'First name',
-            array(
+            [
                 'oninvalid' => $onInvalidMsg,
                 'onchange'  => "this.setCustomValidity('')",
                 'pattern'   => '^\s*\S.{0,119}\s*$',
                 'required'  => true,
-            )
+            ]
         );
         // The supplied pattern is:
         //   - must have at least one non-whitespace characters
@@ -697,12 +697,12 @@ class Edit_User extends \NDB_Form
         $this->addBasicText(
             'Last_name',
             'Last name',
-            array(
+            [
                 'oninvalid' => $onInvalidMsg,
                 'onchange'  => "this.setCustomValidity('')",
                 'pattern'   => '^\s*\S.{0,119}\s*$',
                 'required'  => true,
-            )
+            ]
         );
 
         // extra info
@@ -723,7 +723,7 @@ class Edit_User extends \NDB_Form
         }
 
         // email address
-        $group   = array();
+        $group   = [];
         $group[] = $this->createText('Email', 'Email address');
         $group[] = $this->createCheckbox('SendEmail', 'Send email to user');
         $this->addGroup(
@@ -745,8 +745,8 @@ class Edit_User extends \NDB_Form
 
         // get user permissions
         $editor      = \User::singleton();
-        $siteOptions = array();
-        $site        = array();
+        $siteOptions = [];
+        $site        = [];
 
         // center ID
         if ($editor->hasPermission('user_accounts_multisite')) {
@@ -765,13 +765,13 @@ class Edit_User extends \NDB_Form
             'CenterIDs',
             'Sites',
             $siteOptions,
-            array('multiple' => 'multiple')
+            ['multiple' => 'multiple']
         );
 
         // START PROJECT SECTION
         $editorProjects = $editor->getData('ProjectIDs');
         $projects       = \Utility::getProjectList();
-        $projectOptions = array();
+        $projectOptions = [];
         foreach ($editorProjects as $key => $projectID) {
             $projectOptions[$projectID] = $projects[$projectID];
         }
@@ -780,23 +780,23 @@ class Edit_User extends \NDB_Form
             'ProjectIDs',
             'Projects',
             $projectOptions,
-            array('multiple' => 'multiple')
+            ['multiple' => 'multiple']
         );
         // END PROJECT SECTION
 
         if ($editor->hasPermission('examiner_multisite')) {
-            $groupA = array();
-            $groupB = array();
+            $groupA = [];
+            $groupB = [];
 
             //get site aliases
             $DB      = \Database::singleton();
-            $aliases = $DB->pselect("SELECT CenterID, Alias FROM psc ", array());
+            $aliases = $DB->pselect("SELECT CenterID, Alias FROM psc ", []);
 
             foreach ($aliases as $row) {
                 $groupA[] = $this->createCheckbox(
                     'ex_'.$row['CenterID'],
                     $row['Alias'],
-                    array()
+                    []
                 );
             }
             $groupB[] = $this->createLabel(
@@ -805,11 +805,11 @@ class Edit_User extends \NDB_Form
             $groupB[] = $this->createSelect(
                 "examiner_radiologist",
                 "Radiologist: ",
-                array(
+                [
                     null => "",
                     'Y'  => 'Yes',
                     'N'  => 'No',
-                )
+                ]
             );
 
             $groupB[] = $this->createLabel(
@@ -818,11 +818,11 @@ class Edit_User extends \NDB_Form
             $groupB[] = $this->createSelect(
                 "examiner_pending",
                 "Pending Approval: ",
-                array(
+                [
                     null => "",
                     'Y'  => 'Yes',
                     'N'  => 'No',
-                )
+                ]
             );
             $this->addGroup(
                 $groupA,
@@ -849,26 +849,26 @@ class Edit_User extends \NDB_Form
             $this->addSelect(
                 'Pending_approval',
                 'Pending approval',
-                array(
+                [
                     'Y' => 'Yes',
                     'N' => 'No',
-                )
+                ]
             );
 
             $this->addSelect(
                 'Active',
                 'Active',
-                array(
+                [
                     'Y' => 'Yes',
                     'N' => 'No'
-                )
+                ]
             );
 
-            $dateOptions = array(
+            $dateOptions = [
                 'language'       => 'en',
                 'format'         => 'YMd',
                 'addEmptyOption' => 'true',
-            );
+            ];
 
             $dateAttributes = ['class' => 'form-control input-sm input-date'];
 
@@ -901,7 +901,7 @@ class Edit_User extends \NDB_Form
 
         $perms    = $editor->getPermissionsVerbose();
         $lastRole = '';
-        $group    = array();
+        $group    = [];
         foreach ($perms as $row) {
             if ($row['type'] != $lastRole) {
                 $lastRole = $row['type'];
@@ -922,7 +922,7 @@ class Edit_User extends \NDB_Form
             // If the user is editing his/her own account, disable all permission
             // checkboxes. Note that they will not be submitted when the form is
             // saved
-            $attribs = array("class" => "perm_$lastRole");
+            $attribs = ["class" => "perm_$lastRole"];
             if ($this->_isEditingOwnAccount()) {
                 $attribs['disabled'] = true;
             }
@@ -943,9 +943,9 @@ class Edit_User extends \NDB_Form
                   JOIN users u ON (u.ID = up.userID)
                   WHERE p.code = 'send_to_dcc'";
 
-        $results = \Database::singleton()->pselect($query, array());
+        $results = \Database::singleton()->pselect($query, []);
 
-        $group   = array();
+        $group   = [];
         $group[] = $this->form->createElement(
             'static',
             null,
@@ -957,7 +957,7 @@ class Edit_User extends \NDB_Form
             . "<div id=\"perms_supervisors\" style=\"margin-top: 5px;\">"
         );
 
-        $attribs = $this->_isEditingOwnAccount() ? array('disabled' => true) : null;
+        $attribs = $this->_isEditingOwnAccount() ? ['disabled' => true] : null;
         foreach ($results as $row) {
             $group[] = $this->createCheckbox(
                 'supervisorEmail[' . $row['email'] .']',
@@ -986,7 +986,7 @@ class Edit_User extends \NDB_Form
         //------------------------------------------------------------
 
         // unique key and password rules
-        $this->form->addFormRule(array(&$this, '_validateEditUser'));
+        $this->form->addFormRule([&$this, '_validateEditUser']);
     }
 
     /**
@@ -1016,7 +1016,7 @@ class Edit_User extends \NDB_Form
         $editor = \User::singleton();
         // create DB object
         $DB     = \Database::singleton();
-        $errors = array();
+        $errors = [];
 
         // NOTE The 'Password_hash' key actually represents a plaintext password
         $plaintext = $values['Password_hash'];
@@ -1049,7 +1049,7 @@ class Edit_User extends \NDB_Form
                 // check username's uniqueness
                 $result = $DB->pselectOne(
                     "SELECT COUNT(*) FROM users WHERE UserID = :UID",
-                    array('UID' => $effectiveUID)
+                    ['UID' => $effectiveUID]
                 );
 
                 if ($result > 0) {
@@ -1094,7 +1094,7 @@ class Edit_User extends \NDB_Form
             $pass = $DB->pselectOne(
                 "SELECT COALESCE(Password_hash) "
                 . "as Current_password FROM users WHERE UserID = :UID",
-                array('UID' => $this->identifier)
+                ['UID' => $this->identifier]
             );
 
             //case of new user the password column will be null
@@ -1266,7 +1266,7 @@ class Edit_User extends \NDB_Form
 
         // check email address' uniqueness
         $query  = "SELECT COUNT(*) FROM users WHERE Email = :VEmail ";
-        $params = array('VEmail' => $email);
+        $params = ['VEmail' => $email];
         if (!is_null($this->identifier)) {
             $query        .= " AND userID <> :UID";
             $params['UID'] = $this->identifier;
@@ -1295,7 +1295,7 @@ class Edit_User extends \NDB_Form
 
         $description = $db->pselectOne(
             "SELECT Description FROM permissions WHERE permID =:pID",
-            array('pID' => $permID)
+            ['pID' => $permID]
         );
 
         return $description;
@@ -1313,7 +1313,7 @@ class Edit_User extends \NDB_Form
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/user_accounts/js/rejectUser.js")
+            [$baseURL . "/user_accounts/js/rejectUser.js"]
         );
     }
 }

--- a/modules/user_accounts/php/my_preferences.class.inc
+++ b/modules/user_accounts/php/my_preferences.class.inc
@@ -34,7 +34,7 @@ class My_Preferences extends \NDB_Form
      */
     function _getDefaults()
     {
-        $defaults = array();
+        $defaults = [];
 
         $user = \User::factory($this->identifier);
         // get the user defaults
@@ -43,7 +43,7 @@ class My_Preferences extends \NDB_Form
         unset($defaults['Password_hash']);
 
         // An array of each field that requires front-end sanitization
-        $fieldsThatAreStrings = array(
+        $fieldsThatAreStrings = [
             'UserID',
             'First_name',
             'Last_name',
@@ -57,7 +57,7 @@ class My_Preferences extends \NDB_Form
             'Zip_code',
             'Country',
             'Fax',
-        );
+        ];
         // Prevent Javascript injection on all fields
         foreach ($fieldsThatAreStrings as $fieldName) {
             // this check prevents PHP Notices
@@ -154,22 +154,22 @@ class My_Preferences extends \NDB_Form
                         if ($subscribed === 'N') {
                             $DB->insert(
                                 'users_notifications_rel',
-                                array(
+                                [
                                     "module_id"  => $module_id,
                                     "service_id" => $service_id,
                                     "user_id"    => $user->getData("ID"),
-                                )
+                                ]
                             );
                         }
                     } else {
                         if ($subscribed === 'Y') {
                             $DB->delete(
                                 'users_notifications_rel',
-                                array(
+                                [
                                     "module_id"  => $module_id,
                                     "service_id" => $service_id,
                                     "user_id"    => $user->getData("ID"),
-                                )
+                                ]
                             );
                         }
                     }
@@ -178,7 +178,7 @@ class My_Preferences extends \NDB_Form
             }
         }
         // END NOTIFICATIONS UPDATE
-        $set = array();
+        $set = [];
         foreach ($values as $key => $value) {
             // Password updates are handled separately. Password_hash is removed
             // from the initial update as otherwise it will be recorded in the
@@ -208,7 +208,7 @@ class My_Preferences extends \NDB_Form
         $config  = $factory->config();
 
         // send the user an email
-        $msg_data          = array();
+        $msg_data          = [];
         $msg_data['study'] = $config->getSetting('title');
         $msg_data['url']   = $factory->settings()->getBaseURL();
         $msg_data['realname'] = $values['Real_name'];
@@ -255,12 +255,12 @@ class My_Preferences extends \NDB_Form
         $this->addBasicText(
             'First_name',
             'First name',
-            array(
+            [
                 'oninvalid' => "this.setCustomValidity('$firstNameInvalidMsg')",
                 'onchange'  => "this.setCustomValidity('')",
                 'pattern'   => '^\s*\S.{0,119}\s*$',
                 'required'  => true,
-            )
+            ]
         );
         // The supplied pattern is:
         //   - must have at least one non-whitespace characters (i.e. required)
@@ -271,22 +271,22 @@ class My_Preferences extends \NDB_Form
         $this->addBasicText(
             'Last_name',
             'Last name',
-            array(
+            [
                 'oninvalid' => "this.setCustomValidity('$lastNameInvalidMsg')",
                 'onchange'  => "this.setCustomValidity('')",
                 'pattern'   => '^\s*\S.{0,119}\s*$',
                 'required'  => true,
-            )
+            ]
         );
 
         // email address
         $this->addBasicText(
             'Email',
             'Email address',
-            array(
+            [
                 'oninvalid' => "this.setCustomValidity('Email address is required')",
                 'onchange'  => "this.setCustomValidity('')",
-            )
+            ]
         );
 
         // email address rules
@@ -307,7 +307,7 @@ class My_Preferences extends \NDB_Form
         $this->addSelect('language_preference', 'Language preference', $languages);
 
         // Notification headers
-        $nGroup   = array();
+        $nGroup   = [];
         $nGroup[] = $this->createLabel("Module");
         $nGroup[] = $this->createLabel("Operation");
         $nGroup[] = $this->createLabel("Description");
@@ -325,10 +325,10 @@ class My_Preferences extends \NDB_Form
         unset($nGroup);
 
         // Notification rows
-        $notification_rows =array();
+        $notification_rows =[];
         foreach ($notifier_list as $module=>$operation_services) {
             foreach ($operation_services as $operation=>$services) {
-                $nGroup   = array();
+                $nGroup   = [];
                 $nGroup[] = $this->createLabel($module);
                 $nGroup[] = $this->createLabel($operation);
                 $nGroup[] = $this->createLabel($services['desc']);
@@ -373,7 +373,7 @@ class My_Preferences extends \NDB_Form
         //------------------------------------------------------------
 
         // unique key and password rules
-        $this->form->addFormRule(array(&$this, '_validateMyPreferences'));
+        $this->form->addFormRule([&$this, '_validateMyPreferences']);
     }
 
 
@@ -388,7 +388,7 @@ class My_Preferences extends \NDB_Form
     {
         // create DB object
         $DB     = \Database::singleton();
-        $errors = array();
+        $errors = [];
 
         // NOTE The 'Password_hash' key actually represents a plaintext password
         $plaintext = $values['Password_hash'];
@@ -454,7 +454,7 @@ class My_Preferences extends \NDB_Form
 
         // check email address' uniqueness
         $query  = "SELECT COUNT(*) FROM users WHERE Email = :VEmail ";
-        $params = array('VEmail' => $email);
+        $params = ['VEmail' => $email];
         if (!is_null($this->identifier)) {
             $query        .= " AND userID <> :UID";
             $params['UID'] = $this->identifier;

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -59,7 +59,7 @@ class User_Accounts extends \NDB_Menu_Filter
         }
 
         // set the class variables
-        $this->columns      = array(
+        $this->columns      = [
             "COALESCE(GROUP_CONCAT(
                                 psc.Name SEPARATOR '; '),'Not Assigned'
                                 ) AS Sites",
@@ -68,11 +68,11 @@ class User_Accounts extends \NDB_Menu_Filter
             'Email',
             'Active',
             'Pending_approval',
-        );
+        ];
         $this->query        = $query;
         $this->order_by     = 'Username';
         $this->group_by     = 'users.ID';
-        $this->validFilters = array(
+        $this->validFilters = [
             'user_psc_rel.CenterID',
             'users.UserID',
             'users.Real_name',
@@ -80,16 +80,16 @@ class User_Accounts extends \NDB_Menu_Filter
             'users.Active',
             'users.Examiner',
             'users.Pending_approval',
-        );
+        ];
 
-        $this->formToFilter = array(
+        $this->formToFilter = [
             'centerID'  => 'user_psc_rel.CenterID',
             'active'    => 'users.Active',
             'userID'    => 'users.UserID',
             'real_name' => 'users.Real_name',
             'email'     => 'users.Email',
             'pending'   => 'users.Pending_approval',
-        );
+        ];
     }
 
     /**
@@ -109,15 +109,15 @@ class User_Accounts extends \NDB_Menu_Filter
         // PSC
         if ($user->hasPermission('user_accounts_multisite')) {
             // get the list of study sites - to be replaced by the Site object
-            $list_of_sites = array();
+            $list_of_sites = [];
             $site_arr      = \Utility::getSiteList(false);
             foreach ($site_arr as $key=>$val) {
                 $list_of_sites[$val] = $val;
             }
         } else {
             // allow only to view own site data
-            $list_of_sites = array();
-            $site          = array();
+            $list_of_sites = [];
+            $site          = [];
             $site_arr      = $user->getData('CenterIDs');
             foreach ($site_arr as $key=>$val) {
                 $site[$key] = \Site::singleton($val);
@@ -125,16 +125,16 @@ class User_Accounts extends \NDB_Menu_Filter
                     = $site[$key]->getCenterName();
             }
         }
-        $yesNoOptions = array(
+        $yesNoOptions = [
             'Y' => 'Yes',
             'N' => 'No',
-        );
+        ];
 
-        $this->fieldOptions = array(
+        $this->fieldOptions = [
             'sites'            => $list_of_sites,
             'actives'          => $yesNoOptions,
             'pendingApprovals' => $yesNoOptions,
-        );
+        ];
     }
     /**
      * Gathers JS dependecies and merge them with the parent
@@ -148,7 +148,7 @@ class User_Accounts extends \NDB_Menu_Filter
         $deps    = parent::getJSDependencies();
         return array_merge(
             $deps,
-            array($baseURL . "/user_accounts/js/userAccountsIndex.js")
+            [$baseURL . "/user_accounts/js/userAccountsIndex.js"]
         );
     }
 }

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -65,7 +65,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $password = new \Password($this->validPassword);
         $this->DB->insert(
             "users",
-            array(
+            [
                 'ID'               => 999995,
                 'UserID'           => 'UnitTesterTwo',
                 'Real_name'        => 'Unit Tester 2',
@@ -78,23 +78,23 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                 'Password_hash'    => $password,
                 'Password_expiry'  => '2099-12-31',
                 'Pending_approval' => 'N',
-            )
+            ]
         );
 
         $this->DB->insert(
             "user_psc_rel",
-            array(
+            [
                 'UserID'   => 999995,
                 'CenterID' => 1,
-            )
+            ]
         );
 
         $this->DB->insert(
             "user_project_rel",
-            array(
+            [
                 'UserID'    => 999995,
                 'ProjectID' => 1,
-            )
+            ]
         );
     }
 
@@ -615,10 +615,10 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      */
     function tearDown()
     {
-        $this->DB->delete("users", array("UserID" => 'userid'));
-        $this->DB->delete("user_psc_rel", array("UserID" => 999995));
-        $this->DB->delete("user_project_rel", array("UserID" => 999995));
-        $this->DB->delete("users", array("UserID" => 'UnitTesterTwo'));
+        $this->DB->delete("users", ["UserID" => 'userid']);
+        $this->DB->delete("user_psc_rel", ["UserID" => 999995]);
+        $this->DB->delete("user_project_rel", ["UserID" => 999995]);
+        $this->DB->delete("users", ["UserID" => 'UnitTesterTwo']);
         parent::tearDown();
     }
 }

--- a/php/exceptions/DatabaseException.class.inc
+++ b/php/exceptions/DatabaseException.class.inc
@@ -36,7 +36,7 @@ class DatabaseException extends LorisException
      * @param array  $bindparams The prepared statement bindings used to try
      *                           and execute this statement
      */
-    function __construct($msg, $query = '', $bindparams = array())
+    function __construct($msg, $query = '', $bindparams = [])
     {
         parent::__construct($msg);
         $this->query  = $query;

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -94,7 +94,7 @@ class Database
     public function databaseExists($database)
     {
         $stmt = $this->PDO->prepare("SHOW DATABASES LIKE :v_db");
-        $stmt->execute(array('v_db' => $database ));
+        $stmt->execute(['v_db' => $database ]);
         $exists = !empty($stmt->fetchAll());
 
         return $exists;

--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -32,6 +32,6 @@ class AnonymousUser extends \User
      */
     public function getSiteNames() : array
     {
-        return array();
+        return [];
     }
 }

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -100,7 +100,7 @@ class BVL_Feedback_Panel
         $this->tpl_data['thread_summary_headers'] = json_encode($summary);
 
         $field_names = Utility::getSourcefields($_REQUEST['test_name'] ?? '');
-        $fields      = array();
+        $fields      = [];
         $fields['Across All Fields'] = 'Across All Fields';
         foreach ($field_names as $field_name) {
             $fields[$field_name['SourceField']] = $field_name['SourceField'];

--- a/php/libraries/Breadcrumb.class.inc
+++ b/php/libraries/Breadcrumb.class.inc
@@ -63,10 +63,10 @@ class Breadcrumb
     public function __toString() : string
     {
         return json_encode(
-            array(
+            [
                 'text'  => $this->label,
                 'query' => $this->link,
-            ),
+            ],
             JSON_FORCE_OBJECT
         );
     }

--- a/php/libraries/BreadcrumbTrail.class.inc
+++ b/php/libraries/BreadcrumbTrail.class.inc
@@ -40,7 +40,7 @@ class BreadcrumbTrail
      */
     public function __construct(Breadcrumb ...$crumbs)
     {
-        $this->breadcrumbs = $crumbs ?? array();
+        $this->breadcrumbs = $crumbs ?? [];
     }
 
     /**

--- a/php/libraries/CandIDGenerator.php
+++ b/php/libraries/CandIDGenerator.php
@@ -66,7 +66,7 @@ class CandIDGenerator extends IdentifierGenerator
             $validID = \Database::singleton()
                 ->pselectOne(
                     "SELECT count(CandID) FROM candidate WHERE CandID=:id",
-                    array('id' => (string) $id)
+                    ['id' => (string) $id]
                 ) == 0;
         } while (! $validID);
 
@@ -84,7 +84,7 @@ class CandIDGenerator extends IdentifierGenerator
         // immediately.
         return \Database::singleton()->pselectCol(
             'SELECT CandID from candidate',
-            array()
+            []
         );
     }
 }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -69,7 +69,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         $factory = NDB_Factory::singleton();
         $config  = $factory->config();
 
-        $CandArray = array('Candidate' => (string) $candID);
+        $CandArray = ['Candidate' => (string) $candID];
 
         // make a local reference to the Database object
         $db = $factory->database();
@@ -102,10 +102,10 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
 
         $headerSetting = $config->getSetting('HeaderTable');
         if (!empty($headerSetting)) {
-            $params = array();
+            $params = [];
             $parameterCandSettings = $headerSetting['parameter_candidate'];
             if (!is_array($parameterCandSettings)) {
-                $parameterCandSettings = array($parameterCandSettings);
+                $parameterCandSettings = [$parameterCandSettings];
             }
             foreach ($parameterCandSettings as $parameter_type) {
                 $row = $db->pselectRow(
@@ -115,10 +115,10 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
                     LEFT JOIN parameter_type pt ON
                     (pc.ParameterTypeID=pt.ParameterTypeID)
                     WHERE c.CandID=:Candidate AND pt.Name=:PTName",
-                    array(
+                    [
                         'Candidate' => $candID,
                         'PTName'    => $parameter_type,
-                    )
+                    ]
                 );
                 // Sanitize values coming from the parameter_candidate table
                 // before injecting them into the HTML table.
@@ -250,7 +250,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         }
 
         // Insert the new candidate into the database if everything is fine.
-        $setArray = array(
+        $setArray = [
             'RegistrationCenterID'  => $centerID,
             'PSCID'                 => $PSCID,
             'DoB'                   => $dateOfBirth,
@@ -262,7 +262,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             'Entity_type'           => 'Human',
             'RegisteredBy'          => $user->getUsername(),
             'UserID'                => $user->getUsername(),
-        );
+        ];
 
         if ($config->getSetting('useExternalID') === 'true') {
             $externalID = (new \ExternalIDGenerator(
@@ -313,10 +313,10 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         $factory = NDB_Factory::singleton();
         $db      = $factory->database();
 
-        $candidateIDs = array(
+        $candidateIDs = [
             ':candidate_id' => $candID,
             ':pscid'        => $PSCID,
-        );
+        ];
 
         // get candidate data from database
         $query = "SELECT CandID
@@ -401,9 +401,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         \NDB_Factory::singleton()->database()->update(
             'candidate',
             $newData,
-            array(
+            [
                 'CandID' => $this->getData('CandID'),
-            )
+            ]
         );
         return true;
     }
@@ -556,7 +556,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
     {
         $factory = NDB_Factory::singleton();
         //make sure it returns an array
-        $visitLabelArray = array();
+        $visitLabelArray = [];
 
         $candID = $this->getCandID();
 
@@ -566,7 +566,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
 
         $query  = "SELECT ID, Visit_label FROM session
             WHERE CandID=:Candidate AND Active='Y' ORDER BY ID";
-        $result = $db->pselect($query, array('Candidate' => $candID));
+        $result = $db->pselect($query, ['Candidate' => $candID]);
 
         // map the array [VisitNo]=>Visit_label
         foreach ($result as $row) {
@@ -585,13 +585,13 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
      */
     public function getValidSubprojects(): array
     {
-        $subprojList = array();
+        $subprojList = [];
 
         $projID  = $this->getProjectID();
         $query   = "SELECT SubprojectID 
                     FROM project_subproject_rel 
                     WHERE ProjectID = :prj";
-        $params  = array('prj' => $projID);
+        $params  = ['prj' => $projID];
         $subproj = \NDB_Factory::singleton()
             ->database()
             ->pselect($query, $params);
@@ -621,7 +621,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
           LEFT JOIN candidate USING (CandID)
           WHERE CandID = :cid AND VisitNo = 1
           AND Entity_type <> 'Scanner'";
-        $where  = array('cid' => $candID);
+        $where  = ['cid' => $candID];
         try {
             $result = $db->pselectOne($query, $where);
         } catch (DomainException $ex) {
@@ -648,7 +648,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
                     FROM candidate AS c
                         LEFT JOIN session AS s USING (CandID)
                     WHERE c.CandID=:CaID AND s.Active='Y' AND c.Active='Y'";
-        $result = $db->pselectOne($query, array('CaID' => $this->getCandID()));
+        $result = $db->pselectOne($query, ['CaID' => $this->getCandID()]);
 
         if ($result === null) {
             return 1;
@@ -672,7 +672,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         $query = "SELECT ConsentID, Name, Status, DateGiven, DateWithdrawn
             FROM candidate_consent_rel cc JOIN consent c USING (ConsentID)
             WHERE CandidateID=:cid";
-        $where = array('cid' => $candID);
+        $where = ['cid' => $candID];
         $key   = "ConsentID";
 
         $consentList = $db->pselectWithIndexKey($query, $where, $key);
@@ -727,9 +727,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             "SELECT ID,Description
             FROM participant_status_options
             WHERE parentID IS NULL",
-            array()
+            []
         );
-        $option_array = array();
+        $option_array = [];
         foreach ($options as $option) {
             $option_array[$option['ID']] = $option['Description'];
         }
@@ -751,9 +751,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             "SELECT ID,Description 
             FROM participant_status_options 
             WHERE parentID=:pid",
-            array('pid' => $parentID)
+            ['pid' => $parentID]
         );
-        $option_array = array();
+        $option_array = [];
         foreach ($options as $option) {
             $option_array[$option['ID']] = $option['Description'];
         }

--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -39,7 +39,7 @@ class ConflictDetector
         string $commentId1,
         string $commentId2
     ): array {
-        $diffResult = array();
+        $diffResult = [];
 
         // Get data entry status for $commentId1
         $status = new NDB_BVL_InstrumentStatus();
@@ -103,7 +103,7 @@ class ConflictDetector
      */
     function clearConflictsForField(array $diffLine): void
     {
-        $deleteWhere = array(
+        $deleteWhere = [
             'TableName'      => $diffLine['TableName'],
             'ExtraKeyColumn' => $diffLine['ExtraKeyColumn'],
             'ExtraKey1'      => $diffLine['ExtraKey1'],
@@ -111,7 +111,7 @@ class ConflictDetector
             'FieldName'      => $diffLine['FieldName'],
             'CommentId1'     => $diffLine['CommentId1'],
             'CommentId2'     => $diffLine['CommentId2'],
-        );
+        ];
 
         \Database::singleton()->delete('conflicts_unresolved', $deleteWhere);
     }
@@ -128,7 +128,7 @@ class ConflictDetector
     {
         \Database::singleton()->delete(
             'conflicts_unresolved',
-            array('CommentId1' => $commentId)
+            ['CommentId1' => $commentId]
         );
     }
 
@@ -143,7 +143,7 @@ class ConflictDetector
     {
         $conflictCount = \Database::singleton()->pselectOne(
             "SELECT COUNT(*) FROM conflicts_unresolved WHERE CommentId1=:CID",
-            array('CID' => $commentId)
+            ['CID' => $commentId]
         );
         return ($conflictCount != 0);
     }

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -159,7 +159,7 @@ class CouchDB
     /**
      * This array keep a reference for each instance of this class.
      */
-    private static $_instances = array();
+    private static $_instances = [];
 
     /**
      * Keep the database name
@@ -195,7 +195,7 @@ class CouchDB
      * Array of documents to be commited when the current bulk transaction
      * ends.
      */
-    public $bulkDocuments = array();
+    public $bulkDocuments = [];
 
     /**
      * An instance of SocketWrapper used in network interaction with a CouchDB
@@ -346,7 +346,7 @@ class CouchDB
     function _getURL(
         string $url,
         string $op = 'GET',
-        array $headers = array()
+        array $headers = []
     ): string {
         $handler = $this->SocketHandler;
         $handler->setHost($this->_host);
@@ -441,7 +441,7 @@ class CouchDB
     function _postURL(
         string $url,
         string $data,
-        array  $headers = array(),
+        array  $headers = [],
         bool   $printValue = false
     ): ?string {
         $handler = $this->SocketHandler;
@@ -513,7 +513,7 @@ class CouchDB
         return $this->_postURL(
             $this->_constructURL($op, $url),
             $data,
-            array(),
+            [],
             $printValue
         );
     }
@@ -526,7 +526,7 @@ class CouchDB
      *
      * @return array An associative array representing the document
      */
-    function getDoc(string $id, array $options = array()): array
+    function getDoc(string $id, array $options = []): array
     {
         $json = $this->_getRelativeURL($id);
 
@@ -548,7 +548,7 @@ class CouchDB
         }
 
         if (isset($data['error']) && $data['error'] === 'not_found') {
-            return array();
+            return [];
         }
 
         return $data;
@@ -658,7 +658,7 @@ class CouchDB
     function replaceDoc(string $id, array $doc): string
     {
         $original_doc = $this->getDoc($id);
-        if ($original_doc === array() ) {
+        if ($original_doc === [] ) {
             $this->putDoc($id, $doc);
             return "new";
         }
@@ -710,7 +710,7 @@ class CouchDB
 
             $query = $this->_postRelativeURL(
                 $url,
-                json_encode(array('keys' => $keys)),
+                json_encode(['keys' => $keys]),
                 'POST',
                 $full_json
             );
@@ -722,7 +722,7 @@ class CouchDB
         }
 
         if ($full_json) {
-            return $query ?? array();
+            return $query ?? [];
         }
         $data = json_decode($query ?? '', true);
         if (is_null($data)) {
@@ -732,7 +732,7 @@ class CouchDB
         }
 
         if (isset($data['error']) && $data['error'] == 'not_found') {
-            return array();
+            return [];
         }
         return $data['rows'];
     }
@@ -765,10 +765,10 @@ class CouchDB
         if ($this->bulk !== true) {
             return '';
         }
-        $docs = json_encode(array('docs' => $this->bulkDocuments));
+        $docs = json_encode(['docs' => $this->bulkDocuments]);
 
         $this->bulk          = false;
-        $this->bulkDocuments = array();
+        $this->bulkDocuments = [];
 
         return $this->_postRelativeURL('_bulk_docs', $docs);
     }

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -76,7 +76,7 @@ class Database
         bool   $trackChanges = true
     ): \Database {
 
-        static $connections = array();
+        static $connections = [];
 
         // if no arguments, try to get the first connection or choke
         if (empty($database)
@@ -338,7 +338,7 @@ class Database
      */
     private function _HTMLEscapeArray(array $set): array
     {
-        $retVal = array();
+        $retVal = [];
         foreach ($set as $key => $val) {
             /* FIXME this check is only here because of a quirk of the
              * imaging browser. The module should be refactored and this check
@@ -394,7 +394,7 @@ class Database
         $prepQ  = $query;
         $query .= $this->_implodeWithKeys(', ', $set, 'set_');
 
-        $exec_params = array();
+        $exec_params = [];
         $prepQ      .= $this->_implodeAsPrepared(",", $set, $exec_params);
 
         if ($onDuplicateUpdate) {
@@ -547,7 +547,7 @@ class Database
 
         /* This generates the version of the update statement which is
          * executed. */
-        $exec_params = array();
+        $exec_params = [];
         $prepQ       = "UPDATE $table SET ";
         $prepQ      .= $this->_implodeAsPrepared(",", $set, $exec_params, 'set_');
         $prepQ      .= " WHERE ";
@@ -616,7 +616,7 @@ class Database
 
         // There is no set clause for a delete, so add a fake
         // one.
-        $this->trackChanges($table, array(), $where, 'D');
+        $this->trackChanges($table, [], $where, 'D');
 
         $this->_printQuery($query);
         $result = $this->_PDO->exec($query);
@@ -685,7 +685,7 @@ class Database
     function execute(
         $prepared,
         array $params,
-        array $options = array()
+        array $options = []
     ): array {
 
         $execRun = $prepared->execute($params);
@@ -695,7 +695,7 @@ class Database
         }
 
         if (!empty($options['nofetch']) && $options['nofetch'] == true) {
-            return array();
+            return [];
         }
 
         $rows = $prepared->fetchAll(PDO::FETCH_ASSOC);
@@ -768,7 +768,7 @@ class Database
             return $result;
         }
 
-        $filteredResult = array();
+        $filteredResult = [];
         // re-order the return array
         foreach ($result as $row) {
             // Check first that the row contains the primary key supplied
@@ -839,7 +839,7 @@ class Database
     {
         $unprocessed = $this->pselect($query, $params);
 
-        $result = array();
+        $result = [];
         foreach ($unprocessed as $k=>$row) {
             $colNumber = count($row);
             if ($colNumber !== 1) {
@@ -895,7 +895,7 @@ class Database
             return $result;
         }
 
-        $filteredResult = array();
+        $filteredResult = [];
         // re-order the return array
         foreach ($result as $row) {
             $colNumber = count($row);
@@ -977,7 +977,7 @@ class Database
         array $dataArray,
         string $clause = 'set_'
     ): string {
-        $output = array();
+        $output = [];
         if (!is_array($dataArray) || count($dataArray)==0) {
             return '';
         }
@@ -1023,7 +1023,7 @@ class Database
             return '';
         }
 
-        $output = array();
+        $output = [];
         foreach ($dataArray as $key => $item ) {
             $varname = str_replace("%", "_percent_", $key);
             if (is_null($item)) {
@@ -1079,10 +1079,10 @@ class Database
         }
 
         // get the table description
-        $description = $this->pselect("SHOW INDEX FROM $table", array());
+        $description = $this->pselect("SHOW INDEX FROM $table", []);
 
         // find the primary key columns
-        $primaryKeys = array();
+        $primaryKeys = [];
         if (is_array($description)) {
             foreach ($description AS $column) {
                 if ($column['Key_name']=='PRIMARY') {
@@ -1115,7 +1115,7 @@ class Database
             foreach (array_keys($set) AS $column) {
                 $this->_preparedStoreHistory->bindParam(":histcolumn", $column);
                 // find the primary key values
-                $primaryValues = array();
+                $primaryValues = [];
 
                 $usePDOID = false;
                 foreach ($primaryKeys AS $key) {
@@ -1130,7 +1130,7 @@ class Database
                     if (is_array($this->lastInsertID)) {
                         $primaryValues = $this->lastInsertID;
                     } else {
-                        $primaryValues = array($this->lastInsertID);
+                        $primaryValues = [$this->lastInsertID];
                     }
                 }
 
@@ -1144,20 +1144,20 @@ class Database
             $query = "SELECT * FROM $table WHERE $where";
 
             // select the database data
-            $oldRows = $this->pselect($query, array());
+            $oldRows = $this->pselect($query, []);
 
             // track history for all affected rows
             foreach ($oldRows AS $oldRow) {
                 // compute the difference between the two arrays
                 if ($type == 'D') {
                     $delta = $oldRow;
-                    $set   = array();
+                    $set   = [];
                 } else {
                     $delta = array_diff_assoc($set, $oldRow);
                 }
 
                 // find the primary key values
-                $primaryValues = array();
+                $primaryValues = [];
                 foreach ($primaryKeys AS $key) {
                     $primaryValues[] = $oldRow[$key];
                 }
@@ -1192,7 +1192,7 @@ class Database
      * @return void As a side-effect, prints to the screen if config option is
      *              enabled
      */
-    function _printQuery(string $query, array $params = array()): void
+    function _printQuery(string $query, array $params = []): void
     {
         if (!$this->_showQueries) {
             return;
@@ -1274,10 +1274,10 @@ class Database
 
         $result = $this->pselectOne(
             $query,
-            array(
+            [
                 'tn' => $test_name,
                 'db' => $database['database'],
-            )
+            ]
         );
 
         if (!empty($result)) {
@@ -1305,11 +1305,11 @@ class Database
             AND TABLE_SCHEMA = :db";
         $effected = $this->pselectOne(
             $query,
-            array(
+            [
                 'tn' => $test_name,
                 'cn' => $column,
                 'db' => $database['database'],
-            )
+            ]
         );
         if ($effected) {
             return true;
@@ -1331,7 +1331,7 @@ class Database
         // http://php.net/manual/en/function.mysql-real-escape-string.php
         if (!empty($tableName) && is_string($tableName)) {
             $stringWithEscapedChars = str_replace(
-                array(
+                [
                     '\\',
                     "\0",
                     "\n",
@@ -1340,8 +1340,8 @@ class Database
                     '"',
                     "\x1a",
                     "`",
-                ),
-                array(
+                ],
+                [
                     '\\\\',
                     '\\0',
                     '\\n',
@@ -1350,7 +1350,7 @@ class Database
                     '\\"',
                     '\\Z',
                     "\\`",
-                ),
+                ],
                 $tableName
             );
             $fullyEscapedString     = "`".$stringWithEscapedChars."`";

--- a/php/libraries/DicomTar.class.inc
+++ b/php/libraries/DicomTar.class.inc
@@ -54,7 +54,7 @@ class DicomTar
                       WHERE
                         TarchiveID = :v_tarchiveid
                     ',
-                    array('v_tarchiveid' => $tarchiveid)
+                    ['v_tarchiveid' => $tarchiveid]
                 );
             if (empty($dbrow)) {
                 throw new \NotFound('There is no tarchive with that id');
@@ -90,7 +90,7 @@ class DicomTar
     public function getSeries(): array
     {
         if ($this->_tarchiveid === null) {
-            return array();
+            return [];
         }
 
         $dbrow = \NDB_Factory::singleton()
@@ -112,7 +112,7 @@ class DicomTar
                  WHERE
                    TarchiveID = :v_tarchiveid
                 ',
-                array('v_tarchiveid' => $this->_tarchiveid)
+                ['v_tarchiveid' => $this->_tarchiveid]
             );
 
         return array_map(

--- a/php/libraries/Email.class.inc
+++ b/php/libraries/Email.class.inc
@@ -49,7 +49,7 @@ class Email
     static function send(
         string $to,
         string $template,
-        array $tpl_data = array(),
+        array $tpl_data = [],
         string $reply_to = '',
         string $from = '',
         string $cc = '',

--- a/php/libraries/FeedbackMRI.class.inc
+++ b/php/libraries/FeedbackMRI.class.inc
@@ -144,9 +144,9 @@ class FeedbackMRI
                       FROM feedback_mri_comments
                   WHERE ".$this->_buildWhere();
 
-        $result = $DB->pselect($query, array());
+        $result = $DB->pselect($query, []);
 
-        $comments = array();
+        $comments = [];
         // build the output array
         if (is_array($result)) {
             foreach ($result as $row) {
@@ -184,14 +184,14 @@ class FeedbackMRI
                     FROM feedback_mri_predefined_comments
                   WHERE CommentTypeID=:CTID";
 
-        $result = $DB->pselect($query, array('CTID' => $commentTypeID));
+        $result = $DB->pselect($query, ['CTID' => $commentTypeID]);
 
         // build the output array
-        $comments = array();
+        $comments = [];
         if (is_array($result)) {
             foreach ($result as $row) {
                 $PredefinedID       = $row['PredefinedCommentID'];
-                $preDefinedComments = array();
+                $preDefinedComments = [];
                 $preDefinedComments['Comment'] = stripslashes($row['Comment']);
                 $comments[$PredefinedID]       = $preDefinedComments;
             }
@@ -222,7 +222,7 @@ class FeedbackMRI
         // get the parameter type id
         $query = "SELECT ParameterTypeID FROM parameter_type WHERE Name=:FName";
 
-        $parameterTypeID = $DB->pselectOne($query, array('FName' => $fieldName));
+        $parameterTypeID = $DB->pselectOne($query, ['FName' => $fieldName]);
         if (empty($parameterTypeID)) {
             return false;
         }
@@ -234,10 +234,10 @@ class FeedbackMRI
 
         $value = $DB->pselectOne(
             $query,
-            array(
+            [
                 'PTID' => $parameterTypeID,
                 'FID'  => $this->fileID,
-            )
+            ]
         );
         if (empty($value)) {
             return false;
@@ -268,7 +268,7 @@ class FeedbackMRI
         // get the parameter type id
         $query = "SELECT ParameterTypeID FROM parameter_type WHERE Name=:FName";
 
-        $parameterTypeID = $DB->pselectOne($query, array('FName' => $fieldName));
+        $parameterTypeID = $DB->pselectOne($query, ['FName' => $fieldName]);
         if (empty($parameterTypeID)) {
             return false;
         }
@@ -280,31 +280,31 @@ class FeedbackMRI
 
         $updateNeeded = $DB->pselectOne(
             $query,
-            array(
+            [
                 'PTID' => $parameterTypeID,
                 'FID'  => $this->fileID,
-            )
+            ]
         );
 
         // build the query
         if ($updateNeeded) {
             $DB->update(
                 'parameter_file',
-                array('Value' => $value),
-                array(
+                ['Value' => $value],
+                [
                     'ParameterTypeID' => $parameterTypeID,
                     'FileID'          => $this->fileID,
-                )
+                ]
             );
         } else {
             $DB->insert(
                 'parameter_file',
-                array(
+                [
                     'Value'           => $value,
                     'ParameterTypeID' => $parameterTypeID,
                     'FileID'          => $this->fileID,
                     'InsertTime'      => time(),
-                )
+                ]
             );
         }
 
@@ -329,17 +329,17 @@ class FeedbackMRI
                     FROM feedback_mri_comment_types
                   WHERE CommentType=:CT";
 
-        $result = $DB->pselect($query, array('CT' => $this->objectType));
+        $result = $DB->pselect($query, ['CT' => $this->objectType]);
 
         // build the output array and keep overall section at the end of the array
-        $commentNames = array();
-        $overallName  = array();
-        $overallType  = array();
+        $commentNames = [];
+        $overallName  = [];
+        $overallType  = [];
         if (is_array($result)) {
             foreach ($result as $row) {
                 $CommentName = $row['CommentName'];
                 $CTID        = $row['CommentTypeID'];
-                $statusField = array();
+                $statusField = [];
                 // deal with CommentStatusField
                 if (!empty($row['CommentStatusField'])) {
                     $statusField = unserialize($row['CommentStatusField']);
@@ -349,18 +349,18 @@ class FeedbackMRI
                 // commentNames array we want them only at the end
                 if ($CommentName == "Overall") {
                     $overallType = $CTID;
-                    $overallName = array(
+                    $overallName = [
                         'name'   => stripslashes($CommentName),
                         'field'  => $statusField['field'] ?? 'overall',
                         'values' => $statusField['values'] ?? '',
-                    );
+                    ];
                 } else {
                     // add a row to the output array
-                    $commentNames[$CTID] = array(
+                    $commentNames[$CTID] = [
                         'name'   => stripslashes($CommentName) ?? '',
                         'field'  => $statusField['field'] ?? '',
                         'values' => $statusField['values'] ?? '',
-                    );
+                    ];
                 }
 
                 unset($statusField);
@@ -408,7 +408,7 @@ class FeedbackMRI
         $DB = \Database::singleton();
 
         // object identifier
-        $set = array();
+        $set = [];
         if ($this->objectType == 'volume') {
             // per-volume
             $set['FileID'] = $this->fileID;
@@ -429,7 +429,7 @@ class FeedbackMRI
 
             $commentTypeID = $DB->pselectOne(
                 $subquery,
-                array('PCID' => $predefinedCommentID)
+                ['PCID' => $predefinedCommentID]
             );
 
             if (empty($commentTypeID)) {
@@ -482,10 +482,10 @@ class FeedbackMRI
         // build the where depending on object and subject type
         if ($this->objectType == 'volume') {
             // per-volume
-            $where = array('FileID' => $this->fileID);
+            $where = ['FileID' => $this->fileID];
         } else {
             // per-visit
-            $where = array('SessionID' => $this->sessionID);
+            $where = ['SessionID' => $this->sessionID];
         }
         return $where;
     }

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -33,7 +33,7 @@ class File_Upload
     public $fileImport        = true;
     public $filenamePrefix    = "";
     public $createDirectories = true;
-    public $errorLog          = array();
+    public $errorLog          = [];
     public $moveOrCopy        = "move";
     public $isCLImport        = false;
     public $handlerArgs;
@@ -190,7 +190,7 @@ class File_Upload
     {
         $class  =$this->fileHandlers[$field]['class'];
         $method =$this->fileHandlers[$field]['methods'][$action];
-        $args   =array();
+        $args   =[];
 
         //If handlerArgs are being passed, include them
         if (is_array($this->handlerArgs)) {
@@ -198,14 +198,14 @@ class File_Upload
         }
 
         //Call the method
-        $func = array(
+        $func = [
             $class,
             $method,
-        );
-        $args = array(
+        ];
+        $args = [
             &$this,
             $args,
-        );
+        ];
 
         $output =call_user_func_array($func, $args);
 
@@ -420,13 +420,13 @@ class File_Upload
      * @return boolean true
      * @see    File_Upload::processFiles()
      */
-    function setFileHandler($fieldName, $className, $methods=array())
+    function setFileHandler($fieldName, $className, $methods=[])
     {
-        $default_methods =array(
+        $default_methods =[
             "verify" => "isValid",
             "import" => "importFile",
             "move"   => "getTargetDirectory",
-        );
+        ];
         if (!empty($methods) && is_array($methods)) {
             $methods =array_merge($default_methods, $methods);
         } else {
@@ -493,7 +493,7 @@ class File_Upload
       */
     function getSplitFilename($name)
     {
-        $file = array();
+        $file = [];
         // NOTE This could probably be better written using pathinfo()
         if (strstr($name, ".")) {
             $extpos       =strrpos($name, ".");
@@ -751,7 +751,7 @@ class File_Upload
     function setError($field, $msg)
     {
         if (!is_array($this->errorLog[$field])) {
-            $this->errorLog[$field] = array();
+            $this->errorLog[$field] = [];
         }
         if (is_array($msg)) {
             $this->errorLog[$field] =array_merge($this->errorLog[$field], $msg);

--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -45,7 +45,7 @@ class FilesUploadHandler implements RequestHandlerInterface
      *
      * @var string[]
      */
-    protected $permittedMIMETypes = array();
+    protected $permittedMIMETypes = [];
 
     /**
      * A UNIX permissions octet.
@@ -157,7 +157,7 @@ class FilesUploadHandler implements RequestHandlerInterface
                     ->withBody(
                         new \LORIS\Http\StringStream(
                             json_encode(
-                                array('error' => $message)
+                                ['error' => $message]
                             )
                         )
                     );
@@ -192,7 +192,7 @@ class FilesUploadHandler implements RequestHandlerInterface
                         ->withBody(
                             new \LORIS\Http\StringStream(
                                 json_encode(
-                                    array('error' => 'File type not allowed')
+                                    ['error' => 'File type not allowed']
                                 )
                             )
                         );
@@ -211,7 +211,7 @@ class FilesUploadHandler implements RequestHandlerInterface
                     ->withBody(
                         new \LORIS\Http\StringStream(
                             json_encode(
-                                array('error' => 'Could not upload file')
+                                ['error' => 'Could not upload file']
                             )
                         )
                     );

--- a/php/libraries/IdentifierGenerator.php
+++ b/php/libraries/IdentifierGenerator.php
@@ -40,7 +40,7 @@ abstract class IdentifierGenerator
      * @var array<int,float|int|string> This is derived from the return type of PHP's
      *                              range() which is used to generate the alphabet.
      */
-    protected $alphabet = array();
+    protected $alphabet = [];
     /**
      * The length of the "suffix" portion of the ID.
      * e.g. for an ID `MON1234` with prefix `MON`, the suffix is length 4.

--- a/php/libraries/Image.class.inc
+++ b/php/libraries/Image.class.inc
@@ -67,7 +67,7 @@ class Image
                        ON (mst.ID = f.AcquisitionProtocolID)
                      WHERE f.FileID = :v_fileid
                     ',
-                    array('v_fileid' => $fileid)
+                    ['v_fileid' => $fileid]
                 );
             if (empty($dbrow)) {
                 throw new \NotFound('There is no file with that FileID');
@@ -109,10 +109,10 @@ class Image
                          f.FileID = :v_fileid AND
                          pt.Name = :v_headername
                       ',
-                array(
+                [
                     'v_fileid'     => $this->_fileid,
                     'v_headername' => $headername,
-                )
+                ]
             );
         return $dbrow['Value'] ?? '';
     }
@@ -140,7 +140,7 @@ class Image
                        WHERE
                          f.FileID = :v_fileid
                       ',
-                array('v_fileid' => $this->_fileid)
+                ['v_fileid' => $this->_fileid]
             );
         return array_reduce(
             $dbrows,
@@ -148,7 +148,7 @@ class Image
                 $carry[$row['name']] = $row['value'];
                 return $carry;
             },
-            array()
+            []
         );
     }
 
@@ -171,7 +171,7 @@ class Image
              WHERE
                FileID = :v_fileid
             ',
-            array('v_fileid' => $this->_fileid)
+            ['v_fileid' => $this->_fileid]
         );
 
         if (is_array($row)) {
@@ -197,12 +197,12 @@ class Image
      */
     public function saveQcStatus(\LORIS\ImageQcStatus $qcstatus): void
     {
-        $values = array(
+        $values = [
             'QCStatus'         => $qcstatus->getQcStatus(),
             'Selected'         => $qcstatus->isSelected() ? 'true' : 'false',
             'QCLastChangeTime' => time(),
             'FileID'           => $this->_fileid,
-        );
+        ];
 
         \NDB_Factory::singleton()->database()->replace(
             'files_qcstatus',
@@ -231,7 +231,7 @@ class Image
              WHERE
                f.FileID = :v_fileid
             ',
-            array('v_fileid' => $this->_fileid)
+            ['v_fileid' => $this->_fileid]
         );
 
         return array_map(

--- a/php/libraries/InstrumentFlags.class.inc
+++ b/php/libraries/InstrumentFlags.class.inc
@@ -46,10 +46,10 @@ class InstrumentFlags
      */
     public function toArray(): array
     {
-        return array(
+        return [
             'Data_entry'     => $this->_dataentry,
             'Administration' => $this->_administration,
             'Validity'       => $this->_validity,
-        );
+        ];
     }
 }

--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -40,7 +40,7 @@ trait LegacyInstrumentTrait
 
         $success = $db->pselectOne(
             "SELECT Full_name FROM test_names WHERE Test_name=:TN",
-            array('TN' => $this->testName)
+            ['TN' => $this->testName]
         );
         return $success;
     }
@@ -63,7 +63,7 @@ trait LegacyInstrumentTrait
             WHERE Test_name=:TN
                 ORDER BY Order_number";
 
-        $results = $db->pselect($query, array('TN' => $this->testName));
+        $results = $db->pselect($query, ['TN' => $this->testName]);
 
         return $results;
     }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -31,16 +31,16 @@
 class LorisForm
 {
 
-    var $form          = array();
-    var $defaultValues = array();
-    var $formRules     = array();
-    var $errors        = array();
-    var $filters       = array();
+    var $form          = [];
+    var $defaultValues = [];
+    var $formRules     = [];
+    var $errors        = [];
+    var $filters       = [];
     var $frozen        = false;
     var $enctype       = '';
-    var $groupMapping  = array();
+    var $groupMapping  = [];
     var $action        = '';
-    var $allowedRules  = array(
+    var $allowedRules  = [
         'compare',
         'requiredIf',
         'required',
@@ -48,7 +48,7 @@ class LorisForm
         'regex',
         'email',
         'maxlength',
-    );
+    ];
     public $validOperators;
     public $encrypt;
 
@@ -66,9 +66,9 @@ class LorisForm
      *
      * @return array describing the form element
      */
-    protected function &createBase($name, $label, $attribs=array())
+    protected function &createBase($name, $label, $attribs=[])
     {
-        $el = array('label' => $label);
+        $el = ['label' => $label];
 
         if (!empty($name)) {
             $el['name'] = $name;
@@ -123,7 +123,7 @@ class LorisForm
      *
      * @return &array A reference to the array that was added to $this->form
      */
-    protected function &addBase($name, $label, $attribs = array())
+    protected function &addBase($name, $label, $attribs = [])
     {
         $el   = $this->createBase($name, $label, $attribs);
         $name = $this->_generateName($name);
@@ -144,7 +144,7 @@ class LorisForm
      *
      * @return &array
      */
-    public function addSelect($name, $label, $options, $attribs = array())
+    public function addSelect($name, $label, $options, $attribs = [])
     {
         $el            =& $this->addBase($name, $label, $attribs);
         $el['type']    = 'select';
@@ -168,7 +168,7 @@ class LorisForm
      */
     public function addStatic($name, $label)
     {
-        $el         =& $this->addBase($name, $label, array());
+        $el         =& $this->addBase($name, $label, []);
         $el['type'] = 'static';
         return $el;
     }
@@ -184,7 +184,7 @@ class LorisForm
      *
      * @return &array
      */
-    public function addPassword($name, $label, $options=array())
+    public function addPassword($name, $label, $options=[])
     {
         $el         =& $this->addBase($name, $label, $options);
         $el['type'] = 'password';
@@ -200,12 +200,12 @@ class LorisForm
      *
      * @return &array
      */
-    public function addHidden($name, $value, $attributes=array())
+    public function addHidden($name, $value, $attributes=[])
     {
         $el         =& $this->addBase(
             $name,
             null,
-            array_merge(array('value' => $value), $attributes)
+            array_merge(['value' => $value], $attributes)
         );
         $el['type'] = 'hidden';
         return $el;
@@ -222,7 +222,7 @@ class LorisForm
      *
      * @return &array
      */
-    public function addText($name, $label, $options=array())
+    public function addText($name, $label, $options=[])
     {
         $el         =& $this->addBase($name, $label, $options);
         $el['type'] = 'text';
@@ -241,7 +241,7 @@ class LorisForm
      *
      * @return &array
      */
-    public function addTextArea($elname, $label, $options=array())
+    public function addTextArea($elname, $label, $options=[])
     {
         $el         =& $this->addBase($elname, $label, $options);
         $el['type'] = 'textarea';
@@ -269,7 +269,7 @@ class LorisForm
      *
      * @return &array
      */
-    public function addDate($name, $label, $options, $attribs = array())
+    public function addDate($name, $label, $options, $attribs = [])
     {
         $el            =& $this->addBase($name, $label, $attribs);
         $el['type']    = 'date';
@@ -347,7 +347,7 @@ class LorisForm
      *
      * @return &array
      */
-    function addHeader($name, $label, $options = array())
+    function addHeader($name, $label, $options = [])
     {
         $el         =& $this->addBase($name, $label, $options);
         $el['type'] = 'header';
@@ -413,8 +413,8 @@ class LorisForm
         $type,
         $name,
         $label='',
-        $options=array(),
-        $attribs=array()
+        $options=[],
+        $attribs=[]
     ) {
         $el = null;
         switch($type)  {
@@ -496,7 +496,7 @@ class LorisForm
      *
      * @return array of the form that can be added to $this->form
      */
-    function createText($elname, $label, $attribs = array())
+    function createText($elname, $label, $attribs = [])
     {
         $el         =& $this->createBase($elname, $label, $attribs);
         $el['type'] = 'text';
@@ -518,7 +518,7 @@ class LorisForm
      *
      * @return array of the form that can be added to $this->form
      */
-    function createSubmit($elname, $value, $attribs = array())
+    function createSubmit($elname, $value, $attribs = [])
     {
         $attribs['value'] = $value;
         $el         =& $this->createBase($elname, null, $attribs);
@@ -564,7 +564,7 @@ class LorisForm
             // If submitted value in $_REQUEST is an array return the array
             // of filtered values
             if (is_array($_REQUEST[$name])) {
-                $filteredValues = array();
+                $filteredValues = [];
                 foreach (array_keys($_REQUEST[$name]) as $k) {
                     // Checkbox values get converted from (on,off) to (1,0)
                     if ($this->_isAdvCheckbox("{$name}[$k]")) {
@@ -676,14 +676,14 @@ class LorisForm
         }
 
         // Apply filters that should be applied on all fields
-        $count = count($this->filters['__ALL__'] ?? array());
+        $count = count($this->filters['__ALL__'] ?? []);
         if (isset($this->filters['__ALL__'])) {
             for ($i = 0; $i < $count; $i++) {
-                if (in_array('trim', $this->filters['__ALL__'] ?? array())) {
+                if (in_array('trim', $this->filters['__ALL__'] ?? [])) {
                     // Value for the element is in array so filter all
                     // elements in the array of values
                     if (is_array($value)) {
-                        $newValue = array();
+                        $newValue = [];
                         foreach ($value as $k => $v) {
                             $newValue[$k]
                                 = $this->_getFilteredValue("{$name}[$k]", $v);
@@ -714,7 +714,7 @@ class LorisForm
     protected function selectHTML($el)
     {
         $strOptions    = '';
-        $options       = $el['options'] ?? array();
+        $options       = $el['options'] ?? [];
         $cls           = '';
         $changehandler = '';
         $multiple      = '';
@@ -1036,11 +1036,11 @@ class LorisForm
     {
         $timeStamp = $this->getValue($el['name']);
         $smarty    = new Smarty_NeuroDB;
-        $value     = array(
+        $value     = [
             'H' => null,
             'i' => null,
-        );
-        $bits      = array();
+        ];
+        $bits      = [];
 
         if (is_array($timeStamp)) {
             $value = $timeStamp;
@@ -1206,7 +1206,7 @@ class LorisForm
             return false;
         }
         $values = $this->getSubmitValues();
-        $errors = array();
+        $errors = [];
         foreach ($this->form as $elName => $el) {
             if ($el['type'] === 'group') {
                 if (isset($el['required'])) {
@@ -1457,7 +1457,7 @@ class LorisForm
     {
         if ($filterType == 'trim') {
             if (!isset($this->filters[$elementName])) {
-                $this->filters[$elementName] = array();
+                $this->filters[$elementName] = [];
             }
 
             $this->filters[$elementName][] = 'trim';
@@ -1686,11 +1686,11 @@ class LorisForm
     function toElementArray()
     {
 
-        $curPage = array(
-            'elements' => array(),
+        $curPage = [
+            'elements' => [],
             'type'     => 'page',
             'errors'   => $this->errors,
-        );
+        ];
         $retVal  = $curPage;
 
         // Hack to populate the HTML elements
@@ -1702,11 +1702,11 @@ class LorisForm
                     $retVal['elements'][] = $curPage;
                 }
 
-                $curPage = array(
-                    'elements'    => array(),
+                $curPage = [
+                    'elements'    => [],
                     'Description' => $el['label'],
                     'type'        => 'page',
-                );
+                ];
             } else {
                 $curPage['elements'][] = $el;
             }
@@ -1766,11 +1766,11 @@ class LorisForm
                 $this->form[$element[0]]['compare'] = $element[1];
                 $this->form[$element[1]]['compare'] = $element[0];
             } else if ($type === 'requiredIf') {
-                $this->formRules[]['requiredIf'] = array(
+                $this->formRules[]['requiredIf'] = [
                     "elements" => $element,
                     "format"   => func_get_arg(3),
                     "message"  => $message,
-                );
+                ];
             }
             return;
         }
@@ -1792,10 +1792,10 @@ class LorisForm
         }
 
         if ($type === 'regex') {
-            $this->form[$element]['regex'][] = array(
+            $this->form[$element]['regex'][] = [
                 'regexMsg' => $message,
                 'match'    => func_get_arg(3),
-            );
+            ];
         }
 
         if ($type === 'email') {
@@ -1804,10 +1804,10 @@ class LorisForm
         }
 
         if ($type === 'maxlength') {
-            $this->form[$element]['maxlength'] = array(
+            $this->form[$element]['maxlength'] = [
                 'message'   => $message,
                 'maxlength' => func_get_arg(3),
-            );
+            ];
         }
     }
 
@@ -1901,24 +1901,24 @@ class LorisForm
      *
      * @return void
      */
-    function addGroup($array, $name, $label, $delimiter, $options = array())
+    function addGroup($array, $name, $label, $delimiter, $options = [])
     {
         $name = $this->_generateName($name);
         foreach ($array as $key => $value) {
              $group_key = $value['name'] ?? $this->_generateName('');
-             $this->groupMapping[$group_key] = array(
+             $this->groupMapping[$group_key] = [
                  'groupName' => $name,
                  'index'     => $key,
-             );
+             ];
         }
-        $this->form[$name] = array(
+        $this->form[$name] = [
             'type'      => 'group',
             'name'      => $name,
             'elements'  => $array,
             'label'     => $label,
             'delimiter' => empty($delimiter) ? ' ' : $delimiter,
             'options'   => $options,
-        );
+        ];
 
     }
 
@@ -1956,8 +1956,8 @@ class LorisForm
         $type,
         $elname,
         $label='',
-        $options=array(),
-        $attribs=array()
+        $options=[],
+        $attribs=[]
     ) {
         switch($type) {
         case 'text':
@@ -2035,7 +2035,7 @@ class LorisForm
      *
      * @return array of the form supported by $this->form
      */
-    public function createSelect($name, $label, $options, $attribs = array())
+    public function createSelect($name, $label, $options, $attribs = [])
     {
         $el            =& $this->createBase($name, $label, $attribs);
         $el['type']    = 'select';
@@ -2170,7 +2170,7 @@ class LorisForm
      */
     function getSubmitValues()
     {
-        $retVal     = array();
+        $retVal     = [];
         $submitKeys = $_POST + $_FILES;
 
         $this->getGroupValues(array_keys($submitKeys), $retVal);

--- a/php/libraries/MRIFile.class.inc
+++ b/php/libraries/MRIFile.class.inc
@@ -22,11 +22,11 @@
  */
 class MRIFile
 {
-    public $fileData    = array();
-    public $parameters  = array();
-    public $QCData      = array();
-    public $intermFiles = array();
-    public $protFiles   = array();
+    public $fileData    = [];
+    public $parameters  = [];
+    public $QCData      = [];
+    public $intermFiles = [];
+    public $protFiles   = [];
 
     /**
      * Construct an MRIFile
@@ -36,7 +36,7 @@ class MRIFile
     function __construct(int $fileID)
     {
         $db     = \Database::singleton();
-        $params = array('FID' => $fileID);
+        $params = ['FID' => $fileID];
 
         $query    = "SELECT * FROM files WHERE FileID=:FID";
         $fileData = $db->pselectRow($query, $params);
@@ -117,7 +117,7 @@ class MRIFile
 
         return \Database::singleton()->pselectOne(
             'SELECT Scan_type FROM mri_scan_type WHERE ID=:ProtoID',
-            array('ProtoID' => $this->fileData['AcquisitionProtocolID'])
+            ['ProtoID' => $this->fileData['AcquisitionProtocolID']]
         );
     }
 }

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -182,7 +182,7 @@ class NDB_BVL_Battery
 
         // get SessionID, UserID
         $query = "SELECT ID as SessionID, UserID FROM session WHERE ID=:SID";
-        $rows  = $DB->pselect($query, array('SID' => $this->sessionID));
+        $rows  = $DB->pselect($query, ['SID' => $this->sessionID]);
         if (count($rows)==0) {
             throw new Exception(
                 "Failed to get SessionID, and UserID when trying to add $testName"
@@ -197,34 +197,34 @@ class NDB_BVL_Battery
         $obj = NDB_BVL_Instrument::factory($testName, '', '');
 
         // insert into the test table
-        $DB->insert($obj->table, array('CommentID' => $commentID));
+        $DB->insert($obj->table, ['CommentID' => $commentID]);
 
         // insert into the flag table
         $DB->insert(
             'flag',
-            array(
+            [
                 'SessionID' => $sessionData['SessionID'],
                 'Test_name' => $testName,
                 'CommentID' => $commentID,
                 'UserID'    => $sessionData['UserID'],
-            )
+            ]
         );
 
         // generate the double data entry commentid
         $ddeCommentID = 'DDE_'.$commentID;
 
         // insert the dde into the test table
-        $DB->insert($obj->table, array('CommentID' => $ddeCommentID));
+        $DB->insert($obj->table, ['CommentID' => $ddeCommentID]);
 
         // insert the dde into the flag table
         $DB->insert(
             'flag',
-            array(
+            [
                 'SessionID' => $sessionData['SessionID'],
                 'Test_name' => $testName,
                 'CommentID' => $ddeCommentID,
                 'UserID'    => $sessionData['UserID'],
-            )
+            ]
         );
 
         return $commentID ?? '';
@@ -274,11 +274,11 @@ class NDB_BVL_Battery
             JOIN candidate c ON (c.CandID=s.CandID)
             WHERE f.SessionID=:SID AND s.Active='Y' AND c.Active='Y'
                AND f.CommentID NOT LIKE 'DDE%'";
-        $qparams = array('SID' => $this->sessionID);
+        $qparams = ['SID' => $this->sessionID];
         $rows    = $DB->pselect($query, $qparams);
 
         // repackage the array
-        $tests = array();
+        $tests = [];
         foreach ($rows AS $row) {
             $tests[] = $row['Test_name'];
         }
@@ -319,7 +319,7 @@ class NDB_BVL_Battery
         $query  .= " FROM flag f
             	JOIN test_names t ON (f.Test_name=t.Test_name)
             	JOIN test_subgroups ts ON (ts.ID = t.Sub_group) ";
-        $qparams = array('SID' => $this->sessionID);
+        $qparams = ['SID' => $this->sessionID];
 
         if (!is_null($stage)) {
             $query .= "
@@ -386,7 +386,7 @@ class NDB_BVL_Battery
         return \NDB_Factory::singleton()->database()
             ->pselectOne(
                 "SELECT Test_name FROM flag WHERE CommentID=:CID",
-                array('CID' => $commentId)
+                ['CID' => $commentId]
             );
     }
 
@@ -430,10 +430,10 @@ class NDB_BVL_Battery
         if (empty($this->age)) {
             $this->age = $age;
         }
-        $qparams = array(
+        $qparams = [
             'vAge'      => $this->age,
             'SubprojID' => $SubprojectID,
-        );
+        ];
         // The query to lookup the battery uses the min/max age ranges
         // if they are not 0
         $query = "
@@ -454,10 +454,10 @@ class NDB_BVL_Battery
                 "SELECT COUNT(*)
                     FROM test_battery
                     WHERE Visit_label =:VL AND SubprojectID=:SubID",
-                array(
+                [
                     'VL'    => $visit_label,
                     'SubID' => $SubprojectID,
-                )
+                ]
             );
             if ($VisitBatteryExists > 0) {
                 $query        .= " AND b.Visit_label=:VL";
@@ -486,7 +486,7 @@ class NDB_BVL_Battery
         }
 
         // get the list of instruments
-        $tests = array();
+        $tests = [];
         $rows  = $DB->pselect($query, $qparams);
 
         // repackage the array
@@ -499,10 +499,10 @@ class NDB_BVL_Battery
                 SELECT DISTINCT Test_name
                 FROM test_battery
                 WHERE firstVisit=:FV AND SubprojectID=:subID";
-            $where            = array(
+            $where            = [
                 'FV'    => 'Y',
                 'subID' => $SubprojectID,
-            );
+            ];
             $rows_firstVisit  = $DB->pselect($query_firstVisit, $where);
 
             foreach ($rows_firstVisit as $row) {
@@ -515,10 +515,10 @@ class NDB_BVL_Battery
                 SELECT DISTINCT Test_name
                 FROM test_battery
                 WHERE firstVisit=:FV AND SubprojectID=:subID";
-            $where = array(
+            $where = [
                 'FV'    => 'N',
                 'subID' => $SubprojectID,
-            );
+            ];
 
             $rows_notfirstVisit = $DB->pselect($query_notfirstVisit, $where);
             foreach ($rows_notfirstVisit as $row) {
@@ -568,14 +568,14 @@ class NDB_BVL_Battery
 
         $TestID = $DB->pselectOne(
             "SELECT ID FROM test_names WHERE Test_name=:TN",
-            array('TN' => $Test_name)
+            ['TN' => $Test_name]
         );
 
         $OtherInfo = $DB->pselectRow(
             "SELECT CandID, c.PSCID, s.SubprojectID FROM session s
                     JOIN candidate c USING (CandID)
                 WHERE c.Active='Y' AND s.Active='Y' AND s.ID=:SID",
-            array('SID' => $SessionID)
+            ['SID' => $SessionID]
         );
 
         if (empty($TestID) || empty($OtherInfo)) {
@@ -617,7 +617,7 @@ class NDB_BVL_Battery
     {
         $DB    = Database::singleton();
         $query = "SELECT COUNT(*) AS counter FROM test_names WHERE Test_name=:TN";
-        $row   = $DB->pselectRow($query, array('TN' => $testName));
+        $row   = $DB->pselectRow($query, ['TN' => $testName]);
 
         return ($row['counter'] ?? 0) >= 1;
     } // end _assertValidInstrument()

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -46,12 +46,12 @@ class NDB_BVL_Feedback
     var $_feedbackCandidateProfileInfo = [];
 
     // set of status options
-    var $_feedbackStatusOptions = array(
+    var $_feedbackStatusOptions = [
         'opened',
         'answered',
         'closed',
         'comment',
-    );
+    ];
 
     var $_username ='';
 
@@ -84,7 +84,7 @@ class NDB_BVL_Feedback
             );
         }
 
-        static $feedbackList = array();
+        static $feedbackList = [];
 
         $objectName = md5(
             sprintf(
@@ -176,7 +176,7 @@ class NDB_BVL_Feedback
         }
 
         $query  .= " FROM candidate as c";
-        $qparams = array();
+        $qparams = [];
 
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query .= " JOIN session as s
@@ -241,15 +241,15 @@ class NDB_BVL_Feedback
         $query = "SELECT Feedback_type as Type, Name, Description
             FROM feedback_bvl_type";
 
-        $result = \Database::singleton()->pselect($query, array());
+        $result = \Database::singleton()->pselect($query, []);
 
-        $list = array();
+        $list = [];
         foreach ($result as $record) {
-            $list[$record['Type']] = array(
+            $list[$record['Type']] = [
                 'Type'  => $record['Type'],
                 'Name'  => $record['Name'],
                 'Label' => $record['Description'],
-            );
+            ];
         }
         return $list;
     }
@@ -271,7 +271,7 @@ class NDB_BVL_Feedback
                     FROM  `feedback_bvl_type`
                     WHERE  `Name` =  :name ";
 
-        return $db->pselectOne($query, array(':name' => $name));
+        return $db->pselectOne($query, [':name' => $name]);
     }
 
     /**
@@ -297,10 +297,10 @@ class NDB_BVL_Feedback
         $factory = NDB_Factory::singleton();
         $db      = $factory->Database();
 
-        $values = array(
+        $values = [
             'Name'        => $name,
             'Description' => $description,
-        );
+        ];
         $db->insert("feedback_bvl_type", $values);
         return intval($db->getLastInsertId());
     }
@@ -323,7 +323,7 @@ class NDB_BVL_Feedback
                   feedback_bvl_type.Feedback_type = feedback_bvl_thread.Feedback_type
                   WHERE feedback_bvl_thread.FeedbackID = :FID";
 
-        $result = $db->pselectOne($query, array('FID' => $feedbackID));
+        $result = $db->pselectOne($query, ['FID' => $feedbackID]);
         return $result;
     }
 
@@ -360,7 +360,7 @@ class NDB_BVL_Feedback
 
         $query = "SELECT Status FROM feedback_bvl_thread WHERE FeedbackID = :FID";
 
-        $result = $db->pselectOne($query, array('FID' => $feedbackID));
+        $result = $db->pselectOne($query, ['FID' => $feedbackID]);
         return $result;
     }
 
@@ -380,7 +380,7 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         $query   = "SELECT MAX(Status) FROM feedback_bvl_thread WHERE";
-        $qparams = array();
+        $qparams = [];
         if (!empty($this->_feedbackObjectInfo['CandID'])) {
             $query         .= " CandID = :CID";
             $qparams['CID'] = $this->_feedbackObjectInfo['CandID'];
@@ -419,7 +419,7 @@ class NDB_BVL_Feedback
         $query   = "SELECT COUNT(*)
             FROM feedback_bvl_thread
             WHERE Active ='Y' AND Public = 'Y' AND Status <> 'closed'";
-        $qparams = array();
+        $qparams = [];
         if (!empty($this->_feedbackObjectInfo['CommentID'])) {
             $query           .= " AND CommentID = :ComID";
             $qparams['ComID'] = $this->_feedbackObjectInfo['CommentID'];
@@ -473,7 +473,7 @@ class NDB_BVL_Feedback
         $query  .= " FROM candidate as c
                         JOIN feedback_bvl_thread as ft ON (c.CandID=ft.CandID)
                         LEFT JOIN session as s ON (s.ID = ft.SessionID)";
-        $qparams = array();
+        $qparams = [];
         if (empty($this->_feedbackObjectInfo['CandID'])) {
             $query .= " LEFT JOIN flag as f ON (ft.CommentID = f.CommentID)";
         }
@@ -523,7 +523,7 @@ class NDB_BVL_Feedback
         $hasReadPermission = $user->hasPermission('access_all_profiles');
 
         $query   = "SELECT c.CandID as CandID, c.PSCID as PSCID";
-        $qparams = array();
+        $qparams = [];
         if (!empty($this->_feedbackObjectInfo['SessionID'])
             || !empty($this->_feedbackObjectInfo['CommentID'])
         ) {
@@ -634,7 +634,7 @@ class NDB_BVL_Feedback
                    AND ft.Feedback_type = ftp.Feedback_type
              ORDER BY ft.FeedbackID, fe.Testdate DESC";
 
-        $result = $db->pselect($query, array('FID' => $feedbackID));
+        $result = $db->pselect($query, ['FID' => $feedbackID]);
 
         return $result;
     }
@@ -677,7 +677,7 @@ class NDB_BVL_Feedback
         $active = 'Y';
 
         // create SET array for the INSERT into the feedback_bvl_thread table
-        $setArray = array(
+        $setArray = [
             'FeedbackID'    => null,
             'Feedback_type' => $type,
             'Public'        => $public,
@@ -685,38 +685,38 @@ class NDB_BVL_Feedback
             'Active'        => $active,
             'Date_taken'    => $today,
             'UserID'        => $this->_username,
-        );
+        ];
         if ($level == 'instrument' || $this->_feedbackLevel=='instrument') {
             $feedbackInfo =& $this->_feedbackCandidateProfileInfo;
 
             $setArray = array_merge(
                 $setArray,
-                array(
+                [
                     "CommentID"      => $this->_feedbackObjectInfo['CommentID'],
                     "SessionID"      => $feedbackInfo['SessionID'],
                     "CandID"         => $feedbackInfo['CandID'],
                     "Feedback_level" => "instrument",
                     "FieldName"      => $fieldname,
-                )
+                ]
             );
 
         } elseif ($level == 'visit' || $this->_feedbackLevel=='visit') {
             $candID   = $this->_feedbackCandidateProfileInfo['CandID'];
             $setArray = array_merge(
                 $setArray,
-                array(
+                [
                     "SessionID"      => $this->_feedbackObjectInfo['SessionID'],
                     "CandID"         => $candID,
                     "Feedback_level" => "visit",
-                )
+                ]
             );
         } elseif ($level == 'profile' || $this->_feedbackLevel=='profile') {
             $setArray = array_merge(
                 $setArray,
-                array(
+                [
                     "CandID"         => $this->_feedbackObjectInfo['CandID'],
                     "Feedback_level" => "profile",
-                )
+                ]
             );
         } else {
             throw new Exception(
@@ -732,7 +732,7 @@ class NDB_BVL_Feedback
         // INSERT entry for the the thread into the feedback_bvl_thread
         $this->createEntry($feedbackID, $comment, $this->_username);
 
-        $newEntryValues = array();
+        $newEntryValues = [];
         $newEntryValues["feedbackID"] = $feedbackID;
         $newEntryValues["comment"]    = $comment;
         if ($fieldname != null) {
@@ -765,11 +765,11 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         // create SET array for the INSERT
-        $setArray = array(
+        $setArray = [
             'FeedbackID' => $feedbackID,
             'Comment'    => $comment,
             'UserID'     => $username,
-        );
+        ];
 
         $db->insert('feedback_bvl_entry', $setArray);
 
@@ -818,23 +818,23 @@ class NDB_BVL_Feedback
             }
         }
         // needed to avoid php complaints
-        $setArray = array();
+        $setArray = [];
         if (!empty($status)) {
-            $setArray = array_merge($setArray, array("Status" => $status));
+            $setArray = array_merge($setArray, ["Status" => $status]);
         }
         if (!empty($type)) {
-            $setArray = array_merge($setArray, array("Feedback_type" => $type));
+            $setArray = array_merge($setArray, ["Feedback_type" => $type]);
         }
         if (!empty($public)) {
-            $setArray = array_merge($setArray, array("Public" => $public));
+            $setArray = array_merge($setArray, ["Public" => $public]);
         }
         if (!empty($fieldname)) {
-            $setArray = array_merge($setArray, array("FieldName" => $fieldname));
+            $setArray = array_merge($setArray, ["FieldName" => $fieldname]);
         }
 
         // needed to avoid php complaints
-        $whereArray = array();
-        $whereArray = array_merge($whereArray, array("FeedbackID" => $feedbackID));
+        $whereArray = [];
+        $whereArray = array_merge($whereArray, ["FeedbackID" => $feedbackID]);
 
         if (is_array($setArray) && count($setArray)>0) {
             // update the thread only if the form data was changed
@@ -858,13 +858,13 @@ class NDB_BVL_Feedback
         // DELETE the thread's entries
         $db->delete(
             'feedback_bvl_entry',
-            array("FeedbackID" => $feedbackID)
+            ["FeedbackID" => $feedbackID]
         );
 
         // DELETE the thread
         $db->delete(
             'feedback_bvl_thread',
-            array("FeedbackID" => '$feedbackID')
+            ["FeedbackID" => '$feedbackID']
         );
 
     }
@@ -882,7 +882,7 @@ class NDB_BVL_Feedback
         $db =& Database::singleton();
 
         // DELETE the thread entries
-        $db->delete('feedback_bvl_entry', array("ID" => $entryID));
+        $db->delete('feedback_bvl_entry', ["ID" => $entryID]);
     }
 
     /**
@@ -897,36 +897,36 @@ class NDB_BVL_Feedback
         // new DB Object
         $db =& Database::singleton();
 
-        $setArray = array(
+        $setArray = [
             "Active"   => 'Y',
             "Testdate" => "NULL",
-        );
+        ];
 
         // only inactive threads can be activated
-        $whereArray = array("Active" => 'N');
+        $whereArray = ["Active" => 'N'];
         if (!empty($feedbackID)) {
             // only one thread to be activated
             $whereArray = array_merge(
                 $whereArray,
-                array("FeedbackID" => $feedbackID)
+                ["FeedbackID" => $feedbackID]
             );
         } elseif (!empty($this->_feedbackObjectInfo['CommentID'])) {
             // activate all thread for the instruments
             $whereArray = array_merge(
                 $whereArray,
-                array("CommentID" => $this->_feedbackObjectInfo['CommentID'])
+                ["CommentID" => $this->_feedbackObjectInfo['CommentID']]
             );
         } elseif (!empty($this->_feedbackObjectInfo['SessionID'])) {
             // activate all thread for the timepoint
             $whereArray = array_merge(
                 $whereArray,
-                array("SessionID" => $this->_feedbackObjectInfo['SessionID'])
+                ["SessionID" => $this->_feedbackObjectInfo['SessionID']]
             );
         } elseif (!empty($this->_feedbackObjectInfo['CandID'])) {
             // activate all thread for the candidate
             $whereArray = array_merge(
                 $whereArray,
-                array("CandID" => $this->_feedbackObjectInfo['CandID'])
+                ["CandID" => $this->_feedbackObjectInfo['CandID']]
             );
         } else {
             // at least one of the above has to be true
@@ -952,25 +952,25 @@ class NDB_BVL_Feedback
         if (!empty($feedbackID)) {
             // only one thread to be closed
             $whereStr .= 'AND FeedbackID = :v_feedbackid ';
-            $params    = array('v_feedbackid' => $feedbackID);
+            $params    = ['v_feedbackid' => $feedbackID];
 
         } elseif (!empty($this->_feedbackObjectInfo['CommentID'])) {
             // close all threads for the instruments
             $commentid = $this->_feedbackObjectInfo['CommentID'];
             $whereStr .= 'AND CommentID = :v_commentid ';
-            $params    = array('v_commentid' => $commentid);
+            $params    = ['v_commentid' => $commentid];
 
         } elseif (!empty($this->_feedbackObjectInfo['SessionID'])) {
             // close all threads for the timepoint
             $sessionid = $this->_feedbackObjectInfo['SessionID'];
             $whereStr .= 'AND SessionID = :v_sessionid ';
-            $params    = array('v_sessionid' => $sessionid);
+            $params    = ['v_sessionid' => $sessionid];
 
         } elseif (!empty($this->_feedbackObjectInfo['CandID'])) {
             // close all threads for the candidate
             $candid    = $this->_feedbackObjectInfo['CandID'];
             $whereStr .= 'AND CandID = :v_candid ';
-            $params    = array('v_candid' => $candid);
+            $params    = ['v_candid' => $candid];
 
         } else {
             // at least one of the above has to be true
@@ -985,7 +985,7 @@ class NDB_BVL_Feedback
             SET Status = \'closed\', UserID = \'' . $this->_username . '\'
             WHERE ' . $whereStr
         );
-        $db->execute($stmt, $params, array('nofetch' => true));
+        $db->execute($stmt, $params, ['nofetch' => true]);
         return $stmt->rowCount();
     }
 
@@ -1006,7 +1006,7 @@ class NDB_BVL_Feedback
 
         $whereStr .= 'AND FeedbackID = :v_feedbackid ';
 
-        $params = array('v_feedbackid' => $feedbackID);
+        $params = ['v_feedbackid' => $feedbackID];
 
         $stmt = $db->prepare(
             '
@@ -1014,7 +1014,7 @@ class NDB_BVL_Feedback
             SET Status = \'opened\', UserID = \'' . $this->_username . '\'
             WHERE ' . $whereStr
         );
-        $db->execute($stmt, $params, array('nofetch' => true));
+        $db->execute($stmt, $params, ['nofetch' => true]);
         return $stmt->rowCount();
 
     }
@@ -1040,12 +1040,12 @@ class NDB_BVL_Feedback
         // new DB Object
         $db = Database::singleton();
 
-        $record =array();
+        $record =[];
         // StatusID is passed in as an integer, but the field in the database
         // is an enum, so we need to do WHERE Status+0= .. to convert it to
         // an int (of the index into the enum) so that this query works.
         $query  = "SELECT Status FROM feedback_bvl_thread WHERE Status+0=:StatID";
-        $param  = array('StatID' => $statusID);
+        $param  = ['StatID' => $statusID];
         $record = $db->pselectOne($query, $param);
         return $record;
     }
@@ -1078,7 +1078,7 @@ class NDB_BVL_Feedback
                 $instruments_q = \NDB_Factory::singleton()->database()
                     ->pselectOne(
                         "SELECT Count(*) FROM test_names WHERE Test_name=:testName",
-                        array('testName' => $test_name)
+                        ['testName' => $test_name]
                     );
                 if ($instruments_q == 1) {
                     return true;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -85,7 +85,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @access private
      */
-    var $localDefaults = array('emptyCell' => '&nbsp;');
+    var $localDefaults = ['emptyCell' => '&nbsp;'];
 
     /**
      * String to separate the group elements
@@ -106,7 +106,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @access private
      */
-    var $_requiredElements = array();
+    var $_requiredElements = [];
 
     /**
      * Array of date fields to be processed into QuickForm dates
@@ -116,26 +116,26 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * all other dates in the table that appear on other pages (if they are
      * listed in the array of date fields) - note by @dariovins
      */
-    var $dateTimeFields = array();
+    var $dateTimeFields = [];
 
     /**
      * Array of date fields that contain only month year fields in frontend with
      * a static value for the date
      */
-    var $monthYearFields = array();
+    var $monthYearFields = [];
     /**
      * Array of column names to be ignored by the double data entry conflict
      * detector.
      */
     var $_doubleDataEntryDiffIgnoreColumns
-        = array(
+        = [
             'CommentID',
             'UserID',
             'Testdate',
             'Window_Difference',
             'Candidate_Age',
             'Data_entry_completion_status',
-        );
+        ];
 
     /**
      * Whether the "Validity" field is shown as a flag for an instrument
@@ -161,9 +161,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     var $displayAllFields = false;
 
-    var $WrapperTextElements           = array();
-    var $WrapperNumericElements        = array();
-    var $WrapperDateWithStatusElements = array();
+    var $WrapperTextElements           = [];
+    var $WrapperNumericElements        = [];
+    var $WrapperDateWithStatusElements = [];
 
     /**
      * True if the instrument is administered after the candidate's death.
@@ -315,7 +315,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         //get config
         $config = \NDB_Config::singleton();
         $instrumentPermissions = $config->getSetting("instrumentPermissions");
-        $instrumentPerms       = array();
+        $instrumentPerms       = [];
 
         //check if instrumentPermissions are being used.
         if (!is_array($instrumentPermissions)) {
@@ -414,7 +414,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $scorer = $base . "project/instruments/" . $this->testName . ".score";
 
         if (file_exists($scorer)) {
-            $output = array();
+            $output = [];
             exec(
                 escapeshellarg($scorer) . " " . escapeshellarg(
                     $this->getCommentID()
@@ -464,12 +464,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // because that's part of the DirectEntry template
         // and has Save/Continue and go back buttons
         if (!$this->form->isFrozen() && $this->DataEntryType === 'normal') {
-            $buttons   = array();
+            $buttons   = [];
             $buttons[] = $this->form->createElement(
                 'submit',
                 'fire_away',
                 'Save Data',
-                array('class' => 'button')
+                ['class' => 'button']
             );
             //$buttons[] = $this->form->createElement('reset', null, 'Reset');
             $this->addGroup($buttons, null, null, "&nbsp;");
@@ -479,7 +479,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         // set the defaults (call private method _setDefaultsArray
         // which could be overridden if necessary)
-        $defaults = $this->_setDefaultsArray($defaults ?? array());
+        $defaults = $this->_setDefaultsArray($defaults ?? []);
 
         // merge in the localDefaults property so that simple
         // additions to the defaults array no longer requires
@@ -531,7 +531,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     {
         //Convert date/time fields into lorisform date/timestamps
         if (empty($this->dateTimeFields)) {
-            $this->dateTimeFields = array("Date_taken");
+            $this->dateTimeFields = ["Date_taken"];
         }
 
         if (isset($defaults['Window_Difference'])
@@ -565,7 +565,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function save(): bool
     {
         if ($this->form->validate()) {
-            $this->form->process(array(&$this, '_saveValues'), true);
+            $this->form->process([&$this, '_saveValues'], true);
             $this->score();
 
             // determine the data entry completion status, and store that in
@@ -637,10 +637,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $agemonths = $this->calculateAgeMonths($age);
 
             if (!empty($age)) {
-                $query_params = array(
+                $query_params = [
                     'TN'  => $this->testName,
                     'CID' => $this->getCommentID(),
-                );
+                ];
 
                 $validage = $DB->pselectOne(
                     "SELECT MAX($agedays BETWEEN AgeMinDays AND AgeMaxDays)
@@ -755,7 +755,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     {
         //Convet date/timestamps into database format
         if (empty($this->dateTimeFields)) {
-            $this->dateTimeFields = array("Date_taken");
+            $this->dateTimeFields = ["Date_taken"];
         }
 
         if (strrpos($this->testName, "_proband") === false) {
@@ -818,7 +818,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $db->update(
                 $this->table,
                 $values,
-                array('CommentID' => $this->getCommentID())
+                ['CommentID' => $this->getCommentID()]
             );
         }
 
@@ -826,16 +826,16 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // don't overwrite data from other pages.
         $oldData = $db->pselectOne(
             "SELECT Data FROM flag WHERE CommentID=:cid",
-            array('cid' => $this->getCommentID())
+            ['cid' => $this->getCommentID()]
         );
 
         // (The PDO driver seems to return null as "null" for JSON column types)
         if (!empty($oldData) && $oldData !== "null") {
             $oldData = json_decode($oldData, true);
         } else {
-            $oldData = array();
+            $oldData = [];
         }
-        $newData = array_merge($oldData ?? array(), $values);
+        $newData = array_merge($oldData ?? [], $values);
 
         // Save the JSON to the flag.Data column.
         //
@@ -843,8 +843,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         // HTML encoding the quotation marks will make it invalid JSON.
         $db->unsafeUpdate(
             "flag",
-            array("Data" => json_encode($newData)),
-            array('CommentID' => $this->getCommentID())
+            ["Data" => json_encode($newData)],
+            ['CommentID' => $this->getCommentID()]
         );
 
     }
@@ -860,14 +860,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function _addMetadataFields(): void
     {
         $config      = \NDB_Config::singleton();
-        $dateOptions = array(
+        $dateOptions = [
             'language'         => 'en',
             'format'           => 'YMd',
             'minYear'          => $config->getSetting('startYear'),
             'maxYear'          => $config->getSetting('endYear'),
             'addEmptyOption'   => true,
             'emptyOptionValue' => null,
-        );
+        ];
 
         $this->dateOptions = $dateOptions;
 
@@ -922,8 +922,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $CertificationConfig      = $config->getSetting("Certification");
         $CertificationEnabled     = $CertificationConfig['EnableCertification'];
-        $CertificationProjects    = array();
-        $CertificationInstruments = array();
+        $CertificationProjects    = [];
+        $CertificationInstruments = [];
 
         if ($CertificationEnabled) {
             // Throw exception if config file is formatted incorrectly.
@@ -965,11 +965,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 }
             }
         }
-        return array(
+        return [
             $CertificationEnabled,
             $CertificationProjects,
             $CertificationInstruments,
-        );
+        ];
     }
 
 
@@ -985,7 +985,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $centerID = $db->pselectOne(
             "SELECT session.CenterID FROM session, flag
             WHERE session.ID=flag.SessionID AND flag.CommentID=:cmnt_id",
-            array('cmnt_id' => $this->getCommentID())
+            ['cmnt_id' => $this->getCommentID()]
         );
         if (is_array($centerID)) {
             $centerID = null;
@@ -997,10 +997,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $project = $db->pselectOne(
             "SELECT ProjectID from session where CandID =:cnd_id AND ID=:sid",
-            array(
+            [
                 'cnd_id' => $candID,
                 'sid'    => $sessionID,
-            )
+            ]
         );
 
         list(
@@ -1013,7 +1013,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         ) {
             $test_id = $db->pselectOne(
                 "SELECT ID FROM test_names WHERE Test_name=:tst_name",
-                array('tst_name' => $this->testName)
+                ['tst_name' => $this->testName]
             );
             $results = $db->pselect(
                 "SELECT c.examinerID, e.full_name
@@ -1026,11 +1026,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     AND c.pass =:cert_id
                     AND epr.centerID =:cid
                  ORDER BY full_name",
-                array(
+                [
                     'tid'     => $test_id,
                     'cert_id' => 'certified',
                     'cid'     => $centerID,
-                )
+                ]
             );
         } else {
             $results = $db->pselect(
@@ -1040,11 +1040,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                              ON (epr.examinerID=e.examinerID)
                  WHERE epr.centerID=:centID
                      ORDER BY full_name",
-                array('centID' => $centerID)
+                ['centID' => $centerID]
             );
         }
 
-        $examiners = array('' => '');
+        $examiners = ['' => ''];
         if (is_array($results) && !empty($results)) {
             foreach ($results AS $row) {
                 $examiners[$row['examinerID']] = $row['full_name'];
@@ -1101,7 +1101,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $db  = \Database::singleton();
         $doa = $db->pselectOne(
             "SELECT Date_taken FROM $this->table WHERE CommentID=:CID",
-            array('CID' => $this->getCommentID())
+            ['CID' => $this->getCommentID()]
         );
         $this->dateOfAdministration = $doa;
 
@@ -1226,7 +1226,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         unset($elements['key'], $elements['pageNum'], $elements['nextpage']);
         $this->XINDebug = false;  //Turn this on to see rules debuggin output
 
-        $errors = array();
+        $errors = [];
         foreach ($elements AS $elname => $elvalue) {
             //If the element is a group (and thus elvalue is an array)
             //trigger the Null Value default rule if ANY of the values
@@ -1257,7 +1257,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                         $errors += $result;
                     }
                 } else if (substr($elname, -7) != "_status"
-                    && !in_array($elname, array("page", "subtest"))
+                    && !in_array($elname, ["page", "subtest"])
                 ) {
                     $errors[$elname] = "Required.";
                     if ($this->XINDebug) {
@@ -1327,10 +1327,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         array $elements,
         array $rules
     ): array {
-        $errors = array();
+        $errors = [];
         //Conditions for the rule to be true, thus the element to be required.
-        $rule_outcomes = array();
-        $rules_array   = array();
+        $rule_outcomes = [];
+        $rules_array   = [];
 
         foreach ($rules['rules'] AS $rule) {
             //Loop through the assigned rules (which is the array of formatted
@@ -1353,7 +1353,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 if (stristr($rule[2], "|")) {  //ex: q_1{@}=={@}yes|no
                     $values = explode("|", $rule[2]);
                 } else {  //ex: q_1{@}=={@}yes
-                    $values = array($rule[2]);
+                    $values = [$rule[2]];
                 }
 
                 //Test the condition
@@ -1366,7 +1366,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
                 //explicitly cast the controller value as an array
                 if (!is_array($elements[$rule[0]])) {
-                    $elements[$rule[0]] = array($elements[$rule[0]]);
+                    $elements[$rule[0]] = [$elements[$rule[0]]];
                 }
                 //Foreach controller value run the rule.
                 foreach ($elements[$rule[0]] as $controller_value) {
@@ -1418,7 +1418,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         //will only be one value)
         //If all of the conditions are true (ie: all conditions are met
         //to pop a required rule)
-        $valFlag = array();
+        $valFlag = [];
         foreach ($values AS $value) {
             switch ($operator) {
             case '==':
@@ -1479,9 +1479,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $query      = "SELECT SessionID FROM flag WHERE CommentID = :CID";
         $fieldValue = \Database::singleton()->pselectOne(
             $query,
-            array(
+            [
                 'CID' => $this->getCommentID(),
-            )
+            ]
         );
 
         if (!empty($fieldValue)) {
@@ -1571,7 +1571,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _setDataEntryCompletionStatus(string $status): void
     {
-        if (!in_array($status, array('Complete', 'Incomplete'))) {
+        if (!in_array($status, ['Complete', 'Incomplete'])) {
             throw new Exception(
                 "Invalid status passed to _setDataEntryCompletionStatus - "
                 . "'$status' should have been either "
@@ -1579,7 +1579,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             );
         }
 
-        $this->_save(array("Data_entry_completion_status" => $status));
+        $this->_save(["Data_entry_completion_status" => $status]);
     }
 
     /**
@@ -1597,18 +1597,18 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function addYesNoElement(
         string $field,
         string $label,
-        array $rules=array(),
+        array $rules=[],
         string $rule_message='This field is required.'
     ): void {
         $this->addSelect(
             $field,
             $label,
-            array(
+            [
                 null           => '',
                 'yes'          => 'Yes',
                 'no'           => 'No',
                 'not_answered' => 'Not Answered',
-            )
+            ]
         );
 
         if (!empty($rules)) {
@@ -1637,26 +1637,26 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function addTextElement(
         string $field,
         string $label,
-        array $rules=array(),
+        array $rules=[],
         string $rule_message='This field is required.',
-        array $refusals = array(
+        array $refusals = [
             ''             => '',
             'not_answered' => 'Not Answered',
-        )
+        ]
     ): void {
-        $group   = array();
+        $group   = [];
         $group[] = $this->createText($field, $label);
         $this->WrapperTextElements[$field] = $group[0];
         $group[] = $this->createSelect(
             $field."_status",
             "",
             $refusals,
-            array('class' => 'form-control input-sm not-answered')
+            ['class' => 'form-control input-sm not-answered']
         );
 
         $this->addGroup($group, $field.'_group', $label, null, false);
         unset($group);
-        $rules_array = array_merge(array($field.'_status{@}=={@}'), $rules);
+        $rules_array = array_merge([$field.'_status{@}=={@}'], $rules);
         $this->XINRegisterRule($field, $rules_array, $rule_message, $field.'_group');
     }
 
@@ -1675,33 +1675,33 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function addTextAreaElementRD(string $field,
         string $label,
-        array $rules=array(),
+        array $rules=[],
         string $rule_message='You must specify or select from the drop-down'
     ): void {
-        $group   = array();
+        $group   = [];
         $group[] = $this->form->createElement(
             "textarea",
             $field,
             null,
-            array(
+            [
                 'cols' => 25,
                 'rows' => 4,
-            )
+            ]
         );
         $group[] = $this->createSelect(
             $field."_status",
             "",
-            array(
+            [
                 null             => '',
                 "88_refused"     => "88 Refused",
                 "99_do_not_know" => "99 Do not know",
                 'not_answered'   => 'Not Answered',
-            )
+            ]
         );
 
         $this->addGroup($group, $field.'_group', $label, null, false);
         unset($group);
-        $rules_array = array_merge(array($field.'_status{@}=={@}'), $rules);
+        $rules_array = array_merge([$field.'_status{@}=={@}'], $rules);
         $this->XINRegisterRule($field, $rules_array, $rule_message, $field.'_group');
     }
 
@@ -1719,33 +1719,33 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function addTextAreaElement(
         string $field,
         string $label,
-        array $rules=array(),
+        array $rules=[],
         string $rule_message='This field is required.'
     ): void {
-        $group   = array();
+        $group   = [];
         $group[] = $this->form->createElement(
             "textarea",
             $field,
             $label,
-            array(
+            [
                 'cols'  => 25,
                 'rows'  => 4,
                 'class' => 'form-control',
-            )
+            ]
         );
         $this->WrapperTextElements[$field] = $group[0];
         $group[] = $this->createSelect(
             $field."_status",
             "",
-            array(
+            [
                 null           => '',
                 'not_answered' => 'Not Answered',
-            ),
-            array('class' => 'form-control input-sm not-answered')
+            ],
+            ['class' => 'form-control input-sm not-answered']
         );
         $this->addGroup($group, $field.'_group', $label, null, false);
         unset($group);
-        $rules_array = array_merge(array($field.'_status{@}=={@}'), $rules);
+        $rules_array = array_merge([$field.'_status{@}=={@}'], $rules);
         $this->XINRegisterRule(
             $field,
             $rules_array,
@@ -1770,7 +1770,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function addHourMinElement(
         string $field,
         string $label,
-        array $rules = array(),
+        array $rules = [],
         ?string $rule_message = null
     ): void {
         if ($rule_message === null) {
@@ -1778,7 +1778,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 . "if you want to leave this time blank.";
         }
 
-        $group   = array();
+        $group   = [];
         $group[] = $this->form->createElement(
             "time",
             $field,
@@ -1790,17 +1790,17 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $group[] = $this->createSelect(
             $field . "_status",
             "",
-            array(
+            [
                 null           => '',
                 "dnk"          => "DNK",
                 "refusal"      => "Refusal",
                 'not_answered' => 'Not Answered',
-            )
+            ]
         );
         $this->addGroup($group, $field . "_group", $label, null, false);
         $this->XINRegisterRule(
             $field,
-            array_merge($rules, array($field . '_status{@}=={@}')),
+            array_merge($rules, [$field . '_status{@}=={@}']),
             $rule_message,
             $field . '_group'
         );
@@ -1821,22 +1821,22 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function addDateElement(
         string $name,
         string $label,
-        array $options = array()
+        array $options = []
     ): void {
 
         if (empty($options)) {
             $options = $this->dateOptions;
         }
 
-        $group   = array();
+        $group   = [];
         $group[] = $this->createDate(
             $name . "_date",
             $label,
             $options,
-            array(
+            [
                 'class' => 'form-control input-sm '.$name."_date",
                 'style' => 'max-width:33%; display:inline-block;',
-            )
+            ]
         );
         $this->WrapperDateWithStatusElements[$name . "_date"] = $group[0];
         if (!in_array($name . "_date", $this->dateTimeFields)) {
@@ -1846,11 +1846,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $group[] = $this->createSelect(
             $name . "_date_status",
             null,
-            array(
+            [
                 null           => "",
                 'not_answered' => "Not Answered",
-            ),
-            array('class' => 'form-control input-sm not-answered')
+            ],
+            ['class' => 'form-control input-sm not-answered']
         );
 
         $this->addGroup(
@@ -1864,7 +1864,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         unset($group);
         $this->XINRegisterRule(
             $name . "_date",
-            array($name . "_date_status{@}=={@}"),
+            [$name . "_date_status{@}=={@}"],
             "A Date, or Not Answered is required.",
             $name . "_date_group"
         );
@@ -1883,7 +1883,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @return void
      */
-    function addMonthYear(string $field, string $label, array $options=array()): void
+    function addMonthYear(string $field, string $label, array $options=[]): void
     {
         if (is_array($options)) {
             $options['format'] = 'YM';
@@ -1909,19 +1909,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         string $label,
         array $dateArray
     ): void {
-        $group   = array();
+        $group   = [];
         $group[] = $this->createDate($name . "_date", null, $dateArray);
         //add to array of dates and times.
         $this->dateTimeFields[] = $name . "_date";
         $group[] = $this->createSelect(
             $name . "_date_status",
             null,
-            array(
+            [
                 null             => "",
                 '88_refused'     => "88 Refused",
                 '99_do_not_know' => "99 Do not know",
                 'not_answered'   => "Not Answered",
-            )
+            ]
         );
         $this->addGroup(
             $group,
@@ -1933,13 +1933,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         unset($group);
         $this->XINRegisterRule(
             $name . "_date",
-            array($name . "_date_status{@}=={@}"),
+            [$name . "_date_status{@}=={@}"],
             "You must specify or select from the drop-down",
             $name . "_date_group"
         );
         $this->XINRegisterRule(
             $name . "_date_status",
-            array($name . "_date{@}=={@}"),
+            [$name . "_date{@}=={@}"],
             "You must specify or select from the drop-down",
             $name . "_date_group"
         );
@@ -1962,27 +1962,27 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         string $field,
         string $label
     ): void {
-        $group   = array();
+        $group   = [];
         $group[] = $this->createText($field, $label);
         $this->WrapperNumericElements[$field] = $group[0];
         $group[] = $this->createSelect(
             $field . "_status",
             null,
-            array(
+            [
                 null           => "",
                 'not_answered' => "Not Answered",
-            ),
-            array('class' => 'form-control input-sm not-answered')
+            ],
+            ['class' => 'form-control input-sm not-answered']
         );
         $this->addGroup($group, $field . "_group", $label, null, false);
         unset($group);
         $this->addGroupRule(
             $field . "_group",
-            array(array(array("Value must be numeric.", 'numeric')))
+            [[["Value must be numeric.", 'numeric']]]
         );
         $this->XINRegisterRule(
             $field,
-            array($field . '_status{@}=={@}'),
+            [$field . '_status{@}=={@}'],
             'This field is required',
             $field . '_group'
         );
@@ -1999,28 +1999,28 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function addNumericElementRD(string $field, string $label): void
     {
-        $group   = array();
+        $group   = [];
         $group[] = $this->createText($field, $label);
         $group[] = $this->createSelect(
             $field . "_status",
             null,
-            array(
+            [
                 null             => "",
                 "88_refused"     => "88 Refused",
                 "99_do_not_know" => "99 Do not know",
                 'not_answered'   => "Not Answered",
-            ),
-            array('class' => 'form-control input-sm not-answered')
+            ],
+            ['class' => 'form-control input-sm not-answered']
         );
         $this->addGroup($group, $field . "_group", $label, null, false);
         unset($group);
         $this->addGroupRule(
             $field . "_group",
-            array(array(array("Numbers only, please", 'numeric')))
+            [[["Numbers only, please", 'numeric']]]
         );
         $this->XINRegisterRule(
             $field,
-            array($field . '_status{@}=={@}'),
+            [$field . '_status{@}=={@}'],
             'This field is required',
             $field . '_group'
         );
@@ -2079,13 +2079,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $otherData = NDB_BVL_Instrument::loadInstanceData($otherInstrument);
 
         // Create the return object data structure
-        $diff = array();
+        $diff = [];
 
         // Loop over this instance data
         foreach ($thisData AS $key=>$value) {
             if (!in_array($key, $this->_doubleDataEntryDiffIgnoreColumns)) {
                 if ($otherData[$key] != $value) {
-                    $diff[] = array(
+                    $diff[] = [
                         'TableName'      => $this->table,
                         'ExtraKeyColumn' => null,
                         'ExtraKey1'      => ' ',
@@ -2095,7 +2095,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                         'Value1'         => $value,
                         'CommentId2'     => $otherInstrument->getCommentID(),
                         'Value2'         => $otherData[$key],
-                    );
+                    ];
                 }
             }
         }
@@ -2120,15 +2120,15 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if ($instrumentInstance->jsonData) {
             $jsondata = $db->pselectOne(
                 "SELECT Data FROM flag WHERE CommentID=:CID",
-                array('CID' => $instrumentInstance->getCommentID())
+                ['CID' => $instrumentInstance->getCommentID()]
             );
-            return json_decode($jsondata, true) ?? array();
+            return json_decode($jsondata, true) ?? [];
         } else {
             $defaults = $db->pselectRow(
                 "SELECT * FROM $instrumentInstance->table WHERE CommentID=:CID",
-                array('CID' => $instrumentInstance->getCommentID())
+                ['CID' => $instrumentInstance->getCommentID()]
             );
-            return $defaults ?? array();
+            return $defaults ?? [];
         }
     }
 
@@ -2149,14 +2149,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getCandidateAge(?string $date = null): array
     {
-        $dates     = array(
+        $dates     = [
             'Date_taken' => $this->getFieldValue('Date_taken'),
             'DoB'        => $this->getDoB(),
             'DoD'        => $this->getDoD(),
-        );
+        ];
         $dateTaken = empty($date) ? $dates['Date_taken'] : $date;
 
-        $age = array();
+        $age = [];
         if (empty($dates['DoD']) || $dates['DoD'] > $dateTaken) {
             $age = Utility::calculateAge($dates['DoB'], $dateTaken);
         } else {
@@ -2181,7 +2181,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
             WHERE f.CommentID=:CID",
-            array('CID' => $CommentID)
+            ['CID' => $CommentID]
         );
         return $dob;
     }
@@ -2200,7 +2200,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
             WHERE f.CommentID=:CID",
-            array('CID' => $CommentID)
+            ['CID' => $CommentID]
         );
         return $dod ?? null;
     }
@@ -2220,7 +2220,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             JOIN session s ON (f.SessionID=s.ID)
             JOIN candidate c USING (CandID)
             WHERE f.CommentID=:CID",
-            array('CID' => $CommentID)
+            ['CID' => $CommentID]
         );
         return $pscid;
     }
@@ -2238,13 +2238,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $columns  = $db->pselect(
             "SELECT COLUMN_NAME FROM information_schema.columns
             WHERE TABLE_NAME=:table AND TABLE_SCHEMA=:db",
-            array(
+            [
                 'table' => $this->table,
                 'db'    => $dbconfig['database'],
-            )
+            ]
         );
 
-        $values = array();
+        $values = [];
         foreach ($columns as $row) {
             switch ($row['COLUMN_NAME']) {
             case 'CommentID':
@@ -2257,15 +2257,15 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $values[$row['COLUMN_NAME']] = null;
             }
         }
-        $db->update($this->table, $values, array('CommentID' => $this->commentID));
+        $db->update($this->table, $values, ['CommentID' => $this->commentID]);
         $prepQ = $db->prepare(
             "DELETE FROM conflicts_unresolved
              WHERE (CommentId1=:CID OR CommentId2=:CID)"
         );
         $db->execute(
             $prepQ,
-            array('CID' => $this->commentID),
-            array('nofetch' => true)
+            ['CID' => $this->commentID],
+            ['nofetch' => true]
         );
     }
 
@@ -2389,19 +2389,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $DB = Database::singleton();
 
         $smarty   = new Smarty_NeuroDB();
-        $tpl_data = array();
+        $tpl_data = [];
 
         $tpl_data['questions'] = $DB->pselect(
             "SELECT Description as question,
             SourceField FROM parameter_type
             WHERE SourceFrom=:TN AND
             SourceField NOT IN ('Validity', 'Administration')",
-            array('TN' => $this->testName)
+            ['TN' => $this->testName]
         );
 
         $Responses = $DB->pselectRow(
             "SELECT * FROM " . $this->table . " WHERE CommentID=:CID",
-            array('CID' => $this->getCommentID())
+            ['CID' => $this->getCommentID()]
         );
 
         foreach ($tpl_data['questions'] as &$row) {
@@ -2435,7 +2435,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $html = new DOMDocument();
             $html->loadHTML($element['html']);
 
-            $element['options'] = array();
+            $element['options'] = [];
 
             $selectEl = $html->getElementsByTagName("select")->item(0);
 
@@ -2453,11 +2453,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             }
         } else if ($element['type'] === "date") {
             if (get_class($this->form) === 'LorisForm') {
-                $element['options'] = array(
+                $element['options'] = [
                     'mindate'         => "1990-01-01",
                     'maxdate'         => "2000-12-31",
                     'RequireResponse' => false,
-                );
+                ];
                 //$element['RequireResponse'] = false;
             } else {
                 $html = new DOMDocument();
@@ -2485,10 +2485,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     // the last item is the maximum year
                     $maxYear = $year->lastChild->textContent;
 
-                    $element['options'] = array(
+                    $element['options'] = [
                         'mindate' => $minYear . "-01-01",
                         'maxdate' => $maxYear . "-12-31",
-                    );
+                    ];
 
                 }
             }
@@ -2631,7 +2631,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $this->form->addPageBreak(
                     $subtest['Name'],
                     $subtest['Description'],
-                    array()
+                    []
                 );
             }
             $this->page = $subtest['Name'];
@@ -2657,7 +2657,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $DB    = Database::singleton();
         $entry = $DB->pselectOne(
             "SELECT Data_entry FROM flag WHERE CommentID=:CID",
-            array('CID' => $this->getCommentId())
+            ['CID' => $this->getCommentId()]
         );
 
         if ($entry === 'Complete') {
@@ -2693,7 +2693,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
              FROM
                flag
              WHERE CommentID = :v_commentid',
-            array('v_commentid' => $this->getCommentId())
+            ['v_commentid' => $this->getCommentId()]
         );
 
         $dataentry      = $row['dataentry'] ?? null;

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -38,40 +38,40 @@ class NDB_BVL_InstrumentStatus
     /**
      * The set of valid options for the data entry flag
      */
-    var $_dataEntryOptions = array(
+    var $_dataEntryOptions = [
         null,
         'In Progress',
         'Complete',
-    );
+    ];
 
     /**
      * The set of valid options for the administration flag
      */
-    var $_administrationOptions = array(
+    var $_administrationOptions = [
         null,
         'None',
         'Partial',
         'All',
-    );
+    ];
 
     /**
      * The set of valid options for the validity flag
      */
-    var $_validityOptions = array(
+    var $_validityOptions = [
         null,
         'Valid',
         'Questionable',
         'Invalid',
-    );
+    ];
 
     /**
      * The set of valid options for the exclusion flag
      */
-    var $_exclusionOptions = array(
+    var $_exclusionOptions = [
         null,
         'Fail',
         'Pass',
-    );
+    ];
 
     /**
      * Loads the object with the current status of the instrument
@@ -91,7 +91,7 @@ class NDB_BVL_InstrumentStatus
         $query = "SELECT SessionID, Data_entry, Administration, Validity, Exclusion
             FROM flag
             WHERE CommentID=:CID";
-        $row   = $db->pselectRow($query, array('CID' => $this->_commentID));
+        $row   = $db->pselectRow($query, ['CID' => $this->_commentID]);
         if (is_null($row)) {
             throw new \LorisException(
                 'No information exists in the database for the specified '
@@ -177,8 +177,8 @@ class NDB_BVL_InstrumentStatus
 
         $GLOBALS['DB']->update(
             'flag',
-            array('Data_entry' => $status),
-            array('CommentID' => $this->_commentID)
+            ['Data_entry' => $status],
+            ['CommentID' => $this->_commentID]
         );
 
         $this->select($this->_commentID);
@@ -194,10 +194,10 @@ class NDB_BVL_InstrumentStatus
             $query = $GLOBALS['DB']->pselect(
                 "SELECT Data_entry FROM flag
                 WHERE CommentID=:PCID OR CommentID=:DDECID",
-                array(
+                [
                     'PCID'   => $principalCommentId,
                     'DDECID' => $DDECommentId,
-                )
+                ]
             );
 
             // Run ConflictDetector if Data_entry of SDE and DDE are both Complete
@@ -225,8 +225,8 @@ class NDB_BVL_InstrumentStatus
         // Remove conflicts for SDE & DDE form from the
         // Conflict Resolver if new status is 'In Progress'
         if ($this->getDataEntryStatus() != null && $status == 'In Progress') {
-            $deleteWhere1 = array('CommentId1' => $this->_commentID);
-            $deleteWhere2 = array('CommentId2' => $this->_commentID);
+            $deleteWhere1 = ['CommentId1' => $this->_commentID];
+            $deleteWhere2 = ['CommentId2' => $this->_commentID];
             $GLOBALS['DB']->delete('conflicts_unresolved', $deleteWhere1);
             $GLOBALS['DB']->delete('conflicts_unresolved', $deleteWhere2);
         }
@@ -253,8 +253,8 @@ class NDB_BVL_InstrumentStatus
 
         $GLOBALS['DB']->update(
             'flag',
-            array('Administration' => $status),
-            array('CommentID' => $this->_commentID)
+            ['Administration' => $status],
+            ['CommentID' => $this->_commentID]
         );
         $this->select($this->_commentID);
     }
@@ -279,8 +279,8 @@ class NDB_BVL_InstrumentStatus
 
         $GLOBALS['DB']->update(
             'flag',
-            array('Validity' => $status),
-            array('CommentID' => $this->_commentID)
+            ['Validity' => $status],
+            ['CommentID' => $this->_commentID]
         );
         $this->select($this->_commentID);
     }
@@ -304,8 +304,8 @@ class NDB_BVL_InstrumentStatus
 
         $GLOBALS['DB']->update(
             'flag',
-            array('Exclusion' => $status),
-            array('CommentID' => $this->_commentID)
+            ['Exclusion' => $status],
+            ['CommentID' => $this->_commentID]
         );
         $this->select($this->_commentID);
     }

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -176,11 +176,11 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             }
         }
         // get control panel selections from _REQUEST
-        $possibleFlags = array(
+        $possibleFlags = [
             'setDataEntry',
             'setAdministration',
             'setValidity',
-        );
+        ];
         $flagsToSave   = array_intersect($possibleFlags, array_keys($_REQUEST));
 
         // make sure there are at least one flag to save

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -32,9 +32,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
     public $InstrumentType = 'LINST';
 
-    public $LinstQuestions = array();
+    public $LinstQuestions = [];
 
-    public $LinstLines = array();
+    public $LinstLines = [];
 
     private $_selectMultipleElements;
 
@@ -65,14 +65,14 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         $factory = \NDB_Factory::singleton();
         $config  = $factory->config();
 
-        $dateOptions = array(
+        $dateOptions = [
             'language'         => 'en',
             'format'           => 'YMd',
             'minYear'          => $config->getSetting('startYear'),
             'maxYear'          => $config->getSetting('endYear'),
             'addEmptyOption'   => true,
             'emptyOptionValue' => null,
-        );
+        ];
 
         $this->dateOptions = $dateOptions;
 
@@ -122,7 +122,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         unset($elements['key'], $elements['pageNum'], $elements['nextpage']);
         $this->XINDebug = false;  //Turn this on to see rules debuggin output
 
-        $errors = array();
+        $errors = [];
         foreach ($elements AS $elname => $elvalue) {
             //If the element is a group (and thus elvalue is an array)
             //trigger the Null Value default rule if ANY of the values
@@ -197,7 +197,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     //debugging code
                     echo "<p><b>$elname</b><br> ";
                 }
-                $rules_array = array();
+                $rules_array = [];
                 foreach ($registered_rules as $registered) {
                     $rules = $registered['rules'];
 
@@ -263,7 +263,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         }
                     }
                 } else if (substr($elname, -7) != "_status"
-                    && !in_array($elname, array("page", "subtest"))
+                    && !in_array($elname, ["page", "subtest"])
                 ) {
                     $errors[$elname] = "Required.";
                     if ($this->XINDebug) {
@@ -362,11 +362,11 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         // the if statement and use the same logic for "old" instruments and "new"
         // instruments
         //  -- Dave
-        $rule = array(
+        $rule = [
             'message' => $message,
             'group'   => $group,
-            'rules'   => array(),
-        );
+            'rules'   => [],
+        ];
 
         foreach ($rules AS $rule_cmd) {
             $rule['rules'][] = $rule_cmd;
@@ -397,10 +397,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             if (!isset($this->form)) {
                 $this->form = new \LorisForm();
             }
-            $this->dateTimeFields = array("Date_taken");
+            $this->dateTimeFields = ["Date_taken"];
             $this->formType       = 'XIN';
 
-            $this->form->addFormRule(array(&$this, 'XINValidate'));
+            $this->form->addFormRule([&$this, 'XINValidate']);
             $fp = fopen($filename, "r");
 
             // Add elements is only true if we're parsing the current page,
@@ -418,11 +418,11 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             $parsingPage       = 'top';
             $firstSelectOfPage = true;
 
-            $Group = array(
+            $Group = [
                 'Name'      => null,
-                'Elements'  => array(),
+                'Elements'  => [],
                 'Delimiter' => $this->_GUIDelimiter,
-            );
+            ];
 
             while (($line = fgets($fp, 4096)) !== false) {
                 $pieces = preg_split("/{@}/", $line);
@@ -447,10 +447,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         "SELECT Subtest_name
                         FROM instrument_subtests
                         WHERE Test_name=:testinst AND Description=:parsing",
-                        array(
+                        [
                             'testinst' => $this->testName,
                             'parsing'  => $parsingPage,
-                        )
+                        ]
                     );
                     if ($currentPage == $pageName) {
                         $addElements = true;
@@ -495,7 +495,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         );
 
                         $Group['Name']     = null;
-                        $Group['Elements'] = array();
+                        $Group['Elements'] = [];
                     }
                     break;
 
@@ -531,7 +531,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $this->addTextElement($pieces[1], $pieces[2]);
                         }
                     }
-                    $this->LinstQuestions[$pieces[1]] = array('type' => 'text');
+                    $this->LinstQuestions[$pieces[1]] = ['type' => 'text'];
                     break;
                 case 'textarea':
                     $this->_doubleDataEntryDiffIgnoreColumns[] = $pieces[1];
@@ -545,7 +545,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             $this->addTextAreaElement($pieces[1], $pieces[2]);
                         }
                     }
-                    $this->LinstQuestions[$pieces[1]] = array('type' => 'textarea');
+                    $this->LinstQuestions[$pieces[1]] = ['type' => 'textarea'];
                     break;
                 case 'date':
                     if (strpos($pieces[1], "_date") !== false) {
@@ -559,14 +559,14 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         if ($pieces[3] == 1900 && $pieces[4] == 2100) {
                             $dateOptions = null;
                         } else {
-                            $dateOptions = array(
+                            $dateOptions = [
                                 'language'         => 'en',
                                 'format'           => 'YMd',
                                 'minYear'          => $pieces[3],
                                 'maxYear'          => $pieces[4],
                                 'addEmptyOption'   => true,
                                 'emptyOptionValue' => null,
-                            );
+                            ];
                         }
 
                         // Set date format
@@ -597,19 +597,19 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             );
                         }
                     }
-                    $this->LinstQuestions[$pieces[1]] = array('type' => 'date');
+                    $this->LinstQuestions[$pieces[1]] = ['type' => 'date'];
                     break;
                 case 'numeric':
                     if ($addElements) {
                         $this->addNumericElement($pieces[1], $pieces[2]);
                     }
                     // FIXME: This variable is never populated.
-                    $options = array();
+                    $options = [];
                     $this->LinstQuestions[$pieces[1]]
-                        = array(
+                        = [
                             'type'    => 'numeric',
                             'options' => $options,
-                        );
+                        ];
                     break;
 
                 case 'selectmultiple':
@@ -618,7 +618,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     // fall through and also execute select code below
                 case 'select':
                     $options = preg_split("/{-}/", trim($pieces[3]));
-                    $opt     = array();
+                    $opt     = [];
 
                     foreach ($options as $o) {
                         $arr = explode("=>", $o);
@@ -662,7 +662,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                     $pieces[1],
                                     $pieces[2],
                                     $opt,
-                                    array("multiple" => "multiple")
+                                    ["multiple" => "multiple"]
                                 );
                             } else {
                                 $this->form->addElement(
@@ -679,7 +679,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         $this->_requiredElements[] = $pieces[1];
                         $firstSelectOfPage         = false;
                     }
-                    $this->LinstQuestions[$pieces[1]] = array('type' => 'select');
+                    $this->LinstQuestions[$pieces[1]] = ['type' => 'select'];
                     break;
                 case 'header':
                     if ($addElements) {
@@ -706,7 +706,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             );
                         }
                     }
-                    $this->LinstQuestions[$pieces[1]] = array('type' => 'score');
+                    $this->LinstQuestions[$pieces[1]] = ['type' => 'score'];
                     break;
                 default:
                     break;
@@ -795,17 +795,17 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
      */
     function toJSON(): string
     {
-        $jsonObject = array(
-            'Meta'     => array(
+        $jsonObject = [
+            'Meta'     => [
                 "InstrumentVersion"       => "1l",
                 "InstrumentFormatVersion" => "v0.0.1a-dev",
                 "ShortName"               => "",
                 "LongName"                => "",
                 "IncludeMetaDataFields"   => "true",
-            ),
-            'Elements' => array(),
-        );
-        $elements   = array();
+            ],
+            'Elements' => [],
+        ];
+        $elements   = [];
         $pageTitle  = 'Top';
 
         foreach ($this->LinstLines as $value) {
@@ -813,7 +813,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 $lastIndex = count($elements) - 1;
                 $elements[$lastIndex]['Options']['RequireResponse'] = true;
             } else {
-                $element         = array();
+                $element         = [];
                 $element['Type'] = $value[0];
                 $element['Name'] = $value[1];
                 $specialCase     = false;
@@ -826,7 +826,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $element['Type'] = 'select';
                 case 'select':
                     $selectOptions = preg_split("/{-}/", trim($value[3]));
-                    $opt           = array();
+                    $opt           = [];
                     $RequireResponse = false;
                     foreach ($selectOptions as $o) {
                         $arr = explode("=>", $o);
@@ -847,35 +847,35 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         }
                     }
                     $AllowMultiple      = ($specialCase ? true : false);
-                    $element['Options'] = array(
+                    $element['Options'] = [
                         'Values'          => $opt,
                         'AllowMultiple'   => $AllowMultiple,
                         'RequireResponse' => $RequireResponse,
-                    );
+                    ];
                     break;
                 case 'textarea':
                     $specialCase     = true;
                     $element['Type'] = 'text';
                 case 'text':
                     $textType           = ($specialCase ? 'large' : 'small');
-                    $element['Options'] = array('Type' => $textType);
+                    $element['Options'] = ['Type' => $textType];
                     break;
                 case 'date':
                     $minDate            = $value[3] . "-01-01";
                     $maxDate            = rtrim($value[4]) . "-12-31";
-                    $element['Options'] = array(
+                    $element['Options'] = [
                         'MinDate' => $minDate,
                         'MaxDate' => $maxDate,
-                    );
+                    ];
                     break;
                 case 'numeric':
                     $minval = isset($value[3]) ? (int) $value[3] : null;
                     $maxval = (int) rtrim($value[4] ?? null);
-                    $element['Options'] = array(
+                    $element['Options'] = [
                         'NumberType' => 'integer',
                         'MinValue'   => $minval,
                         'MaxValue'   => $maxval,
-                    );
+                    ];
                     break;
                 case 'score':
                     break;
@@ -884,15 +884,15 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     unset($element['Name']);
                     break;
                 case 'page':
-                    $pageElement = array(
+                    $pageElement = [
                         "Type"        => "ElementGroup",
                         "GroupType"   => "Page",
                         "Description" => $pageTitle,
                         "Elements"    => $elements,
-                    );
+                    ];
                     $jsonObject['Elements'][] = $pageElement;
                     unset($element['Type']);
-                    $elements  = array();
+                    $elements  = [];
                     $pageTitle = rtrim($value[2]);
                     break;
                 case 'table':
@@ -912,12 +912,12 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         if (empty($jsonObject['Elements'])) {
             $jsonObject['Elements'] = $elements;
         } else {
-            $pageElement = array(
+            $pageElement = [
                 "Type"        => "ElementGroup",
                 "GroupType"   => "Page",
                 "Description" => $pageTitle,
                 "Elements"    => $elements,
-            );
+            ];
             $jsonObject['Elements'][] = $pageElement;
         }
         return json_encode($jsonObject);

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -98,7 +98,7 @@ class NDB_Client
             FROM Config c
             JOIN ConfigSettings cs ON (c.ConfigID=cs.ID)
             WHERE cs.Name=:nm",
-            array("nm" => "CSPAdditionalHeaders")
+            ["nm" => "CSPAdditionalHeaders"]
         );
         if (empty($config_additions)) {
             $config_additions = "";
@@ -132,7 +132,7 @@ class NDB_Client
             . $config_additions
         );
         // start php session
-        $sessionOptions = array('cookie_httponly' => true);
+        $sessionOptions = ['cookie_httponly' => true];
         $sessionOptions['cookie_samesite'] = true;
 
         // API Detect

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -36,7 +36,7 @@ class NDB_Config
      *
      * @access private
      */
-    var $_settings = array();
+    var $_settings = [];
 
     /**
      * An optional override for the location of the config file.
@@ -164,7 +164,7 @@ class NDB_Config
      */
     static function convertToArray(SimpleXMLElement $xml)
     {
-        $retVal   = array();
+        $retVal   = [];
         $children = $xml->children();
         if ($children->count() > 0) {
             foreach ($children as $child) {
@@ -176,7 +176,7 @@ class NDB_Config
                         // be stored in an array. Create a new array and replace
                         // the tag with what was already parsed before appending
                         // the child
-                        $newArray = array();
+                        $newArray = [];
 
                         $Extant        = $retVal[$name];
                         $newArray[]    = $Extant;
@@ -189,9 +189,9 @@ class NDB_Config
                     $attributes = $child->attributes();
                     if (count($attributes) > 0) {
                         if (!is_array($Converted)) {
-                            $Converted = array($Converted);
+                            $Converted = [$Converted];
                         }
-                        $Converted['@'] = array();
+                        $Converted['@'] = [];
                         foreach ($attributes as $atname => $val) {
                             $Converted['@'][$atname] = $val->__toString();
                         }
@@ -203,9 +203,9 @@ class NDB_Config
 
                     if (count($attributes) > 0) {
                         if (!is_array($retVal[$name])) {
-                            $retVal[$name] = array($retVal[$name]);
+                            $retVal[$name] = [$retVal[$name]];
                         }
-                        $retVal[$name]['@'] = array();
+                        $retVal[$name]['@'] = [];
                         foreach ($attributes as $atname => $val) {
                             $retVal[$name]['@'][$atname] = $val->__toString();
 
@@ -217,10 +217,10 @@ class NDB_Config
             $retVal     = $xml->__toString();
             $attributes = $xml->attributes();
             if ($attributes->count() > 0) {
-                $retVal = array(
+                $retVal = [
                     '#' => $retVal,
-                    '@' => array(),
-                );
+                    '@' => [],
+                ];
                 foreach ($attributes as $name => $val) {
                     $retVal['@'][$name] = $val->__toString();
 
@@ -243,7 +243,7 @@ class NDB_Config
      */
     static function isNumericArray(array $arr): bool
     {
-        if ($arr === array()) {
+        if ($arr === []) {
             return true;
         }
         return array_keys($arr) === range(0, count($arr) - 1);
@@ -295,7 +295,7 @@ class NDB_Config
                 FROM ConfigSettings cs
                     LEFT JOIN ConfigSettings child ON (child.Parent=cs.ID)
                 WHERE cs.Name=:nm",
-                array("nm" => $name)
+                ["nm" => $name]
             );
 
             if (count($configSetting) === 0) {
@@ -310,7 +310,7 @@ class NDB_Config
                 FROM ConfigSettings cs
                     LEFT JOIN ConfigSettings child ON (child.Parent=cs.ID)
                 WHERE cs.ID=:nm",
-                array("nm" => $id)
+                ["nm" => $id]
             );
         }
 
@@ -325,7 +325,7 @@ class NDB_Config
             if ($configSetting['AllowMultiple'] == '0') {
                 $val = $db->pselectOne(
                     "SELECT Value FROM Config WHERE ConfigID=:CID",
-                    array('CID' => $configSetting['ParentID'])
+                    ['CID' => $configSetting['ParentID']]
                 );
                 if (empty($val)) {
                     return null;
@@ -336,9 +336,9 @@ class NDB_Config
                 // as ie. $config->getSetting("DoubleDataEntryInstruments")
                 $val = $db->pselect(
                     "SELECT Value FROM Config WHERE ConfigID=:CID",
-                    array('CID' => $configSetting['ParentID'])
+                    ['CID' => $configSetting['ParentID']]
                 );
-                $ret = array();
+                $ret = [];
                 foreach ($val as $item) {
                     $ret[] = $item['Value'];
                 }
@@ -346,7 +346,7 @@ class NDB_Config
             }
         } else if (count($configSetting) > 1) {
             // This was a parent element, so construct the children.
-            $tree = array();
+            $tree = [];
             foreach ($configSetting as $childSetting) {
                 $childName        = $childSetting['Name'];
                 $childID          = $childSetting['ChildID'];
@@ -446,18 +446,18 @@ class NDB_Config
                 "SELECT ProjectID, Name, Alias, recruitmentTarget
                  FROM Project
                  WHERE ProjectID=:sp",
-                array('sp' => $ProjectID)
+                ['sp' => $ProjectID]
             );
 
         //Format the result into config.xml format.
         return is_null($info) ?
             null
-            : array(
+            : [
                 'id'                => $info['ProjectID'],
                 'Name'              => $info['Name'],
                 'Alias'             => $info['Alias'],
                 'recruitmentTarget' => $info['recruitmentTarget'],
-            );
+            ];
     }
 
     /**
@@ -478,24 +478,24 @@ class NDB_Config
 
         $info = $DB->pselectRow(
             "SELECT * FROM subproject WHERE SubprojectID=:sp",
-            array('sp' => $subprojectID)
+            ['sp' => $subprojectID]
         );
         // Format the results the same way it was formatted in config.xml
         // This variable assignment was done for phpcs... if anyone figures out
         // a way around this, please correct it
         if (!empty($info)) {
             $x = $info['WindowDifference'];
-            return array(
+            return [
                 'id'                => $info['SubprojectID'],
                 'title'             => $info['title'],
-                'options'           => array(
+                'options'           => [
                     'useEDC'           => $info['useEDC'],
                     'WindowDifference' => $x,
-                ),
+                ],
                 'RecruitmentTarget' => $info['RecruitmentTarget'],
-            );
+            ];
         }
-        return array();
+        return [];
     }
 
 
@@ -516,10 +516,10 @@ class NDB_Config
                 FROM ExternalLinks l JOIN ExternalLinkTypes lt
                     ON (l.LinkTypeID=lt.LinkTypeID)
                 WHERE lt.LinkType=:name",
-            array('name' => $type)
+            ['name' => $type]
         );
 
-        $mapped = array();
+        $mapped = [];
         foreach ($results as $row) {
             $mapped[$row['LinkText']] = $row['LinkURL'];
         }

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -37,10 +37,10 @@ class NDB_Factory
     public static $db     = null;
     public static $config = null;
 
-    private static $_couchdb    = array();
+    private static $_couchdb    = [];
     private static $_user       = null;
-    private static $_candidates = array();
-    private static $_timepoints = array();
+    private static $_candidates = [];
+    private static $_timepoints = [];
 
     private $_baseURL = "";
     var $Testing; // Whether or not Mock objects should be returned instead of
@@ -94,15 +94,15 @@ class NDB_Factory
         self::$testdb = null;
         self::$db     = null;
 
-        self::$_couchdb = array();
+        self::$_couchdb = [];
         self::$_user    = null;
 
         self::$config = null;
 
         self::$_settings = null;
 
-        self::$_candidates = array();
-        self::$_timepoints = array();
+        self::$_candidates = [];
+        self::$_timepoints = [];
 
         $this->_baseURL = "";
     }
@@ -344,12 +344,12 @@ class NDB_Factory
                 'CouchDB',
                 'MockCouchDBWrap',
                 /* mock out the functions that make HTTP requests */
-                array(
+                [
                     '_getRelativeURL',
                     '_postRelativeURL',
                     '_postURL',
                     '_getURL',
-                )
+                ]
             );
             self::$_couchdb[$database] = new MockCouchDBWrap();
         } else {

--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -125,7 +125,7 @@ class NDB_Form extends NDB_Page
     function save()
     {
         if ($this->form->validate()) {
-            $this->form->process(array(&$this, "_save"));
+            $this->form->process([&$this, "_save"]);
         }
     }
 
@@ -200,9 +200,9 @@ class NDB_Form extends NDB_Page
      */
     function toArray(): array
     {
-        return array(
+        return [
             'fieldOptions' => $this->fieldOptions,
-        );
+        ];
     }
 
     /**

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -127,6 +127,6 @@ class NDB_Menu extends NDB_Page
      */
     function toJSON(): string
     {
-        return json_encode(array('error' => 'Not implemented'));
+        return json_encode(['error' => 'Not implemented']);
     }
 }

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -72,7 +72,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @var    array
      * @access private
      */
-    var $validFilters = array();
+    var $validFilters = [];
 
     /**
      * Items selected from the GUI to filter, where the underlying
@@ -84,14 +84,14 @@ class NDB_Menu_Filter extends NDB_Menu
     /**
      * Filters that the
      */
-    var $validHavingFilters = array();
+    var $validHavingFilters = [];
     /**
      * Associates the form element to the appropriate filter
      *
      * @var    array
      * @access private
      */
-    var $formToFilter = array();
+    var $formToFilter = [];
 
     /**
      * An array of all the table headers (optional)
@@ -101,7 +101,7 @@ class NDB_Menu_Filter extends NDB_Menu
      * @var    array
      * @access private
      */
-    var $headers = array();
+    var $headers = [];
 
     /**
      * The list of candidates, users, etc
@@ -117,13 +117,13 @@ class NDB_Menu_Filter extends NDB_Menu
      * (Note that HTTP sends nothing if a checkbox is
      * unchecked.)
      */
-    var $CheckboxFilters = array();
+    var $CheckboxFilters = [];
 
     /**
      * A list of fields which are to be searched if the
      * search keyword is used.
      */
-    var $searchKey = array();
+    var $searchKey = [];
 
     /**
      * Calls other member functions to do all the work necessary to create the menu
@@ -223,7 +223,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function _setFilters($values)
     {
-        $newFormFilters = array();
+        $newFormFilters = [];
 
         // Go through the form's fields and set the valid ones.
         foreach ($this->formToFilter as $formKey => $dbField) {
@@ -267,7 +267,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // the session previously in $this->_setupFilters.
         $savedFilters = $_SESSION['State']->getProperty('filter');
         if (!is_array($savedFilters)) {
-            $savedFilters = array();
+            $savedFilters = [];
         }
         if (is_array($order) && in_array($order['field'], $this->headers)) {
             $savedFilters['order'] = $order;
@@ -288,7 +288,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function _setSearchKeyword($keyword)
     {
-        $this->searchKey = array('keyword' => $keyword);
+        $this->searchKey = ['keyword' => $keyword];
     }
 
     /**
@@ -467,7 +467,7 @@ class NDB_Menu_Filter extends NDB_Menu
         // create DB object
         $DB =& Database::singleton();
 
-        $qparams = array();
+        $qparams = [];
         // add the base query
         $query  = '';
         $query .= $this->_getBaseQuery();
@@ -508,7 +508,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function _getBaseFilter()
     {
-        $qparams     = array();
+        $qparams     = [];
         $WhereClause = '';
         // add filters to query
         if (is_array($this->filter) && count($this->filter) > 0) {
@@ -534,7 +534,7 @@ class NDB_Menu_Filter extends NDB_Menu
             && !empty($this->searchKey['keyword'])
         ) {
             $WhereClause .= " AND (";
-            $fields       = array();
+            $fields       = [];
             foreach ($this->searchKeyword as $field) {
                 $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
             }
@@ -571,10 +571,10 @@ class NDB_Menu_Filter extends NDB_Menu
             }
         }
 
-        return array(
+        return [
             'clause' => $WhereClause,
             'params' => $qparams,
-        );
+        ];
     }
 
     /**
@@ -716,10 +716,10 @@ class NDB_Menu_Filter extends NDB_Menu
     function getCSVData()
     {
         return $this->arrayToCSV(
-            array(
+            [
                 'data'    => $this->_getFullList(),
                 'headers' => $this->headers,
-            )
+            ]
         );
 
     }
@@ -789,16 +789,16 @@ class NDB_Menu_Filter extends NDB_Menu
             $this->headers
         );
 
-        $MappedData = array();
+        $MappedData = [];
         foreach ($data as $row) {
             $MappedData[] = array_values($row);
         }
 
-        return array(
+        return [
             'Headers'      => $headers,
             'Data'         => $MappedData,
             'fieldOptions' => $this->fieldOptions,
-        );
+        ];
     }
 
     /**
@@ -823,7 +823,7 @@ class NDB_Menu_Filter extends NDB_Menu
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $qparams = array();
+        $qparams = [];
         // add the base query
         $query  = '';
         $query .= $this->_getBaseQuery();
@@ -857,7 +857,7 @@ class NDB_Menu_Filter extends NDB_Menu
      */
     function _getFilterValues()
     {
-        $FilterValues = array();
+        $FilterValues = [];
         foreach (array_keys($this->formToFilter) as $formName) {
             if (isset($_REQUEST[$formName])) {
                 $FilterValues[$formName] = $_REQUEST[$formName];
@@ -881,11 +881,11 @@ class NDB_Menu_Filter extends NDB_Menu
         $baseURL = $factory->settings()->getBaseURL();
         return array_merge(
             $depends,
-            array(
+            [
                 $baseURL . '/js/components/PaginationLinks.js',
                 $baseURL . '/js/components/StaticDataTable.js',
                 $baseURL . '/js/components/DynamicDataTable.js',
-            )
+            ]
         );
     }
 }

--- a/php/libraries/NDB_Menu_Filter_Form.class.inc
+++ b/php/libraries/NDB_Menu_Filter_Form.class.inc
@@ -47,7 +47,7 @@ class NDB_Menu_Filter_Form extends NDB_Menu_Filter
             || !empty($_REQUEST['fire_away'])
         ) {
             if ($this->form->validate()) {
-                $this->form->process(array(&$this, "_save"));
+                $this->form->process([&$this, "_save"]);
             }
         }
     }

--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -37,7 +37,7 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     public function __construct(
         string $module_name,
         string $operation_type,
-        array $extra_tpl_data = array(),
+        array $extra_tpl_data = [],
         bool $asAdmin = false
     ) {
         parent::__construct(
@@ -58,7 +58,7 @@ class NDB_Notifier extends NDB_Notifier_Abstract
      * @return void
      */
     public function notify(
-        array $extra_tpl_data=array(),
+        array $extra_tpl_data=[],
         ?string $custom_message=null
     ): void {
         $this->tpl_data = $this->tpl_data + $extra_tpl_data;

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -75,7 +75,7 @@ abstract class NDB_Notifier_Abstract
      *
      * @var array
      */
-    protected $notified =array();
+    protected $notified =[];
 
     /**
      * Module for which the notifier is setup
@@ -103,7 +103,7 @@ abstract class NDB_Notifier_Abstract
      *
      * @var array
      */
-    protected $tpl_data =array();
+    protected $tpl_data =[];
 
     /**
      * NDB_Notifier constructor.
@@ -199,12 +199,12 @@ abstract class NDB_Notifier_Abstract
     {
         $result = \Database::singleton()->pselectRow(
             "SELECT ID, Real_name, Email FROM users WHERE UserID='admin'",
-            array()
+            []
         );
         if (is_null($result)) {
-            return array();
+            return [];
         }
-        $info_array          = array();
+        $info_array          = [];
         $info_array['ID']    = $result['ID'];
         $info_array['name']  = $result['Real_name'];
         $info_array['email'] = $result['Email'];
@@ -241,10 +241,10 @@ abstract class NDB_Notifier_Abstract
                   WHERE nm.module_name=:nm
                     AND nm.operation_type=:ot
                     ";
-        $params = array(
+        $params = [
             "nm" => $this->module,
             "ot" => $this->operation,
-        );
+        ];
 
         if (!$this->_asAdmin) {
             $query        .=" AND (FIND_IN_SET(upsc.CenterID,:cid) > 0 
@@ -260,7 +260,7 @@ abstract class NDB_Notifier_Abstract
         $result = \Database::singleton()->pselect($query, $params);
 
         //parse $result and create 2D array
-        $n_list = array();
+        $n_list = [];
         foreach ($result as $row) {
             if ($this->_hasNotificationPermission((int)$row['user'])) {
                 $n_list[$row['service']][$row['Real_name']] = $row['user'];
@@ -283,7 +283,7 @@ abstract class NDB_Notifier_Abstract
         $DB      = Database::singleton();
         $current = $DB->pselect(
             "SELECT * FROM user_perm_rel WHERE userID=:uid",
-            array("uid" => $uid)
+            ["uid" => $uid]
         );
 
         $necessary = $DB->pselect(
@@ -292,14 +292,14 @@ abstract class NDB_Notifier_Abstract
                   JOIN notification_modules nm ON (nm.id=mp.notification_module_id)
              WHERE nm.module_name=:mid
                   AND nm.operation_type=:ot",
-            array(
+            [
                 "mid" => $this->module,
                 "ot"  => $this->operation,
-            )
+            ]
         );
 
-        $reqPerm  =array();
-        $userPerm =array();
+        $reqPerm  =[];
+        $userPerm =[];
         //Build and compare arrays
         foreach ($necessary as $k=>$row) {
             $reqPerm[] =$row['perm_id'];
@@ -328,7 +328,7 @@ abstract class NDB_Notifier_Abstract
     {
         return \Database::singleton()->pselectOne(
             "SELECT Email FROM users WHERE ID=:uid",
-            array("uid" => $uid)
+            ["uid" => $uid]
         );
     }
 
@@ -343,7 +343,7 @@ abstract class NDB_Notifier_Abstract
     {
         return \Database::singleton()->pselectOne(
             "SELECT Phone FROM users WHERE ID=:uid",
-            array("uid" => $uid)
+            ["uid" => $uid]
         );
     }
 
@@ -372,7 +372,7 @@ abstract class NDB_Notifier_Abstract
 
         \Database::singleton()->insert(
             'notification_history',
-            array(
+            [
                 "module_id"    => $this->getNotificationModuleID(
                     $this->module,
                     $this->operation
@@ -382,7 +382,7 @@ abstract class NDB_Notifier_Abstract
                 ),
                 "trigger_user" => $trigger_user,
                 "target_user"  => $target_user,
-            )
+            ]
         );
     }
 
@@ -413,10 +413,10 @@ abstract class NDB_Notifier_Abstract
                       ON (mp.notification_module_id=nm.id)
               LEFT JOIN permissions p ON (p.permID=mp.perm_id)
                       ";
-        $params = array();
+        $params = [];
         $result = $DB->pselect($query, $params);
 
-        $n_list =array();
+        $n_list =[];
         foreach ($result as $row) {
             $mn   = $row['module_name'];
             $ot   = $row['operation_type'];
@@ -439,10 +439,10 @@ abstract class NDB_Notifier_Abstract
     {
         $result = \Database::singleton()->pselect(
             'SELECT * FROM notification_services',
-            array()
+            []
         );
 
-        $n_services =array();
+        $n_services =[];
         foreach ($result as $row) {
             $n_services[$row['id']] = $row['service'];
         }
@@ -459,10 +459,10 @@ abstract class NDB_Notifier_Abstract
     {
         $result = \Database::singleton()->pselect(
             'SELECT * FROM notification_modules',
-            array()
+            []
         );
 
-        $n_modules =array();
+        $n_modules =[];
         foreach ($result as $row) {
             $n_modules[$row['id']]['module_name']    = $row['module_name'];
             $n_modules[$row['id']]['operation_type'] = $row['operation_type'];
@@ -491,10 +491,10 @@ abstract class NDB_Notifier_Abstract
                   WHERE module_name=:mn
                       AND operation_type=:ot
                     ";
-        $params = array(
+        $params = [
             "mn" => $module,
             "ot" => $operation_type,
-        );
+        ];
         return intval(\Database::singleton()->pselectOne($query, $params));
     }
 
@@ -511,7 +511,7 @@ abstract class NDB_Notifier_Abstract
                   FROM notification_services
                   WHERE service=:serv
                     ";
-        $params = array("serv" => $service);
+        $params = ["serv" => $service];
         return intval(\Database::singleton()->pselectOne($query, $params));
     }
 
@@ -540,10 +540,10 @@ abstract class NDB_Notifier_Abstract
                                                         AND un.user_id=:uid
                                                       )
                       ";
-        $params = array("uid" => $uid);
+        $params = ["uid" => $uid];
         $result = \Database::singleton()->pselect($query, $params);
 
-        $user_n_list =array();
+        $user_n_list =[];
         foreach ($result as $row) {
             $mn = $row['module_name'];
             $ot = $row['operation_type'];

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -55,7 +55,7 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Form defaults
      */
-    var $defaults = array();
+    var $defaults = [];
 
     /**
      * If true, the default display function will not try to load any template.
@@ -68,7 +68,7 @@ class NDB_Page implements RequestHandlerInterface
      * A list of arrays to be used as field options on
      * front-end forms and menu filters.
      */
-    var $fieldOptions = array();
+    var $fieldOptions = [];
 
     public $Module;
     public $template;
@@ -89,7 +89,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @var array<mixed>
      */
-    protected $tpl_data = array();
+    protected $tpl_data = [];
 
     /**
      * Does the setup required for this page. By default, sets up elements
@@ -114,7 +114,7 @@ class NDB_Page implements RequestHandlerInterface
         $this->page       = $page;
         $this->identifier = $identifier;
         $this->commentID  = $commentID;
-        $this->defaults   = array();
+        $this->defaults   = [];
 
         $this->template = $page;
     }
@@ -152,13 +152,13 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addFile($name, $label, $options=array())
+    function addFile($name, $label, $options=[])
     {
         $this->form->addElement(
             'file',
             $name,
             $label,
-            array_merge(array('class' => 'fileUpload'), $options)
+            array_merge(['class' => 'fileUpload'], $options)
         );
     }
 
@@ -186,10 +186,10 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addSelect($name, $label, $options, $optional=array())
+    function addSelect($name, $label, $options, $optional=[])
     {
         $optional = array_merge(
-            array('class' => 'form-control input-sm'),
+            ['class' => 'form-control input-sm'],
             $optional
         );
         $this->form->addElement('select', $name, $label, $options, $optional);
@@ -231,9 +231,9 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addBasicText($field, $label, $options=array())
+    function addBasicText($field, $label, $options=[])
     {
-        $options = array_merge(array('class' => 'form-control input-sm'), $options);
+        $options = array_merge(['class' => 'form-control input-sm'], $options);
         $this->form->addElement('text', $field, $label, $options);
     }
 
@@ -250,10 +250,10 @@ class NDB_Page implements RequestHandlerInterface
     function addBasicTextArea(
         $field,
         $label,
-        $specifications=array()
+        $specifications=[]
     ) {
         $specifications = array_merge(
-            array('class' => 'form-control input-sm'),
+            ['class' => 'form-control input-sm'],
             $specifications
         );
         $this->form->addElement('textarea', $field, $label, $specifications);
@@ -276,13 +276,13 @@ class NDB_Page implements RequestHandlerInterface
     function addBasicDate(
         $field,
         $label,
-        $options=array(),
-        $attr=array(
+        $options=[],
+        $attr=[
             'class' => 'form-control input-sm',
             'style' => 'max-width:33%; display:inline-block;',
-        )
+        ]
     ) {
-        if ($options === array() && !empty($this->dateOptions)) {
+        if ($options === [] && !empty($this->dateOptions)) {
             $options = $this->dateOptions;
         }
         $this->form->addElement('date', $field, $label, $options, $attr);
@@ -306,10 +306,10 @@ class NDB_Page implements RequestHandlerInterface
      *       whereas before it was in the $optional array.
      *        - Alexandra Livadas
      */
-    function addCheckbox($name, $label, $options, $optional=array())
+    function addCheckbox($name, $label, $options, $optional=[])
     {
         $options = array_merge(
-            array('class' => 'form-control input-sm'),
+            ['class' => 'form-control input-sm'],
             $options
         );
         $this->form->addElement('advcheckbox', $name, $label, $options, $optional);
@@ -331,15 +331,15 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addRadio($name, $groupLabel, $radios, $options=array())
+    function addRadio($name, $groupLabel, $radios, $options=[])
     {
-        $radGroup = array();
+        $radGroup = [];
         foreach ($radios as $radElement) {
             $tempOptions = array_merge(
-                array(
+                [
                     'class' => 'form-control input-sm',
                     'value' => $radElement['value'],
-                ),
+                ],
                 $options
             );
             $radGroup[]  = $this->createRadio(
@@ -361,7 +361,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addHidden($name, $value=null, $attributes=array())
+    function addHidden($name, $value=null, $attributes=[])
     {
         $this->form->addElement('hidden', $name, $value, $attributes);
     }
@@ -380,18 +380,18 @@ class NDB_Page implements RequestHandlerInterface
     function addTextAreaGroup(
         $field,
         $label,
-        $not_answered_options=array(
+        $not_answered_options=[
             ''             => '',
             'not_answered' => 'Not Answered',
-        )
+        ]
     ) {
-        $group   = array();
+        $group   = [];
         $group[] = $this->createTextArea($field, '');
         $group[] = $this->createSelect(
             $field . '_status',
             '',
             $not_answered_options,
-            array('class' => 'form-control input-sm not-answered')
+            ['class' => 'form-control input-sm not-answered']
         );
 
         $this->addGroup($group, $field . '_group', $label, null, false);
@@ -410,7 +410,7 @@ class NDB_Page implements RequestHandlerInterface
     function addPassword(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=['class' => 'form-control input-sm']
     ) {
         $this->form->addElement('password', $field, $label, $attr);
     }
@@ -489,7 +489,7 @@ class NDB_Page implements RequestHandlerInterface
         $field,
         $label,
         $options=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=['class' => 'form-control input-sm']
     ) {
         return $this->form->createElement("select", $field, $label, $options, $attr);
     }
@@ -528,9 +528,9 @@ class NDB_Page implements RequestHandlerInterface
     function createText(
         $field,
         $label=null,
-        $attribs=array()
+        $attribs=[]
     ) {
-        $attr =array_merge($attribs, array('class' => 'form-control input-sm'));
+        $attr =array_merge($attribs, ['class' => 'form-control input-sm']);
         return $this->form->createElement("text", $field, $label, $attr);
     }
 
@@ -548,7 +548,7 @@ class NDB_Page implements RequestHandlerInterface
             "textarea",
             $field,
             $label,
-            array('class' => 'form-control input-sm')
+            ['class' => 'form-control input-sm']
         );
     }
 
@@ -570,10 +570,10 @@ class NDB_Page implements RequestHandlerInterface
         $field,
         $label,
         $dateOptions=null,
-        $attr=array(
+        $attr=[
             'class' => 'form-control input-sm',
             'style' => 'max-width:33%; display:inline-block;',
-        )
+        ]
     ) {
         return $this->form->createElement(
             "date",
@@ -603,7 +603,7 @@ class NDB_Page implements RequestHandlerInterface
             $field,
             $label,
             $options,
-            array()
+            []
         );
     }
 
@@ -623,7 +623,7 @@ class NDB_Page implements RequestHandlerInterface
             $field,
             $label,
             $options,
-            array()
+            []
         );
     }
 
@@ -639,7 +639,7 @@ class NDB_Page implements RequestHandlerInterface
     function createPassword(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attr=['class' => 'form-control input-sm']
     ) {
         return $this->form->createElement('password', $field, $label, $attr);
     }
@@ -741,7 +741,7 @@ class NDB_Page implements RequestHandlerInterface
         // get the defaults
         $localDefaults = $this->_getDefaults();
         if (!is_array($localDefaults)) {
-            $localDefaults = array();
+            $localDefaults = [];
         }
         // set the quickform object defaults
         $this->_setDefaults(array_merge($this->defaults, $localDefaults));
@@ -778,7 +778,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return array The defaults
      */
-    function _setDefaults($defaults = array())
+    function _setDefaults($defaults = [])
     {
         $this->defaults = $defaults;
         $this->form->setDefaults($defaults);
@@ -804,7 +804,7 @@ class NDB_Page implements RequestHandlerInterface
         // In the future release, dialogs should be replaced with bootstrap dialogs
         // and datepickers only created by modernizr
 
-        $files = array(
+        $files = [
             $baseurl . '/js/jquery/jquery-1.11.0.min.js',
             $baseurl . '/js/helpHandler.js',
             $baseurl . '/js/modernizr/modernizr.min.js',
@@ -828,7 +828,7 @@ class NDB_Page implements RequestHandlerInterface
             $baseurl . "/js/util/queryString.js",
             $baseurl . '/js/components/Form.js',
             $baseurl . '/js/components/Markdown.js',
-        );
+        ];
         return $files;
     }
 
@@ -845,12 +845,12 @@ class NDB_Page implements RequestHandlerInterface
         $factory = NDB_Factory::singleton();
         $baseurl = $factory->settings()->getBaseURL();
 
-        $files = array(
+        $files = [
             $baseurl . "/bootstrap/css/bootstrap.min.css",
             $baseurl . "/bootstrap/css/custom-css.css",
             $baseurl . "/js/jquery/datepicker/datepicker.css",
             $baseurl . '/vendor/sweetalert/sweetalert.css',
-        );
+        ];
         return $files;
     }
 
@@ -910,6 +910,6 @@ class NDB_Page implements RequestHandlerInterface
      */
     function toJSON(): string
     {
-        return json_encode(array('error' => 'Not implemented'));
+        return json_encode(['error' => 'Not implemented']);
     }
 }

--- a/php/libraries/Notify.class.inc
+++ b/php/libraries/Notify.class.inc
@@ -46,12 +46,12 @@ class Notify
             );
         }
 
-        $setArray = array(
+        $setArray = [
             'NotificationTypeID' => $typeID,
             'TimeSpooled'        => date("Y-m-d H:i:s"),
             'Message'            => $message,
             'CenterID'           => $centerID,
-        );
+        ];
         \Database::singleton()->insert('notification_spool', $setArray);
     }
 
@@ -66,7 +66,7 @@ class Notify
     {
         $typeID = \Database::singleton()->pselectOne(
             "SELECT NotificationTypeID FROM notification_types WHERE Type=:TP",
-            array('TP' => $type)
+            ['TP' => $type]
         );
         return $typeID;
     }

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -23,7 +23,7 @@
  */
 class Project
 {
-    private static $_instances = array();
+    private static $_instances = [];
 
     /**
      * The id of the project in database.
@@ -71,7 +71,7 @@ class Project
                       Project
                     WHERE name = :v_project_name
                     ",
-                array('v_project_name' => $projectName)
+                ['v_project_name' => $projectName]
             );
 
             if (empty($projectData)) {
@@ -113,7 +113,7 @@ class Project
                       Project
                     WHERE ProjectID = :pid
                     ",
-            array('pid' => $projectID)
+            ['pid' => $projectID]
         );
 
         if (empty($projectName)) {
@@ -160,7 +160,7 @@ class Project
             WHERE
               name = :v_project_name
             ",
-            array('v_project_name' => $projectName)
+            ['v_project_name' => $projectName]
         );
         if (!empty($projectId)) {
             throw new \LorisException("The project $projectName already exists");
@@ -168,11 +168,11 @@ class Project
 
         $factory->database()->insert(
             'Project',
-            array(
+            [
                 'Name'              => $projectName,
                 'Alias'             => $projectAlias,
                 'recruitmentTarget' => $recruitmentTarget,
-            )
+            ]
         );
 
         $project = $factory->project($projectName);
@@ -348,8 +348,8 @@ class Project
         \NDB_Factory::singleton()->database()
             ->update(
                 "Project",
-                array($field => (string) $value),
-                array("ProjectID" => $this->_projectId)
+                [$field => (string) $value],
+                ["ProjectID" => $this->_projectId]
             );
     }
 
@@ -376,18 +376,18 @@ class Project
             WHERE
               psr.projectId = :v_project_id
             ",
-            array('v_project_id' => $this->_projectId)
+            ['v_project_id' => $this->_projectId]
         );
 
         return array_map(
             function ($row) {
-                return (object) array(
+                return (object) [
                     'subprojectId'      => (int) $row['subprojectId'],
                     'title'             => $row['title'],
                     'useEDC'            => $row['useEDC'],
                     'windowDifference'  => $row['windowDifference'],
                     'recruitmentTarget' => $row['recruitmentTarget'],
-                );
+                ];
             },
             $subProjectData
         );
@@ -402,7 +402,7 @@ class Project
     {
         $factory = \NDB_Factory::singleton();
 
-        $p = array($this->_projectId);
+        $p = [$this->_projectId];
         $candidatesData = $factory->database()->pselect(
             "
             SELECT
@@ -413,7 +413,7 @@ class Project
               active = 'Y' AND
               FIND_IN_SET(IFNULL(RegistrationProjectID, '-1'), :v_project_id)
             ",
-            array('v_project_id' => implode(',', $p))
+            ['v_project_id' => implode(',', $p)]
         );
         return array_map(
             function ($row) {
@@ -437,10 +437,10 @@ class Project
         foreach ($ids as $id) {
             $db->insertIgnore(
                 'project_subproject_rel',
-                array(
+                [
                     'ProjectID'    => $this->_projectId,
                     'SubprojectID' => $id,
-                )
+                ]
             );
         }
     }
@@ -460,10 +460,10 @@ class Project
         foreach ($ids as $id) {
             $db->delete(
                 'project_subproject_rel',
-                array(
+                [
                     'ProjectID'    => $this->_projectId,
                     'SubprojectID' => $id,
-                )
+                ]
             );
         }
     }

--- a/php/libraries/SinglePointLogin.class.inc
+++ b/php/libraries/SinglePointLogin.class.inc
@@ -200,7 +200,7 @@ class SinglePointLogin
 
         //$jwt = \Firebase\JWT\JWT::encode($token, $sharedKey);
         try {
-            $decoded = \Firebase\JWT\JWT::decode($token, $sharedKey, array("HS256"));
+            $decoded = \Firebase\JWT\JWT::decode($token, $sharedKey, ["HS256"]);
         } catch (Exception $e) {
             return false;
         }
@@ -239,7 +239,7 @@ class SinglePointLogin
          //////////////////////////
         $this->_username = isset($username) ? $username : 'Unknown';
 
-        $setArray = array(
+        $setArray = [
             'userID'          => $this->_username,
             'Success'         => 'Y',
             'Failcode'        => null,
@@ -250,7 +250,7 @@ class SinglePointLogin
             'Page_requested'  => isset($_SERVER['REQUEST_URI'])
                                               ? $_SERVER['REQUEST_URI']
                                               : 'Unknown',
-        );
+        ];
         // don't waste execution time if no form was submitted
 
         if (empty($username)) {
@@ -288,7 +288,7 @@ class SinglePointLogin
                     FROM users
                   WHERE UserID = :username
                   GROUP BY UserID";
-        $row   = $DB->pselectRow($query, array('username' => $username));
+        $row   = $DB->pselectRow($query, ['username' => $username]);
 
         if (is_null($row) || intval($row['User_count'] ?? 0) !== 1) {
             /* Display generic failure message to front-end so that an
@@ -329,8 +329,8 @@ class SinglePointLogin
                     );
                     \NDB_Factory::singleton()->database()->update(
                         'users',
-                        array('Password_hash' => $newHash),
-                        array('UserID' => $username)
+                        ['Password_hash' => $newHash],
+                        ['UserID' => $username]
                     );
                 }
 
@@ -480,11 +480,11 @@ class SinglePointLogin
             "WHERE userID = :username " .
             "AND Success = 'Y'" .
         ");";
-        $params = array(
+        $params = [
             'username'            => $username,
             'timeWindowInMinutes' => $shortWindowInMinutes,
             'ip'                  => $_SERVER['REMOTE_ADDR'],
-        );
+        ];
 
         // Query DB for login attempts.
         $database  = \NDB_Factory::singleton()->database();
@@ -582,7 +582,7 @@ class SinglePointLogin
                   FROM user_login_history 
                   WHERE UserID = :username";
 
-        $row = $DB->pselectRow($query, array('username' => $username));
+        $row = $DB->pselectRow($query, ['username' => $username]);
 
         /* If the login timestamp is null then this is the user's first time
          * logging in. This will always be the case in our CI environment.
@@ -598,8 +598,8 @@ class SinglePointLogin
         if ($interval->days > $maximumDaysInactive) {
             $DB->update(
                 'users',
-                array('Active' => 'N'),
-                array('UserID' => $username)
+                ['Active' => 'N'],
+                ['UserID' => $username]
             );
             return true;
         }

--- a/php/libraries/Site.class.inc
+++ b/php/libraries/Site.class.inc
@@ -34,7 +34,7 @@ class Site
      */
     static function &singleton(int $centerID)
     {
-        static $siteList = array();
+        static $siteList = [];
         if (!isset($siteList[$centerID])) {
             try {
                 $siteList[$centerID] = new Site();
@@ -67,7 +67,7 @@ class Site
         $query  = "SELECT Name, PSCArea, Alias, MRI_alias, Account, Study_site
                       FROM psc
                    WHERE CenterID = :CID";
-        $result = $db->pselectRow($query, array('CID' => $centerID));
+        $result = $db->pselectRow($query, ['CID' => $centerID]);
 
         //store site data in the object property
         if (is_array($result) && count($result) > 0) {

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -132,10 +132,10 @@ class SiteIDGenerator extends IdentifierGenerator
             "SELECT substring($this->kind, LENGTH('{$this->prefix}') +1)
             from candidate
             WHERE {$this->kind} LIKE '{$this->prefix}%'",
-            array()
+            []
         );
         if (empty($ids)) {
-            return array();
+            return [];
         }
         // Filter out non-numeric ids if using a numeric alphabet.
         if (empty(array_diff($this->alphabet, range('0', '9')))) {
@@ -171,7 +171,7 @@ class SiteIDGenerator extends IdentifierGenerator
         if (!$idStructure[0]) {
             // There's only one seq tag so the param format
             // needs to be fixed
-            $temp        = array();
+            $temp        = [];
             $temp[]      = $idStructure;
             $idStructure = $temp;
         }
@@ -303,7 +303,7 @@ class SiteIDGenerator extends IdentifierGenerator
         array $idStructure,
         string $setting
     ): array {
-        $seqAttributes = array();
+        $seqAttributes = [];
         foreach ($idStructure as $seq) {
             if (isset($seq['@'][$setting])) {
                 $seqAttributes[] = $seq['@'][$setting];

--- a/php/libraries/Smarty_hook.class.inc
+++ b/php/libraries/Smarty_hook.class.inc
@@ -89,15 +89,15 @@ class Smarty_NeuroDB extends Smarty
         $currentDir = $this->getConfigDir();
 
         if (!is_array($currentDir)) {
-            $currentDir = array('base' => $this->loristemplate_dir);
+            $currentDir = ['base' => $this->loristemplate_dir];
         }
 
         $newdir = array_merge(
             $currentDir,
-            array(
+            [
                 'template' => $this->loristemplate_dir,
                 'project'  => $this->project_template_dir,
-            )
+            ]
         );
         $this->setConfigDir($newdir);
 

--- a/php/libraries/State.class.inc
+++ b/php/libraries/State.class.inc
@@ -106,11 +106,11 @@ class State
      */
     function getLastURL(): ?string
     {
-        $timepointSubMenus = array(
+        $timepointSubMenus = [
             'instrument_list',
             'create_timepoint',
             'demographics',
-        );
+        ];
 
         $caller =& NDB_Caller::singleton();
         if (isset($_REQUEST['test_name'])

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -29,7 +29,7 @@ class TimePoint
      */
     var $_timePointInfo;
 
-    var $_stageOptions = array(
+    var $_stageOptions = [
         null,
         'Not Started',
         'Screening',
@@ -37,38 +37,38 @@ class TimePoint
         'Approval',
         'Subject',
         'Recycling Bin',
-    );
+    ];
 
-    var $_dynamicStageOptions = array(
+    var $_dynamicStageOptions = [
         'Screening',
         'Visit',
         'Approval',
-    );
+    ];
 
-    var $_statusOptions = array(
+    var $_statusOptions = [
         null,
         'Pass',
         'Failure',
         'Withdrawal',
         'In Progress',
-    );
+    ];
 
-    var $bvlQcTypes = array(
+    var $bvlQcTypes = [
         null,
         'Visual',
         'Hardcopy',
-    );
+    ];
 
-    var $bvlQcStatuses = array(
+    var $bvlQcStatuses = [
         null,
         'Complete',
-    );
+    ];
 
-    var $bvlQcExclusionStatuses = array(
+    var $bvlQcExclusionStatuses = [
         null,
         'Excluded',
         'Not Excluded',
-    );
+    ];
 
 
     /**
@@ -83,7 +83,7 @@ class TimePoint
     static function &singleton(int $sessionID)
     {
         // instantiate new TimePoint object
-        static $timePointList = array();
+        static $timePointList = [];
         if (!isset($timePointList[$sessionID])) {
             try {
                 $timePointList[$sessionID] = new TimePoint();
@@ -134,7 +134,7 @@ class TimePoint
                         LEFT JOIN users AS u on (s.registeredBy=u.UserID)
                         LEFT JOIN Project AS pr USING(ProjectID)
                     WHERE s.ID = :SID AND s.Active = 'Y'";
-        $row   = $db->pselectRow($query, array('SID' => $sessionID));
+        $row   = $db->pselectRow($query, ['SID' => $sessionID]);
 
         // store user data in object property
         if (is_array($row) && count($row) > 0) {
@@ -159,10 +159,10 @@ class TimePoint
                             JOIN session s ON (s.ID=ss.SessionID)
                         WHERE s.ID=:sessionID AND s.Active='Y'";
 
-            $statuses = $db->pselect($query, array(":sessionID" => $sessionID));
+            $statuses = $db->pselect($query, [":sessionID" => $sessionID]);
             foreach ($statuses as $row) {
                 if (!isset($this->_timePointInfo['status'])) {
-                    $this->_timePointInfo['status'] = array();
+                    $this->_timePointInfo['status'] = [];
                 }
                 $this->_timePointInfo['status'][$row['Name']] = $row['Value'];
             }
@@ -180,7 +180,7 @@ class TimePoint
                             LOWER(w.Visit_label)=LOWER(s.Visit_label)
                         )
                     WHERE s.ID=:sessionID",
-                array(":sessionID" => $sessionID)
+                [":sessionID" => $sessionID]
             );
 
         }
@@ -246,7 +246,7 @@ class TimePoint
             $language = array_key_first($langList);
         }
 
-        $insertData = array(
+        $insertData = [
             'CandID'          => $candidate->getCandID(),
             'SubprojectID'    => $SubprojectID,
             'VisitNo'         => $visitNo,
@@ -260,7 +260,7 @@ class TimePoint
             'Date_registered' => $today,
             'Date_active'     => $today,
             'languageID'      => $language,
-        );
+        ];
 
         // insert the data
         $db->insert('session', $insertData);
@@ -380,9 +380,9 @@ class TimePoint
         \Database::singleton()->update(
             'session',
             $newData,
-            array(
+            [
                 'ID' => $this->getData('SessionID'),
-            )
+            ]
         );
         // this select updates the timepoint object
         $this->select(intval($this->getData('SessionID')));
@@ -729,7 +729,7 @@ class TimePoint
         $db =& Database::singleton();
 
         // this class does not handle Subject & Recycling Bin stage at the moment
-        if (in_array($this->getCurrentStage(), array('Subject', 'Recycling Bin'))) {
+        if (in_array($this->getCurrentStage(), ['Subject', 'Recycling Bin'])) {
             return;
         }
 
@@ -740,11 +740,11 @@ class TimePoint
                 // delete from conflicts_unresolved if marked Recycling Bin
                 $commentIDs = $db->pselect(
                     "SELECT CommentID FROM flag WHERE SessionID=:SID",
-                    array('SID' => $this->getSessionID())
+                    ['SID' => $this->getSessionID()]
                 );
                 foreach ($commentIDs as $commentID) {
-                    $deleteWhere1 = array('CommentId1' => $commentID);
-                    $deleteWhere2 = array('CommentId2' => $commentID);
+                    $deleteWhere1 = ['CommentId1' => $commentID];
+                    $deleteWhere2 = ['CommentId2' => $commentID];
                     $db->delete('conflicts_unresolved', $deleteWhere1);
                     $db->delete('conflicts_unresolved', $deleteWhere2);
                 }
@@ -767,15 +767,15 @@ class TimePoint
         $today = date("Y-m-d");
 
         // update session table
-        $update_columns = array(
+        $update_columns = [
             "Date_stage_change" => $today,
             'Current_stage'     => $newCurrentStage,
-        );
+        ];
 
         $db->update(
             'session',
             $update_columns,
-            array('ID' => $this->getSessionID())
+            ['ID' => $this->getSessionID()]
         );
 
         // reload TimePoint object
@@ -793,10 +793,10 @@ class TimePoint
      */
     function startStage(string $stage): void
     {
-        $setArray = array(
+        $setArray = [
             'Current_stage'     => $stage,
             'Date_stage_change' => date('Y-m-d'),
-        );
+        ];
 
         if (in_array($stage, $this->_dynamicStageOptions)
             && $this->getData($stage) == null
@@ -829,13 +829,13 @@ class TimePoint
             throw new Exception("You need to specify a valid BVL QC Type");
         }
 
-        $setArray = array('BVLQCType' => $type);
+        $setArray = ['BVLQCType' => $type];
 
         // update session table
         $db->update(
             'session',
             $setArray,
-            array('ID' => $this->getSessionID())
+            ['ID' => $this->getSessionID()]
         );
 
         // reload TimePoint object
@@ -866,13 +866,13 @@ class TimePoint
             throw new Exception("Cannot complete QC until the type is defined");
         }
 
-        $setArray = array('BVLQCStatus' => $status);
+        $setArray = ['BVLQCStatus' => $status];
 
         // update session table
         $db->update(
             'session',
             $setArray,
-            array('ID' => $this->getSessionID())
+            ['ID' => $this->getSessionID()]
         );
 
         // reload TimePoint object
@@ -900,13 +900,13 @@ class TimePoint
         }
 
         // fields to update
-        $setArray = array('BVLQCExclusion' => $status);
+        $setArray = ['BVLQCExclusion' => $status];
 
         // update session table
         $db->update(
             'session',
             $setArray,
-            array('ID' => $this->getSessionID())
+            ['ID' => $this->getSessionID()]
         );
 
         // reload TimePoint object
@@ -936,7 +936,7 @@ class TimePoint
         if ($currentStage == 'Not Started') {
             return true;
         } elseif ($currentStage == 'Screening'
-            && in_array($this->getData('Screening'), array('Pass', 'Failure'))
+            && in_array($this->getData('Screening'), ['Pass', 'Failure'])
         ) {
             return true;
         }
@@ -1052,10 +1052,10 @@ class TimePoint
              WHERE
                tarchive.SessionID = :v_sessionid AND
                tarchive.ArchiveLocation LIKE :v_basename',
-            array(
+            [
                 'v_sessionid' => $this->getSessionID(),
                 'v_basename'  => '%' . $tarname,
-            )
+            ]
         );
 
         if (empty($row)) {
@@ -1084,7 +1084,7 @@ class TimePoint
              WHERE
                ID = :v_sessionid
             ',
-            array('v_sessionid' => $this->getSessionID())
+            ['v_sessionid' => $this->getSessionID()]
         );
 
         return new \LORIS\TimePointImagingQC(
@@ -1114,7 +1114,7 @@ class TimePoint
              WHERE
                SessionID = :v_sessionid
             ',
-            array('v_sessionid' => $this->getSessionID())
+            ['v_sessionid' => $this->getSessionID()]
         );
         return $result;
     }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -29,7 +29,7 @@ class User extends UserPermissions
      * @var    array
      * @access private
      */
-    protected $userInfo = array();
+    protected $userInfo = [];
     /**
      * The date format used by MySQL.
      *
@@ -73,7 +73,7 @@ class User extends UserPermissions
             WHERE users.UserID = :UID
             GROUP BY users.ID";
 
-        $row = $DB->pselectRow($query, array('UID' => $username));
+        $row = $DB->pselectRow($query, ['UID' => $username]);
 
         if (is_null($row)) {
             $obj = new \LORIS\AnonymousUser();
@@ -87,9 +87,9 @@ class User extends UserPermissions
         $user_centerID_query =  $DB->pselect(
             "SELECT CenterID FROM user_psc_rel upr
                         WHERE upr.UserID= :UID",
-            array('UID' => $row['ID'])
+            ['UID' => $row['ID']]
         );
-        $user_cid            = array();
+        $user_cid            = [];
         foreach ($user_centerID_query as $key=>$val) {
             // Convert string representation of ID to int
             $user_cid[$key] = intval($val['CenterID']);
@@ -97,7 +97,7 @@ class User extends UserPermissions
 
         $user_pid = $DB->pselectCol(
             "SELECT ProjectID FROM user_project_rel upr WHERE upr.UserId=:uid",
-            array('uid' => $row['ID'])
+            ['uid' => $row['ID']]
         );
         foreach ($user_pid as $k=>$pid) {
             $user_pid[$k] = intval($pid);
@@ -116,21 +116,21 @@ class User extends UserPermissions
                     AND (epr.active='Y'
                           OR (epr.active='N' AND epr.pending_approval='Y')
                         )",
-            array(
+            [
                 "fn" => $row['Real_name'],
-            )
+            ]
         );
 
-        $examiner_info =array();
+        $examiner_info =[];
         if (!empty($examiner_check) && !is_null($examiner_check)) {
             foreach ($examiner_check as $val) {
                 if ($val['active'] == 'Y') {
                     $examiner_info['pending'] = $val['pending_approval'];
                 }
-                $examiner_info[$val['centerID']] =array(
+                $examiner_info[$val['centerID']] =[
                     $val['active'],
                     $val['radiologist'],
-                );
+                ];
             }
         }
         // store user data in object property
@@ -190,7 +190,7 @@ class User extends UserPermissions
         \Database::singleton()->update(
             'users',
             $set,
-            array('UserID' => $this->userInfo['UserID'])
+            ['UserID' => $this->userInfo['UserID']]
         );
     }
 
@@ -350,8 +350,8 @@ class User extends UserPermissions
     function getStudySites(): array
     {
         $site_arr         = $this->getCenterIDs();
-        $user_study_sites = array();
-        $site = array();
+        $user_study_sites = [];
+        $site = [];
         foreach ($site_arr as $key => $val) {
             $site[$key] = &Site::singleton($val);
             if ($site[$key]->isStudySite()) {
@@ -472,7 +472,7 @@ class User extends UserPermissions
                userID = :v_userid AND
                Success = 'Y'
             ",
-            array('v_userid' => $this->userInfo['UserID'])
+            ['v_userid' => $this->userInfo['UserID']]
         );
         return $count > 0;
     }
@@ -503,10 +503,10 @@ class User extends UserPermissions
         );
 
         $this->update(
-            array(
+            [
                 'Password_hash'   => $password,
                 'Password_expiry' => $expiry->format(self::MYSQL_DATE_FORMAT),
-            )
+            ]
         );
         // XXX This class should use DateTime objects instead of strings so
         // that formatting doens't need to be specified and so that Date math
@@ -550,7 +550,7 @@ class User extends UserPermissions
                     FROM user_login_history
                     WHERE userID=:UserID AND Success='Y')
                 AND userID=:UserID AND Success='Y'",
-            array('UserID' => $this->getUsername())
+            ['UserID' => $this->getUsername()]
         );
         if (empty($time)) {
             return null;

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -36,7 +36,7 @@ class UserPermissions
      * @var    array<string,bool>
      * @access private
      */
-    var $permissions = array();
+    var $permissions = [];
 
 
     /**
@@ -52,7 +52,7 @@ class UserPermissions
     {
         // get the proper ID from the database
         $query  = "SELECT ID FROM users WHERE UserID =:UName";
-        $params = array('UName' => $username);
+        $params = ['UName' => $username];
 
         $this->userID = \Database::singleton()->pselectOne($query, $params);
         if (empty($this->userID)) {
@@ -82,10 +82,10 @@ class UserPermissions
             LEFT JOIN user_perm_rel pr
             ON (p.permID=pr.permID AND pr.userID=:UID)";
 
-        $results = $DB->pselect($query, array('UID' => $this->userID));
+        $results = $DB->pselect($query, ['UID' => $this->userID]);
 
         // reset the array
-        $this->permissions = array();
+        $this->permissions = [];
 
         // Fill the permissions array of this UserPermissions object with the
         // values extracted for this user from the database.
@@ -202,10 +202,10 @@ class UserPermissions
         foreach ($set as $value) {
             $DB->insert(
                 'user_perm_rel',
-                array(
+                [
                     'userID' => $this->userID,
                     'permID' => $value,
-                )
+                ]
             );
         }
 
@@ -230,17 +230,17 @@ class UserPermissions
             // remove all permissions
             $DB->delete(
                 'user_perm_rel',
-                array('userID' => $this->userID)
+                ['userID' => $this->userID]
             );
         } else {
             // remove the permissions
             foreach ($set as $value) {
                 $DB->delete(
                     'user_perm_rel',
-                    array(
+                    [
                         'userID' => $this->userID,
                         'permID' => $value,
-                    )
+                    ]
                 );
             }
         }
@@ -266,10 +266,10 @@ class UserPermissions
             FROM permissions, user_perm_rel
             WHERE permissions.permID = user_perm_rel.permID AND userID = :UID";
 
-        $results = $DB->pselect($query, array('UID' => $this->userID));
+        $results = $DB->pselect($query, ['UID' => $this->userID]);
 
         // isolate and return numeric permission values
-        $permIDs = array();
+        $permIDs = [];
         foreach ($results as $row) {
             foreach ($row as $v) {
                 $permIDs[] = $v;
@@ -296,7 +296,7 @@ class UserPermissions
                 LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
             WHERE up.userID = :UID
                 ORDER BY p.categoryID, p.description";
-        $results = $DB->pselect($query, array('UID' => $this->userID));
+        $results = $DB->pselect($query, ['UID' => $this->userID]);
 
         return $results;
     }
@@ -320,11 +320,11 @@ class UserPermissions
         //insert into the login_history
         $DB->insert(
             'user_account_history',
-            array(
+            [
                 'userID'     => $this->userID,
                 'PermID'     => $PermID,
                 'PermAction' => $permAction,
-            )
+            ]
         );
     }
 }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -58,11 +58,11 @@ class Utility
                 "Argument 1 does not match expected date format (YYYY-MM-DD)"
             );
         }
-        $dob = array(
+        $dob = [
             'year' => $matches[1],
             'mon'  => $matches[2],
             'day'  => $matches[3],
-        );
+        ];
 
         if (!preg_match(
             "/([0-9]{4})-?([0-9]{1,2})-?([0-9]{1,2})/",
@@ -74,11 +74,11 @@ class Utility
                 "Argument 2 does not match expected date format (YYYY-MM-DD)"
             );
         }
-        $testdate = array(
+        $testdate = [
             'year' => $matches[1],
             'mon'  => $matches[2],
             'day'  => $matches[3],
-        );
+        ];
 
         if ($testdate['day'] < $dob['day']) {
             $testdate['day'] += 30;
@@ -89,11 +89,11 @@ class Utility
             $testdate['year']--;
         }
 
-        $age = array(
+        $age = [
             'year' => (int)$testdate['year'] - (int)$dob['year'],
             'mon'  => (int)$testdate['mon'] - (int)$dob['mon'],
             'day'  => (int)$testdate['day'] - (int)$dob['day'],
-        );
+        ];
 
         return $age;
     }
@@ -111,7 +111,7 @@ class Utility
         $query = "SELECT ConsentID, Name, Label FROM consent";
         $key   = "ConsentID";
 
-        $result = $DB->pselectWithIndexKey($query, array(), $key);
+        $result = $DB->pselectWithIndexKey($query, [], $key);
 
         return $result;
     }
@@ -140,10 +140,10 @@ class Utility
             $query .= " AND CenterID <> 1";
         }
 
-        $result = $DB->pselect($query, array());
+        $result = $DB->pselect($query, []);
 
         // fix the array
-        $list = array();
+        $list = [];
         foreach ($result as $row) {
             $list[$row["CenterID"]] = $row["Name"];
         }
@@ -188,9 +188,9 @@ class Utility
 
         $query = "SELECT Visit_label from Visit_Windows ORDER BY Visit_label";
 
-        $result = $DB->pselect($query, array());
+        $result = $DB->pselect($query, []);
 
-        $list = array();
+        $list = [];
         foreach ($result as $row) {
             $list[$row["Visit_label"]] = ucfirst($row["Visit_label"]);
         }
@@ -210,9 +210,9 @@ class Utility
         // get the list of projects
         $projects = $DB->pselectColWithIndexKey(
             "SELECT ProjectID, Name FROM Project",
-            array(),
+            [],
             'ProjectID'
-        ) ?? array();
+        ) ?? [];
         return $projects;
     }
 
@@ -234,13 +234,13 @@ class Utility
                 "SELECT * FROM subproject
                 JOIN project_subproject_rel USING (SubprojectID) 
                 WHERE ProjectID=:pID",
-                array('pID' => $projectID)
+                ['pID' => $projectID]
             );
         } else {
-            $subprojects = $DB->pselect("SELECT * FROM subproject", array());
+            $subprojects = $DB->pselect("SELECT * FROM subproject", []);
         }
 
-        $subprojs = array();
+        $subprojs = [];
         foreach ($subprojects as $row) {
             $subprojs[$row['SubprojectID']] = $row['title'];
         }
@@ -258,7 +258,7 @@ class Utility
     static function getSubprojectsForProject(?int $projectID = null): array
     {
         if (is_null($projectID)) {
-            return array();
+            return [];
         }
         return self::getSubprojectList($projectID);
     }
@@ -280,7 +280,7 @@ class Utility
         $db      = $factory->database();
 
         $query    = "SELECT Test_name FROM flag WHERE CommentID=:CID";
-        $testName = $db->pselectOne($query, array('CID' => $commentID));
+        $testName = $db->pselectOne($query, ['CID' => $commentID]);
 
         return $testName;
     }
@@ -308,7 +308,7 @@ class Utility
         $seqs = $structure['seq'];
         // handle the situation where there exists only one seq
         if (isset($seqs['#'])) {
-            $seqs = array($seqs);
+            $seqs = [$seqs];
         }
         $regex = "";
         foreach ($seqs AS $seq) {
@@ -396,7 +396,7 @@ class Utility
             WHERE t.Test_name=b.Test_name
             AND b.AgeMinDays<=:CandAge AND b.AgeMaxDays>=:CandAge
             AND b.Active='Y'";
-        $params = array('CandAge' => $age);
+        $params = ['CandAge' => $age];
 
         if (!is_null($stage)) {
             $query .= " AND b.Stage=:BatStage";
@@ -406,8 +406,8 @@ class Utility
         $query .= " GROUP BY Test_name ORDER BY Test_name";
 
         // get the list of instruments
-        $rows  = array();
-        $tests = array();
+        $rows  = [];
+        $tests = [];
         $rows  = $DB->pselect($query, $params);
 
         // repackage the array
@@ -432,7 +432,7 @@ class Utility
     static function associativeToNumericArray(array $associative_array): array
     {
         if (!array_key_exists(0, $associative_array)) {
-            return array($associative_array);
+            return [$associative_array];
         }
         return $associative_array;
     }
@@ -471,7 +471,7 @@ class Utility
     static function asArray($var): array
     {
         if (!is_array($var)) {
-            return array($var);
+            return [$var];
         }
         return $var;
     }
@@ -515,9 +515,9 @@ class Utility
         $DB            = $Factory->Database();
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names ORDER BY Full_name",
-            array()
+            []
         );
-        $instruments   = array();
+        $instruments   = [];
         foreach ($instruments_q as $row) {
             if (isset($row['Test_name']) && isset($row['Full_name'])) {
                 $instruments[$row['Test_name']] =$row['Full_name'];
@@ -539,13 +539,13 @@ class Utility
         $config        = $Factory->config();
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names",
-            array()
+            []
         );
         $doubleDataEntryInstruments = $config->getSetting(
             'DoubleDataEntryInstruments'
         );
 
-        $instruments = array();
+        $instruments = [];
         foreach ($instruments_q as $row) {
             if (isset($row['Test_name']) && isset($row['Full_name'])) {
                 if (in_array($row['Test_name'], $doubleDataEntryInstruments)) {
@@ -569,11 +569,11 @@ class Utility
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $instruments   = array();
+        $instruments   = [];
         $instruments_q = $DB->pselect(
             "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true 
              ORDER BY Full_name",
-            array()
+            []
         );
         foreach ($instruments_q as $key) {
             $instruments[$key['Test_name']] =$key['Full_name'];
@@ -601,7 +601,7 @@ class Utility
         $DB       =& \Database::singleton();
         $num_null = $DB->pselectOne(
             $query,
-            array()
+            []
         );
         if ($num_null > 0) {
             return true;
@@ -624,7 +624,7 @@ class Utility
 
         $query = "select DISTINCT Current_stage from session where ".
             "CandID = :Cand_id";
-        $stage = $db->pselect($query, array('Cand_id' => $Cand_id));
+        $stage = $db->pselect($query, ['Cand_id' => $Cand_id]);
         return $stage[0]['Current_stage'];
     }
 
@@ -642,7 +642,7 @@ class Utility
         $db      = $factory->database();
 
         $query = "select DISTINCT SubprojectID from session where CandID = :CandID";
-        $stage = $db->pselect($query, array('CandID' => $Cand_id));
+        $stage = $db->pselect($query, ['CandID' => $Cand_id]);
         return intval($stage[0]['SubprojectID']);
     }
 
@@ -664,7 +664,7 @@ class Utility
         $db         = $factory->database();
         $instrument = $db->pselect(
             "SELECT Test_name FROM test_names WHERE Full_name =:fname",
-            array('fname' => $fullname)
+            ['fname' => $fullname]
         );
         if (is_array($instrument) && count($instrument)) {
             list(,$test_name) = each($instrument[0]);
@@ -704,29 +704,29 @@ class Utility
         $DB      = $factory->database();
 
         //get sourcefield using instrument
-        $sourcefields = array();
+        $sourcefields = [];
         if (!is_null($instrument)) {
             $sourcefields = $DB->pselect(
                 "SELECT SourceField, Name FROM parameter_type
                 WHERE queryable='1' AND sourcefrom = :sf
                 ORDER BY Name",
-                array('sf' => $instrument)
+                ['sf' => $instrument]
             );
         } elseif (!is_null($commentID)) { //get sourcefield using commentid
             $instrument   = $DB->pselectOne(
                 "SELECT Test_name FROM flag WHERE CommentID = :cid",
-                array('cid' => $commentID)
+                ['cid' => $commentID]
             );
             $sourcefields = $DB->pselect(
                 "SELECT SourceField, Name FROM parameter_type
                 WHERE queryable = '1' AND sourcefrom = :instrument
                 ORDER BY Name",
-                array('instrument' => $instrument)
+                ['instrument' => $instrument]
             );
         } elseif (!is_null($name)) { //get all source fields
             $sourcefields = $DB->pselectRow(
                 "SELECT * FROM parameter_type WHERE Name = :pn",
-                array('pn' => $name)
+                ['pn' => $name]
             );
         }
         return $sourcefields;
@@ -753,7 +753,7 @@ class Utility
     {
         $factory = \NDB_Factory::singleton();
         $db      = $factory->database();
-        $qparams = array();
+        $qparams = [];
 
         if ($projectID != null) {
             $ExtraProject_Criteria
@@ -771,7 +771,7 @@ class Utility
             AND psc.CenterID!= '1'
             $ExtraProject_Criteria ORDER BY Visit_label";
         $visitlabels    = $db->pselect($query, $qparams);
-        $visits         = array();
+        $visits         = [];
         $numVisitLabels = count($visitlabels);
         for ($i = 0; $i < $numVisitLabels; $i++) {
             $visits[$visitlabels[$i]['Visit_label']]
@@ -807,7 +807,7 @@ class Utility
             $test_names = $DB->pselect(
                 "SELECT DISTINCT Test_name_display FROM test_battery
                 WHERE Visit_label=:vl",
-                array('vl' => $visit_label)
+                ['vl' => $visit_label]
             );
         } else {
             $test_names = $DB->pselect(
@@ -819,7 +819,7 @@ class Utility
                 WHERE c.Active='Y' AND s.Active='Y' AND s.Visit_label =:vl
                 AND psc.CenterID != '1' AND c.Entity_type != 'Scanner'
                 ORDER BY t.Full_name",
-                array('vl' => $visit_label)
+                ['vl' => $visit_label]
             );
         }
 
@@ -835,7 +835,7 @@ class Utility
      */
     static function resolvePath(string $path): string
     {
-        $resolvedPath = array();
+        $resolvedPath = [];
         // do some normalization
         $path        = str_replace('//', '/', $path);
         $path_pieces = explode('/', $path);
@@ -912,9 +912,9 @@ class Utility
         $languagesDB = $DB->pselect(
             "SELECT language_id, language_label
              FROM language",
-            array()
+            []
         );
-        $languages   = array();
+        $languages   = [];
         foreach ($languagesDB as $language) {
             $languages[$language['language_id']] = $language['language_label'];
         }
@@ -1009,10 +1009,10 @@ class Utility
             "SELECT ID, Scan_type 
              FROM mri_scan_type mri
                 JOIN files f ON (f.AcquisitionProtocolID=mri.ID)",
-            array()
+            []
         );
 
-        $scan_types = array();
+        $scan_types = [];
         foreach ($scan_types_DB as $scan_type) {
             $scan_types[$scan_type['ID']] = $scan_type['Scan_type'];
         }

--- a/php/libraries/VisitController.class.inc
+++ b/php/libraries/VisitController.class.inc
@@ -65,7 +65,7 @@ class VisitController
                  visit v
 ORDER BY ID
                 ',
-                array()
+                []
             )
         );
     }
@@ -95,7 +95,7 @@ ORDER BY ID
                  v.VisitName = :name
                 ORDER BY ID
                 ',
-                array('name' => $visit)
+                ['name' => $visit]
             )
         );
     }
@@ -109,11 +109,11 @@ ORDER BY ID
     {
         return array_map(
             function ($row) {
-                return array(
+                return [
                     new \LORIS\Visit($row['name'], $row['ID']),
                     $row['project'],    // will be modified to object when
                     $row['subproject'], // available
-                );
+                ];
             },
             $this->database->pselect(
                 'SELECT
@@ -131,7 +131,7 @@ ORDER BY ID
                  ON vps.ProjectSubprojectRelID = psr.ProjectSubprojectRelID
                 ORDER BY ID, project, subproject
                 ',
-                array()
+                []
             )
         );
     }

--- a/test/LorisCS.xml
+++ b/test/LorisCS.xml
@@ -70,4 +70,8 @@
      </rule>
      <!-- Do not allow PHP closing tags because they can cause problems -->
      <rule ref="PSR2.Files.ClosingTag"/>
+
+     <!-- Force short array syntax -->
+     <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found"/>
+
 </ruleset>

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -40,7 +40,7 @@ abstract class LorisIntegrationTest extends TestCase
      */
     protected $validPassword = 'sufficient length and complexity';
 
-    private $_oldConfig = array();
+    private $_oldConfig = [];
 
     /**
      * Does basic setting up of Loris variables for this test, such as
@@ -72,7 +72,7 @@ abstract class LorisIntegrationTest extends TestCase
 
         $this->DB->insert(
             "users",
-            array(
+            [
                 'ID'               => 999990,
                 'UserID'           => 'UnitTester',
                 'Real_name'        => 'Unit Tester',
@@ -85,23 +85,23 @@ abstract class LorisIntegrationTest extends TestCase
                 'Password_hash'    => $password,
                 'Password_expiry'  => '2099-12-31',
                 'Pending_approval' => 'N',
-            )
+            ]
         );
 
         $this->DB->insert(
             "user_psc_rel",
-            array(
+            [
                 'UserID'   => 999990,
                 'CenterID' => 1,
-            )
+            ]
         );
 
         $this->DB->insert(
             "user_project_rel",
-            array(
+            [
                 'UserID'    => 999990,
                 'ProjectID' => 1,
-            )
+            ]
         );
 
         $this->resetPermissions();
@@ -202,9 +202,9 @@ abstract class LorisIntegrationTest extends TestCase
         }
 
         // Delete the temporary user.
-        $this->DB->delete("user_login_history", array('userID' => 'UnitTester'));
-        $this->DB->delete("user_perm_rel", array("UserID" => '999990'));
-        $this->DB->delete("users", array("UserID" => 'UnitTester'));
+        $this->DB->delete("user_login_history", ['userID' => 'UnitTester']);
+        $this->DB->delete("user_perm_rel", ["UserID" => '999990']);
+        $this->DB->delete("users", ["UserID" => 'UnitTester']);
         // Close the browser and end the session
         if ($this->webDriver) {
             $this->webDriver->quit();
@@ -228,7 +228,7 @@ abstract class LorisIntegrationTest extends TestCase
     {
         $configID = $this->DB->pselectOne(
             "SELECT ID FROM ConfigSettings WHERE Name=:configName",
-            array("configName" => $configName)
+            ["configName" => $configName]
         );
 
         if (is_array($configID) && empty($configID)) {
@@ -238,18 +238,18 @@ abstract class LorisIntegrationTest extends TestCase
         }
         $oldVal = $this->DB->pselectOne(
             "SELECT Value FROM Config WHERE ConfigID=:confID",
-            array("confID" => $configID)
+            ["confID" => $configID]
         );
 
-        $this->_oldConfig[$configName] = array(
+        $this->_oldConfig[$configName] = [
             'ConfigID' => $configID,
             'OldValue' => $oldVal,
-        );
+        ];
 
         $this->DB->update(
             "Config",
-            array("Value" => $value),
-            array("ConfigID" => $configID)
+            ["Value" => $value],
+            ["ConfigID" => $configID]
         );
     }
 
@@ -268,8 +268,8 @@ abstract class LorisIntegrationTest extends TestCase
         if (isset($this->_oldConfig[$configName])) {
             $this->DB->update(
                 "Config",
-                array("Value" => $this->_oldConfig[$configName]['OldValue']),
-                array("ConfigID" => $this->_oldConfig[$configName]['ConfigID'])
+                ["Value" => $this->_oldConfig[$configName]['OldValue']],
+                ["ConfigID" => $this->_oldConfig[$configName]['ConfigID']]
             );
         }
     }
@@ -285,7 +285,7 @@ abstract class LorisIntegrationTest extends TestCase
      */
     function setupPermissions($permissions)
     {
-        $this->DB->delete("user_perm_rel", array("UserID" => '999990'));
+        $this->DB->delete("user_perm_rel", ["UserID" => '999990']);
         $prepare = $this->DB->prepare(
             "INSERT INTO user_perm_rel
                 SELECT 999990, PermID
@@ -295,8 +295,8 @@ abstract class LorisIntegrationTest extends TestCase
         foreach ($permissions as $value) {
             $this->DB->execute(
                 $prepare,
-                array("perm" => $value),
-                array('nofetch' => true)
+                ["perm" => $value],
+                ['nofetch' => true]
             );
         }
     }
@@ -321,11 +321,11 @@ abstract class LorisIntegrationTest extends TestCase
      */
     function changeStudySite()
     {
-        $this->DB->insert("psc", array("CenterID" => 99, "Alias" => "BBQ"));
+        $this->DB->insert("psc", ["CenterID" => 99, "Alias" => "BBQ"]);
         $this->DB->update(
             "user_psc_rel",
-            array("CenterID" => 99),
-            array("UserID" => 999990)
+            ["CenterID" => 99],
+            ["UserID" => 999990]
         );
     }
 
@@ -339,10 +339,10 @@ abstract class LorisIntegrationTest extends TestCase
         $this->DB->run('SET foreign_key_checks =0');
         $this->DB->update(
             "user_psc_rel",
-            array("CenterID" => 1),
-            array("UserID" => 999990)
+            ["CenterID" => 1],
+            ["UserID" => 999990]
         );
-        $this->DB->delete("psc", array("CenterID" => 99));
+        $this->DB->delete("psc", ["CenterID" => 99]);
         $this->DB->run('SET foreign_key_checks =1');
     }
 
@@ -358,12 +358,12 @@ abstract class LorisIntegrationTest extends TestCase
     {
         $this->DB->insert(
             "subproject",
-            array(
+            [
                 "SubprojectID"      => $SubprojectID,
                 "title"             => $title,
                 "WindowDifference"  => "optimal",
                 "RecruitmentTarget" => "100",
-            )
+            ]
         );
     }
 
@@ -378,11 +378,11 @@ abstract class LorisIntegrationTest extends TestCase
     {
         $this->DB->delete(
             "subproject",
-            array(
+            [
                 "title"             => $title,
                 "WindowDifference"  => "optimal",
                 "RecruitmentTarget" => "100",
-            )
+            ]
         );
     }
 
@@ -426,7 +426,7 @@ abstract class LorisIntegrationTest extends TestCase
      */
     function deleteCandidate($pscid)
     {
-        $this->DB->delete("candidate", array("PSCID" => $pscid));
+        $this->DB->delete("candidate", ["PSCID" => $pscid]);
     }
 
     /**
@@ -562,7 +562,7 @@ abstract class LorisIntegrationTest extends TestCase
 
             $this->webDriver->executeScript(
                 "arguments[0].click();",
-                array($webElement)
+                [$webElement]
             );
         }
     }
@@ -644,7 +644,7 @@ abstract class LorisIntegrationTest extends TestCase
         string $path,
         string $permission = ''
     ): string {
-        $this->setupPermissions(array($permission));
+        $this->setupPermissions([$permission]);
         $this->safeGet($this->url . $path);
         return $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/test/integrationtests/LorisIntegrationTestWithCandidate.class.inc
+++ b/test/integrationtests/LorisIntegrationTestWithCandidate.class.inc
@@ -30,7 +30,7 @@ abstract class LorisIntegrationTestWithCandidate extends LorisIntegrationTest
 
         $this->DB->insert(
             "candidate",
-            array(
+            [
                 'CandID'                => '900000',
                 'PSCID'                 => 'TST0001',
                 'RegistrationCenterID'  => 1,
@@ -38,19 +38,19 @@ abstract class LorisIntegrationTestWithCandidate extends LorisIntegrationTest
                 'Active'                => 'Y',
                 'UserID'                => 1,
                 'Entity_type'           => 'Human'
-            )
+            ]
         );
 
         $this->DB->insert(
             'session',
-            array(
+            [
                 'ID'            => '999999',
                 'CandID'        => '900000',
                 'Visit_label'   => 'Test',
                 'CenterID'      => 1,
                 'ProjectID'     => 1,
                 'Current_stage' => 'Not Started',
-            )
+            ]
         );
         // Set up database wrapper and config
     }
@@ -62,8 +62,8 @@ abstract class LorisIntegrationTestWithCandidate extends LorisIntegrationTest
      */
     public function tearDown(): void
     {
-        $this->DB->delete("session", array('CandID' => '900000'));
-        $this->DB->delete("candidate", array('CandID' => '900000'));
+        $this->DB->delete("session", ['CandID' => '900000']);
+        $this->DB->delete("candidate", ['CandID' => '900000']);
         parent::tearDown();
     }
 }

--- a/tools/assign_missing_instruments.php
+++ b/tools/assign_missing_instruments.php
@@ -68,7 +68,7 @@ if (!empty($argv[1]) && $argv[1]!="confirm") {
         "SELECT DISTINCT Visit_label FROM session
         WHERE Active='Y' AND Visit_label NOT LIKE '%phantom%' AND Visit_label
         NOT LIKE 'Vsup%' AND COALESCE(Submitted,'N')='N'  ",
-        array()
+        []
     );
 }
 
@@ -134,7 +134,7 @@ if (isset($visit_label)) {
             s LEFT JOIN candidate c USING (CandID) 
             WHERE s.Active='Y'
             AND c.Active='Y' AND s.visit_label=:vl";
-    $where = array('vl' => $argv[1]);
+    $where = ['vl' => $argv[1]];
 
     $results = $DB->pselect($query, $where);
     foreach ($results as $result) {
@@ -144,7 +144,7 @@ if (isset($visit_label)) {
     $query   ="SELECT s.ID, s.subprojectID, s.Visit_label, s.CandID from session s 
             LEFT JOIN candidate c USING (CandID) WHERE s.Active='Y' 
             AND c.Active='Y' AND s.Visit_label NOT LIKE 'Vsup%'";
-    $results = $DB->pselect($query, array());
+    $results = $DB->pselect($query, []);
     foreach ($results as $result) {
         populateVisitLabel($result, $result['Visit_label']);
     }

--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -44,7 +44,7 @@ require_once "generic_includes.php";
 const MIN_NUMBER_OF_ARGS = 4;
 
 // Possible script actions
-$actions = array('delete_candidate');
+$actions = ['delete_candidate'];
 
 //define the command line parameters
 if (count($argv) < MIN_NUMBER_OF_ARGS
@@ -89,10 +89,10 @@ $candExists = $DB->pselectOne(
     "SELECT COUNT(*) 
       FROM candidate 
       WHERE CandID = :cid AND PSCID = :pid AND Active ='Y'",
-    array(
+    [
         'cid' => $CandID,
         'pid' => $PSCID,
-    )
+    ]
 );
 if ($candExists == 0) {
     echo "\nThe candidate with CandID : $CandID  and PSCID : $PSCID either does ".
@@ -103,10 +103,10 @@ $entityType = $DB->pselectOne(
     "SELECT Entity_type 
       FROM candidate 
       WHERE CandID = :cid AND PSCID = :pid AND Active ='Y'",
-    array(
+    [
         'cid' => $CandID,
         'pid' => $PSCID,
-    )
+    ]
 );
 if ($entityType === "Scanner") {
     echo "\nThe candidate with CandID : $CandID  and PSCID : $PSCID is a scanner ".
@@ -191,7 +191,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
                 " $CandID $PSCID $sid $subOutputType"
             );
             //echo $out;
-            $match    = array();
+            $match    = [];
             $nbDelete = preg_match_all("/(DELETE FROM .*;)/", $out, $match);
             if ($nbDelete > 0) {
                 for ($i=0; $i < $nbDelete; $i++) {
@@ -207,7 +207,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "--------------------\n";
     $result = $DB->pselect(
         'SELECT * FROM participant_status WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -216,7 +216,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "----------------------------\n";
     $result = $DB->pselect(
         'SELECT * FROM participant_status_history WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -225,7 +225,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "---------------------\n";
     $result = $DB->pselect(
         'SELECT * FROM parameter_candidate WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -234,7 +234,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "-----------\n";
     $result = $DB->pselect(
         'SELECT * FROM SNP_candidate_rel WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -243,7 +243,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "-----------\n";
     $result = $DB->pselect(
         'SELECT * FROM CNV WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -252,7 +252,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "-----------\n";
     $result = $DB->pselect(
         'SELECT * FROM genomic_candidate_files_rel WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -261,7 +261,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "-----------\n";
     $result = $DB->pselect(
         'SELECT * FROM genomic_sample_candidate_rel WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -270,7 +270,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "-----------\n";
     $result = $DB->pselect(
         'SELECT * FROM issues WHERE candID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -279,7 +279,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     echo "-----------\n";
     $result = $DB->pselect(
         'SELECT * FROM candidate WHERE CandID=:cid',
-        array('cid' => $CandID)
+        ['cid' => $CandID]
     );
     print_r($result);
 
@@ -290,37 +290,37 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
             $PSCID . "\n";
 
         //delete from the participant_status table
-        $DB->delete("participant_status", array("CandID" => $CandID));
+        $DB->delete("participant_status", ["CandID" => $CandID]);
 
         //delete from the participant_status_history table
-        $DB->delete("participant_status_history", array("CandID" => $CandID));
+        $DB->delete("participant_status_history", ["CandID" => $CandID]);
 
         //delete from parameter_candidate
-        $DB->delete("parameter_candidate", array("CandID" => $CandID));
+        $DB->delete("parameter_candidate", ["CandID" => $CandID]);
 
         //delete from SNP_candidate_rel
-        $result = $DB->delete("SNP_candidate_rel", array("CandID" => $CandID));
+        $result = $DB->delete("SNP_candidate_rel", ["CandID" => $CandID]);
 
         //delete from CNV
-        $result = $DB->delete("CNV", array("CandID" => $CandID));
+        $result = $DB->delete("CNV", ["CandID" => $CandID]);
 
         //delete from genomic_candidate_files_rel
         $result = $DB->delete(
             "genomic_candidate_files_rel",
-            array("CandID" => $CandID)
+            ["CandID" => $CandID]
         );
 
         //delete from genomic_sample_candidate_rel
         $result = $DB->delete(
             "genomic_sample_candidate_rel",
-            array("CandID" => $CandID)
+            ["CandID" => $CandID]
         );
 
         //delete from issues
-        $result = $DB->delete("issues", array("candID" => $CandID));
+        $result = $DB->delete("issues", ["candID" => $CandID]);
 
         //delete from candidate
-        $DB->delete("candidate", array("CandID" => $CandID));
+        $DB->delete("candidate", ["CandID" => $CandID]);
     } elseif ($printToSQL) {
         echo "Generating all DELETE statements for CandID: " . $CandID
             . " And PSCID: " .
@@ -329,7 +329,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         //delete from the participant_status table
         _printResultsSQL(
             "participant_status",
-            array("CandID" => $CandID),
+            ["CandID" => $CandID],
             $output,
             $DB
         );
@@ -337,7 +337,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         //delete from the participant_status_history table
         _printResultsSQL(
             "participant_status_history",
-            array("CandID" => $CandID),
+            ["CandID" => $CandID],
             $output,
             $DB
         );
@@ -345,7 +345,7 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         //delete from parameter_candidate
         _printResultsSQL(
             "parameter_candidate",
-            array("CandID" => $CandID),
+            ["CandID" => $CandID],
             $output,
             $DB
         );
@@ -353,18 +353,18 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         //delete from SNP_candidate_rel
         _printResultsSQL(
             "SNP_candidate_rel",
-            array("CandID" => $CandID),
+            ["CandID" => $CandID],
             $output,
             $DB
         );
 
         //delete from CNV
-        _printResultsSQL("CNV", array("CandID" => $CandID), $output, $DB);
+        _printResultsSQL("CNV", ["CandID" => $CandID], $output, $DB);
 
         //delete from genomic_candidate_files_rel
         _printResultsSQL(
             "genomic_candidate_files_rel",
-            array("CandID" => $CandID),
+            ["CandID" => $CandID],
             $output,
             $DB
         );
@@ -372,16 +372,16 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         //delete from genomic_sample_candidate_rel
         _printResultsSQL(
             "genomic_sample_candidate_rel",
-            array("CandID" => $CandID),
+            ["CandID" => $CandID],
             $output,
             $DB
         );
 
         //delete from issues
-        _printResultsSQL("issues", array("candID" => $CandID), $output, $DB);
+        _printResultsSQL("issues", ["candID" => $CandID], $output, $DB);
 
         //delete from candidate
-        _printResultsSQL("candidate", array("CandID" => $CandID), $output, $DB);
+        _printResultsSQL("candidate", ["CandID" => $CandID], $output, $DB);
 
         _exportSQL($output, $CandID);
     }

--- a/tools/delete_ignored_conflicts.php
+++ b/tools/delete_ignored_conflicts.php
@@ -42,16 +42,16 @@ $client->initialize();
 $config =& NDB_Config::singleton();
 
 // Meta fields that should be removed
-$defaultFields = array(
+$defaultFields = [
     'CommentID',
     'UserID',
     'Testdate',
     'Window_Difference',
     'Candidate_Age',
     'Data_entry_completion_status',
-);
+];
 
-$instruments         = array();
+$instruments         = [];
 $instrumentSpecified = false;
 
 $confirm = false;
@@ -92,7 +92,7 @@ if ($confirm === false) {
  */
 function detectIgnoreColumns($instruments)
 {
-    $instrumentFields = array();
+    $instrumentFields = [];
 
     foreach ($instruments as $instrument) {
         echo "Checking DDE ignore fields for " . $instrument . "\n";
@@ -109,7 +109,7 @@ function detectIgnoreColumns($instruments)
                     if (!in_array($DDEField, $this->defaultFields)) {
                         $instrumentFields = array_merge(
                             $instrumentFields,
-                            array($DDEField => $instrument)
+                            [$DDEField => $instrument]
                         );
                     }
                 }
@@ -145,7 +145,7 @@ function defaultIgnoreColumns()
         foreach ($this->defaultFields as $field) {
             $defaultQuery  = "SELECT TableName, FieldName, Value1, Value2 
           FROM conflicts_unresolved WHERE FieldName = '$field'";
-            $defaultColumn = $db->pselectOne($defaultQuery, array());
+            $defaultColumn = $db->pselectOne($defaultQuery, []);
             echo "TableName, FieldName, Value1, Value2: ";
             print_r($defaultColumn);
             echo "\n";
@@ -178,7 +178,7 @@ function ignoreColumn($instrument, $instrumentFields)
             $query        = "SELECT TableName, FieldName, Value1, Value2 
                 FROM conflicts_unresolved 
                 WHERE TableName = '$instrument' AND FieldName = '$field'";
-            $ignoreColumn = $db->pselectOne($query, array());
+            $ignoreColumn = $db->pselectOne($query, []);
             echo "TableName, FieldName, Value1, Value2: ";
             print_r($ignoreColumn);
             echo  "\n";

--- a/tools/detect_duplicated_commentids.php
+++ b/tools/detect_duplicated_commentids.php
@@ -78,26 +78,26 @@ $config         = NDB_Config::singleton();
 $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 $dataDir        = "logs";
 $diff           = null;
-$commentids     = array();
+$commentids     = [];
 //Check to see if the variable instrument is set
 if (($instrument=='all') ||($instrument=='All')) {
     $instruments = Utility::getAllInstruments();
 } else {
-    $instruments = array($instrument => $instrument);
+    $instruments = [$instrument => $instrument];
 }
 
 //get all candidates
-$candidates = $DB->pselect("SELECT CandID, PSCID FROM candidate", array());
+$candidates = $DB->pselect("SELECT CandID, PSCID FROM candidate", []);
 //get all subprojectids
 $subprojectids = $DB->pselect(
     "SELECT DISTINCT subprojectid FROM session",
-    array()
+    []
 );
 
 foreach ($instruments as $instrument => $full_name) {
     if ((isset($instrument)) && (hasData($instrument))) {
         print "instrument is $instrument \n";
-        $commentids = array();
+        $commentids = [];
         foreach ($candidates as $candidate) {
             $candid = $candidate['CandID'];
             $pscid  = $candidate['PSCID'];
@@ -108,11 +108,11 @@ foreach ($instruments as $instrument => $full_name) {
                     JOIN flag f on (f.sessionid=s.id)
                     WHERE s.candID = :cid AND f.test_name = :fname AND
                     s.subprojectid = :subid",
-                    array(
+                    [
                         'cid'   => $candid,
                         'fname' => $instrument,
                         'subid' => $subprojectid['subprojectid'],
-                    )
+                    ]
                 );
                 if (($session_info!=null) && (!empty($session_info))) {
                     $sessionid   = $session_info['ID'];
@@ -167,8 +167,8 @@ function getCommentIDs(
 ) {
 
     $commentID  = $candid. $pscid. $sid . $subprojectid;
-    $commentids = array();
-    $flag_info  = array();
+    $commentids = [];
+    $flag_info  = [];
 
     if ($commentID !=null && $test_name!=null) {
         $query = " SELECT '$pscid' AS PSCID,'$visit_label' AS VisitLabel,
@@ -185,10 +185,10 @@ function getCommentIDs(
     ///include the flag_data_entry and in_flag
     if ($commentids !=null) {
         foreach ($commentids as $key => $commentid) {
-            $flag = array();
+            $flag = [];
             $flag = $GLOBALS['DB']->pselectRow(
                 "SELECT * FROM flag WHERE CommentID = :cid",
-                array('cid' => $commentid['CommentID'])
+                ['cid' => $commentid['CommentID']]
             );
             $flag_info['flag_data_entry'] = $flag['Data_entry'];
             $flag_info['in_flag']         = 'No';
@@ -249,7 +249,7 @@ function hasData($instrument)
 {
     $commentids = $GLOBALS['DB']->pselect(
         "SELECT COUNT(*) FROM $instrument",
-        array()
+        []
     );
     if ((count($commentids)) > 0) {
         return true;

--- a/tools/populate_examiners_psc_rel.php
+++ b/tools/populate_examiners_psc_rel.php
@@ -25,13 +25,13 @@ $db     =& Database::singleton();
 
 $examinersRows = $db->pselect(
     "SELECT * FROM examiners",
-    array()
+    []
 );
 
 //get all instruments to update examiner fields
 $instruments = Utility::getAllInstruments();
 
-$examinersOrganized =array();
+$examinersOrganized =[];
 
 // ASSERT DB state
 // Make sure there is no cause for errors
@@ -39,7 +39,7 @@ $errorPRE =false;
 ///////// examiners.centerID not in psc.CenterID
 $pscCheck = $db->pselect(
     "SELECT * FROM examiners WHERE centerID NOT IN (SELECT centerID FROM psc)",
-    array()
+    []
 );
 if (!empty($pscCheck)) {
     $errorPRE =true;
@@ -51,7 +51,7 @@ if (!empty($pscCheck)) {
 ///////// examiners.centerID is null
 $pscNullCheck = $db->pselect(
     "SELECT * FROM examiners WHERE centerID IS NULL",
-    array()
+    []
 );
 if (!empty($pscNullCheck)) {
     $errorPRE =true;
@@ -63,7 +63,7 @@ if (!empty($pscNullCheck)) {
 ///////// examiners.full_name is null
 $nameNullCheck = $db->pselect(
     "SELECT * FROM examiners WHERE full_name IS NULL OR full_name =''",
-    array()
+    []
 );
 if (!empty($nameNullCheck)) {
     $errorPRE =true;
@@ -75,7 +75,7 @@ if (!empty($nameNullCheck)) {
 ///////// examiners.full_name is null
 $activeNullCheck = $db->pselect(
     "SELECT * FROM examiners WHERE active IS NULL OR active =''",
-    array()
+    []
 );
 if (!empty($activeNullCheck)) {
     $errorPRE =true;
@@ -87,7 +87,7 @@ if (!empty($activeNullCheck)) {
 ///////// examiners.full_name is null
 $pendingNullCheck = $db->pselect(
     "SELECT * FROM examiners WHERE pending_approval IS NULL OR pending_approval =''",
-    array()
+    []
 );
 if (!empty($pendingNullCheck)) {
     $errorPRE =true;
@@ -101,7 +101,7 @@ $certCheck = $db->pselect(
     "SELECT DISTINCT examinerID 
      FROM certification 
      WHERE examinerID NOT IN (SELECT examinerID FROM examiners)",
-    array()
+    []
 );
 if (!empty($certCheck)) {
     $errorPRE =true;
@@ -116,7 +116,7 @@ foreach ($instruments as $table => $name) {
         $instCheck = $db->pselect(
             "SELECT * FROM ".$table
             ." WHERE Examiner NOT IN (SELECT examinerID FROM examiners)",
-            array()
+            []
         );
         if (!empty($instCheck)) {
             $errorPRE =true;
@@ -131,7 +131,7 @@ $frrCheck = $db->pselect(
     "SELECT * FROM final_radiological_review 
       WHERE Final_Examiner2 NOT IN (SELECT examinerID FROM examiners) 
           OR Final_Examiner NOT IN (SELECT examinerID FROM examiners) ",
-    array()
+    []
 );
 if (!empty($frrCheck)) {
     $errorPRE =true;
@@ -154,12 +154,12 @@ ERRORS;
 }
 
 foreach ($examinersRows as $k => $row) {
-    $item = array(
+    $item = [
         'examinerID'       => $row['examinerID'],
         'centerID'         => $row['centerID'],
         'active'           => $row['active'],
         'pending_approval' => $row['pending_approval'],
-    );
+    ];
     // Compare without spaces, without cases
     $examinersOrganized[strtolower(
         str_replace(
@@ -203,8 +203,8 @@ foreach ($examinersOrganized as $name => $data_array) {
             .$oldExaminerID."=>".$finalExaminerID."\n";
         $db->update(
             'certification',
-            array('examinerID' => $finalExaminerID),
-            array('examinerID' => $oldExaminerID)
+            ['examinerID' => $finalExaminerID],
+            ['examinerID' => $oldExaminerID]
         );
 
         // UPDATE final_radiological_review
@@ -212,13 +212,13 @@ foreach ($examinersOrganized as $name => $data_array) {
             .$oldExaminerID."=>".$finalExaminerID."\n";
         $db->update(
             'final_radiological_review',
-            array('Final_Examiner' => $finalExaminerID),
-            array('Final_Examiner' => $oldExaminerID)
+            ['Final_Examiner' => $finalExaminerID],
+            ['Final_Examiner' => $oldExaminerID]
         );
         $db->update(
             'final_radiological_review',
-            array('Final_Examiner2' => $finalExaminerID),
-            array('Final_Examiner2' => $oldExaminerID)
+            ['Final_Examiner2' => $finalExaminerID],
+            ['Final_Examiner2' => $oldExaminerID]
         );
         // UPDATE instrument tables
         foreach ($instruments as $table => $name) {
@@ -229,14 +229,14 @@ foreach ($examinersOrganized as $name => $data_array) {
                     . "$oldExaminerID => $finalExaminerID\n";
                 $db->update(
                     $table,
-                    array('Examiner' => $finalExaminerID),
-                    array('Examiner' => $oldExaminerID)
+                    ['Examiner' => $finalExaminerID],
+                    ['Examiner' => $oldExaminerID]
                 );
             }
         }
         // DELETE examiners additional entries
         echo "    -> DELETING duplicate examinerID: ".$oldExaminerID."\n\n";
-        $db->delete('examiners', array('examinerID' => $oldExaminerID));
+        $db->delete('examiners', ['examinerID' => $oldExaminerID]);
     }
 }
 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -210,7 +210,7 @@ printHeader('Changing the admin password...');
 echo 'Please choose a new password for the admin user:' . PHP_EOL;
 flush();
 // Invoke the script `tools/resetpassword.php` for user 'admin'.
-$cmd = implode(' ', array('php', __DIR__ . '/resetpassword.php', 'admin'));
+$cmd = implode(' ', ['php', __DIR__ . '/resetpassword.php', 'admin']);
 exec($cmd);
 
 printHeader('Test data successfully installed.');

--- a/tools/resetpassword.php
+++ b/tools/resetpassword.php
@@ -30,7 +30,7 @@ $user = $args[1];
 
 $validate = $DB->pselectOne(
     "SELECT UserID FROM users WHERE UserID=:username",
-    array("username" => $user)
+    ["username" => $user]
 );
 if (empty($validate)) {
     fwrite(STDERR, "Invalid username: $user\n");
@@ -49,5 +49,5 @@ $newHash = password_hash($newPass, PASSWORD_DEFAULT);
 
 // this script is assumed to be being run by an admin, since they have local
 // access to the server. There's no validation of the old password.
-$DB->update("users", array("Password_hash" => $newHash), array("UserID" => $user));
+$DB->update("users", ["Password_hash" => $newHash], ["UserID" => $user]);
 echo "\nUpdated password for $user\n";

--- a/tools/setconfig.php
+++ b/tools/setconfig.php
@@ -38,7 +38,7 @@ $value   = $args[2];
 
 $config = $DB->pselectRow(
     "SELECT ID, AllowMultiple FROM ConfigSettings WHERE Name=:config",
-    array('config' => $setting)
+    ['config' => $setting]
 );
 
 if (count($config ?? []) === 0) {
@@ -58,11 +58,11 @@ if ($multiple == '1') {
 // Determine whether to insert or update
 $newconfig = (int )$DB->pselectOne(
     "SELECT COUNT(*) FROM Config WHERE ConfigID=:id",
-    array('id' => $id)
+    ['id' => $id]
 );
 
 if ($newconfig === 0) {
-    $DB->insert("Config", array('Value' => $value, 'ConfigID' => $id));
+    $DB->insert("Config", ['Value' => $value, 'ConfigID' => $id]);
 } else {
-    $DB->update("Config", array('Value' => $value), array('ConfigID' => $id));
+    $DB->update("Config", ['Value' => $value], ['ConfigID' => $id]);
 }

--- a/tools/single_use/Cleanup_multiple_firstVisits.php
+++ b/tools/single_use/Cleanup_multiple_firstVisits.php
@@ -27,7 +27,7 @@ $query_candID = "SELECT CandID
                   WHERE VisitNo=1 
                   GROUP BY CandID 
                   HAVING COUNT(CandID) > 1";
-$candIDs      = $db->pselect($query_candID, array());
+$candIDs      = $db->pselect($query_candID, []);
 
 if (empty($candIDs)) {
     echo "No multiple first visits.\n";
@@ -40,7 +40,7 @@ if (empty($candIDs)) {
                             FROM `session` 
                             WHERE CandID=:candID 
                             ORDER BY Date_visit";
-        $where           = array('candID' => $candID);
+        $where           = ['candID' => $candID];
         $sessionIDs      = $db->pselect($query_sessionID, $where);
 
         // Reset visit number in order of date of visit
@@ -48,8 +48,8 @@ if (empty($candIDs)) {
         foreach ($sessionIDs as $result) {
             echo "      Changing visit number: $result[VisitNo] to $visitNo\n";
             $sessionID = $result['ID'];
-            $set       = array('VisitNo' => $visitNo);
-            $where_sessionID = array('ID' => $sessionID);
+            $set       = ['VisitNo' => $visitNo];
+            $where_sessionID = ['ID' => $sessionID];
             if ($confirm) {
                 $db->update('session', $set, $where_sessionID);
             }


### PR DESCRIPTION
## Brief summary of changes

Commit 1 - Add PHPCS rule that we must use short array syntax
Commit 2 - use PHPCBF to change all the array declarations

We can go the other way instead (force long arrays) but I think this is better.