### PR TITLE
Variable name changed from candID to CandID

### DIFF
--- a/htdocs/api/v0.0.2/candidates/Visit.php
+++ b/htdocs/api/v0.0.2/candidates/Visit.php
@@ -230,7 +230,7 @@ class Visit extends \Loris\API\Candidates\Candidate
             $this->safeExit(0);
         }
 
-        $cand        = \Candidate::singleton($candID);
+        $cand        = \Candidate::singleton($CandID);
         $sessionSite = \Site::singleton($CID);
 
         \TimePoint::createNew($cand, $subprojectID, $VL, $sessionSite);


### PR DESCRIPTION
This was preventing the creation go Visits because the variable "candID" does not exits.

## Brief summary of changes

- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
