### PR TITLE
Fix data in fields where HTML characters were double escaped

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -693,10 +693,10 @@ class LorisForm
                 }
             }
         }
-        // Always sanitize user-controlled input
-        if (!is_array($newValue)) {
-            $newValue = htmlspecialchars($newValue);
-        }
+        //        // Always sanitize user-controlled input
+        //        if (!is_array($newValue)) {
+        //            $newValue = htmlspecialchars($newValue);
+        //        }
 
         return $newValue;
     }

--- a/tools/single_use/fix_double_escape.php
+++ b/tools/single_use/fix_double_escape.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * This tool scores any registered instrument that was built using the
+ * NDB_BVL_Instrument class and that has a working score() method.
+ * The command line arguments need to contain a valid test_name, a 'all' or 'one'
+ * option, a CandID and a SessionID.
+ *
+ * The 'all' option scores all existing records of an instrument if and only if
+ *  - They belong to an active timepoint
+ *  - The data-entry status of the timepoint is set to `complete`
+ *  - The administration of the timepoint is NOT `none`
+ *
+ * Note: This tool can also be used to debug the scoring algorithms for development.
+ *
+ * Limitation: This tool does not reset or nullify the score of an instrument
+ * which was previously scored but no longer meets the criteria above (i.e. if the
+ * administration was changed from `all` to `none`, the score will not be removed).
+ *
+ * @package behavioural
+ */
+
+require_once __DIR__."/../generic_includes.php";
+
+// LOGGING
+$dir = __DIR__ . "/../logs/";
+if (!is_dir($dir)) {
+    mkdir($dir);
+}
+$today   = getdate();
+$date    = strftime("%Y-%m-%d_%H:%M");
+$logPath = "$dir/fix_double_escaped_fields_$date.log";
+$logfp   = fopen($logPath, 'a');
+
+if (!$logfp) {
+    printError(
+        "No logs can be generated, path:$logPath ".
+        "does not exist or can not be written to.\n"
+    );
+}
+
+if (isset($argv[1]) && $argv[1] === 'help' || in_array('-h', $argv, true)) {
+    showHelp();
+}
+$confirm = false;
+if (isset($argv[1]) && $argv[1] === 'confirm') {
+    $confirm =true;
+}
+
+$instrumentNames = $DB->pselectCol("SELECT Test_name FROM test_names", array());
+$errorsDetected  = false;
+
+// get the list of CommentIDs for valid timepoints
+foreach($instrumentNames as $instrumentName) {
+    printOut("Checking $instrumentName");
+    try{
+        $instrument = \NDB_BVL_Instrument::factory($instrumentName);
+    } catch (Exception $e) {
+        printError(
+            "There was an error instantiating instrument $instrumentName.
+            This instrument will be skipped."
+        );
+        continue;
+    }
+    $instrumentCIDs = $DB->pselectCol(
+        "SELECT CommentID FROM flag WHERE Test_name=:tn",
+        array("tn" => $instrumentName)
+    );
+    foreach ($instrumentCIDs as $cid) {
+        $instrumentInstance = \NDB_BVL_Instrument::factory($instrumentName, $cid);
+
+        $instrumentData = \NDB_BVL_Instrument::loadInstanceData(
+            $instrumentInstance
+        );
+        $set            = array();
+        foreach ($instrumentData as $field=>$value){
+            // Each of the expressions below uniquely match each of the targeted
+            // characters indicated in the comment above the function.
+
+            // < : match any substring starting with `&`
+            // followed by 1 or more `amp;` and ending with `lt;`
+            $newValue = preg_replace('/&(amp;)+lt;/', '<', $value);
+            // > : match any substring starting with `&`
+            // followed by 1 or more `amp;` and ending with `gt;`
+            $newValue = preg_replace('/&(amp;)+gt;/', '>', $newValue);
+            // " : match any substring starting with `&`
+            // followed by 1 or more `amp;` and ending with `quot;`
+            $newValue = preg_replace('/&(amp;)+quot;/', '"', $newValue);
+            // & : match any substring starting with `&`
+            // followed by 2 or more `amp;` (because 1 is normal in the database
+            // since it is the escaped form of `&`) and
+            // NOT ending with `lt;` or `gt;` or `quot;` or `amp;`
+            // (the last one is to ensure we don't match subsequences from the
+            // case above).
+            $newValue = preg_replace('/&(amp;){2,}(?!(lt;|gt;|quot;|amp;))/', '&', $newValue);
+
+            if (!empty($value) && !empty($newValue) && $newValue !== $value) {
+                printOut(
+                    "CommentID: $cid - Value at $field will be modified. ".
+                    "\n\tCurrent Value: $value".
+                    "\n\tWill be replaced by: $newValue\n"
+                );
+
+                $set[$field]    = $newValue;
+                $errorsDetected = true;
+            }
+        }
+        if (!empty($set) && $confirm) {
+            $instrumentInstance->_save($set);
+        }
+    }
+}
+
+if (!$confirm && $errorsDetected) {
+    printOut("\nRun tool again with `confirm` argument to apply changes");
+} else {
+    printOut("End");
+}
+fclose($logfp);
+
+/*
+ * Prints to log file
+ */
+function logMessage($message)
+{
+    global $logfp;
+    if (!$logfp) {
+        //The log file could not be instantiated
+        //use print instead
+        print_r($message);
+    }
+    $now_string = strftime("%Y-%m-%d %H:%M:%S");
+    fwrite($logfp, "[$now_string] $message\n");
+
+}
+
+/*
+ * Prints to STDERR
+ */
+function printError($message)
+{
+    logMessage($message);
+    fwrite(STDERR, "$message \n");
+}
+
+/*
+ * Prints to STDOUT
+ */
+function printOut($message)
+{
+    logMessage($message);
+    print_r("$message\n");
+}
+
+function showHelp()
+{
+    echo "\n\n*** Fix Double Escaped Fields ***\n\n";
+
+    echo "Usage:
+    fix_double_escape.php [help | -h]   -> displays this message
+    fix_double_escape.php               -> runs tool without making any changes
+    fix_double_escape.php confirm       -> runs tool and rectifies erroneous data
+    \n\n";
+
+    die();
+}

