### PR TITLE
Remove superfluous parameter comments in src/

### DIFF
--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -64,9 +64,6 @@ class LorisInstance
     /**
      * Retrieve all active module descriptors from the given database.
      *
-     * @param \Database $db an open connection to a database containing a 'modules'
-     *                      table
-     *
      * @return \Module[]
      */
     public function getActiveModules(): array
@@ -91,6 +88,8 @@ class LorisInstance
      * Return true if the LORISInstance has a module named
      * $name. To be installed it must be both available on
      * the filesystem and active in the modules table.
+     *
+     * @param string $name The name of a LORIS module.
      *
      * @return bool
      */

--- a/src/Router/ModuleRouter.php
+++ b/src/Router/ModuleRouter.php
@@ -41,7 +41,6 @@ class ModuleRouter implements RequestHandlerInterface
      * Constructs a ModuleRouter
      *
      * @param \Module $module    The module being accessed
-     * @param string  $moduledir The base directory of $module.
      */
     public function __construct(\Module $module)
     {

--- a/test/SrcCS.xml
+++ b/test/SrcCS.xml
@@ -20,6 +20,9 @@
         </properties>
     </rule>
 
+    <!-- Make sure there aren't extra parameters in function docs -->
+    <rule ref="PEAR.Commenting.FunctionComment.ExtraParamComment"/>
+
     <!-- Equal signs need to be aligned with other equal signs -->
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>


### PR DESCRIPTION
## Brief summary of changes

Adds a PHPCS rule to forbid superfluous parameter comments from function docs in the `src/` directory.