### PR TITLE
[Release Notes] Add Data Release Duplicate Specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ the list of modules.(PR #5824)
 exception). It is recommended to run this tool for existing projects (PR #5270)
 - New tool for automatically adding modules to the modules table. This tool should 
 be used by projects having custom modules not in LORIS. (PR #5913)
+- Duplicate filename in the data release module will cause an error when downloading. Make sure to remove all duplications before upgrading to this version. (PR #6461)
 
 ### Notes For Developers
 - The tool `phpstan` has been added to our automated test suite. (PR #4928)


### PR DESCRIPTION
NOTE: I've never made a change to release notes before and not sure if this is how it should be done. This addition was requested by @ridz1208 

## Brief summary of changes
If projects have duplicate file names in their data_release tables, this will cause errors when downloading files. Projects should remove duplicates before updating their version.

Related PR:  #6461 