### PR TITLE
[candidate_profile] Add behavioural data widget

### DIFF
--- a/modules/instruments/jsx/CandidateInstrumentList.js
+++ b/modules/instruments/jsx/CandidateInstrumentList.js
@@ -1,0 +1,37 @@
+import VisitInstrumentList from './VisitInstrumentList';
+
+/**
+ * A CandidateInstrumentList provides a list of instruments for
+ * a candidate and their status in a widget. There is one card
+ * for each visit, and clicking on the visit expands to display
+ * a list of instruments in that visit.
+ *
+ * @param {object} props - React props
+ *
+ * @return {object} - The JSX component
+ */
+function CandidateInstrumentList(props) {
+    const visits = props.Visits.map((visit) => {
+        return (
+            <VisitInstrumentList
+                BaseURL={props.BaseURL}
+                Candidate={props.Candidate}
+                VisitMap={props.VisitMap}
+                Visit={visit} />
+        );
+    });
+
+    const style={
+        display: 'flex',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'space-evenly',
+        padding: 0,
+        margin: 0,
+    };
+    return <div style={style}>
+        {visits}
+        </div>;
+}
+
+export default CandidateInstrumentList;

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -194,7 +194,7 @@ class VisitInstrumentList extends Component {
                                 <tr>
                                     <th>Instrument</th>
                                     <th style={{textAlign: 'center'}}>Completion</th>
-                                    <th>Conflicts?</th>
+                                    <th style={{textAlign: 'center'}}>Conflicts?</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -83,6 +83,7 @@ class VisitInstrumentList extends Component {
             boxSizing: 'border-box',
             transition: 'flex 0.3s, width 0.3s ease-out, height 0.3s ease-out',
             width: '98%',
+            marginBottom: '1ex',
         };
 
         let vstatus = 'Not Started';
@@ -105,7 +106,10 @@ class VisitInstrumentList extends Component {
             width: '100%',
             height: '100%',
             alignItems: 'flex-start',
-            paddingBottom: '1em',
+            border: '1px solid #E4EBF2',
+            borderTopRightRadius: '10px',
+            borderBottomRightRadius: '10px',
+            alignItems: 'center',
         };
         flexcontainer.justifyContent = 'flex-start';
 
@@ -196,6 +200,7 @@ class VisitInstrumentList extends Component {
             width: '100%',
             justifyContent: 'space-between',
             margin: 0,
+            padding: '1ex',
         };
 
         return (<div style={style} onClick={this.toggleExpanded}>

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -192,7 +192,7 @@ class VisitInstrumentList extends Component {
                         <table style={{width: '95%'}}>
                             <tr>
                                 <th>Instrument</th>
-                                <th>Completion</th>
+                                <th style={{textAlign: 'center'}}>Completion</th>
                                 <th>Conflicts?</th>
                             </tr>
                         {instruments}

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -97,13 +97,6 @@ class VisitInstrumentList extends Component {
             backgroundColor: 'transparent',
         };
 
-        if (!this.state.expanded) {
-            style.cursor = 'pointer';
-            if (this.state.hover) {
-                style.backgroundColor = 'rgb(235, 235, 235)';
-            }
-        }
-
         let vstatus = 'Not Started';
         let bg = '#ea9999';
         if (this.props.Visit.Stages.Approval) {
@@ -115,6 +108,19 @@ class VisitInstrumentList extends Component {
         } else if (this.props.Visit.Stages.Screening) {
             vstatus = 'Screening - ' + this.props.Visit.Stages.Screening.Status;
             bg = '#f9cb9c';
+        }
+
+        let clickEnabled = true;
+        if (!this.state.expanded) {
+            if (vstatus === 'Not Started') {
+                style.cursor = 'not-allowed';
+                clickEnabled = false;
+            } else {
+                style.cursor = 'pointer';
+            }
+            if (this.state.hover) {
+                style.backgroundColor = 'rgb(235, 235, 235)';
+            }
         }
 
         let flexcontainer = {
@@ -178,17 +184,21 @@ class VisitInstrumentList extends Component {
                     </tr>);
             });
 
-            instruments = <div>
-                <h5>Instruments</h5>
-                <table style={{width: '95%'}}>
-                    <tr>
-                        <th>Instrument</th>
-                        <th>Completion</th>
-                        <th>Conflicts?</th>
-                    </tr>
-                    {instruments}
-                </table>
-                </div>;
+            if (this.state.instruments.length === 0) {
+                instruments = <div>Visit has no registered instruments in test battery.</div>;
+            } else {
+                instruments = (<div>
+                    <h5>Instruments</h5>
+                        <table style={{width: '95%'}}>
+                            <tr>
+                                <th>Instrument</th>
+                                <th>Completion</th>
+                                <th>Conflicts?</th>
+                            </tr>
+                        {instruments}
+                        </table>
+                    </div>);
+            }
         }
         if (!this.state.expanded || vstatus === 'Not Started') {
             instruments = null;
@@ -221,7 +231,7 @@ class VisitInstrumentList extends Component {
             padding: '1ex',
         };
 
-        return (<div style={style} onClick={this.toggleExpanded}
+        return (<div style={style} onClick={clickEnabled ? this.toggleExpanded : null}
                 onMouseEnter={this.toggleHover}
                 onMouseLeave={this.toggleHover}
             >

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -18,10 +18,20 @@ class VisitInstrumentList extends Component {
          super(props);
          this.state = {
              expanded: false,
+             hover: false,
          };
          this.toggleExpanded = this.toggleExpanded.bind(this);
+         this.toggleHover = this.toggleHover.bind(this);
          this.getInstruments = this.getInstruments.bind(this);
-         this.calcAge= this.calcAge.bind(this);
+         this.calcAge = this.calcAge.bind(this);
+     }
+
+    /**
+     * Toggle determine whether this item is being hovered over.
+     * This is used for styling the background.
+     */
+     toggleHover() {
+         this.setState({hover: !this.state.hover});
      }
 
     /**
@@ -84,7 +94,15 @@ class VisitInstrumentList extends Component {
             transition: 'flex 0.3s, width 0.3s ease-out, height 0.3s ease-out',
             width: '98%',
             marginBottom: '1ex',
+            backgroundColor: 'transparent',
         };
+
+        if (!this.state.expanded) {
+            style.cursor = 'pointer';
+            if (this.state.hover) {
+                style.backgroundColor = 'rgb(235, 235, 235)';
+            }
+        }
 
         let vstatus = 'Not Started';
         let bg = '#ea9999';
@@ -203,7 +221,10 @@ class VisitInstrumentList extends Component {
             padding: '1ex',
         };
 
-        return (<div style={style} onClick={this.toggleExpanded}>
+        return (<div style={style} onClick={this.toggleExpanded}
+                onMouseEnter={this.toggleHover}
+                onMouseLeave={this.toggleHover}
+            >
             <div style={flexcontainer}>
                 <div style={{background: bg, width: '1%', height: '100%'}}>
                 </div>

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -190,12 +190,16 @@ class VisitInstrumentList extends Component {
                 instruments = (<div>
                     <h5>Instruments</h5>
                         <table style={{width: '95%'}}>
-                            <tr>
-                                <th>Instrument</th>
-                                <th style={{textAlign: 'center'}}>Completion</th>
-                                <th>Conflicts?</th>
-                            </tr>
-                        {instruments}
+                            <thead>
+                                <tr>
+                                    <th>Instrument</th>
+                                    <th style={{textAlign: 'center'}}>Completion</th>
+                                    <th>Conflicts?</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {instruments}
+                            </tbody>
                         </table>
                     </div>);
             }

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -189,7 +189,7 @@ class VisitInstrumentList extends Component {
             } else {
                 instruments = (<div>
                     <h5>Instruments</h5>
-                        <table style={{width: '95%'}}>
+                        <table className="table table-hover table-bordered" style={{width: '95%'}}>
                             <thead>
                                 <tr>
                                     <th>Instrument</th>

--- a/modules/instruments/jsx/VisitInstrumentList.js
+++ b/modules/instruments/jsx/VisitInstrumentList.js
@@ -1,0 +1,241 @@
+import React, {Component} from 'react';
+
+/**
+ * A VisitInstrumentList is a type of React component which displays
+ * a visit. Clicking on the visit expands to display or hide all instruments
+ * in that visit and their data entry status.
+ *
+ * The instruments themselves link to the data entry, and the visit goes
+ * to the timepoint_list page.
+ */
+class VisitInstrumentList extends Component {
+    /**
+     * Construct the VisitInstrumentList
+     *
+     * @param {object} props - React props
+     */
+     constructor(props) {
+         super(props);
+         this.state = {
+             expanded: false,
+         };
+         this.toggleExpanded = this.toggleExpanded.bind(this);
+         this.getInstruments = this.getInstruments.bind(this);
+         this.calcAge= this.calcAge.bind(this);
+     }
+
+    /**
+     * Calculate the age at a visit.
+     *
+     * @param {string} dob - The date of birth as a string
+     * @param {string} visit - The visit date as a string
+     *
+     * @return {string} - A human readable description of the age
+     */
+     calcAge(dob, visit) {
+        let dobdate = new Date(dob);
+        let vdate = new Date(visit);
+        let years = vdate.getFullYear()-dobdate.getFullYear();
+        let months = years*12 + vdate.getMonth() - dobdate.getMonth();
+        if (months <= 36) {
+            return months + ' months old';
+        }
+        return years + ' years old';
+    }
+
+    /**
+     * Toggle whether instruments are displayed.
+     */
+    toggleExpanded() {
+        // Only get the instruments the first time, otherwise just reuse
+        // what the data from state.
+        if (!this.state.expanded === true && !this.state.instruments) {
+            this.getInstruments();
+        }
+        this.setState({expanded: !this.state.expanded});
+    }
+
+    /**
+     * Get a list of instruments and their data entry completion percentage.
+     *
+     * The list of instruments will be stored in the component's state.
+     */
+    getInstruments() {
+        fetch(this.props.BaseURL + '/instruments/visitsummary?CandID='
+            + this.props.Candidate.Meta.CandID
+            + '&VisitLabel=' + this.props.Visit.Meta.Visit)
+        .then((response) => response.json())
+        .then((json) => {
+            this.setState({instruments: json});
+        });
+    }
+
+    /**
+     * React lifecycle method. Render the component
+     *
+     * @return {object} - The rendered JSX
+     */
+    render() {
+        let style = {
+            marginBottom: '0.5%',
+            marginRight: '0.5%',
+            textAlign: 'center',
+            boxSizing: 'border-box',
+            transition: 'flex 0.3s, width 0.3s ease-out, height 0.3s ease-out',
+            width: '98%',
+        };
+
+        let vstatus = 'Not Started';
+        let bg = '#ea9999';
+        if (this.props.Visit.Stages.Approval) {
+            vstatus = 'Approval - ' + this.props.Visit.Stages.Approval.Status;
+            bg = '#b6d7a8';
+        } else if (this.props.Visit.Stages.Visit) {
+            vstatus = 'Visit - ' + this.props.Visit.Stages.Visit.Status;
+            bg = '#ffe599';
+        } else if (this.props.Visit.Stages.Screening) {
+            vstatus = 'Screening - ' + this.props.Visit.Stages.Screening.Status;
+            bg = '#f9cb9c';
+        }
+
+        let flexcontainer = {
+            display: 'flex',
+            flexDirection: 'row',
+            flexWrap: 'nowrap',
+            width: '100%',
+            height: '100%',
+            alignItems: 'flex-start',
+            paddingBottom: '1em',
+        };
+        flexcontainer.justifyContent = 'flex-start';
+
+        let center = {
+            display: 'flex',
+            width: '12%',
+            height: '100%',
+            alignItems: 'center',
+            justifyContent: 'center',
+        };
+
+        const termstyle = {paddingLeft: '2em', paddingRight: '2em'};
+
+        let instruments = null;
+        if (!this.state.instruments) {
+            instruments = 'Loading...';
+        } else {
+            instruments = this.state.instruments.map((instrument) => {
+                let conflicterror = null;
+                if (instrument.NumOfConflict != 0) {
+                    conflicterror = (<a href={
+                        this.props.BaseURL
+                        + '/conflict_resolver/?candidateID='
+                        + this.props.Candidate.Meta.CandID
+                        + '&instrument=' + instrument.Test_name
+                        + '&visitLabel=' + this.props.Visit.Meta.Visit}>
+                        <i style={{color: 'red'}}
+                           className="fas fa-exclamation-triangle"></i>
+                    </a>);
+                }
+                return (<tr key={instrument.Test_name}>
+                    <td style={{textAlign: 'left'}}>
+                        <a href={this.props.BaseURL
+                            + '/instruments/' + instrument.Test_name
+                            + '?commentID='
+                            + instrument.CommentID}>
+                            {instrument.Test_name}
+                        </a>
+                    </td>
+                    <td>
+                        <progress
+                            value={instrument.Completion}
+                            max='100'>
+                            {instrument.Completion + '%'}
+                        </progress>
+                    </td>
+                    <td>{conflicterror}</td>
+                    </tr>);
+            });
+
+            instruments = <div>
+                <h5>Instruments</h5>
+                <table style={{width: '95%'}}>
+                    <tr>
+                        <th>Instrument</th>
+                        <th>Completion</th>
+                        <th>Conflicts?</th>
+                    </tr>
+                    {instruments}
+                </table>
+                </div>;
+        }
+        if (!this.state.expanded || vstatus === 'Not Started') {
+            instruments = null;
+        }
+
+        // We don't show the visit date of age if it's not possible because
+        // the visit wasn't started.
+        let vdate = null;
+        let vage = null;
+        if (this.props.Visit.Stages.Visit) {
+          vdate = (<div style={termstyle}>
+                <dt>Date Of Visit</dt>
+                <dd>{this.props.Visit.Stages.Visit.Date}</dd>
+            </div>);
+          vage = (<div style={termstyle}>
+                      <dt>Age</dt>
+                      <dd>{this.calcAge(
+                              this.props.Candidate.Meta.DoB,
+                              this.props.Visit.Stages.Visit.Date
+                      )}</dd>
+                </div>);
+        }
+        const defliststyle = {
+            display: 'flex',
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            width: '100%',
+            justifyContent: 'space-between',
+            margin: 0,
+        };
+
+        return (<div style={style} onClick={this.toggleExpanded}>
+            <div style={flexcontainer}>
+                <div style={{background: bg, width: '1%', height: '100%'}}>
+                </div>
+                <div style={center}>
+                    <h4 style={{width: '100%', padding: 0, margin: 0}}>
+                        <a href={this.props.BaseURL
+                            + '/instrument_list/?candID='
+                            + this.props.Candidate.Meta.CandID
+                            + '&sessionID='
+                            + this.props.VisitMap[this.props.Visit.Meta.Visit]}>
+                            {this.props.Visit.Meta.Visit}
+                        </a>
+                    </h4>
+                </div>
+                <div>
+                <dl style={defliststyle}>
+                    <div style={termstyle}>
+                        <dt>Subproject</dt>
+                        <dd>{this.props.Visit.Meta.Battery}</dd>
+                    </div>
+                    <div style={termstyle}>
+                        <dt>Site</dt>
+                        <dd>{this.props.Visit.Meta.Site}</dd>
+                    </div>
+                    {vdate}
+                    {vage}
+                    <div style={termstyle}>
+                        <dt>Status</dt>
+                        <dd>{vstatus}</dd>
+                    </div>
+                </dl>
+                {instruments}
+                </div>
+            </div>
+            </div>
+        );
+    }
+}
+
+export default VisitInstrumentList;

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -42,17 +42,16 @@ class Module extends \Module
             return $resp;
         }
 
+        $path           = $request->getURI()->getPath();
         $pathComponents = array();
 
         // Breakdown path information from the request.
         preg_match(
             "#(/*)([a-zA-Z0-9_-]+)(/*)(.*)#",
-            $request->getURI()->getPath(),
+            $path,
             $pathComponents
         );
 
-        // TODO These magic numbers should be changed to constants so that
-        // it's easier to tell what they're referring to.
         $instrumentName = $pathComponents[2];
         $page           = $pathComponents[4];
 
@@ -118,7 +117,23 @@ class Module extends \Module
                 ),
 
             ];
+        case 'candidate':
+            $factory = \NDB_Factory::singleton();
+            $baseurl = $factory->settings()->getBaseURL();
+
+            $candidate = $options['candidate'];
+            return [
+                new \LORIS\candidate_profile\CandidateWidget(
+                    "Behavioural Data",
+                    $baseurl . "/instruments/js/CandidateInstrumentList.js",
+                    'lorisjs.instruments.CandidateInstrumentList.default',
+                    [],
+                    2,
+                    2,
+                ),
+            ];
         }
         return [];
     }
 }
