### PR TITLE
[My Preferences] Change contents of email sent to user upon changing their account details

### DIFF
--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -195,18 +195,6 @@ class My_Preferences extends \NDB_Form
         $factory = \NDB_Factory::singleton();
         $config  = $factory->config();
 
-        // send the user an email
-        $msg_data          = [];
-        $msg_data['study'] = $config->getSetting('title');
-        $msg_data['url']   = $factory->settings()->getBaseURL();
-        $msg_data['realname'] = $values['Real_name'];
-        $msg_data['username'] = $user->getUsername();
-        $msg_data['password'] = $values['Password_hash'];
-
-        $template = (is_null($this->identifier))
-            ? 'new_user.tpl' : 'edit_user.tpl';
-        \Email::send($values['Email'], $template, $msg_data);
-
         $this->tpl_data['success'] = true;
     }
 

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -110,13 +110,6 @@ class My_Preferences extends \NDB_Form
 
         $user = \User::factory($this->identifier);
 
-        // If editing a user and nothing was specified in the password text field
-        // remove the key from the value set, otherwise Password_hash
-        // will be set to '' by the system
-        if ($values['Password_hash'] == '') {
-            unset($values['Password_hash']);
-        }
-
         // START NOTIFICATIONS UPDATE
         // get current notifications for user
         $curr_sub = \NDB_Notifier::getUserNotificationModuleServices(
@@ -167,6 +160,12 @@ class My_Preferences extends \NDB_Form
         }
         // END NOTIFICATIONS UPDATE
         $set = [];
+        // If editing a user and nothing was specified in the password text field
+        // remove the key from the value set, otherwise Password_hash
+        // will be set to '' by the system
+        if ($values['Password_hash'] == '') {
+            unset($values['Password_hash']);
+        }
         foreach ($values as $key => $value) {
             // Password updates are handled separately. Password_hash is removed
             // from the initial update as otherwise it will be recorded in the
@@ -191,9 +190,12 @@ class My_Preferences extends \NDB_Form
             );
         }
 
-        // create an instance of the config object
-        $factory = \NDB_Factory::singleton();
-        $config  = $factory->config();
+        // send the user an email
+        $msg_data          = array();
+        $msg_data['study'] = $config->getSetting('title');
+        $msg_data['realname'] = $values['Real_name'];
+
+        \Email::send($values['Email'], 'account_details_changed.tpl', $msg_data);
 
         $this->tpl_data['success'] = true;
     }

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -191,7 +191,7 @@ class My_Preferences extends \NDB_Form
         }
 
         // send the user an email
-        $msg_data          = array();
+        $msg_data          = [];
         $msg_data['study'] = $config->getSetting('title');
         $msg_data['realname'] = $values['Real_name'];
 

--- a/smarty/templates/email/account_details_changed.tpl
+++ b/smarty/templates/email/account_details_changed.tpl
@@ -1,0 +1,14 @@
+Subject: Your Account Details Have Changed
+
+{$realname},
+
+Your account details have changed for the LORIS study {$study}.
+
+If you made these changes then you can ignore this email.
+
+If you did not make these changes, please contact your project administrator
+immediately.
+
+Thank you,
+
+LORIS Team


### PR DESCRIPTION
## Brief summary of changes

My Preferences was sending a user's password in plaintext to their email whenever they changed it.

Edit User does this when a user has a password generated for them by the server. In this case it is acceptable because the password must be reset on login. My Preferences shares a lot of code with User Accounts so I believe it was included as a feature accidentally.

I've created a new email template notifying a user that their account details have changed.

This PR also does a bit of cleanup within the function.

#### Testing instructions (if applicable)

1. Change your account details via the My Preferences module. You should receive an email. That email should not display your password.

#### Link(s) to related issue(s)

* Resolves #6079 
