### PR TITLE
[candidate_profile] Add media widget

### DIFF
--- a/modules/media/README.md
+++ b/modules/media/README.md
@@ -56,3 +56,5 @@ uploaded for it.
 
 Uploaded files are displayed in the browse tab. Each entry has a link to download 
 the file itself and a link to the timepoint the file was uploaded for.
+
+The media module registers a widget on the candidate dashboard.

--- a/modules/media/jsx/CandidateMediaWidget.js
+++ b/modules/media/jsx/CandidateMediaWidget.js
@@ -16,7 +16,7 @@ function CandidateMediaWidget(props) {
                     + '/media/ajax/FileDownload.php?File='
                     + encodeURIComponent(file.Filename)}>
                 <span className="pull-right text-muted small">
-                    Uploaded: {file.UploadDate}
+                    Last modified : {file.LastModified}
                 </span>
                 <br />
                 {file.Filename}

--- a/modules/media/jsx/CandidateMediaWidget.js
+++ b/modules/media/jsx/CandidateMediaWidget.js
@@ -1,0 +1,29 @@
+/**
+ * React component for a widget on the candidate dashboard
+ * displaying the media associated with the candidate.
+ *
+ * @param {array} props - The React props
+ *
+ * @return {object} - The component
+ */
+function CandidateMediaWidget(props) {
+    let files = [];
+    for (let i = 0; i < props.Files.length; i++) {
+        const file = props.Files[i];
+        files.push(
+            <a className="list-group-item" key={i}
+                href={props.BaseURL
+                    + '/media/ajax/FileDownload.php?File='
+                    + encodeURIComponent(file.Filename)}>
+                <span className="pull-right text-muted small">
+                    Uploaded: {file.UploadDate}
+                </span>
+                <br />
+                {file.Filename}
+            </a>
+        );
+    }
+    return <div className="list-group">{files}</div>;
+}
+
+export default CandidateMediaWidget;

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -5,7 +5,7 @@ use LORIS\candidate_profile\CandidateWidget;
 /**
  * {@inheritDoc}
  *
- * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class Module extends \Module
 {
@@ -56,8 +56,8 @@ class Module extends \Module
     {
         switch($type) {
         case 'candidate':
-            $factory = \NDB_Factory::singleton();
-            $baseurl = $factory->settings()->getBaseURL();
+            $factory   = \NDB_Factory::singleton();
+            $baseurl   = $factory->settings()->getBaseURL();
             $candidate = $options['candidate'];
             if ($candidate === null) {
                 return [];

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -72,6 +72,9 @@ class Module extends \Module
                     AND hide_file=false",
                 ['cid' => $candidate->getCandID()],
             );
+            if (empty($media)) {
+                return [];
+            }
             return [
                 new CandidateWidget(
                     "Candidate Media",

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -65,10 +65,11 @@ class Module extends \Module
             $db = $factory->database();
 
             $media = $db->pselect(
-                "SELECT file_name as Filename, date_uploaded as UploadDate
+                "SELECT file_name as Filename, last_modified as LastModified
                  FROM media m
                     JOIN session s ON (m.session_id=s.ID)
-                 WHERE s.CandID=:cid",
+                 WHERE s.CandID=:cid
+                    AND hide_file=false",
                 ['cid' => $candidate->getCandID()],
             );
             return [

--- a/modules/media/php/module.class.inc
+++ b/modules/media/php/module.class.inc
@@ -1,28 +1,11 @@
 <?php
-/**
- * This serves as a hint to LORIS that this module is a real module.
- * It does nothing but implement the module class in the module's namespace.
- *
- * PHP Version 5
- *
- * @category   Behavioural
- * @package    Main
- * @subpackage Media
- * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
- * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link       https://www.github.com/aces/Loris-Trunk/
- */
 namespace LORIS\media;
+use LORIS\candidate_profile\CandidateWidget;
 
 /**
- * Class module implements the basic LORIS module functionality
+ * {@inheritDoc}
  *
- * @category   Behavioural
- * @package    Main
- * @subpackage Media
- * @author     Dave MacFarlane <david.macfarlane2@mcgill.ca>
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link       https://www.github.com/aces/Loris-Trunk/
  */
 class Module extends \Module
 {
@@ -57,5 +40,48 @@ class Module extends \Module
     public function getLongName() : string
     {
         return "Media";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param string $type    The type of widgets to get.
+     * @param \User  $user    The user widgets are being retrieved for.
+     * @param array  $options A type dependent list of options to provide
+     *                        to the widget.
+     *
+     * @return \LORIS\GUI\Widget[]
+     */
+    public function getWidgets(string $type, \User $user, array $options) : array
+    {
+        switch($type) {
+        case 'candidate':
+            $factory = \NDB_Factory::singleton();
+            $baseurl = $factory->settings()->getBaseURL();
+            $candidate = $options['candidate'];
+            if ($candidate === null) {
+                return [];
+            }
+            $db = $factory->database();
+
+            $media = $db->pselect(
+                "SELECT file_name as Filename, date_uploaded as UploadDate
+                 FROM media m
+                    JOIN session s ON (m.session_id=s.ID)
+                 WHERE s.CandID=:cid",
+                ['cid' => $candidate->getCandID()],
+            );
+            return [
+                new CandidateWidget(
+                    "Candidate Media",
+                    $baseurl . "/media/js/CandidateMediaWidget.js",
+                    "lorisjs.media.CandidateMediaWidget.default",
+                    [ 'Files' => $media],
+                    1,
+                    1,
+                )
+            ];
+        }
+        return [];
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,7 +139,7 @@ const config = [
         module: mod,
     },
     // Modules
-    lorisModule('media', ['mediaIndex']),
+    lorisModule('media', ['CandidateMediaWidget', 'mediaIndex']),
     lorisModule('issue_tracker', ['issueTrackerIndex', 'index']),
     lorisModule('publication', ['publicationIndex', 'viewProjectIndex']),
     lorisModule('document_repository', ['docIndex', 'editFormIndex']),


### PR DESCRIPTION
This adds a widget to the candidate dashboard to display
any media associated with the candidate from the media
module. The visualization of how the data is displayed
is the same as the "Document Repository" widget on the
main LORIS dashboard.