### PR TITLE
Fixed Pagination for Data Query Tools

### DIFF
--- a/modules/dataquery/jsx/react.fieldselector.js
+++ b/modules/dataquery/jsx/react.fieldselector.js
@@ -189,19 +189,20 @@ class FieldList extends Component {
       start = 0;
     }
 
-    // Display the fields using the FieldItem component
-    for (let i = start; i < items.length; i += 1) {
-      fieldName = items[i].key[1];
-      desc = items[i].value.Description;
-      type = items[i].value.Type || 'varchar(255)';
+    let filteredItems = items.filter((item) => {
+        const name = item.key[1];
+        const desc = item.value.Description;
+        return (name.toLowerCase().indexOf(filter) != -1 ||
+            desc.toLowerCase().indexOf(filter) != -1);
+    });
 
-      if (fieldName.toLowerCase().indexOf(filter) == -1 && desc.toLowerCase().indexOf(filter) == -1) {
-        continue;
-      }
+    // Display the fields using the FieldItem component
+    for (let i = start; i < filteredItems.length; i += 1) {
+      type = filteredItems[i].value.Type || 'varchar(255)';
 
       // Check if field is a file, if so set flag to true
       isFile = false;
-      if (items[i].value.IsFile) {
+      if (filteredItems[i].value.IsFile) {
         isFile = true;
       }
 
@@ -238,7 +239,7 @@ class FieldList extends Component {
     return (
       <div className='list-group col-md-9 col-sm-12'>
         {fields}
-        <PaginationLinks Total={items.length} Active={this.props.PageNumber} onChangePage={this.props.changePage} RowsPerPage={rowsPerPage}/>
+        <PaginationLinks Total={filteredItems.length} Active={this.props.PageNumber} onChangePage={this.props.changePage} RowsPerPage={rowsPerPage}/>
       </div>
     );
   }

--- a/modules/dataquery/jsx/react.paginator.js
+++ b/modules/dataquery/jsx/react.paginator.js
@@ -27,11 +27,11 @@ class PaginationLinks extends Component {
     let rowsPerPage = this.props.RowsPerPage;
     let pageLinks = [];
     let classList;
-    let lastPage = Math.ceil(this.props.total / rowsPerPage);
+    let lastPage = Math.ceil(this.props.Total / rowsPerPage);
     let startPage = Math.max(1, this.props.Active - 3);
     let lastShownPage = Math.min(this.props.Active + 3, lastPage);
 
-    if (this.props.total === 0) {
+    if (this.props.Total === 0) {
       return <div/>;
     }
 

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -110,38 +110,22 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         if (preg_match("/^([0-9]{6})$/", $components[0])) {
             // FIXME: This assumes the baseURL is under /
             $path    = $uri->getPath();
-            $baseurl = $uri->withPath("/")->withQuery("");
+            $baseurl = $uri->withPath("")->withQuery("");
 
             $factory = \NDB_Factory::singleton();
             $factory->setBaseURL($baseurl);
-            switch (count($components)) {
-                case 1:
-                    $request = $request
-                    ->withAttribute("baseurl", rtrim($baseurl->__toString(), '/'))
-                    ->withAttribute("CandID", $components[0]);
-                    $module  = \Module::factory("timepoint_list");
-                    $mr      = new ModuleRouter($module);
-                    return $mr->handle($request);
-                case 2:
-                    // CandID/SessionID, inherited from htaccess
-                    $request = $request
-                    ->withAttribute("baseurl", $baseurl->__toString())
-                    ->withAttribute("CandID", $components[0]);
-                    // FIXME: Validate CandID is valid before continuing.
-                    $request    = $request
-                    ->withAttribute(
-                        "TimePoint",
-                        \TimePoint::singleton($components[1])
-                    );
-                        $module = \Module::factory("instrument_list");
-                        $mr     = new ModuleRouter($module);
-                    return $mr->handle($request);
-                default:
-                    // Fall through to 404. We don't have any routes that go farther
-                    // than 2 levels..
+            if (count($components) == 1) {
+                $request = $request
+                ->withAttribute("baseurl", $baseurl->__toString())
+                ->withAttribute("CandID", $components[0]);
+                $module  = \Module::factory("timepoint_list");
+                $mr      = new ModuleRouter($module);
+                return $mr->handle($request);
             }
         }
 
+        // Fall through to 404. We don't have any routes that go farther
+        // than 1 level..
         return (new \LORIS\Middleware\PageDecorationMiddleware(
             $this->user
         ))->process(


### PR DESCRIPTION
## Brief summary of changes
Fixes a bug with Data Query Tool where pagination list would not update based on the amount of results displayed.

#### Testing instructions
1. Go to `Define Fields` tabe of DQT
2. Choose an instrument and filter instruments by 'Searching within Instrument'
3. Check that the pagination is displaying correctly.

#### Link(s) to related issue(s)
* Resolves #6247