--- a/tools/single_use/fix_double_escape.php
+++ b/tools/single_use/fix_double_escape.php
@@ -96,7 +96,7 @@ foreach($instrumentNames as $instrumentName) {
         // Go through all fields and identify which have any escaped characters
         foreach ($instrumentData as $field => $value) {
             // regex detecting any escaped character in the database
-            if (preg_match('/&(amp;)+(gt;|lt;|quot;)?/', $value)) {
+            if (preg_match('/&(amp;)+(gt;|lt;|quot;|amp;)/', $value)) {
                 $escapedEntries[$instrumentName][$cid][$field] = $value;
                 $errorsDetected = true;
             }

--- a/tools/single_use/instrument_double_escape_report.php
+++ b/tools/single_use/instrument_double_escape_report.php
@@ -1,0 +1,225 @@
+<?php declare(strict_types=1);
+/**
+ * This tool checks instrument data for multi-escaped characters that have
+ * been stored in the database due to a bug present in LORIS since before
+ * version 19.0.
+ *
+ * This tool can be used to report cases of multi-escaped character as well
+ * as identify if the escaping caused data truncation.
+ *
+ * This tool does not fix or modify the data in anyway, it simply reads from t
+ * he database.
+ *
+ */
+
+require_once __DIR__."/../generic_includes.php";
+
+// LOGGING
+$dir = __DIR__ . "/../logs/";
+if (!is_dir($dir)) {
+    mkdir($dir);
+}
+$today   = getdate();
+$date    = strftime("%Y-%m-%d_%H:%M");
+$logPath = "$dir/instrument_double_escape_report_$date.log";
+$logfp   = fopen($logPath, 'a');
+
+if (!$logfp) {
+    printError(
+        "No logs can be generated, path:$logPath ".
+        "does not exist or can not be written to.\n"
+    );
+}
+//PARSE ARGUMENTS
+$actions = array(
+    'use-database',
+    'use-objects',
+);
+if (
+    !isset($argv[1])
+    || $argv[1] === 'help'
+    || in_array('-h', $argv, true)
+    || !in_array($argv[1], $actions, true)
+    || $argc !== 2
+) {
+    showHelp();
+}
+$useDatabase = false;
+if (isset($argv[1]) && $argv[1] === 'use-database') {
+    $useDatabase =true;
+}
+$useObjects = false;
+if (isset($argv[1]) && $argv[1] === 'use-objects') {
+    $useObjects =true;
+}
+
+// DEFINE VARIABLES
+// All instruments looked at
+$instrumentNames = $DB->pselectCol("SELECT Test_name FROM test_names", array());
+// Array of all fields containing any escaped characters
+$escapedEntries = array();
+// Array of database tables and columns containing escaped characters.
+$escapedFields = array();
+// Array of confirmed truncations based on size of fields and content
+$confirmedTruncations = array();
+// Boolean flag for identify non-impacted databases and terminating.
+$errorsDetected = false;
+// Array of CHARACTER_MAXIMUM_LENGTH for each affected field.
+$maxFieldLengths = array();
+
+$databaseName = $config->getSetting('database')['database'];
+
+// FIRST loop just reporting all potential problematic fields
+foreach($instrumentNames as $instrumentName) {
+    printOut("Checking $instrumentName");
+
+    //default value for table name
+    $tableName=$instrumentName;
+
+    $instrumentCIDs = $DB->pselectCol(
+        "SELECT CommentID FROM flag WHERE Test_name=:tn",
+        array("tn" => $instrumentName)
+    );
+
+    $instrumentData=array();
+    if ($useObjects) {
+        try {
+            $instrument = \NDB_BVL_Instrument::factory($instrumentName);
+        } catch (Exception $e) {
+            printError(
+                "There was an error instantiating instrument $instrumentName.
+            This instrument will be skipped."
+            );
+            printError($e->getMessage());
+            continue;
+        }
+        foreach ($instrumentCIDs as $cid) {
+            $instrumentInstance = \NDB_BVL_Instrument::factory($instrumentName, $cid);
+            $instrumentCandData = \NDB_BVL_Instrument::loadInstanceData($instrumentInstance);
+
+            // instrument name and table name might differ
+            $tableName = $instrumentInstance->table;
+            $instrumentData[$cid] = $instrumentCandData;
+        }
+    } else if ($useDatabase) {
+        //Check if table by that name exists
+        if(!$DB->tableExists($instrumentName)) {
+            printError("No table by the name `$instrumentName` was found in the
+            database. This instrument will be skipped");
+        };
+        $instrumentData = $DB->pselectWithIndexKey(
+            "SELECT * FROM $instrumentName",
+            array(),
+            "CommentID"
+        );
+    }
+    // Go through all fields and identify which have any escaped characters
+    foreach ($instrumentData as $cid => $instrumentCandData) {
+        foreach ($instrumentCandData as $field => $value) {
+            // regex detecting any escaped character in the database
+            if (!empty($value) && preg_match('/&(amp;)+(gt;|lt;|quot;|amp;)/', $value)) {
+                $escapedEntries[$tableName][$cid][$field] = $value;
+                $escapedFields[$tableName][] = $field;
+                $errorsDetected = true;
+            }
+        }
+    }
+}
+
+//SECOND loop, depending on flags, report or fix values.
+if ($errorsDetected) {
+    foreach ($escapedFields as $tableName => $fieldsArray) {
+        $fieldsList = "'" . implode($fieldsArray, "','") . "'";
+
+        $maxFieldLengths[$tableName] = $DB->pselectWithIndexKey(
+            "SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_MAXIMUM_LENGTH
+			FROM INFORMATION_SCHEMA.COLUMNS
+			WHERE TABLE_SCHEMA=:dbn AND TABLE_NAME=:tbl AND COLUMN_NAME IN ($fieldsList)",
+            array('dbn'=>$databaseName,'tbl' => $tableName),
+            'COLUMN_NAME'
+        );
+    }
+
+    // Start comparing the value length of the escaped entry to the character maximum for that field
+    // In order to begin identifying cases of truncation
+    foreach ($escapedEntries as $tableName => $rows) {
+        foreach ($rows as $cid => $entries) {
+            foreach ($entries as $field => $value) {
+                if (strlen($value) == $maxFieldLengths[$tableName][$field]['CHARACTER_MAXIMUM_LENGTH']) {
+                    $confirmedTruncations[$tableName][$cid][$field] = $value;
+                }
+            }
+        }
+    }
+
+    if(!empty($escapedEntries)) {
+        printOut(
+            "Below is a list of all entries in the database instruemnts which " .
+            "contain escaped characters"
+        );
+        print_r($escapedEntries);
+        print_r("\n\n");
+    }
+    if (!empty($confirmedTruncations)) {
+        printOut(
+            "Below is the list of truncations automatically detected. This " .
+            "list might not be exhaustive, truncation can occur without being " .
+            "automatically detected by this script."
+        );
+        print_r($confirmedTruncations);
+    }
+} else {
+    printOut("No errors have been detected. End !");
+}
+
+fclose($logfp);
+
+
+/*
+ * Prints to log file
+ */
+function logMessage($message)
+{
+    global $logfp;
+    if (!$logfp) {
+        //The log file could not be instantiated
+        //use print instead
+        print_r($message);
+    }
+    $now_string = strftime("%Y-%m-%d %H:%M:%S");
+    fwrite($logfp, "[$now_string] $message\n");
+
+}
+
+/*
+ * Prints to STDERR
+ */
+function printError($message)
+{
+    logMessage($message);
+    fwrite(STDERR, "$message \n");
+}
+
+/*
+ * Prints to STDOUT
+ */
+function printOut($message)
+{
+    logMessage($message);
+    print_r("$message\n");
+}
+
+function showHelp()
+{
+    echo "\n\n*** Fix Double Escaped Fields ***\n\n";
+
+    echo "Usage:
+    instrument_double_escape_report.php [help | -h]  -> displays this message
+    instrument_double_escape_report.php use-database -> Runs the reporter using only the database instrument names and tables
+    instrument_double_escape_report.php use-objects  -> Runs the reporter using the database and instantiating Instrument objects.
+
+    Note: in the event where use-objects fails, try use-database.
+    \n\n";
+
+    die();
+}


### PR DESCRIPTION
## Brief summary of changes
This fixes the issue where HTML special characters were escaped twice before being saved causing every save to re-escape the `&` of the previously escaped values.

The problematic characters are `&><"`

Example, if an instrument field contains a `>`:
after first save value becomes `&amp;gt;`
after second save `&amp;amp;amp;gt;`

Causing some values to look like this on projects running cronjobs nightly
`&amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;amp;gt;`

#### Testing instructions (if applicable)

1. before checking out this branch, go to an instrument and save any of the characters listed above.
2. reload the page
3. [optional] save multiple times (make sure to reload the page before re-saving because values do not get refetched from the database automatically in instruments)
4. checkout this branch, and test out the script.
5. end result should show normal characters on the front end. Database values should still be escaped but without duplication

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
