### PR TITLE
[issue_tracker] Handle a CenterID of NULL in issues table.

### DIFF
--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -58,7 +58,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
 
         $user = \User::singleton();
 
-        if ($user->hasPermission('access_all_profiles') === false) {
+        If ($user->hasPermission('access_all_profiles') === false) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\UserSiteMatch()
             );

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -58,7 +58,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
 
         $user = \User::singleton();
 
-        If ($user->hasPermission('access_all_profiles') === false) {
+        if ($user->hasPermission('access_all_profiles') === false) {
             $provisioner = $provisioner->filter(
                 new \LORIS\Data\Filters\UserSiteMatch()
             );

--- a/modules/issue_tracker/php/issuerow.class.inc
+++ b/modules/issue_tracker/php/issuerow.class.inc
@@ -1,18 +1,4 @@
 <?php
-/**
- * This class implements a data Instance which represents a single
- * row in the issue tracker menu table.
- *
- * PHP Version 7
- *
- * @category   Behavioural
- * @package    Main
- * @subpackage Tools
- * @author     Henri Rabalais <henri.rabalais@mcin.ca>
- * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link       https://www.github.com/aces/Loris/
- */
-
 namespace LORIS\issue_tracker;
 
 /**
@@ -28,7 +14,7 @@ namespace LORIS\issue_tracker;
 class IssueRow implements \LORIS\Data\DataInstance
 {
     protected $DBRow;
-    protected $CenterID;
+    protected $CenterIDs;
     protected $Module;
 
     /**
@@ -36,14 +22,14 @@ class IssueRow implements \LORIS\Data\DataInstance
      *
      * @param array   $row    The row (in the same format as \Database::pselectRow
      *                        returns.
-     * @param integer $cid    The centerID affiliated with this row.
+     * @param array   $cids   The centerIDs affiliated with this row.
      * @param \Module $module The module that this issue is for.
      */
-    public function __construct(array $row, $cid, \Module $module)
+    public function __construct(array $row, array $cids, \Module $module)
     {
-        $this->DBRow    = $row;
-        $this->CenterID = $cid;
-        $this->Module   = $module;
+        $this->DBRow     = $row;
+        $this->CenterIDs = $cids;
+        $this->Module    = $module;
 
         $this->DBRow['module'] = $module->getLongName();
     }
@@ -62,11 +48,11 @@ class IssueRow implements \LORIS\Data\DataInstance
      * Returns the CenterID for this row, for filters such as
      * \LORIS\Data\Filters\UserSiteMatch to match again.
      *
-     * @return integer The CenterID
+     * @return array The CenterIDs
      */
-    public function getCenterID()
+    public function getCenterIDs()
     {
-        return $this->CenterID;
+        return $this->CenterIDs;
     }
 
     /**

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -30,16 +30,16 @@ namespace LORIS\issue_tracker;
  */
 class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
-    private $siteList;
+    private $_siteList;
 
     /**
      * Create a IssueRowProvisioner, which gets rows for the issues menu table.
      */
     function __construct()
     {
-        $this->siteList = array_keys(\Utility::getSiteList(false));
-        $user   = \User::singleton();
-        $userID = $user->getUsername();
+        $this->_siteList = array_keys(\Utility::getSiteList(false));
+        $user            = \User::singleton();
+        $userID          = $user->getUsername();
         //note that this needs to be in the same order as the headers array
         parent::__construct(
             "SELECT i.issueID,
@@ -99,7 +99,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             $module = &$modules[$mname];
         }
 
-        $cids = isset($row['centerId']) ? [$row['centerId']] : $this->siteList;
+        $cids = isset($row['centerId']) ? [$row['centerId']] : $this->_siteList;
         $row['lastUpdate'] = \Utility::toDateDisplayFormat($row['lastUpdate']);
         return new IssueRow($row, $cids, $module);
     }

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -30,11 +30,14 @@ namespace LORIS\issue_tracker;
  */
 class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
+    private $siteList;
+
     /**
      * Create a IssueRowProvisioner, which gets rows for the issues menu table.
      */
     function __construct()
     {
+        $this->siteList = array_keys(\Utility::getSiteList(false));
         $user   = \User::singleton();
         $userID = $user->getUsername();
         //note that this needs to be in the same order as the headers array
@@ -96,8 +99,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             $module = &$modules[$mname];
         }
 
-        $cids = isset($row['centerId']) ?
-            [$row['centerId']] : array_keys(\Utility::getSiteList(false));
+        $cids = isset($row['centerId']) ? [$row['centerId']] : $this->siteList;
         $row['lastUpdate'] = \Utility::toDateDisplayFormat($row['lastUpdate']);
         return new IssueRow($row, $cids, $module);
     }

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -96,8 +96,9 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             $module = &$modules[$mname];
         }
 
-        $cid = $row['centerId'];
+        $cids = isset($row['centerId']) ?
+            [$row['centerId']] : array_keys(\Utility::getSiteList(false));
         $row['lastUpdate'] = \Utility::toDateDisplayFormat($row['lastUpdate']);
-        return new IssueRow($row, $cid, $module);
+        return new IssueRow($row, $cids, $module);
     }
 }

--- a/modules/issue_tracker/php/issuewatchermapper.class.inc
+++ b/modules/issue_tracker/php/issuewatchermapper.class.inc
@@ -60,7 +60,7 @@ class IssueWatcherMapper implements Mapper
 
         return new IssueRow(
             $newrow,
-            $resource->getCenterID(),
+            $resource->getCenterIDs(),
             $resource->getModule()
         );
     }


### PR DESCRIPTION
## Brief summary of changes
This PR handles values of NULL in the centerID column of the `issues` table by converting `NULL` values to an array of all centerIDs in the `psc` table in the `issuerowprovisioner` class.

#### Testing instructions (if applicable)
1. Create an issue with no CenterID, or set centerID to null for an issue already in the `issues` database table.
2. Login as user who does not have access to all centers.
3. Make sure the Issue Tracker Module is working for that user.

#### Link(s) to related issue(s)
* Resolves #6470
