### PR TITLE
[MRI Violations] Fixing a bug in dashboard widget registration and adding some tests

### DIFF
--- a/modules/dashboard/php/taskquerywidget.class.inc
+++ b/modules/dashboard/php/taskquerywidget.class.inc
@@ -75,7 +75,6 @@ class TaskQueryWidget extends TaskWidget
             $label .= "s";
         }
 
-        parent::__construct($label, $number, $link, $cssclass);
-        $this->setSiteLabel($siteLabel);
+        parent::__construct($label, $number, $link, $cssclass, $siteLabel);
     }
 }

--- a/modules/dashboard/php/taskquerywidget.class.inc
+++ b/modules/dashboard/php/taskquerywidget.class.inc
@@ -31,14 +31,6 @@ namespace LORIS\dashboard;
 class TaskQueryWidget extends TaskWidget
 {
     /**
-     * The site label to display beside the widget for which site
-     * this task is for.
-     *
-     * @var string
-     */
-    protected $sitelabel;
-
-    /**
      * Construct a TaskQueryWidget
      *
      * @param \User     $user      The user whose tasks are being displayed
@@ -67,14 +59,14 @@ class TaskQueryWidget extends TaskWidget
         string $link,
         string $cssclass
     ) {
-        $queryparams     = [];
-        $this->sitelabel = "Site: All";
+        $queryparams = [];
+        $siteLabel   = 'Site: All';
         if ($allperm != '') {
             if (!$user->hasPermission($allperm)) {
                 $sites = $user->getCenterIDs();
                 $queryparams['SiteID'] = implode(',', $sites);
-                $dbquery        .= " AND FIND_IN_SET($sitefield, :SiteID)";
-                $this->sitelabel = "Site: All User Sites";
+                $dbquery  .= " AND FIND_IN_SET($sitefield, :SiteID)";
+                $siteLabel = 'Site: All User Sites';
             }
         }
 
@@ -84,16 +76,6 @@ class TaskQueryWidget extends TaskWidget
         }
 
         parent::__construct($label, $number, $link, $cssclass);
-    }
-
-    /**
-     * Provides a site label for this widget based on user permissions
-     * and whether the task is site restricted.
-     *
-     * @return string
-     */
-    public function siteLabel() : string
-    {
-        return $this->sitelabel;
+        $this->setSiteLabel($siteLabel);
     }
 }

--- a/modules/dashboard/php/taskwidget.class.inc
+++ b/modules/dashboard/php/taskwidget.class.inc
@@ -41,22 +41,25 @@ class TaskWidget implements \LORIS\GUI\Widget
     /**
      * Construct a TaskWidget with the given properties.
      *
-     * @param string $label    The label to describe the task.
-     * @param int    $number   The number of outstanding items for the task.
-     * @param string $link     A URL to go to when the user clicks on the task.
-     * @param string $cssclass A CSS class to add to the element. This is primarily
-     *                         used for testing.
+     * @param string $label     The label to describe the task.
+     * @param int    $number    The number of outstanding items for the task.
+     * @param string $link      A URL to go to when the user clicks on the task.
+     * @param string $cssclass  A CSS class to add to the element. This is primarily
+     *                          used for testing.
+     * @param string $siteLabel Site label to display besides the widget.
      */
     public function __construct(
         string $label,
         int $number,
         string $link,
-        string $cssclass
+        string $cssclass,
+        string $siteLabel=''
     ) {
-        $this->label    = $label;
-        $this->number   = $number;
-        $this->link     = $link;
-        $this->cssclass = $cssclass;
+        $this->label     = $label;
+        $this->number    = $number;
+        $this->link      = $link;
+        $this->cssclass  = $cssclass;
+        $this->sitelabel = $siteLabel;
     }
 
     /**
@@ -87,18 +90,6 @@ class TaskWidget implements \LORIS\GUI\Widget
     public function link() : string
     {
         return $this->link;
-    }
-
-    /**
-     * Mutator method for field $sitelabel.
-     *
-     * @param string $newSiteLabel new value for field $sitelabel.
-     *
-     * @return void
-     */
-    public function setSiteLabel(string $newSiteLabel)
-    {
-        $this->sitelabel = $newSiteLabel;
     }
 
     /**

--- a/modules/dashboard/php/taskwidget.class.inc
+++ b/modules/dashboard/php/taskwidget.class.inc
@@ -31,6 +31,14 @@ class TaskWidget implements \LORIS\GUI\Widget
     protected $cssclass;
 
     /**
+     * The site label to display beside the widget for which site
+     * this task is for.
+     *
+     * @var string
+     */
+    protected $sitelabel;
+
+    /**
      * Construct a TaskWidget with the given properties.
      *
      * @param string $label    The label to describe the task.
@@ -82,6 +90,18 @@ class TaskWidget implements \LORIS\GUI\Widget
     }
 
     /**
+     * Mutator method for field $sitelabel.
+     *
+     * @param string $newSiteLabel new value for field $sitelabel.
+     *
+     * @return void
+     */
+    public function setSiteLabel(string $newSiteLabel)
+    {
+        $this->sitelabel = $newSiteLabel;
+    }
+
+    /**
      * If non-empty, return a label to use to describe
      * which sites the number of open task issues is for.
      *
@@ -89,7 +109,7 @@ class TaskWidget implements \LORIS\GUI\Widget
      */
     public function siteLabel() : string
     {
-        return "";
+        return $this->sitelabel;
     }
 
     /**

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -11,7 +11,6 @@
  * @link     https://github.com/aces/Loris
  */
 use Facebook\WebDriver\WebDriverBy;
