### PR TITLE
[Candidate Profile /  Test Plan] replaced candID for testing Widget.

### DIFF
--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -16,7 +16,7 @@
 
 ## Widget Permissions
 For a module that adds a widget and a candidate which has data for
-that widget (ie. the media module for CandID 491446 in Raisinbread):
+that widget (ie. the media module for CandID 587630 in Raisinbread):
 1. Ensure that the card appears when accessing that candidate as a
    user who has appropriate permission and access to the module
    itself.

--- a/modules/candidate_profile/test/TestPlan.md
+++ b/modules/candidate_profile/test/TestPlan.md
@@ -16,7 +16,7 @@
 
 ## Widget Permissions
 For a module that adds a widget and a candidate which has data for
-that widget (ie. the media module for CandID 587630 in Raisinbread):
+that widget (ie. the media module for CandID 587630 (DCC090) or CandID 300001 (MTL001) in Raisinbread):
 1. Ensure that the card appears when accessing that candidate as a
    user who has appropriate permission and access to the module
    itself.


### PR DESCRIPTION
### Brief summary of changes

The `CandID `suggested for testing the Widget permissions doesn't longer exist in the current version  of the database. Replaced for a new ones.

#### Testing instructions (if applicable)

The new suggested `CandID ` should be available and matching required conditions for testing the Widget.