### PR TITLE
[users] Add 'request account date' to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ changes in the following format: PR #1234***
 #### Updates and Improvements
 - Module-specific permissions added for Survey Accounts, Imaging Behavioural
 Quality Control, and Behavioural Quality Control. (PR #6041)
+- Addition of a new `account_request_date` in `users` table that will be used when
+requesting a new account and will be displayed in the User Accounts module (PR #6191)
 #### Bug Fixes
 - *Add item here*
 ### Modules
@@ -44,8 +46,6 @@ database (PR #5260)
 - New documentation for file permissions has been added to the README.md file. (PR #5323)
 - Dashboard study progression section performance improvement (PR #5887)
 documentation for file permissions has been added to the README.md file (PR #5323)
-- Addition of a new `account_request_date` in `users` table that will be used when
-requesting a new account and will be displayed in the User Accounts module (PR #6191)
 
 #### Bug Fixes
 - Fix edge-case that gave a confusing error message when changing password (PR #5956)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Quality Control, and Behavioural Quality Control. (PR #6041)
 database (PR #5260)
 - New documentation for file permissions has been added to the README.md file. (PR #5323)
 - Dashboard study progression section performance improvement (PR #5887)
+documentation for file permissions has been added to the README.md file (PR #5323)
+- Addition of a new `account_request_date` in `users` table that will be used when
+requesting a new account and will be displayed in the User Accounts module (PR #6191)
 
 #### Bug Fixes
 - Fix edge-case that gave a confusing error message when changing password (PR #5956)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 database (PR #5260)
 - New documentation for file permissions has been added to the README.md file. (PR #5323)
 - Dashboard study progression section performance improvement (PR #5887)
-documentation for file permissions has been added to the README.md file (PR #5323)
 
 #### Bug Fixes
 - Fix edge-case that gave a confusing error message when changing password (PR #5956)

--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -100,6 +100,7 @@ CREATE TABLE `users` (
   `language_preference` integer unsigned default NULL,
   `active_from` date default NULL,
   `active_to` date default NULL,
+  `account_request_date` date default NULL,
   PRIMARY KEY  (`ID`),
   UNIQUE KEY `Email` (`Email`),
   UNIQUE KEY `UserID` (`UserID`),

--- a/SQL/New_patches/2020-03-26_add_account_request_date_to_users_table.sql
+++ b/SQL/New_patches/2020-03-26_add_account_request_date_to_users_table.sql
@@ -1,0 +1,14 @@
+-- add a new column to the users table to store the date at which
+-- the user requested an account
+ALTER TABLE users
+  ADD COLUMN account_request_date DATE DEFAULT NULL;
+
+-- determine the account_request_date based on what is present in the history
+-- table for when the user was inserted the first time in the history table
+UPDATE users u, history h 
+  SET u.account_request_date=h.changeDate 
+  WHERE 
+    h.tbl='users'  AND 
+    h.col='UserID' AND
+    h.old IS NULL  AND
+    u.UserID=h.new;

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -182,7 +182,7 @@ class RequestAccount extends \NDB_Form
         $project  = $_REQUEST["project"];
         $fullname = $name." ".$lastname;
 
-        $vals = [ 
+        $vals = [
             'UserID'               => $from,
             'Real_name'            => $fullname,
             'First_name'           => $name,

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -182,14 +182,15 @@ class RequestAccount extends \NDB_Form
         $project  = $_REQUEST["project"];
         $fullname = $name." ".$lastname;
 
-        $vals = [
-            'UserID'           => $from,
-            'Real_name'        => $fullname,
-            'First_name'       => $name,
-            'Last_name'        => $lastname,
-            'Pending_approval' => 'Y',
-            'Email'            => $from,
-        ];
+        $vals = array(
+            'UserID'               => $from,
+            'Real_name'            => $fullname,
+            'First_name'           => $name,
+            'Last_name'            => $lastname,
+            'Pending_approval'     => 'Y',
+            'Email'                => $from,
+            'account_request_date' => date('Y-m-d'),
+        );
 
         // check email address' uniqueness
         $result = $DB->pselectOne(

--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -182,7 +182,7 @@ class RequestAccount extends \NDB_Form
         $project  = $_REQUEST["project"];
         $fullname = $name." ".$lastname;
 
-        $vals = array(
+        $vals = [ 
             'UserID'               => $from,
             'Real_name'            => $fullname,
             'First_name'           => $name,
@@ -190,7 +190,7 @@ class RequestAccount extends \NDB_Form
             'Pending_approval'     => 'Y',
             'Email'                => $from,
             'account_request_date' => date('Y-m-d'),
-        );
+        ];
 
         // check email address' uniqueness
         $result = $DB->pselectOne(

--- a/modules/user_accounts/jsx/userAccountsIndex.js
+++ b/modules/user_accounts/jsx/userAccountsIndex.js
@@ -171,6 +171,11 @@ class UserAccountsIndex extends Component {
         type: 'select',
         options: options.pendingApprovals,
       }},
+      {label: 'Account Request Date', show: true, filter: {
+        name: 'accountRequestDate',
+        type: 'date',
+        hide: true,
+      }},
     ];
     const actions = [
       {label: 'Add User', action: this.addUser},

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -653,8 +653,9 @@ class Edit_User extends \NDB_Form
 
         } else {
             // It is an existing user:
-            //     display user name
+            //     display user name and account request date
             $this->addScoreColumn('UserID', 'User name');
+            $this->addScoreColumn('account_request_date', 'Account Request Date');
         }
 
         // password

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -24,7 +24,8 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
                     u.Real_name as real_name,
                     u.Email as email,
                     u.Active as active,
-                    u.Pending_approval as pending
+                    u.Pending_approval as pending,
+                    u.account_request_date as account_request_date
              FROM users u
              LEFT JOIN user_psc_rel upsr ON (upsr.UserID=u.ID)
              LEFT JOIN user_project_rel uprr ON (uprr.UserID=u.ID)

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -406,6 +406,15 @@
 		 </div>
 	</div>
 
+    <div class="row form-group form-inline">
+        <label class="col-sm-12 col-sm-2 form-label">
+            {$form.account_request_date.label}
+        </label>
+        <div class="col-sm-10">
+            {$form.account_request_date.html|default:'None'}
+        </div>
+    </div>
+
       <div class="row form-group form-inline">
        <label class="col-sm-2">
           {$form.Pending_approval.label}

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -63,7 +63,8 @@ class UserTest extends TestCase
                 'Doc_Repo_Notifications' => 'Y',
                 'language_preference'    => 2,
                 'active_from'            => '2017-07-16',
-                'active_to'              => '2020-07-16'
+                'active_to'              => '2020-07-16',
+                'account_request_date'   => null
           );
     /**
      * The userInfo table that should result from calling the factory function


### PR DESCRIPTION
## Brief summary of changes

This adds a new `account_request_date` field to the `users` table to register information about when a given user requested an account.

#### Testing instructions

1. source the SQL patch attached to the PR
2. test that requesting a new account (on the login page) inserts a new user with the date properly filled
3. test that the 'Account Request Date' is properly displayed in the menu filter page of user accounts
4. check that the 'Account Request Date' is properly displayed after the 'Active from' and 'Active to' fields in the edit user page of user accounts.

#### Link(s) to related issue(s)

* I don't believe an issue was created for that but this came up with Open PREVENT-AD where they wanted to have information about when a user requested access