### PR TITLE
[issue_tracker] Add foreign key from issues attachments to issue

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -1372,6 +1372,21 @@ CREATE TABLE `issues_watching` (
   CONSTRAINT `fk_issues_watching_1` FOREIGN KEY (`userID`) REFERENCES `users` (`UserID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `issues_attachments` (
+    `ID` int(11) unsigned NOT NULL AUTO_INCREMENT,
+    `issueID` int(11) unsigned NOT NULL,
+    `file_hash` varchar(64) NOT NULL,
+    `date_added` timestamp NOT NULL DEFAULT current_timestamp(),
+    `file_name` varchar(255) NOT NULL DEFAULT '',
+    `deleted` tinyint(1) NOT NULL DEFAULT 0,
+    `user` varchar(255) NOT NULL DEFAULT '',
+    `description` text DEFAULT NULL,
+    `file_size` int(20) DEFAULT NULL,
+    `mime_type` varchar(255) NOT NULL DEFAULT '',
+    CONSTRAINT `fk_issues_attachments_issue` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`),
+    PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- ********************************
 -- parameter tables
 -- ********************************
@@ -2096,16 +2111,3 @@ CREATE TABLE `publication_users_edit_perm_rel` (
   CONSTRAINT `FK_publication_users_edit_perm_rel_UserID` FOREIGN KEY (`UserID`) REFERENCES `users` (`ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET='utf8';
 
-CREATE TABLE `issues_attachments` (
-    `ID` int NOT NULL AUTO_INCREMENT,
-    `issueID` int(11) NOT NULL,
-    `file_hash` varchar(64) NOT NULL,
-    `date_added` timestamp NOT NULL DEFAULT current_timestamp(),
-    `file_name` varchar(255) NOT NULL DEFAULT '',
-    `deleted` tinyint(1) NOT NULL DEFAULT 0,
-    `user` varchar(255) NOT NULL DEFAULT '',
-    `description` text DEFAULT NULL,
-    `file_size` int(20) DEFAULT NULL,
-    `mime_type` varchar(255) NOT NULL DEFAULT '',
-    PRIMARY KEY (`ID`)
-) DEFAULT CHARSET=utf8mb4;

--- a/SQL/New_patches/2019-10-29_adding_issues_attachments_table.sql
+++ b/SQL/New_patches/2019-10-29_adding_issues_attachments_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `issues_attachments` (
-    `ID` int NOT NULL AUTO_INCREMENT,
-    `issueID` int(11) NOT NULL,
+    `ID` int(11) unsigned NOT NULL AUTO_INCREMENT,
+    `issueID` int(11) unsigned NOT NULL,
     `file_hash` varchar(64) NOT NULL,
     `date_added` timestamp NOT NULL DEFAULT current_timestamp(),
     `file_name` varchar(255) NOT NULL DEFAULT '',
@@ -9,8 +9,9 @@ CREATE TABLE `issues_attachments` (
     `description` text DEFAULT NULL,
     `file_size` int(20) DEFAULT NULL,
     `mime_type` varchar(255) NOT NULL DEFAULT '',
+    CONSTRAINT `fk_issues_attachments_issue` FOREIGN KEY (`issueID`) REFERENCES `issues` (`issueID`),
     PRIMARY KEY (`ID`)
-) DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber)
 VALUES('IssueTrackerDataPath', 'Path to Issue Tracker data files', 1, 0, 'web_path', 26, 'Issue Tracker Data Path', 8);


### PR DESCRIPTION
This adds a foreign key from the issues_attachments table to the issue table. Since the issues_attachments hasn't been released yet, the existing patch is modified instead of adding a new patch for existing projects. (I also moved the issues_attachments table to be grouped with all the other issues related tables in the default schema.)