### PR TITLE
[Instruments] Bugfix multi-escaped special characters

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -695,10 +695,6 @@ class LorisForm
                 }
             }
         }
-        // Always sanitize user-controlled input
-        if (!is_array($newValue)) {
-            $newValue = htmlspecialchars($newValue);
-        }
 
         return $newValue;
     }


### PR DESCRIPTION
## Brief summary of changes
Removed duplicate call to `HTMLSpecialChars()` causing double escaping on any instrument field with one of the following characters `& < > "`

The removal is justified since these fields are being escaped directly in the database class
https://github.com/aces/Loris/blob/master/php/libraries/Database.class.inc#L538
