### PR TITLE
[MRI Violations] Fixed bug in filter of the MRI violations module.

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -109,7 +109,8 @@ INSERT INTO `permissions` VALUES
     (61,'battery_manager_edit','Add, activate, and deactivate entries in Test Battery',2),
     (62,'module_manager_view', 'Module Manager: access the module', 2),
     (63,'module_manager_edit', 'Module Manager: edit installed modules', 2),
-    (64,'candidate_dod_edit', 'Edit dates of death', 2);
+    (64,'candidate_dod_edit', 'Edit dates of death', 2)
+    (65,'violated_scans_view_ownsite','Violated Scans: View Violated Scans from own site','2');
 
 INSERT INTO `user_perm_rel` (userID, permID)
   SELECT u.ID, p.permID

--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -109,7 +109,7 @@ INSERT INTO `permissions` VALUES
     (61,'battery_manager_edit','Add, activate, and deactivate entries in Test Battery',2),
     (62,'module_manager_view', 'Module Manager: access the module', 2),
     (63,'module_manager_edit', 'Module Manager: edit installed modules', 2),
-    (64,'candidate_dod_edit', 'Edit dates of death', 2)
+    (64,'candidate_dod_edit', 'Edit dates of death', 2),
     (65,'violated_scans_view_ownsite','Violated Scans: View Violated Scans from own site','2');
 
 INSERT INTO `user_perm_rel` (userID, permID)

--- a/SQL/New_patches/2020-04-27-AddViolatedScansOwnSitePermission.sql
+++ b/SQL/New_patches/2020-04-27-AddViolatedScansOwnSitePermission.sql
@@ -1,0 +1,8 @@
+INSERT INTO permissions (code, description, categoryID) VALUES
+    ('violated_scans_view_ownsite','Violated Scans: View Violated Scans from own site','2');
+    
+INSERT INTO user_perm_rel VALUES
+    (
+     (SELECT ID FROM users WHERE UserID='admin'),
+     (SELECT permID FROM permissions WHERE code='violated_scans_view_ownsite')
+    );

--- a/modules/mri_violations/README.md
+++ b/modules/mri_violations/README.md
@@ -54,16 +54,10 @@ flag should have either a drop down menu or open text for the person
 approving the insertion to indicate what the flag is for
 - **Other**: resolutions that don't fit in any of the above categories 
 
-Finally, the `mri_protocol` table can be updated directly from
-the frontend if the user has the permission for it.
-
 ## Permissions
 
-The permission `violated_scans_view_allsites` is required to access
-the MRI violated module.
-
-In addition, the permission `violated_scans_edit` allows the user to
-edit the `mri_protocol` table directly from the browser.
+To access the MRI violated module, one must have either the `violated_scans_view_allsites`
+or the `violated_scans_view_ownsites` permission.
 
 ## Configurations
 

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -28,17 +28,19 @@ class Module extends \Module
      * Gets the base query (FROM and WHERE clause) used to retrieve
      * all the MRI violations for a given user.
      *
-     * @return void
+     * @return string the computed query.
      */
     public static function getMriViolatedScanQuery()
     {
         // Find which sites the user has access to
-        $accessibleSites = \User::singleton()->hasPermission('access_all_profiles')
+        $user            = \User::singleton();
+        $accessibleSites = $user->hasPermission('violated_scans_view_allsites')
             ? \Utility::getSiteList() : \User::singleton()->getStudySites();
 
         // Build the component of the WHERE clause (for the query below)
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
+        $siteClauseElements = [];
         foreach (array_keys($accessibleSites) as $siteID) {
             $siteClauseElements[] = \Database::singleton()->quote($siteID);
         }
@@ -171,7 +173,7 @@ class Module extends \Module
             $user->hasAnyPermission(
                 [
                     'violated_scans_view_allsites',
-                    'violated_scans_edit'
+                    'violated_scans_view_ownsite'
                 ]
             );
     }
