### PR TITLE
[Imaging Browser] Cleanup test plan

### DIFF
--- a/modules/imaging_browser/test/TestPlan.md
+++ b/modules/imaging_browser/test/TestPlan.md
@@ -1,44 +1,43 @@
 ## Imaging Browser test plan
 	
-### A. Imaging Browser front page
-1. User can load Imaging Browser module front page IFF has permission imaging_browser_view_site, imaging_browser_view_allsites, imaging_browser_phantom_allsites or imaging_browser_phantom_ownsite [Partial Automation Testing; To ADD phantom permissions automated tests]
+### Imaging Browser main page
+1. User can access Imaging Browser module front page IFF has permission imaging_browser_view_site, imaging_browser_view_allsites, imaging_browser_phantom_allsites or imaging_browser_phantom_ownsite [Partial Automation Testing; To ADD phantom permissions automated tests]
 2. User can see other sites Imaging datasets IFF has permission imaging_browser_view_allsites. User can see only own site Imaging datasets IFF has permission imaging_browser_view_site. User can see phantom data only from across all sites with the imaging_browser_phantom_allsites, and from own sites with imaging_browser_phantom_ownsite [Partial Automation Testing; TO ADD phantom permissions automated tests]
-3. Test that all Filters work.  Upon first loading, Site filter should be set to 'All User Sites' (with the dropdown menu populated with the sites the logged on user is affiliated with) IFF user does not have permission imaging_browser_view_allsites nor imaging_browser_phantom_allsites, and is set to 'All' otherwise.
+3. Test that all filters work.
+    - When the Site filter is empty, all sites with which the user is associated should be displayed. Every site should be displayed if the user has the `imaging_browser_view_allsites` permission.
 4. Test Clear Filters button
 5. Test column table is sortable by headers
-6. Test that Links work, to correct dataset (selected/native)
-7. Add more modalities (from the Scan_type column of the mri_scan_type table) to the Configuration/Imaging Modules/Tabulated Scan Types field, and ensure that for each added modality, a new corresponding column shows up in the Imaging Browser table    
+6. Ensure that the hyperlinks in the Links column are active and load the correct dataset.
+7. Add more modalities (from the Scan_type column of the `mri_scan_type` table) to the Configuration/Imaging Modules/Tabulated Scan Types field, and ensure that for each added modality, a new corresponding column shows up in the Imaging Browser table. (This requires back-end access.)
 
-### B. ViewSession / Volume List
+### View Session / Volume List
 
-8. Sidebar:  all links work, including the Download DICOM option. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
-9. 3d panel overlay etc - they work.  Add panel checkbox works. 3D only or 3D+Overlay loads files if at least one image exists and is selected
-10. "Visit Level Feedback" - pops up QC window (see section E below)
-11. Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission imaging_browser_qc
-12. Save button appears IFF permission imaging_browser_qc
-13. Test Save button works 
-14. Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved
-15. Test Breadcrumb link back to Imaging Browser
+Sidebar:  all links work, including the Download DICOM option. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
+Select an image using the checkbox above the volume previews. Click the "3D Only" and "3D + Overlay" buttons. These should load the Brain Browser module.
+Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission imaging_browser_qc
+Save button appears IFF permission imaging_browser_qc
+Test Save button works 
+Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved
+Test Breadcrumb link back to Imaging Browser
 
-### C. Main panel:  per acquisition:
+### Main panel:  per acquisition:
 
-16. Files can be downloaded (links clickable) only IFF has permission. Ensure that DICOM downloads are
+Files can be downloaded (links clickable) only IFF has permission. Ensure that DICOM downloads are
 prepended with the Patient Name.
-17. Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable IFF permission imaging_browser_qc. Caveat List link is viewable with the Violated Scans: View all-sites Violated Scans permission
-18. Selected:  can be set back to Null (blank)
-19. BrainBrowser link works (launches window)
-20. Link to Comments link works (launches window)
-21. Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints
+Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable IFF permission `imaging_browser_qc`. 
+Caveat List link is viewable with the Violated Scans: View all-sites Violated Scans permission
+Selected:  can be set back to Null (blank)
+Clicking on an image should launch BrainBrowser
+Clicking on the "QC Comments" button should open the QC comments window
+Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints
 
-### D. MRI-QC : Scan-level (Link to Comments) dialog window
+### MRI-QC : Scan-level (QC Comments) dialog window
 
