### PR TITLE
[issue_tracker] Include all sites in dropdown for issue tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,14 @@ database (PR #5260)
 - Fix bug where examiner form field was incorrectly hidden (PR #6085)
 
 ### Modules 
-
 #### Candidate Profile
 - New module created to provide dashboard of a single candidate's data across all
   modules. (Various PRs)
+
+##### Issue Tracker
+- The issue_tracker module now has the feature of uploading attachments to new or existing issues.
+- All sites now appear in the dropdown for site, not only study sites. (PR #6135)
+
 
 #### Battery Manager
 - New module created to manage the entries in the `test_battery` table of the database.

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -577,7 +577,7 @@ function getIssueFields()
     //get field options
     if ($user->hasPermission('access_all_profiles')) {
         // get the list of study sites - to be replaced by the Site object
-        $sites = Utility::getSiteList();
+        $sites = Utility::getSiteList(false, true);
     } else {
         // allow only to view own site data
         $sites = $user->getStudySites();


### PR DESCRIPTION
The issue tracker currently limits the dropdown to non-DCC study sites.
When entering a PSCID from a site such as the DCC, this means that there
is an (unresolvable) error about the PSCID and CenterID not matching,
because the candidate's site doesn't exist in the dropdown. This
updates the issue tracker to display all sites.