### PR TITLE
[Documentation] Fix ReadTheDocs

### DIFF
--- a/docs/wiki/99 - Developers/Automated Testing.md
+++ b/docs/wiki/99 - Developers/Automated Testing.md
@@ -91,7 +91,7 @@ We use Docker to help us simulate a server running LORIS. The installation and u
 
 LORIS uses the [PHPUnit library](https://phpunit.de/) for unit tests.
 
-Unit testing is covered in depth in our [Unit Test Guide](../../../test/UnitTestGuide.md).
+Unit testing is covered in depth in our [Unit Test Guide](test/UnitTestGuide.md).
 
 Unit test files can be found in the folder `test/unittests/`.
 

--- a/docs/wiki/99 - Developers/Automated Testing.md
+++ b/docs/wiki/99 - Developers/Automated Testing.md
@@ -91,7 +91,7 @@ We use Docker to help us simulate a server running LORIS. The installation and u
 
 LORIS uses the [PHPUnit library](https://phpunit.de/) for unit tests.
 
-Unit testing is covered in depth in our [Unit Test Guide](test/UnitTestGuide.md).
+Unit testing is covered in depth in our [Unit Test Guide](https://github.com/aces/Loris/blob/master/test/UnitTestGuide.md).
 
 Unit test files can be found in the folder `test/unittests/`.
 

--- a/docs/wiki/99 - Developers/Automated Testing.md
+++ b/docs/wiki/99 - Developers/Automated Testing.md
@@ -91,7 +91,7 @@ We use Docker to help us simulate a server running LORIS. The installation and u
 
 LORIS uses the [PHPUnit library](https://phpunit.de/) for unit tests.
 
-Unit testing is covered in depth in our [Unit Test Guide](https://github.com/aces/Loris/blob/master/test/UnitTestGuide.md).
+Unit testing is covered in depth in our [Unit Test Guide](../../../test/UnitTestGuide.md).
 
 Unit test files can be found in the folder `test/unittests/`.
 

--- a/docs/wiki/99 - Developers/LORIS-REST-API-0.0.2.md
+++ b/docs/wiki/99 - Developers/LORIS-REST-API-0.0.2.md
@@ -1,1 +1,1 @@
-modules/api/docs/LorisRESTAPI.md
+../../../modules/api/docs/LorisRESTAPI.md

--- a/docs/wiki/99 - Developers/LORIS-REST-API-0.0.2.md
+++ b/docs/wiki/99 - Developers/LORIS-REST-API-0.0.2.md
@@ -1,1 +1,0 @@
-../../../modules/api/docs/LorisRESTAPI.md

--- a/docs/wiki/99 - Developers/LORIS-REST-API-0.0.2.md
+++ b/docs/wiki/99 - Developers/LORIS-REST-API-0.0.2.md
@@ -1,0 +1,1 @@
+../../../modules/api/docs/LorisRESTAPI.md

--- a/docs/wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md
+++ b/docs/wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md
@@ -1,1 +1,1 @@
-modules/api/docs/LorisRESTAPI_v0.0.3.md
+../../../modules/api/docs/LorisRESTAPI_v0.0.3.md

--- a/docs/wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md
+++ b/docs/wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md
@@ -1,1 +1,0 @@
-../../../modules/api/docs/LorisRESTAPI_v0.0.3.md

--- a/docs/wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md
+++ b/docs/wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md
@@ -1,0 +1,1 @@
+../../../modules/api/docs/LorisRESTAPI_v0.0.3.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,8 @@ nav:
     - Getting Started: 'wiki/02 - GETTING STARTED/README.md'
     - Help and Troubleshooting: 'wiki/03 - HELP AND TROUBLESHOOTING/README.md'
     - REST API:
-        - 'Stable' : 'wiki/99 - Developers/LORIS-REST-API-0.0.2.md'
-        - 'Dev' : 'wiki/99 - Developers/LORIS-REST-API-0.0.3-dev.md'
+        - 'Stable' : '../../../modules/api/docs/LorisRESTAPI.md'
+        - 'Dev' : '../../../modules/api/docs/LorisRESTAPI_v0.0.3.md'
     - Developers: 
         - 'Overview': 'wiki/99 - Developers/README.md'
         - 'Coding Standards': 'CodingStandards.md'


### PR DESCRIPTION
## Brief summary of changes
Fix issues in Pull Request #6276 and try to fix ReadTheDocs based on @johnsaigle's comments. The build passed this time for my forked repository as shown in the snapshot. However, there is a warning in the build log saying that the file the link points to is outside the docs folder.
![image](https://user-images.githubusercontent.com/42322196/78588529-d2374680-780c-11ea-849f-cd3ea07648d5.png)
- [x] Have you updated related documentation?

Haowei Qiu, GSOC Applicant
CC @christinerogers 

#### Testing instructions (if applicable)

1. Build with ReadTheDocs.

#### Link(s) to related issue(s)

* Resolves #6209   (Reference the issue this fixes, if any.)
