### PR TITLE
[Login] Pwd Expiry - Validation for user's email, name and test plan update

### DIFF
--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -87,6 +87,7 @@ class PasswordExpiry extends \NDB_Form
     function _validate($values)
     {
         $this->_user = \User::factory($this->_username);
+        $data        = $this->_user->getData();
         $plaintext   = htmlspecialchars_decode($values['password']);
         $confirm     = htmlspecialchars_decode($values['confirm']);
 
@@ -98,15 +99,26 @@ class PasswordExpiry extends \NDB_Form
         }
 
         if (!$this->_user->isPasswordDifferent($plaintext)) {
-            $this->tpl_data['error_message'] = 'You cannot keep the same password';
-            return array('password' => 'You cannot keep the same password');
+            $error_msg = "You cannot keep the same password.";
+            $this->tpl_data['error_message'] = $error_msg;
+            return array('password' => $error_msg);
+        }
+
+        // Ensure that the password is not the user's email
+        // Otherwise an exception is thrown in User.class::updatePassword
+        // TODO This validation should be done on the front-end too.
+        if ($plaintext == $data['Email']) {
+            $error_msg = "You cannot use your email as your password.";
+            $this->tpl_data['error_message'] = $error_msg;
+            return array('password' => $error_msg);
         }
 
         // Ensure that the password and confirm password fields match.
         // TODO This validation should be done on the front-end too.
         if ($plaintext !== $confirm) {
-            $this->tpl_data['error_message'] = 'The passwords do not match';
-            return array('password' => 'The passwords do not match');
+            $error_msg = "The passwords do not match.";
+            $this->tpl_data['error_message'] = $error_msg;
+            return array('password' => $error_msg);
         }
 
         return array();

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -107,8 +107,16 @@ class PasswordExpiry extends \NDB_Form
         // Ensure that the password is not the user's email
         // Otherwise an exception is thrown in User.class::updatePassword
         // TODO This validation should be done on the front-end too.
-        if ($plaintext == $data['Email']) {
+        if ($plaintext === $data['Email']) {
             $error_msg = "You cannot use your email as your password.";
+            $this->tpl_data['error_message'] = $error_msg;
+            return array('password' => $error_msg);
+        }
+
+        // Ensure that the password is not the user's username
+        // TODO This validation should be done on the front-end too.
+        if ($plaintext === $this->_username) {
+            $error_msg = "You cannot use your username as your password.";
             $this->tpl_data['error_message'] = $error_msg;
             return array('password' => $error_msg);
         }

--- a/modules/login/test/Reset_Password_Test_Plan.md
+++ b/modules/login/test/Reset_Password_Test_Plan.md
@@ -2,15 +2,17 @@
 
 1. In the `users` table in the database, update the `Password_expiry` cell for a user you are testing to be a date in the past.
 2. Login as that user. You should see an update password page.
-3. Try using a very weak password (e.g. "password"). You should get an error.
-4. Try entering unmatched passwords. You should get an error notice.
-5. Try entering the same password that you currently have. You should get an error notice.
-6. Enable the `usePwnedPasswordsAPI` via the Configuration module or the back-end. Enter the password "correct horse battery staple".
+3. Try using a very short password (e.g. "pass"). You should get an error.
+4. Try using a very weak password (e.g. "password"). You should get an error.
+5. Try entering unmatched passwords. You should get an error notice.
+6. Try entering the same password that you currently have. You should get an error notice.
+7. Try entering the user's email as the new password. You should get an error.
+8. Enable the `usePwnedPasswordsAPI` via the Configuration module or the back-end. Enter the password "correct horse battery staple".
     (The service will report that this password is known to be exposed in online password breaches and, while complex in terms of entropy,
      should not be used as a password.) You should get an error notice. If your firewall is configured to prevent a connection with this
     API, you will NOT get an error message and the password will successfully register in LORIS. 
-6. Create a new, complex password and submit. A complex password is usually one that is long or contains many different kinds of characters,
+9. Create a new, complex password and submit. A complex password is usually one that is long or contains many different kinds of characters,
     such as numbers, upper and lower case letters, and special characters.
     You can use the website https://lowe.github.io/tryzxcvbn/ to interactively create a password using the same complexity-scoring algorithm as LORIS. 
     A password receiving at least a score of 3 on this site will work for LORIS.
-7. Logout. Try logging back in with new password to see if it works.
+10. Logout. Try logging back in with new password to see if it works.

--- a/modules/login/test/Reset_Password_Test_Plan.md
+++ b/modules/login/test/Reset_Password_Test_Plan.md
@@ -7,12 +7,13 @@
 5. Try entering unmatched passwords. You should get an error notice.
 6. Try entering the same password that you currently have. You should get an error notice.
 7. Try entering the user's email as the new password. You should get an error.
-8. Enable the `usePwnedPasswordsAPI` via the Configuration module or the back-end. Enter the password "correct horse battery staple".
+8. Try entering the user's username as the new password. You should get an error.
+9. Enable the `usePwnedPasswordsAPI` via the Configuration module or the back-end. Enter the password "correct horse battery staple".
     (The service will report that this password is known to be exposed in online password breaches and, while complex in terms of entropy,
      should not be used as a password.) You should get an error notice. If your firewall is configured to prevent a connection with this
     API, you will NOT get an error message and the password will successfully register in LORIS. 
-9. Create a new, complex password and submit. A complex password is usually one that is long or contains many different kinds of characters,
+10. Create a new, complex password and submit. A complex password is usually one that is long or contains many different kinds of characters,
     such as numbers, upper and lower case letters, and special characters.
     You can use the website https://lowe.github.io/tryzxcvbn/ to interactively create a password using the same complexity-scoring algorithm as LORIS. 
     A password receiving at least a score of 3 on this site will work for LORIS.
-10. Logout. Try logging back in with new password to see if it works.
+11. Logout. Try logging back in with new password to see if it works.


### PR DESCRIPTION
In login/password-expiry/, I added a validation to display an error if the new password is set for the user's email, as otherwise, an exception is thrown from in User.class::updatePassword.
I also updated the test plan to add this test case and and password too short.

**To test**
In the users table in the database, update the Password_expiry cell for a user you are testing to be a date in the past.
Login as that user. You should see an update password page.

* Resolves #6607