### PR TITLE
[Loris Instance] Add NDB_Config property

### DIFF
--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -115,29 +115,16 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function handlePOST(ServerRequestInterface $request): ResponseInterface
     {
+        $loris = $request->getAttribute('loris');
         // Ensure the user is allowed to upload.
-        if (! \User::singleton()->hasPermission('superuser')) {
-            return (new \LORIS\Http\Response())
-                ->withStatus(403, 'Forbidden')
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array('error' => 'Forbidden')
-                        )
-                    )
-                );
+        if (! $request->getAttribute('user')->hasPermission('superuser')) {
+            return new \LORIS\Http\Response\JSON\Forbidden();
         }
         // Ensure the server is properly configured.
         if (!$this->canWriteFiles()) {
-            return (new \LORIS\Http\Response())
-                ->withStatus(500, 'Internal Server Error')
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array('error' => self::CANNOT_WRITE_FILES)
-                        )
-                    )
-                );
+            return new \LORIS\Http\Response\JSON\InternalServerError(
+                self::CANNOT_WRITE_FILES
+            );
         }
 
         $uploaded_file = $request->getUploadedFiles()['install_file'];
@@ -188,18 +175,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
             . escapeshellarg($fullpath)
         );
 
-        if (!$this->isQuatUserConfigured()) {
+        if (!$this->isAdminUserConfigured()) {
             // If no adminUser is configured, automatic installation is not
             // possible, so this is the last step.
-            return (new \LORIS\Http\Response())
-                ->withStatus(200, 'OK')
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array('message' => self::UPLOAD_NO_INSTALL)
-                        )
-                    )
-                );
+            return new \LORIS\Http\Response\JSON\OK(
+                self::UPLOAD_NO_INSTALL
+            );
         }
 
         // Install the instrument by directly sourcing the SQL file
@@ -215,12 +196,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 $e->getMessage()
             ));
         } catch (\Exception $e) {
-            return (new \LORIS\Http\Response\JSON\InternalServerError(
+            return new \LORIS\Http\Response\JSON\InternalServerError(
                 $e->getMessage()
-            ));
+            );
         }
 
-        $db_config = $this->factory->config()->getSetting('database');
+        $db_config = $loris->getConfiguration()->getSetting('database');
         exec(
             "mysql".
             " -h" . escapeshellarg($db_config['host']).
@@ -242,20 +223,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 . "credentials supplied in the config file. "
                 . "Exec output: `" . implode("\n", $output) . "`"
             );
-            return (new \LORIS\Http\Response())
-                ->withStatus(500, 'Internal Server Error')
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode(
-                            array('error' => self::UPLOAD_INSTALL_FAILED)
-                        )
-                    )
-                );
+            return new \LORIS\Http\Response\JSON\InternalServerError(
+                self::UPLOAD_INSTALL_FAILED
+            );
         }
 
-        return (new \LORIS\Http\Response())
-            ->withStatus(201, 'Created')
-            ->withBody(new EmptyStream());
+        return new \LORIS\Http\Response\JSON\Created();
     }
 
     /**
@@ -319,7 +292,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
             'Data'         => $MappedData,
             'fieldOptions' => $this->fieldOptions,
             'writable'     => $this->canWriteFiles(),
-            'caninstall'   => $this->isQuatUserConfigured(),
+            'caninstall'   => $this->isAdminUserConfigured(),
         );
     }
 
@@ -598,7 +571,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      *
      * @return bool True if a adminUser is configured properly. False if not.
      */
