### PR TITLE
[Candidate Profile] Add basic test plan

### DIFF
--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -14,17 +14,19 @@ or will not load at all.
     * Imaging QC Summary
     * Behavioural Data
 2. Within the Candidate Info panel:
-    * Click a link under the Vists heading. This should take you to the instrument_list module.
+    * Click a link under the Vists heading. This should take you to the `instrument_list` module.
 3. Click a file under Candidate Media. This should trigger a file download.
 4. Within the Imaging QC Summary panel:
     * Hover over a bar in the chart. A legend should be displayed.
-    * Click a bar in the chart. This should take you to the imaging browser module.
+    * Click a bar in the chart. This should take you to the `imaging_browser` module.
 5. Within the Behavioural Data panel:
     * Hover over a row. It should turn grey.
     * Click a row. It should expand to show instruments associated with the visit.
-    * Click on a link to one of the instruments. This should load the instrument in the instruments module.
+    * Click on a link to one of the instruments. This should load the instrument in the `instruments` module.
 6. Disable one of the modules listed above. This can be done using the `Manage Modules` module. Make sure the corresponding panel disappers from the candidate_profile.
 7. Click the breadcrumb 'Candidate Dashboard...' under the menu bar. This should refresh the page. It should not bring you to the old candidate profile.
 
-Using a user with fewer privileges, visit the same candidate profile. Make sure
-that some of the above panels do not load when you don't have permission.
+Using a user with fewer privileges:
+8. Visit the same candidate profile. Make sure that some of the above panels do not load when you don't have permission. For example, the Candidate Media panel should not load when you do
+not have permissions to view the `media` module.
+9. Try to access a candidate with whom the current user does not share a project or site. You should get message telling you that you do not have access.

--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -1,0 +1,30 @@
+# Candidate Profile (beta) Test Plan
+
+The following tests should be performed by a user with the `superuser` permission.
+This module loads information from many modules so this is the easiest way to
+make sure data from other modules will load properly.
+
+Depending on the permissions the user account has, some of these panels will not function
+or will not load at all.
+
+1. Ensure that data loads in each of the panels on the page:
+    * Candidate Info (basic candidate data)
+    * Consent Summary
+    * Candidate Media
+    * Imaging QC Summary
+    * Behavioural Data
+2. Within the Candidate Info panel:
+    * Click a link under the Vists heading. This should take you to the instrument_list module.
+3. Click a file under Candidate Media. This should trigger a file download.
+4. Within the Imaging QC Summary panel:
+    * Hover over a bar in the chart. A legend should be displayed.
+    * Click a bar in the chart. This should take you to the imaging browser module.
+5. Within the Behavioural Data panel:
+    * Hover over a row. It should turn grey.
+    * Click a row. It should expand to show instruments associated with the visit.
+    * Click on a link to one of the instruments. This should load the instrument in the instruments module.
+6. Disable one of the modules listed above. This can be done using the `Manage Modules` module. Make sure the corresponding panel disappers from the candidate_profile.
+7. Click the breadcrumb 'Candidate Dashboard...' under the menu bar. This should refresh the page. It should not bring you to the old candidate profile.
+
+Using a user with fewer privileges, visit the same candidate profile. Make sure
+that some of the above panels do not load when you don't have permission.


### PR DESCRIPTION
## Brief summary of changes

Adds a basic candidate_profile test plan. I did not develop the module, and it is in beta, so this test plan should be improved upon as things change.

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Follow the test plan and make sure it makes sense.

#### Link(s) to related issue(s)

* Resolves #6207 