### PR TITLE
[Imaging Browser] Reformat SQL commands in row provisioner

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -71,15 +71,15 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
             $newQueryCase = '';
             foreach ($scan_id_types as $key => $value) {
                 if ($isFirst) {
-                    $acqpif       = "IF(FIND_IN_SET({$key},GROUP_CONCAT(
-                        DISTINCT AcquisitionProtocolID))>0 ";
-                    $newQueryCase = "AND(FIND_IN_SET({$key},GROUP_CONCAT(
-                        DISTINCT AcquisitionProtocolID))";
+                    $acqpif       = "IF(FIND_IN_SET({$key},GROUP_CONCAT(\n".
+                        "DISTINCT AcquisitionProtocolID))>0 ";
+                    $newQueryCase = "AND(FIND_IN_SET({$key},GROUP_CONCAT(\n".
+                        "DISTINCT AcquisitionProtocolID))";
                 } else {
-                    $acqpif       .= "OR FIND_IN_SET({$key},GROUP_CONCAT(
-                        DISTINCT AcquisitionProtocolID))>0 ";
-                    $newQueryCase .= " OR FIND_IN_SET({$key},GROUP_CONCAT(
-                        DISTINCT AcquisitionProtocolID))";
+                    $acqpif       .= "OR FIND_IN_SET({$key},GROUP_CONCAT(\n".
+                        "DISTINCT AcquisitionProtocolID))>0 ";
+                    $newQueryCase .= " OR FIND_IN_SET({$key},GROUP_CONCAT(\n".
+                        "DISTINCT AcquisitionProtocolID))";
                 }
                 $isFirst = false;
             }
@@ -91,14 +91,13 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
             $newQueryCase ='';
         }
 
-        $NewDataSubquery = "
-            CASE 
-                COALESCE(Max(fqc.QCLastChangeTime), 'new')
-                WHEN 'new' THEN {$acqpif}
-                WHEN ''    THEN {$acqpif}
-                WHEN NULL  THEN {$acqpif}
-                ELSE ''
-            END";
+        $NewDataSubquery = "CASE\n".
+                "COALESCE(Max(fqc.QCLastChangeTime), 'new')\n".
+                "WHEN 'new' THEN {$acqpif}\n".
+                "WHEN ''    THEN {$acqpif}\n".
+                "WHEN NULL  THEN {$acqpif}\n".
+                "ELSE ''\n".
+            "END";
 
         // =====================================================
         // Create Pending Fail and Pending New subquery
@@ -112,30 +111,26 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
             $pass[$id]          = $type . 'pass';
             $qc[$id]            = $type . 'QC';
             $coalesce_desc[$id] = $pass[$id] . '.' . $qc[$id];
-            $case_desc[$id]     = "
-                CASE
-                    COALESCE($coalesce_desc[$id], '')
-                    WHEN '' THEN ''
-                    WHEN 1 THEN 'Passed'
-                    WHEN 2 THEN 'Failed'
-                END";
+            $case_desc[$id]     = "CASE\n".
+                    "COALESCE($coalesce_desc[$id], '')\n".
+                    "WHEN '' THEN ''\n".
+                    "WHEN 1 THEN 'Passed'\n".
+                    "WHEN 2 THEN 'Failed'\n".
+                "END";
         }
 
-        $PendingFailSubquery = "
-            CASE s.MRIQCStatus
-                WHEN 'Fail' THEN
-                    IF(s.MRIQCPending='Y', 'Pending Fail', 'Fail')
-                WHEN 'Pass' THEN
-                    IF(s.MRIQCPending='Y', 'Pending Pass', 'Pass') 
-                ELSE s.MRIQCStatus
-            END 
-            ";
+        $PendingFailSubquery = "CASE s.MRIQCStatus\n".
+                "WHEN 'Fail' THEN\n" .
+                    "IF(s.MRIQCPending='Y', 'Pending Fail', 'Fail')".
+                "WHEN 'Pass' THEN\n".
+                    "IF(s.MRIQCPending='Y', 'Pending Pass', 'Pass')\n".
+                "ELSE s.MRIQCStatus\n".
+            "END\n";
 
