### PR TITLE
[Candidate_parameters] Consent Status - Change label to 'Response'

### DIFF
--- a/modules/candidate_parameters/jsx/ConsentStatus.js
+++ b/modules/candidate_parameters/jsx/ConsentStatus.js
@@ -248,21 +248,25 @@ class ConsentStatus extends Component {
         i = 0;
         for (let consentStatus in this.state.Data.consents) {
             if (this.state.Data.consents.hasOwnProperty(consentStatus)) {
-                let label = this.state.Data.consents[consentStatus];
+                let consentLabel = this.state.Data.consents[consentStatus];
+                let statusLabel = 'Response';
                 let consentDate = consentStatus + '_date';
                 let consentDate2 = consentStatus + '_date2';
-                let consentDateLabel = 'Date of ' + label;
-                let consentDateConfirmationLabel = 'Confirmation Date of ' + label;
+                let consentDateLabel = 'Date of ' + statusLabel;
+                let consentDateConfirmationLabel = 'Confirmation Date of ' + statusLabel;
                 let consentWithdrawal = consentStatus + '_withdrawal';
                 let consentWithdrawal2 = consentStatus + '_withdrawal2';
-                let consentWithdrawalLabel = 'Date of Withdrawal of ' + label;
+                let consentWithdrawalLabel = 'Date of Withdrawal of Consent';
                 let consentWithdrawalConfirmationLabel =
-                    'Confirmation Date of Withdrawal of ' + label;
+                    'Confirmation Date of Withdrawal of Consent';
 
                 const consent = (
                     <div key={i}>
+                        <HeaderElement
+                          text={consentLabel}
+                        />
                         <SelectElement
-                            label={label}
+                            label={statusLabel}
                             name={consentStatus}
                             options={this.state.consentOptions}
                             value={this.state.formData[consentStatus]}


### PR DESCRIPTION
## Brief summary of changes

As discussed in today's Loris meeting, this PR changes the select field label to simply 'Response', the DateGiven field to 'Date of Response' and the DateWithdrawn field to 'Date of Withdrawal of Consent'. In place of the consent label being displayed in the label of the response select field, I have added a HeaderElement to display the consent label.

#### Testing instructions (if applicable)

1. On 23.0-release, go to a candidate's consent status tab and see the UI
2. On this branch, see that the field labels have changed as described above and that the consent label is now being rendered as a header. Play around and see that there are no functional changes to the tab. Save a consent and verify nothing is broken.

<img width="800" alt="Screenshot 2020-03-03 12 46 40" src="https://user-images.githubusercontent.com/17415878/75803826-0c648280-5d4d-11ea-8251-e576fa0b23b2.png">