### PR TITLE
[ElectrophysiologyBrowser] Adding manual TestPlan

### DIFF
--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -12,7 +12,7 @@
 
 ### B. subpage: Sessions 
 
-7. Sidebar:  Navigation links work. 
+7. Sidebar: Navigation links work. 
 8. Data table display : information displayed looks decently laid out, not garbled 
 9. Click each "Download" button (there should be 5). Check: Does the download button work?  Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
 10. Test Breadcrumb link back to Electrophysiology Browser

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -13,7 +13,7 @@
 ### B. subpage: Sessions 
 
 7. Sidebar: Navigation links work. 
-8. Data table display : information displayed looks decently laid out, not garbled 
+8. Data table display: information displayed looks decently laid out, not garbled.
 9. Click each "Download" button (there should be 5). Check: Does the download button work?  Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
 10. Test Breadcrumb link back to Electrophysiology Browser
 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -1,7 +1,7 @@
 ## Electrophysiology Browser test plan
 	
 ### A. Electrophysiology Browser front page
-1. User can load Electrophysiology Browser module front page IFF has either permission:
+1. User can load Electrophysiology Browser module front page if and only if user has either permission:
    * `electrophysiology_browser_view_site` : _"View all-sites Electrophysiology Browser pages"_
    * `electrophysiology_browser_view_allsites` : _"View own site Electrophysiology Browser pages"_
 2. User can see other sites Electrophysiology datasets IFF has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets IFF has permission `electrophysiology_browser_view_site`. 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -6,7 +6,7 @@
    * `electrophysiology_browser_view_allsites` : _"View own site Electrophysiology Browser pages"_
 2. User can see other sites Electrophysiology datasets if and only if user has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets if and only if user has permission `electrophysiology_browser_view_site`. 
 3. Test that all Filters work.  
-4. Test Clear Filters button
+4. Test Clear Filters button.
 5. Test column table is sortable by headers.
 6. Test that Links work, to correct dataset (raw/all types)
 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -18,6 +18,6 @@
 10. Test Breadcrumb link back to Electrophysiology Browser
 
 _For extra credit: Verify LORIS Menu permissions_ 
-User can view the top-level LORIS Menu _Electrophysiology_ and Menu item : _Electrophysiology Browser_ IFF user has either permission:
+User can view the top-level LORIS Menu _Electrophysiology_ and Menu item : _Electrophysiology Browser_ if and only if user has either permission:
    * `electrophysiology_browser_view_site` : _"View all-sites Electrophysiology Browser pages"_
    * `electrophysiology_browser_view_allsites` : _"View own site Electrophysiology Browser pages"_

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -10,7 +10,7 @@
 5. Test column table is sortable by headers.
 6. Test that Links work and point to correct dataset (raw/all types).
 
-### B. subpage: Sessions 
+### B. Subpage: Sessions 
 
 7. Sidebar: Navigation links work. 
 8. Data table display: information displayed looks decently laid out, not garbled.

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -4,7 +4,7 @@
 1. User can load Electrophysiology Browser module front page if and only if user has either permission:
    * `electrophysiology_browser_view_site` : _"View all-sites Electrophysiology Browser pages"_
    * `electrophysiology_browser_view_allsites` : _"View own site Electrophysiology Browser pages"_
-2. User can see other sites Electrophysiology datasets IFF has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets IFF has permission `electrophysiology_browser_view_site`. 
+2. User can see other sites Electrophysiology datasets if and only if user has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets if and only if user has permission `electrophysiology_browser_view_site`. 
 3. Test that all Filters work.  
 4. Test Clear Filters button
 5. Test column table is sortable by headers

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -1,7 +1,9 @@
 ## Electrophysiology Browser test plan
 	
 ### A. Electrophysiology Browser front page
