### PR TITLE
[Core] Changed call to baseURL for integration tests

### DIFF
--- a/Dockerfile.test.db
+++ b/Dockerfile.test.db
@@ -33,6 +33,6 @@ RUN echo "Use LorisTest;" | cat - \
 
 RUN echo "Use LorisTest;" >> /docker-entrypoint-initdb.d/0001-paths.sql
 RUN echo "UPDATE Config SET Value='${BASE_DIR}/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base');" >> /docker-entrypoint-initdb.d/0001-paths.sql
-RUN echo "UPDATE Config SET Value='http://web:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='url');" >> /docker-entrypoint-initdb.d/0001-paths.sql
+RUN echo "UPDATE Config SET Value='web:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='host');" >> /docker-entrypoint-initdb.d/0001-paths.sql
 
 RUN echo "GRANT UPDATE,INSERT,SELECT,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'%' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION;" >> /docker-entrypoint-initdb.d/0004-sql-user.sql

--- a/Dockerfile.test.db
+++ b/Dockerfile.test.db
@@ -33,6 +33,4 @@ RUN echo "Use LorisTest;" | cat - \
 
 RUN echo "Use LorisTest;" >> /docker-entrypoint-initdb.d/0001-paths.sql
 RUN echo "UPDATE Config SET Value='${BASE_DIR}/' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='base');" >> /docker-entrypoint-initdb.d/0001-paths.sql
-RUN echo "UPDATE Config SET Value='web:8000' WHERE ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='host');" >> /docker-entrypoint-initdb.d/0001-paths.sql
-
 RUN echo "GRANT UPDATE,INSERT,SELECT,DELETE,DROP,CREATE TEMPORARY TABLES ON LorisTest.* TO 'SQLTestUser'@'%' IDENTIFIED BY 'TestPassword' WITH GRANT OPTION;" >> /docker-entrypoint-initdb.d/0004-sql-user.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     environment:
       - LORIS_DB_CONFIG=test/config.xml
       - SELENIUM_REQUIRED=true
+      - DOCKER_URL=http://web:8000
     depends_on:
       - db
       - selenium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     environment:
       - LORIS_DB_CONFIG=test/config.xml
       - SELENIUM_REQUIRED=true
-      - DOCKER_URL=http://web:8000
+      - DOCKER_WEB_SERVER=http://web:8000
     depends_on:
       - db
       - selenium

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,8 +77,7 @@ abstract class LorisIntegrationTest extends TestCase
             $database['host'],
             1
         );
-        $this->url = $this->config->getSetting("host");
-        $this->url = "http://" . $this->url;
+        $this->url = getenv('DOCKER_URL');
         $password  = new \Password($this->validPassword);
 
         $this->DB->insert(

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,7 +77,7 @@ abstract class LorisIntegrationTest extends TestCase
             $database['host'],
             1
         );
-        $this->url = $this->config->getSetting("url");
+	$this->url = $this->factory->settings()->getBaseURL();
         $password  = new \Password($this->validPassword);
 
         $this->DB->insert(

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,7 +77,7 @@ abstract class LorisIntegrationTest extends TestCase
             $database['host'],
             1
         );
-	$this->url = $this->factory->settings()->getBaseURL();
+        $this->url = $this->factory->settings()->getBaseURL();
         $password  = new \Password($this->validPassword);
 
         $this->DB->insert(

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -78,7 +78,7 @@ abstract class LorisIntegrationTest extends TestCase
             1
         );
         $this->url = $this->config->getSetting("host");
-        $this->url = "https://" . $this->url;
+        $this->url = "http://" . $this->url;
         $password  = new \Password($this->validPassword);
 
         $this->DB->insert(

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,7 +77,8 @@ abstract class LorisIntegrationTest extends TestCase
             $database['host'],
             1
         );
-        $this->url = $this->factory->settings()->getBaseURL();
+        $this->url = $this->config->getSetting("host");
+        $this->url = "https://" . $this->url;
         $password  = new \Password($this->validPassword);
 
         $this->DB->insert(

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -77,7 +77,7 @@ abstract class LorisIntegrationTest extends TestCase
             $database['host'],
             1
         );
-        $this->url = getenv('DOCKER_URL');
+        $this->url = getenv('DOCKER_WEB_SERVER');
         $password  = new \Password($this->validPassword);
 
         $this->DB->insert(


### PR DESCRIPTION
## Brief summary of changes

Changed the way that integration tests set up their baseURL value. 

#### Testing instructions (if applicable)

1. Check out Travis or run `npm run tests:integration` if you have a test environment set up.

* Resolves #6562 
* Related to #6019