### PR TITLE
[User Accounts] Disable password auto-completion on edit_user page

### DIFF
--- a/modules/my_preferences/templates/form_my_preferences.tpl
+++ b/modules/my_preferences/templates/form_my_preferences.tpl
@@ -1,5 +1,5 @@
 <br />
-<form method="post" name="edit_user" id="edit_user">
+<form method="post" name="my_preferences" id="my_preferences" autocomplete="off">
     <h3>Password Rules</h3>
       <ul>
         <li>The password must be at least 8 characters long.</li>

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -667,7 +667,7 @@ class Edit_User extends \NDB_Form
         $this->addGroup(
             $group,
             'Password_Group',
-            'Password',
+            'New Password',
             $this->_GUIDelimiter,
             false
         );

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -28,7 +28,7 @@
 });
 </script>
 {/literal}
-<form method="post" name="edit_user" autocomplete="new-password">
+<form method="post" name="edit_user" autocomplete="off">
     {if $form.errors}
     <div class="alert alert-danger" role="alert">
         The form you submitted contains data entry errors


### PR DESCRIPTION
## Brief summary of changes

The password field gets auto-completed on the edit_user page. This is a problem because the back-end expects this value to be blank unless you are changing a user's password.

What often happens is that when a user submits an unrelated account change and they get an error message saying that they must change their password.

This is symptomatic of general UI clunkiness in this module. Until it's reworked, disabling autocomplete seems like the best solution.

#### Testing instructions (if applicable)

1. Visit `edit_user` and make sure the password fields are empty when you load the module.

#### Link(s) to related issue(s)

I think this Resolves #6319 
