### PR TITLE
[Statistics] Update User::singleton() declarations to facilitate unit testing

### DIFF
--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -119,8 +119,7 @@ class Statistics_Site extends \NDB_Menu
             $this->query_vars['cid'] = $centerID;
         } else {
             $list_of_permitted_sites = (array) null;
-            $factory     = \NDB_Factory::singleton();
-            $currentUser = $factory->user();
+            $currentUser = \NDB_Factory::singleton()->user();
 
             if ($currentUser->hasPermission('access_all_profiles')) {
                 $list_of_permitted_sites = array_keys(\Utility::getSiteList());

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -119,7 +119,8 @@ class Statistics_Site extends \NDB_Menu
             $this->query_vars['cid'] = $centerID;
         } else {
             $list_of_permitted_sites = (array) null;
-            $currentUser = \User::singleton();
+            $factory     = \NDB_Factory::singleton();
+            $currentUser = $factory->user();
 
             if ($currentUser->hasPermission('access_all_profiles')) {
                 $list_of_permitted_sites = array_keys(\Utility::getSiteList());


### PR DESCRIPTION
## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvements.

@christinerogers 