### PR TITLE
[raisinbread] missing electrophysiology_browser module. 

### DIFF
--- a/raisinbread/RB_files/RB_modules.sql
+++ b/raisinbread/RB_files/RB_modules.sql
@@ -41,5 +41,7 @@ INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (37,'timepoint_list','Y');
 INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (38,'user_accounts','Y');
 INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (39,'battery_manager','Y');
 INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (40,'module_manager','Y');
+INSERT INTO `modules` (`ID`, `Name`, `Active`) VALUES (41,'electrophysiology_browser','Y');
+
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes
add electrophysiology_browser into raisinbread. 

#### Testing instructions (if applicable)
Electrophysiology_browser shows after runing raisinbread in local Loris.

