### PR TITLE
[Raisinbread] Instructions and clarifications added to RaisinBread README

### DIFF
--- a/raisinbread/README.md
+++ b/raisinbread/README.md
@@ -29,8 +29,17 @@ that is not the case, replace all `mysql` commands below by the necessary values
 `mysql -u user -p -h host database_name`*
 
 ##### Sourcing SQL
-In order to be able to use the RaisinBread dataset, the LORIS SQL schema needs to be 
-sourced, followed by the different instrument schemas and finally the actual RB data. 
+If the database being used is already populated and contains any tables or data, the following
+command must be used in the main LORIS root directory:
+
+```bash
+cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql \
+    SQL/9999-99-99-drop_tables.sql | mysql
+```
+***Note:** This command can also be used at any step to empty and delete all RaisinBread tables.*
+
+In order to be able to use the RaisinBread dataset, the LORIS SQL schema needs to be
+sourced, followed by the different instrument schemas and finally the actual RB data.
 The commands below assume that the current working directory is the main LORIS root
 directory.
 
@@ -49,13 +58,14 @@ cat SQL/0000-00-00-schema.sql \
     raisinbread/RB_files/*.sql | mysql
 ```
 
-Note: to empty and delete all RaisinBread tables, use the following command in the 
-main LORIS root directory
-```bash
-cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql \
-    SQL/9999-99-99-drop_tables.sql | mysql
+***Important:** Ensure that the above commands (including those to drop tables) were all completed properly.* 
+If there is a foreign key constraint error, run the following command on the mysql command line to mitigate the error:
+
+```bash 
+SET FOREIGN_KEY_CHECKS=0;
 ```
 
+If the tables were not deleted or created properly, the above schemas can be sourced directly on the mysql command line.
 
 ##### Configuring
 In order to be able to load the LORIS front-end while using the RaisinBread dataset 

--- a/raisinbread/README.md
+++ b/raisinbread/README.md
@@ -30,13 +30,16 @@ that is not the case, replace all `mysql` commands below by the necessary values
 
 ##### Sourcing SQL
 If the database being used is already populated and contains any tables or data, the following
-command must be used in the main LORIS root directory:
+command must be used in the main LORIS root directory. Note that these commands will erase all the data
+in the database. Ensure that a backup is available if this data is important:
 
 ```bash
 cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql \
     SQL/9999-99-99-drop_tables.sql | mysql
 ```
 ***Note:** This command can also be used at any step to empty and delete all RaisinBread tables.*
+
+***Important:** Ensure that the above commands were completed properly and that all the tables were dropped before continuing the installation process.*
 
 In order to be able to use the RaisinBread dataset, the LORIS SQL schema needs to be
 sourced, followed by the different instrument schemas and finally the actual RB data.
@@ -56,13 +59,6 @@ cat SQL/0000-00-00-schema.sql \
     raisinbread/instruments/instrument_sql/mri_parameter_form.sql \
     raisinbread/instruments/instrument_sql/radiology_review.sql \
     raisinbread/RB_files/*.sql | mysql
-```
-
-***Important:** Ensure that the above commands (including those to drop tables) were all completed properly.* 
-If there is a foreign key constraint error, run the following command on the mysql command line to mitigate the error:
-
-```bash 
-SET FOREIGN_KEY_CHECKS=0;
 ```
 
 If the tables were not deleted or created properly, the above schemas can be sourced directly on the mysql command line.

--- a/raisinbread/README.md
+++ b/raisinbread/README.md
@@ -44,7 +44,8 @@ cat raisinbread/instruments/instrument_sql/9999-99-99-drop_instrument_tables.sql
 In order to be able to use the RaisinBread dataset, the LORIS SQL schema needs to be
 sourced, followed by the different instrument schemas and finally the actual RB data.
 The commands below assume that the current working directory is the main LORIS root
-directory.
+directory. If the tables were not deleted or created properly, the schemas can be sourced 
+directly on the mysql command line.
 
 ```bash
 cat SQL/0000-00-00-schema.sql \
@@ -60,8 +61,6 @@ cat SQL/0000-00-00-schema.sql \
     raisinbread/instruments/instrument_sql/radiology_review.sql \
     raisinbread/RB_files/*.sql | mysql
 ```
-
-If the tables were not deleted or created properly, the above schemas can be sourced directly on the mysql command line.
 
 ##### Configuring
 In order to be able to load the LORIS front-end while using the RaisinBread dataset 


### PR DESCRIPTION
The Raisinbread README was updated to include specific instructions for dropping all tables pre-installation. A note about foreign key constraints and sourcing the schema files directly on the MySQL command line was also added. 

* Resolves #6495   
