### PR TITLE
[candidate_profile] Add Candidate Parameters to Candidate Info card

### DIFF
--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -1,6 +1,5 @@
 <?php
 namespace LORIS\candidate_parameters;
-use LORIS\candidate_profile\CandidateWidget;
 use LORIS\candidate_profile\CandidateInfo;
 
 /**
@@ -155,7 +154,7 @@ class Module extends \Module
      * @param \Database  $db        A LORIS database connection
      * @param \Candidate $candidate The candidate being accessed
      *
-     * @return ?CandidateInfo
+     * @return CandidateInfo[]
      */
     private function _getCandidateParamTerms(
         \Database $db,

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -1,6 +1,7 @@
 <?php
 namespace LORIS\candidate_parameters;
 use LORIS\candidate_profile\CandidateWidget;
+use LORIS\candidate_profile\CandidateInfo;
 
 /**
  * {@inheritDoc}
@@ -68,6 +69,63 @@ class Module extends \Module
                     1,
                 )
             ];
+        case 'candidateinfo':
+            // We add 3 extra types of cards to the candidate info card on the candidate
+            // dashboard based on the default LORIS candidate_parameter module:
+            // 1. The Participant Status
+            // 2. The "Candidate Parameters" category variables which are displayed in the
+            //     Candidate Information tab of the Candidate Parameters
+            // 3. The Caveat flag description/reason for the candidate. (Only if there is
+            //    a caveat.)
+            // Most other tabs in the candidate_profile page are either duplicates of the
+            // information already present (ie. DoB) or complicated enough to merit their
+            // own card on the dashboard.
+            $factory = \NDB_Factory::singleton();
+            $db = $factory->database();
+            $candidate = $options['candidate'];
+            if($candidate === null) {
+                return [];
+            }
+
+            // Participant Status
+            $entries = [
+                new CandidateInfo("Participant Status", $candidate->getParticipantStatusDescription($db)),
+            ];
+
+            // Only display the caveat status if there is a caveat.
+            $caveat = $db->pselectRow(
+                "SELECT flagged_caveatemptor, flagged_reason, flagged_other, co.Description
+                 FROM candidate c
+                    JOIN caveat_options co ON (co.ID=c.flagged_reason)
+                 WHERE CandID=:cid",
+                ['cid' => $candidate->getCandID()],
+            );
+
+            if($caveat !== null && $caveat['flagged_caveatemptor'] === 'true') {
+                if ($caveat['Description'] == 'Other') {
+                    $entries[] = new CandidateInfo("Caveat", $caveat['flagged_other']);
+                } else {
+                    $entries[] = new CandidateInfo("Caveat", $caveat['Description']);
+                }
+            }
+
+            // Display the same Candidate Parameters as the "Candidate Info"
+            // page of the Candidate Parameters page in the candidate info
+            // summary. (We may need to further limit these in the future if
+            // they're overused and make the card too big.)
+            $candidateparams = $db->pselect(
+                "SELECT pt.Description, pc.Value
+                 FROM parameter_type pt
+                    JOIN parameter_candidate pc USING (ParameterTypeID)
+                    JOIN parameter_type_category_rel ptcr USING (ParameterTypeID)
+                    JOIN parameter_type_category ptc USING (ParameterTypeCategoryID)
+                WHERE ptc.Name='Candidate Parameters' AND pc.CandID=:cid",
+                ['cid' => $candidate->getCandID()]
+            );
+            foreach($candidateparams as $param) {
+                $entries[] = new CandidateInfo($param['Description'], $param['Value']);
+            }
+            return $entries;
         }
         return [];
     }

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -70,63 +70,115 @@ class Module extends \Module
                 )
             ];
         case 'candidateinfo':
-            // We add 3 extra types of cards to the candidate info card on the candidate
-            // dashboard based on the default LORIS candidate_parameter module:
+            // We add 3 extra types of cards to the candidate info card on
+            // the candidate dashboard based on the default LORIS candidate_parameter
+            // module:
+            //
             // 1. The Participant Status
-            // 2. The "Candidate Parameters" category variables which are displayed in the
-            //     Candidate Information tab of the Candidate Parameters
-            // 3. The Caveat flag description/reason for the candidate. (Only if there is
-            //    a caveat.)
-            // Most other tabs in the candidate_profile page are either duplicates of the
-            // information already present (ie. DoB) or complicated enough to merit their
-            // own card on the dashboard.
+            // 2. The "Candidate Parameters" category variables which are displayed
+            //    in the Candidate Information tab of the Candidate Parameters page
+            // 3. The Caveat flag description/reason for the candidate. (Only if
+            //    there is a caveat.)
+            //
+            // Most other tabs in the candidate_profile page are either duplicates
+            // of the information already present (ie. DoB) or complicated enough to
+            // merit their own card on the dashboard.
             $factory = \NDB_Factory::singleton();
-            $db = $factory->database();
+            $db      = $factory->database();
+
             $candidate = $options['candidate'];
-            if($candidate === null) {
+            if ($candidate === null) {
                 return [];
             }
 
             // Participant Status
             $entries = [
-                new CandidateInfo("Participant Status", $candidate->getParticipantStatusDescription($db)),
+                new CandidateInfo(
+                    "Participant Status",
+                    $candidate->getParticipantStatusDescription($db)
+                ),
             ];
 
-            // Only display the caveat status if there is a caveat.
-            $caveat = $db->pselectRow(
-                "SELECT flagged_caveatemptor, flagged_reason, flagged_other, co.Description
-                 FROM candidate c
-                    JOIN caveat_options co ON (co.ID=c.flagged_reason)
-                 WHERE CandID=:cid",
-                ['cid' => $candidate->getCandID()],
-            );
-
-            if($caveat !== null && $caveat['flagged_caveatemptor'] === 'true') {
-                if ($caveat['Description'] == 'Other') {
-                    $entries[] = new CandidateInfo("Caveat", $caveat['flagged_other']);
-                } else {
-                    $entries[] = new CandidateInfo("Caveat", $caveat['Description']);
-                }
+            $caveat = $this->_getCaveatTerm($db, $candidate);
+            if ($caveat) {
+                $entries[] = $caveat;
             }
 
-            // Display the same Candidate Parameters as the "Candidate Info"
-            // page of the Candidate Parameters page in the candidate info
-            // summary. (We may need to further limit these in the future if
-            // they're overused and make the card too big.)
-            $candidateparams = $db->pselect(
-                "SELECT pt.Description, pc.Value
-                 FROM parameter_type pt
-                    JOIN parameter_candidate pc USING (ParameterTypeID)
-                    JOIN parameter_type_category_rel ptcr USING (ParameterTypeID)
-                    JOIN parameter_type_category ptc USING (ParameterTypeCategoryID)
-                WHERE ptc.Name='Candidate Parameters' AND pc.CandID=:cid",
-                ['cid' => $candidate->getCandID()]
-            );
-            foreach($candidateparams as $param) {
-                $entries[] = new CandidateInfo($param['Description'], $param['Value']);
+            $params = $this->_getCandidateParamTerms($db, $candidate);
+            foreach ($params as $term) {
+                $entries[] = $term;
             }
+
             return $entries;
         }
         return [];
+    }
+
+    /**
+     * Return a caveat CandidateInfo card (if applicable)
+     *
+     * @param \Database  $db        A LORIS database connection
+     * @param \Candidate $candidate The candidate being accessed
+     *
+     * @return ?CandidateInfo
+     */
+    private function _getCaveatTerm(
+        \Database $db,
+        \Candidate $candidate
+    ) : ?CandidateInfo {
+        // Only display the caveat status if there is a caveat.
+        $caveat = $db->pselectRow(
+            "SELECT flagged_caveatemptor,
+                flagged_reason,
+                flagged_other,
+                co.Description
+             FROM candidate c
+                JOIN caveat_options co ON (co.ID=c.flagged_reason)
+             WHERE CandID=:cid",
+            ['cid' => $candidate->getCandID()],
+        );
+
+        if ($caveat === null || $caveat['flagged_caveatemptor'] !== 'true') {
+            return null;
+        }
+
+        if ($caveat['Description'] == 'Other') {
+            return new CandidateInfo("Caveat", $caveat['flagged_other']);
+        }
+        return new CandidateInfo("Caveat", $caveat['Description']);
+    }
+
+    /**
+     * Return a list of CandidateInfo terms to add to a candidate based on the
+     * "Candidate Parameters" category.
+     *
+     * @param \Database  $db        A LORIS database connection
+     * @param \Candidate $candidate The candidate being accessed
+     *
+     * @return ?CandidateInfo
+     */
+    private function _getCandidateParamTerms(
+        \Database $db,
+        \Candidate $candidate
+    ) : array {
+        // Display the same Candidate Parameters as the "Candidate Info"
+        // page of the Candidate Parameters page in the candidate info
+        // summary. (We may need to further limit these in the future if
+        // they're overused and make the card too big.)
+        $candidateparams = $db->pselect(
+            "SELECT pt.Description, pc.Value
+             FROM parameter_type pt
+                JOIN parameter_candidate pc USING (ParameterTypeID)
+                JOIN parameter_type_category_rel ptcr USING (ParameterTypeID)
+                JOIN parameter_type_category ptc USING (ParameterTypeCategoryID)
+             WHERE ptc.Name='Candidate Parameters' AND pc.CandID=:cid",
+            ['cid' => $candidate->getCandID()]
+        );
+
+        $entries = [];
+        foreach ($candidateparams as $param) {
+            $entries[] = new CandidateInfo($param['Description'], $param['Value']);
+        }
+        return $entries;
     }
 }

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -1,6 +1,7 @@
 <?php
 namespace LORIS\candidate_parameters;
 use LORIS\candidate_profile\CandidateInfo;
