### PR TITLE
Make bug report template more clear and require less deletion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,29 +7,35 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is
+### Describe the bug
+<!-- A clear and concise description of what the bug is -->
 
-**To Reproduce**
-Steps to reproduce the behavior (attach screenshots if applicable):
+### To Reproduce
+<!--Steps to reproduce the behavior (attach screenshots if applicable):
+    e.g.
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
 
-**What did you expect to happen?**
-A clear and concise description of what you expected to happen.
+### What did you expect to happen?
+<!--A clear and concise description of what you expected to happen. -->
 
-**Browser Environment (please complete the following information):**
-- OS: [e.g. Plan9, HURD, Oberon, etc]
-- Browser [e.g. chrome, firefox] (note that only these two browsers are supported)
-- Version [e.g. 22]
+### Your Environment
+<!--[e.g. MacOS Catalina, Windows 10 -->
+- Your OS: 
+<!-- Only Chrome and Firefox are supported. -->
+- Browser: 
 
-**Server Environment (if known):**
-_Note: We only support the most recent release of LORIS._
-- LORIS Version: [e.g. 22.0.0]
-- Linux distribution and Version: [e.g. Ubuntu 16.04, CentOS 7]
-- MySQL/MariaDB Version: [e.g. MySQL 5.7, MariaDB 10.3]
+### Server Environment (if known):
+<!-- We only support the most recent release of LORIS.
 
-**Additional context**
-Add any other context about the problem here.
+e.g. 22.0.0-->
+- LORIS Version: 
+<!-- e.g. Ubuntu 18.04, CentOS 7 -->
+- Linux distribution and Version:
+<!-- e.g. MySQL 5.7 -->
+- Database Version: 
+
+### Additional context
+<!-- Any other considerations or nuances we should know about. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 <!-- Before opening a new issue, please search for related issues or duplicates. -->
 <!-- For install questions and support for ongoing project, please contact our community listserv: loris-dev [at] bic.mni.mcgill.ca --> 
 ### Describe the bug
-<!-- A clear and concise description of what the bug is -->
+<!-- A clear and concise description of what the bug is, including links to related issues. -->
 
 ### To Reproduce
 <!--Steps to reproduce the behavior (attach screenshots if applicable):

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+<!-- Before opening a new issue, please search for related issues or duplicates. -->
+<!-- For install questions and support for ongoing project, please contact our community listserv: loris-dev [at] bic.mni.mcgill.ca --> 
 ### Describe the bug
 <!-- A clear and concise description of what the bug is -->
 


### PR DESCRIPTION
Modifies the issue template to make use of HTML comments. These will provide explainer text to the author without requiring them to delete a bunch of examples.

Also changes formatting.

The commented code will be displayed to the author but not to others viewing the issue.

This is what will be displayed to people reading the issue:

<img width="529" alt="Screen Shot 2020-04-07 at 13 11 22" src="https://user-images.githubusercontent.com/4022790/78699121-5f43d380-78d1-11ea-8115-1ba00552999d.png">
