### PR TITLE
[DataTable] - Fix Frozen Headers

### DIFF
--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -271,7 +271,6 @@
           let top = 0;
           if (eTop < 0) {
             top = Math.abs(eTop);
-          } else {
           }
           $(headers).css({top: top});
           $('.headerColm').css({top: top});

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -272,7 +272,6 @@
           if (eTop < 0) {
             top = Math.abs(eTop);
           } else {
-            top = eTop;
           }
           $(headers).css({top: top});
           $('.headerColm').css({top: top});

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -270,9 +270,9 @@
           // near LORIS header
           let top = 0;
           if (eTop < 0) {
-            top = Math.abs(eTop) + 50;
+            top = Math.abs(eTop);
           } else {
-            top = 50 - eTop;
+            top = eTop;
           }
           $(headers).css({top: top});
           $('.headerColm').css({top: top});


### PR DESCRIPTION
## Brief summary of changes
To be honest, I'm not sure how this became broken or 100% why this fixes it because the jQuery file doesn't seem to have been changed in a long time, but it does. This entire jQuery file should probably be moved to React at some point in the near future.

#### Testing instructions (if applicable)
1. On aces/23.0-release, run make dev
2. Go to any Menu Filter module (e.g. media, candidate_list) with a large enough number of rows that you can scroll down the page.
3. See frozen headers work properly.
