### PR TITLE
Timepoint list baseurl problem fix

### DIFF
--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -110,38 +110,22 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         if (preg_match("/^([0-9]{6})$/", $components[0])) {
             // FIXME: This assumes the baseURL is under /
             $path    = $uri->getPath();
-            $baseurl = $uri->withPath("/")->withQuery("");
+            $baseurl = $uri->withPath("")->withQuery("");
 
             $factory = \NDB_Factory::singleton();
             $factory->setBaseURL($baseurl);
-            switch (count($components)) {
-                case 1:
-                    $request = $request
-                    ->withAttribute("baseurl", rtrim($baseurl->__toString(), '/'))
-                    ->withAttribute("CandID", $components[0]);
-                    $module  = \Module::factory("timepoint_list");
-                    $mr      = new ModuleRouter($module);
-                    return $mr->handle($request);
-                case 2:
-                    // CandID/SessionID, inherited from htaccess
-                    $request = $request
-                    ->withAttribute("baseurl", $baseurl->__toString())
-                    ->withAttribute("CandID", $components[0]);
-                    // FIXME: Validate CandID is valid before continuing.
-                    $request    = $request
-                    ->withAttribute(
-                        "TimePoint",
-                        \TimePoint::singleton($components[1])
-                    );
-                        $module = \Module::factory("instrument_list");
-                        $mr     = new ModuleRouter($module);
-                    return $mr->handle($request);
-                default:
-                    // Fall through to 404. We don't have any routes that go farther
-                    // than 2 levels..
+            if (count($components) == 1) {
+                $request = $request
+                ->withAttribute("baseurl", $baseurl->__toString())
+                ->withAttribute("CandID", $components[0]);
+                $module  = \Module::factory("timepoint_list");
+                $mr      = new ModuleRouter($module);
+                return $mr->handle($request);
             }
         }
 
+        // Fall through to 404. We don't have any routes that go farther
+        // than 1 level..
         return (new \LORIS\Middleware\PageDecorationMiddleware(
             $this->user
         ))->process(


### PR DESCRIPTION
## Brief summary of changes

This PR solves wrong URL problem in timepoint list at single parameter mode and the 404 error in the #6323. The PRs could be separated, but since the fix was applied to the same file instead of modifying instrument_list module, I just put the PRs together. The work were done in two steps.

Possible issue: if the value doesn't exist, the system will return an empty page with 500 error, #6325 which could be addressed in another PR.

Test directive:

Go to 'candidate profile'
Click on any profile

To test:
The issue #6271
Click on 'Create time point' button in the Actions zone
See the link itself, "v.loris.ca//create_timepoint..."

The correct one should not have double "/"

The issue #6272
Click on 'Candidate Info' button in the Actions zone
See the link itself, "v.loris.ca//candidate_parameters/...."
The correct one should not have double "/"

The issue #6323: (This issue should be considered useless, I remove this feature in the new commit)
When you click on any visit label to access the instrument list, you can see the candidate id, and the session id in the url, use the format `base url / candidate id / session id` to test the 2 parameter mode

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
Issue #6271, #6272 and #6323 