### PR TITLE
add nii file type to the list of file types to show in the query

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -206,7 +206,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               $left_joins 
             WHERE 
               s.Active = 'Y' AND
-              f.FileType='mnc'
+              f.FileType IN ('mnc', 'nii')
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label
             ",


### PR DESCRIPTION
## Brief summary of changes

This fixes projects that only inserts NIfTI files and not MINC files into the database. The query in the imagingbrowserrowprovisioner.class.inc file was limiting the query to `filettype='mnc'` only while we should also allow for `filetype='nii'`.

#### Testing instructions (if applicable)

1. Ensure the imaging browser filter menu still loads.

#### Link(s) to related issue(s)

no issues reported but a user of LORIS loading only BIDS dataset (aka NIfTI file types) could not see anything on the imaging browser menu filter page as there are no MINC files in their database, only NIfTI files.