### PR TITLE
[candidate_profile] Improve gridyness of grid

### DIFF
--- a/jsx/CSSGrid.js
+++ b/jsx/CSSGrid.js
@@ -1,4 +1,5 @@
 import Card from 'Card';
+import React, {useState, useEffect, useRef} from 'react';
 
 /**
  * Create a three column grid of cards using a CSS grid.
@@ -16,38 +17,108 @@ import Card from 'Card';
  * @return {object} - A React component for a CSS grid of cards
  */
 function CSSGrid(props) {
-  const grid = {
-    display: 'grid',
-    gridTemplateColumns: '33% 33% 33%',
-    gridAutoFlow: 'row dense',
-    gridRowGap: '1em',
-    rowGap: '1em',
-  };
+    const cardsRef = useRef(null);
+    const [cardWidth, setCardWidth] = useState(0);
+    const [panelHeights, setPanelHeights] = useState({});
 
-  let cards = props.Cards.map((value, idx) => {
-    let cardID = 'card' + idx;
+    useEffect(() => {
+        // Upon load, store the calculated height of every rendered panel
+        // in state, so that we can use it to dynamically set the heights
+        // (number of rows spanned) in the CSS grid.
+        if (cardsRef.current.childNodes.length < 1) {
+            return;
+        }
 
-    let style = {};
-    if (value.Width) {
-      style.gridColumnEnd = 'span ' + value.Width;
+        // All rows in the width have the same width, so only look
+        // up the first.
+        const wSize = cardsRef.current.childNodes[0].clientWidth;
+
+        // Do not change the state unless the width changed to avoid
+        // infinite re-render loops.
+        if (wSize == cardWidth) {
+            return;
+        }
+        setCardWidth(wSize);
+
+        // Store the height in pixels of each panel. The first node is
+        // the CSS grid element, the first child is the panel.
+        // The childNodes are the DOM elements, not the React elements,
+        // but we make the assumption that they're in the same order
+        // as props.Cards in the DOM, and any re-arranging was done by
+        // using the CSS order property.
+        const heights = Array.from(cardsRef.current.childNodes.values()).map(
+            (node) => (node.firstChild.clientHeight)
+        );
+        setPanelHeights(heights);
+    });
+    const grid = {
+        display: 'grid',
+        gridTemplateColumns: '33% 33% 33%',
+        gridAutoFlow: 'row dense',
+        gridRowGap: '1em',
+        rowGap: '1em',
+    };
+
+    let orderedCards = [];
+    for (let i = 0; i < props.Cards.length; i++) {
+       orderedCards.push(props.Cards[i]);
+        if (!props.Cards[i].Order) {
+            orderedCards[i].Order = 1;
+        }
     }
-    if (value.Height) {
-      style.gridRowEnd = 'span ' + value.Height;
-    }
-    if (value.Order) {
-      style.order = value.Order;
+    orderedCards.sort((a, b) => (a.Order - b.Order));
+
+    let lastLargeCardIdx = 0;
+    for (let i = 0; i < orderedCards.length; i++) {
+        if (orderedCards[i].Width >= 2) {
+            lastLargeCardIdx = i;
+        }
     }
 
-    style.alignSelf = 'stretch';
+    const cards = orderedCards.map((value, idx) => {
+        let cardID = 'card' + idx;
+
+        let pSize;
+        let style = {};
+        if (value.Width) {
+            style.gridColumnEnd = 'span ' + value.Width;
+            if (value.Width == 1 || value.Width === 3) {
+                if (idx < lastLargeCardIdx) {
+                    style.gridColumnStart = 1;
+                }
+            } else if (value.Width == 2) {
+                style.gridColumnStart = 2;
+            }
+        }
+
+        if (cardWidth != 0) {
+            const pxHeight = panelHeights[idx];
+            let spanHeight = 1;
+            const hSpan = 100;
+            if ((pxHeight % hSpan) === 0) {
+                spanHeight = pxHeight / hSpan;
+            } else {
+                spanHeight = Math.floor(pxHeight / hSpan) + 1;
+            }
+            style.gridRowEnd = 'span ' + spanHeight;
+            pSize = spanHeight * hSpan;
+        }
+        if (value.Order) {
+            style.order = value.Order;
+        }
+
+        style.alignSelf = 'stretch';
+        return (
+            <Card title={value.Title} id={cardID} key={cardID} style={style}
+                cardSize={pSize}>
+            {value.Content}
+            </Card>
+        );
+    });
+
     return (
-      <Card title={value.Title} id={cardID} key={cardID} style={style}>
-        {value.Content}
-      </Card>
+        <div ref={cardsRef} style={grid}>{cards}</div>
     );
-  });
-  return (
-    <div style={grid}>{cards}</div>
-  );
 }
 
 export default CSSGrid;

--- a/jsx/Card.js
+++ b/jsx/Card.js
@@ -48,9 +48,13 @@ class Card extends Component {
     let divStyling = {
       marginLeft: '5px',
       marginRight: '5px',
+      boxSizing: 'border-box',
     };
     if (this.props.style) {
         divStyling = {...divStyling, ...this.props.style};
+    }
+    if (this.props.cardSize) {
+        divStyling.height = this.props.cardSize;
     }
     return (
       <div style={divStyling}>
@@ -59,6 +63,7 @@ class Card extends Component {
           title={this.props.title}
           initCollapsed={this.props.initCollapsed}
             style={{overflow: 'auto'}}
+           panelSize={this.props.cardSize}
         >
           <div
             onClick={this.handleClick}

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -71,9 +71,9 @@ class Panel extends Component {
     ) : '';
 
     return (
-      <div className="panel panel-primary">
+      <div className="panel panel-primary" style={{height: this.props.panelSize}}>
         {panelHeading}
-        <div id={this.props.id} className={this.panelClass} role="tabpanel">
+        <div id={this.props.id} className={this.panelClass} role="tabpanel" style={{height: '100%'}}>
           <div className="panel-body"
                style={{...this.props.style, height: this.props.height}}>
             {this.props.children}

--- a/jsx/Panel.js
+++ b/jsx/Panel.js
@@ -63,7 +63,7 @@ class Panel extends Component {
         onClick={this.toggleCollapsed}
         data-toggle="collapse"
         data-target={'#' + this.props.id}
-        style={{cursor: 'pointer'}}
+        style={{cursor: 'pointer', height: '3em'}}
       >
         {this.props.title}
         <span className={glyphClass}></span>
@@ -73,7 +73,7 @@ class Panel extends Component {
     return (
       <div className="panel panel-primary" style={{height: this.props.panelSize}}>
         {panelHeading}
-        <div id={this.props.id} className={this.panelClass} role="tabpanel" style={{height: '100%'}}>
+        <div id={this.props.id} className={this.panelClass} role="tabpanel" style={{height: 'calc(100% - 3em)'}}>
           <div className="panel-body"
                style={{...this.props.style, height: this.props.height}}>
             {this.props.children}


### PR DESCRIPTION
This attempts to improve the layout of the CSS grid used by the `candidate_profile` page and after testing the page as a whole, rather than on an individual card basis.

- Height (in terms of number of grid rows spanned) of a card is now calculated dynamically, rather than needing to be heuristically guessed by the module registering the widget. 1 row = 100px. 
- Cards that have a width of "1" are always placed in the left column, until there are no more "large" (> 2) cards left, after which they start filling in underneath the other columns, so that column sizes the sizes are relatively balanced.

Combined, this improves the number of gaps when there are multiple cards added to the dashboard.

Before: 
<img width="1215" alt="Screenshot with big gaps" src="https://user-images.githubusercontent.com/498329/77655941-8b626a80-6f49-11ea-8c04-dafa5dfc103f.png">

After:
<img width="1200" alt="More balanced screenshot" src="https://user-images.githubusercontent.com/498329/77655993-9d440d80-6f49-11ea-8408-fe26a0358ce3.png">