@@ -212,23 +214,18 @@ class Module extends \Module
         case "usertasks":
             $factory = \NDB_Factory::singleton();
             $DB      = $factory->database();
-            $baseURL = $factory->settings()->getBaseURL();
+            $link    = $factory->settings()->getBaseURL() . '/' . $this->getName();
+            $number  = (int) $DB->pselectOne(
+                "SELECT count(*) " . $this->getMriViolatedScanQuery(),
+                []
+            );
+            $label   = $number >  1 ? 'Violated scans' : 'Violated scan';
 
             return [
-                new \LORIS\dashboard\TaskQueryWidget(
-                    $user,
-                    "Violated scan",
-                    $DB,
-                    "SELECT
-               count(*)". $this->getMriViolatedScanQuery(),
-                    "violated_scans_view_allsites",
-                    "c.RegistrationCenterID",
-                    $baseURL . "/" . $this->getName(),
-                    ""
-                )
+                new \LORIS\dashboard\TaskWidget($label, $number, $link, '')
             ];
-
         }
+
         return [];
     }
 }

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -24,117 +24,140 @@ namespace LORIS\mri_violations;
  */
 class Module extends \Module
 {
+    /**
+     * Gets the base query (FROM and WHERE clause) used to retrieve
+     * all the MRI violations for a given user.
+     *
+     * @return void
+     */
+    public static function getMriViolatedScanQuery()
+    {
+        // Find which sites the user has access to
+        $accessibleSites = \User::singleton()->hasPermission('access_all_profiles')
+            ? \Utility::getSiteList() : \User::singleton()->getStudySites();
 
-    /* The below class constant is created to fetch the mri violations log
-    from database.
-    Recreating the path (MincFileViolated field) to the minc file
-    for the table mri_violations_log is more complicated
-    because of the 3 cases that can occur as we pull the data from the db.
-         1. if the Mincfile starts with "assembly" then we need to
-            add the directory path in front of it.
-         2. if the word "assembly" is there but not at the beginning,
-           then uses it as is, the path is correct.
-         3. if it is not in the assembly dir, then it is in the trashbin,
-            so we fix the path with that in mind.
-      */
+        // Build the component of the WHERE clause (for the query below)
+        // that will be used to restrict the search to the data associated
+        // to sites the user has access to
+        foreach ($accessibleSites as $siteID => $siteName) {
+            $siteClauseElements[] = \Database::singleton()->quote($siteID);
+        }
+        $siteClause = sprintf(
+            "(v.Site IS NULL OR v.Site IN (%s))",
+            implode(',', $siteClauseElements)
+        );
 
-    const MRI_VIOLATED_SCAN_QUERY_CONST = " FROM (
-            SELECT PatientName as PatientName,
-                time_run as TimeRun,
-                s.ProjectID as Project,
-                s.SubprojectID as Subproject,
-                minc_location as MincFile,
-                series_description as Series_Description,
-                'Could not identify scan type' as Problem,
-                SeriesUID,
-                md5(concat_WS(':',minc_location,PatientName,SeriesUID,time_run))
-                  as hash,
-                mpvs.ID as join_id,
-                p.CenterID as Site,
-                violations_resolved.Resolved as Resolved,
-                mpvs.TarchiveID as TarchiveID,
-                mpvs.CandID as CandID,
-                c.PSCID as PSCID
+        // Subquery to retrieve tghe violations in table mri_protocol_violated_scans
+        $mriProtocolViolatedScansSubquery = "
+            SELECT PatientName    AS PatientName,
+                   time_run       AS TimeRun,
+                   s.ProjectID    AS Project,
+                   s.SubprojectID AS Subproject,
+                   minc_location  AS MincFile,
+                   series_description AS Series_Description,
+                   'Could not identify scan type' AS Problem,
+                   SeriesUID,
+                   md5(
+                     concat_WS(
+                       ':',minc_location,PatientName,SeriesUID,time_run
+                     )
+                   ) AS hash,
+                   mpvs.ID AS join_id,
+                   p.CenterID AS Site,
+                   violations_resolved.Resolved AS Resolved,
+                   mpvs.TarchiveID AS TarchiveID,
+                   mpvs.CandID AS CandID,
+                   c.PSCID AS PSCID
             FROM mri_protocol_violated_scans AS mpvs
-            LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mpvs.ID
-            AND violations_resolved.TypeTable='mri_protocol_violated_scans')
-            LEFT JOIN candidate c
-            ON (mpvs.CandID = c.CandID)
-            LEFT JOIN session s
-            ON (SUBSTRING_INDEX(mpvs.PatientName,'_',-1) = s.Visit_label 
-                AND mpvs.CandID = s.CandID
+            LEFT JOIN violations_resolved ON (
+                  violations_resolved.ExtID=mpvs.ID
+              AND violations_resolved.TypeTable='mri_protocol_violated_scans'
             )
-            LEFT JOIN psc p
-            ON (p.CenterID = s.CenterID)
-            WHERE Resolved is NULL"
-    . " UNION " .
-    "SELECT PatientName,
-                TimeRun,
-                s.ProjectID as Project,
-                s.SubprojectID as Subproject,
-                MincFile,
-                mri_scan_type.Scan_type,
-                'Protocol Violation',
-                SeriesUID,
-                md5(concat_WS(':',
-                              MincFile,
-                              PatientName,
-                              SeriesUID,
-                              TimeRun
-                   )
-                ) as hash,
-                mrl.LogID as join_id,
-                p.CenterID as Site,
-                violations_resolved.Resolved as Resolved,
-                mrl.TarchiveID as TarchiveID,
-                mrl.CandID as CandID,
-                c.PSCID as PSCID
+            LEFT JOIN candidate c ON (mpvs.CandID = c.CandID)
+            LEFT JOIN session s ON (
+                  SUBSTRING_INDEX(mpvs.PatientName,'_',-1) = s.Visit_label
+              AND mpvs.CandID = s.CandID
+            )
+            LEFT JOIN psc p ON (p.CenterID = s.CenterID)
+            WHERE Resolved is NULL
+        ";
+
+        // Subquery to retrieve the violations in table mri_violations_log
+        $mriViolationsLogSubquery = "
+            SELECT PatientName,
+                   TimeRun,
+                   s.ProjectID AS Project,
+                   s.SubprojectID AS Subproject,
+                   MincFile,
+                   mri_scan_type.Scan_type,
+                   'Protocol Violation',
+                   SeriesUID,
+                   md5(
+                     concat_WS(':', MincFile, PatientName, SeriesUID, TimeRun)
+                   ) AS hash,
+                   mrl.LogID AS join_id,
+                   p.CenterID AS Site,
+                   violations_resolved.Resolved AS Resolved,
+                   mrl.TarchiveID AS TarchiveID,
+                   mrl.CandID AS CandID,
+                   c.PSCID AS PSCID
             FROM mri_violations_log AS mrl
-            LEFT JOIN mri_scan_type
-            ON (mri_scan_type.ID=mrl.Scan_type)
-            LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mrl.LogID 
-            AND violations_resolved.TypeTable='mri_violations_log')
-            LEFT JOIN candidate c
-            ON (mrl.CandID=c.CandID)
-            LEFT JOIN session s
-            ON (mrl.Visit_label = s.Visit_label AND mrl.CandID=s.CandID)
-            LEFT JOIN psc p
-            ON (p.CenterID = s.CenterID)
-            WHERE Resolved is NULL"
-    . " UNION " .
-    "SELECT PatientName,
-                TimeRun,
-                null,
-                null,
-                MincFile,
-                null,
-                Reason,
-                SeriesUID,
-                md5(concat_WS(':',
-                              MincFile,
-                              PatientName,
-                              SeriesUID,
-                              TimeRun
-                   )
-                ) as hash,
-                MRICandidateErrors.ID as join_id,
-                null,
-                violations_resolved.Resolved as Resolved,
-                MRICandidateErrors.TarchiveID as TarchiveID,
-                NULL as CandID,
-                NULL as PSCID
-            FROM MRICandidateErrors
-            LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=MRICandidateErrors.ID 
-            AND violations_resolved.TypeTable='MRICandidateErrors')
-            WHERE Resolved is NULL)
-            as v LEFT JOIN psc site ON (site.CenterID = v.Site) 
-            LEFT JOIN Project as pjct ON (v.Project = pjct.ProjectID)
-            LEFT JOIN subproject as subpjct
-                ON (v.Subproject = subpjct.SubprojectID)
-            WHERE 1=1";
+            LEFT JOIN mri_scan_type ON (mri_scan_type.ID=mrl.Scan_type)
+            LEFT JOIN violations_resolved ON (
+                  violations_resolved.ExtID=mrl.LogID 
+              AND violations_resolved.TypeTable='mri_violations_log'
+            )
+            LEFT JOIN candidate c ON (mrl.CandID=c.CandID)
+            LEFT JOIN session s ON (
+              mrl.Visit_label = s.Visit_label AND mrl.CandID=s.CandID
+            )
+            LEFT JOIN psc p ON (p.CenterID = s.CenterID)
+            WHERE Resolved is NULL
+        ";
+
+        $mriCandidateErrorsSubquery = "
+              SELECT PatientName,
+                     TimeRun,
+                     null,
+                     null,
+                     MincFile,
+                     null,
+                     Reason,
+                     SeriesUID,
+                     md5(
+                       concat_WS(':', MincFile, PatientName, SeriesUID, TimeRun)
+                     ) AS hash,
+                     MRICandidateErrors.ID AS join_id,
+                     null,
+                     violations_resolved.Resolved AS Resolved,
+                     MRICandidateErrors.TarchiveID AS TarchiveID,
+                     NULL AS CandID,
+                     NULL AS PSCID
+              FROM MRICandidateErrors
+              LEFT JOIN violations_resolved ON (
+                    violations_resolved.ExtID=MRICandidateErrors.ID
+                AND violations_resolved.TypeTable='MRICandidateErrors'
+              )
+              WHERE Resolved is NULL
+        ";
+
+        $query = "
+            FROM (
+              $mriProtocolViolatedScansSubquery
+              UNION
+              $mriViolationsLogSubquery
+              UNION
+              $mriCandidateErrorsSubquery
+            ) AS v 
+            LEFT JOIN psc site ON (site.CenterID = v.Site) 
+            LEFT JOIN Project AS pjct ON (v.Project = pjct.ProjectID)
+            LEFT JOIN subproject AS subpjct ON (v.Subproject = subpjct.SubprojectID)
+            WHERE $siteClause
+        ";
+
+        return $query;
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -197,7 +220,7 @@ class Module extends \Module
                     "Violated scan",
                     $DB,
                     "SELECT
