### PR TITLE
[Issue Tracker] Fix Low priority filter missing

### DIFF
--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -129,6 +129,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         );
 
         $priorities = array(
+            'low'       => 'Low',
             'normal'    => 'Normal',
             'high'      => 'High',
             'urgent'    => 'Urgent',


### PR DESCRIPTION
Adds Low in the priority filter, to let users filter Low priority issues.

Duplicate of PR #6263 (Created for master)

* Resolves #6262 
* Resolves #6608