### PR TITLE
[SQL] remove constraint as an option

### DIFF
--- a/SQL/ByFORCE-drop_tables.sql
+++ b/SQL/ByFORCE-drop_tables.sql
@@ -1,0 +1,5 @@
+SET FOREIGN_KEY_CHECKS=0;
+
+\. ./9999-99-99-drop_tables.sql
+
+SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

Foreign key constraint will block one to remove table if there is data. This could be in the master, but since the issue is reported in 23.0 and not a big change, I add here.

#### Testing instructions (if applicable)

1. Test against a DB with data, see whether all main installation data is not there. Of course instrument table will not be removed if ever they are there.

* Resolves #  (Reference the issue this fixes, if any.)
#6501 