### PR TITLE
[LorisForm&NDB_Page] option vs attribute misuses

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -118,8 +118,7 @@ class LorisForm
      * @param string $name    The element name.
      * @param string $label   The label to attach to this element.
      * @param array  $attribs An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     *                        get added, for example "class" attribute.
      *
      * @return &array A reference to the array that was added to $this->form
      */
@@ -139,8 +138,7 @@ class LorisForm
      * @param array  $options An array of the options (values) to add
      *                        to this select dropdown.
      * @param array  $attribs An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     *                        get added, for example "class" attribute.
      *
      * @return &array
      */
@@ -178,15 +176,14 @@ class LorisForm
      *
      * @param string $name    The element name.
      * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param array  $attribs An array of other attributes that should
+     *                        get added.
      *
      * @return &array
      */
-    public function addPassword($name, $label, $options=array())
+    public function addPassword($name, $label, $attribs=array())
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $attribs);
         $el['type'] = 'password';
         return $el;
     }
@@ -194,18 +191,18 @@ class LorisForm
     /**
      * Reimplementation of HTML_QuickForm's "addHidden" API.
      *
-     * @param string $name       The element name.
-     * @param string $value      The element value.
-     * @param array  $attributes Additional html attributes for element
+     * @param string $name    The element name.
+     * @param string $value   The element value.
+     * @param array  $attribs Additional html attributes for element
      *
      * @return &array
      */
-    public function addHidden($name, $value, $attributes=array())
+    public function addHidden($name, $value, $attribs=array())
     {
         $el         =& $this->addBase(
             $name,
             null,
-            array_merge(array('value' => $value), $attributes)
+            array_merge(array('value' => $value), $attribs)
         );
         $el['type'] = 'hidden';
         return $el;
@@ -216,15 +213,14 @@ class LorisForm
      *
      * @param string $name    The element name.
      * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param array  $attribs An array of other attributes that should
+     *                        get added.
      *
      * @return &array
      */
-    public function addText($name, $label, $options=array())
+    public function addText($name, $label, $attribs=array())
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $attribs);
         $el['type'] = 'text';
         return $el;
     }
@@ -234,22 +230,20 @@ class LorisForm
      *
      * @param string $elname  The element name.
      * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class",
-     *                        "rows", and "cols" attributes will get
-     *                        added.
+     * @param array  $attribs An array of other attributes that should get added,
+     *                        including "class", "rows", "cols" and "disabled", etc.
      *
      * @return &array
      */
-    public function addTextArea($elname, $label, $options=array())
+    public function addTextArea($elname, $label, $attribs=array())
     {
-        $el         =& $this->addBase($elname, $label, $options);
+        $el         =& $this->addBase($elname, $label, $attribs);
         $el['type'] = 'textarea';
-        if (isset($options['cols'])) {
-            $el['cols'] = $options['cols'];
+        if (isset($attribs['cols'])) {
+            $el['cols'] = $attribs['cols'];
         }
-        if (isset($options['rows'])) {
-            $el['rows'] = $options['rows'];
+        if (isset($attribs['rows'])) {
+            $el['rows'] = $attribs['rows'];
         }
         return $el;
     }
@@ -264,8 +258,7 @@ class LorisForm
      * @param array  $options An array of options that should get added,
      *                        such as the date format, min or max date etc.
      * @param array  $attribs An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     *                        get added, for example "class" attribute.
      *
      * @return &array
      */
@@ -282,17 +275,16 @@ class LorisForm
      *
      * @param string $name    The element name.
      * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "class"
-     *                        attribute gets added.
+     * @param array  $attribs An array of other attributes that should
+     *                        get added, for example "class" attribute.
      *
      * @return &array
      */
-    function addFile($name, $label, $options)
+    function addFile($name, $label, $attribs)
     {
         $this->enctype = 'enctype="multipart/form-data"';
 
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $attribs);
         $el['type'] = 'file';
         return $el;
     }
@@ -302,15 +294,14 @@ class LorisForm
      *
      * @param string $name    The element name.
      * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other attributes that should
-     *                        get added. Currently only the "value"
-     *                        attribute gets added.
+     * @param array  $attribs An array of other attributes that should
+     *                        get added, for example "value" attribute.
      *
      * @return &array
      */
-    function &addCheckbox($name, $label, $options)
+    function &addCheckbox($name, $label, $attribs)
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $attribs);
         $el['type'] = 'advcheckbox';
         return $el;
     }