+use LORIS\candidate_profile\CandidateWidget;
 
 /**
  * {@inheritDoc}

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -94,7 +94,7 @@ class Module extends \Module
             $entries = [
                 new CandidateInfo(
                     "Participant Status",
-                    $candidate->getParticipantStatusDescription($db)
+                    $candidate->getParticipantStatusDescription($db) ?: 'N/A',
                 ),
             ];
 

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -74,9 +74,9 @@ class Module extends \Module
             // the candidate dashboard based on the default LORIS candidate_parameter
             // module:
             //
-            // 1. The Participant Status
+            // 1. The Participant Status.
             // 2. The "Candidate Parameters" category variables which are displayed
-            //    in the Candidate Information tab of the Candidate Parameters page
+            //    in the Candidate Information tab of the Candidate Parameters page.
             // 3. The Caveat flag description/reason for the candidate. (Only if
             //    there is a caveat.)
             //

--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -172,7 +172,7 @@ export class CandidateInfo extends Component {
             );
         };
         const cardInfo = data.map(
-            (info) => renderTerm(info.label, info.Value, info)
+            (info) => renderTerm(info.label, info.value, info)
         );
 
         let extrainfo;

--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -152,7 +152,7 @@ export class CandidateInfo extends Component {
             },
         ];
 
-        const cardInfo = data.map((info, index) => {
+        const renderTerm = (label, value, info) => {
             const cardStyle = {
                 width: info.width || '6em',
                 padding: '1em',
@@ -165,16 +165,48 @@ export class CandidateInfo extends Component {
             }
 
             return (
-                <div style={cardStyle} key={info.label}>
-                    <dt style={{whiteSpace: 'nowrap'}}>{info.label}</dt>
-                    <dd style={valueStyle}>{info.value}</dd>
+                <div style={cardStyle} key={label}>
+                    <dt style={{whiteSpace: 'nowrap'}}>{label}</dt>
+                    <dd style={valueStyle}>{value}</dd>
                 </div>
             );
-        });
+        };
+        const cardInfo = data.map(
+            (info) => renderTerm(info.label, info.Value, info)
+        );
+
+        let extrainfo;
+        if (this.props.ExtraCandidateInfo.length > 0) {
+            // We give extra width for generic terms that we don't
+            // know anything about their size, so we err on the
+            // side of caution.
+            extrainfo = (
+                <div>
+                    <hr />
+                    <div style={
+                        {
+                            width: '100%',
+                            display: 'flex',
+                            flexFlow: 'row wrap',
+                            margin: 0,
+                        }
+                    }>
+                        {this.props.ExtraCandidateInfo.map(
+                            (obj) => renderTerm(
+                                obj.term,
+                                obj.value,
+                                {width: '12em'}
+                            )
+                        )}
+                    </div>
+                </div>
+            );
+        }
         return (
             <div style={{width: '100%'}}>
                 <dl style={{display: 'flex', flexFlow: 'wrap', margin: 0}}>
                     {cardInfo}
+                    {extrainfo}
                 </dl>
             </div>
         );

--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -183,22 +183,15 @@ export class CandidateInfo extends Component {
             extrainfo = (
                 <div>
                     <hr />
-                    <div style={
-                        {
-                            width: '100%',
-                            display: 'flex',
-                            flexFlow: 'row wrap',
-                            margin: 0,
-                        }
-                    }>
-                        {this.props.ExtraCandidateInfo.map(
-                            (obj) => renderTerm(
-                                obj.term,
-                                obj.value,
-                                {width: '12em'}
-                            )
-                        )}
-                    </div>
+                    <dl style={{display: 'flex', flexFlow: 'wrap', margin: 0}}>
+                            {this.props.ExtraCandidateInfo.map(
+                                (obj) => renderTerm(
+                                    obj.term,
+                                    obj.value,
+                                    {width: '12em'}
+                                )
+                            )}
+                    </dl>
                 </div>
             );
         }
@@ -206,8 +199,8 @@ export class CandidateInfo extends Component {
             <div style={{width: '100%'}}>
                 <dl style={{display: 'flex', flexFlow: 'wrap', margin: 0}}>
                     {cardInfo}
-                    {extrainfo}
                 </dl>
+                {extrainfo}
             </div>
         );
     }

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -79,7 +79,6 @@ class Candidate_Profile extends \NDB_Page
         $modules = \Module::getActiveModules($DB);
 
         $widgets = [];
-        $params  = [];
         foreach ($modules as $module) {
             if ($module->hasAccess($user)) {
                 $mwidgets = $module->getWidgets(

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -79,6 +79,7 @@ class Candidate_Profile extends \NDB_Page
         $modules = \Module::getActiveModules($DB);
 
         $widgets = [];
+        $params  = [];
         foreach ($modules as $module) {
             if ($module->hasAccess($user)) {
                 $mwidgets = $module->getWidgets(

--- a/modules/candidate_profile/php/candidateinfo.class.inc
+++ b/modules/candidate_profile/php/candidateinfo.class.inc
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+namespace LORIS\candidate_profile;
+
+/**
+ * The CandidateInfo class is used to represent a term to be
+ * displayed in the Candidate Info table of the candidate dashboard.
+ *
+ * It must be a simple term/value pair that can be encoded as a JSON
+ * object to be rendered to the client.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class CandidateInfo implements \LORIS\GUI\Widget
+{
+    /**
+     * Construct a CandidateInfo object
+     *
+     * @param string $term  The term being summarized for the candidate
+     * @param string $value The value of the term
+     */
+    public function __construct(
+        string $term,
+        string $value
+    ) {
+        $this->term  = $term;
+        $this->value = $value;
+    }
+
+    /**
+     * Implement the \LORIS\GUI\Widget interface
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return "";
+    }
+}

--- a/modules/candidate_profile/php/candidateinfo.class.inc
+++ b/modules/candidate_profile/php/candidateinfo.class.inc
@@ -12,6 +12,9 @@ namespace LORIS\candidate_profile;
  */
 class CandidateInfo implements \LORIS\GUI\Widget
 {
+    public $term;
+    public $value;
+
     /**
      * Construct a CandidateInfo object
      *

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -69,12 +69,31 @@ class Module extends \Module
             $factory = \NDB_Factory::singleton();
             $baseurl = $factory->settings()->getBaseURL();
 
+            $DB      = $factory->database();
+            $modules = \Module::getActiveModules($DB);
+
+            $params = [];
+            foreach ($modules as $module) {
+                if (!$module->hasAccess($user)) {
+                    continue;
+                }
+
+                $candidateinfo = $module->getWidgets(
+                    'candidateinfo',
+                    $user,
+                    $options,
+                );
+                foreach($candidateinfo as $widget) {
+                    $params[] = $widget;
+                }
+            }
+
             return [
                 new CandidateWidget(
                     "Candidate Info",
                     $baseurl . "/candidate_profile/js/CandidateInfo.js",
                     "lorisjs.candidate_profile.CandidateInfo.CandidateInfo",
-                    [],
+                    ['ExtraCandidateInfo' => $params],
                     1,
                     1,
                     -100,

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -83,7 +83,7 @@ class Module extends \Module
                     $user,
                     $options,
                 );
-                foreach($candidateinfo as $widget) {
+                foreach ($candidateinfo as $widget) {
                     $params[] = $widget;
                 }
             }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -791,5 +791,14 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         return $projMatch && $centerMatch;
     }
 
+    public function getParticipantStatusDescription(\Database $db) : ?string {
+        $res = $db->pselectRow(
+            "SELECT pso.Description FROM participant_status ps JOIN participant_status_options pso
+ON (ps.participant_status=pso.ID) WHERE CandID=:candid",
+            ['candid' => $this->getCandID()],
+        );
+        return $res['Description'];
+    }
+
 }
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -799,7 +799,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
      *
      * @return string
      */
-    public function getParticipantStatusDescription(\Database $db) : ?string
+    public function getParticipantStatusDescription(\Database $db) : string
     {
         $res = $db->pselectRow(
             "SELECT pso.Description
@@ -808,7 +808,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
              WHERE CandID=:candid",
             ['candid' => $this->getCandID()],
         );
-        return $res['Description'];
+        return $res['Description'] ?? '';
     }
 
 }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -791,10 +791,21 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         return $projMatch && $centerMatch;
     }
 
