### PR TITLE
[Imaging_uploader] Clear front-end console error logs

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -273,7 +273,7 @@ class UploadForm extends Component {
         let messageToPrint = '';
         if (error.responseJSON.errors) {
           errorMessage = error.responseJSON.errors;
-        } else if (error.status == '413') {
+        } else if (error.status == 413) {
           errorMessage = {
             'mriFile': ['Please make sure files are not larger than ' + this.props.maxUploadSize],
           };

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -63,7 +63,7 @@ class UploadForm extends Component {
     formData[field] = value;
 
     if (field === 'mriFile') {
-      if (value.name !== '' && formData.IsPhantom === 'N') {
+      if (value.name && value.name !== '' && formData.IsPhantom === 'N') {
         let patientName = value.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
         let ids = patientName.split('_', 3);
         formData.candID = ids[1];
@@ -269,9 +269,11 @@ class UploadForm extends Component {
       // - Returns to Upload tab
       error: (error, textStatus, errorThrown) => {
         let errorMessage = Object.assign({}, this.state.errorMessage);
-        let hasError = this.state.hasError;
+        let hasError = Object.assign({}, this.state.hasError);
         let messageToPrint = '';
-        errorMessage = (error.responseJSON || {}).errors || 'Submission error!';
+        if (error.responseJSON.errors) {
+          errorMessage = error.responseJSON.errors;
+        }
         for (let i in errorMessage) {
           if (errorMessage.hasOwnProperty(i)) {
             errorMessage[i] = errorMessage[i].toString();

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -275,7 +275,7 @@ class UploadForm extends Component {
           errorMessage = error.responseJSON.errors;
         } else if (error.status == '413') {
           errorMessage = {
-            'mriFile': ["Please make sure files are not larger than " + this.props.maxUploadSize]
+            'mriFile': ['Please make sure files are not larger than ' + this.props.maxUploadSize],
           };
         }
         for (let i in errorMessage) {

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -63,7 +63,7 @@ class UploadForm extends Component {
     formData[field] = value;
 
     if (field === 'mriFile') {
-      if (value.name && value.name !== '' && formData.IsPhantom === 'N') {
+      if (value.name && formData.IsPhantom === 'N') {
         let patientName = value.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
         let ids = patientName.split('_', 3);
         formData.candID = ids[1];

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -273,6 +273,10 @@ class UploadForm extends Component {
         let messageToPrint = '';
         if (error.responseJSON.errors) {
           errorMessage = error.responseJSON.errors;
+        } else if (error.status == '413') {
+          errorMessage = {
+            'mriFile': ["Please make sure files are not larger than " + this.props.maxUploadSize]
+          };
         }
         for (let i in errorMessage) {
           if (errorMessage.hasOwnProperty(i)) {

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -271,7 +271,7 @@ class UploadForm extends Component {
         let errorMessage = Object.assign({}, this.state.errorMessage);
         let hasError = Object.assign({}, this.state.hasError);
         let messageToPrint = '';
-        if (error.responseJSON.errors) {
+        if (error.responseJSON && error.responseJSON.errors) {
           errorMessage = error.responseJSON.errors;
         } else if (error.status == 413) {
           errorMessage = {


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the errors shown in https://github.com/aces/Loris/issues/6314. It also takes into account a 413 error, which should render the same swal error as 'mriFile' 400 error.

#### Testing instructions (if applicable)

1. Go to 'Imaging Uploader' module
2. Click on 'Upload' tab
3. Fill in the form: 'Phantom Scans': Yes/No
4. Upload a file into 'File to Upload' field that is larger than the number stated in the 'Notes' field 'File cannot exceed ...'
5. Click 'Submit'
6. Swal will pop up with "Please make sure files are not larger than .."
7. See console log, which should only have the error `Failed to load resource: the server responded with a status of 400 (Bad Request)`
8. If you can, try to trigger a 413 (Request Entity Too Large) error. The swal should remain the same as above.

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/Loris/issues/6314