-use Facebook\WebDriver\WebDriverExpectedCondition;
 require_once __DIR__ .
     "/../../../test/integrationtests/LorisIntegrationTest.class.inc";
 

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -116,59 +116,6 @@ class DashboardTest extends LorisIntegrationTest
             )
         );
 
-        $this->DB->insert(
-            "mri_protocol_violated_scans",
-            array(
-                'ID'                 => '1001',
-                'CandID'             => '999888',
-                'PatientName'        => '[Test]PatientName',
-                'time_run'           => '2009-06-29 04:00:44',
-                'minc_location'      => 'assembly/test/test/mri/test/test.mnc',
-                'series_description' => 'Test Series Description',
-                'SeriesUID'          => '5555',
-                'MriProtocolGroupID' => 11,
-            )
-        );
-        $this->DB->insert(
-            "mri_protocol_violated_scans",
-            array(
-                'ID'                 => '1002',
-                'CandID'             => '999888',
-                'PatientName'        => '[Test]PatientName',
-                'time_run'           => '2008-06-29 04:00:44',
-                'minc_location'      => 'assembly/test2/test2/mri/test2/test2.mnc',
-                'series_description' => 'Test Series Description',
-                'SeriesUID'          => '5556',
-                'MriProtocolGroupID' => 11,
-            )
-        );
-        $this->DB->insert(
-            "violations_resolved",
-            array(
-                'ExtID'     => '1001',
-                'hash'      => 'this is not a null value',
-                'TypeTable' => 'mri_protocol_violated_scans',
-                'Resolved'  => 'other',
-            )
-        );
-        $this->DB->insert(
-            "violations_resolved",
-            array(
-                'ExtID'     => '1002',
-                'hash'      => 'this is not a null value',
-                'TypeTable' => 'MRICandidateErrors',
-                'Resolved'  => 'unresolved',
-            )
-        );
-        $this->DB->insert(
-            "MRICandidateErrors",
-            array(
-                'ID'          => '1002',
-                'PatientName' => '[Test]PatientName',
-                'MincFile'    => 'assembly/test2/test2/mri/test2/test2.mnc',
-                'SeriesUID'   => '5556',
-            )
-        );
         //Insert an incomplete form data
         $this->DB->insert(
             "test_names",
@@ -328,38 +275,6 @@ class DashboardTest extends LorisIntegrationTest
             array(
                 'CandID'               => '999888',
                 'RegistrationCenterID' => '55',
-            )
-        );
-        $this->DB->delete(
-            "mri_protocol_violated_scans",
-            array(
-                'ID'     => '1001',
-                'CandID' => '999888',
-            )
-        );
-        $this->DB->delete(
-            "mri_protocol_violated_scans",
-            array(
-                'ID'     => '1002',
-                'CandID' => '999888',
-            )
-        );
-        $this->DB->delete(
-            "violations_resolved",
-            array(
-                'ExtID'     => '1001',
-                'TypeTable' => 'mri_protocol_violated_scans',
-            )
-        );
-        $this->DB->delete(
-            "MRICandidateErrors",
-            array('ID' => '1002')
-        );
-        $this->DB->delete(
-            "violations_resolved",
-            array(
-                'ExtID'     => '1002',
-                'TypeTable' => 'mri_protocol_violated_scans',
             )
         );
         $this->DB->delete(
@@ -616,31 +531,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->assertContains("test.jpg", $bodyText);
         $this->resetPermissions();
     }
