### PR TITLE
[FilesUploadHandler] Remove special characters in file names

### DIFF
--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -177,9 +177,9 @@ class FilesUploadHandler implements RequestHandlerInterface
                 . preg_replace(
                     "/[^a-z0-9\_\-\.]/i",
                     '',
-                    $pathinfo[PATHINFO_BASENAME]
+                    $pathinfo['basename']
                 )
-                . $pathinfo[PATHINFO_EXTENSION];
+                . $pathinfo['extension'];
 
             /* If file exists, set response code to 'Conflict' unless the
              * calling code wants to overwrite the file.

--- a/php/libraries/FilesUploadHandler.class.inc
+++ b/php/libraries/FilesUploadHandler.class.inc
@@ -163,12 +163,23 @@ class FilesUploadHandler implements RequestHandlerInterface
                     );
             }
 
-            /* basename() is used here to prevent path traversal characters
-             * from being used.
+            /* Create the target path and clean up the filename.
+             * basename() is used to prevent path traversal.
+             * Use a regular expression to ensure that only the following
+             * characters are used in the filename:
+             *     - Alphaetical characters
+             *     - Numbers
+             *     - Dashes
+             *     - Underscores
              */
-            $targetPath = $this->uploadDirectory->getPathname() . '/' . basename(
-                $file->getClientFilename()
-            );
+            $pathinfo   = pathinfo($file->getClientFilename());
+            $targetPath = $this->uploadDirectory->getPathname() . '/'
+                . preg_replace(
+                    "/[^a-z0-9\_\-\.]/i",
+                    '',
+                    $pathinfo[PATHINFO_BASENAME]
+                )
+                . $pathinfo[PATHINFO_EXTENSION];
 
             /* If file exists, set response code to 'Conflict' unless the
              * calling code wants to overwrite the file.


### PR DESCRIPTION
## Brief summary of changes

Files uploaded using this class can now contain only alphanumeric characters as well as dashes and underscores.

This is to avoid problems with sanitizing and encoding/decoding filenames, such as #6136.

- [ ] Have you updated related documentation? 
No but I don't think this is documented anywhere.

#### Testing instructions (if applicable)

1. On this branch, upload a file to the instrument_manager module containing a forbidden character.
2. Ensure that your file is uploaded successfully but with the offending character removed.

#### Link(s) to related issue(s)

* Resolves #6162 
