### PR TITLE
[Test] unittests for Database.class.inc

### DIFF
--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -22,19 +22,23 @@ require_once __DIR__ . '/../../vendor/autoload.php';
  */
 class FakePDO extends PDO
 {
-    public function __construct () {}
+    public function __construct()
+    {
+    }
 }
 
-class FakeDatabase extends Database {
+class FakeDatabase extends Database
+{
     protected function trackChanges(
         string $table, 
         array $set, 
         string $where, 
         string $type='U'
-    ):void {
+    ) : void {
     }
 }
 
+use PHPUnit\Framework\TestCase;
 /**
  * This tests the LorisForm replacement for HTML_QuickForm used by
  * Loris.
@@ -45,22 +49,31 @@ class FakeDatabase extends Database {
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-use PHPUnit\Framework\TestCase;
 class Database_Test extends TestCase
 {
-    function _getAllMethodsExcept($methods) {
+    /**
+     * Helper function to get all Database class methods except the one specified
+     *
+     * @param array $methods Array of method names to exclude
+     *
+     * @return array
+     */
+    function _getAllMethodsExcept($methods)
+    {
         $AllMethods = get_class_methods('Database');
 
         return array_diff($AllMethods, $methods);
     }
 
     /**
-     * Test that setFakeTableData creates a table with the specified data in the mock DB
+     * Test that setFakeTableData creates a table with the specified data
+     * in the mock DB
      *
      * @return void
      * @covers Database::setFakeTableData
      */
-    function testSetFakeData() {
+    function testSetFakeData()
+    {
         $client = new NDB_Client();
         $client->makeCommandLine();
         $client->initialize();
@@ -100,22 +113,22 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::update
      */
-    function testUpdateEscapesHTML() {
+    function testUpdateEscapesHTML()
+    {
         $this->_factory   = NDB_Factory::singleton();
-        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('update')))->getMock();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('update')))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
 
         $stmt->expects($this->once())->method("execute")->with(
-            $this->equalTo(array(
-                'set_field' => '&lt;b&gt;Hello&lt;/b&gt;'
-            )
-            )
+            $this->equalTo(array('set_field' => '&lt;b&gt;Hello&lt;/b&gt;'))
         );
 
-        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->_PDO->expects($this->once())
+            ->method("prepare")->will($this->returnValue($stmt));
         $stub->update("test", array('field' => '<b>Hello</b>'), array());
 
     }
@@ -126,22 +139,23 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::unsafeupdate
      */
-    function testUnsafeUpdateDoesntEscapeHTML() {
+    function testUnsafeUpdateDoesntEscapeHTML()
+    {
         $this->_factory   = NDB_Factory::singleton();
-        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('unsafeupdate')))->getMock();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('unsafeupdate')))
+            ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
 
         $stmt->expects($this->once())->method("execute")->with(
-            $this->equalTo(array(
-                'set_field' => '<b>Hello</b>'
-            )
-            )
+            $this->equalTo(array('set_field' => '<b>Hello</b>'))
         );
 
-        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->_PDO->expects($this->once())
+            ->method("prepare")->will($this->returnValue($stmt));
         $stub->unsafeupdate("test", array('field' => '<b>Hello</b>'), array());
 
     }
@@ -152,22 +166,22 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::insert
      */
-    function testInsertEscapesHTML() {
+    function testInsertEscapesHTML()
+    {
         $this->_factory   = NDB_Factory::singleton();
-        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('insert')))->getMock();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('insert')))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
 
         $stmt->expects($this->once())->method("execute")->with(
-            $this->equalTo(array(
-                'field' => '&lt;b&gt;Hello&lt;/b&gt;'
-            )
-            )
+            $this->equalTo(array('field' => '&lt;b&gt;Hello&lt;/b&gt;'))
         );
 
-        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->_PDO->expects($this->once())
+            ->method("prepare")->will($this->returnValue($stmt));
         $stub->insert("test", array('field' => '<b>Hello</b>'), array());
 
     }
@@ -178,33 +192,36 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::unsafeinsert
      */
-    function testUnsafeInsertDoesntEscapeHTML() {
+    function testUnsafeInsertDoesntEscapeHTML()
+    {
         $this->_factory   = NDB_Factory::singleton();
-        $stub = $this->getMockBuilder('FakeDatabase')->setMethods($this->_getAllMethodsExcept(array('unsafeinsert')))->getMock();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('unsafeinsert')))
+            ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
 
         $stmt->expects($this->once())->method("execute")->with(
-            $this->equalTo(array(
-                'field' => '<b>Hello</b>'
-            )
-            )
+            $this->equalTo(array('field' => '<b>Hello</b>'))
         );
 
