### PR TITLE
[MRI Violations] Link to DICOM archive broken.

### DIFF
--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -86,6 +86,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
             'ValidRange',
             'ValidRegex',
             'SeriesUID',
+            'TarchiveID'
         );
         $this->tpl_data['hiddenHeaders'] = json_encode(['TarchiveID']);
         $this->validFilters = array(


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the broken links that you find on the MRI protocol checks violations sub-page of the MRI violations module.

#### Testing instructions (if applicable)

Access the MRI violations module and search for violations for which the type of problem is `Protocol Violations`. When the search results are displayed, click on any of the `Protocol Violations` link (column `Problem`). This will take you to the MRI protocol checks violations sub-page. Click on any of the links in the patient name column. You should now be taken to a page of the DICOM archive module but the page will be missing almost all of its fields. This should not happen and the all (or almost all) the fields displayed on the page should have a value.

#### Link(s) to related issue(s)

* Resolves #6318 
