### PR TITLE
[LorisForm] keep old group mode text parameter mode

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1960,7 +1960,13 @@ class LorisForm
         case 'submit':
             return $this->createSubmit($elname, $label, $attribs);
         case 'static':
-            $el         = $this->createBase($elname, $label, $attribs);
+            /* the $options was passed to the 2nd parameter pre-v23.0 for some
+             reason, it is important not to impact the existing instruments. */
+            $el         = $this->createBase(
+                $elname,
+                is_string($options) ? $options : $label,
+                $attribs
+            );
             $el['type'] = 'static';
             break;
         case 'advcheckbox':


### PR DESCRIPTION
## Brief summary of changes

The PR #6395 is radical, so the existing instruments might have table title text display problem, this PR will keep the old format and the new correct format available at the same time

#### Testing instructions (if applicable)

1. Test instrument with table to check whether table title is displayed correctly.
For example: medical_history from raisonbread, check PR #6444

#### Link(s) to related issue(s)
PR #6395, PR #6451