### PR TITLE
[Core] CandID implements JsonSerializable

### DIFF
--- a/modules/api/php/views/candidate.class.inc
+++ b/modules/api/php/views/candidate.class.inc
@@ -44,7 +44,7 @@ class Candidate
     public function toArray(): array
     {
         $meta = array(
-            'CandID'  => (string) $this->_candidate->getCandID(),
+            'CandID'  => $this->_candidate->getCandID(),
             'Project' => $this->_candidate->getProjectTitle(),
             'PSCID'   => $this->_candidate->getPSCID(),
             'Site'    => $this->_candidate->getCandidateSite(),

--- a/modules/api/php/views/visit.class.inc
+++ b/modules/api/php/views/visit.class.inc
@@ -43,7 +43,7 @@ class Visit
     public function toArray(): array
     {
         $meta = array(
-            'CandID'  => (string) $this->_timepoint->getCandID(),
+            'CandID'  => $this->_timepoint->getCandID(),
             'Visit'   => $this->_timepoint->getVisitLabel(),
             'Site'    => $this->_timepoint->getPSC(),
             'Battery' => $this->_timepoint->getData('SubprojectTitle'),

--- a/modules/api/php/views/visit/dicoms.class.inc
+++ b/modules/api/php/views/visit/dicoms.class.inc
@@ -93,7 +93,7 @@ class Dicoms
     public function toArray(): array
     {
         $meta = array(
-            'CandID' => (string) $this->_timepoint->getCandID(),
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
         );
 

--- a/modules/api/php/views/visit/flags.class.inc
+++ b/modules/api/php/views/visit/flags.class.inc
@@ -58,7 +58,7 @@ class Flags
         $isDDE = strpos($instrumentdata['CommentID'], 'DDE_') === 0;
 
         $meta = array(
-            'Candidate'  => (string) $this->_timepoint->getCandID(),
+            'Candidate'  => $this->_timepoint->getCandID(),
             'Visit'      => $this->_timepoint->getVisitLabel(),
             'DDE'        => $isDDE,
             'Instrument' => $instrumentname,

--- a/modules/api/php/views/visit/image/headers/full.class.inc
+++ b/modules/api/php/views/visit/image/headers/full.class.inc
@@ -81,7 +81,7 @@ class Full
      */
     private function _formatMeta(): array
     {
-        $candid     = (string) $this->_visit->getCandID();
+        $candid     = $this->_visit->getCandID();
         $visitlabel = $this->_visit->getVisitLabel();
         $filename   = $this->_image->getFileInfo()->getFilename();
 

--- a/modules/api/php/views/visit/image/headers/specific.class.inc
+++ b/modules/api/php/views/visit/image/headers/specific.class.inc
@@ -83,7 +83,7 @@ class Specific
      */
     private function _formatMeta(): array
     {
-        $candid     = (string) $this->_visit->getCandID();
+        $candid     = $this->_visit->getCandID();
         $visitlabel = $this->_visit->getVisitLabel();
         $filename   = $this->_image->getFileInfo()->getFilename();
 

--- a/modules/api/php/views/visit/image/headers/summary.class.inc
+++ b/modules/api/php/views/visit/image/headers/summary.class.inc
@@ -74,7 +74,7 @@ class Summary
      */
     private function _formatMeta(): array
     {
-        $candid     = (string) $this->_visit->getCandID();
+        $candid     = $this->_visit->getCandID();
         $visitlabel = $this->_visit->getVisitLabel();
         $filename   = $this->_image->getFileInfo()->getFilename();
 

--- a/modules/api/php/views/visit/image/qc.class.inc
+++ b/modules/api/php/views/visit/image/qc.class.inc
@@ -49,7 +49,7 @@ class Qc
     public function toArray(): array
     {
         $meta = array(
-            'CandID' => (string) $this->_timepoint->getCandID(),
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
             'File'   => $this->_image->getFileInfo()->getFilename(),
         );

--- a/modules/api/php/views/visit/images.class.inc
+++ b/modules/api/php/views/visit/images.class.inc
@@ -48,7 +48,7 @@ class Images
     public function toArray(): array
     {
         $meta = array(
-            'CandID' => (string) $this->_timepoint->getCandID(),
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
         );
 

--- a/modules/api/php/views/visit/instrument.class.inc
+++ b/modules/api/php/views/visit/instrument.class.inc
@@ -58,7 +58,7 @@ class Instrument
         $isDDE = strpos($instrumentdata['CommentID'], 'DDE_') === 0;
 
         $meta = array(
-            'Candidate'  => (string) $this->_timepoint->getCandID(),
+            'Candidate'  => $this->_timepoint->getCandID(),
             'Visit'      => $this->_timepoint->getVisitLabel(),
             'DDE'        => $isDDE,
             'Instrument' => $instrumentname,

--- a/modules/api/php/views/visit/instruments.class.inc
+++ b/modules/api/php/views/visit/instruments.class.inc
@@ -44,7 +44,7 @@ class Instruments
     public function toArray(): array
     {
         $meta = array(
-            'CandID' => (string) $this->_timepoint->getCandID(),
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
         );
 

--- a/modules/api/php/views/visit/qc.class.inc
+++ b/modules/api/php/views/visit/qc.class.inc
@@ -49,7 +49,7 @@ class Qc
     public function toArray(): array
     {
         $meta = array(
-            'CandID' => (string) $this->_timepoint->getCandID(),
+            'CandID' => $this->_timepoint->getCandID(),
             'Visit'  => $this->_timepoint->getVisitLabel(),
         );
 

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -88,8 +88,8 @@ class CandID extends ValidatableIdentifier implements \JsonSerializable
      * @see https://www.php.net/manual/en/jsonserializable.jsonserialize.php
      * @return mixed
      */
-     public function jsonSerialize()
-     {
-         return $this->value;
-     }
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
 }

--- a/src/StudyEntities/Candidate/CandID.php
+++ b/src/StudyEntities/Candidate/CandID.php
@@ -22,7 +22,7 @@ namespace LORIS\StudyEntities\Candidate;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class CandID extends ValidatableIdentifier
+class CandID extends ValidatableIdentifier implements \JsonSerializable
 {
     /*
      * The minimum allowed value for valid CandIDs. Origin unclear but
@@ -79,4 +79,17 @@ class CandID extends ValidatableIdentifier
     {
         return $this->value;
     }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     * Returns data which can be serialized by json_encode(), which is a value of
+     * any type other than a resource.
+     *
+     * @see https://www.php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed
+     */
+     public function jsonSerialize()
+     {
+         return $this->value;
+     }
 }


### PR DESCRIPTION
## Brief summary of changes

Since CandID are proper objects and no longer strings or integer, json_encode was returning those objects as `{}`

This add the JsonSerialize function to the class to specify how json_encode should treat thos objects. In this case, as a string which value is the candid.  

 
#### Testing instructions (if applicable)
Query any API endpoint which returns a CandID (most do in the Meta fields)

This will also fix the new endpoints return value in https://github.com/aces/Loris/pull/5739