### PR TITLE
[User Accounts] Update User::singleton() declarations to facilitate unit testing

### DIFF
--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -101,8 +101,9 @@ class My_Preferences extends \NDB_Form
      */
     function _process($values)
     {
-        $config = \NDB_Config::singleton();
-        $DB     = \Database::singleton();
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->config();
+        $DB      = $factory->database();
 
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
@@ -377,8 +378,9 @@ class My_Preferences extends \NDB_Form
     function _validateMyPreferences(array $values): array
     {
         // create DB object
-        $DB     = \Database::singleton();
-        $errors = array();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+        $errors  = array();
 
         // NOTE The 'Password_hash' key actually represents a plaintext password
         $plaintext = $values['Password_hash'];

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -21,8 +21,11 @@
 
 namespace LORIS\user_accounts;
 
+$factory = \NDB_Factory::singleton();
+$user    = $factory->user();
+
 // Make sure the permission is checked first to avoid malicious userID scans
-if (!(\User::singleton())->hasPermission('user_accounts')) {
+if (!$user->hasPermission('user_accounts')) {
     header("HTTP/1.1 403 Forbidden");
     header("Content-Type: text/plain");
     exit(

--- a/modules/user_accounts/ajax/rejectUser.php
+++ b/modules/user_accounts/ajax/rejectUser.php
@@ -23,6 +23,7 @@ namespace LORIS\user_accounts;
 
 $factory = \NDB_Factory::singleton();
 $user    = $factory->user();
+$db      = $factory->database();
 
 // Make sure the permission is checked first to avoid malicious userID scans
 if (!$user->hasPermission('user_accounts')) {
@@ -61,6 +62,5 @@ if (!Edit_User::canRejectAccount($rejectee)) {
     );
 }
 
-(\Database::singleton())->delete('users', array("UserID" => $username));
+$db->delete('users', array("UserID" => $username));
 header("HTTP/1.1 204 No Content");
-

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -172,7 +172,8 @@ class Edit_User extends \NDB_Form
      */
     function _isEditingOwnAccount()
     {
-        $editor = \User::singleton();
+        $factory = \NDB_Factory::singleton();
+        $editor  = $factory->user();
         return !$this->isCreatingNewUser()
             && ($editor->getUsername() == $this->identifier);
     }
@@ -186,12 +187,14 @@ class Edit_User extends \NDB_Form
      */
     function _process($values)
     {
-        $config = \NDB_Config::singleton();
-        $DB     = \Database::singleton();
+        $config  = \NDB_Config::singleton();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
         //The arrays that contain the edited permissions
         $permissionsRemoved = array();
         $permissionsAdded   = array();
-        $editor = \User::singleton();
+        $editor = $factory->user();
+
         // build the "real name"
         $values['Real_name'] = $values['First_name'] . ' ' . $values['Last_name'];
         //create the user
@@ -752,7 +755,8 @@ class Edit_User extends \NDB_Form
         //------------------------------------------------------------
 
         // get user permissions
-        $editor      = \User::singleton();
+        $factory     = \NDB_Factory::singleton();
+        $editor      = $factory->user();
         $siteOptions = array();
         $site        = array();
 
@@ -1021,9 +1025,11 @@ class Edit_User extends \NDB_Form
      */
     function _validateEditUser($values)
     {
-        $editor = \User::singleton();
+        $factory = \NDB_Factory::singleton();
+        $editor  = $factory->user();
         // create DB object
-        $DB     = \Database::singleton();
+        $DB = $factory->database();
+
         $errors = array();
 
         // NOTE The 'Password_hash' key actually represents a plaintext password

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -187,9 +187,10 @@ class Edit_User extends \NDB_Form
      */
     function _process($values)
     {
-        $config  = \NDB_Config::singleton();
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
+        $config  = $factory->config();
+
         //The arrays that contain the edited permissions
         $permissionsRemoved = array();
         $permissionsAdded   = array();
@@ -636,7 +637,8 @@ class Edit_User extends \NDB_Form
         parent::setup();
 
         ///get the value for additional_user_info flag
-        $config = \NDB_Config::singleton();
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->config();
         $additional_user_info = $config->getSetting('additional_user_info');
 
         //------------------------------------------------------------
@@ -801,7 +803,8 @@ class Edit_User extends \NDB_Form
             $groupB = array();
 
             //get site aliases
-            $DB      = \Database::singleton();
+            $factory = \NDB_Factory::singleton();
+            $DB      = $factory->database();
             $aliases = $DB->pselect("SELECT CenterID, Alias FROM psc ", array());
 
             foreach ($aliases as $row) {
@@ -955,7 +958,7 @@ class Edit_User extends \NDB_Form
                   JOIN users u ON (u.ID = up.userID)
                   WHERE p.code = 'send_to_dcc'";
 
-        $results = \Database::singleton()->pselect($query, array());
+        $results = \NDB_Factory::singleton()->database()->pselect($query, array());
 
         $group   = array();
         $group[] = $this->form->createElement(


### PR DESCRIPTION
## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvements.

@christinerogers 