-22. Viewable by all, editable IFF permission imaging_browser_qc
-23. Comments save, checkboxes save, dropdown values save
-24. Save button works
-25. Comments can be deleted (field cleared). checkboxes, dropdown values too. 
+With the permission `imaging_browser_qc`, edit comments, checkboxes, and dropdown values. 
+Clicking Save should update the values.
+Data should not be editable without this permission.
 
-### E. Visit-level QC feedback dialog window
-26. editable IFF permission imaging_browser_qc
-27. Comments save
-28. Save button works
-29. Comments can be deleted (field cleared). 
+### Visit-level QC feedback dialog window
+On the view session page, click the button "Visit Level Feedback".
+The entries in this dialog should be editable when a user has the permission `imaging_browser_qc`.
+Try editing comments (adding new ones, deleting old ones). Click Save and ensure the data is saved.

--- a/modules/imaging_browser/test/TestPlan.md
+++ b/modules/imaging_browser/test/TestPlan.md
@@ -12,43 +12,43 @@
 
 ### View Session / Volume List
 
-Sidebar:  all links work, including the Download DICOM option. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
+8. Sidebar:  all links work, including the Download DICOM option. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
 
-Select an image using the checkbox above the volume previews. Click the "3D Only" and "3D + Overlay" buttons. These should load the Brain Browser module.
+9. Select an image using the checkbox above the volume previews. Click the "3D Only" and "3D + Overlay" buttons. These should load the Brain Browser module.
 
-Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission `imaging_browser_qc`
+10. Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission `imaging_browser_qc`
 
-Save button appears IFF permission `imaging_browser_qc`
+11. Save button appears IFF permission `imaging_browser_qc`
 
-Test Save button works 
+12. Test Save button works 
 
-Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved
+13. Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved
 
-Test Breadcrumb link back to Imaging Browser
+14. Test Breadcrumb link back to Imaging Browser
 
 ### Main panel:  per acquisition:
 
-Files can be downloaded (links clickable) only IFF has permission. Ensure that DICOM downloads are
+15. Files can be downloaded (links clickable) only IFF has permission. Ensure that DICOM downloads are
 prepended with the Patient Name.
 
-Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable IFF permission `imaging_browser_qc`. 
+16. Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable IFF permission `imaging_browser_qc`. 
 Caveat List link is viewable with the Violated Scans: "View all-sites Violated Scans" permission
 
-Selected:  can be set back to Null (blank)
+17. Selected:  can be set back to Null (blank)
 
-Clicking on an image should launch BrainBrowser
+18. Clicking on an image should launch BrainBrowser
 
-Clicking on the "QC Comments" button should open the QC comments window
+19. Clicking on the "QC Comments" button should open the QC comments window
 
-Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints
+20. Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints
 
 ### MRI-QC : Scan-level (QC Comments) dialog window
 
-With the permission `imaging_browser_qc`, edit comments, checkboxes, and dropdown values. 
-Clicking Save should update the values.
-Data should not be editable without this permission.
+21. With the permission `imaging_browser_qc`, edit comments, checkboxes, and dropdown values. 
+22. Clicking Save should update the values.
+23. Data should not be editable without this permission.
 
 ### Visit-level QC feedback dialog window
-On the view session page, click the button "Visit Level Feedback".
-The entries in this dialog should be editable when a user has the permission `imaging_browser_qc`.
-Try editing comments (adding new ones, deleting old ones). Click Save and ensure the data is saved.
+24. On the view session page, click the button "Visit Level Feedback".
+25. The entries in this dialog should be editable when a user has the permission `imaging_browser_qc`.
+26. Try editing comments (adding new ones, deleting old ones). Click Save and ensure the data is saved.

--- a/modules/imaging_browser/test/TestPlan.md
+++ b/modules/imaging_browser/test/TestPlan.md
@@ -13,22 +13,33 @@
 ### View Session / Volume List
 
 Sidebar:  all links work, including the Download DICOM option. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
+
 Select an image using the checkbox above the volume previews. Click the "3D Only" and "3D + Overlay" buttons. These should load the Brain Browser module.
-Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission imaging_browser_qc
-Save button appears IFF permission imaging_browser_qc
+
+Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission `imaging_browser_qc`
+
+Save button appears IFF permission `imaging_browser_qc`
+
 Test Save button works 
+
 Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved
+
 Test Breadcrumb link back to Imaging Browser
 
 ### Main panel:  per acquisition:
 
 Files can be downloaded (links clickable) only IFF has permission. Ensure that DICOM downloads are
 prepended with the Patient Name.
