### PR TITLE
[Lorisform] undefined name fix

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1236,8 +1236,10 @@ class LorisForm
             } else {
                 if ($el['type'] === 'file') {
                     $value = $_FILES[$el['name']]['name'];
-                } else {
+                } elseif (isset($el['name'])) {
                     $value = $this->getValue($el['name']);
+                } else { // If the form element is a static label
+                    $value = null;
                 }
 
                 if (isset($el['required'])


### PR DESCRIPTION
## Brief summary of changes

This PR is the recreation of the PR #5886

A instrument with
`$this->addLabel('<label>')` will always report PHP warning "Undefined index: name in LorisForm.class.inc on line 1242"

This happens because Loris form assumes that a name is mandatory, even for a label. I don't see the necessity here.

#### Testing instructions (if applicable)

1. 1. Create an instrument, or a unit test case, put a label `$this->addLabel('<label>')` anyway in an instrument, click the save button, check whether the PHP warning is in the log.

#### Link(s) to related issue(s)
