### PR TITLE
[install] Add php-curl module in Ubuntu documentation

### DIFF
--- a/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/Ubuntu/README.md
+++ b/docs/wiki/00 - SERVER INSTALL AND CONFIGURATION/01 - LORIS Install/Ubuntu/README.md
@@ -38,6 +38,7 @@ The following Ubuntu packages are required and should be installed using
 * php7.3-mbstring
 * php7.3-gd
 * php7.3-zip
+* php7.3-curl
 * libapache2-mod-php7.3
 
 ## Getting the source code


### PR DESCRIPTION
## Brief summary of changes
The curl php module is required in order to complete successfully the installation, but is missing in the ubuntu install wiki.
- [x] Have you updated related documentation?

* Resolves #6473
