### PR TITLE
[candidate_parameters] Display Candidate Info button without data_entry permission

### DIFF
--- a/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
+++ b/modules/timepoint_list/templates/timepoint_list_controlpanel.tpl
@@ -1,4 +1,4 @@
 {if $isDataEntryPerson}
 <a class="btn btn-default" role="button" href="{$baseurl}/create_timepoint/?candID={$candID}&identifier={$candID}">Create time point</a>
-<a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Candidate Info</a>
 {/if}
+<a class="btn btn-default" role="button" href="{$baseurl}/candidate_parameters/?candID={$candID}&identifier={$candID}">Candidate Info</a>


### PR DESCRIPTION
## Brief summary of changes

The PR will now make the "Candidate Info" button be shown when the user doesn't have data_entry role permissions.

#### Testing instructions (if applicable)

1. Make a user without data_entry role but with the necessary permissions to view Candidate Info.
2. Visit the Candidate Info with that user.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)

#6275