@@ -343,13 +334,13 @@ class LorisForm
      *
      * @param string $name    The name of the header element, may be null
      * @param string $label   The description for the header
-     * @param array  $options Other options for this header element
+     * @param array  $attribs Other attributes for this header element
      *
      * @return &array
      */
-    function addHeader($name, $label, $options = array())
+    function addHeader($name, $label, $attribs = array())
     {
-        $el         =& $this->addBase($name, $label, $options);
+        $el         =& $this->addBase($name, $label, $attribs);
         $el['type'] = 'header';
         return $el;
     }
@@ -406,6 +397,7 @@ class LorisForm
      *                        where "options" has a different meaning
      *                        and attribs takes the place of what "options"
      *                        is for other types.
+     * @param array  $customs Only used in a certain mode of advcheckbox
      *
      * @return void (but modifies this->form as a side-effect)
      */
@@ -414,7 +406,8 @@ class LorisForm
         $name,
         $label='',
         $options=array(),
-        $attribs=array()
+        $attribs=array(),
+        $customs=array()
     ) {
         $el = null;
         switch($type)  {
@@ -425,19 +418,19 @@ class LorisForm
             $el = $this->addDate($name, $label, $options, $attribs);
             break;
         case 'file':
-            $el = $this->addFile($name, $label, $options);
+            $el = $this->addFile($name, $label, $attribs);
             break;
         case 'static':
             $el = $this->addStatic($name, $label);
             break;
         case 'textarea':
-            $el = $this->addTextArea($name, $label, $options);
+            $el = $this->addTextArea($name, $label, $attribs);
             break;
         case 'password':
-            $el = $this->addPassword($name, $label, $options);
+            $el = $this->addPassword($name, $label, $attribs);
             break;
         case 'header':
-            $el = $this->addHeader($name, $label, $options);
+            $el = $this->addHeader($name, $label, $attribs);
             break;
         case 'advcheckbox':
             $args = func_get_args();
@@ -462,21 +455,21 @@ class LorisForm
                 $el['checkStates'] = $args[5];
                 $el['_text']       = $args[3];
             } else {
-                $el = $this->addCheckbox($name, $label, $options);
+                $el = $this->addCheckbox($name, $label, $attribs);
             }
             break;
         case 'radio':
             $el = $this->addRadio($name, $label, $options, $attribs);
             break;
         case 'hidden':
-            $el = $this->addHidden($name, $label, $options);
+            $el = $this->addHidden($name, $label, $attribs);
             break;
         case 'link':
             $el = $this->addLink($name, $label, $options, $attribs);
             break;
         case 'text':
         default:
-            $el = $this->addText($name, $label, $options);
+            $el = $this->addText($name, $label, $attribs);
             break;
         }
     }
@@ -1945,6 +1938,7 @@ class LorisForm
      *                        to create* wrappers
      * @param array  $attribs An array of extra HTML attributes to
      *                        add to the element.
+     * @param array  $customs Only used in a certain mode of advcheckbox
      *
      * @return array of the form supported by $this->form
      */
@@ -1953,15 +1947,16 @@ class LorisForm
         $elname,
         $label='',
         $options=array(),
