### PR TITLE
[NDB_BVL_Instrument_LINST] Show subtests

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -408,7 +408,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             // parse the whole file for table{@} and other meta elements
             $addElements = true;
             if (!empty($this->page)) {
-                $currentPage = $_REQUEST['subtest'];
+                $currentPage = $this->page;
                 $addElements = false;
             } else {
                 $currentPage = 'top';


### PR DESCRIPTION
## Brief summary of changes

Linst instrument subtests are blank and not able to render its fields. This is because of legacy request variable left over from before PR https://github.com/aces/Loris/pull/4229 that introduced a new instruments loading module.

This PR replaces the call for a request variable that doesn't exist with the class' $this->page

#### Testing instructions (if applicable)

*This might only be testable by a project developer who has access to a multi-page linst instrument. Raisinbread currently only has the bmi.linst, which does not have subtests. 

1. Go to any multi-page php instrument with subtests. There will be no errors. You are able to view everything fine.
2. Do the same with a mutli-page linst instrument with subtests. You will only be able to see the 'top' page, and not any of the other subtests.
3. On this PR branch, you will be able to see the linst subtests.