-               count(*)".self::MRI_VIOLATED_SCAN_QUERY_CONST,
+               count(*)". $this->getMriViolatedScanQuery(),
                     "violated_scans_view_allsites",
                     "c.RegistrationCenterID",
                     $baseURL . "/" . $this->getName(),

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -39,7 +39,7 @@ class Module extends \Module
         // Build the component of the WHERE clause (for the query below)
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
-        foreach ($accessibleSites as $siteID => $siteName) {
+        foreach (array_keys($accessibleSites) as $siteID) {
             $siteClauseElements[] = \Database::singleton()->quote($siteID);
         }
         $siteClause = sprintf(

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -41,7 +41,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         return $user->hasAnyPermission(
             array(
                 'violated_scans_view_allsites',
-                'violated_scans_edit'
+                'violated_scans_view_ownsite'
             )
         );
     }
@@ -53,12 +53,34 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
      */
     function _setupVariables()
     {
+        // Find which sites the user has access to
+        $user            = \User::singleton();
+        $accessibleSites = $user->hasPermission('violated_scans_view_allsites')
+            ? \Utility::getSiteList() : \User::singleton()->getStudySites();
+
+        // Build the component of the WHERE clause (for the query below)
+        // that will be used to restrict the search to the data associated
+        // to sites the user has access to
+        $siteClauseElements = [];
+        foreach (array_keys($accessibleSites) as $siteID) {
+            $siteClauseElements[] = \Database::singleton()->quote($siteID);
+        }
+        $siteClause = sprintf(
+            "(p.CenterID IS NULL OR p.CenterID IN (%s))",
+            implode(',', $siteClauseElements)
+        );
+
         $this->query    = " FROM mri_violations_log l 
             LEFT JOIN mri_scan_type m
             ON m.ID=l.Scan_type 
             LEFT JOIN mri_protocol_checks_group mpcg 
             ON (mpcg.MriProtocolChecksGroupID = l.MriProtocolChecksGroupID)
-            WHERE 1=1 ";
+            LEFT JOIN candidate c ON (l.CandID=c.CandID)
+            LEFT JOIN session s ON (
+              l.Visit_label = s.Visit_label AND l.CandID=s.CandID
+            )
+            LEFT JOIN psc p ON (p.CenterID = s.CenterID)
+            WHERE $siteClause";
         $this->columns  = array(
             'l.PatientName',
             'l.CandID',

--- a/modules/mri_violations/php/mri_protocol_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_violations.class.inc
@@ -37,12 +37,10 @@ class Mri_Protocol_Violations extends \NDB_Menu_Filter
      */
     function _hasAccess(\User $user) : bool
     {
-        $this->tpl_data['violated_scans_modifications']
-            = $user->hasPermission('violated_scans_edit');
         return $user->hasAnyPermission(
             array(
                 'violated_scans_view_allsites',
-                'violated_scans_edit'
+                'violated_scans_view_ownsite'
             )
         );
     }

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -212,7 +212,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             ]
         );
 
-        $this->query = Module::MRI_VIOLATED_SCAN_QUERY_CONST;
+        $this->query = Module::getMriViolatedScanQuery();
 
         $this->order_by = 'v.TimeRun DESC';
 
@@ -241,6 +241,54 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         );
 
         $this->EqualityFilters[] = 'v.Site';
