### PR TITLE
[ImagingBrowser] Fixed typo in Visit Label under Selection Filter

### DIFF
--- a/modules/imaging_browser/jsx/imagingBrowserIndex.js
+++ b/modules/imaging_browser/jsx/imagingBrowserIndex.js
@@ -127,7 +127,7 @@ class ImagingBrowserIndex extends Component {
         type: 'select',
         options: options.projects,
       }},
-      {label: 'Vist Label', show: true, filter: {
+      {label: 'Visit Label', show: true, filter: {
         name: 'visitLabel',
         type: 'text',
       }},


### PR DESCRIPTION
#### Changes
Fixed typo `Vist Label` to `Visit Label` in ImagingBrowser under `Selection Filter`.

#### Testing instructions
1. Go to Imaging/Imaging Browser.
2. Observe `Visit Label` is spelled correctly under the selection filter and in the column names of the table below.

#### Related issues
* Resolves #6507
* Related to #6493