### PR TITLE
[DataFramework Filters] Check Site Permissions Filter

### DIFF
--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -47,7 +47,7 @@ class Candidate_List extends \DataFrameworkMenu
      */
     public function useSiteFilter() : bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -56,7 +56,7 @@ class Candidate_List extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return ['access_all_profiles'];
     }

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -40,17 +40,6 @@ class Candidate_List extends \DataFrameworkMenu
     }
 
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserSiteMatch filter.
-     *
-     * @return bool always true
-     */
-    public function useSiteFilter() : bool
-    {
-        return true;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -47,7 +47,18 @@ class Candidate_List extends \DataFrameworkMenu
      */
     public function useSiteFilter() : bool
     {
-        return true;
+        return false;
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return ['access_all_profiles'];
     }
 
     /**

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -40,18 +40,6 @@ class Datadict extends \DataFrameworkMenu
     }
 
     /**
-     * The data dictionary has no sites affiliated with it and as
-     * such can not add site filters without an exception being
-     * thrown
-     *
-     * @return bool
-     */
-    public function useSiteFilter() : bool
-    {
-        return false;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -57,7 +57,7 @@ class Datadict extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return null;
     }

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -52,6 +52,17 @@ class Datadict extends \DataFrameworkMenu
     }
 
     /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return null;
+    }
+
+    /**
      * Returns a list of instruments to use as the "Source From"
      * filter options
      *

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -41,17 +41,6 @@ class Dicom_Archive extends \DataFrameworkMenu
     }
 
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserSiteMatch filter.
-     *
-     * @return bool always false
-     */
-    public function useSiteFilter() : bool
-    {
-        return true;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -52,6 +52,17 @@ class Dicom_Archive extends \DataFrameworkMenu
     }
 
     /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return ['dicom_archive_view_allsites'];
+    }
+
+    /**
      * Tells the base class that this page's provisioner can support
      * the UserProjectMatch filter.
      *

--- a/modules/dicom_archive/php/dicom_archive.class.inc
+++ b/modules/dicom_archive/php/dicom_archive.class.inc
@@ -48,7 +48,7 @@ class Dicom_Archive extends \DataFrameworkMenu
      */
     public function useSiteFilter() : bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -57,7 +57,7 @@ class Dicom_Archive extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return ['dicom_archive_view_allsites'];
     }

--- a/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
@@ -51,7 +51,18 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
      */
     public function useSiteFilter(): bool
     {
-        return true;
+        return false;
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return ['electrophysiology_browser_view_allsites'];
     }
 
     /**

--- a/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
@@ -44,17 +44,6 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
     }
 
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserSiteMatch filter.
-     *
-     * @return bool always true
-     */
-    public function useSiteFilter(): bool
-    {
-        return true;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *

--- a/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiology_browser.class.inc
@@ -51,7 +51,7 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
      */
     public function useSiteFilter(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -60,7 +60,7 @@ class Electrophysiology_Browser extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return ['electrophysiology_browser_view_allsites'];
     }

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -67,6 +67,17 @@ class Imaging_Browser extends \DataFrameworkMenu
     }
 
     /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return null;