+    }
+
+    /**
+     * Updates the array of query parameters (if needed) for a given field.
+     *
+     * @param array  $qparams      array of query parameters.
+     * @param string $field        field that appears in the query.
+     * @param string $prepared_key string to use as a placeholder in the query
+     *                             for the field.
+     * @param string $val          field value.
+     *
+     * @return void
+     *
+     * @override
+     */
+    function _addQueryParam(&$qparams, $field, $prepared_key, $val)
+    {
+        // No parameter should be added for the prepared statement if
+        // 'Unknown' or 'AllKnown' were selected in the site drop-down
+        if ($field != 'v.Site' || ($val != 'Unknown' && $val != 'AllKnown')) {
+            parent::_addQueryParam($qparams, $field, $prepared_key, $val);
+        }
+    }
+
+    /**
+     * Adds filters
+     *
+     * @param string $prepared_key filter key
+     * @param string $field        filter field
+     * @param string $val          filter value
+     *
+     * @return string ($query)
+     *
+     * @override
+     */
+    function _addValidFilters($prepared_key, $field, $val)
+    {
+        // The added AND clause differs from the one returned by
+        // parent::__addValidFilter when 'Unknown' or 'AllKnown' are
+        // selected in the sites drop-down
+        if ($field == 'v.Site' && ($val == 'Unknown' || $val == 'AllKnown')) {
+            return $val == 'Unknown'
+                ? ' AND v.Site IS NULL'
+                : ' AND v.Site IS NOT NULL';
+        }
+
+        // Standard behaviour for cases other than the above
+        return parent::_addValidFilters($prepared_key, $field, $val);
     }
 
     /**
@@ -314,18 +362,23 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
         // Get sites
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
-            $sites = \Utility::getSiteList();
-            if (is_array($sites)) {
-                $sites = array('' => 'All') + $sites;
-            }
+            $sites  = array(
+                ''         => 'All (including unknown)',
+                'AllKnown' => 'All (excluding unknown)',
+                'Unknown'  => 'Unknown'
+            );
+            $sites += \Utility::getSiteList();
         } else {
             // allow only to view own site data
-            $sites = $user->getStudySites();
-            $sites = array('' => 'All User Sites') + $sites;
+            $sites  = array(
+                ''         => 'All user sites (including unknown)',
+                'AllKnown' => 'All user sites (excluding unknown)',
+                'Unknown'  => 'Unknown'
+            );
+            $sites +=  $user->getStudySites();
         }
         $this->addSelect('Site', 'Site', $sites);
     }
-
 
     /**
      * Gathers JS dependecies and merge them with the parent

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -37,12 +37,10 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        $this->tpl_data['violated_scans_modifications']
-            = $user->hasPermission('violated_scans_edit');
         return $user->hasAnyPermission(
             array(
                 'violated_scans_view_allsites',
-                'violated_scans_edit'
+                'violated_scans_view_ownsite'
             )
         );
     }
@@ -212,7 +210,7 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             ]
         );
 
-        $this->query = Module::getMriViolatedScanQuery();
+        $this->query = \LORIS\mri_violations\Module::getMriViolatedScanQuery();
 
         $this->order_by = 'v.TimeRun DESC';
 

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -194,6 +194,21 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             ]
         );
 
+        // Find which sites the user has access to
+        $accessibleSites = \User::singleton()->hasPermission('access_all_profiles')
+            ? \Utility::getSiteList() : \User::singleton()->getStudySites();
+
+        // Build the component of the WHERE clause (for the query below)
+        // that will be used to restrict the search to the data associated
+        // to sites the user has access to
+        foreach ($accessibleSites as $siteID => $siteName) {
+            $siteClauseElements[] = \Database::singleton()->quote($siteID);
+        }
+        $siteClause = sprintf(
+            "(v.Site IS NULL OR v.Site IN (%s))",
+            implode(',', $siteClauseElements)
+        );
+
         $this->query    = " FROM (
             SELECT PatientName as PatientName,
                 time_run as TimeRun,
@@ -276,7 +291,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
             LEFT JOIN Project as pjct ON (v.Project = pjct.ProjectID)
             LEFT JOIN subproject as subpjct
                  ON (v.Subproject = subpjct.SubprojectID)
-            WHERE 1=1";
+            WHERE $siteClause";
         $this->order_by = 'v.TimeRun DESC';
 
         $this->formToFilter = array(
@@ -378,18 +393,72 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         // Get sites
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
-            $sites = \Utility::getSiteList();
-            if (is_array($sites)) {
-                $sites = array('' => 'All') + $sites;
-            }
+            $sites  = array(
+                ''         => 'All (including unknown)',
+                'AllKnown' => 'All (excluding unknown)',
+                'Unknown'  => 'Unknown'
+            );
+            $sites += \Utility::getSiteList();
         } else {
             // allow only to view own site data
-            $sites = $user->getStudySites();
-            $sites = array('' => 'All User Sites') + $sites;
+            $sites  = array(
+                ''         => 'All user sites (including unknown)',
+                'AllKnown' => 'All user sites (excluding unknown)',
+                'Unknown'  => 'Unknown'
+            );
+            $sites +=  $user->getStudySites();
         }
         $this->addSelect('Site', 'Site', $sites);
-
     }
+
+    /**
+     * Updates the array of query parameters (if needed) for a given field.
+     *
+     * @param array  $qparams      array of query parameters.
+     * @param string $field        field that appears in the query.
+     * @param string $prepared_key string to use as a placeholder in the query
+     *                             for the field.
+     * @param string $val          field value.
+     *
+     * @return void
+     *
+     * @override
+     */
+    function _addQueryParam(&$qparams, $field, $prepared_key, $val)
+    {
+        // No parameter should be added for the prepared statement if
+        // 'Unknown' or 'AllKnown' were selected in the site drop-down
+        if ($field != 'v.Site' || ($val != 'Unknown' && $val != 'AllKnown')) {
+            parent::_addQueryParam($qparams, $field, $prepared_key, $val);
+        }
+    }
+
+    /**
+     * Adds filters
+     *
+     * @param string $prepared_key filter key
+     * @param string $field        filter field
+     * @param string $val          filter value
+     *
+     * @return string ($query)
+     *
+     * @override
+     */
+    function _addValidFilters($prepared_key, $field, $val)
+    {
+        // The added AND clause differs from the one returned by
+        // parent::__addValidFilter when 'Unknown' or 'AllKnown' are
+        // selected in the sites drop-down
+        if ($field == 'v.Site' && ($val == 'Unknown' || $val == 'AllKnown')) {
+            return $val == 'Unknown'
+                ? ' AND v.Site IS NULL'
+                : ' AND v.Site IS NOT NULL';
+        }
+
+        // Standard behaviour for cases other than the above
+        return parent::_addValidFilters($prepared_key, $field, $val);
+    }
+
     /**
      * Gathers JS dependecies and merge them with the parent
      *

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -201,6 +201,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         // Build the component of the WHERE clause (for the query below)
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
+        $siteClauseElements = array();
         foreach (array_keys($accessibleSites) as $siteID) {
             $siteClauseElements[] = \Database::singleton()->quote($siteID);
         }

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -41,7 +41,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         return $user->hasAnyPermission(
             array(
                 'violated_scans_view_allsites',
-                'violated_scans_edit'
+                'violated_scans_view_ownsite'
             )
         );
     }
@@ -195,7 +195,8 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         );
 
         // Find which sites the user has access to
-        $accessibleSites = \User::singleton()->hasPermission('access_all_profiles')
+        $user            = \User::singleton();
+        $accessibleSites = $user->hasPermission('violated_scans_view_allsites')
             ? \Utility::getSiteList() : \User::singleton()->getStudySites();
 
         // Build the component of the WHERE clause (for the query below)

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -201,7 +201,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
         // Build the component of the WHERE clause (for the query below)
         // that will be used to restrict the search to the data associated
         // to sites the user has access to
-        foreach ($accessibleSites as $siteID => $siteName) {
+        foreach (array_keys($accessibleSites) as $siteID) {
             $siteClauseElements[] = \Database::singleton()->quote($siteID);
         }
         $siteClause = sprintf(

--- a/modules/mri_violations/test/TestPlan.md
+++ b/modules/mri_violations/test/TestPlan.md
@@ -21,9 +21,9 @@
 6. Ensure all filters and sorting work in the `Resolved` tab.
 7. Click on the question mark on the right upper side of the windows and ensure
    that the help content about MRI Violation is showing up and is up-to-date.
-8. Ensure user has access to this page iff he/she has either permission
+8. Ensure user has access to this page if and only if he/she has either permission
    `mri_violations_view_allsite` or `mri_violations_view_ownsite`.
-9. Check that if the user has permission `mri_violations_view_ownsite`, he/she
+9. Check that if the user only has the permission `mri_violations_view_ownsite`, he/she
    is not allowed to see the violations associated to sites other than his/her
    own.
 10. Check that the violations for which the site is unknown can always be seen 

--- a/modules/mri_violations/test/TestPlan.md
+++ b/modules/mri_violations/test/TestPlan.md
@@ -21,6 +21,11 @@
 6. Ensure all filters and sorting work in the `Resolved` tab.
 7. Click on the question mark on the right upper side of the windows and ensure
    that the help content about MRI Violation is showing up and is up-to-date.
+8. Ensure user has access to this page iff he/she has either permission
+   `mri_violations_view_allsite` or `mri_violations_view_ownsite`.
+9. Check that if the user has permission `mri_violations_view_ownsite`, he/she
+   is not allowed to see the violations associated to sites other than his/her
+   own.
 
 ### MRI Protocol Violations Page
  This page contains two 

--- a/modules/mri_violations/test/TestPlan.md
+++ b/modules/mri_violations/test/TestPlan.md
@@ -26,6 +26,10 @@
 9. Check that if the user has permission `mri_violations_view_ownsite`, he/she
    is not allowed to see the violations associated to sites other than his/her
    own.
+10. Check that the violations for which the site is unknown can always be seen 
+    no matter what permission the user has (violated_scans_view_allsite or
+    violated_scans_view_ownsite).
+
 
 ### MRI Protocol Violations Page
  This page contains two 

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -362,13 +362,13 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
 
     /**
      * Tests loading the module with the permission
-     * 'violated_scans_edit'
+     * 'violated_scans_view_ownsite'
      *
      * @return void
      */
