### PR TITLE
Password validate static

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -90,7 +90,7 @@ class PasswordExpiry extends \NDB_Form
         $plaintext   = htmlspecialchars_decode($values['password']);
 
         try {
-            new \Password($plaintext);
+            \Password::validate($plaintext);
         } catch (\InvalidArgumentException $e) {
             $this->tpl_data['error_message'] = $e->getMessage();
             return array('password' => $e->getMessage());

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -392,11 +392,11 @@ class My_Preferences extends \NDB_Form
         // if password is user-defined, and user wants to change password
         if (!empty($values['Password_hash'])) {
             try {
-                // The Password class is self-validating and will throw an
+                // Password::validate will throw an
                 // InvalidArgumentException if the value passed to it is
                 // bad or the input is too weak to be a good password.
                 $decoded = htmlspecialchars_decode($plaintext);
-                new \Password($decoded);
+                \Password::validate($decoded);
                 // New password must be different than current one
                 if (! \User::factory($this->identifier)->isPasswordDifferent(
                     $decoded

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -396,7 +396,7 @@ class Edit_User extends \NDB_Form
                 //Check if examiner already in db for site
                 $result = $DB->pselectRow(
                     "SELECT epr.centerID
-                           FROM examiners_psc_rel epr 
+                           FROM examiners_psc_rel epr
                            WHERE epr.examinerID=:eid AND epr.centerID=:cid",
                     array(
                         "eid" => $examinerID,
@@ -1123,11 +1123,11 @@ class Edit_User extends \NDB_Form
             && (!empty($values['Password_hash']) || !empty($values['__Confirm']))
         ) {
             try {
-                // The Password class is self-validating and will throw an
+                // Password::validate will throw an
                 // InvalidArgumentException if the value passed to it is
                 // bad or the input is too weak to be a good password.
                 $decoded = htmlspecialchars_decode($plaintext);
-                new \Password($decoded);
+                \Password::validate($decoded);
                 $isPasswordDifferent = \User::factory($this->identifier)
                     ->isPasswordDifferent($decoded);
                 if (! $isPasswordDifferent) {
@@ -1244,7 +1244,7 @@ class Edit_User extends \NDB_Form
             && ($values['active_from'] > $values['active_to'])
         ) {
             $errors['active_timeWindows']
-                = 'Please notice that the "Active from" 
+                = 'Please notice that the "Active from"
                 date should be lesser or equal to the "Active to" date.';
         }
         return $errors;

--- a/php/libraries/Password.class.inc
+++ b/php/libraries/Password.class.inc
@@ -67,7 +67,7 @@ class Password
      * @return bool Whether the submitted value has length of at least
      *              MIN_PASSWORD_LENGTH;
      */
-    private function _hasSufficientLength(string $value): bool
+    private static function _hasSufficientLength(string $value): bool
     {
         // Check length
         return strlen($value) >= self::MIN_PASSWORD_LENGTH;
@@ -82,7 +82,7 @@ class Password
      * @return bool Whether the submitted value meets the minimum score defined
      *              above and given by Zxcvbn.
      */
-    private function _hasSufficientComplexity(string $value): bool
+    private static function _hasSufficientComplexity(string $value): bool
     {
         // Return true if the password's complexity score exceeds
         // MIN_COMPLEXITY_SCORE and false otherwise.
@@ -99,14 +99,14 @@ class Password
      *
      * @throws \InvalidArgumentException When password is too short or weak.
      */
-    private function _validate($value): void
+    public static function validate($value): void
     {
         // Check length and complexity separately in order to return a precise
         // error message upon failure.
-        if (!$this->_hasSufficientLength($value)) {
+        if (!Password::_hasSufficientLength($value)) {
             throw new \InvalidArgumentException('The password is too short');
         }
-        if (!$this->_hasSufficientComplexity($value)) {
+        if (!Password::_hasSufficientComplexity($value)) {
             throw new \InvalidArgumentException(
                 'The password is not complex enough.'
             );
@@ -115,7 +115,7 @@ class Password
             'usePwnedPasswordsAPI'
         )
         ) {
-            if ($this->_pwned($value)) {
+            if (Password::_pwned($value)) {
                 throw new \InvalidArgumentException(
                     'This password is known to be exposed in online data '
                     . 'breaches.'
@@ -142,7 +142,7 @@ class Password
      *
      * @return bool Whether the password is known to be pwned.
      */
-    private function _pwned(string $password): bool
+    private static function _pwned(string $password): bool
     {
 
         // If the project is configured to disable the Pwned Password check,
@@ -201,7 +201,7 @@ class Password
     public final function __construct(string $value)
     {
         // Ensure proposed value is well-formed.
-        $this->_validate($value);
+        $this->validate($value);
         // Don't store the value in the object; instead use the hashed version
         // This mitigates the risk of accidentally revealing the plaintext.
         $this->_hash = password_hash($value, PASSWORD_DEFAULT);


### PR DESCRIPTION
## Brief summary of changes
I made Password::validate() static. Password::validate() can be used directly for password validation in place of the Password constructor.

Side note: trim_trailing_whitespace = true in .editorconfig, and some lines were altered on save.

#### Link(s) to related issue(s)

* Resolves #6449