### PR TITLE
[Configuration] Improve error message

### DIFF
--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -89,7 +89,7 @@ foreach ($_POST as $key => $value) {
                 continue;
             }
             if (isDuplicate($ConfigSettingsID, $value)) {
-                displayError(400, "Duplicate Value In The Instrument Form");
+                displayError(400, "Duplicate value submitted");
                 exit;
             }
             // Get all the IDs in ConfigSettings with the web_path data type.

--- a/modules/configuration/ajax/process.php
+++ b/modules/configuration/ajax/process.php
@@ -89,7 +89,11 @@ foreach ($_POST as $key => $value) {
                 continue;
             }
             if (isDuplicate($ConfigSettingsID, $value)) {
-                displayError(400, "Duplicate value submitted");
+                displayError(
+                    400,
+                    "Duplicate value submitted: "
+                    . htmlspecialchars($value, ENT_QUOTES)
+                );
                 exit;
             }
             // Get all the IDs in ConfigSettings with the web_path data type.


### PR DESCRIPTION
## Brief summary of changes

In the Config module, this error message is thrown whenever a duplicate value is submitted for a config ID (read the code comment for more details).

Previously this error message was targeted toward a specific part of the config module when it is in fact a more general error message. 

#### Testing instructions (if applicable)

1. Reproduce the bug in #6287. You should get the new error message.

#### Link(s) to related issue(s)

* This was brought up by #6287 but does not fully resolve it. The ticket requests error highlighting for the field generating the error which entails more significant changes to the module.