-    function testModuleLoadsWithEditPermission()
+    function testModuleLoadsWithOwnSitePermission()
     {
-        $this->setupPermissions(array("violated_scans_edit"));
+        $this->setupPermissions(array("violated_scans_view_ownsite"));
         $this->safeGet($this->url . "/mri_violations/");
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -499,6 +499,24 @@ class NDB_Menu_Filter extends NDB_Menu
     }
 
     /**
+     * Updates the array of query parameters (if needed) for a given field.
+     *
+     * @param array  $qparams      array of query parameters.
+     * @param string $field        field that appears in the query.
+     * @param string $prepared_key string to use as a placeholder in the query
+     *                             for the field.
+     * @param string $val          field value.
+     *
+     * @return void
+     */
+    function _addQueryParam(&$qparams, $field, $prepared_key, $val)
+    {
+        if ($prepared_key != 'pending') {
+            $qparams["v_$prepared_key"] = $val;
+        }
+    }
+
+    /**
      * Constructs the base filter (WHERE clause) to use for this
      * menu.
      *
@@ -521,9 +539,7 @@ class NDB_Menu_Filter extends NDB_Menu
                     if (in_array($field, $this->CheckboxFilters)) {
                         continue;
                     }
-                    if ($prepared_key != 'pending') {
-                        $qparams["v_$prepared_key"] = $val;
-                    }
+                    $this->_addQueryParam($qparams, $field, $prepared_key, $val);
                 }
             }
         }

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -64,5 +64,6 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (62,'module_manager_view','Module Manager: access the module',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (63,'module_manager_edit','Module Manager: edit installed modules',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (64,'candidate_dod_edit','Edit dates of death',2);
+INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (65,'violated_scans_view_ownsite','Violated Scans: View Violated Scans from own site',2);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the following bugs in the MRI violations module, both in the `Not Resolved` and `Resolved` tabs:

1. When you select a given site in the drop-down list, the results contain records for which the site entry is empty: these should not be part of the result set.
2. When you access the MRI violations page for the first time or hit the `Clear Filter` button, all the MRI violations are shown even if the user does not have the `access_all_profiles` permission.

#### Testing instructions (if applicable)

1. Check that the filter's sites drop-down list offers choices that allow you to see/hide the violations that are not associated to any site.
2. Make sure that as a user that does not have the `access_all_profiles` permission you can never see the violations that is associated to a site you do not belong to (this happens when you first access the page and when you click on the `Clear Filter` button).

These tests should be performed on both the `Not Resolved` and `Resolved` tabs. 

3. On the dashboard page, check that the count of violated scans for a user that has access to the MRI violated scans module is correct. A test should be done for a user that has the `access_all_profile` permission and for a user that hasn't.

Note that it is assumed that violations not associated to any site can be seen by anybody, as long as that person has access to the MRI violations module.

#### Link(s) to related issue(s)

* Resolves #6279 
