### PR TITLE
[candidate_profile] Add widget for open candidate issues to the candidate_profile

### DIFF
--- a/modules/issue_tracker/README.md
+++ b/modules/issue_tracker/README.md
@@ -20,4 +20,4 @@ Future development includes the ability to edit one’s own comments after submi
 
 ## Interactions with LORIS
 
-The issue tracker registers widgets on the `dashboard` and `candidate_profile` dashboard
+The issue tracker registers widgets on the `dashboard` and `candidate_profile` dashboard.

--- a/modules/issue_tracker/README.md
+++ b/modules/issue_tracker/README.md
@@ -17,3 +17,7 @@ Most of the permissions are controlled in `IssueForm.js`, dependent on values re
 
 ## Future Development
 Future development includes the ability to edit one’s own comments after submission, a pop-up or sliding view within other modules for easy issue reporting, further integration with the dashboard and with statistics, refinement of the form UI, a tabular sortable view of comments, the ability to click watching within the filter-form table and the inclusion of default users to notify in the config settings.
+
+## Interactions with LORIS
+
+The issue tracker registers widgets on the `dashboard` and `candidate_profile` dashboard

--- a/modules/issue_tracker/jsx/CandidateIssuesWidget.js
+++ b/modules/issue_tracker/jsx/CandidateIssuesWidget.js
@@ -1,0 +1,30 @@
+/**
+ * CandidateIssuesWidget represents a list of open issues to be displayed
+ * for a candidate on the candidate dashboard. It's displayed as a list
+ * with links to the issue tracker for each widget
+ *
+ * @param {array} props - the React props
+ *
+ * @return {object}
+ */
+function CandidateIssuesWidget(props) {
+    const issues = props.Issues.map(function(issue) {
+        let comments;
+        if (issue.comments && issue.comments != '0' ) {
+            comments = ' ('+ issue.comments + ' comment';
+            if (issue.comments != '1') {
+                comments += 's';
+            };
+            comments += ')';
+        }
+        return (<li key={issue.ID}>
+                  <a href={props.BaseURL + '/issue_tracker/issue/' + issue.ID}>
+                    {issue.Title}
+                  </a>
+                  {comments}
+            </li>);
+    });
+    return <ul>{issues}</ul>;
+}
+
+export default CandidateIssuesWidget;

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -110,8 +110,8 @@ class Module extends \Module
                     LEFT JOIN issues_comments ic ON (i.issueID=ic.issueID)
                  WHERE status != 'closed' AND CandID=:cid
                  GROUP BY i.issueID, i.Title",
-                     [ 'cid' => $candidate->getCandID() ],
-                 );
+                [ 'cid' => $candidate->getCandID() ],
+            );
             if (empty($issues)) {
                 return [];
             }

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -112,6 +112,21 @@ class Module extends \Module
                  GROUP BY i.issueID, i.Title",
                      [ 'cid' => $candidate->getCandID() ],
                  );
+            if (empty($issues)) {
+                return [];
+            }
+            return [
+                new \LORIS\candidate_profile\CandidateWidget(
+                    "Open Issues",
+                    $baseURL . "/issue_tracker/js/CandidateIssuesWidget.js",
+                    "lorisjs.issue_tracker.CandidateIssuesWidget.default",
+                    [
+                        'Issues' => $issues,
+                    ],
+                    1,
+                    1,
+                )
+            ];
 
         }
         return [];

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -93,6 +93,26 @@ class Module extends \Module
                     "issue_tracker"
                 )
             ];
+        case 'candidate':
+            $factory = \NDB_Factory::singleton();
+            $DB      = $factory->database();
+            $baseURL = $factory->settings()->getBaseURL();
+
+            $candidate = $options['candidate'];
+            if ($candidate === null) {
+                return [];
+            }
+            $issues = $DB->pselect(
+                "SELECT i.issueID as ID,
+                        i.title as Title,
+                        COUNT(DISTINCT ic.issueCommentID) as comments
+                 FROM issues i
+                    LEFT JOIN issues_comments ic ON (i.issueID=ic.issueID)
+                 WHERE status != 'closed' AND CandID=:cid
+                 GROUP BY i.issueID, i.Title",
+                     [ 'cid' => $candidate->getCandID() ],
+                 );
+
         }
         return [];
 

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -74,11 +74,16 @@ class Module extends \Module
      */
     public function getWidgets(string $type, \User $user, array $options) : array
     {
+        if (!in_array($type, ['usertasks', 'candidate'], true)) {
+            return [];
+        }
+
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+        $baseURL = $factory->settings()->getBaseURL();
+
         switch($type) {
         case 'usertasks':
-            $factory = \NDB_Factory::singleton();
-            $DB      = $factory->database();
-            $baseURL = $factory->settings()->getBaseURL();
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
@@ -94,10 +99,6 @@ class Module extends \Module
                 )
             ];
         case 'candidate':
-            $factory = \NDB_Factory::singleton();
-            $DB      = $factory->database();
-            $baseURL = $factory->settings()->getBaseURL();
-
             $candidate = $options['candidate'];
             if ($candidate === null) {
                 return [];
@@ -130,6 +131,5 @@ class Module extends \Module
 
         }
         return [];
-
     }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,7 +139,6 @@ const config = [
         module: mod,
     },
     // Modules
-    lorisModule('issue_tracker', ['issueTrackerIndex', 'index']),
     lorisModule('media', ['CandidateMediaWidget', 'mediaIndex']),
     lorisModule('issue_tracker', ['issueTrackerIndex', 'index', 'CandidateIssuesWidget']),
     lorisModule('publication', ['publicationIndex', 'viewProjectIndex']),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,8 +139,9 @@ const config = [
         module: mod,
     },
     // Modules
-    lorisModule('media', ['CandidateMediaWidget', 'mediaIndex']),
     lorisModule('issue_tracker', ['issueTrackerIndex', 'index']),
+    lorisModule('media', ['CandidateMediaWidget', 'mediaIndex']),
+    lorisModule('issue_tracker', ['issueTrackerIndex', 'index', 'CandidateIssuesWidget']),
     lorisModule('publication', ['publicationIndex', 'viewProjectIndex']),
     lorisModule('document_repository', ['docIndex', 'editFormIndex']),
     lorisModule('candidate_parameters', ['CandidateParameters', 'ConsentWidget']),


### PR DESCRIPTION
This adds a widget for any unclosed issues associated with a candidate to the
candidate dashboard. If there are no unresolved issues, the card is not displayed.

Issues are displayed as a simple list with links to the issue.
