### PR TITLE
Add .gitignorefile and remove unnecessary transpiling of files

### DIFF
--- a/modules/data_release/.gitignore
+++ b/modules/data_release/.gitignore
@@ -1,2 +1,1 @@
-user_uploads/*
-js/dataReleaseIndex.js
+js/*

--- a/modules/data_release/.gitignore
+++ b/modules/data_release/.gitignore
@@ -1,1 +1,2 @@
 user_uploads/*
+js/dataReleaseIndex.js

--- a/modules/electrophysiology_browser/.gitignore
+++ b/modules/electrophysiology_browser/.gitignore
@@ -1,2 +1,1 @@
-js/electrophysiologySessionView.js
-js/electrophysiologyBrowserIndex.js
+js/*

--- a/modules/electrophysiology_browser/.gitignore
+++ b/modules/electrophysiology_browser/.gitignore
@@ -1,0 +1,2 @@
+js/electrophysiologySessionView.js
+js/electrophysiologyBrowserIndex.js

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,8 +160,6 @@ const config = [
     lorisModule('datadict', ['dataDictIndex']),
     lorisModule('data_release', [
         'dataReleaseIndex',
-        'uploadFileForm',
-        'addPermissionForm',
     ]),
     lorisModule('dataquery', [
         'react.app',
@@ -176,9 +174,6 @@ const config = [
     lorisModule('electrophysiology_browser', [
         'electrophysiologyBrowserIndex',
         'electrophysiologySessionView',
-        'components/electrophysiology_session_panels',
-        'components/Sidebar',
-        'components/SidebarContent',
     ]),
     lorisModule('genomic_browser', ['profileColumnFormatter']),
     lorisModule('imaging_browser', ['ImagePanel', 'imagingBrowserIndex']),


### PR DESCRIPTION
## Brief summary of changes
After `make` command is run, some files were showing up in the untracked files category, we can ignore these JS files because they are compiled.

Also, some imported JSX files were being compiled unecessarily, I removed them from the webpack file
