### PR TITLE
[Dashboard] Update User::singleton() declarations to facilitate unit testing

### DIFF
--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -63,8 +63,9 @@ class Dashboard extends \NDB_Form
         // javascript are available for getCSSDependencies and getJSDependencies,
         // otherwise setup() only gets called by handle() of NDB_Page while
         // calculating the body.
-        $DB   = \NDB_Factory::singleton()->database();
-        $user = \User::singleton();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
+        $user    = $factory->user();
 
         // FIXME: This should use \LORIS\LorisInstance->getActiveModules(), but there
         // is no access to a LORISInstance object at this point in the code.

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -135,9 +135,10 @@ class Module extends \Module
      */
     private function _getTasksWidget()
     {
-        $DB      = \NDB_Factory::singleton()->database();
+        $factory = \NDB_Factory::singleton();
+        $DB      = $factory->database();
         $modules = \Module::getActiveModules($DB);
-        $user    = \User::singleton();
+        $user    = $factory->user();
 
         $widgets = [];
         foreach ($modules as $module) {


### PR DESCRIPTION
## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvements.

@christinerogers 