### PR TITLE
[Install] Prevent unbound variable error

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -160,6 +160,7 @@ if [ -d logs ]; then
 fi
 
 echo ""
+export projectname=""
 
 if [[ " ${debian[*]} " == *" $os_distro "* ]]; then
 echo "Ubuntu distribution detected."
@@ -170,7 +171,6 @@ echo "Ubuntu distribution detected."
         echo $yn | tee -a $LOGFILE > /dev/null
         case $yn in
             [Yy]* )
-                export projectname=""
                 while [ "$projectname" == "" ]; do
                         read -p "Please enter your Project name (if unsure, use LORIS) : " projectname
                         echo $projectname | tee -a $LOGFILE > /dev/null


### PR DESCRIPTION
## Brief summary of changes

This PR fixes an issue where a variable was used in the install script without being declared. It caused a bug during CentOS installation.

#### Testing instructions (if applicable)

1. On CentOS, run the install script.

#### Link(s) to related issue(s)

* Resolves #6185 