-    public function getParticipantStatusDescription(\Database $db) : ?string {
+    /**
+     * Return a human readable description of the participant status for this
+     * candidate.
+     *
+     * @param \Database $db The database to get the description from
+     *
+     * @return string
+     */
+    public function getParticipantStatusDescription(\Database $db) : ?string
+    {
         $res = $db->pselectRow(
-            "SELECT pso.Description FROM participant_status ps JOIN participant_status_options pso
-ON (ps.participant_status=pso.ID) WHERE CandID=:candid",
+            "SELECT pso.Description
+             FROM participant_status ps
+                JOIN participant_status_options pso ON (ps.participant_status=pso.ID)
+             WHERE CandID=:candid",
             ['candid' => $this->getCandID()],
         );
         return $res['Description'];


### PR DESCRIPTION
This adds a new type of widget ('candidateinfo') which can be used by modules or projects to add information to the "Candidate Info" card on the `candidate_profile` page. The new type of widget can be used by a module (or project module) to add information that can be summarized as a scalar to the quick summary.

It uses the new type to add information from the `candidate_parameters` module that make sense as an overview for the candidate. The Participant Status, Caveat, and any 'Candidate Parameters' category variables from the `parameter_candidate` table are now summarized in the card.

Other information from the candidate_parameters module is complex enough to merit its own card (ie. Consent often contains multiple entries to be summarized for different types of consent, and shouldn't be in the top-level summary.)