### PR TITLE
[data_release] Preventing Duplication of File Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ the list of modules.(PR #5824)
 exception). It is recommended to run this tool for existing projects (PR #5270)
 - New tool for automatically adding modules to the modules table. This tool should 
 be used by projects having custom modules not in LORIS. (PR #5913)
+- Duplicate filenames in the data release module will cause an error when downloading. Make sure to remove all filename duplications before upgrading to this version. (PR #6461)
 
 ### Notes For Developers
 - The tool `phpstan` has been added to our automated test suite. (PR #4928)

--- a/htdocs/js/jquery.dynamictable.js
+++ b/htdocs/js/jquery.dynamictable.js
@@ -270,9 +270,7 @@
           // near LORIS header
           let top = 0;
           if (eTop < 0) {
-            top = Math.abs(eTop) + 50;
-          } else {
-            top = 50 - eTop;
+            top = Math.abs(eTop);
           }
           $(headers).css({top: top});
           $('.headerColm').css({top: top});

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -61,7 +61,7 @@ if ($_GET['action'] == 'upload') {
             if (!isset($userPermission) && !$user->hasPermission('superuser')) {
                 $msg = "File overwrite failed. Current user does not have
                         permission for file.";
-                $error_log('ERROR: ' . $msg);
+                error_log('ERROR: ' . $msg);
                 header("HTTP/1.1 403 Forbidden");
                 exit;
             }

--- a/modules/data_release/ajax/FileUpload.php
+++ b/modules/data_release/ajax/FileUpload.php
@@ -25,6 +25,7 @@ if (!$user->hasPermission('data_release_upload')) {
 if ($_GET['action'] == 'upload') {
     $fileName    = $_FILES["file"]["name"];
     $version     = !empty($_POST['version']) ? $_POST['version'] : null;
+    $overwrite   = $_GET['overwrite'] ?? false;
     $upload_date = date('Y-m-d');
 
     $settings = $factory->settings();
@@ -40,32 +41,27 @@ if ($_GET['action'] == 'upload') {
         error_log('ERROR: ' . $msg);
         header("HTTP/1.1 500 Internal Server Error");
     } else {
-        $files = $DB->pselect(
-            "SELECT id, file_name FROM data_release",
+        $fileNames = $DB->pselectcol(
+            "SELECT file_name FROM data_release",
             array()
         );
-        $duplicates = [];
-        foreach ($files as $file) {
-            if ($fileName == $file['file_name']) {
-                $duplicates[$file['id']] = $file['file_name'];
-            }
+
+        if (in_array($fileName, $fileNames) && !$overwrite) {
+            header("Location: {$baseURL}/data_release/?duplicate=true");
+            exit;
         }
 
         $target_path = $path . $fileName;
         if (move_uploaded_file($_FILES["file"]["tmp_name"], $target_path)) {
-            if (!empty($duplicates)) {
-                $DB->delete('data_release', ['file_name' => $fileName]);
-                foreach ($duplicates as $id => $name) {
-                    $DB->update(
-                        'data_release',
-                        [
-                         'file_name'   => $fileName,
-                         'version'     => $version,
-                         'upload_date' => $upload_date,
-                        ],
-                        ['id' => $id] 
-                    );
-                }
+            if (in_array($fileName, $fileNames)) {
+                $DB->update(
+                    'data_release',
+                    [
+                        'version'     => $version,
+                        'upload_date' => $upload_date,
+                    ],
+                    ['file_name' => $fileName]
+                );
             } else {
                 // insert the file into the data_release table
                 $DB->insert(
@@ -76,37 +72,38 @@ if ($_GET['action'] == 'upload') {
                         'upload_date' => $upload_date,
                     )
                 );
+                // get the ID of the user who uploaded the file
+                $user_ID = $DB->pselectOne(
+                    "SELECT ID FROM users WHERE userid=:UserID",
+                    array('UserID' => $user->getUsername())
+                );
+                // get the ID of the file inserted in the data_release table
+                $version_where = $version ? "version=:version"
+                    : "version IS :version";
+                $ID            = $DB->pselectOne(
+                    "SELECT 
+                   id 
+                 FROM 
+                   data_release 
+                 WHERE 
+                   file_name=:file_name 
+                   AND $version_where
+                   AND upload_date=:upload_date",
+                    array(
+                        'file_name'   => $fileName,
+                        'version'     => $version,
+                        'upload_date' => $upload_date,
+                    )
+                );
+                // add permission to the user for the uploaded data_release file
+                $DB->insert(
+                    'data_release_permissions',
+                    array(
+                        'userid'          => $user_ID,
+                        'data_release_id' => $ID,
+                    )
+                );
             }
-            // get the ID of the user who uploaded the file
-            $user_ID = $DB->pselectOne(
-                "SELECT ID FROM users WHERE userid=:UserID",
-                array('UserID' => $user->getUsername())
-            );
-            // get the ID of the file inserted in the data_release table
-            $version_where = $version ? "version=:version" : "version IS :version";
-            $ID            = $DB->pselectOne(
-                "SELECT 
-               id 
-             FROM 
-               data_release 
-             WHERE 
-               file_name=:file_name 
-               AND $version_where
-               AND upload_date=:upload_date",
-                array(
-                    'file_name'   => $fileName,
-                    'version'     => $version,
-                    'upload_date' => $upload_date,
-                )
-            );
-            // add permission to the user for the uploaded data_release file
-            $DB->insert(
-                'data_release_permissions',
-                array(
-                    'userid'          => $user_ID,
-                    'data_release_id' => $ID,
-                )
-            );
         }
         header("Location: {$baseURL}/data_release/?uploadSuccess=true");
         header("HTTP/1.1 201 Created");

--- a/modules/data_release/jsx/uploadFileForm.js
+++ b/modules/data_release/jsx/uploadFileForm.js
@@ -166,8 +166,10 @@ class UploadFileForm extends Component {
 
   /**
    * Upload the file to the server
+   *
+   * @param {boolean} overwrite
    */
-  uploadFile() {
+  uploadFile(overwrite) {
     let formData = this.state.formData;
     let formObj = new FormData();
     for (let key in formData) {
@@ -177,7 +179,9 @@ class UploadFileForm extends Component {
     }
 
     // fetch API to upload the file
-    fetch(this.props.action, {
+    const url = overwrite ? this.props.action + '&overwrite=true'
+      : this.props.action;
+    fetch(url, {
       method: 'post',
       body: formObj,
       cache: 'no-cache',
@@ -191,25 +195,41 @@ class UploadFileForm extends Component {
         swal(msg, '', 'error');
         console.error(msg);
       } else {
-        // Add file to the list of existing files
-        let files = JSON.parse(JSON.stringify(this.state.data.files));
-        files.push(formData.file.name);
-        // Trigger an update event to update all observers (i.e. DataTable)
-        let event = new CustomEvent('update-datatable');
-        window.dispatchEvent(event);
-        this.setState({
-          files: files,
-          formData: {}, // reset form data after successful file upload
-          uploadProgress: -1,
-        });
-        swal({
-          text: 'Upload Successful!',
-          title: '',
-          type: 'success',
-        }, function() {
-          window.location.assign('/data_release');
-        });
-        this.props.fetchData();
+        const responseUrl = new URL(response.url);
+        if (responseUrl.searchParams.has('duplicate')) {
+          swal({
+            title: 'Are you sure?',
+            text: 'A file with this name already exists!\n Would you like to overwrite existing file?\n Note that the version associated with the file will also be overwritten.',
+            type: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Yes, I am sure!',
+            cancelButtonText: 'No, cancel it!',
+          }, (isConfirm) => {
+            if (isConfirm) {
+              this.uploadFile(true);
+            }
+          });
+        } else {
+          // Add file to the list of existing files
+          let files = JSON.parse(JSON.stringify(this.state.data.files));
+          files.push(formData.file.name);
+          // Trigger an update event to update all observers (i.e. DataTable)
+          let event = new CustomEvent('update-datatable');
+          window.dispatchEvent(event);
+          this.setState({
+            files: files,
+            formData: {}, // reset form data after successful file upload
+            uploadProgress: -1,
+          });
+          swal({
+            text: 'Upload Successful!',
+            title: '',
+            type: 'success',
+          }, function() {
+            window.location.assign('/data_release');
+          });
+          this.props.fetchData();
+        }
       }
     }).catch( (error) => {
       let msg = error.message ? error.message : 'Upload error!';

--- a/modules/data_release/jsx/uploadFileForm.js
+++ b/modules/data_release/jsx/uploadFileForm.js
@@ -106,7 +106,6 @@ class UploadFileForm extends Component {
    * Validate and submit the upload
    */
   validateAndSubmit() {
-    let files = this.state.data.files ? this.state.data.files : [];
     let formData = this.state.formData;
 
     let errorMessage = {

--- a/modules/data_release/jsx/uploadFileForm.js
+++ b/modules/data_release/jsx/uploadFileForm.js
@@ -143,30 +143,7 @@ class UploadFileForm extends Component {
       return;
     }
 
-    // Grep the uploaded file name
-    let fileName = formData.file ? formData.file.name.replace(/\s+/g, '_') : null;
-
-    // Check for duplicate file names
-    let isDuplicate = files.indexOf(fileName);
-    if (isDuplicate >= 0) {
-      swal({
-        title: 'Are you sure?',
-        text: 'A file with this name already exists!\n Would you like to override existing file?',
-        type: 'warning',
-        showCancelButton: true,
-        confirmButtonText: 'Yes, I am sure!',
-        cancelButtonText: 'No, cancel it!',
-        closeOnConfirm: false,
-      }, function(isConfirm) {
-        if (isConfirm) {
-          this.uploadFile();
-        } else {
-          swal('Cancelled', 'Your file is safe :)', 'error');
-        }
-      }.bind(this));
-    } else {
-      this.uploadFile();
-    }
+    this.uploadFile();
   }
 
   /**


### PR DESCRIPTION
## Brief summary of changes
This PR Prevents the duplication of file_names in the data_release table. If there is an attempt to submit a filename that already exists in the table, the user is given the option of overwriting the previous entry.

#### Testing instructions
Part 1
1. Upload a file to data_release.
2. Upload file with same name but different content.
3. Make sure a swal appears asking whether you want overwrite the file.
4. Overwrite file and make sure of it by downloading the new resource.

Part 2
1. Upload file as user who is not super user.
2. Remove permission to that file for that user.
3. Have that user try to overwrite the file.
4. Receive "Forbidden" error message.
5. Repeat steps 1-4 with super user. They should be able to overwrite the file even if they don't have permission for it.

#### Link(s) to related issue(s)
* Resolves #6435 