### PR TITLE
[media] File download should retrieve decoded path

### DIFF
--- a/modules/media/ajax/FileDownload.php
+++ b/modules/media/ajax/FileDownload.php
@@ -24,7 +24,7 @@ if (!$user->hasPermission('media_write')) {
 
 // Make sure that the user isn't trying to break out of the $path
 // by using a relative filename.
-$file     = basename($_GET['File']);
+$file     = html_entity_decode(basename($_GET['File']));
 $config   =& NDB_Config::singleton();
 $path     = $config->getSetting('mediaPath');
 $filePath = $path . $file;


### PR DESCRIPTION
## Brief summary of changes
This PR is related to issue #6136. This PR aims to fix a bug that was experienced by a CCNA user when trying to download a file that had a '&' in the name. SQL encodes strings containing special chars and thus we need to use the decoded file names in the path when downloading files from media module. 

Issuing this fix to the 21.0-release branch as it is affecting our users and current instance on CCNA. 

#### Testing instructions (if applicable)

1. Upload a file to media module that contains special chars (&, >, <, etc)
2. Try downloading the file and ensure that you do not receive an error. 

#### Link(s) to related issue(s)
* Resolves #6136 
