### PR TITLE
[instrument_list] cleanup browser console errors

### DIFF
--- a/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
+++ b/modules/bvl_feedback/jsx/react.behavioural_feedback_panel.js
@@ -22,7 +22,7 @@ class SliderPanel extends Component {
 }
 SliderPanel.propTypes = {
   pscid: PropTypes.string,
-  children: PropTypes.string,
+  children: PropTypes.array,
 };
 
 class FeedbackPanelContent extends Component {
@@ -376,7 +376,7 @@ class AccordionPanel extends Component {
 }
 AccordionPanel.propTypes = {
   title: PropTypes.string,
-  children: PropTypes.string,
+  children: PropTypes.object,
 };
 
 class NewThreadPanel extends Component {
@@ -604,7 +604,7 @@ class FeedbackPanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      threads: '',
+      threads: [],
       summary: null,
     };
     this.loadSummaryServerData = this.loadSummaryServerData.bind(this);
@@ -754,7 +754,7 @@ class FeedbackPanel extends Component {
   }
 }
 FeedbackPanel.propTypes = {
-  selectOptions: PropTypes.array,
+  selectOptions: PropTypes.object,
   feedbackLevel: PropTypes.string,
   candID: PropTypes.string,
   sessionID: PropTypes.string,


### PR DESCRIPTION
## Brief summary of changes

Cleanup console log errors when viewing instrument_list and from mismatched react propTypes.

#### Testing instructions (if applicable)

1.  View the browser console when viewing the module "instrument_list" on 23.0-release branch.
2. Checkout PR and do the same.

edit: Make sure the sandbox value is set to 1.
```
<config>
    <!-- set to 1 if development environment -->
    <dev>
        <sandbox>1</sandbox>
    </dev>
...
</config>
```

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
#6381