-        $attribs=array()
+        $attribs=array(),
+        $customs=array()
     ) {
         switch($type) {
         case 'text':
-            return $this->createText($elname, $label, $options);
+            return $this->createText($elname, $label, $attribs);
         case 'select':
             return $this->createSelect($elname, $label, $options, $attribs);
         case 'submit':
-            return $this->createSubmit($elname, $label, $options);
+            return $this->createSubmit($elname, $label, $attribs);
         case 'static':
             /* Label seems to usually be the wrong attribute for static
              * elements?
@@ -1993,7 +1988,7 @@ class LorisForm
                 $el['checkStates'] = $args[5];
                 $el['_text']       = $args[3];
             } else {
-                $el         = $this->createBase($elname, $label, $options);
+                $el         = $this->createBase($elname, $label, $attribs);
                 $el['type'] = 'advcheckbox';
             }
             break;
@@ -2004,13 +1999,13 @@ class LorisForm
             $el['options'] = $options;
             break;
         case 'radio':
-            $el         = $this->createBase($elname, $label, $options);
+            $el         = $this->createBase($elname, $label, $attribs);
             $el['type'] = 'radio';
             break;
         case 'time':
         case 'textarea':
         case 'password':
-            $el         = $this->createBase($elname, $label, $options);
+            $el         = $this->createBase($elname, $label, $attribs);
             $el['type'] = $type;
             break;
         default:

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -147,18 +147,19 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @param string $name    The name of this file element
      * @param string $label   The label to attach to this element
-     * @param array  $options Options to pass to the form for this
+     * @param array  $attribs Attributes to pass to the form for this
      *                        file chooser.
      *
      * @return void
      */
-    function addFile($name, $label, $options=array())
+    function addFile($name, $label, $attribs=array())
     {
         $this->form->addElement(
             'file',
             $name,
             $label,
-            array_merge(array('class' => 'fileUpload'), $options)
+            array(),
+            array_merge(array('class' => 'fileUpload'), $attribs)
         );
     }
 
@@ -177,22 +178,22 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Wrapper to create a select drop-down list
      *
-     * @param string $name     The field name of this select dropdown
-     * @param string $label    The label to attach to this dropdown
-     * @param array  $options  Options to pass to QuickForm for this
-     *                         select
-     * @param array  $optional Optional extra HTML attributes to add
-     *                         to the select
+     * @param string $name    The field name of this select dropdown
+     * @param string $label   The label to attach to this dropdown
+     * @param array  $options Options to pass to QuickForm for this
+     *                        select
+     * @param array  $attribs Optional extra HTML attributes to add
+     *                        to the select
      *
      * @return void
      */
-    function addSelect($name, $label, $options, $optional=array())
+    function addSelect($name, $label, $options, $attribs=array())
     {
-        $optional = array_merge(
+        $attribs = array_merge(
             array('class' => 'form-control input-sm'),
-            $optional
+            $attribs
         );
-        $this->form->addElement('select', $name, $label, $options, $optional);
+        $this->form->addElement('select', $name, $label, $options, $attribs);
     }
 
     /**
@@ -228,35 +229,36 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $field   The name of the text element to add
      * @param string $label   Label to attach to the text element
      * @param array  $options QuickForm options to pass to addElement
+     * @param array  $attribs QuickForm attributes to pass to addElement
      *
      * @return void
      */
-    function addBasicText($field, $label, $options=array())
+    function addBasicText($field, $label, $options=array(), $attribs=array())
     {
-        $options = array_merge(array('class' => 'form-control input-sm'), $options);
-        $this->form->addElement('text', $field, $label, $options);
+        $attribs = array_merge(array('class' => 'form-control input-sm'), $attribs);
+        $this->form->addElement('text', $field, $label, $options, $attribs);
     }
 
     /**
      * Adds a text area to the current page with no accompanying not answered
      * option.
      *
-     * @param string $field          The name of the text area to add
-     * @param string $label          Label to attach to the text area field
-     * @param array  $specifications Extra HTML options to add to the textarea
+     * @param string $field   The name of the text area to add
+     * @param string $label   Label to attach to the text area field
+     * @param array  $attribs Extra HTML options to add to the textarea
      *
      * @return void
      */
     function addBasicTextArea(
         $field,
         $label,
-        $specifications=array()
+        $attribs=array()
     ) {
-        $specifications = array_merge(
+        $attribs = array_merge(
             array('class' => 'form-control input-sm'),
-            $specifications
+            $attribs
         );
-        $this->form->addElement('textarea', $field, $label, $specifications);
+        $this->form->addElement('textarea', $field, $label, array(), $attribs);
     }
 
     /**
@@ -266,7 +268,7 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $field   The name of the date field
      * @param string $label   Label to attach to the date field in the frontend
      * @param array  $options Options to pass to HTML_QuickForm
-     * @param array  $attr    Extra HTML attributes to add to the date group.
+     * @param array  $attribs Extra HTML attributes to add to the date group.
      *
      * @return void
      *
@@ -277,7 +279,7 @@ class NDB_Page implements RequestHandlerInterface
         $field,
         $label,
         $options=array(),
-        $attr=array(
+        $attribs=array(
             'class' => 'form-control input-sm',
             'style' => 'max-width:33%; display:inline-block;',
         )
@@ -285,34 +287,26 @@ class NDB_Page implements RequestHandlerInterface
         if ($options === array() && !empty($this->dateOptions)) {
             $options = $this->dateOptions;
         }
-        $this->form->addElement('date', $field, $label, $options, $attr);
+        $this->form->addElement('date', $field, $label, $options, $attribs);
     }
 
     /**
      * Wrapper to create a checkbox
      *
-     * @param string $name     The field name of this checkbox
-     * @param string $label    The label to attach to this checkbox
-     * @param array  $options  Options to pass to QuickForm for this
-     *                         checkbox
-     * @param array  $optional Optional extra HTML attributes to add
-     *                         to the checkbox
+     * @param string $name    The field name of this checkbox
+     * @param string $label   The label to attach to this checkbox
+     * @param array  $attribs Optional extra HTML attributes to add
+     *                        to the checkbox
      *
      * @return void
-     *
-     * @note The optional array is never actually put into the element
-     *       because LorisForm::addHeader does not take it as a parameter.
-     *       The 'class' attribute is now added to the $options array instead
-     *       whereas before it was in the $optional array.
-     *        - Alexandra Livadas
      */
-    function addCheckbox($name, $label, $options, $optional=array())
+    function addCheckbox($name, $label, $attribs=array())
     {
-        $options = array_merge(
+        $attribs = array_merge(
             array('class' => 'form-control input-sm'),
-            $options
+            $attribs
         );
-        $this->form->addElement('advcheckbox', $name, $label, $options, $optional);
+        $this->form->addElement('advcheckbox', $name, $label, array(), $attribs);
     }
 
     /**
@@ -335,17 +329,14 @@ class NDB_Page implements RequestHandlerInterface
     {
         $radGroup = array();
         foreach ($radios as $radElement) {
-            $tempOptions = array_merge(
+            $radGroup[] = $this->createRadio(
+                $name,
+                $radElement['label'],
+                $options,
                 array(
                     'class' => 'form-control input-sm',
                     'value' => $radElement['value'],
-                ),
-                $options
-            );
-            $radGroup[]  = $this->createRadio(
-                $name,
-                $radElement['label'],
-                $tempOptions
+                )
             );
         }
         $this->addGroup($radGroup, $name . '_group', $groupLabel, null, false);
@@ -355,15 +346,15 @@ class NDB_Page implements RequestHandlerInterface
      * Adds a hidden element to the current page. Note if the hidden element
      * needs a value it should be added to the defaults.
      *
-     * @param string $name       The name of the hidden element to add
-     * @param array  $value      The value of the hidden element to add
-     * @param array  $attributes Additional html attributes for element
+     * @param string $name    The name of the hidden element to add
+     * @param array  $value   The value of the hidden element to add
+     * @param array  $attribs Additional html attributes for element
      *
      * @return void
      */
-    function addHidden($name, $value=null, $attributes=array())
+    function addHidden($name, $value=null, $attribs=array())
     {
-        $this->form->addElement('hidden', $name, $value, $attributes);
+        $this->form->addElement('hidden', $name, $value, array(), $attribs);
     }
 
     /**
@@ -401,18 +392,18 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Creates a password element and adds it to the current form.
      *
-     * @param string $field The name of the password field to add
-     * @param string $label The label to attach to this element
-     * @param array  $attr  List of extra HTML attributes to add to the element
+     * @param string $field   The name of the password field to add
+     * @param string $label   The label to attach to this element
+     * @param array  $attribs List of extra HTML attributes to add to the element
      *
      * @return void
      */
     function addPassword(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attribs=array('class' => 'form-control input-sm')
     ) {
-        $this->form->addElement('password', $field, $label, $attr);
+        $this->form->addElement('password', $field, $label, array(), $attribs);
     }
 
     /**
@@ -481,7 +472,7 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $field   The field name for this select
      * @param string $label   The label to attach to the element
      * @param array  $options Extra options to pass to QuickForm
-     * @param array  $attr    Extra HTML attributes to add to the element
+     * @param array  $attribs Extra HTML attributes to add to the element
      *
      * @return array representing select element
      */
@@ -489,9 +480,15 @@ class NDB_Page implements RequestHandlerInterface
         $field,
         $label,
         $options=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attribs=array('class' => 'form-control input-sm')
     ) {
-        return $this->form->createElement("select", $field, $label, $options, $attr);
+        return $this->form->createElement(
+            "select",
+            $field,
+            $label,
+            $options,
+            $attribs
+        );
     }
 
     /**
@@ -530,8 +527,8 @@ class NDB_Page implements RequestHandlerInterface
         $label=null,
         $attribs=array()
     ) {
-        $attr =array_merge($attribs, array('class' => 'form-control input-sm'));
-        return $this->form->createElement("text", $field, $label, $attr);
+        $attr = array_merge(array('class' => 'form-control input-sm'), $attribs);
+        return $this->form->createElement("text", $field, $label, array(), $attr);
     }
 
     /**
@@ -548,6 +545,7 @@ class NDB_Page implements RequestHandlerInterface
             "textarea",
             $field,
             $label,
+            array(),
             array('class' => 'form-control input-sm')
         );
     }
@@ -558,7 +556,7 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $field       The fieldname for this date field
      * @param string $label       The label to attach to this date
      * @param array  $dateOptions List of options to pass to QuickForm
-     * @param array  $attr        List of HTML attributes to add to the date
+     * @param array  $attribs     List of HTML attributes to add to the date
      *                            group.
      *
      * @return array representing date element
@@ -570,7 +568,7 @@ class NDB_Page implements RequestHandlerInterface
         $field,
         $label,
         $dateOptions=null,
-        $attr=array(
+        $attribs=array(
             'class' => 'form-control input-sm',
             'style' => 'max-width:33%; display:inline-block;',
         )
@@ -580,7 +578,7 @@ class NDB_Page implements RequestHandlerInterface
             $field,
             $label,
             $dateOptions,
-            $attr
+            $attribs
         );
     }
 
@@ -591,19 +589,18 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @param string $field   The fieldname for this checkbox
      * @param string $label   The label to attach to this checkbox
-     * @param string $options Options to pass to HTML_QuickForm
-     * @param string $closer  ?????
+     * @param string $attribs Attributes to pass to HTML_QuickForm
      *
      * @return array representing checkbox
      */
-    function createCheckbox($field, $label, $options=null, $closer='</label>')
+    function createCheckbox($field, $label, $attribs=null)
     {
         return $this->form->createElement(
             "advcheckbox",
             $field,
             $label,
-            $options,
-            array()
+            array(),
+            $attribs
         );
     }
 
@@ -613,35 +610,43 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $field   The fieldname for this radio button
      * @param string $label   The label to attach to this radio button
      * @param string $options Options to pass to LorisForm
+     * @param array  $attribs An array of extra HTML attributes to
+     *                        add to the element.
      *
      * @return array representing radio button
      */
-    function createRadio($field, $label, $options=null)
+    function createRadio($field, $label, $options=null, $attribs=null)
     {
         return $this->form->createElement(
             "radio",
             $field,
             $label,
             $options,
-            array()
+            $attribs
         );
     }
 
     /**
      * Creates a password form element but does not add it to the page
      *
-     * @param string $field The fieldname for the password box
-     * @param string $label The label to attach to the form element
-     * @param array  $attr  List of HTML attributes to add to the element
+     * @param string $field   The fieldname for the password box
+     * @param string $label   The label to attach to the form element
+     * @param array  $attribs List of HTML attributes to add to the element
      *
      * @return array representing form element
      */
     function createPassword(
         $field,
         $label=null,
-        $attr=array('class' => 'form-control input-sm')
+        $attribs=array('class' => 'form-control input-sm')
     ) {
-        return $this->form->createElement('password', $field, $label, $attr);
+        return $this->form->createElement(
+            'password',
+            $field,
+            $label,
+            array(),
+            $attribs
+        );
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

This is the recreation of the PR #6347 but without `var` to `public` variable declaration modifications at the beginnings of the two classes, the latter is not necessary as the others included in this PR.

Quite often the term `options` are mixed with the term `attributes` at different meanings and locations, this will create confusion for the programmers. This PR tries to correct this problem. This PR has also a little doc modification and the removal of the variable `$closer`, the latter is not too much related with the main task.