### PR TITLE
[Core] Add new FilesDownloadHandler class

### DIFF
--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -1,6 +1,9 @@
 <?php
+namespace LORIS\document_repository;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
 /**
- * It includes two functions.
  * Post method handles updating a file.
  * Delete method handles deleting a file.
  * Get method handles getting a file.
@@ -8,30 +11,7 @@
  *            (Files/name) will download this file
  * Put method handles editing a file.
  *
- * PHP Version 7
- *
- * @category Main
- * @package  Document_Repository
- * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris/
- */
-namespace LORIS\document_repository;
-use \Psr\Http\Message\ServerRequestInterface;
-use \Psr\Http\Message\ResponseInterface;
-
-/**
- * It includes two functions.
- * Post method handles updating a file.
- * Delete method handles deleting a file.
- *
- * PHP Version 7
- *
- * @category Main
- * @package  Document_Repository
- * @author   Loris Team <loris.mni@bic.mni.mcgill.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://www.github.com/aces/Loris/
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class Files extends \NDB_Page
 {
@@ -67,8 +47,8 @@ class Files extends \NDB_Page
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $config = \NDB_Factory::singleton()->config();
-        $path   = \Utility::appendForwardSlash(
+        $config       = \NDB_Factory::singleton()->config();
+        $downloadpath = \Utility::appendForwardSlash(
             $config->getSetting("documentRepositoryPath")
         );
         switch ($request->getMethod()) {
@@ -108,34 +88,15 @@ class Files extends \NDB_Page
                     )
                 );
         case "GET":
-            $record = urldecode(basename($request->getUri()->getPath()));
-
-            if (!is_numeric($record)) {
-                $factory    = \NDB_Factory::singleton();
-                $DB         = $factory->database();
-                $uploadedBy = $DB->pselectOne(
-                    "SELECT uploaded_by FROM document_repository
-                    WHERE File_Name=:name",
-                    ['name' => $record]
-                );
-                $file       = $path. "$uploadedBy/$record";
-                return (new \LORIS\Http\Response())
-                    ->withHeader('Content-Type', 'application/octet-stream')
-                    ->withHeader(
-                        'Content-Disposition',
-                        'attachment; filename=' . basename($file)
-                    )
-                    ->withStatus(200)
-                    ->withBody(new \LORIS\Http\FileStream($file));
-            }
-            return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
-                ->withStatus(200)
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode($this->getUploadDocFields($record))
-                    )
-                );
+            $filename   = urldecode(basename($request->getUri()->getPath()));
+            $downloader = new \LORIS\FilesDownloadHandler(
+                new \SPLFileInfo(
+                    $downloadpath . $request->getAttribute('user')->getUsername()
+                )
+            );
+            return $downloader->handle(
+                $request->withAttribute('filename', $filename)
+            );
         default:
             return (new \LORIS\Http\Response())
                 ->withHeader("Content-Type", "text/plain")

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -7,8 +7,6 @@ use \Psr\Http\Message\ResponseInterface;
  * Post method handles updating a file.
  * Delete method handles deleting a file.
  * Get method handles getting a file.
- *            (Files/id) will return file's infomation
- *            (Files/name) will download this file
  * Put method handles editing a file.
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -64,17 +64,18 @@ class FilesDownloadHandler implements RequestHandlerInterface
                 ['GET']
             );
         }
-        $filename = $request->getAttribute('filename');
+        //Use basename to remove path traversal characters.
+        $filename = basename($request->getAttribute('filename'));
+
         if (is_null($filename)) {
             throw new \LorisException(
                 'Must supply "filename" as a parameter'
             );
         }
 
-        //Use basename to remove path traversal characters.
         $targetPath = \Utility::appendForwardSlash(
             $this->downloadDirectory->getPathname()
-        ) . basename($filename);
+        ) . $filename;
 
         if (!file_exists($targetPath)) {
             return new \LORIS\Http\Response\JSON\NotFound();

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -55,11 +55,6 @@ class FilesDownloadHandler implements RequestHandlerInterface
     /**
      * Given an HTTP request, serve the file to the client.
      *
-     * All files uploaded will get the same permissions.
-     *
-     * If the overwrite property is set to true, existing files will be
-     * overwritten.
-     *
      * @param ServerRequestInterface $request An HTTP Request that contains files.
      *
      * @return ResponseInterface

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -17,7 +17,7 @@ class FilesDownloadHandler implements RequestHandlerInterface
 {
 
     const ERROR_EMPTY_FILENAME = 'Invalid filename: cannot be empty';
-    const ERROR_FILE_NOT_FILE = 'File requested is not a file';
+    const ERROR_FILE_NOT_FILE  = 'File requested is not a file';
     /**
      * The target download directory.
      *

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -82,10 +82,6 @@ class FilesDownloadHandler implements RequestHandlerInterface
             return new \LORIS\Http\Response\JSON\Forbidden();
         }
 
-        // Serve the file. If configured, the X-Sendfile header will serve
-        // the file directly from the filesystem instead of first loading it
-        // into PHP's memory. This allows LORIS to serve very large files more
-        // reliably.
         $mime = mime_content_type($targetPath);
         return (new \LORIS\Http\Response\JSON\OK())
             ->withHeader(
@@ -96,7 +92,6 @@ class FilesDownloadHandler implements RequestHandlerInterface
                 'Content-Type',
                 $mime !== false ? $mime : 'application/octet-stream'
             )
-            ->withHeader('X-Sendfile', $targetPath)
             ->withBody(new \LORIS\Http\FileStream($targetPath));
     }
 }

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace LORIS;
+
+use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * This class handles files being downloaded from LORIS. It should
+ * serve as the ONLY way that files are downloaded so that all file downloading
+ * functionality can occur on a well-tested foundation.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class FilesDownloadHandler implements RequestHandlerInterface
+{
+
+    /**
+     * The target download directory.
+     *
+     * @var \SplFileInfo
+     */
+    protected $downloadDirectory;
+
+    /**
+     * Create new instance of a File Downloader.
+     *
+     * @param \SplFileInfo $downloadDirectory The target download directory
+     */
+    public function __construct(\SplFileInfo $downloadDirectory)
+    {
+        $this->downloadDirectory = $downloadDirectory;
+
+        if (! $this->downloadDirectory->isDir()) {
+            throw new \LorisException(
+                'Download directory is not a directory'
+            );
+        }
+
+        if (! $this->downloadDirectory->isReadable()) {
+            throw new \LorisException(
+                'Download directory is not readable'
+            );
+        }
+    }
+
+    /**
+     * Given an HTTP request, serve the file to the client.
+     *
+     * All files uploaded will get the same permissions.
+     *
+     * If the overwrite property is set to true, existing files will be
+     * overwritten.
+     *
+     * @param ServerRequestInterface $request An HTTP Request that contains files.
+     *
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $filename = $request->getAttribute('filename');
+        if (is_null($filename)) {
+            throw new \LorisException(
+                'Must supply "filename" as a parameter'
+            );
+        }
+
+        //Use basename to remove path traversal characters.
+        $targetPath = $this->downloadDirectory->getPathname() . '/' . basename(
+            $filename
+        );
+
+        /* If file exists, set response code to 'Conflict' unless the
+         * calling code wants to overwrite the file.
+         */
+        if (!file_exists($targetPath)) {
+            return new \LORIS\Http\Response\JSON\NotFound();
+        }
+
+        if (!is_readable($targetPath)) {
+            return new \LORIS\Http\Response\JSON\Forbidden();
+        }
+
+        // Serve the file. If configured, the X-Sendfile header will serve
+        // the file directly from the filesystem instead of first loading it
+        // into PHP's memory. This allows LORIS to serve very large files more
+        // reliably.
+        $mime = mime_content_type($targetPath);
+        return (new \LORIS\Http\Response\JSON\OK())
+            ->withHeader(
+                'Content-Disposition',
+                'attachment; filename=' . $filename
+            )
+            ->withHeader(
+                'Content-Type',
+                $mime !== false ? $mime : 'application/octet-stream'
+            )
+            ->withHeader('X-Sendfile', $targetPath)
+            ->withBody(new \LORIS\Http\FileStream($targetPath));
+    }
+}
+

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -67,9 +67,9 @@ class FilesDownloadHandler implements RequestHandlerInterface
         //Use basename to remove path traversal characters.
         $filename = basename($request->getAttribute('filename'));
 