+

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -121,7 +121,6 @@ class Module extends \Module
             $factory = \NDB_Factory::singleton();
             $baseurl = $factory->settings()->getBaseURL();
 
-            $candidate = $options['candidate'];
             return [
                 new \LORIS\candidate_profile\CandidateWidget(
                     "Behavioural Data",

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace LORIS\instruments;
+
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use \LORIS\StudyEntities\Candidate\CandID;
+
+/**
+ * The VisitSummary endpoint returns a summary of instrument
+ * data entry for a particular candidate's visit. This is primarily
+ * to be used by the instrument list widget.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class VisitSummary extends \NDB_Page
+{
+    /**
+     * Temp for testing.
+     *
+     * @param \User $user The user whose access is to be verified
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $user = $request->getAttribute("user");
+        if ($user === null && !($user instanceof \User)) {
+            return new \LORIS\Http\Response\JSON\InternalServerError(
+                "No valid user"
+            );
+        }
+        if (!($this->_hasAccess($user))) {
+            return new \LORIS\Http\Response\JSON\Forbidden();
+        }
+
+        $params = $request->getQueryParams();
+        if (!isset($params['CandID'])) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                "Missing CandID query parameter"
+            );
+        }
+
+        if (!isset($params['VisitLabel'])) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                "Missing VisitLabel query parameter"
+            );
+        }
+
+        switch ($request->getMethod()) {
+        case 'GET':
+            return $this->_handleGet(
+                new CandID($params['CandID']),
+                $params['VisitLabel'],
+            );
+        default:
+            return new \LORIS\Http\Response\JSON\MethodNotAllowed(
+                array('GET')
+            );
+        }
+    }
+
+    /**
+     * Helper to specifically handle PATCH HTTP methods to the endpoint.
+     *
+     * @param CandID $candid     The CandID for the visit.
+     * @param string $visitLabel The visit label string.
+     *
+     * @return ResponseInterface
+     */
+    private function _handleGET(
+        CandID $candid, string $visitLabel
+    ) : ResponseInterface {
+        $DB = \NDB_Factory::singleton()->database();
+
+        $bvl_result = $DB->pselect(
+            "SELECT
+                f.Test_name,
+                f.CommentID,
+                COUNT(cu.ConflictID) AS NumOfConflict
+            FROM session s
+                LEFT JOIN flag f ON (s.ID = f.SessionID)
+                LEFT JOIN conflicts_unresolved cu
+                    ON (cu.CommentId1=f.CommentID OR cu.CommentID2=f.CommentID)
+                LEFT JOIN candidate c USING (CandID)
+            WHERE c.Active='Y' AND s.Active='Y' AND 
+                c.CandID=:candid AND s.Visit_Label=:vl
+                AND f.CommentID NOT LIKE 'DDE%'
+            GROUP BY
+                s.Visit_label,
+                s.ID,
+                s.Date_visit,
+                f.Test_name,
+                f.CommentID,
+                s.Current_stage,
+                s.Screening,
+                s.Visit,
+                s.Approval
+            ORDER BY s.Visit_label, f.Test_name, f.CommentID",
+            array('candid' => $candid, 'vl' => $visitLabel)
+        );
+
+        $instrumentList = \Utility::getAllInstruments();
+        foreach ($bvl_result as $key => $row) {
+            $testName  = $row['Test_name'];
+            $commentID = $row['CommentID'];
+
+            $instrument = \NDB_BVL_Instrument::factory(
+                $testName,
+                $commentID,
+                '',
+                false
+            );
+            if ($instrument === null) {
+                $bvl_result[$key]['Completion'] = 0;
+            } else {
+                $completion = $instrument->determineDataEntryCompletionProgress();
+                $bvl_result[$key]['Completion'] = $completion;
+            }
+        }
+
+        return new \LORIS\Http\Response\JSON\OK($bvl_result);
+    }
+}

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -112,7 +112,6 @@ class VisitSummary extends \NDB_Page
             array('candid' => $candid, 'vl' => $visitLabel)
         );
 
