### PR TITLE
[conflict_resolver] Fix links to conflict resolver with filters set

### DIFF
--- a/modules/conflict_resolver/jsx/conflictResolverIndex.js
+++ b/modules/conflict_resolver/jsx/conflictResolverIndex.js
@@ -161,6 +161,9 @@ class ConflictResolverApp extends Component {
             Data: data,
             isLoaded: true,
           });
+          if (this.child !== undefined) {
+            this.child.updateFilterState(this.state.filter);
+          }
         }).catch((error) => {
           // console.log('error: ' + error);
     });


### PR DESCRIPTION
The conflict resolver updates the URL when filters are modified to
reflect the current state of the filters. However, when these links
are loaded on their own the filters are not reflected in the results
until some other filter is changed.

This fixes the conflict resolver so that after data is loaded the
filter automatically applies to the results.