### PR TITLE
[Instruments] Change examiner location question for instrument AOSI.

### DIFF
--- a/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
@@ -124,7 +124,7 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
 
         $this->addSelect(
             "examiner_location",
-            "(Circle One)",
+            "Examiner location",
             array(
              null               => '',
              "examiner"         => "Examiner",


### PR DESCRIPTION
## Brief summary of changes

As the title says

#### Testing instructions (if applicable)

Access the AOSI instrument and check that the question for the examiner location is 'Examiner location' and not 'Circle One'.

#### Link(s) to related issue(s)

* Resolves #6269 
