### PR TITLE
[Imaging Uploader] Corrected swal displayed for file uploads done when the network is down.

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -273,9 +273,17 @@ class UploadForm extends Component {
         let messageToPrint = '';
         if (error.responseJSON && error.responseJSON.errors) {
           errorMessage = error.responseJSON.errors;
+        } else if (error.status == 0) {
+          errorMessage = {
+            'mriFile': ['Upload failed: a network error occured'],
+          };
         } else if (error.status == 413) {
           errorMessage = {
             'mriFile': ['Please make sure files are not larger than ' + this.props.maxUploadSize],
+          };
+        } else {
+          errorMessage = {
+            'mriFile': ['Upload failed: received HTTP response code ' + error.status],
           };
         }
         for (let i in errorMessage) {


### PR DESCRIPTION
# Brief summary of changes

This PR changes the swal displayed for MRI file uploads done when the network is down: the swal now displays an error message saying that the upload failed because of a network error. This PR also changes the swal displayed when HTTP codes other than 400 and 413 are received when the upload request is sent: the swal now displays the HTTP code received (the swal was empty before...)

#### Testing instructions (if applicable)

Access the imaging uploader and fill out the upload form with valid data. Shutdown your server (`% sudo service apache2 stop`). Click on `Submit`: you should see the swal mentioned above.

#### Link(s) to related issue(s)

* Resolves #6468 
