### PR TITLE
[API]Fix some issues reported in 6321

### DIFF
--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -151,16 +151,17 @@ Will return a JSON object of the form:
 {
   "Images" : [
     {
-      "Candidate": "123456",
-      "PSCID": "MTL001",
-      "Visit": "V1",
-      "Visit_date": "2016-08-09", /* The date of the session. This will be null for phantoms and session that are not yet started */
-      "Site": "Montreal Neurological Institute",
-      "ScanType": "t2", /* Acquisition protocol */
-      "QC_status": "Pass|Fail|null",
-      "Selected": "true|false|null",
-      "Link": "\/candidates\/300022\/V1\/images\/loris-MRI_123456_V1_t2_001.mnc", /* URL relative to this API */
-      "InsertTime": "2016-08-09T14:15:30-05:00" /* The inserted date ISO 8601 */
+      "Candidate": "400168",
+      "File": "assembly/400168/V2/mri/native/demo_400168_V2_t1_001.mnc",
+      "InsertTime": "2019-05-23T18:28:55-04:00",
+      "Link": "/candidates/400168/V2/images/demo_400168_V2_t1_001.mnc",
+      "PSCID": "ROM168",
+      "QC_status": "Pass",
+      "ScanType": "t1",
+      "Selected": "true",
+      "Site": "Rome",
+      "Visit": "V2",
+      "Visit_date": "2016-08-19"
     },
     ...
   ]

--- a/docs/API/LorisRESTAPI_v0.0.3.md
+++ b/docs/API/LorisRESTAPI_v0.0.3.md
@@ -152,7 +152,6 @@ Will return a JSON object of the form:
   "Images" : [
     {
       "Candidate": "400168",
-      "File": "assembly/400168/V2/mri/native/demo_400168_V2_t1_001.mnc",
       "InsertTime": "2019-05-23T18:28:55-04:00",
       "Link": "/candidates/400168/V2/images/demo_400168_V2_t1_001.mnc",
       "PSCID": "ROM168",

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -21,7 +21,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Project
+class Project implements \JsonSerializable
 {
     private static $_instances = array();
 
@@ -466,5 +466,18 @@ class Project
                 )
             );
         }
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     * Returns data which can be serialized by json_encode(), which is a value of
+     * any type other than a resource.
+     *
+     * @see    https://www.php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed
+     */
+    public function jsonSerialize()
+    {
+        return $this->_projectName;
     }
 }


### PR DESCRIPTION
It addresses point 1 and 2 of Issue #6321 :
1. `GET /projects/$ProjectName/images/` returns "File" key (not in spec)
I added the File key in the documentation example response.

2. `GET /candidates/$CandID/$VisitLabel` returns value {} for 'Project' key
Project now implements `JsonSerializable`

