### PR TITLE
Instruments variable incorrectly defined

### DIFF
--- a/docs/deprecated_wiki/How-to-Code-an-Instrument.md
+++ b/docs/deprecated_wiki/How-to-Code-an-Instrument.md
@@ -11,7 +11,7 @@
   * Element names must be lowercase and fewer than 64 characters (e.g. `q07_mother_maiden_name`). Never use hyphens, as it is confused with the MySQL minus sign. Element names `*_status` are reserved for select boxes accompanying text fields.
   * Use `addDateElement` wrapper for dates. Modify `dateTimeFields` array to include all date elements for proper conversion to database date/timestamp format.
   * Any date elements used should be added to the `dateTimeFields` array (so that they will be converted between HTML_Quickform and MySQL formats automagically).
-  * Any multiple select elements should be added to the `_selectMultipleElements` array.  This way they will be transferred between the database and the QuickForm smoothly.
+  * Any multiple select elements should be added to the `selectMultipleElements` array.  This way they will be transferred between the database and the QuickForm smoothly.
   * For question **dependencies**, use [XIN Rules](https://github.com/aces/Loris/wiki/XIN-Rules).
   * For formatting questions into tables, see [[Instrument Groups]].
 6. To ensure instrument completeness for all pages, modify `_requiredElements()` array to include 'Examiner' field and first question of each page, e.g. `$this->_requiredElements=array('Examiner', 'q1', 'q19', 'q37', 'q55'));` These array items must be entered to mark instrument as 'Complete'

--- a/docs/instruments/NDB_BVL_Instrument_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_TEMPLATE.class.inc
@@ -55,7 +55,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
 
         //The array of selects with multiple answers allowed
         //Any HTML_Quickform multiple selects must be listed here
-        $this->_selectMultipleElements = array();
+        $this->selectMultipleElements = array();
 
         // required fields for data entry completion status
         $this->_requiredElements = array(

--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -29,7 +29,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
 
         //The array of selects with multiple answers allowed
         //Any HTML_Quickform multiple selects must be listed here
-        $this->_selectMultipleElements = array();
+        $this->selectMultipleElements = array();
 
         // required fields for data entry completion status
         $this->_requiredElements = array('Examiner', '<FIRST QUESTION OF EACH PAGE>');
@@ -125,7 +125,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
 
 
 
-            //If the form is validated, call File_Upload::processFiles() which loops through the files and 
+            //If the form is validated, call File_Upload::processFiles() which loops through the files and
             //proccesses them (including verify, move, and import steps)
             $file->processFiles();
         }
@@ -138,7 +138,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
          }
         }
         unset($values['candID'], $values['sessionID'], $values['commentID'], $values['test_name'],
-              $values['page'], $values['fire_away'], $values['subtest'], $values['MAX_FILE_SIZE'], 
+              $values['page'], $values['fire_away'], $values['subtest'], $values['MAX_FILE_SIZE'],
               $values['upload_file']);
       $this->_save($values);
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -183,7 +183,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     public $preview = false;
 
     /**
-     * Array conaining all multiselct elements in an instrument.
+     * Array containing all multiselct elements in an instrument.
      */
     protected $selectMultipleElements;
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -183,7 +183,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     public $preview = false;
 
     /**
-     * Array containing all multiselct elements in an instrument.
+     * Array containing all multiselect elements in an instrument.
      */
     protected $selectMultipleElements;
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -183,6 +183,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     public $preview = false;
 
     /**
+     * Array used by LINST instruments
+     */
+    protected $selectMultipleElements;
+
+    /**
      * Factory generates a new instrument instance of type
      * $instrument, and runs the setup() method on that new
      * instrument.
@@ -541,8 +546,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 = $defaults['Candidate_Age'] . " (Age out of range)";
         }
         //Convert select multiple elements into a lorisform array
-        if (!empty($this->_selectMultipleElements)) {
-            foreach ($this->_selectMultipleElements AS $elname) {
+        if (!empty($this->selectMultipleElements)) {
+            foreach ($this->selectMultipleElements AS $elname) {
                 if (isset($defaults[$elname])
                     && stristr($defaults[$elname], "{@}")
                 ) {
@@ -763,8 +768,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         }
 
         //Convert select multiple elements into database storable values
-        if (!empty($this->_selectMultipleElements)) {
-            foreach ($this->_selectMultipleElements AS $elname) {
+        if (!empty($this->selectMultipleElements)) {
+            foreach ($this->selectMultipleElements AS $elname) {
                 if (isset($values[$elname]) && is_array($values[$elname])) {
                     $values[$elname] = implode("{@}", $values[$elname]);
                 }

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -183,7 +183,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     public $preview = false;
 
     /**
-     * Array used by LINST instruments
+     * Array conaining all multiselct elements in an instrument.
      */
     protected $selectMultipleElements;
 

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -36,8 +36,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
     public $LinstLines = array();
 
-    private $_selectMultipleElements;
-
     /**
      * Sets up the variables required for a LINST instrument to load
      *
@@ -614,7 +612,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
                 case 'selectmultiple':
                     $type = 'multiple';
-                    $this->_selectMultipleElements[] = $pieces[1];
+                    $this->selectMultipleElements[] = $pieces[1];
                     // fall through and also execute select code below
                 case 'select':
                     $options = preg_split("/{-}/", trim($pieces[3]));

--- a/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
@@ -51,7 +51,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
 
         //The array of selects with multiple answers allowed
         //Any LorisForm multiple selects must be listed here
-        $this->_selectMultipleElements = array();
+        $this->selectMultipleElements = array();
 
         // required fields for data entry completion status
         $this->_requiredElements = array(
@@ -165,7 +165,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
         $this->addHeader("Item Administration");
 
         $this->addLabel(
-            "Please replace all Not Applicable entries 
+            "Please replace all Not Applicable entries
             in presses for items 1, 2, 3, and 6."
         );
         $this->addLabel(

--- a/raisinbread/instruments/NDB_BVL_Instrument_medical_history.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_medical_history.class.inc
@@ -54,7 +54,7 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
 
         //The array of selects with multiple answers allowed
         //Any HTML_Quickform multiple selects must be listed here
-        $this->_selectMultipleElements = array('current_concussion_symptoms');
+        $this->selectMultipleElements = array('current_concussion_symptoms');
 
         // required fields for data entry completion status
         $this->_requiredElements = array(

--- a/raisinbread/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
@@ -64,7 +64,7 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
 
         //The array of selects with multiple answers allowed
         //Any LorisForm multiple selects must be listed here
-        //$this->_selectMultipleElements = array();
+        $this->selectMultipleElements = array();
 
         // required fields for data entry completion status
         $this->_requiredElements = array(


### PR DESCRIPTION
## Brief summary of changes
This was showing up as an error on my IDE, the variable is defined as private in the hchild class while the parent class refers to it.

change from `_select...` to `select...` because static checks enforce the ugly `_` before private variable rule