### PR TITLE
[user_accounts] Resolve Notice: Undefined index: permID

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -213,7 +213,8 @@ class Edit_User extends \NDB_Form
         // 2) Certain old permissions that the editor is not permitted to alter
         // In addition, old permissions should be removed if the editor has
         // removed them and the editor has permissions to remove them.
-        $newPermissions    = array_keys($values['permID']) ?? array();
+        $newPermissions    = isset($values['permID'])
+            ? array_keys($values['permID']) : array();
         $editorPermissions = $editor->getPermissionIDs() ?? array();
         $permIDs           = array();
         // store the permission IDs


### PR DESCRIPTION
## Brief summary of changes

Solves the `undefined index` error from polluting the error_log and when removing pending approval for a user in user_accounts module. 

#### Testing instructions (if applicable)

1. Request account
2. Visit user_accounts module as admin
3. Remove pending approval for account.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
#6353