-1. User can load Electrophysiology Browser module front page IFF has permission `electrophysiology_browser_view_site` or `electrophysiology_browser_view_allsites`
+1. User can load Electrophysiology Browser module front page IFF has either permission:
+   * `electrophysiology_browser_view_site` : _"View all-sites Electrophysiology Browser pages"_
+   * `electrophysiology_browser_view_allsites` : _"View own site Electrophysiology Browser pages"_
 2. User can see other sites Electrophysiology datasets IFF has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets IFF has permission `electrophysiology_browser_view_site`. 
 3. Test that all Filters work.  
 4. Test Clear Filters button
@@ -15,3 +17,7 @@
 9. Click each "Download" button (there should be 5). Check: Does the download button work?  Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
 10. Test Breadcrumb link back to Electrophysiology Browser
 
+_For extra credit: Verify LORIS Menu permissions_ 
+User can view the top-level LORIS Menu _Electrophysiology_ and Menu item : _Electrophysiology Browser_ IFF user has either permission:
+   * `electrophysiology_browser_view_site` : _"View all-sites Electrophysiology Browser pages"_
+   * `electrophysiology_browser_view_allsites` : _"View own site Electrophysiology Browser pages"_

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -15,7 +15,7 @@
 7. Sidebar: Navigation links work. 
 8. Data table display: information displayed looks decently laid out, not garbled.
 9. Click each "Download" button (there should be 5). Check: Does the download button work? Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
-10. Test Breadcrumb link back to Electrophysiology Browser
+10. Test Breadcrumb link back to Electrophysiology Browser.
 
 _For extra credit: Verify LORIS Menu permissions_ 
 User can view the top-level LORIS Menu _Electrophysiology_ and Menu item : _Electrophysiology Browser_ if and only if user has either permission:

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -14,7 +14,7 @@
 
 7. Sidebar: Navigation links work. 
 8. Data table display: information displayed looks decently laid out, not garbled.
-9. Click each "Download" button (there should be 5). Check: Does the download button work?  Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
+9. Click each "Download" button (there should be 5). Check: Does the download button work? Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
 10. Test Breadcrumb link back to Electrophysiology Browser
 
 _For extra credit: Verify LORIS Menu permissions_ 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -1,0 +1,17 @@
+## Electrophysiology Browser test plan
+	
+### A. Electrophysiology Browser front page
+1. User can load Electrophysiology Browser module front page IFF has permission `electrophysiology_browser_view_site` or `electrophysiology_browser_view_allsites`
+2. User can see other sites Electrophysiology datasets IFF has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets IFF has permission `electrophysiology_browser_view_site`. 
+3. Test that all Filters work.  
+4. Test Clear Filters button
+5. Test column table is sortable by headers
+6. Test that Links work, to correct dataset (raw/all types)
+
+### B. subpage: Sessions 
+
+7. Sidebar:  Navigation links work. 
+8. Data table display : information displayed looks decently laid out, not garbled 
+9. Click each "Download" button (there should be 5). Check: Does the download button work?  Does the file that is downloaded have greater than 0kb size? Is a different file downloaded by each button? 
+10. Test Breadcrumb link back to Electrophysiology Browser
+

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -7,7 +7,7 @@
 2. User can see other sites Electrophysiology datasets if and only if user has permission `electrophysiology_browser_view_allsites`. User can see only own-site datasets if and only if user has permission `electrophysiology_browser_view_site`. 
 3. Test that all Filters work.  
 4. Test Clear Filters button
-5. Test column table is sortable by headers
+5. Test column table is sortable by headers.
 6. Test that Links work, to correct dataset (raw/all types)
 
 ### B. subpage: Sessions 

--- a/modules/electrophysiology_browser/test/TestPlan.md
+++ b/modules/electrophysiology_browser/test/TestPlan.md
@@ -8,7 +8,7 @@
 3. Test that all Filters work.  
 4. Test Clear Filters button.
 5. Test column table is sortable by headers.
-6. Test that Links work, to correct dataset (raw/all types)
+6. Test that Links work and point to correct dataset (raw/all types).
 
 ### B. subpage: Sessions 
 


### PR DESCRIPTION
First commit of a manual test plan for the Electrophysiological Browser module - for the 23.0.0 release
Partially modelled on the Imaging Browser test plan.

Resolves #6313 

To test : validate the test plan, and check for clarity and completeness of instructions