-        $PendingNewquery = "
-            CASE 
-                WHEN s.MRIQCPending='Y' THEN 'P'
-                WHEN MAX(fqc.QCFirstChangeTime) IS NULL $newQueryCase THEN  'N'      
-            END";
+        $PendingNewquery = "CASE\n".
+                "WHEN s.MRIQCPending='Y' THEN 'P'\n".
+                "WHEN MAX(fqc.QCFirstChangeTime) IS NULL $newQueryCase THEN  'N'\n".
+            "END\n";
 
         // ====================================================
         // Create left join to include QC status for specific
@@ -144,17 +139,14 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
 
         $left_joins = "";
         foreach ($case_desc as $key => $value) {
-            $left_joins .= "
-            LEFT JOIN (
-              SELECT files.SessionID, 
-                MIN(files_qcstatus.QCStatus+0) as $qc[$key] 
-              FROM files 
-              JOIN files_qcstatus USING (FileID) 
-              WHERE files.AcquisitionProtocolID= $key 
-                AND files_qcstatus.QCStatus IN (1, 2) 
-              GROUP BY files.SessionID) $pass[$key] 
-                ON ($pass[$key].SessionID=f.SessionID
-            ) ";
+            $left_joins .= "LEFT JOIN (\n".
+                "SELECT files.SessionID,\n".
+                "MIN(files_qcstatus.QCStatus+0) as $qc[$key]\n".
+              "FROM files JOIN files_qcstatus USING (FileID)\n".
+              "WHERE files.AcquisitionProtocolID= $key\n".
+                "AND files_qcstatus.QCStatus IN (1, 2)\n".
+                "GROUP BY files.SessionID) $pass[$key]\n".
+                "ON ($pass[$key].SessionID=f.SessionID) ";
         }
 
         // ===============================================
@@ -174,42 +166,31 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // =================================================
 
         parent::__construct(
-            "SELECT 
-              p.Name as Site,
-              c.PSCID as PSCID,
-              c.CandID as DCCID,
-              Project.Name as project,
-              s.Visit_label as visitLabel,
-              $PendingFailSubquery as Visit_QC_Status,
-              DATE_FORMAT(MIN(pf.Value), \"%Y-%m-%d\") as First_Acquisition,
-              FROM_UNIXTIME(MIN(f.InsertTime)) as First_Insertion,
-              FROM_UNIXTIME(MAX(fqc.QCLastChangeTime)) as Last_QC,
-              $NewDataSubquery as New_Data,
-              GROUP_CONCAT(DISTINCT OutputType) as Links,
-              s.ID as sessionID,
-              GROUP_CONCAT(DISTINCT modality.Scan_type) as sequenceType,
-              $PendingNewquery as pending," .
-              ($modalities_subquery==''?'':"$modalities_subquery,") .
-              "s.CenterID as CenterID,
-              c.Entity_type as entityType,
-              s.ProjectID
-            FROM psc AS p 
-              JOIN session s ON (s.CenterID=p.CenterID) 
-              JOIN candidate c ON (c.CandID=s.CandID) 
-              LEFT JOIN Project ON (s.ProjectID=Project.ProjectID)
-              JOIN files f ON (f.SessionID=s.ID) 
-              LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID) 
-              JOIN parameter_file pf ON (f.FileID=pf.FileID)
-              JOIN parameter_type pt USING (ParameterTypeID)
-              LEFT JOIN mri_scan_type modality ON 
-                (f.AcquisitionProtocolID=modality.ID)
-              $left_joins 
-            WHERE 
-              s.Active = 'Y' AND
-              f.FileType='mnc'
-            GROUP BY s.ID
-            ORDER BY c.PSCID, s.Visit_label
-            ",
+            "SELECT p.Name as Site, c.PSCID as PSCID, c.CandID as DCCID,\n".
+            "Project.Name as project, s.Visit_label as visitLabel,".
+            $PendingFailSubquery . " as Visit_QC_Status,\n".
+            "DATE_FORMAT(MIN(pf.Value), \"%Y-%m-%d\") as First_Acquisition,\n".
+            "FROM_UNIXTIME(MIN(f.InsertTime)) as First_Insertion,\n".
+            "FROM_UNIXTIME(MAX(fqc.QCLastChangeTime)) as Last_QC,\n".
+            $NewDataSubquery . " as New_Data,\n".
+            "GROUP_CONCAT(DISTINCT OutputType) as Links,".
+            "s.ID as sessionID,\n".
+            "GROUP_CONCAT(DISTINCT modality.Scan_type) as sequenceType,\n".
+            $PendingNewquery . " as pending, ".
+            ($modalities_subquery==''?'':"$modalities_subquery,\n").
+            "s.CenterID as CenterID, c.Entity_type as entityType, s.ProjectID ".
+            "FROM psc AS p \n".
+            "JOIN session s ON (s.CenterID=p.CenterID)\n".
+            "JOIN candidate c ON (c.CandID=s.CandID)\n".
+            "LEFT JOIN Project ON (s.ProjectID=Project.ProjectID)\n".
+            "JOIN files f ON (f.SessionID=s.ID)\n".
+            "LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID)\n".
+            "JOIN parameter_file pf ON (f.FileID=pf.FileID)\n".
+            "JOIN parameter_type pt USING (ParameterTypeID)\n".
+            "LEFT JOIN mri_scan_type modality ON\n".
+            "  (f.AcquisitionProtocolID=modality.ID)\n".
+            $left_joins . " WHERE s.Active = 'Y' AND f.FileType='mnc'\n".
+            "GROUP BY s.ID ORDER BY c.PSCID, s.Visit_label",
             array()
         );
     }


