### PR TITLE
[Publication] Update User::singleton() declarations to facilitate unit testing

### DIFF
--- a/modules/publication/ajax/FileDelete.php
+++ b/modules/publication/ajax/FileDelete.php
@@ -13,8 +13,9 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 $uploadID = $_REQUEST['uploadID'];
-$db       = \Database::singleton();
-$user     = \User::singleton();
+$factory  = \NDB_Factory::singleton();
+$db       = $factory->database();
+$user     = $factory->user();
 $config   = \NDB_Config::singleton();
 
 $query      = "SELECT PublicationID, Filename ".

--- a/modules/publication/ajax/FileDownload.php
+++ b/modules/publication/ajax/FileDownload.php
@@ -11,7 +11,8 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 
-$user    = \User::singleton();
+$factory = \NDB_Factory::singleton();
+$user    = $factory->user();
 $message = array('message' => null);
 
 if (userCanDownload($user)) {

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -31,8 +31,9 @@ if (isset($_REQUEST['action'])) {
  */
 function uploadPublication() : void
 {
-    $db   = Database::singleton();
-    $user = \User::singleton();
+    $factory = \NDB_Factory::singleton();
+    $db      = $factory->database();
+    $user    = $factory->user();
     if (!$user->hasPermission('publication_propose')
         || !$user->hasPermission('publication_view')
     ) {
@@ -131,8 +132,9 @@ function processFiles($pubID) : void
     if (empty($_FILES)) {
         return;
     }
-    $db     = \Database::singleton();
-    $config = \NDB_Config::singleton();
+    $factory = \NDB_Factory::singleton();
+    $db      = $factory->database();
+    $config  = \NDB_Config::singleton();
 
     $publicationPath = $config->getSetting('publication_uploads');
 
@@ -419,9 +421,10 @@ function notify($pubID, $type) : void
         showPublicationError("Unexpected notification type: $type", 400);
     }
 
-    $db        = \Database::singleton();
+    $factory   = \NDB_Factory::singleton();
+    $db        = $factory->database();
     $config    = \NDB_Config::singleton();
-    $user      = \User::singleton();
+    $user      = $factory->user();
     $emailData = array();
 
     $data = $db->pselectRow(
@@ -480,7 +483,8 @@ function editProject() : void
 
     if (isset($id)) {
         // double check that current user has edit access
-        $user        = \User::singleton();
+        $factory     = \NDB_Factory::singleton();
+        $user        = $factory->user();
         $creatorUser = $db->pselectOne(
             'SELECT UserID FROM publication WHERE PublicationID=:id',
             array('id' => $id)

--- a/modules/publication/ajax/getData.php
+++ b/modules/publication/ajax/getData.php
@@ -13,8 +13,9 @@
  * @link     https://github.com/aces/Loris-Trunk
  */
 if (isset($_REQUEST['action'])) {
-    $db      = \Database::singleton();
-    $user    = \User::singleton();
+    $factory = \NDB_Factory::singleton();
+    $db      = $factory->database();
+    $user    = $factory->user();
     $action  = $_REQUEST['action'];
     $message = array('message' => null);
 

--- a/modules/publication/php/publication.class.inc
+++ b/modules/publication/php/publication.class.inc
@@ -36,8 +36,9 @@ class Publication extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        $user = \User::singleton();
-        $db   = \Database::singleton();
+        $factory = \NDB_Factory::singleton();
+        $db      = $factory->database();
+        $user    = $factory->user();
 
         $nProjects = $db->pselectOne(
             'SELECT COUNT(*) FROM publication_users_edit_perm_rel '.
@@ -58,8 +59,9 @@ class Publication extends \NDB_Menu_Filter_Form
      */
     function _setupVariables() : void
     {
-        $user  = \User::singleton();
-        $query = " FROM publication p ".
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $query   = " FROM publication p ".
             "LEFT JOIN publication_status ps ".
             "ON ps.PublicationStatusID=p.PublicationStatusID ".
             "LEFT JOIN publication_parameter_type_rel pptr ".

--- a/modules/publication/php/view_project.class.inc
+++ b/modules/publication/php/view_project.class.inc
@@ -36,9 +36,10 @@ class View_Project extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        $user  = \User::singleton();
-        $db    = \Database::singleton();
-        $pubID = $_GET['id'];
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $db      = $factory->database();
+        $pubID   = $_GET['id'];
 
         $nProjects = $db->pselectOne(
             'SELECT COUNT(*) FROM publication_users_edit_perm_rel '.


### PR DESCRIPTION
## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvements.

@christinerogers 