### PR TITLE
[issue_tracker] Update validation to allow NULL Site

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -583,6 +583,8 @@ function getIssueFields()
         $sites = $user->getStudySites();
     }
 
+    $sites[0] = "All Sites";
+
     //not yet ideal permissions
     $assignees = array();
     if ($user->hasPermission('access_all_profiles')) {

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -89,6 +89,11 @@ class IssueForm extends Component {
     let attachmentUploadBtn = null;
     let attachmentFileElement = null;
 
+    const siteOptions = this.state.Data.sites;
+    // Add an 'All Sites' options in the Site dropdown
+    // to allow NULL value
+    siteOptions['all'] = 'All Sites';
+
     if (this.state.isNewIssue) {
       headerText = 'Create New Issue';
       lastUpdateValue = 'Never!';
@@ -223,7 +228,7 @@ class IssueForm extends Component {
             name='centerID'
             label='Site'
             emptyOption={true}
-            options={this.state.Data.sites}
+            options={siteOptions}
             onUserInput={this.setFormData}
             disabled={!hasEditPermission}
             value={this.state.formData.centerID}
@@ -379,6 +384,10 @@ class IssueForm extends Component {
 
     for (let key in myFormData) {
       if (myFormData[key] !== '') {
+        // All Sites selected - Ignore value to store NULL in DB
+        if (myFormData['centerID'] == 'all') {
+          myFormData['centerID'] = null;
+        }
         formData.append(key, myFormData[key]);
       }
     }

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -330,7 +330,13 @@ class IssueForm extends Component {
         // is set to the empty option instead of an array of
         // the user's sites.
         if (newIssue) {
-            formData.centerID = null;
+          formData.centerID = null;
+        } else {
+          // if we edit an issue
+          // a NULL centerID (= All Sites) is converted to the ALL Sites option
+          if (formData.centerID == null) {
+            formData.centerID = 'all';
+          }
         }
 
         this.setState({
@@ -373,9 +379,6 @@ class IssueForm extends Component {
 
     for (let key in myFormData) {
       if (myFormData[key] !== '') {
-        // All Sites selected - Ignore value to store NULL in DB
-        if (key == 'centerID' && myFormData[key] == '0') continue;
-
         formData.append(key, myFormData[key]);
       }
     }

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -227,6 +227,7 @@ class IssueForm extends Component {
             onUserInput={this.setFormData}
             disabled={!hasEditPermission}
             value={this.state.formData.centerID}
+            required={true}
           />
           <SelectElement
             name='status'
@@ -372,6 +373,9 @@ class IssueForm extends Component {
 
     for (let key in myFormData) {
       if (myFormData[key] !== '') {
+        // All Sites selected - Ignore value to store NULL in DB
+        if (key == 'centerID' && myFormData[key] == '0') continue;
+
         formData.append(key, myFormData[key]);
       }
     }

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -227,7 +227,6 @@ class IssueForm extends Component {
             onUserInput={this.setFormData}
             disabled={!hasEditPermission}
             value={this.state.formData.centerID}
-            required={true}
           />
           <SelectElement
             name='status'

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -95,7 +95,14 @@ class IssueTrackerIndex extends Component {
       };
       break;
     case 'Site':
-      result = <td>{this.state.data.fieldOptions.sites[cell]}</td>;
+      let sites = [];
+      if (cell.includes('all')) {
+        sites.push(this.state.data.fieldOptions.sites['all']);
+      } else {
+        sites = cell.map((v) => this.state.data.fieldOptions.sites[v]).filter((v) => v != undefined);
+      }
+
+      result = <td>{sites.join(', ')}</td>;
       break;
     case 'PSCID':
       if (row.PSCID !== null) {
@@ -109,7 +116,7 @@ class IssueTrackerIndex extends Component {
       break;
     case 'Visit Label':
       if (row['Visit Label'] !== null) {
-        link =(
+        link = (
           <a href={loris.BaseURL + '/instrument_list/?candID=' +
                   row.CandID + '&sessionID=' + row.SessionID }>
             {cell}
@@ -203,7 +210,7 @@ class IssueTrackerIndex extends Component {
       {label: 'Watching', show: false, filter: {
         name: 'watching',
         type: 'checkbox',
-        }},
+      }},
     ];
 
     const filterPresets = [

--- a/modules/issue_tracker/jsx/issueTrackerIndex.js
+++ b/modules/issue_tracker/jsx/issueTrackerIndex.js
@@ -95,14 +95,12 @@ class IssueTrackerIndex extends Component {
       };
       break;
     case 'Site':
-      let sites = [];
-      if (cell.includes('all')) {
-        sites.push(this.state.data.fieldOptions.sites['all']);
+      // if cell is an array containing all sites values
+      if (JSON.stringify(Object.keys(this.state.data.centerIDs)) == JSON.stringify(cell)) {
+        result = <td>All Sites</td>;
       } else {
-        sites = cell.map((v) => this.state.data.fieldOptions.sites[v]).filter((v) => v != undefined);
+        result = <td>{cell.map((v) => this.state.data.fieldOptions.sites[v]).filter((v) => v != undefined).join(', ')}</td>;
       }
-
-      result = <td>{sites.join(', ')}</td>;
       break;
     case 'PSCID':
       if (row.PSCID !== null) {
@@ -189,7 +187,7 @@ class IssueTrackerIndex extends Component {
         }},
       {label: 'Site', show: true, filter: {
         name: 'site',
-        type: 'select',
+        type: 'multiselect',
         options: options.sites,
         }},
       {label: 'PSCID', show: true, filter: {

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -68,6 +68,27 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     }
 
     /**
+     * Returns a list of sites in the database with an additional All Sites option
+     *
+     * @return array an associative array("center ID" => "site name")
+     */
+    static function getSiteOptions(): array
+    {
+        $user  = \User::singleton();
+        $sites = array();
+        if ($user->hasPermission('access_all_profiles')) {
+            // get the list of study sites - to be replaced by the Site object
+            $sites = \Utility::getSiteList();
+        } else {
+            // allow only to view own site data
+            $sites = $user->getStudySites();
+        }
+        $sites["all"] = "All Sites";
+
+        return $sites;
+    }
+
+    /**
      * Converts the results of this menu filter to a JSON format to be retrieved
      * with ?format=json
      *
@@ -79,13 +100,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         $db   = \Database::singleton();
 
         //sites
-        $sites = array();
-        if ($user->hasPermission('access_all_profiles')) {
-            $sites = \Utility::getSiteList();
-        } else {
-            // allow only to view own site data
-            $sites = $user->getStudySites();
-        }
+        $sites = Issue_Tracker::getSiteOptions();
 
         //reporters
         $reporters         = array();

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -70,21 +70,25 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
     /**
      * Returns a list of sites in the database with an additional All Sites option
      *
+     * @param boolean $study_site if true only return study sites from psc
+     *                            table
+     * @param boolean $DCC        Whether the DCC should be included or not
+     *
      * @return array an associative array("center ID" => "site name")
      */
-    static function getSiteOptions(): array
-    {
+    static function getSites(
+        bool $study_site = true,
+        bool $DCC = true
+    ): array {
         $user  = \User::singleton();
         $sites = array();
         if ($user->hasPermission('access_all_profiles')) {
             // get the list of study sites - to be replaced by the Site object
-            $sites = \Utility::getSiteList();
+            $sites = \Utility::getSiteList($study_site, $DCC);
         } else {
             // allow only to view own site data
             $sites = $user->getStudySites();
         }
-        $sites["all"] = "All Sites";
-
         return $sites;
     }
 
@@ -99,10 +103,10 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         $user = \User::singleton();
         $db   = \Database::singleton();
 
-        //sites
-        $sites = Issue_Tracker::getSiteOptions();
+        // sites
+        $sites = Issue_Tracker::getSites();
 
-        //reporters
+        // reporters
         $reporters         = array();
         $reporter_expanded = $db->pselect(
             "SELECT u.UserID,
@@ -116,7 +120,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             $reporters[$r_row['UserID']] = $r_row['Real_name'];
         }
 
-        //assignees
+        // assignees
         $assignees         = array();
         $assignee_expanded = $db->pselect(
             "SELECT u.UserID,
@@ -196,6 +200,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
             [
                 'data'         => $arr,
                 'fieldOptions' => $fieldOptions,
+                'centerIDs'    => \Utility::getSiteList()
             ]
         );
     }

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -100,13 +100,9 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         }
 
         if (isset($row['centerId'])) {
-            // $cids: int array
-            // If centerId is set
             // convert the value from string to int array
             $cids = [intval($row['centerId'])];
 
-            // $row['centerId']: string array
-            // If $row['centerId'] is not set
             // convert the value from string to string array
             $row['centerId'] = [$row['centerId']];
         } else {
@@ -117,10 +113,8 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             // Use getCenterIDs and convert values to string (string array)
             $row['centerId'] = array_map(
                 "strval",
-                \User::singleton()->getCenterIDs()
+                $this->_siteList
             );
-            // For filter to work for 'All Sites'
-            array_push($row['centerId'], "all");
         }
 
         $row['lastUpdate'] = \Utility::toDateDisplayFormat($row['lastUpdate']);

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -61,7 +61,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             FROM issues as i
             LEFT JOIN modules m
               ON (m.ID=i.module)
-            LEFT JOIN candidate c 
+            LEFT JOIN candidate c
               ON (i.candID=c.CandID)
             LEFT JOIN session s
               ON (i.sessionID = s.ID)
@@ -99,7 +99,30 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
             $module = &$modules[$mname];
         }
 
-        $cids = isset($row['centerId']) ? [$row['centerId']] : $this->_siteList;
+        if (isset($row['centerId'])) {
+            // $cids: int array
+            // If centerId is set
+            // convert the value from string to int array
+            $cids = [intval($row['centerId'])];
+
+            // $row['centerId']: string array
+            // If $row['centerId'] is not set
+            // convert the value from string to string array
+            $row['centerId'] = [$row['centerId']];
+        } else {
+            // set $cids to all centersID (int array)
+            $cids = $this->_siteList;
+
+            // set $row['centerId'] to all centersID
+            // Use getCenterIDs and convert values to string (string array)
+            $row['centerId'] = array_map(
+                "strval",
+                \User::singleton()->getCenterIDs()
+            );
+            // For filter to work for 'All Sites'
+            array_push($row['centerId'], "all");
+        }
+
         $row['lastUpdate'] = \Utility::toDateDisplayFormat($row['lastUpdate']);
         return new IssueRow($row, $cids, $module);
     }

--- a/modules/issue_tracker/test/issue_tracker_test_plan.md
+++ b/modules/issue_tracker/test/issue_tracker_test_plan.md
@@ -8,21 +8,22 @@
 5. Test that the watching checkbox works correctly (issues that your userID is watching in issues_watching table)
 6. Check that links to issues in table are correct.
 7. Check that table sorts and displays additional pages correctly 
-8. Check that a user who does not have access_all_profiles permission and limited sites access (see __user_psc_rel__ table for user/CenterID relationships) can see all issues with a site set to NULL.
+8. Check that a user who does not have access_all_profiles permission and belongs to only one site can see all issues with a site set to NULL.
 
 ## Issue Tracker Create New Issue [Manual Testing]
 1. User can access the page if they have `issue_tracker_reporter` or `issue_tracker_developer` permission.
-2. Check that title and assignee are required. 
-3. Do not provide a PSCID value and check that site can be null or populated by one of the dropdown values. 
-4. Submit a PSCID and leave the Site blank. This should work if the PSCID exists in the database.
-5. Submit a PSCID with a Site value. This should not work if the PSCID does not exists or if the PSCID does not match with the site.
-6. Should display message, and redirect after success. 
-7. Submit invalid and valid PSCID and visit label pairs. Error messages should display accordingly. 
-8. A user should be able to submit a PSCID from other sites only if they have `access_all_profiles` permission. 
-9. Submit just a visit label - this should give an error message.
-10. Check that all values are propagated and saved correctly.
-11. Add an attachment to the new issue and make sure that it is successfully uploaded.
-12. Check that watching logging is working - turn it off and on for your current user, and for other watchers on the issue
+2. Check that title, assignee and site are required.
+3. Do not provide a PSCID value and set site to All Sites. This should set Site to NULL after success.
+4. Do not provide a PSCID value and and check that site can be populated by a particular site (except All Sites) in the dropdown values.
+5. Submit a PSCID and set Site to All Sites. This should work if the PSCID exists in the database.
+6. Submit a PSCID with a Site value (except All Sites). This should not work if the PSCID does not exists or if the PSCID does not match with the site.
+7. Should display message, and redirect after success. 
+8. Submit invalid and valid PSCID and visit label pairs. Error messages should display accordingly. 
+9. A user should be able to submit a PSCID from other sites only if they have `access_all_profiles` permission. 
+10. Submit just a visit label - this should give an error message.
+11. Check that all values are propagated and saved correctly.
+12. Add an attachment to the new issue and make sure that it is successfully uploaded.
+13. Check that watching logging is working - turn it off and on for your current user, and for other watchers on the issue
 
 ## Issue Tracker Edit Existing Issue [Manual Testing]
 1. User can access the page if they fulfill all the following conditions:

--- a/modules/issue_tracker/test/issue_tracker_test_plan.md
+++ b/modules/issue_tracker/test/issue_tracker_test_plan.md
@@ -8,15 +8,18 @@
 5. Test that the watching checkbox works correctly (issues that your userID is watching in issues_watching table)
 6. Check that links to issues in table are correct.
 7. Check that table sorts and displays additional pages correctly 
+8. Check that a user who does not have access to all centers can see all issues with a site set to NULL.
 
 ## Issue Tracker Create New Issue [Manual Testing]
 1. User can access the page if they have `issue_tracker_reporter` or `issue_tracker_developer` permission.
 2. Check that title and assignee are required. 
-3. Should display message, and redirect after success. 
-4. Submit invalid and valid PSCID and visit label pairs. Error messages should respond accordingly. Not that you cannot submit PSCIDs from other sites unless you have `access_all_profiles` permission
-5. Submit just a visit label - this should give an error message.
-6. Check that all values are propagated and saved correctly.
-7. Check that watching options are working - turn it off and on for your current user, and for other watchers on the issue, and check that values are saved.
+3. Check that site can be null or populated by one of the dropdown values. 
+4. Should display message, and redirect after success. 
+5. Submit invalid and valid PSCID and visit label pairs. Error messages should respond accordingly. Note that you cannot submit PSCIDs from other sites unless you have `access_all_profiles` permission
+6. Submit just a visit label - this should give an error message.
+7. Check that all values are propagated and saved correctly.
+8. Add an attachment to the new issue and make sure that it is successfully uploaded.
+9. Check that watching options are working - turn it off and on for your current user, and for other watchers on the issue, and check that values are saved.
 
 ## Issue Tracker Edit Existing Issue [Manual Testing]
 1. User can access the page if they fulfill all the following conditions:

--- a/modules/issue_tracker/test/issue_tracker_test_plan.md
+++ b/modules/issue_tracker/test/issue_tracker_test_plan.md
@@ -8,18 +8,21 @@
 5. Test that the watching checkbox works correctly (issues that your userID is watching in issues_watching table)
 6. Check that links to issues in table are correct.
 7. Check that table sorts and displays additional pages correctly 
-8. Check that a user who does not have access to all centers can see all issues with a site set to NULL.
+8. Check that a user who does not have access_all_profiles permission and limited sites access (see __user_psc_rel__ table for user/CenterID relationships) can see all issues with a site set to NULL.
 
 ## Issue Tracker Create New Issue [Manual Testing]
 1. User can access the page if they have `issue_tracker_reporter` or `issue_tracker_developer` permission.
 2. Check that title and assignee are required. 
-3. Check that site can be null or populated by one of the dropdown values. 
-4. Should display message, and redirect after success. 
-5. Submit invalid and valid PSCID and visit label pairs. Error messages should respond accordingly. Note that you cannot submit PSCIDs from other sites unless you have `access_all_profiles` permission
-6. Submit just a visit label - this should give an error message.
-7. Check that all values are propagated and saved correctly.
-8. Add an attachment to the new issue and make sure that it is successfully uploaded.
-9. Check that watching options are working - turn it off and on for your current user, and for other watchers on the issue, and check that values are saved.
+3. Do not provide a PSCID value and check that site can be null or populated by one of the dropdown values. 
+4. Submit a PSCID and leave the Site blank. This should work if the PSCID exists in the database.
+5. Submit a PSCID with a Site value. This should not work if the PSCID does not exists or if the PSCID does not match with the site.
+6. Should display message, and redirect after success. 
+7. Submit invalid and valid PSCID and visit label pairs. Error messages should display accordingly. 
+8. A user should be able to submit a PSCID from other sites only if they have `access_all_profiles` permission. 
+9. Submit just a visit label - this should give an error message.
+10. Check that all values are propagated and saved correctly.
+11. Add an attachment to the new issue and make sure that it is successfully uploaded.
+12. Check that watching logging is working - turn it off and on for your current user, and for other watchers on the issue
 
 ## Issue Tracker Edit Existing Issue [Manual Testing]
 1. User can access the page if they fulfill all the following conditions:

--- a/modules/issue_tracker/test/issue_tracker_test_plan.md
+++ b/modules/issue_tracker/test/issue_tracker_test_plan.md
@@ -8,7 +8,7 @@
 5. Test that the watching checkbox works correctly (issues that your userID is watching in issues_watching table)
 6. Check that links to issues in table are correct.
 7. Check that table sorts and displays additional pages correctly 
-8. Check that a user who does not have access_all_profiles permission and belongs to only one site can see all issues with a site set to NULL.
+8. Check that a user who does not have `access_all_profiles` permission and belongs to only one site can see all issues with a site set to NULL.
 
 ## Issue Tracker Create New Issue [Manual Testing]
 1. User can access the page if they have `issue_tracker_reporter` or `issue_tracker_developer` permission.
@@ -23,7 +23,7 @@
 10. Submit just a visit label - this should give an error message.
 11. Check that all values are propagated and saved correctly.
 12. Add an attachment to the new issue and make sure that it is successfully uploaded.
-13. Check that watching logging is working - turn it off and on for your current user, and for other watchers on the issue
+13. Check that watching options are working - turn it off and on for your current user, and for other watchers on the issue, and check that values are saved.
 
 ## Issue Tracker Edit Existing Issue [Manual Testing]
 1. User can access the page if they fulfill all the following conditions:
@@ -34,8 +34,12 @@
 4. Submit invalid and valid PSCID and visit label pairs. Error messages should respond accordingly. Not that you cannot submit PSCIDs from other sites unless you have `access_all_profiles` permission
 5. Submit just a visit label - this should give an error message.
 6. Check that all values are propagated and saved correctly.
-7. Check that watching logging is working - turn it off and on for your current user, and for other watchers on the issue
-
+7. Check that watching options are working - turn it off and on for your current user, and for other watchers on the issue, and check that values are saved.
+8. Add an attachment to the new issue and make sure that it is successfully uploaded.
+9. Check that an attachment can be added to an existing issue.
+10. Test if users assigned to issues can upload attachments.
+11. Test if users can delete their own uploaded attachments.
+12. Test if user assigned to issue cannot delete attachments of issue owner.
 
 ## Permissions [Automation Testing]
 1. Remove `access_all_profiles` permission.

--- a/modules/issue_tracker/test/issue_tracker_test_plan.md
+++ b/modules/issue_tracker/test/issue_tracker_test_plan.md
@@ -8,7 +8,7 @@
 5. Test that the watching checkbox works correctly (issues that your userID is watching in issues_watching table)
 6. Check that links to issues in table are correct.
 7. Check that table sorts and displays additional pages correctly 
-8. Check that a user who does not have `access_all_profiles` permission and belongs to only one site can see all issues with a site set to NULL.
+8. Check that a user who does not have `access_all_profiles` permission and belongs to only one site can see all issues with a NULL centerID. Check that they have the label `All Sites` in the Site column. 
 
 ## Issue Tracker Create New Issue [Manual Testing]
 1. User can access the page if they have `issue_tracker_reporter` or `issue_tracker_developer` permission.


### PR DESCRIPTION
## Brief summary of changes
Since we want to allow new issues with NULL centerID to be created, the following changes have been made:

### Add/Edit issue
- a new Site option All Sites allows a user to save an issue with a NULL site
- The Comment History section displays **site to All sites** if an issue is edited/modified with the All Sites option.
- Alternatively, in the Comment History section, All sites can be replaced with a comma separated list of all CenterID (to discuss)

### Index
- An issue with a null centerID displays **All Sites** in the site column
- Issues can be filtered by sites: All Sites. 
- Alternatively, All sites can be replaced with a comma separated list of all CenterID (to discuss) in the datatable column, and sites can be made multi-selectable.

### Test plan
* Add modification to test instructions to handle the NULL CenterIDs
* Reintroduce Attachment testing instruction deleted by accident in #6636
 
### Linked Issues
* Resolves #6518