### PR TITLE
[Core] Update User::singleton() declarations to facilitate unit testing (#5015)

### DIFF
--- a/docs/wiki/99 - Developers/UnitTestGuide.md
+++ b/docs/wiki/99 - Developers/UnitTestGuide.md
@@ -391,12 +391,13 @@ This can be used for almost any class within LORIS. In the section right below, 
 
 ### **Testing Queries**
 
-**To know before starting:** if you encounter a user/database object declaration like this: 
+**To know before starting:** if you encounter a user/database/config object declaration like this: 
 
 
 ```
-    $DB   = \Database::singleton();
-    $user = \User::singleton();
+    $DB      = \Database::singleton();
+    $config  = \NDB_Config::singleton();
+    $user    = \User::singleton();
 ```
 
 
@@ -406,6 +407,7 @@ Please update the code to use this LORIS standard declaration:
 ```
     $factory = NDB_Factory::singleton();
     $DB      = $factory->database();
+    $config  = $factory->config();
     $user    = $factory->user();
 ```
 

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -35,7 +35,8 @@ $middlewarechain = (new \LORIS\Middleware\ContentLength())
 $serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();
 
 // Now that we've created the ServerRequest, handle it.
-$user = \User::singleton();
+$factory = \NDB_Factory::singleton();
+$user    = $factory->user();
 
 $entrypoint = new \LORIS\Router\BaseRouter(
     $user,

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -138,7 +138,7 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
             function ($row) {
                 return array_values($row);
             },
-            json_decode($table->toJSON(\User::singleton()), true)
+            json_decode($table->toJSON(\NDB_Factory::singleton()->user()), true)
         );
 
         return json_encode(


### PR DESCRIPTION
…

## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015 (Core files only)

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvement.

@christinerogers 