### PR TITLE
[instrument_list] control whether to show a imaging_browser link & active Module support

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -134,6 +134,31 @@ class Instrument_List extends \NDB_Menu_Filter
             // the candidate exists before getting here.
             throw new \LorisException("Timepoint list requires a timepoint.");
         }
+
+        // Check imaging_browser permission, used to control imaging_browser link
+        // on the instrument_list main page
+        $DB      =& \Database::singleton();
+        $modules = \Module::checkActiveModules($DB, ['imaging_browser']);
+
+        $perm = false;
+        if ($modules['imaging_browser']) {
+            $user = $request->getAttribute("user");
+            if ($this->candidate->getData('Entity_type') == 'Scanner') {
+                $perm = $user->hasPermission('imaging_browser_phantom_allsites')
+                || $user->hasCenterPermission(
+                    'imaging_browser_phantom_ownsite',
+                    $this->timePoint->getCenterID()
+                );
+            } elseif ($this->candidate->getData('Entity_type') == 'Human') {
+                $perm = $user->hasPermission('imaging_browser_view_allsites')
+                || $user->hasCenterPermission(
+                    'imaging_browser_view_site',
+                    $this->timePoint->getCenterID()
+                );
+            }
+        }
+        $this->tpl_data['imaging_browser_permission'] = $perm;
+
         return parent::process($request, $handler);
     }
 

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -217,9 +217,11 @@
      <tr><td nowrap="nowrap">The battery has no registered instruments</td></tr>
 {/section}
 </table>
+{if $imaging_browser_permission}
   <div class="col-xs-12 row">
   </div>
   <div class="col-xs-12 row">
     <button class="btn btn-primary" onclick="location.href='{$baseurl}/imaging_browser/viewSession/?sessionID={$sessionID}'">View Imaging data</button>
   </div>
+{/if}
 </div>

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -94,7 +94,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
         }
 
         if ($moduleCnt < count($modules)) {
-            // In rare occaision, the $modules might have more but never less.
+            // In some occasions, the $modules might contain more but never less.
             $keys = array_keys($moduleStatus);
             foreach ($modules as $key => $name) {
                 if (!in_array($name, $keys)) {

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -63,6 +63,51 @@ abstract class Module extends \LORIS\Router\PrefixRouter
     }
 
     /**
+     * Checks whether one or more modules are active in the given database.
+     *
+     * @param \Database $db      an open connection to a database containing a
+     *                           'modules' table
+     * @param array     $modules the names of the modules to check
+     *
+     * @return array of module name => boolean (active or not)
+     */
+    static public function checkActiveModules(\Database $db, array $modules): array
+    {
+        $params = array();
+        $values = array();
+        foreach ($modules as $key => $name) {
+            $para          = "n$key";
+            $params[]      = ":$para";
+            $values[$para] = $name;
+        }
+        $list = $db->pselect(
+            "SELECT Name, Active FROM modules WHERE Name IN (" .
+            implode(', ', $params) . ")",
+            $values
+        );
+
+        $moduleStatus = [];
+        $moduleCnt    = 0;
+        foreach ($list as $item) {
+            $moduleStatus[$item['Name']] = $item['Active'] == 'Y';
+            $moduleCnt ++;
+        }
+
+        if ($moduleCnt < count($modules)) {
+            // In rare occaision, the $modules might have more but never less.
+            $keys = array_keys($moduleStatus);
+            foreach ($modules as $key => $name) {
+                if (!in_array($name, $keys)) {
+                    $moduleStatus[$name] = false;
+                }
+            }
+            // This process will help return a full length status array.
+        }
+
+        return $moduleStatus;
+    }
+
+    /**
      * Retrieve all active module descriptors from the given database, indexed
      * by their primary key in the database.
      *


### PR DESCRIPTION
## Brief summary of changes

Control whether showing an imaging_browser link depending on the user permission & the status of the `imaging_browser` module. The necessary method is added in the `Module`

#### Testing instructions (if applicable)

1. Create a user without imaging_browser permission;
2. Login with the new user to verify whether the imaging_browser will be shown at the end of the instrument_list, which could be find if you click on a candidate profile -> timepoint -> visit;
3. The user without proper permission should not see the imaging_browser link;
4. Logout the new created user, login with one with the imaging_browser permission, check to make sure that the imaging_browser link is there;
5. Disable `imaging_browser` module, check again to see that the imaging_browser link is no longer displayed.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
#6266, at the same time, the `checkActiveModules` could be used to solve part of the problem mentioned in the #6360, but the work itself is not done here.