### PR TITLE
[Candidate List] Update User::singleton() declarations to facilitate unit testing

### DIFF
--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -74,8 +74,9 @@ class Candidate_List extends \DataFrameworkMenu
         \Module::factory('candidate_parameters');
 
         // create user object
-        $user   = \User::singleton();
-        $config = \NDB_Config::singleton();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $config  = \NDB_Config::singleton();
 
         // get the list of visit labels
         $visit_label_options = \Utility::getVisitList();

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -76,7 +76,7 @@ class Candidate_List extends \DataFrameworkMenu
         // create user object
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
-        $config  = \NDB_Config::singleton();
+        $config  = $factory->config();
 
         // get the list of visit labels
         $visit_label_options = \Utility::getVisitList();

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -36,7 +36,8 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
      */
     function __construct()
     {
-        $config   = \NDB_Config::singleton();
+        $factory  = \NDB_Factory::singleton();
+        $config   = $factory->config();
         $maybeEDC = '';
 
         if ($config->getSetting("useEDC") === "true") {


### PR DESCRIPTION
## Brief summary of changes

Replaced occurence of 
$user = \User::singleton();
$db = \Database::singleton();

by

$factory  = \NDB_Factory::singleton();
$db       = $factory->database();
$user     = $factory->user(); 

according to the unit test guide (UnitTestGuide.md).

#### Link(s) to related issue(s)

* Resolves #5015

#### About me
GOSC applicant, happy to join the community!
This is my first contribution, don't hesitate to comment on the possible improvements.

@christinerogers 