### PR TITLE
[New Profile] Add back-end validation for dates; cleanup

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -1,43 +1,25 @@
-<?php
-declare(strict_types=1);
-/**
- * New_profile
- *
- * PHP Version 7
- *
- * @category Main
- * @package  Loris
- * @author   Shen Wang <shen.wang2@mcgill.ca>
- *           Zaliqa Rosli <zaliqa.rosli@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
- */
+<?php declare(strict_types=1);
 namespace LORIS\new_profile;
 
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 
 /**
- * New_profile
+ * New_profile module. This class handles the creation of new candidates from
+ * the front-end of LORIS.
  *
- * PHP Version 7
- *
- * @category Main
- * @package  Loris
- * @author   Shen Wang <shen.wang2@mcgill.ca>
- *           Zaliqa Rosli <zaliqa.rosli@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
 class New_Profile extends \NDB_Form
 {
-    public  $skipTemplate = true;
+    public $skipTemplate = true;
     private $_candID;
     private $_pscid;
     private $_error;
 
     /**
-     * Tie the access to a data_entry permission
+     * Determines whether a user can access the page. The access to tied to
+     * the data_entry permission.
      *
      * @param \User $user The user whose access is being checked
      *
@@ -45,18 +27,17 @@ class New_Profile extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        $site_arr      = $user->getData('CenterIDs');
-        $userInDCCSite = in_array("1", $site_arr);
-        if ($user->hasStudySite() or $userInDCCSite) {
+        if ($user->hasStudySite() || $user->hasCenter(1)) {
             return $user->hasPermission('data_entry');
         }
 
         return false;
     }
     /**
-     * Processes the values and saves to database
+     * Creates a new candidate using values supplied from the front-end. This
+     * data is validated in validateNewCandidate().
      *
-     * @param array $values form values
+     * @param array $values An array of form values POSTed to new_profile.
      *
      * @return void
      */
@@ -81,10 +62,15 @@ class New_Profile extends \NDB_Form
         /* Create the candidate and retrieve its ID.
          * Use form values when present, otherwise default to null.
          */
+        $dob = (new \DateTime($values['dobDate']))->format('Y-m-d');
+        $edc = $values['edcDate'] ?? null;
+        if (!is_null($edc)) {
+            $edc = (new \DateTime($edc))->format('Y-m-d');
+        }
         $candID = \Candidate::createNew(
             (int)$values['site'],
-            $values['dobDate'],
-            $values['edcDate'] ?? null,
+            $dob,
+            $edc,
             $values['sex'],
             $values['pscid'] ?? null,
             intval($values['project'])
@@ -114,13 +100,15 @@ class New_Profile extends \NDB_Form
         if ($request->getMethod() === "POST") {
             $this->save();
             if (!empty($this->_error)) {
-                return new \LORIS\Http\Response\JSON\BadRequest($this->_error);
+                return new \LORIS\Http\Response\JSON\BadRequest(
+                    json_encode($this->_error)
+                );
             }
             $result = array(
                 'candID' => $this->_candID,
                 'pscid'  => $this->_pscid,
             );
-            return (new \LORIS\Http\Response\JSON\Created($result))
+            return (new \LORIS\Http\Response\JSON\Created(json_encode($result)))
                 ->withHeader("Allow", "POST");
         }
 
@@ -137,9 +125,10 @@ class New_Profile extends \NDB_Form
      */
     function setup(): void
     {
-        $DB        = \Database::singleton();
-        $config    = \NDB_Config::singleton();
-        $user      = \User::singleton();
+        $factory   = \NDB_Factory::singleton();
+        $DB        = $factory->database();
+        $config    = $factory->config();
+        $user      = $factory->user();
         $startYear = $config->getSetting('startYear');
         $endYear   = $config->getSetting('endYear');
         $ageMax    = $config->getSetting('ageMax');
@@ -211,11 +200,11 @@ class New_Profile extends \NDB_Form
     {
         $this->_error = null;
         $errors       = array();
-        $config       = \NDB_Config::singleton();
-        $user         = \User::singleton();
-        $db           = \Database::singleton();
+        $factory      = \NDB_Factory::singleton();
+        $config       = $factory->config();
+        $user         = $factory->user();
+        $db           = $factory->database();
 
-        // Validate DOB fields
         if (empty($values['dobDate'])) {
             $errors['dobDate'] = 'Date of Birth field is required.';
         }
@@ -224,6 +213,12 @@ class New_Profile extends \NDB_Form
         }
         if ($values['dobDate'] != $values['dobDateConfirm']) {
             $errors['dobDate'] = 'Date of Birth fields must match.';
+        }
+        // Validate DOB fields
+        try {
+            new \DateTime($values['dobDate']);
+        } catch (\Exception $e) {
+            $errors['dobDate'] = 'Date of Birth is not a valid date.';
         }
 
         // Validate EDC fields
@@ -238,23 +233,15 @@ class New_Profile extends \NDB_Form
             }
 
             if ($values['edcDate'] != $values['edcDateConfirm']) {
-                $errors['edDate'] = 'Expected Date of Confinement fields must
+                $errors['edcDate'] = 'Expected Date of Confinement fields must
                                      match.';
             }
-        }
-
-        // Validate date format
-        $dobFormat = $config->getSetting('dobFormat');
-        if (strtolower($dobFormat) == 'ym' || strtolower($dobFormat) == 'my') {
-            // Dates still need to be submitted into the database in format
-            // YYYY-DD-MM. This is a last check before _process is called.
-            if ($config->getSetting('useEDC') == "true"
-                && strlen($values['edcDate']) < 10
-            ) {
-                $errors['edcFormat'] = 'EDC is not in valid date format.';
-            }
-            if (strlen($values['dobDate'] ?? '') < 10) {
-                $errors['dobFormat'] = 'DOB is not in valid date format.';
+            // Validate DOB fields
+            try {
+                new \DateTime($values['edcDate']);
+            } catch (\Exception $e) {
+                $errors['edcDate'] = 'Expected Date of Confinement is not a '
+                    . 'valid date.';
             }
         }
 
@@ -269,11 +256,11 @@ class New_Profile extends \NDB_Form
             if (empty($values['site'])) { // user is in only one site
                 $centerIDs = $user->getData('CenterIDs');
                 $centerID  = $centerIDs[0];
-                $site      =& \Site::singleton($centerID);
+                $site      = \Site::singleton($centerID);
             } else {
                 // user has multiple sites,
                 // so validate PSCID against the Site selected
-                $site =& \Site::singleton((int) $values['site']);
+                $site = \Site::singleton((int) $values['site']);
             }
 
             $project = \Project::getProjectFromID(intval($values['project']));

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -216,7 +216,9 @@ class New_Profile extends \NDB_Form
         }
         // Validate DOB fields
         try {
-            new \DateTime($values['dobDate']);
+            if ((new \DateTime($values['dobDate'])) > new \DateTime('now')) {
+                $errors['dobDate'] = 'Date of Birth cannot be set in the future.';
+            }
         } catch (\Exception $e) {
             $errors['dobDate'] = 'Date of Birth is not a valid date.';
         }


### PR DESCRIPTION
## Brief summary of changes

Complementary effort to #5758 -- dates are now validated on the back-end as well as the front-end.

Also cleans up some of the related code.

#### Testing instructions (if applicable)

1. Create a new candidate in `new_profile`. Try setting the date of birth to a date greater than today's date. You should get an error.