### PR TITLE
[Genomic Browser] Make SNP,CNV,CPG 'Y' links obvious

### DIFF
--- a/modules/genomic_browser/jsx/profileColumnFormatter.js
+++ b/modules/genomic_browser/jsx/profileColumnFormatter.js
@@ -54,14 +54,14 @@ function formatColumn(column, cell, rowData, rowHeaders) {
       if (cell === 'Y') {
         reactElement = (
           <td>
-            <span
+            <a
               style={{cursor: 'pointer'}}
               onClick={loris.loadFilteredMenuClickHandler(
                 'genomic_browser/' + column.toLowerCase() + '_browser/', {DCCID: rowData[1]}
               )}
             >
               {cell}
-            </span>
+            </a>
           </td>
         );
       } else {


### PR DESCRIPTION
**Summary**

The link for a candidate's SNP (as well as the CNV, CPG) from the Genomic browser's profile tab doesn't have any visual indication that it can be clicked on. I changed the tag from `<span>` to `<a>` around the cell entry to properly format it as a hyperlink. 

**Testing instructions**
Navigate to the genomic browser, observe the SNP, CNV and CPG columns (CNV and CPG columns do not have data for their links to be tested as per #6302) . Cells with a 'Y' should be colored blue and change color on hover with an underline:

![image](https://i.imgur.com/9ys3H35.png)

**Link(s) to related issue(s)**

* Related to #6302 but only addresses point B.