-        $stub->_PDO->expects($this->once())->method("prepare")->will($this->returnValue($stmt));
+        $stub->_PDO->expects($this->once())->method("prepare")
+            ->will($this->returnValue($stmt));
         $stub->unsafeinsert("test", array('field' => '<b>Hello</b>'), array());
 
     }
 
     /**
-     * Test that delete deletes a row from a specified table when provided null values
+     * Test that delete deletes a row from a specified table
+     * when provided null values
      *
      * @return void
      * @covers Database::delete
      */
-    function testDeleteWithIsNull() {
+    function testDeleteWithIsNull()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -226,7 +243,9 @@ class Database_Test extends TestCase
         );
 
         $DB->delete("ConfigSettings", array('Visible' => 1, 'Description' => null));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -248,7 +267,8 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::delete
      */
-    function testDelete() {
+    function testDelete()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -269,8 +289,12 @@ class Database_Test extends TestCase
             )
         );
 
-        $DB->delete("ConfigSettings", array('Visible' => 1, 'Description' => 'deleting'));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->delete(
+            "ConfigSettings", array('Visible' => 1, 'Description' => 'deleting')
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -288,12 +312,14 @@ class Database_Test extends TestCase
 
 
     /**
-     * Test that update updates a specified row in a specified table when given null values
+     * Test that update updates a specified row in a specified table
+     * when given null values
      *
      * @return void
      * @covers Database::update
      */
-    function testUpdateWithIsNull() {
+    function testUpdateWithIsNull()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -313,8 +339,14 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->update("ConfigSettings", array('Visible' => null, 'Description' => 'new description'), array('Description' => null));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->update(
+            "ConfigSettings", 
+            array('Visible' => null, 'Description' => 'new description'),
+            array('Description' => null)
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -342,7 +374,8 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::update
      */
-    function testUpdate() {
+    function testUpdate()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -362,8 +395,14 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->update("ConfigSettings", array('Visible' => null, 'Description' => 'new description'), array('Description' => 'first description'));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->update(
+            "ConfigSettings", 
+            array('Visible' => null, 'Description' => 'new description'), 
+            array('Description' => 'first description')
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -386,12 +425,14 @@ class Database_Test extends TestCase
 
 
     /**
-     * Test that insert correctly inserts a specified row into a specified table when given null values
+     * Test that insert correctly inserts a specified row into a table
+     * when given null values
      *
      * @return void
      * @covers Database::insert
      */
-    function testInsertWithIsNull() {
+    function testInsertWithIsNull()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -405,8 +446,18 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->insert("ConfigSettings", array('ID' => 99992, 'Name' => 'test 2', 'Visible' => 1, 'Description' => null));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->insert(
+            "ConfigSettings",
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Visible' => 1,
+                'Description' => null
+            )
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -434,7 +485,8 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::insert
      */
-    function testInsert() {
+    function testInsert()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -448,8 +500,18 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->insert("ConfigSettings", array('ID' => 99992, 'Name' => 'test 2', 'Visible' => 1, 'Description' => 'test description'));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->insert(
+            "ConfigSettings",
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Visible' => 1,
+                'Description' => 'test description'
+            )
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -472,12 +534,14 @@ class Database_Test extends TestCase
 
 
     /**
-     * Test that replace correctly replaces a given row and adds a row to a table when given null values
+     * Test that replace correctly replaces a given row and adds a row
+     * to a table when given null values
      *
      * @return void
      * @covers Database::replace
      */
-    function testReplaceWithIsNull() {
+    function testReplaceWithIsNull()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -491,9 +555,27 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->replace("ConfigSettings", array('ID' => 99991, 'Name' => 'test 1', 'Visible' => 1, 'Description' => null));
-        $DB->replace("ConfigSettings", array('ID' => 99992, 'Name' => 'test 2', 'Visible' => 1, 'Description' => null));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->replace(
+            "ConfigSettings",
+            array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Visible' => 1,
+                'Description' => null
+            )
+        );
+        $DB->replace(
+            "ConfigSettings",
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Visible' =>  1,
+                'Description' => null
+            )
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -521,7 +603,8 @@ class Database_Test extends TestCase
      * @return void
      * @covers Database::replace
      */
-    function testReplace() {
+    function testReplace()
+    {
         $this->_factory   = NDB_Factory::singleton();
         $DB = Database::singleton();
         $DB->setFakeTableData(
@@ -535,9 +618,27 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->replace("ConfigSettings", array('ID' => 99991, 'Name' => 'test 1', 'Visible' => 1, 'Description' => 'description 1'));
-        $DB->replace("ConfigSettings", array('ID' => 99992, 'Name' => 'test 2', 'Visible' => 1, 'Description' => 'description 2'));
-        $allSetting = $DB->pselect("SELECT ID, Name, Description, Visible FROM ConfigSettings", array());
+        $DB->replace(
+            "ConfigSettings",
+            array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Visible' => 1,
+                'Description' => 'description 1'
+            )
+        );
+        $DB->replace(
+            "ConfigSettings",
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Visible' => 1,
+                'Description' => 'description 2'
+            )
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
         $DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
@@ -557,4 +658,300 @@ class Database_Test extends TestCase
             )
         );
     }
+
+    /**
+     * Test that insertOnDuplicateUpdate either inserts or updates an entry
+     * if the entry already exists in the DB table
+     *
+     * @return void
+     * @covers Database::insertOnDuplicateUpdate
+     */
+    function testInsertOnDuplicateUpdate()
+    {
+        $this->_factory = NDB_Factory::singleton();
+        $DB = Database::singleton();
+        $DB->setFakeTableData(
+            "ConfigSettings",
+            array(
+                0 => array(
+                    'ID' => 99991,
+                    'Name' => 'test 1',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                )
+            )
+        );
+        $DB->insertOnDuplicateUpdate(
+            "ConfigSettings",
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Visible' => 1,
+                'Description' => 'description 2'
+            )
+        );
+        $DB->insertOnDuplicateUpdate(
+            "ConfigSettings",
+            array(
+                'ID' => 99991,
+                'Name' => 'test 1 updated',
+                'Visible' => 1, 
+                'Description' => 'description updated'
+            )
+        );
+        $allSetting = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
+        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->assertEquals(
+            $allSetting,
+            array(
+                0 => array(
+                    'ID' => 99991,
+                    'Name' => 'test 1 updated',
+                    'Description' => 'description updated',
+                    'Visible' => '1'
+                ),
+                1 => array(
+                    'ID' => 99992,
+                    'Name' => 'test 2',
+                    'Description' => 'description 2',
+                    'Visible' => '1'
+                )
+            )
+        );
+    }
+
+    /**
+     * Test that insertOnDuplicateUpdate automatically escapes any HTML
+     * in the data for security
+     *
+     * @return void
+     * @covers Database::insertOnDuplicateUpdate
+     */
+    function testInsertOnDuplicateUpdateEscapesHTML()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods(
+                $this->_getAllMethodsExcept(array('insertOnDuplicateUpdate'))
+            )
+            ->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+
+        $stmt->expects($this->once())->method("execute")->with(
+            $this->equalTo(array('field' => '&lt;b&gt;Hello&lt;/b&gt;'))
+        );
+
+        $stub->_PDO->expects($this->once())
+            ->method("prepare")->will($this->returnValue($stmt));
+        $stub->insertOnDuplicateUpdate(
+            "test", array('field' => '<b>Hello</b>'), array()
+        );
+    }
+
+    /**
+     * Test that unsafeInsertOnDuplicateUpdate does not escape HTML
+     *
+     * @return void
+     * @covers Database::unsafeInsertOnDuplicateUpdate
+     */
+    function testUnsafeInsertOnDuplicateUpdateDoesntEscapeHTML()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods(
+                $this->_getAllMethodsExcept(array('unsafeInsertOnDuplicateUpdate'))
+            )
+            ->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+        $stmt->expects($this->once())->method("execute")->with(
+            $this->equalTo(array('field' => '<b>Hello</b>'))
+        );
+
+        $stub->_PDO->expects($this->once())
+            ->method("prepare")->will($this->returnValue($stmt));
+        $stub->unsafeInsertOnDuplicateUpdate(
+            "test", array('field' => '<b>Hello</b>'), array()
+        );
+    }
+
+    /**
+     * Tests that getLastInsertId gets the ID of the row just inserted
+     *
+     * @return void
+     * @covers Database::getLastInsertId
+     */
+    function testGetLastInsertId()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $DB = Database::singleton();
+        $DB->setFakeTableData(
+            "ConfigSettings",
+            array(
+                0 => array(
+                    'ID' => 99991,
+                    'Name' => 'test 1',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                )
+            )
+        );
+        $DB->insert(
+            "ConfigSettings",
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Visible' => 1,
+                'Description' => 'test description'
+            )
+        );
+        $lastInsertId = $DB->getLastInsertId();
+        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->assertEquals($lastInsertId, '99992');
+    }
+
+    /**
+     * Test that run calls the exec function on the PDO with the given query
+     *
+     * @return void
+     * @covers Database::run
+     */
+    function testRun()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('run')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+        $stub->_PDO->expects($this->once())
+            ->method("exec")->with($this->equalTo("SHOW TABLES"));
+        $stub->run("SHOW TABLES");
+    }
+
+    /**
+     * Test that prepare calls the prepare function on the PDO with the given query
+     *
+     * @return void
+     * @covers Database::prepare
+     */
+    function testPrepare()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('prepare')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
+
+        $stub->_PDO->expects($this->once())
+            ->method("prepare")->with($this->equalTo("SHOW TABLES"));
+        $stub->prepare("SHOW TABLES");
+    }
+
+    /**
+     * Test that execute returns the proper array when a SELECT query is given
+     *
+     * @return void
+     * @covers Database::execute
+     */
+    function testExecuteNoOptions()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $DB = Database::singleton();
+        $DB->setFakeTableData(
+            "ConfigSettings",
+            array(
+                0 => array(
+                    'ID' => 99991,
+                    'Name' => 'test 1',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                ),
+                1 => array(
+                    'ID' => 99992,
+                    'Name' => 'test 2',
+                    'Description' => 'permanent 2',
+                    'Visible' => '1'
+                )
+            )
+        );
+        $statement = $DB->prepare(
+            'SELECT ID, Name, Description, Visible
+            FROM ConfigSettings WHERE ID=:id AND Name=:name'
+        );
+        $allSetting = $DB->execute(
+            $statement,
+            array(':id' => 99992, 'name' => 'test 2')
+        );
+        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->assertEquals(
+            $allSetting,
+            array(
+                0 => array(
+                    'ID' => 99992,
+                    'Name' => 'test 2',
+                    'Description' => 'permanent 2',
+                    'Visible' => '1'
+                )
+            )
+        );
+    }
+
+    /**
+     * Tests that execute returns an empty array when the option
+     * 'nofetch' is set to true. Also tests that execute updates the table correctly
+     *
+     * @return void
+     * @covers Database::execute
+     */
+    function testExecuteWithOptions()
+    {
+        $this->_factory = NDB_Factory::singleton();
+        $DB = Database::singleton();
+        $DB->setFakeTableData(
+            "ConfigSettings",
+            array(
+                0 => array(
+                    'ID' => 99991,
+                    'Name' => 'test 1',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                )
+            )
+        );
+        $statement = $DB->prepare(
+            "UPDATE ConfigSettings SET Name=:name WHERE ID=:id"
+        );
+        $allSetting = $DB->execute(
+            $statement,
+            array(':id' => 99991, ':name' => 'new name'),
+            array('nofetch' => true)
+        );
+        $check = $DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
+        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->assertEquals(
+            $check,
+            array(
+                0 => array(
+                    'ID' => 99991,
+                    'Name' => 'new name',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                )
+            )
+        );
+        $this->assertEquals($allSetting, array());
+    }
+
 }

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -51,6 +51,43 @@ use PHPUnit\Framework\TestCase;
  */
 class Database_Test extends TestCase
 {
+    protected $factory;
+    protected $DB;
+    /**
+     * This method is called before each test is executed.
+     * Sets up fixtures: factory, config, database
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        $this->factory = NDB_Factory::singleton();
+        $this->factory->reset();
+        $this->factory->setTesting(false);
+        $this->config = $this->factory->Config(CONFIG_XML);
+        $database = $this->config->getSetting('database');
+        $this->DB = Database::singleton(
+            $database['database'],
+            $database['username'],
+            $database['password'],
+            $database['host'],
+            1
+        );
+    }
+
+    /**
+     * Tears down the fixture, for example, close a network connection.
+     * This method is called after a test is executed.
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->factory->reset();
+        $this->DB->run("DROP TEMPORARY TABLE IF EXISTS ConfigSettings");
+    }
+
     /**
      * Helper function to get all Database class methods except the one specified
      *
@@ -78,10 +115,7 @@ class Database_Test extends TestCase
         $client->makeCommandLine();
         $client->initialize();
 
-
-        $DB = Database::singleton();
-
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "Config",
             array(
                 0 => array(
@@ -92,7 +126,7 @@ class Database_Test extends TestCase
             )
         );
 
-        $allCandidates = $DB->pselect("SELECT * FROM Config", array());
+        $allCandidates = $this->DB->pselect("SELECT * FROM Config", array());
 
         $this->assertEquals(
             $allCandidates,
@@ -222,9 +256,7 @@ class Database_Test extends TestCase
      */
     function testDeleteWithIsNull()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -242,11 +274,14 @@ class Database_Test extends TestCase
             )
         );
 
