### PR TITLE
Change Travis distribution target from Ubuntu 16.04 to 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: php
 php: 
   - 7.3
   - 7.4
+    
+# Testing Ubuntu 18.04
+dist: bionic
 
 matrix:
     fast_finish: true
@@ -15,6 +18,7 @@ env:
   - TEST_SUITE=integration
 
 services:
+- mysql
 - docker
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: php
 
 php: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - sudo apt-get update
 - sudo apt-get install -y libapparmor1
 - pecl install -f ast-1.0.3
-- sudo apt-get install npm
+- sudo apt-get install nodejs-dev node-gyp libssl1.0-dev npm
 - make dev
 
 script: "npm run tests:$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: php
 
 php: 
@@ -17,7 +19,6 @@ env:
   - TEST_SUITE=integration
 
 services:
-- mysql
 - docker
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: php
 
 php: 
@@ -7,6 +5,7 @@ php:
   - 7.4
     
 # Testing Ubuntu 18.04
+os: linux
 dist: bionic
 
 matrix:


### PR DESCRIPTION
## Brief summary of changes

16.04 is nearly 4 years old now. This PR changes Travis to test a more recent OS. It looks like it may also cut down on the start up time of the tests.

Modifications to the config file are made based on the official Travis update guide. https://docs.travis-ci.com/user/reference/bionic/

#### Link(s) to related issue(s)

* #5253 should be updated with version information following this PR being merged.
