### PR TITLE
[MRI Violations] Filter not populated completely after following links.

### DIFF
--- a/modules/mri_violations/jsx/columnFormatterUnresolved.js
+++ b/modules/mri_violations/jsx/columnFormatterUnresolved.js
@@ -21,6 +21,12 @@ function formatColumn(column, cell, rowData, rowHeaders) {
   let hashName;
   let patientname = row.PatientName;
   let uid = row.SeriesUID;
+  let tarchiveId = row.TarchiveID;
+  let candId = row.CandID;
+  let pscId = row.PSCID;
+  let timeRun = row.TimeRun != null && row.TimeRun.length >= 'YYYY-MM-DD'.length
+      ? row.TimeRun.substr(0, 'YYYY-MM-DD'.length) : null;
+  let seriesDescription = row['Series Description Or Scan Type'];
   let url;
   let log;
 
@@ -31,7 +37,9 @@ function formatColumn(column, cell, rowData, rowHeaders) {
                   onClick={loris.loadFilteredMenuClickHandler(
                       'mri_violations/mri_protocol_check_violations',
                       {PatientName: patientname,
-                       SeriesUID: uid}
+                       SeriesUID: uid,
+                       TarchiveID: tarchiveId,
+                       CandID: candId}
                   )}>Protocol Violation</a>
            </td>
            );
@@ -43,7 +51,12 @@ function formatColumn(column, cell, rowData, rowHeaders) {
                onClick={loris.loadFilteredMenuClickHandler(
                    'mri_violations/mri_protocol_violations',
                       {PatientName: patientname,
-                       SeriesUID: uid}
+                       SeriesUID: uid,
+                       TarchiveID: tarchiveId,
+                       CandID: candId,
+                       PSCID: pscId,
+                       TimeRun: timeRun,
+                       SeriesDescription: seriesDescription}
                )}>Could not identify scan type</a>
            </td>
            );

--- a/modules/mri_violations/php/mri_violations.class.inc
+++ b/modules/mri_violations/php/mri_violations.class.inc
@@ -178,6 +178,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             'v.hash',
             'v.join_id',
             'v.Resolved',
+            'v.TarchiveID',
+            'v.CandID',
+            'v.PSCID'
         );
 
         $this->headers = array(
@@ -193,6 +196,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
             'Hash',
             'JoinID',
             'Resolution_status',
+            'TarchiveID',
+            'CandID',
+            'PSCID'
         );
 
         $this->tpl_data['hiddenHeaders'] = json_encode(
@@ -200,6 +206,9 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                 'SeriesUID',
                 'Hash',
                 'JoinID',
+                'TarchiveID',
+                'CandID',
+                'PSCID'
             ]
         );
 
@@ -226,7 +235,10 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                   as hash,
                 mpvs.ID as join_id,
                 p.CenterID as Site,
-                violations_resolved.Resolved as Resolved
+                violations_resolved.Resolved as Resolved,
+                mpvs.TarchiveID as TarchiveID,
+                mpvs.CandID as CandID,
+                c.PSCID as PSCID
             FROM mri_protocol_violated_scans AS mpvs
             LEFT JOIN violations_resolved
             ON (violations_resolved.ExtID=mpvs.ID
@@ -258,7 +270,10 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                 ) as hash,
                 mrl.LogID as join_id,
                 p.CenterID as Site,
-                violations_resolved.Resolved as Resolved
+                violations_resolved.Resolved as Resolved,
+                mrl.TarchiveID as TarchiveID,
+                mrl.CandID as CandID,
+                c.PSCID as PSCID
             FROM mri_violations_log AS mrl
             LEFT JOIN mri_scan_type
             ON (mri_scan_type.ID=mrl.Scan_type)
@@ -290,7 +305,10 @@ class Mri_Violations extends \NDB_Menu_Filter_Form
                 ) as hash,
                 MRICandidateErrors.ID as join_id,
                 null,
-                violations_resolved.Resolved as Resolved
+                violations_resolved.Resolved as Resolved,
+                MRICandidateErrors.TarchiveID as TarchiveID,
+                NULL as CandID,
+                NULL as PSCID
             FROM MRICandidateErrors
             LEFT JOIN violations_resolved
             ON (violations_resolved.ExtID=MRICandidateErrors.ID 


### PR DESCRIPTION
## Brief summary of changes

This PR makes sure that when you click on any of the links in the MRI violations search results table, you are taken to a page where the filter is entirely filled out.

#### Testing instructions (if applicable)

1. Access the MRI violations page and search for violations of type `Protocol Violations`. Click on the `Protocol Violation` link in the problem column when the search results are displayed. Ensure that the filter of the page you are taken to has entries for all its fields and that those correspond to the values found for the record displayed on the page you came from.
2. Test the same thing but for violations of type `Could not identify scan type`.

#### Link(s) to related issue(s)

* Resolves #6300 