-        $DB->delete("ConfigSettings", array('Visible' => 1, 'Description' => null));
-        $allSetting = $DB->pselect(
+        $this->DB->delete(
+            "ConfigSettings",
+            array('Visible' => 1, 'Description' => null)
+        );
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -269,9 +304,7 @@ class Database_Test extends TestCase
      */
     function testDelete()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -289,13 +322,13 @@ class Database_Test extends TestCase
             )
         );
 
-        $DB->delete(
+        $this->DB->delete(
             "ConfigSettings", array('Visible' => 1, 'Description' => 'deleting')
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -320,9 +353,7 @@ class Database_Test extends TestCase
      */
     function testUpdateWithIsNull()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -339,15 +370,15 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->update(
+        $this->DB->update(
             "ConfigSettings", 
             array('Visible' => null, 'Description' => 'new description'),
             array('Description' => null)
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -376,9 +407,7 @@ class Database_Test extends TestCase
      */
     function testUpdate()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -395,15 +424,15 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->update(
+        $this->DB->update(
             "ConfigSettings", 
             array('Visible' => null, 'Description' => 'new description'), 
             array('Description' => 'first description')
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -433,9 +462,7 @@ class Database_Test extends TestCase
      */
     function testInsertWithIsNull()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -446,7 +473,7 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->insert(
+        $this->DB->insert(
             "ConfigSettings",
             array(
                 'ID' => 99992,
@@ -455,10 +482,10 @@ class Database_Test extends TestCase
                 'Description' => null
             )
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -487,9 +514,7 @@ class Database_Test extends TestCase
      */
     function testInsert()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -500,7 +525,7 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->insert(
+        $this->DB->insert(
             "ConfigSettings",
             array(
                 'ID' => 99992,
@@ -509,10 +534,10 @@ class Database_Test extends TestCase
                 'Description' => 'test description'
             )
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -542,9 +567,7 @@ class Database_Test extends TestCase
      */
     function testReplaceWithIsNull()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -555,7 +578,7 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->replace(
+        $this->DB->replace(
             "ConfigSettings",
             array(
                 'ID' => 99991,
@@ -564,7 +587,7 @@ class Database_Test extends TestCase
                 'Description' => null
             )
         );
-        $DB->replace(
+        $this->DB->replace(
             "ConfigSettings",
             array(
                 'ID' => 99992,
@@ -573,10 +596,10 @@ class Database_Test extends TestCase
                 'Description' => null
             )
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -605,9 +628,7 @@ class Database_Test extends TestCase
      */
     function testReplace()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -618,7 +639,7 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->replace(
+        $this->DB->replace(
             "ConfigSettings",
             array(
                 'ID' => 99991,
@@ -627,7 +648,7 @@ class Database_Test extends TestCase
                 'Description' => 'description 1'
             )
         );
-        $DB->replace(
+        $this->DB->replace(
             "ConfigSettings",
             array(
                 'ID' => 99992,
@@ -636,10 +657,10 @@ class Database_Test extends TestCase
                 'Description' => 'description 2'
             )
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -668,9 +689,7 @@ class Database_Test extends TestCase
      */
     function testInsertOnDuplicateUpdate()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -681,7 +700,7 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->insertOnDuplicateUpdate(
+        $this->DB->insertOnDuplicateUpdate(
             "ConfigSettings",
             array(
                 'ID' => 99992,
@@ -690,7 +709,7 @@ class Database_Test extends TestCase
                 'Description' => 'description 2'
             )
         );
-        $DB->insertOnDuplicateUpdate(
+        $this->DB->insertOnDuplicateUpdate(
             "ConfigSettings",
             array(
                 'ID' => 99991,
@@ -699,10 +718,10 @@ class Database_Test extends TestCase
                 'Description' => 'description updated'
             )
         );
-        $allSetting = $DB->pselect(
+        $allSetting = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -790,9 +809,7 @@ class Database_Test extends TestCase
      */
     function testGetLastInsertId()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -803,7 +820,7 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $DB->insert(
+        $this->DB->insert(
             "ConfigSettings",
             array(
                 'ID' => 99992,
@@ -812,8 +829,8 @@ class Database_Test extends TestCase
                 'Description' => 'test description'
             )
         );
-        $lastInsertId = $DB->getLastInsertId();
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $lastInsertId = $this->DB->getLastInsertId();
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals($lastInsertId, '99992');
     }
 
@@ -865,9 +882,7 @@ class Database_Test extends TestCase
      */
     function testExecuteNoOptions()
     {
-        $this->_factory   = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -884,15 +899,15 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $statement = $DB->prepare(
+        $statement = $this->DB->prepare(
             'SELECT ID, Name, Description, Visible
             FROM ConfigSettings WHERE ID=:id AND Name=:name'
         );
-        $allSetting = $DB->execute(
+        $allSetting = $this->DB->execute(
             $statement,
             array(':id' => 99992, 'name' => 'test 2')
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $allSetting,
             array(
@@ -915,9 +930,7 @@ class Database_Test extends TestCase
      */
     function testExecuteWithOptions()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $DB = Database::singleton();
-        $DB->setFakeTableData(
+        $this->DB->setFakeTableData(
             "ConfigSettings",
             array(
                 0 => array(
@@ -928,18 +941,18 @@ class Database_Test extends TestCase
                 )
             )
         );
-        $statement = $DB->prepare(
+        $statement = $this->DB->prepare(
             "UPDATE ConfigSettings SET Name=:name WHERE ID=:id"
         );
-        $allSetting = $DB->execute(
+        $allSetting = $this->DB->execute(
             $statement,
             array(':id' => 99991, ':name' => 'new name'),
             array('nofetch' => true)
         );
-        $check = $DB->pselect(
+        $check = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
         );
-        $DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
         $this->assertEquals(
             $check,
             array(
@@ -954,4 +967,761 @@ class Database_Test extends TestCase
         $this->assertEquals($allSetting, array());
     }
 
+    /**
+     * Tests that pselect calls the "prepare" and "execute" functions with the proper
+     * parameters.
+     *
+     * @return void
+     * @covers Database::pselect
+     */
+    function testPselectCallsFunctions()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('pselect')))->getMock();
+
+        $stmt = $stub->prepare("SHOW TABLES");
+        $params = array('test' => 'test');
+
+        $stub->expects($this->once())
+            ->method("prepare")->with($this->equalTo("SHOW TABLES"));
+        $stub->expects($this->once())->method("execute")
+            ->with($this->equalTo($stmt), $this->equalTo($params), array());
+        $stub->pselect("SHOW TABLES", $params);
+    }
+
+    /**
+     * Test that pselect returns the proper information
+     *
+     * @return void
+     * @covers Database::pselect
+     */
+    function testPselectReturnsCorrectArray()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $allSetting = $this->DB->pselect(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->assertEquals($allSetting, $data);
+    }
+
+    /**
+     * Test that pselectRow calls the prepare function
+     * and adds "LIMIT 2" to the query
+     *
+     * @return void
+     * @covers Database::pselectRow
+     */
+    function testPselectRowCallsPrepare()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('pselectRow')))
+            ->getMock();
+
+        $query = "SELECT ID, Name, Description, Visible FROM ConfigSettings";
+        $params = array('test' => 'test');
+        $stub->expects($this->once())->method("pselect")
+            ->with(
+                $this->equalTo($query . " LIMIT 2"),
+                $params
+            );
+        $stub->pselectRow(
+            $query,
+            $params
+        );
+    }
+
+    /**
+     * Test that pselectRow returns the correct data for a given query
+     *
+     * @return void
+     * @covers Database::pselectRow
+     */
+    function testPselectRowReturnsData()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $allSetting = $this->DB->pselectRow(
+            "SELECT ID, Name, Description, Visible 
+            FROM ConfigSettings WHERE ID=99992",
+            array()
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+
+        $this->assertEquals(
+            $allSetting,
+            array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+    }
+
+    /**
+     * Test that pselectRow throws a DomainException if the query
+     * returns more than one row
+     *
+     * @return void
+     * @covers Database::pselectRow
+     */
+    function testPselectRowThrowsException()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $this->expectException("DomainException");
+        $allSetting = $this->DB->pselectRow(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings", array()
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Test that pselectCol returns the proper data
+     *
+     * @return void
+     * @covers Database::pselectCol
+     */
+    function testPselectColReturnsData()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $allSetting = $this->DB
+            ->pselectCol("SELECT Name FROM ConfigSettings", array());
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+
+        $this->assertEquals($allSetting, array(0 => 'test 1', 1 => 'test 2'));
+    }
+
+    /**
+     * Test that pselectCol throws a DatabaseException if the query
+     * asks for more than one column
+     *
+     * @return void
+     * @covers Database::pselectCol
+     */
+    function testPselectColThrowsException()
+    {
+        $this->expectException("DatabaseException");
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $this->DB->pselectCol("SELECT ID, Name FROM ConfigSettings", array());
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Test that pselectOne returns just one value
+     *
+     * @return void
+     * @covers Database::pselectOne
+     */
+    function testPselectOne()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $allSetting = $this->DB->pselectOne(
+            "SELECT ID, Name FROM ConfigSettings WHERE ID=99991",
+            array()
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+
+        $this->assertEquals($allSetting, '99991');
+    }
+
+    /**
+     * Tests that tableExists returns true if a table exists in the database
+     *
+     * @return void
+     * @covers Database::tableExists
+     */
+    function testTableExists()
+    {
+        $exists = $this->DB->tableExists("ConfigSettings");
+        $this->assertEquals(true, $exists);
+    }
+
+    /**
+     * Tests that tableExists returns false if a table doesn't exist in the database
+     *
+     * @return void
+     * @covers Database::tableExists
+     */
+    function testTableDoesNotExist()
+    {
+        $exists = $this->DB->tableExists("TestTable");
+        $this->assertEquals(false, $exists);
+    }
+
+    /**
+     * Tests that columnExists returns true if a column exists in a table
+     *
+     * @return void
+     * @covers Database::tableExists
+     */
+    function testColumnExists()
+    {
+        $exists = $this->DB->columnExists("ConfigSettings", "Name");
+        $this->assertEquals(true, $exists);
+    }
+
+    /**
+     * Tests that columnExists returns false if a column does not exist in a table
+     *
+     * @return void
+     * @covers Database::tableExists
+     */
+    function testColumnDoesNotExist()
+    {
+        $exists = $this->DB->columnExists("ConfigSettings", "TestCol");
+        $this->assertEquals(false, $exists);
+    }
+
+    /**
+     * Test that insertIgnore calls _realInsert with ignore set to true
+     *
+     * @return void
+     * @covers Database::insertIgnore
+     */
+    function testInsertIgnore()
+    {
+        $this->markTestIncomplete(
+            "This test calls a private method, making it fail for now"
+        );
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('insertIgnore')))
+            ->getMock();
+
+        $table = "ConfigSettings";
+        $set = array('ID' => 99991);
+
+        $stub->expects($this->once())
+            ->method("_realinsert")->with($this->equalTo($table), $set, true, true);
+        $stub->insertIgnore($table, $set);
+    }
+
+    /**
+     * Test that pselectWithIndexKey re-indexes the results in terms
+     * of given index key
+     *
+     * @return void
+     * @covers Database::pselectWithIndexKey
+     */
+    function testPselectWithIndexKey()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $allSetting = $this->DB->pselectWithIndexKey(
+            "SELECT ID, Name, Description, Visible FROM ConfigSettings",
+            array(),
+            "ID"
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+        $this->assertEquals(
+            $allSetting,
+            array(
+                99991 => array(
+                    'ID' => 99991,
+                    'Name' => 'test 1',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                ),
+                99992 => array(
+                    'ID' => 99992,
+                    'Name' => 'test 2',
+                    'Description' => 'permanent',
+                    'Visible' => '1'
+                )
+            )
+        );
+    }
+
+    /**
+     * Test that pselectWithIndexKey throws a LorisException if the
+     * given index key is null/empty
+     *
+     * @return void
+     * @covers Database::pselectWithIndexKey
+     */
+    function testPselectWithIndexKeyThrowsLorisException()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+        $this->expectException("LorisException");
+        $this->DB->pselectWithIndexKey(
+            "SELECT ID, Name FROM ConfigSettings", array(), ""
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Test that pselectWithIndexKey throws a DatabaseException if the
+     * index key provided does not exist in the row
+     *
+     * @return void
+     * @covers Database::pselectWithIndexKey
+     */
+    function testPselectWithIndexKeyThrowsDbException()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+        $this->expectException("DatabaseException");
+        $this->DB->pselectWithIndexKey(
+            "SELECT ID, Name FROM ConfigSettings", array(), "Test"
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Test that pselectColWithIndexKey returns the correct data that is indexed
+     * with the correct index key
+     *
+     * @return void
+     * @covers Database::pselectColWithIndexKey
+     */
+    function testPselectColWithIndexKey()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $allSetting = $this->DB->pselectColWithIndexKey(
+            "SELECT ID, Name FROM ConfigSettings", array(), "ID"
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+
+        $this->assertEquals(
+            $allSetting, array(99991 => 'test 1', 99992 => 'test 2')
+        );
+    }
+
+    /**
+     * Test that pselectColWithIndexKey throws a LorisException if the index key
+     * is null/emptu
+     *
+     * @return void
+     * @covers Database::pselectColWithIndexKey
+     */
+    function testPselectColWithIndexKeyThrowsLorisException()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $this->expectException("LorisException");
+        $this->DB->pselectColWithIndexKey(
+            "SELECT ID, Name FROM ConfigSettings", array(), ""
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Test that pselectColWithIndexKey returns a DatabaseException if the
+     * index key is not included in the SELECT query
+     *
+     * @return void
+     * @covers Database::pselectColWithIndexKey
+     */
+    function testPselectColWithIndexKeyThrowsDbExceptionOne()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $this->expectException("DatabaseException");
+        $this->DB->pselectColWithIndexKey(
+            "SELECT Name FROM ConfigSettings", array(), "ID"
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Test that pselectColWithIndexKey throws a DatabaseException if the index key
+     * given is not a unique key
+     *
+     * @return void
+     * @covers Database::pselectColWithIndexKey
+     */
+    function testPselectColWithIndexKeyThrowsDbExceptionTwo()
+    {
+        $data = array(
+            0 => array(
+                'ID' => 99991,
+                'Name' => 'test 1',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            ),
+            1 => array(
+                'ID' => 99992,
+                'Name' => 'test 2',
+                'Description' => 'permanent',
+                'Visible' => '1'
+            )
+        );
+        $this->DB->setFakeTableData("ConfigSettings", $data);
+
+        $this->expectException("DatabaseException");
+        $this->DB->pselectColWithIndexKey(
+            "SELECT Visible, Name FROM ConfigSettings", array(), "Visible"
+        );
+        $this->DB->run("DROP TEMPORARY TABLE ConfigSettings");
+    }
+
+    /**
+     * Tests that quote calls the PDO::quote function
+     *
+     * @return void
+     * @covers Database::quote
+     */
+    function testQuote()
+    {
+
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('quote')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $string = "Co'mpl''ex \"st'\"ring";
+        $stub->_PDO->expects($this->once())->method("quote")
+            ->willReturn("Complex string");
+        $stub->quote($string);
+    }
+
+    /**
+     * Test that escape properly escapes a string and adds backticks
+     *
+     * @return void
+     * @covers Database::escape
+     */
+    function testEscape()
+    {
+        $allSetting = $this->DB->escape("'`\\TableName\0\n\r\x1a`'");
+        $this->assertEquals($allSetting, "`\\'\\`\\\\TableName\\0\\n\\r\\Z\\`\\'`");
+    }
+
+    /**
+     * Tests that inTransaction calls the PDO::inTransaction function
+     *
+     * @return void
+     * @covers Database::inTransaction
+     */
+    function testInTransaction()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('inTransaction')))
+            ->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->_PDO->expects($this->once())->method("inTransaction")
+            ->willReturn(true);
+        $stub->inTransaction();
+    }
+
+    /**
+     * Test that beginTransaction calls PDO::beginTransaction
+     * if inTransaction is false
+     *
+     * @return void
+     * @covers Database::beginTransaction
+     */
+    function testBeginTransaction()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('beginTransaction')))
+            ->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->expects($this->once())->method("inTransaction")->willReturn(false);
+        $stub->_PDO->expects($this->once())->method("beginTransaction")
+            ->willReturn(true);
+        $stub->beginTransaction();
+    }
+
+    /**
+     * Test that beginTransaction throws a DatabaseException if inTransaction true
+     *
+     * @return void
+     * @covers Database::beginTransaction
+     */
+    function testBeginTransactionThrowsException()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('beginTransaction')))
+            ->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->expects($this->once())->method("inTransaction")->willReturn(true);
+        $this->expectException("DatabaseException");
+        $stub->beginTransaction();
+    }
+
+    /**
+     * Test that rollBack calls PDO::rollBack if inTransaction is true
+     *
+     * @return void
+     * @covers Database::rollBack
+     */
+    function testRollback()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('rollBack')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->expects($this->once())->method("inTransaction")->willReturn(true);
+        $stub->_PDO->expects($this->once())->method("rollBack")->willReturn(true);
+        $stub->rollBack();
+    }
+
+    /**
+     * Test that rollBack throws a DatabaseException if inTransaction is false
+     *
+     * @return void
+     * @covers Database::rollBack
+     */
+    function testRollbackThrowsException()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('rollBack')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->expects($this->once())->method("inTransaction")->willReturn(false);
+        $this->expectException("DatabaseException");
+        $stub->rollBack();
+    }
+
+    /**
+     * Test that commit calls PDO::commit if inTransaction is true
+     *
+     * @return void
+     * @covers Database::commit
+     */
+    function testCommit()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('commit')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->expects($this->once())->method("inTransaction")->willReturn(true);
+        $stub->_PDO->expects($this->once())->method("commit")->willReturn(true);
+        $stub->commit();
+    }
+
+    /**
+     * Test that commit throws a DatabaseException if inTransaction is false
+     *
+     * @return void
+     * @covers Database::commit
+     */
+    function testCommitThrowsException()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('commit')))->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $stub->expects($this->once())->method("inTransaction")->willReturn(false);
+        $this->expectException("DatabaseException");
+        $stub->commit();
+    }
+
+    /**
+     * Test that isConnected returns false if the PDO is not setup
+     *
+     * @return void
+     * @covers Database::isConnected
+     */
+    function testIsConnectedNoPDO()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('isConnected')))
+            ->getMock();
+
+        $val = $stub->isConnected();
+        $this->assertEquals($val, false);
+    }
+
+    /**
+     * Test that isConnected returns true if the PDO is setup
+     *
+     * @return void
+     * @covers Database::isConnected
+     */
+    function testIsConnectedWithPDO()
+    {
+        $this->_factory   = NDB_Factory::singleton();
+        $stub = $this->getMockBuilder('FakeDatabase')
+            ->setMethods($this->_getAllMethodsExcept(array('isConnected')))
+            ->getMock();
+
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $val = $stub->isConnected();
+        $this->assertEquals($val, true);
+    }
 }


### PR DESCRIPTION
## Brief summary of changes

Unit tests for the Database library under `php/libraries`. This PR will be updated as more unit test coverage is added. Comments were added to pre-existing and new unit tests.

setUp and tearDown functions were added as well.

As of 06/16: All **public** methods are covered except for `connect` and `singleton`. 

#### Testing instructions

1. Run `npm run tests:unit -- --filter Database` or check out the Travis output.

