### PR TITLE
[Instrument_controlpanel] Add tooltip to explain 'Complete'

### DIFF
--- a/htdocs/js/instrument_controlpanel_control.js
+++ b/htdocs/js/instrument_controlpanel_control.js
@@ -1,0 +1,3 @@
+$(function () {
+    $('[data-toggle="tooltip"]').tooltip();
+});

--- a/htdocs/js/instrument_controlpanel_control.js
+++ b/htdocs/js/instrument_controlpanel_control.js
@@ -1,3 +1,3 @@
-$(function () {
+$(function() {
     $('[data-toggle="tooltip"]').tooltip();
 });

--- a/htdocs/main.css
+++ b/htdocs/main.css
@@ -414,7 +414,7 @@ table.data {
 .controlPanel li {
     list-style-position:inside;
     list-style-type: none;
-    white-space: nowrap; 
+    white-space: normal;
     margin-top: 4px;
 }
 .controlPanel {

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -249,7 +249,8 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
                             if (!$showLink) {
                                 $this->tpl_data['data_entry'][$i]['tooltip']
-                                    = "To enable link, required fields must be filled in";
+                                    = "To enable link, required fields must be
+                                      filled in";
                             }
                         }
                     }
@@ -260,7 +261,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                     $this->tpl_data['data_entry'][$i]['showlink'] = true;
                 }
             } else {
-                $this->tpl_data['data_entry'][$i]['icon'] = 'fas fa-times';
+                $this->tpl_data['data_entry'][$i]['icon']    = 'fas fa-times';
                 $this->tpl_data['data_entry'][$i]['tooltip']
                     = "To enable link, Administration option must be selected";
             }
@@ -342,11 +343,11 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             if ($validityStatus == $option) {
                 $this->tpl_data['validity'][$i]['icon'] = 'far fa-check-square';
             } else {
-              if ($data_entry_status == 'Complete') {
-                  $this->tpl_data['validity'][$i]['showLink'] = false;
-              } else {
-                  $this->tpl_data['validity'][$i]['showLink'] = true;
-              }
+                if ($data_entry_status == 'Complete') {
+                    $this->tpl_data['validity'][$i]['showLink'] = false;
+                } else {
+                    $this->tpl_data['validity'][$i]['showLink'] = true;
+                }
             }
             $i++;
         }

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -228,6 +228,10 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                     && $this->getAdministrationStatus() != 'None'
                 ) {
                     $showLink = false;
+                    if ($option == 'Complete') {
+                        $this->tpl_data['data_entry'][$i]['tooltip']
+                            = "To enable link, Validity option must be selected";
+                    }
                 }
 
                 if ($option == 'In Progress') {
@@ -242,6 +246,11 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                                 = $this->instrument->getDataEntryCompletionStatus();
 
                             $showLink = $CompStatus == 'Complete';
+
+                            if (!$showLink) {
+                                $this->tpl_data['data_entry'][$i]['tooltip']
+                                    = "To enable link, required fields must be filled in";
+                            }
                         }
                     }
                 }
@@ -252,6 +261,8 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
                 }
             } else {
                 $this->tpl_data['data_entry'][$i]['icon'] = 'fas fa-times';
+                $this->tpl_data['data_entry'][$i]['tooltip']
+                    = "To enable link, Administration option must be selected";
             }
             $i++;
         }
@@ -330,11 +341,12 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             // highlight the current option if it's the current status
             if ($validityStatus == $option) {
                 $this->tpl_data['validity'][$i]['icon'] = 'far fa-check-square';
-            }
-            if ($data_entry_status == 'Complete') {
-                $this->tpl_data['validity'][$i]['showLink'] = false;
             } else {
-                $this->tpl_data['validity'][$i]['showLink'] = true;
+              if ($data_entry_status == 'Complete') {
+                  $this->tpl_data['validity'][$i]['showLink'] = false;
+              } else {
+                  $this->tpl_data['validity'][$i]['showLink'] = true;
+              }
             }
             $i++;
         }

--- a/smarty/templates/instrumentstatus_controlpanel.tpl
+++ b/smarty/templates/instrumentstatus_controlpanel.tpl
@@ -49,7 +49,7 @@
         <a href="?commentID={$commentID}&candID={$candID}&sessionID={$sessionID}&setDataEntry={$data_entry[item].label}&test_name={$test_name}">{$data_entry[item].label}</a>
     {else}
         {if $data_entry[item].tooltip}
-        <span data-toggle="tooltip" data-placement="bottom" title="{$data_entry[item].tooltip}">
+        <span data-toggle="tooltip" data-placement="right" title="{$data_entry[item].tooltip}">
             {$data_entry[item].label}
         </span>
         {else}

--- a/smarty/templates/instrumentstatus_controlpanel.tpl
+++ b/smarty/templates/instrumentstatus_controlpanel.tpl
@@ -1,3 +1,4 @@
+<script type="text/javascript" src="{$baseurl}/js/instrument_controlpanel_control.js"></script>
 
 {if $InstrumentResetting }
 <h3 class="controlPanelSection">Clear Instrument</h3>
@@ -47,7 +48,13 @@
     {if $access.data_entry and $data_entry[item].showlink}
         <a href="?commentID={$commentID}&candID={$candID}&sessionID={$sessionID}&setDataEntry={$data_entry[item].label}&test_name={$test_name}">{$data_entry[item].label}</a>
     {else}
+        {if $data_entry[item].tooltip}
+        <span data-toggle="tooltip" data-placement="bottom" title="{$data_entry[item].tooltip}">
+            {$data_entry[item].label}
+        </span>
+        {else}
         {$data_entry[item].label}
+        {/if}
     {/if}
     </li>
 {/section}


### PR DESCRIPTION
## Brief summary of changes

As a result of discussions springing up on https://github.com/aces/Loris/pull/5949, this PR adds a hover over tooltip on the Data Entry 'Complete' option in the instrument control panel to explain why 'Complete' is not clickable.

If the whole instrument is empty i.e. required fields have not been filled out, the workflow goes like this:

**1. If Administration and Validation empt**y
- 'Complete' not clickable

**2. If Administration 'None':**
- 'Complete' clickable

**3. If Administration 'Partial':**
- If Validity doesn't exist, 'Complete' clickable
- If Validity exists and empty - 'Complete' not clickable
- Validity selected - 'Complete' clickable

**4. If Administration 'All':**
- If Validity exists and empty - 'Complete' not clickable
- Validity selected or doesn't exist - 'Complete' not clickable until required fields are filled. Only then will 'Complete' be clickable.

#### Testing instructions (if applicable)

1. Start with a blank fresh instrument that has had no data entry done. Leave the instrument fields empty and test only the control panel on the left. Ignore 'Clear Instrument' and 'Delete instrument data'.
2. Test through the 4 cases described above. When the 'Complete' option is not clickable, verify that the reason for this is described in the tooltip that appears when you hover over it. When the option is clickable, verify that there is no tooltip.
3. Verify that the tooltip doesn't randomly appear in places other than to the right of the 'Complete' option.
