### PR TITLE
[Login] Password reset password mismatch

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -88,6 +88,7 @@ class PasswordExpiry extends \NDB_Form
     {
         $this->_user = \User::factory($this->_username);
         $plaintext   = htmlspecialchars_decode($values['password']);
+        $confirm     = htmlspecialchars_decode($values['confirm']);
 
         try {
             new \Password($plaintext);
@@ -99,6 +100,13 @@ class PasswordExpiry extends \NDB_Form
         if (!$this->_user->isPasswordDifferent($plaintext)) {
             $this->tpl_data['error_message'] = 'You cannot keep the same password';
             return array('password' => 'You cannot keep the same password');
+        }
+
+        // Ensure that the password and confirm password fields match.
+        // TODO This validation should be done on the front-end too.
+        if ($plaintext !== $confirm) {
+            $this->tpl_data['error_message'] = 'The passwords do not match';
+            return array('password' => 'The passwords do not match');
         }
 
         return array();


### PR DESCRIPTION
In login/password-expiry/, I added a validation to display an error if the 2 passwords do not match.
This validation may have been removed [here](https://github.com/aces/Loris/commit/9c8a24bb395444a118c06b579cc4e44aeeceeb1d#diff-1dc7c9358a505a311690636f4e1bf51cL124)

**To test**
In the users table in the database, update the Password_expiry cell for a user you are testing to be a date in the past.
Login as that user. You should see an update password page.

* Related to #5417
* Resolves #6606