### PR TITLE
[ElectrophysiologyBrowser] Fix typo in label

### DIFF
--- a/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
+++ b/modules/electrophysiology_browser/jsx/electrophysiologyBrowserIndex.js
@@ -123,7 +123,7 @@ class ElectrophysiologyBrowserIndex extends Component {
         type: 'select',
         options: options.projects,
       }},
-      {label: 'Vist Label', show: true, filter: {
+      {label: 'Visit Label', show: true, filter: {
         name: 'visitLabel',
         type: 'text',
       }},


### PR DESCRIPTION
**Changes:**
`Vist`  --> `Visit` in EEGBrowser, under the `Selection Filter` 

**Testing instructions**

1. Navigate to the EEGBrowser
2. Observe `Visit` label spelled correctly under the selection filter.



* Resolves #6493