+
 Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable IFF permission `imaging_browser_qc`. 
-Caveat List link is viewable with the Violated Scans: View all-sites Violated Scans permission
+Caveat List link is viewable with the Violated Scans: "View all-sites Violated Scans" permission
+
 Selected:  can be set back to Null (blank)
+
 Clicking on an image should launch BrainBrowser
+
 Clicking on the "QC Comments" button should open the QC comments window
+
 Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints
 
 ### MRI-QC : Scan-level (QC Comments) dialog window

--- a/modules/imaging_browser/test/TestPlan.md
+++ b/modules/imaging_browser/test/TestPlan.md
@@ -3,7 +3,7 @@
 ### Imaging Browser main page
 1. User can access Imaging Browser module front page if and only if they have permission `imaging_browser_view_site`, `imaging_browser_view_allsites`, `imaging_browser_phantom_allsites` or `imaging_browser_phantom_ownsite`.
  [Partial Automation Testing]
-2. User can see other sites Imaging datasets if and only if has permission imaging_browser_view_allsites. User can see only own site Imaging datasets if and only if has permission imaging_browser_view_site. User can see phantom data only from across all sites with the imaging_browser_phantom_allsites, and from own sites with imaging_browser_phantom_ownsite. 
+2. User can see other sites Imaging datasets if and only if has permission `imaging_browser_view_allsites`. User can see only own site Imaging datasets if and only if has permission `imaging_browser_view_site`. User can see phantom data only from across all sites with the `imaging_browser_phantom_allsites`, and from own sites with `imaging_browser_phantom_ownsite`. 
  [Partial Automation Testing]
 3. Test that all filters work. When the Site filter is empty, all sites with which the user is associated should be displayed. Every site should be displayed if the user has the `imaging_browser_view_allsites` permission.
 4. Test Clear Filters button.
@@ -23,7 +23,7 @@
 14. Test Breadcrumb link back to Imaging Browser.
 
 ### Main panel:  Per Acquisition
-15. Files can be downloaded (links clickable) if and only if user has permission ????. Ensure that DICOM downloads are
+15. Files can be downloaded (links clickable) if and only if user has at least one of the module permissions. Ensure that DICOM downloads are
 prepended with the Patient Name.
 16. Scan-level QC flags (Selected, pass/fail, Caveat emptor) are viewable to all, modifiable if and only if user has permission `imaging_browser_qc`.  
 17. Caveat List link is viewable with the Violated Scans if and only if user has `View all-sites Violated Scans` permission.

--- a/modules/imaging_browser/test/TestPlan.md
+++ b/modules/imaging_browser/test/TestPlan.md
@@ -1,54 +1,43 @@
 ## Imaging Browser test plan
 	
 ### Imaging Browser main page
-1. User can access Imaging Browser module front page IFF has permission imaging_browser_view_site, imaging_browser_view_allsites, imaging_browser_phantom_allsites or imaging_browser_phantom_ownsite [Partial Automation Testing; To ADD phantom permissions automated tests]
-2. User can see other sites Imaging datasets IFF has permission imaging_browser_view_allsites. User can see only own site Imaging datasets IFF has permission imaging_browser_view_site. User can see phantom data only from across all sites with the imaging_browser_phantom_allsites, and from own sites with imaging_browser_phantom_ownsite [Partial Automation Testing; TO ADD phantom permissions automated tests]
-3. Test that all filters work.
-    - When the Site filter is empty, all sites with which the user is associated should be displayed. Every site should be displayed if the user has the `imaging_browser_view_allsites` permission.
-4. Test Clear Filters button
-5. Test column table is sortable by headers
+1. User can access Imaging Browser module front page if and only if they have permission `imaging_browser_view_site`, `imaging_browser_view_allsites`, `imaging_browser_phantom_allsites` or `imaging_browser_phantom_ownsite`.
+ [Partial Automation Testing]
+2. User can see other sites Imaging datasets if and only if has permission imaging_browser_view_allsites. User can see only own site Imaging datasets if and only if has permission imaging_browser_view_site. User can see phantom data only from across all sites with the imaging_browser_phantom_allsites, and from own sites with imaging_browser_phantom_ownsite. 
+ [Partial Automation Testing]
+3. Test that all filters work. When the Site filter is empty, all sites with which the user is associated should be displayed. Every site should be displayed if the user has the `imaging_browser_view_allsites` permission.
+4. Test Clear Filters button.
+5. Test column table is sortable by headers.
 6. Ensure that the hyperlinks in the Links column are active and load the correct dataset.