-        $instrumentList = \Utility::getAllInstruments();
         foreach ($bvl_result as $key => $row) {
             $testName  = $row['Test_name'];
             $commentID = $row['CommentID'];

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -16,18 +16,6 @@ use \LORIS\StudyEntities\Candidate\CandID;
 class VisitSummary extends \NDB_Page
 {
     /**
-     * Temp for testing.
-     *
-     * @param \User $user The user whose access is to be verified
-     *
-     * @return bool
-     */
-    function _hasAccess(\User $user) : bool
-    {
-        return true;
-    }
-
-    /**
      * {@inheritDoc}
      *
      * @param ServerRequestInterface $request The incoming PSR7 request

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -61,7 +61,7 @@ class VisitSummary extends \NDB_Page
 
         switch ($request->getMethod()) {
         case 'GET':
-            return $this->_handleGet(
+            return $this->_handleGET(
                 new CandID($params['CandID']),
                 $params['VisitLabel'],
             );

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2813,35 +2813,4 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
     }
 
-    /**
-     * Determines what percentage of the data entry has been completed, based on the
-     * number of fields in $_requiredElements having data
-     *
-     * @return int the data entry completion percentage
-     */
-    function determineDataEntryCompletionProgress(): int
-    {
-        // don't bother checking anything if the required elements array is empty
-        if (empty($this->_requiredElements)) {
-            return 100;
-        }
-        $allData       = $this->loadInstanceData($this);
-        $unanswered    = 0;
-        $totalElements = count($this->_requiredElements);
-        foreach ($this->_requiredElements as $field) {
-            // this shouldn't be just empty() b/c 0 is a valid
-            // value for some required fields
-            if (is_null($allData[$field] ?? null) || $allData[$field] === "") {
-                $unanswered++;
-            }
-        }
-        if ($unanswered == 0) {
-            return 100;
-        } else if ($unanswered == $totalElements) {
-            return 0;
-        }
-
-        return (int)round((($totalElements-$unanswered)/$totalElements)*100);
-    }
-
 }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2813,4 +2813,35 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
     }
 
