### PR TITLE
[electrophysiology_browser] Fix session breadcrumb

### DIFF
--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -36,6 +36,7 @@ class Sessions extends \NDB_Page
 
     public $skipTemplate = true; // stops from looking for a smarty template
     protected $timepoint;
+    protected $sessionID;
 
     /**
      * Determine whether the user has permission to view this page
@@ -82,6 +83,7 @@ class Sessions extends \NDB_Page
             $this->timepoint = \NDB_Factory::singleton()->timepoint(
                 $session_id
             );
+            $this->sessionID = $session_id;
         } catch(\LorisException $e) {
             return (new \LORIS\Middleware\PageDecorationMiddleware($user))
                 ->process(
@@ -126,19 +128,18 @@ class Sessions extends \NDB_Page
             ));
         }
 
-        return $this->getSessionData($session_id, $outputType);
+        return $this->getSessionData($outputType);
     }
 
 
     /**
      * Get the session data information.
      *
-     * @param int    $sessionID  ID of the session to display
      * @param string $outputType output type to be displayed
      *
      * @return ResponseInterface The JSON response
      */
-    function getSessionData($sessionID, $outputType)
+    function getSessionData($outputType)
     {
         $db = \NDB_Factory::singleton()->database();
 
@@ -161,10 +162,10 @@ class Sessions extends \NDB_Page
         $sessions            = array_column($sessions, 'SessionID');
         $response['patient'] = $this->getSubjectData($outputType);
         $response['database']    = array_values(
-            $this->getFilesData($sessionID, $outputType)
+            $this->getFilesData($outputType)
         );
         $response['sessions']    = $sessions;
-        $currentIndex            = array_search($sessionID, $sessions);
+        $currentIndex            = array_search($this->sessionID, $sessions);
         $response['nextSession'] = $sessions[$currentIndex+1] ?? '';
         $response['prevSession'] = $sessions[$currentIndex-1] ?? '';
 
@@ -204,18 +205,17 @@ class Sessions extends \NDB_Page
     /**
      * Get the list of electrophysiology recordings with their recording information.
      *
-     * @param int    $sessionID  ID of the electrophysiology session
      * @param string $outputType output type to be displayed
      *
      * @return array with the file collection
      */
-    function getFilesData(int $sessionID, string $outputType)
+    function getFilesData(string $outputType)
     {
         $db = \NDB_Factory::singleton()->database();
 
         $fileCollection = array();
         $params         = array();
-        $params['SID']  = $sessionID;
+        $params['SID']  = $this->sessionID;
         $query          = 'SELECT 
                          pf.PhysiologicalFileID, 
                          pf.FilePath 
@@ -456,6 +456,25 @@ class Sessions extends \NDB_Page
             )
         );
         return $depends;
+    }
+
+    /**
+     * Generate a breadcrumb trail for this page.
+     *
+     * @return \LORIS\BreadcrumbTrail
+     */
+    public function getBreadcrumbs(): \LORIS\BreadcrumbTrail
+    {
+        return new \LORIS\BreadcrumbTrail(
+            new \LORIS\Breadcrumb(
+                'Electrophysiology Browser',
+                '/electrophysiology_browser'
+            ),
+            new \LORIS\Breadcrumb(
+                'View Session',
+                "/electrophysiology_browser/sessions/$this->sessionID"
+            )
+        );
     }
 
 }


### PR DESCRIPTION
## Brief summary of changes

This fixes the broken breadcrumb on the electrophysiology browser session page.

#### Testing instructions (if applicable)

1. Check that the Session breadcrumb works on an electrophysiology session page.

#### Link(s) to related issue(s)

* Resolves #6212 