### PR TITLE
[issue_tracker] Fix Priority Ordering.

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -66,7 +66,13 @@ class Filter extends Component {
           element = <TextboxElement key={filter.name}/>;
           break;
         case 'select':
-          element = <SelectElement key={filter.name} options={filter.options}/>;
+          element = (
+            <SelectElement
+              key={filter.name}
+              options={filter.options}
+              sortByValue={filter.sortByValue}
+            />
+          );
           break;
         case 'multiselect':
           element = <SelectElement key={filter.name} options={filter.options} multiple={true} emptyOption={false}/>;

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -249,6 +249,7 @@ class IssueForm extends Component {
             required={false}
             disabled={!hasEditPermission}
             value={this.state.formData.priority}
+            sortByValue={false}
           />
           <SelectElement
             name='category'

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -177,6 +177,7 @@ class IssueTrackerIndex extends Component {
       {label: 'Priority', show: true, filter: {
         name: 'priority',
         type: 'select',
+        sortByValue: false,
         options: options.priorities,
         }},
       {label: 'Site', show: true, filter: {


### PR DESCRIPTION
## Brief summary of changes
This PR overrides the default alphabetical sorting of SelectElements for the list of priorities in the issue tracker module.

NOTE: This PR did make me think that maybe the index files for each module should really be passing components for the filter fields rather than a series of parameters from a JSON object. 

#### Testing instructions (if applicable)
1. Go to Issue Tracker module
2. Make sure list of priorities in the menu filter and on the new Issue page are ordered: 
normal, high, urgent, immediate.

#### Link(s) to related issue(s)
* Replaces #6376
* Resolves #6328
