### PR TITLE
[API] Remove -dev suffix from 0.0.3 version of API

### DIFF
--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -1,4 +1,4 @@
-# LORIS API - v0.0.0-dev
+# LORIS API - v0.0.3
 ## 1.0 Overview
 
 This document specifies the Loris REST API.
@@ -8,7 +8,7 @@ or no data. The Loris API uses standard HTTP error codes and the body of any res
 either be empty or contain only a JSON object for any request.
 
 For brevity, the `$LorisRoot/api/$APIVERSION` is omitted from the definitions in this
-document. This document specifies $APIVERSION v0.0.3-dev and it
+document. This document specifies $APIVERSION v0.0.3 and it
 MUST be included before the request in all requests.
 
 HTTP GET requests NEVER modify data. PUT, POST or PATCH requests MUST be used to modify
@@ -1079,7 +1079,7 @@ GET /candidates/$CandID/$VisitLabel/recordings/$Filename/bidsfiles/electrodes
 Returns raw file with the appropriate MimeType headers for the electrodes file 
 retrieved from `/candidates/$CandID/$Visit/recordings/$Filename`.
 
-Only `GET` is currently supported.  
+Only `GET` is currently supported.
 
 #### 6.7.3 Download The BIDS File With Task Events Information
 
@@ -1101,4 +1101,4 @@ GET /candidates/$CandID/$VisitLabel/recordings/$Filename/bidsfiles/archive
 Returns raw file with the appropriate MimeType headers for the archival file
 with all BIDS files retrieved from `/candidates/$CandID/$Visit/recordings/$Filename`.
 
-Only `GET` is currently supported.    
+Only `GET` is currently supported.

