### PR TITLE
[IssueTracker] ActiveIssues tab displays Status filter: Closed

### DIFF
--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -61,33 +61,54 @@ class Filter extends Component {
       const filter = field.filter;
       if (filter && filter.hide !== true) {
         let element;
+        let value = (this.props.filter[filter.name] || {}).value || false;
+
         switch (filter.type) {
-        case 'text':
-          element = <TextboxElement key={filter.name}/>;
-          break;
-        case 'select':
-          element = (
-            <SelectElement
-              key={filter.name}
-              options={filter.options}
-              sortByValue={filter.sortByValue}
-            />
-          );
-          break;
-        case 'multiselect':
-          element = <SelectElement key={filter.name} options={filter.options} multiple={true} emptyOption={false}/>;
-          break;
-        case 'numeric':
-          element = <NumericElement key={filter.name} options={filter.options}/>;
-          break;
-        case 'date':
-          element = <DateElement key={filter.name}/>;
-          break;
-        case 'checkbox':
-          element = <CheckboxElement key={filter.name}/>;
-          break;
-        default:
-          element = <TextboxElement key={filter.name}/>;
+          case 'text':
+            element = <TextboxElement key={filter.name}/>;
+            break;
+          case 'select':
+            element = (
+              <SelectElement
+                key={filter.name}
+                options={filter.options}
+                sortByValue={filter.sortByValue}
+              />
+            );
+            break;
+          case 'multiselect':
+            element = <SelectElement key={filter.name} options={filter.options} multiple={true} emptyOption={false}/>;
+
+            value = [];
+            const filterOptions = this.props.filter[filter.name];
+            if (!filterOptions || !filterOptions.value) break;
+
+            let values = [];
+            if (Array.isArray(filterOptions.value)) {
+              values = filterOptions.value;
+            } else if (typeof filterOptions.value === 'string') {
+              values = filterOptions.value.split(',').map((el) => (el.trim())) || [];
+            }
+            value = values;
+
+            // If opposite is true, return the complement filters
+            if (filterOptions.hasOwnProperty('opposite') && filterOptions.opposite === true) {
+              value = Object.keys(filter.options).filter((val) => {
+                return !values.includes(val);
+              });
+            }
+            break;
+          case 'numeric':
+            element = <NumericElement key={filter.name} options={filter.options}/>;
+            break;
+          case 'date':
+            element = <DateElement key={filter.name}/>;
+            break;
+          case 'checkbox':
+            element = <CheckboxElement key={filter.name}/>;
+            break;
+          default:
+            element = <TextboxElement key={filter.name}/>;
         }
 
         // The value prop has to default to false if the first two options
@@ -98,7 +119,7 @@ class Filter extends Component {
           {
             name: filter.name,
             label: field.label,
-            value: (this.props.filter[filter.name] || {}).value || false,
+            value: value,
             onUserInput: this.onFieldUpdate,
           }
         ));

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -37,20 +37,6 @@ class FilterableDataTable extends Component {
   }
 
   /**
-   * Parse filter to remove filter properties when opposite is set to true
-   *
-   * @param {object} filter passed from FilterForm
-   * @return {object} filter
-   */
-  parseFilter(filter) {
-    const parsedFilter = {};
-    for (const [filterId, filterProps] of Object.entries(filter)) {
-      if (filterProps.opposite === undefined || !filterProps.opposite) parsedFilter[filterId] = filterProps;
-    }
-    return parsedFilter;
-  }
-
-  /**
    * Sets Filter to empty object
    */
   clearFilter() {
@@ -64,7 +50,7 @@ class FilterableDataTable extends Component {
         name={this.props.name + '_filter'}
         id={this.props.name + '_filter'}
         columns={this.props.columns}
-        filter={this.parseFilter(this.state.filter)}
+        filter={this.state.filter}
         fields={this.props.fields}
         updateFilter={this.updateFilter}
         clearFilter={this.clearFilter}

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -37,6 +37,20 @@ class FilterableDataTable extends Component {
   }
 
   /**
+   * Parse filter to remove filter properties when opposite is set to true
+   *
+   * @param {object} filter passed from FilterForm
+   * @return {object} filter
+   */
+  parseFilter(filter) {
+    const parsedFilter = {};
+    for (const [filterId, filterProps] of Object.entries(filter)) {
+      if (filterProps.opposite === undefined || !filterProps.opposite) parsedFilter[filterId] = filterProps;
+    }
+    return parsedFilter;
+  }
+
+  /**
    * Sets Filter to empty object
    */
   clearFilter() {
@@ -50,7 +64,7 @@ class FilterableDataTable extends Component {
         name={this.props.name + '_filter'}
         id={this.props.name + '_filter'}
         columns={this.props.columns}
-        filter={this.state.filter}
+        filter={this.parseFilter(this.state.filter)}
         fields={this.props.fields}
         updateFilter={this.updateFilter}
         clearFilter={this.clearFilter}

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -171,7 +171,7 @@ class IssueTrackerIndex extends Component {
       }},
       {label: 'Status', show: true, filter: {
         name: 'status',
-        type: 'select',
+        type: 'multiselect',
         options: options.statuses,
         }},
       {label: 'Priority', show: true, filter: {


### PR DESCRIPTION
I updated the react component FilterableDataTable to add a parseFilter(filter) function.
These function loop over the filters, and copy them in a clone only if they do not have the opposite property. This is applied to the Filter component filters to prevent some field value like status to be updated when opposite is selected.

* Resolves #6517