### PR TITLE
[LorisForm] Form static element bug in group mode

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1967,10 +1967,7 @@ class LorisForm
         case 'submit':
             return $this->createSubmit($elname, $label, $options);
         case 'static':
-            /* Label seems to usually be the wrong attribute for static
-             * elements?
-             */
-            $el         = $this->createBase($elname, $options, $attribs);
+            $el         = $this->createBase($elname, $label, $attribs);
             $el['type'] = 'static';
             break;
         case 'advcheckbox':


### PR DESCRIPTION
## Brief summary of changes

This is the recreation of the PR #6395, the third parameter of the form elements in the group mode was set as the fourth parameter somehow for `static` text Form type, this is clearly a bug.

The change is to pass the label (third parameter) to the second parameter of the createBase instead of the options which is usually the forth parameter. I believe that passing options to the position of label is unacceptable, unfortunately as the comment says, it seems someone did this on purpose, I don't know why.

The old format could be working in the following way (I just pass the label at the wrong place to make the system work):
$this->form->createElement('static', null, null, "label");

I noticed that the [wiki](https://github.com/aces/Loris/wiki/Instrument-Groups) manual suggests to use the format:
$group[] =& $this->form->createElement("static", null, null, "label");

I suggest to use the new format to be consistent with other types:
$this->form->createElement('static', null, "label");

Another way to do is to use the wrong signature, modify the old function signature, and create a new function to use the new format. Which will also create some complexity.

_[Important]_ Possible impact:
Some old instruments will stop displaying correctly once being migrated, some verification required, besides possibly some function signatures changes including setup, score, etc., which is beyond the scope of this PR.

The instrument migration fix could be easy with a full text replacement with further verification. Some project could use module overrides to handle.