### PR TITLE
[smarty template] add possible go back one page function

### DIFF
--- a/smarty/templates/403.tpl
+++ b/smarty/templates/403.tpl
@@ -1,4 +1,4 @@
 <div class="container">
     <h3>{$message}</h3>
-    <div><a href="{$baseurl}">Go to main page</a></div>
+    <div><a href="{$baseurl}">Go to main page</a> | <a onclick="window.history.back();" href="#">Go back one page</a></div>
 </div>


### PR DESCRIPTION
## Brief summary of changes
Add possibility to go back one page because if the permission control kicks in, we have to return to the home page if we don't know click on the browser back button

The #6266 is hard to do optimistically because imaging browser and instrument list are presented as two independent modules. The current solution could solve the similar problem in any module.

#### Testing instructions (if applicable)

1. Click on any link that you don't have the permission, like a profile imaging data link, then the system will ask you to go back to the home page, you will have to start over again to navigate through the system.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
Partially resolves #6266