### PR TITLE
[menu] fix instrument_list display problem

### DIFF
--- a/htdocs/css/simple-sidebar.css
+++ b/htdocs/css/simple-sidebar.css
@@ -18,7 +18,7 @@
     position: fixed;
     height: 100%;
     overflow-y: auto;
-    z-index: 1000;
+    z-index: 999;
     transition: all 0.4s ease 0s;
 }
 


### PR DESCRIPTION
## Brief summary of changes

Display overlap problem fix

#### Testing instructions (if applicable)

1. Open a profile, click instrument list to show sidebar, check whether the menu is visible or not.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
Issue #6411