### PR TITLE
[instrument_list] control whether to show a imaging_browser link & active Module support

### DIFF
--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -134,6 +134,29 @@ class Instrument_List extends \NDB_Menu_Filter
             // the candidate exists before getting here.
             throw new \LorisException("Timepoint list requires a timepoint.");
         }
+
+        // Check imaging_browser permission, used to control imaging_browser link
+        // on the instrument_list main page
+        $loris = $request->getAttribute("loris");
+        $perm  = false;
+        if (!is_null($loris) && $loris->hasModule('imaging_browser')) {
+            $user = $request->getAttribute("user");
+            if ($this->candidate->getData('Entity_type') == 'Scanner') {
+                $perm = $user->hasPermission('imaging_browser_phantom_allsites')
+                || $user->hasCenterPermission(
+                    'imaging_browser_phantom_ownsite',
+                    $this->timePoint->getCenterID()
+                );
+            } elseif ($this->candidate->getData('Entity_type') == 'Human') {
+                $perm = $user->hasPermission('imaging_browser_view_allsites')
+                || $user->hasCenterPermission(
+                    'imaging_browser_view_site',
+                    $this->timePoint->getCenterID()
+                );
+            }
+        }
+        $this->tpl_data['imaging_browser_permission'] = $perm;
+
         return parent::process($request, $handler);
     }
 

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -217,9 +217,11 @@
      <tr><td nowrap="nowrap">The battery has no registered instruments</td></tr>
 {/section}
 </table>
+{if $imaging_browser_permission}
   <div class="col-xs-12 row">
   </div>
   <div class="col-xs-12 row">
     <button class="btn btn-primary" onclick="location.href='{$baseurl}/imaging_browser/viewSession/?sessionID={$sessionID}'">View Imaging data</button>
   </div>
+{/if}
 </div>


### PR DESCRIPTION
## Brief summary of changes

Control whether showing an imaging_browser link depending on the user permission & the status of the `imaging_browser` module.

#### Testing instructions (if applicable)

1. Create a user without imaging_browser permission;
2. Login with the new user to verify whether the imaging_browser will be shown at the end of the instrument_list, which could be find if you click on a candidate profile -> timepoint -> visit;
3. The user without proper permission should not see the imaging_browser link;
4. Logout the new created user, login with one with the imaging_browser permission, check to make sure that the imaging_browser link is there;
5. Disable `imaging_browser` module, check again to see that the imaging_browser link is no longer displayed.