### PR DESCRIPTION
## Brief summary of changes
This is the recreation of the PR #6096, which I gave up but since I worked today on the imaging browser module, I feel that this PR should be reactivated, with the @PapillonMcGill suggested modifications included

This improvement is only to remove some empty spaces, try also to preserve readability with the aggressive commit `6efed57`. This PR might not be necessary. The PR doesn't change any code behavior or solve any bug. Only to improve a little bit error log when I noticed that the customer error report is not readable, an example is like the following: 

[Fri&nbsp;Feb&nbsp;21&nbsp;16:09:51.361873&nbsp;2020]&nbsp;[php7:error]&nbsp;[pid&nbsp;25261]&nbsp;[clientlocalhost]&nbsp;PHP&nbsp;Fatal&nbsp;error:&nbsp;&nbsp;Uncaught&nbsp;Exception:&nbsp;Invalid&nbsp;SQL&nbsp;statement:&nbsp;SELECT&nbsp;\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;p.Name&nbsp;as&nbsp;Site,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c.PSCID&nbsp;as&nbsp;PSCID,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;c.CandID&nbsp;as&nbsp;DCCID,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Project.Name&nbsp;as&nbsp;project,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;s.Visit_label&nbsp;as&nbsp;visitLabel,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CASE&nbsp;s.MRIQCStatus\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;WHEN&nbsp;'Fail'&nbsp;THEN\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;IF(s.MRIQCPending='Y',&nbsp;'Pending&nbsp;Fail',&nbsp;'Fail')\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;WHEN&nbsp;'Pass'&nbsp;THEN\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;IF(s.MRIQCPending='Y',&nbsp;'Pending&nbsp;Pass',&nbsp;'Pass')&nbsp;\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ELSE&nbsp;s.MRIQCStatus\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;END&nbsp;\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;as&nbsp;Visit_QC_Status,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;DATE_FORMAT(MIN(pf.Value),&nbsp;"%Y-%m-%d")&nbsp;as&nbsp;First_Acquisition,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;FROM_UNIXTIME(MIN(f.InsertTime))&nbsp;as&nbsp;First_Insertion,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;FROM_UNIXTIME(MAX(fqc.QCLastChangeTime))&nbsp;as&nbsp;Last_QC,\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CASE&nbsp;\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;COALESCE(Max(fqc.QCLastChangeTime),&nbsp;'new')\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;WHEN&nbsp;'new'&nbsp;THEN&nbsp;'new'\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;WHEN&nbsp;''&nbsp;&nbsp;&nbsp;&nbsp;THEN&nbsp;'new'\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;WHEN&nbsp;NULL&nbsp;&nbsp;THEN&nbsp;'new'\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ELSE&nbsp;''\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;END&nbsp;as&nbsp;New_Da&nbsp;in&nbsp;/var/www/loris/src/Data/Provisioners/DBRowProvisioner.php&nbsp;on&nbsp;line&nbsp;84,&nbsp;referer:&nbsp;http://localhost/imaging_browser/