### PR TITLE
[Utilities] Fix SQL query inside getSiteList function

### DIFF
--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -141,8 +141,9 @@ class Utility
         if (!$DCC) {
                 $whereElements[] = "CenterID <> 1";
         }
-        $query .= !empty($whereElements) ?
-            "WHERE ".implode(" AND ", $whereElements) : "";
+        if (!empty($whereElements)) {
+            $query .= "WHERE ".implode(" AND ", $whereElements);
+        }
         $result = $DB->pselect($query, array());
 
         // fix the array

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -136,11 +136,11 @@ class Utility
         $query .= "WHERE "; 
         if ($study_site) {
             $query .= "Study_site='Y' ";
-        }
-        if (!$DCC) {
-            if ($study_site){
-                $query.= " AND" 
+            
+            if (!$DCC) {
+                $query .= " AND CenterID <> 1";
             }
+        }else if (!$DCC){
             $query .= " CenterID <> 1";
         }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -138,7 +138,10 @@ class Utility
             $query .= "Study_site='Y' ";
         }
         if (!$DCC) {
-            $query .= " AND CenterID <> 1";
+            if ($study_site){
+                $query.= " AND" 
+            }
+            $query .= " CenterID <> 1";
         }
 
         $result = $DB->pselect($query, array());

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -132,20 +132,17 @@ class Utility
         $DB      = $factory->database();
 
         // get the list of study sites - to be replaced by the Site object
-        $query = "SELECT CenterID, Name FROM psc ";
-        if ($study_site || !$DCC) {
-            $query .= "WHERE ";
-        }
+        $query         = "SELECT CenterID, Name FROM psc ";
+        $whereElements = array();
+
         if ($study_site) {
-            $query .= "Study_site='Y' ";
-            if (!$DCC) {
-                $query .= " AND";
-            }
+                $whereElements[] = "Study_site='Y'";
         }
         if (!$DCC) {
-            $query .= " CenterID <> 1";
+                $whereElements[] = "CenterID <> 1";
         }
-
+        $query .= !empty($whereElements) ?
+            "WHERE ".implode(" AND ", $whereElements) : "";
         $result = $DB->pselect($query, array());
 
         // fix the array

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -132,15 +132,14 @@ class Utility
         $DB      = $factory->database();
 
         // get the list of study sites - to be replaced by the Site object
-        $query = "SELECT CenterID, Name FROM psc ";
-        $query .= "WHERE "; 
+        $query  = "SELECT CenterID, Name FROM psc ";
+        $query .= "WHERE ";
         if ($study_site) {
             $query .= "Study_site='Y' ";
-            
             if (!$DCC) {
                 $query .= " AND CenterID <> 1";
             }
-        }else if (!$DCC){
+        } else if (!$DCC) {
             $query .= " CenterID <> 1";
         }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -132,14 +132,17 @@ class Utility
         $DB      = $factory->database();
 
         // get the list of study sites - to be replaced by the Site object
-        $query  = "SELECT CenterID, Name FROM psc ";
-        $query .= "WHERE ";
+        $query = "SELECT CenterID, Name FROM psc ";
+        if ($study_site || !$DCC) {
+            $query .= "WHERE ";
+        }
         if ($study_site) {
             $query .= "Study_site='Y' ";
             if (!$DCC) {
-                $query .= " AND CenterID <> 1";
+                $query .= " AND";
             }
-        } else if (!$DCC) {
+        }
+        if (!$DCC) {
             $query .= " CenterID <> 1";
         }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -133,8 +133,9 @@ class Utility
 
         // get the list of study sites - to be replaced by the Site object
         $query = "SELECT CenterID, Name FROM psc ";
+        $query .= "WHERE "; 
         if ($study_site) {
-            $query .= "WHERE Study_site='Y'";
+            $query .= "Study_site='Y' ";
         }
         if (!$DCC) {
             $query .= " AND CenterID <> 1";


### PR DESCRIPTION
*Summary*

I changed how `$query` is concatenated in `getSiteList` by taking the WHERE clause out of the if statement and adding a possible AND operator only if `$study_site` and `$DCC` are both set to true.

*Testing*

1. calling the `getSiteList` function should not return any error messages 

#### Link(s) to related issue(s)

* Resolves #6489
