### PR TITLE
[issue_tracker] Module filter has entry [object Object]

### DIFF
--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -115,12 +115,18 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             $assignees[$a_row['UserID']] = $a_row['Real_name'];
         }
 
-        $mod_descriptors = \Module::getActiveModules($db);
-        $modules         = array();
-        foreach ($mod_descriptors as $mdesc) {
-            $name           = $mdesc->getLongName();
-            $modules[$name] = $name;
-        }
+        $modules = array_reduce(
+            \Module::getActiveModules($db),
+            function (
+                $result,
+                $module
+            ) {
+                $moduleName          = $module->getLongName();
+                $result[$moduleName] = $moduleName;
+                return $result;
+            },
+            []
+        );
 
         $priorities = array(
             'normal'    => 'Normal',

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -115,7 +115,12 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             $assignees[$a_row['UserID']] = $a_row['Real_name'];
         }
 
-        $modules = \Module::getActiveModules($db);
+        $mod_descriptors = \Module::getActiveModules($db);
+        $modules         = array();
+        foreach ($mod_descriptors as $mdesc) {
+            $name           = $mdesc->getLongName();
+            $modules[$name] = $name;
+        }
 
         $priorities = array(
             'normal'    => 'Normal',


### PR DESCRIPTION
I updated the issue_tracker class to avoid Object object to be populated in the Module dropdown.
I used getLongName() to retrieve the name of the module and populate the json.

* Resolves #6519