### PR TITLE
[media] use languageLabel derived from language_id to display

### DIFF
--- a/modules/media/jsx/editForm.js
+++ b/modules/media/jsx/editForm.js
@@ -40,6 +40,7 @@ class MediaEditForm extends Component {
           dateTaken: data.mediaData.dateTaken,
           comments: data.mediaData.comments,
           hideFile: data.mediaData.hideFile,
+          language: data.mediaData.language,
         };
 
         self.setState({
@@ -136,6 +137,7 @@ class MediaEditForm extends Component {
           />
           <SelectElement
             name='language'
+            id='language_id'
             label='Language'
             options={this.state.Data.language}
             onUserInput={this.setFormData}


### PR DESCRIPTION
## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

- go to media module, check if language of document is properly displayed in table
- edit a document with a language, current language should be displayed in the edit window.
- modify the language and check that change are properly reflected in table

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
https://github.com/aces/Loris/issues/6312