### PR TITLE
[Request Account] fix placeholder message issue

### DIFF
--- a/modules/login/php/requestaccount.class.inc
+++ b/modules/login/php/requestaccount.class.inc
@@ -43,6 +43,7 @@ class RequestAccount extends \NDB_Form
         $this->addBasicText(
             "firstname",
             "First name",
+            [],
             array(
                 "placeholder" => "First Name",
                 "required"    => true,
@@ -51,6 +52,7 @@ class RequestAccount extends \NDB_Form
         $this->addBasicText(
             "lastname",
             "Last name",
+            [],
             array(
                 "placeholder" => "Last Name",
                 "required"    => true,
@@ -59,6 +61,7 @@ class RequestAccount extends \NDB_Form
         $this->addBasicText(
             "from",
             "Email address",
+            [],
             array(
                 "placeholder" => "Email address",
                 "required"    => true,


### PR DESCRIPTION
## Brief summary of changes

The placeholder is at the wrong place, which became an issue after PR #6396. There might be other cases.

#### Testing instructions (if applicable)

1. check request account page to see whether the request account form has placeholder.

#### Link(s) to related issue(s)

* Resolves #6430 
