### PR TITLE
[DQT] Fixes error on View Data > Longitudinal view

### DIFF
--- a/modules/dataquery/jsx/react.tabs.js
+++ b/modules/dataquery/jsx/react.tabs.js
@@ -647,15 +647,15 @@ class StatsVisualizationTabPane extends Component {
       for (let i = 0; i < this.props.Fields.length; i += 1) {
         rows.push(<tr key={'fields_' + i}>
           <td>{this.props.Fields[i]}</td>
-          <td>{min[i] ? min[i].toString() : ''}</td>
-          <td>{max[i] ? max[i].toString() : ''}</td>
-          <td>{stddev[i] ? stddev[i].toString() : ''}</td>
-          <td>{mean[i] ? mean[i].toString() : ''}</td>
-          <td>{meandev[i] ? meandev[i].toString() : ''}</td>
-          <td>{meansqerr[i] ? meansqerr[i].toString() : ''}</td>
-          <td>{quartiles[i] && quartiles[i][0] ? quartiles[i][0].toString() : ''}</td>
-          <td>{quartiles[i] && quartiles[i][1] ? quartiles[i][1].toString() : ''}</td>
-          <td>{quartiles[i] && quartiles[i][2] ? quartiles[i][2].toString() : ''}</td>
+          <td>{min && min[i] ? min[i].toString() : ''}</td>
+          <td>{max && max[i] ? max[i].toString() : ''}</td>
+          <td>{stddev && stddev[i] ? stddev[i].toString() : ''}</td>
+          <td>{mean && mean[i] ? mean[i].toString() : ''}</td>
+          <td>{meandev && meandev[i] ? meandev[i].toString() : ''}</td>
+          <td>{meansqerr && meansqerr[i] ? meansqerr[i].toString() : ''}</td>
+          <td>{quartiles && quartiles[i] && quartiles[i][0] ? quartiles[i][0].toString() : ''}</td>
+          <td>{quartiles && quartiles[i] && quartiles[i][1] ? quartiles[i][1].toString() : ''}</td>
+          <td>{quartiles && quartiles[i] && quartiles[i][2] ? quartiles[i][2].toString() : ''}</td>
         </tr>);
       }
 

--- a/modules/dataquery/jsx/react.tabs.js
+++ b/modules/dataquery/jsx/react.tabs.js
@@ -644,19 +644,18 @@ class StatsVisualizationTabPane extends Component {
         quartiles = stats.quartiles(),
         rows = [];
 
-
       for (let i = 0; i < this.props.Fields.length; i += 1) {
-        rows.push(<tr key={'fields_'.concat(i)}>
+        rows.push(<tr key={'fields_' + i}>
           <td>{this.props.Fields[i]}</td>
-          <td>{min[i]}</td>
-          <td>{max[i]}</td>
-          <td>{stddev[i]}</td>
-          <td>{mean[i]}</td>
-          <td>{meandev[i]}</td>
-          <td>{meansqerr[i]}</td>
-          <td>{quartiles[i][0]}</td>
-          <td>{quartiles[i][1]}</td>
-          <td>{quartiles[i][2]}</td>
+          <td>{min[i] ? min[i].toString() : ''}</td>
+          <td>{max[i] ? max[i].toString() : ''}</td>
+          <td>{stddev[i] ? stddev[i].toString() : ''}</td>
+          <td>{mean[i] ? mean[i].toString() : ''}</td>
+          <td>{meandev[i] ? meandev[i].toString() : ''}</td>
+          <td>{meansqerr[i] ? meansqerr[i].toString() : ''}</td>
+          <td>{quartiles[i] && quartiles[i][0] ? quartiles[i][0].toString() : ''}</td>
+          <td>{quartiles[i] && quartiles[i][1] ? quartiles[i][1].toString() : ''}</td>
+          <td>{quartiles[i] && quartiles[i][2] ? quartiles[i][2].toString() : ''}</td>
         </tr>);
       }
 


### PR DESCRIPTION
## Brief summary of changes

Solves the "Cannot read property '0' of null" type error.

#### Testing instructions (if applicable)

1. Checkout PR.
2. Navigate to DQT.
3. Define Fields: aosi | Candidate_Age
4. Define Filters: aosi | Candidate_Age = 33 All Visits
5. View Data > Run Query
6. Switch to Longitudinal
7. Table should be visible.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
https://github.com/aces/Loris/issues/6595
