### PR TITLE
[Tools] Fix bug where Raisinbread refresh did not install instruments

### DIFF
--- a/raisinbread/README.md
+++ b/raisinbread/README.md
@@ -1,8 +1,5 @@
-*This directory contains all the files necessary to spawn an instance of the Raisin 
-Bread demonstration dataset.*
-
 ### Overview
-The Raisin Bread (RB) database is an example dataset built for demonstration and 
+The RaisinBread (RB) database is an example dataset built for demonstration and 
 testing purposes. This dataset should be expanded when new features are added and 
 adjusted when existing features are changed or removed. 
 
@@ -22,11 +19,18 @@ If RaisinBread is being installed for the first time, the steps outlined below i
 [Configuring](#Configuring) section must be completed. 
 
 ### Manual RB Installation
+You can install test data by running `php tools/raisinbread_refresh.php` or 
+`make testdata`.
+
+If any errors are encountered during the execution of that script, this document
+should assist you in troubleshooting.
+
+### Installing RB
 The RaisinBread data is stored in the form of SQL INSERT statements located in the 
 `/raisinbread/RB_files/` directory and grouped by the database table they belong to. 
 These statements rely on the pre-existence of the SQL tables and thus the data is 
 heavily coupled with the default LORIS schema files located in the `/SQL/` directory.
-The RaisinBread dataset also include a few example instruments, these can be found in
+The RaisinBread dataset also includes a few example instruments, these can be found in
 the `raisinbread/instruments/` directory along with their respective SQL schemas in 
 `raisinbread/instruments/instrument_sql/` and their respective Meta SQL commands in 
 `raisinbread/instruments/instrument_sql/Meta/`. 
@@ -81,7 +85,7 @@ some configurations are necessary.
 1. Copy the `raisinbread/config/config.xml` file into `project/config.xml`
 2. Input the correct `<database>` information in the `project/config.xml` file 
 3. Change the values of the `Config` table of the SQL database to reflect the 
-correct `host`, `url` and `base` values
+correct `host` and `base` values
 4. copy the `raisinbread/instruments/` instrument PHP and LINST files to the 
 `projects/instruments/` directory
 

--- a/raisinbread/README.md
+++ b/raisinbread/README.md
@@ -19,13 +19,6 @@ If RaisinBread is being installed for the first time, the steps outlined below i
 [Configuring](#Configuring) section must be completed. 
 
 ### Manual RB Installation
-You can install test data by running `php tools/raisinbread_refresh.php` or 
-`make testdata`.
-
-If any errors are encountered during the execution of that script, this document
-should assist you in troubleshooting.
-
-### Installing RB
 The RaisinBread data is stored in the form of SQL INSERT statements located in the 
 `/raisinbread/RB_files/` directory and grouped by the database table they belong to. 
 These statements rely on the pre-existence of the SQL tables and thus the data is 

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -28,13 +28,7 @@
  * import Raisinbread data if the user has properly set up a MySQL configuration
  * file and provides the name of their LORIS database.
  *
- * PHP Version 7
- *
- * @category Main
- * @package  Loris
- * @author   John Saigle <john.saigle@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris-Trunk/
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 
 $info = <<<INFO
@@ -165,6 +159,7 @@ if (count($tables) > 0) {
     echo "Do you want to delete them now? (y/N)" . PHP_EOL;
     $input = trim(fgets(STDIN));
     if (mb_strtolower($input) === 'y') {
+        echo 'drop';
         dropRemainingTables($tables);
     }
 }
@@ -188,6 +183,21 @@ printHeader('Importing Raisinbread data...');
 $rbData = glob(__DIR__ . "/../raisinbread/RB_files/*.sql");
 
 array_walk($rbData, 'runPatch');
+
+// Copy Raisinbread instrument files to project/instruments/. This is done using
+// a closure to apply PHP's copy() function to all files in raisinbread/instruemnts/
+// that end with the LINST or .class.inc file extension.
+printHeader('Copying Rasinbread instrument files to project/instruments/...');
+array_map(
+    function ($file) {
+        copy($file, __DIR__ . '/../project/instruments/' . basename($file));
+    },
+    array_merge(
+        glob(__DIR__ . "/../raisinbread/instruments/*.class.inc"),
+        glob(__DIR__ . "/../raisinbread/instruments/*.linst")
+    ),
+);
+
 
 // Restore config settings if they were successfully found before.
 $configSettings = [

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -159,7 +159,6 @@ if (count($tables) > 0) {
     echo "Do you want to delete them now? (y/N)" . PHP_EOL;
     $input = trim(fgets(STDIN));
     if (mb_strtolower($input) === 'y') {
-        echo 'drop';
         dropRemainingTables($tables);
     }
 }

--- a/tools/raisinbread_refresh.php
+++ b/tools/raisinbread_refresh.php
@@ -186,7 +186,7 @@ array_walk($rbData, 'runPatch');
 
 // Copy Raisinbread instrument files to project/instruments/. This is done using
 // a closure to apply PHP's copy() function to all files in raisinbread/instruemnts/
-// that end with the LINST or .class.inc file extension.
+// that are required for scoring instruments
 printHeader('Copying Rasinbread instrument files to project/instruments/...');
 array_map(
     function ($file) {
@@ -194,7 +194,9 @@ array_map(
     },
     array_merge(
         glob(__DIR__ . "/../raisinbread/instruments/*.class.inc"),
-        glob(__DIR__ . "/../raisinbread/instruments/*.linst")
+        glob(__DIR__ . "/../raisinbread/instruments/*.linst"),
+        glob(__DIR__ . "/../raisinbread/instruments/*.score"),
+        glob(__DIR__ . "/../raisinbread/instruments/*.rules")
     ),
 );
 


### PR DESCRIPTION
## Brief summary of changes

When writing this tool, I neglected to automate the part of the instructions where you have to copy the instrument files from `raisinbread/instruments/` to `project/instruments/`. Without this step, accessing instruments via the LORIS front-end will fail and throw a NotFound exception.

This PR automates that step into the raisinbread refresh process.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. On a test VM, delete all LINST and .class.inc files in your `project/instruments/` folder.
2. Run `make testdata`
3. Check that the files from `raisinbread/instruments/` have been copied to `project/instruments/`
