### PR TITLE
[candidate_parameters] Update testing plan info of permission role needed

### DIFF
--- a/modules/candidate_parameters/test/TestPlan.md
+++ b/modules/candidate_parameters/test/TestPlan.md
@@ -3,6 +3,7 @@
 1. Check Permissions:
     * _candidate_parameter_view_ (_View Candidate Parameters_) permission (you should not be able to edit fields)
 	* _candidate_parameter_edit_ (_Edit Candidate Parameters_) permission (you should be able to edit fields)
+	* The user role in permissions should be set to Data entry. 
 	* You need to belong to the same site as the candidate you are accessing, unless...
 	* If you have _access_all_profiles_ you should be able to access all candidate profiles (even without candidate_parameters permissions)
 2. Make sure that the candidate date of birth and sex in the table at the top of the page, match what is stored in the candidate table for this given candidate.

--- a/modules/candidate_parameters/test/TestPlan.md
+++ b/modules/candidate_parameters/test/TestPlan.md
@@ -3,7 +3,7 @@
 1. Check Permissions:
     * _candidate_parameter_view_ (_View Candidate Parameters_) permission (you should not be able to edit fields)
 	* _candidate_parameter_edit_ (_Edit Candidate Parameters_) permission (you should be able to edit fields)
-	* The user role in permissions should be set to Data entry. 
+	* The user should have the Data Entry permission
 	* You need to belong to the same site as the candidate you are accessing, unless...
 	* If you have _access_all_profiles_ you should be able to access all candidate profiles (even without candidate_parameters permissions)
 2. Make sure that the candidate date of birth and sex in the table at the top of the page, match what is stored in the candidate table for this given candidate.


### PR DESCRIPTION
## Brief summary of changes

Updates testing plan to let the user testing know they need the role of data entry in permissions.

#### Link(s) to related issue(s)

https://github.com/aces/Loris/issues/6275
