### PR TITLE
[LorisForm] Form static element bug in group mode

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1960,10 +1960,7 @@ class LorisForm
         case 'submit':
             return $this->createSubmit($elname, $label, $attribs);
         case 'static':
-            /* Label seems to usually be the wrong attribute for static
-             * elements?
-             */
-            $el         = $this->createBase($elname, $options, $attribs);
+            $el         = $this->createBase($elname, $label, $attribs);
             $el['type'] = 'static';
             break;
         case 'advcheckbox':


### PR DESCRIPTION
## Brief summary of changes

This is the recreation of the PR #5884 first commit [e0ffb13](https://github.com/aces/Loris/pull/5884/commits/e0ffb13fb558ad8cde4d5c200e6747ed0daa3f88)

The third parameter of the form elements in the group mode was set as the fourth parameter somehow for `static` text Form type, this is clearly a bug.

The old format could be working in the following way (I just pass the label at the wrong place to make the system work):
$this->form->createElement('static', null, null, "label");

I noticed that the [wiki](https://github.com/aces/Loris/wiki/Instrument-Groups) manual suggests to use the format:
$group[] =& $this->form->createElement("static", null, null, "label");

I suggest to use the new format to be consistent with other types:
$this->form->createElement('static', null, "label");

Another way to do is to use the wrong signature, modify the old function signature, and create a new function to use the new format. Which will also create some complexity.

_[Important]_ Possible impact:
Some old instruments will stop displaying correctly once being migrated, some verification required, besides possibly some function signatures changes including setup, score, etc., which is beyond the scope of this PR.

The instrument migration fix could be easy with a full text replacement with further verification. Some project could use module overrides to handle.

