### PR TITLE
Remove JS as part of "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ clean:
 	rm -f smarty/templates_c/*
 	rm -f VERSION
 	rm -rf vendor
+	rm -rf node_modules
+	rm package-lock.json
 
 # Perform static analysis checks
 checkstatic: phpdev


### PR DESCRIPTION
## Brief summary of changes

This PR enhances the "make clean" target to also remove installed JS libraries and the package-lock.json file from the development environment. It previously only deleted PHP libraries and compiled smarty templates.

#### Testing instructions (if applicable)

1. Run `make clean` and make sure it deletes `node_modules/` and `package-lock.json`.