### PR TITLE
[Forms] fix parameter position problems because of PR #6396

### DIFF
--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -297,6 +297,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
         $this->addBasicText(
             'candID',
             'CandID:',
+            [],
             array(
                 'size'      => 9,
                 'maxlength' => 6,
@@ -305,6 +306,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
         $this->addBasicText(
             'pSCID',
             'PSCID:',
+            [],
             array(
                 'size'      => 9,
                 'maxlength' => 7,
@@ -356,16 +358,16 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
             if ($r['question'] === 'Examiner') {
                 if (!empty($r['Value1'])) {
                     $r['Value1'] = $DB->pselectOne(
-                        'SELECT full_name 
-                         FROM examiners 
+                        'SELECT full_name
+                         FROM examiners
                          WHERE examinerID=:eid',
                         array('eid' => $r['Value1'])
                     );
                 }
                 if (!empty($r['Value2'])) {
                     $r['Value2'] = $DB->pselectOne(
-                        'SELECT full_name 
-                         FROM examiners 
+                        'SELECT full_name
+                         FROM examiners
                          WHERE examinerID=:eid',
                         array('eid' => $r['Value2'])
                     );

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -150,6 +150,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
         $this->addBasicText(
             'candID',
             'CandID:',
+            [],
             array(
                 'size'      => 9,
                 'maxlength' => 6,
@@ -158,6 +159,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
         $this->addBasicText(
             'pSCID',
             'PSCID:',
+            [],
             array(
                 'size'      => 9,
                 'maxlength' => 7,
@@ -210,8 +212,8 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
             if ($r['question'] === 'Examiner') {
                 if (!empty($r['CorrectAnswer'])) {
                     $r['correct_answer'] = $DB->pselectOne(
-                        'SELECT full_name 
-                         FROM examiners 
+                        'SELECT full_name
+                         FROM examiners
                          WHERE examinerID=:eid',
                         array('eid' => $r['correct_answer'])
                     );

--- a/modules/genomic_browser/php/cnv_browser.class.inc
+++ b/modules/genomic_browser/php/cnv_browser.class.inc
@@ -75,7 +75,7 @@ class CNV_Browser extends \NDB_Menu_Filter
             'CNV.StartLoc as StartLoc',
             'CNV.EndLoc as EndLoc',
             'CONCAT(
-                              CNV.Chromosome, 
+                              CNV.Chromosome,
                               ":",
                               CNV.StartLoc,
                               "-",
@@ -252,7 +252,7 @@ class CNV_Browser extends \NDB_Menu_Filter
             'Subproject:',
             array('' => 'Any') + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', [], array('maxlength' => 10));
 
         $show_results_options = array(
             'brief' => 'Summary fields',

--- a/modules/genomic_browser/php/cpg_browser.class.inc
+++ b/modules/genomic_browser/php/cpg_browser.class.inc
@@ -141,9 +141,9 @@ class CpG_Browser extends \NDB_Menu_Filter
 
         // If a candidate has no CPG records, they will not appear.
         $this->query = " FROM candidate
-            LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID 
+            LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID
                     from session s GROUP BY s.CandID) AS cohort
-                ON (cohort.CandID = candidate.CandID) 
+                ON (cohort.CandID = candidate.CandID)
             LEFT JOIN psc
                 ON (psc.CenterID = candidate.RegistrationCenterID)
             LEFT JOIN genomic_sample_candidate_rel gscr
@@ -154,8 +154,8 @@ class CpG_Browser extends \NDB_Menu_Filter
                 USING (cpg_name)
             LEFT JOIN genotyping_platform platform
                 ON (gca.platform_id = platform.PlatformID)
-            WHERE 
-            cpg.beta_value IS NOT NULL AND 
+            WHERE
+            cpg.beta_value IS NOT NULL AND
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";
 
         $user = \User::singleton();
@@ -297,7 +297,7 @@ class CpG_Browser extends \NDB_Menu_Filter
             'Subproject:',
             array('' => 'Any') + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', [], array('maxlength' => 10));
 
         $show_results_options
             = array(

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -232,7 +232,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
             'Subproject:',
             array('' => 'Any') + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', [], array('maxlength' => 10));
 
         $any_options = array(
             ''  => null,

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -275,7 +275,7 @@ class SNP_Browser extends \NDB_Menu_Filter
             'Subproject:',
             array('' => 'Any') + $list_of_subprojects
         );
-        $this->addBasicText('dob', 'Date of Birth:', array('maxlength' => 10));
+        $this->addBasicText('dob', 'Date of Birth:', [], array('maxlength' => 10));
 
         $show_results_options = array(
             'brief' => 'Summary fields',

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -128,6 +128,7 @@ class Edit_Help_Content extends \NDB_Form
         $this->addBasicTextArea(
             'content',
             'Content',
+            [],
             array(
                 'cols' => 140,
                 'rows' => 30,

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -34,7 +34,7 @@ class PasswordReset extends \NDB_Form
     function setup()
     {
         $this->tpl_data['page_title'] = 'Reset Password';
-        $this->addBasicText("username", "", array("required" => true));
+        $this->addBasicText("username", "", [], array("required" => true));
 
     }
 

--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -140,6 +140,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         $this->addBasicText(
             'TarchiveID',
             'Tarchive ID:',
+            [],
             array(
                 "size"      => 9,
                 "maxlength" => 20,
@@ -148,6 +149,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         $this->addBasicText(
             'PatientName',
             'PatientName:',
+            [],
             array(
                 "size"      => 20,
                 "maxlength" => 64,
@@ -156,6 +158,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         $this->addBasicText(
             'CandID',
             'CandID:',
+            [],
             array(
                 "size"      => 20,
                 "maxlength" => 6,
@@ -164,6 +167,7 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
         $this->addBasicText(
             'SeriesUID',
             'DICOM Series UID:',
+            [],
             array(
                 "size"      => 20,
                 "maxlength" => 64,

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -240,6 +240,7 @@ class My_Preferences extends \NDB_Form
         $this->addBasicText(
             'First_name',
             'First name',
+            [],
             array(
                 'oninvalid' => "this.setCustomValidity('$firstNameInvalidMsg')",
                 'onchange'  => "this.setCustomValidity('')",
@@ -256,6 +257,7 @@ class My_Preferences extends \NDB_Form
         $this->addBasicText(
             'Last_name',
             'Last name',
+            [],
             array(
                 'oninvalid' => "this.setCustomValidity('$lastNameInvalidMsg')",
                 'onchange'  => "this.setCustomValidity('')",
@@ -268,6 +270,7 @@ class My_Preferences extends \NDB_Form
         $this->addBasicText(
             'Email',
             'Email address',
+            [],
             array(
                 'oninvalid' => "this.setCustomValidity('Email address is required')",
                 'onchange'  => "this.setCustomValidity('')",

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -397,7 +397,7 @@ class Edit_User extends \NDB_Form
                 //Check if examiner already in db for site
                 $result = $DB->pselectRow(
                     "SELECT epr.centerID
-                           FROM examiners_psc_rel epr 
+                           FROM examiners_psc_rel epr
                            WHERE epr.examinerID=:eid AND epr.centerID=:cid",
                     array(
                         "eid" => $examinerID,
@@ -685,6 +685,7 @@ class Edit_User extends \NDB_Form
         $this->addBasicText(
             'First_name',
             'First name',
+            [],
             array(
                 'oninvalid' => $onInvalidMsg,
                 'onchange'  => "this.setCustomValidity('')",
@@ -702,6 +703,7 @@ class Edit_User extends \NDB_Form
         $this->addBasicText(
             'Last_name',
             'Last name',
+            [],
             array(
                 'oninvalid' => $onInvalidMsg,
                 'onchange'  => "this.setCustomValidity('')",
@@ -1245,7 +1247,7 @@ class Edit_User extends \NDB_Form
             && ($values['active_from'] > $values['active_to'])
         ) {
             $errors['active_timeWindows']
-                = 'Please notice that the "Active from" 
+                = 'Please notice that the "Active from"
                 date should be lesser or equal to the "Active to" date.';
         }
         return $errors;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1727,6 +1727,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             "textarea",
             $field,
             null,
+            [],
             array(
                 'cols' => 25,
                 'rows' => 4,
@@ -1771,6 +1772,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             "textarea",
             $field,
             $label,
+            [],
             array(
                 'cols'  => 25,
                 'rows'  => 4,


### PR DESCRIPTION
## Brief summary of changes

Fix parameter position problem after the merge of the PR #6396. This is in addition to those processed in the PR #6431.

There are some trailing white spaces removed because of editor settings, which I did not notice early, but no much impact so I didn't redo the modification.