### PR TITLE
[jsx/(Filter.js FilterableDataTable.js DataTable.js)] Browser console error cleanup

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -440,7 +440,7 @@ class DataTable extends Component {
                 // Note: Can't currently pass a key, need to update columnFormatter
                 // to not return a <td> node. Using createFragment instead.
                 // let key = 'td_col_' + j;
-                curRow.push(React.cloneElement(cell, {key: 'td_col_1' + j}));
+                curRow.push(React.cloneElement(cell, {key: 'td_col_' + j}));
             } else {
                 curRow.push(createFragment({celldata}));
             }

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -437,9 +437,6 @@ class DataTable extends Component {
                 );
             }
             if (cell !== null) {
-                // Note: Can't currently pass a key, need to update columnFormatter
-                // to not return a <td> node. Using createFragment instead.
-                // let key = 'td_col_' + j;
                 curRow.push(React.cloneElement(cell, {key: 'td_col_' + j}));
             } else {
                 curRow.push(createFragment({celldata}));

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -440,7 +440,7 @@ class DataTable extends Component {
                 // Note: Can't currently pass a key, need to update columnFormatter
                 // to not return a <td> node. Using createFragment instead.
                 // let key = 'td_col_' + j;
-                curRow.push(cell);
+                curRow.push(React.cloneElement(cell, {key: 'td_col_1' + j}));
             } else {
                 curRow.push(createFragment({celldata}));
             }
@@ -449,8 +449,8 @@ class DataTable extends Component {
         const rowIndexDisplay = index[i].Content;
         rows.push(
             <tr key={'tr_' + rowIndex} colSpan={headers.length}>
-            <td>{rowIndexDisplay}</td>
-            {curRow}
+              <td key={'td_' + rowIndex}>{rowIndexDisplay}</td>
+              {curRow}
             </tr>
         );
     }
@@ -573,7 +573,7 @@ DataTable.propTypes = {
   // parameters of the form: func(ColumnName, CellData, EntireRowData)
   getFormattedCell: PropTypes.func,
   onSort: PropTypes.func,
-  actions: PropTypes.object,
+  actions: PropTypes.array,
   hide: PropTypes.object,
   nullTableShow: PropTypes.bool,
 };

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -136,9 +136,9 @@ Filter.propTypes = {
   clearFilter: PropTypes.func.isRequired,
   id: PropTypes.string,
   name: PropTypes.string,
-  columns: PropTypes.string,
+  columns: PropTypes.number,
   title: PropTypes.string,
-  fields: PropTypes.object.isRequired,
+  fields: PropTypes.array.isRequired,
 };
 
 export default Filter;

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -110,12 +110,12 @@ FilterableDataTable.defaultProps = {
 FilterableDataTable.propTypes = {
   name: PropTypes.string.isRequired,
   title: PropTypes.string,
-  data: PropTypes.object.isRequired,
+  data: PropTypes.array.isRequired,
   filterPresets: PropTypes.object,
-  fields: PropTypes.object.isRequired,
+  fields: PropTypes.array.isRequired,
   columns: PropTypes.number,
   getFormattedCell: PropTypes.func,
-  actions: PropTypes.object,
+  actions: PropTypes.array,
 };
 
 export default FilterableDataTable;


### PR DESCRIPTION
## Brief summary of changes

Updated the propTypes to correspond with the correct "type" of the data being passed to the components. Updated DataTable.js to have a key be passed using React.cloneElement.

#### Testing instructions (if applicable)

1. Visit the candidate_list module and view the browser console.

edit: Make sure the sandbox value is set to 1.
```
<config>
    <!-- set to 1 if development environment -->
    <dev>
        <sandbox>1</sandbox>
    </dev>
...
</config>
```

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)

#6379
