### PR TITLE
[InstrumentStatus_ControlPanel] Restore $validity to $Validity

### DIFF
--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -27,8 +27,8 @@ use LORIS\StudyEntities\Candidate\CandID;
 class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 {
     public $tpl_data;
-    public $validityEnabled;
-    public $validityRequired;
+    public $ValidityEnabled;
+    public $ValidityRequired;
     protected $instrument;
     /**
      * Construct a controller for the instrument status control panel
@@ -98,8 +98,8 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
             $this->instrument = $instrument;
 
-            $this->validityEnabled  = $instrument->validityEnabled;
-            $this->validityRequired = $instrument->validityRequired;
+            $this->ValidityEnabled  = $instrument->ValidityEnabled;
+            $this->ValidityRequired = $instrument->ValidityRequired;
 
             // generate the subtest list
             $list = $instrument->getSubtestList();
@@ -122,7 +122,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                 = $this->_displayDataEntry();
 
             // generate the validity flag buttons
-            if ($this->validityEnabled == true) {
+            if ($this->ValidityEnabled == true) {
                 $this->tpl_data['access']['validity'] = $this->_displayValidity();
             }
 
@@ -224,7 +224,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                 $showLink = true;
                 $Validity = $this->getValidityStatus();
                 if ($Validity == null
-                    && $this->instrument->validityRequired == true
+                    && $this->instrument->ValidityRequired == true
                     && $this->getAdministrationStatus() != 'None'
                 ) {
                     $showLink = false;


### PR DESCRIPTION
## Brief summary of changes

Reverses changes from https://github.com/aces/Loris/pull/4928 that renames $ValidityEnabled to $validityEnabled and $ValidityRequired to $validityRequired. The variabes are UpperCamerCase elsewhere on Loris. This PR removes the following error that does not allow the Validity flags to render in instruments' control panels

```
PHP Notice:  Undefined property: NDB_BVL_Instrument_aosi::$validityEnabled in /var/www/loris/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc on line 101

PHP Notice:  Undefined property: NDB_BVL_Instrument_aosi::$validityRequired in /var/www/loris/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc on line 102
```

#### Testing instructions (if applicable)

1. On master, go to any instrument page and verify that the 'Validity' section in the control panel is not there. In your apache log, you will see the above posted error.
2. On this branch, the 'Validity' section will appear and you will see no errors in your apache log.