--- a/modules/api/php/endpoints/candidate/candidate.class.inc
+++ b/modules/api/php/endpoints/candidate/candidate.class.inc
@@ -64,7 +64,7 @@ class Candidate extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicom/dicom.class.inc
@@ -79,7 +79,7 @@ class Dicom extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array('v0.0.3-dev');
+        return array('v0.0.3');
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
@@ -68,7 +68,7 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array('v0.0.3-dev');
+        return array('v0.0.3');
     }
 
     /**

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile.class.inc
@@ -58,7 +58,7 @@ class BidsFile extends Endpoint
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/archive.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/archive.class.inc
@@ -65,7 +65,7 @@ class Archive extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/channels.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/channels.class.inc
@@ -65,7 +65,7 @@ class Channels extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/electrodes.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/electrodes.class.inc
@@ -65,7 +65,7 @@ class Electrodes extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/events.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/bidsfile/events.class.inc
@@ -65,7 +65,7 @@ class Events extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/channels.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/channels.class.inc
@@ -74,7 +74,7 @@ class Channels extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/electrodes.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/electrodes.class.inc
@@ -74,7 +74,7 @@ class Electrodes extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/events.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/events.class.inc
@@ -74,7 +74,7 @@ class Events extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/metadata.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/metadata.class.inc
@@ -75,7 +75,7 @@ class Metadata extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/electrophysiology/recording.class.inc
@@ -69,7 +69,7 @@ class Recording extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/format.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format.class.inc
@@ -62,7 +62,7 @@ class Format extends Endpoint
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/format/brainbrowser.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/brainbrowser.class.inc
@@ -68,7 +68,7 @@ class Brainbrowser extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -63,7 +63,7 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/thumbnail.class.inc
@@ -63,7 +63,7 @@ class Thumbnail extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/headers.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/headers.class.inc
@@ -77,7 +77,7 @@ class Headers extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/image.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/image.class.inc
@@ -73,7 +73,7 @@ class Image extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/qc.class.inc
@@ -80,7 +80,7 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/images.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/images.class.inc
@@ -70,7 +70,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
@@ -77,7 +77,7 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 
@@ -96,7 +96,7 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         case 'PUT':
         case 'PATCH':
-            // TODO :: I don`t think this was working in v0.0.3-dev
+            // TODO :: I don`t think this was working in v0.0.3
             return new \LORIS\Http\Response\JSON\NotImplemented();
 
         case 'OPTIONS':

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -77,7 +77,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/instruments.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instruments.class.inc
@@ -70,7 +70,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/qc.class.inc
@@ -74,7 +74,7 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/recordings.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/recordings.class.inc
@@ -66,7 +66,7 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         return array(
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -76,7 +76,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
     protected function supportedVersions() : array
     {
         // Removed 0.0.2 since session requires a project.
-        return array('v0.0.3-dev');
+        return array('v0.0.3');
     }
 
     /**

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -73,7 +73,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             "v0.0.2",
-            "v0.0.3-dev",
+            "v0.0.3",
         );
     }
 

--- a/modules/api/php/endpoints/login.class.inc
+++ b/modules/api/php/endpoints/login.class.inc
@@ -81,7 +81,7 @@ class Login extends Endpoint
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/project/candidates.class.inc
+++ b/modules/api/php/endpoints/project/candidates.class.inc
@@ -68,7 +68,7 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/project/images.class.inc
+++ b/modules/api/php/endpoints/project/images.class.inc
@@ -66,7 +66,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array("v0.0.3-dev");
+        return array("v0.0.3");
     }
 
     /**

--- a/modules/api/php/endpoints/project/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/project/instrument/instrument.class.inc
@@ -69,7 +69,7 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/project/instruments.class.inc
+++ b/modules/api/php/endpoints/project/instruments.class.inc
@@ -68,7 +68,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/project/project.class.inc
+++ b/modules/api/php/endpoints/project/project.class.inc
@@ -68,7 +68,7 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/project/recordings.class.inc
+++ b/modules/api/php/endpoints/project/recordings.class.inc
@@ -84,7 +84,7 @@ class Recordings extends Endpoint implements \LORIS\Middleware\ETagCalculator
      */
     protected function supportedVersions() : array
     {
-        return array("v0.0.3-dev");
+        return array("v0.0.3");
     }
 
     /**

--- a/modules/api/php/endpoints/project/visits.class.inc
+++ b/modules/api/php/endpoints/project/visits.class.inc
@@ -68,7 +68,7 @@ class Visits extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/php/endpoints/projects.class.inc
+++ b/modules/api/php/endpoints/projects.class.inc
@@ -64,7 +64,7 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
     {
         return array(
             'v0.0.2',
-            'v0.0.3-dev',
+            'v0.0.3',
         );
     }
 

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -92,7 +92,7 @@ class LoginTest extends TestCase
 
         $request = $this->_request
             ->withAttribute('pathparts', array('login'))
-            ->withAttribute('LORIS-API-Version', 'v0.0.3-dev')
+            ->withAttribute('LORIS-API-Version', 'v0.0.3')
             ->withAttribute('user', new \LORIS\AnonymousUser())
             ->withMethod('POST')
             ->withBody(

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -20,7 +20,7 @@ window.addEventListener('load', () => {
     async function loadVisits(candidate) {
         let visits = candidate.Visits.map(async function(visit) {
             // FIXME: This shouldn't use the dev version. See #6058
-            let response = await fetch(loris.BaseURL + '/api/v0.0.3-dev/candidates/' + candidate.Meta.CandID + '/' + visit);
+            let response = await fetch(loris.BaseURL + '/api/v0.0.3/candidates/' + candidate.Meta.CandID + '/' + visit);
             let data = await response.json();
             return data;
         });

--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -138,7 +138,7 @@ class NDB_Client
         // API Detect
         if (strpos(
             $_SERVER['REDIRECT_URL'] ?? $_SERVER['REQUEST_URI'] ?? '',
-            '/api/v0.0.3-dev/'
+            '/api/v0.0.3/'
         ) !== false
         ) {
             session_cache_limiter('private');


### PR DESCRIPTION
There has been a significant amount of changes and endpoints
added since 0.0.2. This removes the `-dev` suffix to officially
release 0.0.3 since it's for the most part what people are using
anyways.

This PR is mostly the result of the command `git grep '0\.0\.3\-dev' | cut -f 1 -d':' | uniq | xargs sed -i -e 's/0\.\0\.3\-dev/0.0.3/g'`