### PR TITLE
[candidate_profile] Add card summarizing candidate consent

### DIFF
--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -58,6 +58,7 @@ class Card extends Component {
           id={this.props.id}
           title={this.props.title}
           initCollapsed={this.props.initCollapsed}
+            style={{overflow: 'auto'}}
         >
           <div
             onClick={this.handleClick}

--- a/modules/candidate_parameters/jsx/ConsentWidget.js
+++ b/modules/candidate_parameters/jsx/ConsentWidget.js
@@ -26,10 +26,16 @@ function ConsentWidget(props) {
     </table>);
 }
 
+/**
+ * Returns a rendered JSX component for a single consent type
+ *
+ * @param {array} consent - The type of consent
+ *
+ * @return {object}
+ */
 function consentTerm(consent) {
     let value;
     let date;
-    console.log(consent);
     switch (consent.Status) {
         case 'yes':
             value = 'Yes';

--- a/modules/candidate_parameters/jsx/ConsentWidget.js
+++ b/modules/candidate_parameters/jsx/ConsentWidget.js
@@ -1,0 +1,61 @@
+/**
+ * A Widget to display consent information for a candidate in
+ * LORIS
+ *
+ * @param {array} props - The React props
+ *
+ * @return {object} - The rendered widget
+ */
+function ConsentWidget(props) {
+    if (props.Consents.length == 0) {
+        return null;
+    }
+
+    const consents = props.Consents.map(consentTerm);
+    return (<table className="table" style={{width: '100%'}}>
+        <thead>
+        <tr>
+            <th>Consent Type</th>
+            <th>Status</th>
+            <th>Date</th>
+        </tr>
+        </thead>
+        <tbody>
+        {consents}
+        </tbody>
+    </table>);
+}
+
+function consentTerm(consent) {
+    let value;
+    let date;
+    console.log(consent);
+    switch (consent.Status) {
+        case 'yes':
+            value = 'Yes';
+            date = consent.DateGiven;
+            break;
+        case 'no':
+            if (consent.DateWithdrawn) {
+                value = 'Withdrawn';
+                date = consent.DateWithdrawn;
+            } else {
+                value = 'No';
+            }
+            break;
+        default:
+            value = consent.Status;
+            return (<tr key={consent.ConsentID}>
+                <th>{consent.Label}</th>
+                <td colSpan="2" align="center">-</td>
+                </tr>);
+    }
+
+    return (<tr key={consent.ConsentID}>
+        <th>{consent.Label}</th>
+        <td>{value}</td>
+        <td>{date}</td>
+        </tr>);
+}
+
+export default ConsentWidget;

--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -1,26 +1,11 @@
 <?php
-/**
- * This serves as a hint to LORIS that this module is a real module.
- * It does nothing but implement the module class in the module's namespace.
- *
- * PHP Version 5
- *
- * @category Behavioural
- * @package  Main
- * @author   Wang Shen <shen.wang2@mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris-Trunk/
- */
 namespace LORIS\candidate_parameters;
+use LORIS\candidate_profile\CandidateWidget;
 
 /**
- * Class module implements the basic LORIS module functionality
+ * {@inheritDoc}
  *
- * @category Behavioural
- * @package  Main
- * @author   Wang Shen <shen.wang2@mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris-Trunk/
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class Module extends \Module
 {
@@ -32,5 +17,58 @@ class Module extends \Module
     public function getLongName() : string
     {
         return "Candidate Parameters";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
+     *
+     * @return \LORIS\GUI\Widget[]
+     */
+    public function getWidgets(string $type, \User $user, array $options) : array
+    {
+        switch($type) {
+        case 'candidate':
+            $factory = \NDB_Factory::singleton();
+            $baseurl = $factory->settings()->getBaseURL();
+
+            $candidate = $options['candidate'];
+            if ($candidate === null) {
+                return [];
+            }
+
+            // The candidate getConsents only returns the types of
+            // consents that the candidate has saved, we want to
+            // summarize all of the types configured in the database.
+            $consents = \Utility::getConsentList();
+
+            foreach ($candidate->getConsents() as $key => $value) {
+                $consents[$key] = $value;
+            }
+
+            // The $consents array was indexed by the consentID (by
+            // both getConsentList and getConsents), which means it'll
+            // get serialized as an object. We need to convert it to
+            // a 0-indexed array so it gets json serialized as an array.
+            $consents = array_values($consents);
+
+            return [
+                new CandidateWidget(
+                    "Consent Summary",
+                    $baseurl . "/candidate_parameters/js/ConsentWidget.js",
+                    "lorisjs.candidate_parameters.ConsentWidget.default",
+                    [
+                        'Consents' => $consents,
+                    ],
+                    1,
+                    1,
+                )
+            ];
+        }
+        return [];
     }
 }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -669,7 +669,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
 
         $candID = $this->getCandID();
 
-        $query = "SELECT ConsentID, Name, Status, DateGiven, DateWithdrawn
+        $query = "SELECT ConsentID, Name, Status, DateGiven, DateWithdrawn, Label
             FROM candidate_consent_rel cc JOIN consent c USING (ConsentID)
             WHERE CandidateID=:cid";
         $where = array('cid' => $candID);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,7 @@ const config = [
     lorisModule('issue_tracker', ['issueTrackerIndex', 'index']),
     lorisModule('publication', ['publicationIndex', 'viewProjectIndex']),
     lorisModule('document_repository', ['docIndex', 'editFormIndex']),
-    lorisModule('candidate_parameters', ['CandidateParameters']),
+    lorisModule('candidate_parameters', ['CandidateParameters', 'ConsentWidget']),
     lorisModule('configuration', ['SubprojectRelations']),
     lorisModule('conflict_resolver', [
         'conflictResolverIndex',


### PR DESCRIPTION
This adds a card with a summary of the candidate's consent to
the candidate_profile module. A table is shown with rows for
each type of consent showing the status and date of the consent
or withdrawal.