-        if (is_null($filename)) {
-            throw new \LorisException(
-                'Must supply "filename" as a parameter'
+        if (empty($filename)) {
+            throw new \InvalidArgumentException(
+                'Invalid filename: cannot be empty'
             );
         }
 

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -79,6 +79,12 @@ class FilesDownloadHandler implements RequestHandlerInterface
             return new \LORIS\Http\Response\JSON\Forbidden();
         }
 
+        if (!is_file($targetPath)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'File requested is not a file.'
+            );
+        }
+
         $mime = mime_content_type($targetPath);
         return (new \LORIS\Http\Response\JSON\OK())
             ->withHeader(

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -67,13 +67,10 @@ class FilesDownloadHandler implements RequestHandlerInterface
         }
 
         //Use basename to remove path traversal characters.
-        $targetPath = $this->downloadDirectory->getPathname() . '/' . basename(
-            $filename
-        );
+        $targetPath = \Utility::appendForwardSlash(
+            $this->downloadDirectory->getPathname()
+        ) . basename($filename);
 
-        /* If file exists, set response code to 'Conflict' unless the
-         * calling code wants to overwrite the file.
-         */
         if (!file_exists($targetPath)) {
             return new \LORIS\Http\Response\JSON\NotFound();
         }

--- a/php/libraries/FilesDownloadHandler.php
+++ b/php/libraries/FilesDownloadHandler.php
@@ -59,6 +59,11 @@ class FilesDownloadHandler implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
+        if ($request->getMethod() != "GET") {
+            return new \LORIS\Http\Response\JSON\MethodNotAllowed(
+                ['GET']
+            );
+        }
         $filename = $request->getAttribute('filename');
         if (is_null($filename)) {
             throw new \LorisException(


### PR DESCRIPTION
## Brief summary of changes

Adds a class to be used for generic file downloading throughout LORIS. This serves as the counterpart to the generic file uploader from #4181.

#### Testing instructions (if applicable)

1. Download a file from the document repository.

#### Link(s) to related issue(s)

This is a remake of #3881