### PR TITLE
[API] Valid POST request of a candidate added to the API TestPlan

### DIFF
--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,10 +33,12 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate:
+Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see Specs for format instructions):
 
 ```bash
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 
 ```
 
 If the candidate is successfully created, the candidate's data is returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`
+
+Otherwise, an error message is returned. For example, the command `curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d ''` returns `{"error":"You are not affiliated with the candidate`s site"}`

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,7 +33,7 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's informations must also be included. The following command contains the minimal informations necessary the the request to create a new candidate:
+This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate:
 
 ```bash
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,7 +33,6 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-Candidate creation
 This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's informations must also be included. The following command contains the minimal informations necessary the the request to create a new candidate:
 
 ```bash

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -39,5 +39,4 @@ This is done by sending a POST request to /candidates with the required data. No
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 
 ```
 
-If the candidate is successfully created, the candidate's informations are returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`
-
+If the candidate is successfully created, the candidate's data are returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,10 +33,10 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate:
+Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate:
 
 ```bash
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 
 ```
 
-If the candidate is successfully created, the candidate's data are returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`
+If the candidate is successfully created, the candidate's data is returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,7 +33,7 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see [docs](https://github.com/aces/Loris/blob/23.0-release/docs/API/LorisRESTAPI_v0.0.3.md#30-candidate-api) for format instructions):
+Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see [docs](../../../../docs/API/LorisRESTAPI_v0.0.3.md#30-candidate-api) for format instructions):
 
 ```bash
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -34,9 +34,11 @@ See specification for the expected response format.
 
 #### Candidate creation - POST /candidates
 Candidate creation
-This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header.
+This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's informations must also be included. The following command contains the minimal informations necessary the the request to create a new candidate:
+
 ```bash
-~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{see specs for content}'
+~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019, "Sex":"Female"}}' 
 ```
 
+If the candidate is successfully created, the candidate's informations are returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`
 

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,7 +33,7 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see Specs for format instructions):
+Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see [docs](https://github.com/aces/Loris/blob/23.0-release/docs/API/LorisRESTAPI_v0.0.3.md#30-candidate-api) for format instructions):
 
 ```bash
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 
@@ -41,4 +41,4 @@ Candidate creation is done by sending a POST request to /candidates with the req
 
 If the candidate is successfully created, the candidate's data is returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`
 
-Otherwise, an error message is returned. For example, the command `curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d ''` returns `{"error":"You are not affiliated with the candidate`s site"}`
+Otherwise, an error message is returned. For example, the command `curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d ''` returns `{"error":"You are not affiliated with the candidate's site"}`

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -33,7 +33,7 @@ See specification for the expected response format.
 
 
 #### Candidate creation - POST /candidates
-Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see [docs](../../../../docs/API/LorisRESTAPI_v0.0.3.md#30-candidate-api) for format instructions):
+Candidate creation is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's information must also be included. The following command contains the minimal information necessary for the request to create a new candidate (see [docs](../../../docs/API/LorisRESTAPI_v0.0.3.md#30-candidate-api) for format instructions):
 
 ```bash
 ~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 

--- a/modules/api/test/TestPlan.md
+++ b/modules/api/test/TestPlan.md
@@ -36,7 +36,7 @@ See specification for the expected response format.
 This is done by sending a POST request to /candidates with the required data. Note the usage of the Authorization header. For a candidate to be created, the candidate's informations must also be included. The following command contains the minimal informations necessary the the request to create a new candidate:
 
 ```bash
-~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019, "Sex":"Female"}}' 
+~$ curl -H "Authorization: Bearer $token" https://<your-hostname>/api/v0.0.3/candidates -d '{"Candidate":{"Project":"Rye","Site":"Montreal","DoB":"2019-01-31", "Sex":"Female"}}' 
 ```
 
 If the candidate is successfully created, the candidate's informations are returned. For example, the previous example returns: `{"CandID":"872451","Project":"Rye","PSCID":"MTL185","Site":"Montreal","EDC":null,"DoB":"2019-01-31","Sex":"Female"}`


### PR DESCRIPTION
## Brief summary of changes

In the API TestPlan, the example of a POST request to create a new candidate does not create a candidate. The new command line example creates a new candidate successfully. 

#### Testing instructions
Follow all the instructions in the API's _TestPlan.md_

#### Link(s) to related issue(s)

* Resolves #6590