### PR TITLE
[23.0 release LorisForm] fix PHP warning for string vs array

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2066,7 +2066,10 @@ class LorisForm
                     // If the value is coming from a React DateElement with input
                     // type='month' and is missing the dd part, convert month-year
                     // format to a valid SQL format (i.e. yyyy-mm-dd)
-                    if (strlen($value) === 7 && strpos(strtolower($key), 'date')) {
+                    if (is_string($value)
+                        && strlen($value) === 7
+                        && strpos(strtolower($key), 'date')
+                    ) {
                         $value = sprintf("%s-01", $value);
                     }
                     $arr[$key] = $value;


### PR DESCRIPTION
## Brief summary of changes

This fix the warning mentioned in the PR #6520

Warning: strlen() expects parameter 1 to be string, array given in /Users/cmadjar/Github/Loris/php/libraries/LorisForm.class.inc on line 2069

#### Testing instructions (if applicable)

1. Check to see whether the warning exists or not with a group element, for example, with the PR #6520.

#### Link(s) to related issue(s)

PR #6520