### PR TITLE
Fix broken links to MCIN websites in README; cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,6 @@ If you would like to contribute to LORIS development, please consult our [Contri
 
 LORIS is made by staff developers at the [McGill Centre for Integrative Neuroscience](http://www.mcin.ca), led by Alan Evans and Samir Das at The Neuro (Montreal Neurological Institute-Hospital).
 
-Visit [the LORIS website](http://loris.ca) for the history of LORIS and our **Technical Papers**.
+Visit [the LORIS website](https://loris.ca) for the history of LORIS and our **Technical Papers**.
 
 The original (pre-GitHub) LORIS development team from 1999-2010 included: Dario Vins, Alex Zijdenbos, Jonathan Harlap, Matt Charlet, Andrew Corderey, Sebastian Muehlboeck, and Samir Das.  

--- a/README.md
+++ b/README.md
@@ -108,15 +108,14 @@ such as the OS you're using, your PHP and Apache versions, etc.
 
 ## Contributing
 
-The [LORIS team](http://loris.ca) at the Montreal Neurological Institute (MNI) is very happy to get code contributions and features from the global LORIS community. 
+We are very happy to get code contributions and features from the global LORIS community. 
 
-### Contributing Code
 If you would like to contribute to LORIS development, please consult our [Contributing Guide](./CONTRIBUTING.md).
 
 ## Powered by MCIN
 
-LORIS is made by staff developers at the McGill Centre for Integrative Neuroscience ([MCIN.ca](www.mcin.ca)), led by Alan Evans and Samir Das at the Montreal Neurological Institute. 
+LORIS is made by staff developers at the [McGill Centre for Integrative Neuroscience](http://www.mcin.ca), led by Alan Evans and Samir Das at The Neuro (Montreal Neurological Institute-Hospital).
 
-See [LORIS.ca](www.loris.ca) for our current team, the history of LORIS, and our **Technical Papers**.
+Visit [the LORIS website](http://loris.ca) for the history of LORIS and our **Technical Papers**.
 
 The original (pre-GitHub) LORIS development team from 1999-2010 included: Dario Vins, Alex Zijdenbos, Jonathan Harlap, Matt Charlet, Andrew Corderey, Sebastian Muehlboeck, and Samir Das.  


### PR DESCRIPTION
## Brief summary of changes

* Fix broken link to LORIS webiste
* Fix broken link to MCIN website
* Change wording to "The Neuro" (this is recommended branding by the institution)
* Remove superfluous subheader
* Remove sudden change from first- to third-person writing style

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Make sure the links work.