+    }
+
+    /**
      * The imaging browser uses the image session's project for filtering projects.
      *
      * @return bool

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -56,17 +56,6 @@ class Imaging_Browser extends \DataFrameworkMenu
     }
 
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserSiteMatch filter.
-     *
-     * @return bool always false
-     */
-    public function useSiteFilter() : bool
-    {
-        return false;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *
@@ -74,7 +63,10 @@ class Imaging_Browser extends \DataFrameworkMenu
      */
     public function allSitePermissionNames() : ?array
     {
-        return null;
+        return [
+            'imaging_browser_view_allsites',
+            'imaging_browser_phantom_allsites',
+        ];
     }
 
     /**

--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -72,7 +72,7 @@ class Imaging_Browser extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return null;
     }

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -54,7 +54,18 @@ class Media extends \DataFrameworkMenu
      */
     public function useSiteFilter(): bool
     {
-        return true;
+        return false;
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return ['access_all_profiles'];
     }
 
     /**

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -54,7 +54,7 @@ class Media extends \DataFrameworkMenu
      */
     public function useSiteFilter(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -63,7 +63,7 @@ class Media extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return ['access_all_profiles'];
     }

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -47,17 +47,6 @@ class Media extends \DataFrameworkMenu
     }
 
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserSiteMatch filter.
-     *
-     * @return bool true
-     */
-    public function useSiteFilter(): bool
-    {
-        return true;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -26,17 +26,6 @@ namespace LORIS\module_manager;
 class Module_Manager extends \DataFrameworkMenu
 {
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserSiteMatch filter.
-     *
-     * @return bool true
-     */
-    public function useSiteFilter(): bool
-    {
-        return false;
-    }
-
-    /**
      * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -42,7 +42,7 @@ class Module_Manager extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return null;
     }

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -37,6 +37,17 @@ class Module_Manager extends \DataFrameworkMenu
     }
 
     /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return null;
+    }
+
+    /**
      * Tells the base class that this page's provisioner can support
      * the UserProjectMatch filter.
      *

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -47,6 +47,17 @@ class Survey_Accounts extends \DataFrameworkMenu
     }
 
     /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function useSitePermissionsFilter() : ?array
+    {
+        return null;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @return bool

--- a/modules/survey_accounts/php/survey_accounts.class.inc
+++ b/modules/survey_accounts/php/survey_accounts.class.inc
@@ -52,7 +52,7 @@ class Survey_Accounts extends \DataFrameworkMenu
      *
      * @return ?array of site permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return null;
     }

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -46,7 +46,7 @@ class User_Accounts extends \DataFrameworkMenu
      */
     public function useSiteFilter() : bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -55,7 +55,7 @@ class User_Accounts extends \DataFrameworkMenu
      *
      * @return ?array of permissions or null
      */
-    public function useSitePermissionsFilter() : ?array
+    public function allSitePermissionNames() : ?array
     {
         return ['user_account_multisite'];
     }

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -40,13 +40,13 @@ class User_Accounts extends \DataFrameworkMenu
 
     /**
      * Tells the base class that this page's provisioner can support the
-     * UserSiteMatch filter.
+     * HasAnyPermissionOrUserSiteMatch filter.
      *
-     * @return bool true
+     * @return ?array of permissions or null
      */
-    public function useSiteFilter() : bool
+    public function useSitePermissionsFilter() : ?array
     {
-        return true;
+        return ['user_account_multisite'];
     }
 
     /**

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -40,6 +40,17 @@ class User_Accounts extends \DataFrameworkMenu
 
     /**
      * Tells the base class that this page's provisioner can support the
+     * UserSiteMatch filter.
+     *
+     * @return bool
+     */
+    public function useSiteFilter() : bool
+    {
+        return false;
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *
      * @return ?array of permissions or null

--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -40,17 +40,6 @@ class User_Accounts extends \DataFrameworkMenu
 
     /**
      * Tells the base class that this page's provisioner can support the
-     * UserSiteMatch filter.
-     *
-     * @return bool
-     */
-    public function useSiteFilter() : bool
-    {
-        return true;
-    }
-
-    /**
-     * Tells the base class that this page's provisioner can support the
      * HasAnyPermissionOrUserSiteMatch filter.
      *
      * @return ?array of permissions or null

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -67,6 +67,15 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
     abstract public function useSiteFilter() : bool;
 
     /**
+     * Determines whether the DataProvisioner should filter out rows based on user's
+     * site viewing permissions.
+     *
+     * @return ?array of permissions to check or null
+     */
+    abstract public function useSitePermissionsFilter() : ?array;
+
+
+    /**
      * Determines whether the DataProvisioner should filter out rows which
      * do not match the user's project.
      *
@@ -106,11 +115,17 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
         // UserSiteMatch throws an exception if used on a model without a getCenterID
         // or getCenterIDs function, so we only apply it on sub-classes that
         // specifically say they support it.
-        if ($this->useSiteFilter()
-            && $user->hasPermission("access_all_profiles") == false
-        ) {
+        if ($this->useSiteFilter()) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\UserSiteMatch()
+            );
+        }
+
+        if ($this->useSitePermissionsFilter()) {
+            $provisioner = $provisioner->filter(
+                new \LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch(
+                    $this->useSitePermissionsFilter()
+                )
             );
         }
 

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -110,8 +110,6 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
     {
         $provisioner = $this->getBaseDataProvisioner();
 
-        $user = \NDB_Factory::singleton()->user();
-
         // UserSiteMatch throws an exception if used on a model without a getCenterID
         // or getCenterIDs function, so we only apply it on sub-classes that
         // specifically say they support it.

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -59,12 +59,14 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
     }
 
     /**
-     * Determines whether the DataProvisioner should filter out rows which
-     * do not match the user's site.
+     * Determines which site permission(s) should be used to determine
+     * whether or not non-user sites are filtered out. If the user has
+     * any of the permissions, non-user sites are *NOT* filtered out.
+     * If the result is null, the page does not use site filters at all.
      *
-     * @return bool true if the data provisioner should filter non-matching sites.
+     * @return ?array
      */
-    abstract public function useSiteFilter() : bool;
+    abstract public function allSitePermissionNames() : ?array;
 
     /**
      * Determines whether the DataProvisioner should filter out rows based on user's
@@ -113,10 +115,11 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
         // UserSiteMatch throws an exception if used on a model without a getCenterID
         // or getCenterIDs function, so we only apply it on sub-classes that
         // specifically say they support it.
-        if ($this->useSiteFilter() || $this->allSitePermissionNames) {
+        $allSitePerms = $this->allSitePermissionNames();
+        if ($allSitePerms != null) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch(
-                    $this->allSitePermissionNames()
+                    $allSitePerms
                 )
             );
         }

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -72,7 +72,7 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
      *
      * @return ?array of permissions to check or null
      */
-    abstract public function useSitePermissionsFilter() : ?array;
+    abstract public function allSitePermissionNames() : ?array;
 
 
     /**
@@ -113,16 +113,10 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
         // UserSiteMatch throws an exception if used on a model without a getCenterID
         // or getCenterIDs function, so we only apply it on sub-classes that
         // specifically say they support it.
-        if ($this->useSiteFilter()) {
-            $provisioner = $provisioner->filter(
-                new \LORIS\Data\Filters\UserSiteMatch()
-            );
-        }
-
-        if ($this->useSitePermissionsFilter()) {
+        if ($this->useSiteFilter() || $this->allSitePermissionNames) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch(
-                    $this->useSitePermissionsFilter()
+                    $this->allSitePermissionNames()
                 )
             );
         }

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -68,14 +68,6 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
      */
     abstract public function allSitePermissionNames() : ?array;
 
-    /**
-     * Determines whether the DataProvisioner should filter out rows based on user's
-     * site viewing permissions.
-     *
-     * @return ?array of permissions to check or null
-     */
-    abstract public function allSitePermissionNames() : ?array;
-
 
     /**
      * Determines whether the DataProvisioner should filter out rows which


### PR DESCRIPTION
## Brief summary of changes
This PR adds a new abstract function to the DataFrameworkMenu: `useSitePermissionsFilter`. This function is meant to signal to the base class that the page's provisioner can support the `HasAnyPermissionOrUserSiteMatch` filter. 

This is needed because currently there is no way to signal to the provisioner that the user has an "across all sites" type of permission for the data being retrieved, and should therefore not filter based on site match.

#### Testing instructions (if applicable)

1. Go through the affected modules and make sure the data tables are filtered properly according to their related site access permissions. 
- [ ] candidate_list:  `access_all_profiles`
- [ ] dicom_archive: `dicom_archive_view_allsites`
- [ ] eeg_browser: `electrophysiology_browser_view_allsites`
- [ ] media: `access_all_profiles`
- [ ] user_accounts: `user_account_multisite`

Should remain unaffected, but should check functionality:
- [ ] datadict
- [ ] imaging_broswer
- [ ] module_manager
- [ ] survery_accounts

#### Link(s) to related issue(s)
* Resolves #  (Reference the issue this fixes, if any.)
#6350
