### PR TITLE
[candidate_profile] Add help text

### DIFF
--- a/modules/candidate_profile/help/candidate_profile.md
+++ b/modules/candidate_profile/help/candidate_profile.md
@@ -1,0 +1,7 @@
+# Candidate Profile
+
+This module allows you to see a summary of a candidate's information
+across all modules. 
+
+Click on the visit link in the "Candidate Info" card in order to access
+that visit for the candidate.


### PR DESCRIPTION
This adds some help text for the candidate_profile module. The help text is somewhat vague by necessity since it isn't context sensitive and the exact set of cards shown depends on the user's permissions and LORIS install's configurations. It only explains the visit link in the Candidate Info card (which is provided by the module itself and has minimal permissions, so should always be present.)

Fixes #6206