### PR TITLE
[Menu] Add new menu item to access beta candidate profile module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,17 @@ database (PR #5260)
 
 ### Modules 
 
+#### Candidate Profile
+- New module created to provide dashboard of a single candidate's data across all
+  modules. (Various PRs)
+
 #### Battery Manager
-- New module created to manage the entries in the test_battery table of the database.
+- New module created to manage the entries in the `test_battery` table of the database.
 This allows projects to modify their instrument battery without requiring backend access.
  (PR #4221)
  
 #### Issue Tracker
-- The issue_tracker module now has the feature of uploading attachments to new or existing
+- The `issue_tracker` module now has the feature of uploading attachments to new or existing
 issues. (PR #5394)
  
 #### Module Manager

--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -103,7 +103,13 @@ class CandidateListIndex extends Component {
    */
   formatColumn(column, cell, row) {
     if (column === 'PSCID') {
-      let url = this.props.baseURL + '/' + row['DCCID'] + '/';
+      let url;
+      if (this.props.betaProfileLink) {
+          url = this.props.baseURL + '/candidate_profile/' + row['DCCID'] + '/';
+      } else {
+          url = this.props.baseURL + '/' + row['DCCID'] + '/';
+      }
+
       return <td><a href ={url}>{cell}</a></td>;
     }
     if (column === 'Feedback') {
@@ -330,7 +336,7 @@ class CandidateListIndex extends Component {
         }}
         onClick={this.openProfile}
       >
-        <OpenProfileForm/>
+        <OpenProfileForm betaProfileLink={this.props.betaProfileLink} />
       </Modal>
     );
 
@@ -370,11 +376,13 @@ CandidateListIndex.propTypes = {
 };
 
 window.addEventListener('load', () => {
+  const args = QueryString.get();
   ReactDOM.render(
     <CandidateListIndex
       dataURL={`${loris.BaseURL}/candidate_list/?format=json`}
       hasPermission={loris.userHasPermission}
       baseURL={loris.BaseURL}
+      betaProfileLink={args['betaprofile']}
     />,
     document.getElementById('lorisworkspace')
   );

--- a/modules/candidate_list/jsx/openProfileForm.js
+++ b/modules/candidate_list/jsx/openProfileForm.js
@@ -69,7 +69,11 @@ class OpenProfileForm extends Component {
               message: 'Opening profile...',
               className: 'alert alert-info text-center',
             };
-            window.location.href = loris.BaseURL + '/' + state.CandID;
+            if (this.props.betaProfileLink) {
+                window.location.href = loris.BaseURL + '/candidate_profile/' + state.CandID;
+            } else {
+                window.location.href = loris.BaseURL + '/' + state.CandID;
+            }
           } else {
             // display error message
             state.error = {

--- a/modules/candidate_list/php/module.class.inc
+++ b/modules/candidate_list/php/module.class.inc
@@ -40,6 +40,28 @@ class Module extends \Module
     }
 
     /**
+     * The candidate_list temporarily overrides the getMenuItems link to
+     * provide 2 menu items, one which links to the old timepoint_list
+     * and one which links to the new candidate profile.
+     *
+     * @return \LORIS\GUI\MenuItem[]
+     */
+    public function getMenuItems() : array
+    {
+        $category = $this->getMenuCategory();
+        $name     = $this->getLongName();
+
+        $factory = \NDB_Factory::singleton();
+        $baseURL = $factory->settings()->getBaseURL();
+        $url     = $baseURL . '/' . $this->getName() . '/';
+
+        return [
+            new \LORIS\GUI\MenuItem($category, $name, $url),
+            new \LORIS\GUI\MenuItem($category, 'New ' . $name . ' (Beta)', $url . "?betaprofile=1"),
+            ];
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @return string The menu category for this module

--- a/modules/candidate_list/php/module.class.inc
+++ b/modules/candidate_list/php/module.class.inc
@@ -57,8 +57,12 @@ class Module extends \Module
 
         return [
             new \LORIS\GUI\MenuItem($category, $name, $url),
-            new \LORIS\GUI\MenuItem($category, 'New ' . $name . ' (Beta)', $url . "?betaprofile=1"),
-            ];
+            new \LORIS\GUI\MenuItem(
+                $category,
+                'New ' . $name . ' (Beta)',
+                $url . "?betaprofile=1"
+            ),
+        ];
     }
 
     /**


### PR DESCRIPTION
Include 2 menu items in the LORIS menu, one of which accesses the
old timepoint_list module and one of which links to the new candidate_profile
module.