### PR TITLE
[Breadcrumbs] Fix React warning about componentWillMount being deprecated

### DIFF
--- a/jsx/Breadcrumbs.js
+++ b/jsx/Breadcrumbs.js
@@ -28,7 +28,7 @@ class Breadcrumbs extends Component {
     this.checkScreenSize = this.checkScreenSize.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.checkScreenSize();
     if (typeof window !== 'undefined') {
       window.addEventListener('resize', this.checkScreenSize);


### PR DESCRIPTION
This fixes the warning:

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: Breadcrumbs
```

That has begun appearing since upgrading React.