-7. Add more modalities (from the Scan_type column of the `mri_scan_type` table) to the Configuration/Imaging Modules/Tabulated Scan Types field, and ensure that for each added modality, a new corresponding column shows up in the Imaging Browser table. (This requires back-end access.)
+7. Add more modalities (from the Scan_type column of the `mri_scan_type` table) to the Configuration -> Imaging Modules -> Tabulated Scan Types field, and ensure that for each added modality, a new corresponding column shows up in the Imaging Browser table. (This requires back-end access)
 
 ### View Session / Volume List
-
-8. Sidebar:  all links work, including the Download DICOM option. Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration/Imaging Modules/Imaging Browser Links to Insruments
-
+8. Sidebar:  
+   - Ensure that all links work, including the Download DICOM option. 
+   - Ensure that projects can customize (add/remove) their list of instruments that can be linked to from the Configuration -> Imaging Modules -> Imaging Browser Links to Insruments.
 9. Select an image using the checkbox above the volume previews. Click the "3D Only" and "3D + Overlay" buttons. These should load the Brain Browser module.
+10. Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable if and only if user has permission `imaging_browser_qc`.
+11. Save button appears if and only if user has permission `imaging_browser_qc`.
+12. Test Save button works.
+13. Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved.
+14. Test Breadcrumb link back to Imaging Browser.
 
-10. Visit level QC controls (Pass/Fail, Pending, Visit Level Caveat) viewable to all, editable IFF permission `imaging_browser_qc`
-
-11. Save button appears IFF permission `imaging_browser_qc`
-
-12. Test Save button works 
-
-13. Verify Visit-level QC controls and comments can be deleted/unchecked/emptied and saved
-
-14. Test Breadcrumb link back to Imaging Browser
-
-### Main panel:  per acquisition:
-
-15. Files can be downloaded (links clickable) only IFF has permission. Ensure that DICOM downloads are
+### Main panel:  Per Acquisition
+15. Files can be downloaded (links clickable) if and only if user has permission ????. Ensure that DICOM downloads are
 prepended with the Patient Name.
-
-16. Scan-level QC flags (Selected, pass/fail, Caveat emptor) viewable to all, modifiable IFF permission `imaging_browser_qc`. 
-Caveat List link is viewable with the Violated Scans: "View all-sites Violated Scans" permission
-
-17. Selected:  can be set back to Null (blank)
-
-18. Clicking on an image should launch BrainBrowser
-
-19. Clicking on the "QC Comments" button should open the QC comments window
-
-20. Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints
+16. Scan-level QC flags (Selected, pass/fail, Caveat emptor) are viewable to all, modifiable if and only if user has permission `imaging_browser_qc`.  
+17. Caveat List link is viewable with the Violated Scans if and only if user has `View all-sites Violated Scans` permission.
+18. Selected:  can be set back to Null (blank).
+19. Clicking on an image launches the BrainBrowser.
+20. Clicking on the "QC Comments" button opens the QC comments window.
+21. Longitudinal View button launches BrainBrowser with images of the chosen modality for that specific candidate across visits/timepoints.
 
 ### MRI-QC : Scan-level (QC Comments) dialog window
-
-21. With the permission `imaging_browser_qc`, edit comments, checkboxes, and dropdown values. 
-22. Clicking Save should update the values.
-23. Data should not be editable without this permission.
+22. With the permission `imaging_browser_qc`, edit comments, checkboxes, and dropdown values. 
+23. Clicking Save should update the values.
+24. Data should not be editable without this permission.
 
 ### Visit-level QC feedback dialog window
-24. On the view session page, click the button "Visit Level Feedback".
-25. The entries in this dialog should be editable when a user has the permission `imaging_browser_qc`.
-26. Try editing comments (adding new ones, deleting old ones). Click Save and ensure the data is saved.
+25. On the view session page, click the button "Visit Level Feedback".
+26. The entries in this dialog should be editable when a user has the permission `imaging_browser_qc`.
+27. Try editing comments (adding new ones, deleting old ones). Click Save and ensure the data is saved.


### PR DESCRIPTION
## Brief summary of changes

I tried to make the test plan a little bit more clear and consistent with other test plans.

* Removed numbering
* Removed letters in front of sub-headings
* Added backticks to denote permissions
* Changed some wording to be more clear

- [x] Have you updated related documentation?
