### PR TITLE
[issue_tracker] Prevent users from accessing issues to which they don't have the appropriate Center

### DIFF
--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -15,6 +15,7 @@
 namespace LORIS\issue_tracker;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
+use \Psr\Http\Server\RequestHandlerInterface;
 /**
  * Creates the form for NDB_Form_issue_tracker
  *
@@ -107,9 +108,34 @@ class Issue extends \NDB_Form
         return (is_null($issueData)
             || in_array($issueData['centerID'], $user->getData('CenterIDs'))
             || ($user->hasPermission('access_all_profiles'))
-            || (!empty($issueData['centerID']))
+            || (empty($issueData['centerID']))
         );
     }
+
+    /**
+     * Ensure $this->issueID is set so that _hasAccess is valid
+     * before calling the parent middleware.
+     *
+     * @param ServerRequestInterface  $request The PSR7 request being processed.
+     * @param RequestHandlerInterface $handler The handler to handle the request
+     *                                         after processing the middleware.
+     *
+     * @return ResponseInterface
+     */
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ) : ResponseInterface {
+        $results = array();
+        preg_match(
+            '#/issue/([0-9]+|new)$#',
+            $request->getURI()->getPath(),
+            $results
+        );
+        $this->issueID = $results[1] ?? null;
+        return parent::process($request, $handler);
+    }
+
     /**
      * Handle the incoming request for an issue. This extracts URLs of the form
      * /issue_tracker/issue/3 and extracts the issueID so that it's accessible
@@ -121,13 +147,6 @@ class Issue extends \NDB_Form
      */
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
-        $results = array();
-        preg_match(
-            '#/issue/([0-9]+|new)$#',
-            $request->getURI()->getPath(),
-            $results
-        );
-        $this->issueID = $results[1] ?? null;
         if (empty($this->issueID) && $this->issueID != "new") {
             // Should probably be a bad request, but we don't have a 400.tpl
             // template.


### PR DESCRIPTION
## Brief summary of changes
This PR fixes an issue which allowed users to view issues to which they didn't have the proper center.

#### Testing instructions (if applicable)
1. Go to issue_tracker module. 
2. Go to an issue url which exists but to which the user doesn't have access based center.
3. Ensure that permission to view is denied.

#### Link(s) to related issue(s)
#6282 
