### PR TITLE
[Issue Tracker] Update User::singleton() declarations to facilitate unit testing

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -51,8 +51,8 @@ if ($_SERVER['REQUEST_METHOD'] === "GET") {
 function editIssue()
 {
     $factory = \NDB_Factory::singleton();
-    $db      =& $factory->database();
-    $user    =& $factory->user();
+    $db      = $factory->database();
+    $user    = $factory->user();
 
     $issueValues    = array();
     $validateValues = array();
@@ -195,7 +195,7 @@ function editIssue()
 function validateInput($values)
 {
     $factory    = \NDB_Factory::singleton();
-    $db         =& $factory->database();
+    $db         = $factory->database();
     $pscid      = (isset($values['PSCID']) ? $values['PSCID'] : null);
     $visitLabel = (isset($values['visitLabel']) ? $values['visitLabel'] : null);
     $centerID   = (isset($values['centerID']) ? $values['centerID'] : null);
@@ -281,7 +281,7 @@ function validateInput($values)
         $query  = "SELECT CandID FROM candidate WHERE PSCID=:PSCID";
         $params = ['PSCID' => $result['PSCID']];
 
-        $user =& $factory->user();
+        $user = $factory->user();
         if (!$user->hasPermission('access_all_profiles')) {
             $params['CenterID'] = implode(',', $user->getCenterIDs());
             $query .= " AND FIND_IN_SET(RegistrationCenterID,:CenterID)";
@@ -340,9 +340,9 @@ function getChangedValues($issueValues, $issueID)
  */
 function updateHistory($values, $issueID)
 {
-    $factory =  \NDB_Factory::singleton();
-    $user    =& $factory->user();
-    $db      =& $factory->database();
+    $factory = \NDB_Factory::singleton();
+    $user    = $factory->user();
+    $db      = $factory->database();
 
     foreach ($values as $key => $value) {
         if (!empty($value)) {
@@ -369,9 +369,9 @@ function updateHistory($values, $issueID)
  */
 function updateComments($comment, $issueID)
 {
-    $factory =  \NDB_Factory::singleton();
-    $user    =& $factory->user();
-    $db      =& $factory->database();
+    $factory = \NDB_Factory::singleton();
+    $user    = $factory->user();
+    $db      = $factory->database();
 
     if (isset($comment) && $comment != "null") {
         $commentValues = array(
@@ -395,9 +395,9 @@ function updateComments($comment, $issueID)
  */
 function updateCommentHistory($issueCommentID, $newCommentValue)
 {
-    $factory =  \NDB_Factory::singleton();
-    $user    =& $factory->user();
-    $db      =& $factory->database();
+    $factory = \NDB_Factory::singleton();
+    $user    = $factory->user();
+    $db      = $factory->database();
 
     $changedValue = array(
         'issueCommentID' => $issueCommentID,
@@ -419,7 +419,8 @@ function updateCommentHistory($issueCommentID, $newCommentValue)
  */
 function getWatching($issueID)
 {
-    $db =& Database::singleton();
+    $factory = \NDB_Factory::singleton();
+    $db      = $factory->database();
 
     $watching = $db->pselect(
         "SELECT userID from issues_watching WHERE issueID=:issueID",
@@ -444,7 +445,9 @@ function getWatching($issueID)
  */
 function getComments($issueID)
 {
-    $db =& Database::singleton();
+    $factory = \NDB_Factory::singleton();
+    $db      = $factory->database();
+
     $unformattedComments = $db->pselect(
         "SELECT newValue, fieldChanged, dateAdded, addedBy " .
         "FROM issues_history where issueID=:issueID " .
@@ -501,9 +504,9 @@ function getComments($issueID)
  */
 function emailUser($issueID, $changed_assignee)
 {
-    $factory =  \NDB_Factory::singleton();
-    $user    =& $factory->user();
-    $db      =& $factory->database();
+    $factory = \NDB_Factory::singleton();
+    $user    = $factory->user();
+    $db      = $factory->database();
     //not sure if this is necessary
     $baseurl = $factory->settings()->getBaseURL();
 
@@ -574,9 +577,9 @@ function emailUser($issueID, $changed_assignee)
  */
 function getIssueFields()
 {
-    $factory =  \NDB_Factory::singleton();
-    $db      =& $factory->database();
-    $user    =& $factory->user();
+    $factory = \NDB_Factory::singleton();
+    $db      = $factory->database();
+    $user    = $factory->user();
     $sites   = array();
 
     //get field options

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -50,8 +50,9 @@ if ($_SERVER['REQUEST_METHOD'] === "GET") {
  */
 function editIssue()
 {
-    $db   =& Database::singleton();
-    $user =& User::singleton();
+    $factory = \NDB_Factory::singleton();
+    $db      =& $factory->database();
+    $user    =& $factory->user();
 
     $issueValues    = array();
     $validateValues = array();
@@ -193,7 +194,8 @@ function editIssue()
  */
 function validateInput($values)
 {
-    $db         =& Database::singleton();
+    $factory    = \NDB_Factory::singleton();
+    $db         =& $factory->database();
     $pscid      = (isset($values['PSCID']) ? $values['PSCID'] : null);
     $visitLabel = (isset($values['visitLabel']) ? $values['visitLabel'] : null);
     $centerID   = (isset($values['centerID']) ? $values['centerID'] : null);
@@ -279,7 +281,7 @@ function validateInput($values)
         $query  = "SELECT CandID FROM candidate WHERE PSCID=:PSCID";
         $params = ['PSCID' => $result['PSCID']];
 
-        $user =& User::singleton();
+        $user =& $factory->user();
         if (!$user->hasPermission('access_all_profiles')) {
             $params['CenterID'] = implode(',', $user->getCenterIDs());
             $query .= " AND FIND_IN_SET(RegistrationCenterID,:CenterID)";
@@ -338,8 +340,9 @@ function getChangedValues($issueValues, $issueID)
  */
 function updateHistory($values, $issueID)
 {
-    $user =& User::singleton();
-    $db   =& Database::singleton();
+    $factory =  \NDB_Factory::singleton();
+    $user    =& $factory->user();
+    $db      =& $factory->database();
 
     foreach ($values as $key => $value) {
         if (!empty($value)) {
@@ -366,8 +369,9 @@ function updateHistory($values, $issueID)
  */
 function updateComments($comment, $issueID)
 {
-    $user =& User::singleton();
-    $db   =& Database::singleton();
+    $factory =  \NDB_Factory::singleton();
+    $user    =& $factory->user();
+    $db      =& $factory->database();
 
     if (isset($comment) && $comment != "null") {
         $commentValues = array(
@@ -391,8 +395,9 @@ function updateComments($comment, $issueID)
  */
 function updateCommentHistory($issueCommentID, $newCommentValue)
 {
-    $user =& User::singleton();
-    $db   =& Database::singleton();
+    $factory =  \NDB_Factory::singleton();
+    $user    =& $factory->user();
+    $db      =& $factory->database();
 
     $changedValue = array(
         'issueCommentID' => $issueCommentID,
@@ -496,10 +501,10 @@ function getComments($issueID)
  */
 function emailUser($issueID, $changed_assignee)
 {
-    $user =& User::singleton();
-    $db   =& Database::singleton();
+    $factory =  \NDB_Factory::singleton();
+    $user    =& $factory->user();
+    $db      =& $factory->database();
     //not sure if this is necessary
-    $factory = NDB_Factory::singleton();
     $baseurl = $factory->settings()->getBaseURL();
 
     $title = $db->pSelectOne(
@@ -569,10 +574,10 @@ function emailUser($issueID, $changed_assignee)
  */
 function getIssueFields()
 {
-
-    $db    =& Database::singleton();
-    $user  =& User::singleton();
-    $sites = array();
+    $factory =  \NDB_Factory::singleton();
+    $db      =& $factory->database();
+    $user    =& $factory->user();
+    $sites   = array();
 
     //get field options
     if ($user->hasPermission('access_all_profiles')) {
@@ -745,9 +750,9 @@ ORDER BY dateAdded LIMIT 1",
  */
 function getIssueData($issueID=null)
 {
-
-    $user = \User::singleton();
-    $db   = \Database::singleton();
+    $factory = \NDB_Factory::singleton();
+    $user    = $factory->user();
+    $db      = $factory->database();
 
     if (!empty($issueID)) {
         return $db->pselectRow(

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -67,7 +67,8 @@ class Attachment extends \NDB_Page implements ETagCalculator
                         ID = :ID';
         $result  = $DB->pselectRow($query, array('ID' => $ID));
 
-        $config = \NDB_Config::singleton();
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->config();
         $attachment_data_dir = rtrim(
             $config->getSetting('IssueTrackerDataPath'),
             '/'

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -38,7 +38,7 @@ class Issue extends \NDB_Form
     {
         parent::setup();
         $factory = \NDB_Factory::singleton();
-        $user    =& $factory->user();
+        $user    = $factory->user();
         $issueID = $this->issueID;
         if ((empty($issueID)
             || !isset($issueID))
@@ -101,7 +101,7 @@ class Issue extends \NDB_Form
         if (!$issueID) {
             return true;
         }
-        $issueData = \Database::singleton()->pselectRow(
+        $issueData = \NDB_Factory::singleton()->database()->pselectRow(
             "SELECT centerID FROM issues WHERE issueID=:issueID",
             array('issueID' => $issueID)
         );

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -37,7 +37,8 @@ class Issue extends \NDB_Form
     function setup()
     {
         parent::setup();
-        $user    =& \User::singleton();
+        $factory = \NDB_Factory::singleton();
+        $user    =& $factory->user();
         $issueID = $this->issueID;
         if ((empty($issueID)
             || !isset($issueID))

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -56,7 +56,8 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     {
         $provisioner = new IssueRowProvisioner();
 
-        $user = \User::singleton();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
 
         if ($user->hasPermission('access_all_profiles') === false) {
             $provisioner = $provisioner->filter(
@@ -75,8 +76,9 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
      */
     function toJSON(): string
     {
-        $user = \User::singleton();
-        $db   = \Database::singleton();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $db      = $factory->database();
 
         //sites
         $sites = array();

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -35,8 +35,9 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     function __construct()
     {
-        $user   = \User::singleton();
-        $userID = $user->getUsername();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $userID  = $user->getUsername();
         //note that this needs to be in the same order as the headers array
         parent::__construct(
             "SELECT i.issueID,

--- a/modules/issue_tracker/php/issuewatchermapper.class.inc
+++ b/modules/issue_tracker/php/issuewatchermapper.class.inc
@@ -46,7 +46,8 @@ class IssueWatcherMapper implements Mapper
 
         static $config = null;
         if ($config === null) {
-            $config = \NDB_Config::singleton()->getSetting("imaging_modules");
+            $factory = \NDB_Factory::singleton();
+            $config  = $factory->config()->getSetting("imaging_modules");
         }
 
         $newrow = json_decode($resource->toJSON(), true);

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -104,7 +104,8 @@ class UploadHelper
      */
     function setFullPath(Object &$fileToUpload) : void
     {
-        $config = \NDB_Config::singleton();
+        $factory = \NDB_Factory::singleton();
+        $config  = $factory->config();
         $attachment_data_dir = trim(
             rtrim(
                 $config->getSetting('IssueTrackerDataPath'),
@@ -221,7 +222,8 @@ class UploadHelper
      */
     function endWithFailure() : void
     {
-        $DB = \Database::singleton();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
         $DB->rollBack();
     }
 
@@ -233,7 +235,8 @@ class UploadHelper
      */
     function endWithSuccess() : void
     {
-        $DB = \Database::singleton();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
         $DB->commit();
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvements.

@christinerogers 