-    protected function isQuatUserConfigured() : bool
+    protected function isAdminUserConfigured() : bool
     {
         $db        = $this->factory->database();
         $db_config = $this->factory->config()->getSetting('database');

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -1,31 +1,13 @@
 <?php
-/**
- * Instrument_manager
- *
- * PHP Version 7
- *
- * @category Main
- * @package  Instrument_Manager
- * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
- */
-
 namespace LORIS\instrument_manager;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
-use \LORIS\Http\EmptyStream;
 
 /**
- * Instrument_manager
+ * Contains functions used to view and manage instruments installed in LORIS.
+ * LINST instruments can be uploaded and installed automatically.
  *
- * PHP Version 7
- *
- * @category Main
- * @package  Instrument_Manager
- * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class Instrument_Manager extends \NDB_Menu_Filter
 {

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 namespace LORIS\instrument_manager;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -612,4 +612,3 @@ class Instrument_Manager extends \NDB_Menu_Filter
         );
     }
 }
-

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -6,11 +6,17 @@ namespace LORIS;
  * A LorisInstance represents an installed instance of a LORIS
  * project.
  *
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class LorisInstance
 {
     protected $modulesDirs;
+    /**
+     * An object representing configuration settings for this LORIS instance.
+     *
+     * @var NDB_Config
+     */
+    private $configuration;
     private $DB;
 
     /**
@@ -22,9 +28,13 @@ class LorisInstance
      * @param string[]  $moduleDirs A list of directories that may
      *                              contain modules for this instance.
      */
-    public function __construct(\Database $db, array $modulesDirs)
-    {
+    public function __construct(
+        \Database $db,
+        \NDB_Config $config,
+        array $modulesDirs
+    ) {
         $this->DB          = $db;
+        $this->configuration      = $config;
         $this->modulesDirs = $modulesDirs;
     }
 
@@ -103,5 +113,16 @@ class LorisInstance
             }
         }
         return false;
+    }
+
+    /**
+     * Returns an NDB_Config object used for interacting with configuration
+     * settings for this instance.
+     *
+     * @return \NDB_Config
+     */
+    public function getConfiguration(): \NDB_Config
+    {
+        return $this->configuration;
     }
 }

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -35,9 +35,9 @@ class LorisInstance
         \NDB_Config $config,
         array $modulesDirs
     ) {
-        $this->DB            = $db;
-        $this->config = $config;
-        $this->modulesDirs   = $modulesDirs;
+        $this->DB          = $db;
+        $this->config      = $config;
+        $this->modulesDirs = $modulesDirs;
     }
 
     /**

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -14,7 +14,7 @@ class LorisInstance
     /**
      * An object representing configuration settings for this LORIS instance.
      *
-     * @var NDB_Config
+     * @var \NDB_Config
      */
     private $configuration;
     private $DB;
@@ -25,6 +25,8 @@ class LorisInstance
      *
      * @param \Database $db         A database connection to this
      *                              instance.
+     * @param \NDB_Config $config   A set of configuration settings used by this
+     *                              instance.
      * @param string[]  $moduleDirs A list of directories that may
      *                              contain modules for this instance.
      */
@@ -33,9 +35,9 @@ class LorisInstance
         \NDB_Config $config,
         array $modulesDirs
     ) {
-        $this->DB          = $db;
-        $this->configuration      = $config;
-        $this->modulesDirs = $modulesDirs;
+        $this->DB            = $db;
+        $this->configuration = $config;
+        $this->modulesDirs   = $modulesDirs;
     }
 
     /**

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -16,7 +16,7 @@ class LorisInstance
      *
      * @var \NDB_Config
      */
-    private $configuration;
+    private $config;
     private $DB;
 
     /**
@@ -36,7 +36,7 @@ class LorisInstance
         array $modulesDirs
     ) {
         $this->DB            = $db;
-        $this->configuration = $config;
+        $this->config = $config;
         $this->modulesDirs   = $modulesDirs;
     }
 
@@ -125,6 +125,6 @@ class LorisInstance
      */
     public function getConfiguration(): \NDB_Config
     {
-        return $this->configuration;
+        return $this->config;
     }
 }

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -46,6 +46,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         $this->user          = $user;
         $this->lorisinstance = new \LORIS\LorisInstance(
             \NDB_Factory::singleton()->database(),
+            \NDB_Factory::singleton()->config(),
             [
              $projectdir . "/modules",
              $moduledir,


### PR DESCRIPTION
## Brief summary of changes

Adds NDB_Config as a property of LorisInstance. See #6118 and #6022 for more details about Loris Instance.

Modifies instrument manager to show an example of its usage. Also cleans up this class.

#### Testing instructions (if applicable)

1. Follow the `instrument_manager` Test Plan.
