### PR TITLE
[Imaging Uploader] Incorrect values in upload form for phantom scans.

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -51,13 +51,19 @@ class UploadForm extends Component {
         delete formData.candID;
         delete formData.pSCID;
         delete formData.visitLabel;
+      } else if (typeof formData.mriFile !== 'undefined') {
+        let patientName = formData.mriFile.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
+        let ids = patientName.split('_', 3);
+        formData.candID = ids[1];
+        formData.pSCID = ids[0];
+        formData.visitLabel = ids[2];
       }
     }
 
     formData[field] = value;
 
     if (field === 'mriFile') {
-      if (value.name !== '') {
+      if (value.name !== '' && formData.IsPhantom === 'N') {
         let patientName = value.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
         let ids = patientName.split('_', 3);
         formData.candID = ids[1];


### PR DESCRIPTION
## Brief summary of changes

This PR corrects the failures or these test cases:

#### Test case 1:

1. Access the Imaging uploader module.
2. Select 'Yes' in the phantom scan drop-down.
3. Select a file with a name of the form `PSCID_CANDID_VISITLABEL.tar.gz`.

You'll that the CandID, PSCID and visit label field get populated even though they should be left empty.

#### Test case 2:

1. Access the Imaging uploader module.
2. Select 'No' in the phantom scan drop-down.
3. Select a file with a name of the form `PSCID_CANDID_VISITLABEL.tar.gz` (the CandID, PS and visit label fields will be populated, which is all right).
4. Select 'Yes' in the phantom scan drop-down.

You'll that the CandID, PSCID and visit label field stay populated even though they should be erased.

#### Testing instructions (if applicable)

See above

#### Link(s) to related issue(s)

* Resolves #6288 