-    /**
-     * Test the link with right value and permission
-     *
-     * @param string $className class Name of template
-     * @param string $value     the total of test data
-     * @param string $dataSeed  test result
-     *
-     * @return void
-     */
-    private function _testMytaskPanelAndLink($className,$value,$dataSeed)
-    {
-        $this->safeGet($this->url . '/dashboard/');
-        $link     =$this->safeFindElement(WebDriverBy::cssSelector($className));
-        $bodyText = $link->findElement(WebDriverBy::cssSelector(".huge"))->getText();
-        $this->assertContains($value, $bodyText);
-        $this->safeClick(WebDriverBy::cssSelector($className));
-        $this->webDriver->wait(3, 500)->until(
-            WebDriverExpectedCondition::presenceOfElementLocated(
-                WebDriverBy::Id('lorisworkspace')
-            )
-        );
-        $pageSource = $this->webDriver->getPageSource();
-        $this->assertContains($dataSeed, $pageSource);
 
-    }
     /**
      *  If test on local machine, then run this function.
      *

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -424,7 +424,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->_testMytaskPanelAndLink(
             ".conflict_resolver",
             "574",
-            "- Conflict Resolzzzz"
+            "- Conflict Resolver"
         );
         $this->resetPermissions();
     }

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -424,7 +424,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->_testMytaskPanelAndLink(
             ".conflict_resolver",
             "574",
-            "- Conflict Resolver"
+            "- Conflict Resolzzzz"
         );
         $this->resetPermissions();
     }

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -221,7 +221,12 @@ class Module extends \Module
             );
             $label   = $number >  1 ? 'Violated scans' : 'Violated scan';
 
-            $widget    = new \LORIS\dashboard\TaskWidget($label, $number, $link, '');
+            $widget    = new \LORIS\dashboard\TaskWidget(
+                $label,
+                $number,
+                $link,
+                'mri_violations'
+            );
             $siteLabel = $user->hasPermission('violated_scans_view_allsites')
                 ? 'Site: All' : 'Site: All User Sites';
 

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -221,16 +221,16 @@ class Module extends \Module
             );
             $label   = $number >  1 ? 'Violated scans' : 'Violated scan';
 
+            $siteLabel = $user->hasPermission('violated_scans_view_allsites')
+                ? 'Site: All' : 'Site: All User Sites';
             $widget    = new \LORIS\dashboard\TaskWidget(
                 $label,
                 $number,
                 $link,
-                'mri_violations'
+                'mri_violations',
+                $siteLabel
             );
-            $siteLabel = $user->hasPermission('violated_scans_view_allsites')
-                ? 'Site: All' : 'Site: All User Sites';
 
-            $widget->setSiteLabel($siteLabel);
             return [ $widget ];
         }
 

--- a/modules/mri_violations/php/module.class.inc
+++ b/modules/mri_violations/php/module.class.inc
@@ -221,9 +221,12 @@ class Module extends \Module
             );
             $label   = $number >  1 ? 'Violated scans' : 'Violated scan';
 
-            return [
-                new \LORIS\dashboard\TaskWidget($label, $number, $link, '')
-            ];
+            $widget    = new \LORIS\dashboard\TaskWidget($label, $number, $link, '');
+            $siteLabel = $user->hasPermission('violated_scans_view_allsites')
+                ? 'Site: All' : 'Site: All User Sites';
+
+            $widget->setSiteLabel($siteLabel);
+            return [ $widget ];
         }
 
         return [];

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -597,7 +597,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
     /**
      * Verify that for a user with 'violated_scans_view_allsites' permission the
      * number of MRI violated scans is reported in the My Task panel.
-     * Also ensure that when you click on this tas, the link takes you to the
+     * Also ensure that when you click on this task, the link takes you to the
      * MRI violated scans page.
      *
      * @return void
@@ -624,7 +624,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
     /**
      * Verify that for a user with 'violated_scans_view_ownsite' permission the
      * number of MRI violated scans is reported in the My Task panel.
-     * Also ensure that when you click on this tas, the link takes you to the
+     * Also ensure that when you click on this task, the link takes you to the
      * MRI violated scans page.
      *
      * @return void

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -108,7 +108,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'UserID'       => '2',
                 'MRIQCStatus'  => 'Pass',
                 'SubprojectID' => '55',
-                'Visit_label'  => 'Test1',
+                'Visit_label'  => 'Test2',
             )
         );
 
@@ -144,15 +144,15 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'TarchiveID'             => '264',
                 'DicomArchiveID'         => '1.3.12.2.1107.5.2.32.35442.30000012' .
                '100912542610900000004',
-                'PatientID'              => '8888_999888_Test1',
-                'PatientName'            => '8888_999888_Test1',
+                'PatientID'              => '8888_999888_Test2',
+                'PatientName'            => '8888_999888_Test2',
                 'CenterName'             => 'Test',
                 'AcquisitionCount'       => '10',
                 'NonDicomFileCount'      => '3',
                 'DicomFileCount'         => '1000',
                 'CreatingUser'           => 'lorisdev',
                 'sumTypeVersion'         => '1',
-                'SourceLocation'         => '/data/incoming/8888_999888_Test1',
+                'SourceLocation'         => '/data/incoming/8888_999888_Test2',
                 'ScannerManufacturer'    => 'Siemens',
                 'ScannerModel'           => 'TrioTim',
                 'ScannerSerialNumber'    => '33333',
@@ -191,7 +191,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             array(
                 'ID'                 => '1002',
                 'CandID'             => '999777',
-                'PatientName'        => '[name]test_Test1',
+                'PatientName'        => '[name]test_Test2',
                 'time_run'           => '2008-06-29 04:00:44',
                 'minc_location'      => 'assembly/test2/test2/mri/test2/test2.mnc',
                 'series_description' => 'Test Series Description',
@@ -592,6 +592,65 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             "Site",
             "TESTinPSC"
         );
+    }
+
+    /**
+     * Verify that for a user with 'violated_scans_view_allsites' permission the
+     * number of MRI violated scans is reported in the My Task panel.
+     * Also ensure that when you click on this tas, the link takes you to the
+     * MRI violated scans page.
+     *
+     * @return void
+     */
+    public function testDashboardWidgetAllSites()
+    {
+        $this->setupPermissions(
+            array(
+                'violated_scans_view_allsites'
+            )
+        );
+        $this->safeGet($this->url . '/dashboard/');
+        // Raisin bread has 206 unresolved violated scans. We are adding three
+        // in setup(): one resolved, and two unresolved. The total
+        // number of unresolved violations is thus 208
+        $this->_testMytaskPanelAndLink(
+            ".mri_violations",
+            "208",
+            "- MRI Violated Scans"
+        );
+        $this->resetPermissions();
+    }
+
+    /**
+     * Verify that for a user with 'violated_scans_view_ownsite' permission the
+     * number of MRI violated scans is reported in the My Task panel.
+     * Also ensure that when you click on this tas, the link takes you to the
+     * MRI violated scans page.
+     *
+     * @return void
+     */
+    public function testDashboardWidgetOwnSite()
+    {
+
+        $this->setupPermissions(
+            array(
+                'violated_scans_view_ownsite'
+            )
+        );
+        $this->safeGet($this->url . '/dashboard/');
+        // Raisin bread has 164 unresolved violated scans that are not assigned
+        // to any site and 18 unresolved violations assigned to DCC. We are
+        // adding three in setup(): one resolved, another unresolved assigned to
+        // center ID 55 and another not assigned to any site. The total number of
+        // unresolved violations that are either assigned to DCC or not assigned to
+        // any site is thus: 164+18+1 = 184.
+        // Note that the test user is only assigned to sites DCC
+        $this->_testMytaskPanelAndLink(
+            ".mri_violations",
+            "183",
+            "- MRI Violated Scans"
+        );
+        $this->resetPermissions();
     }
 
     /**

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -209,7 +209,15 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                 'Resolved'  => 'other',
             )
         );
-
+        $this->DB->insert(
+            "MRICandidateErrors",
+            array(
+                'ID'          => '1002',
+                'PatientName' => '[Test]PatientName',
+                'MincFile'    => 'assembly/test2/test2/mri/test2/test3.mnc',
+                'SeriesUID'   => '5558',
+            )
+        );
     }
     /**
      * Delete the test data
@@ -218,7 +226,10 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      */
     public function tearDown()
     {
-
+        $this->DB->delete(
+            "MRICandidateErrors",
+            array('ID' => '1002')
+        );
         $this->DB->delete(
             "mri_protocol_violated_scans",
             array('ID' => '1001')
@@ -581,7 +592,6 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             "Site",
             "TESTinPSC"
         );
-
     }
 
     /**
@@ -607,7 +617,6 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                     '#datatable > div > div.table-header.panel-heading > div')
                  .textContent"
         );
-
         $this->assertContains("1 rows displayed of 1", $bodyText);
         $this->webDriver->findElement(
             WebDriverBy::Name("reset")

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -681,4 +681,30 @@ abstract class LorisIntegrationTest extends TestCase
             //test clear filter
             $this->safeFindElement(WebDriverBy::cssSelector("$btn"))->click();
     }
+
+    /**
+     * Utility method for classes that register widgets on the dashboard: ensure that
+     * the task panel has the expected content.
+     *
+     * @param string $className class Name of widget in the task panel
+     * @param string $value     the total count displayed for that widget
+     * @param string $label     label for that widget
+     *
+     * @return void
+     */
+    function _testMytaskPanelAndLink($className, $value, $label): void
+    {
+        $this->safeGet($this->url . '/dashboard/');
+        $link     =$this->safeFindElement(WebDriverBy::cssSelector($className));
+        $bodyText = $link->findElement(WebDriverBy::cssSelector(".huge"))->getText();
+        $this->assertContains($value, $bodyText);
+        $this->safeClick(WebDriverBy::cssSelector($className));
+        $this->webDriver->wait(3, 500)->until(
+            WebDriverExpectedCondition::presenceOfElementLocated(
+                WebDriverBy::Id('lorisworkspace')
+            )
+        );
+        $pageSource = $this->webDriver->getPageSource();
+        $this->assertContains($label, $pageSource);
+    }
 }


### PR DESCRIPTION
## Brief summary of changes

- The widget displayed on the `dashboard/My Task` panel for violated scans now specifies whether all known sites or only the user's sites were taken into account when computing the number of violations.
- Deletion from the dashboard module of the tests associated to the violated scans widget in the `My Task` panel.
- Addition of tests in the MRI violations module for the registration of the violated scans widget in the dashboard module.

#### Testing instructions (if applicable)

Make sure that when the dashboard is displayed, there will be either label `Site: All` or `Site: All User Sites` besides the number of violated scans depending on whether the user has the `violated_scans_view_allsites` or `violated_scans_view_ownsite` permission respectively

#### Link(s) to related issue(s)

None
