### PR TITLE
[webpack] restore support for webpack-project

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,16 +72,22 @@ const mod = {
  *
  * @return {object} - The webpack configuration
  */
-function lorisModule(mname, entries) {
+function lorisModule(mname, entries, override=false) {
     let entObj = {};
+    let base = './modules';
+
+    if (override) {
+        base = './project/modules';
+    }
+
     for (let i = 0; i < entries.length; i++) {
         entObj[entries[i]] =
-            './modules/' + mname + '/jsx/' + entries[i] + '.js';
+            base + '/' + mname + '/jsx/' + entries[i] + '.js';
     }
     return {
         entry: entObj,
         output: {
-            path: path.resolve(__dirname, 'modules') + '/' + mname + '/js/',
+            path: path.resolve(__dirname, base) + '/' + mname + '/js/',
             filename: '[name].js',
             library: ['lorisjs', mname, '[name]'],
             libraryTarget: 'window',
@@ -203,8 +209,11 @@ const config = [
 
 // Support project overrides
 if (fs.existsSync('./project/webpack-project.config.js')) {
-  const projConfig = require('./project/webpack-project.config.js');
-  config[0].entry = Object.assign(config[0].entry, projConfig);
+    const projConfig = require('./project/webpack-project.config.js');
+
+    for (const [module, files] of Object.entries(projConfig)) {
+        config.push(lorisModule(module, files, true));
+    }
 }
 
 module.exports = config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,7 @@ const mod = {
  *
  * @param {string} mname - The LORIS module name
  * @param {array} entries - The webpack entry points for the module
+ * @param {boolean} override - Is the module an override or a native LORIS module.
  *
  * @return {object} - The webpack configuration
  */


### PR DESCRIPTION
## Brief summary of changes
Restore functionality broken in #6083 

Projects can define their own targets for webpack to compile. this functionality was already there, this is just a fix for it to be functional again.

projects should define their file as such
filename:`webpack-project.config.js`
```
const entry = {
    'candidate_parameters' : ['CandidateParameters'],
    'study_tracker' : ['index'],
    'user_accounts' : ['userAccountsIndex']
};

module.exports = entry;
```