+    /**
+     * Determines what percentage of the data entry has been completed, based on the
+     * number of fields in $_requiredElements having data
+     *
+     * @return int the data entry completion percentage
+     */
+    function determineDataEntryCompletionProgress(): int
+    {
+        // don't bother checking anything if the required elements array is empty
+        if (empty($this->_requiredElements)) {
+            return 100;
+        }
+        $allData       = $this->loadInstanceData($this);
+        $unanswered    = 0;
+        $totalElements = count($this->_requiredElements);
+        foreach ($this->_requiredElements as $field) {
+            // this shouldn't be just empty() b/c 0 is a valid
+            // value for some required fields
+            if (is_null($allData[$field] ?? null) || $allData[$field] === "") {
+                $unanswered++;
+            }
+        }
+        if ($unanswered == 0) {
+            return 100;
+        } else if ($unanswered == $totalElements) {
+            return 0;
+        }
+
+        return (int)round((($totalElements-$unanswered)/$totalElements)*100);
+    }
+
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,7 +206,7 @@ const config = [
     lorisModule('module_manager', ['modulemanager']),
     lorisModule('imaging_qc', ['imagingQCIndex']),
     lorisModule('server_processes_manager', ['server_processes_managerIndex']),
-    // lorisModule('instruments', ['instrumentlistwidget']),
+    lorisModule('instruments', ['CandidateInstrumentList']),
     lorisModule('candidate_profile', ['CandidateInfo']),
 ];
 


### PR DESCRIPTION
This adds a "Behavioural Data" widget to the candidate_profile
page for anyone who has access to the instruments module. The
Behavioural Data consists of a list of (initially collapsed)
visits which on click expand to a list of instruments and the data entry
percentage which is complete. Links are provided to the instrument
for data entry, the visit, and the conflict resolver (if applicable).