### PR TITLE
[survey_accounts] Error message when survey added on different project

### DIFF
--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -77,36 +77,6 @@ class AddSurvey extends \NDB_Form
               array('CandID' => $error);
         }
 
-        $projectID    = $db->pselectOne(
-            "SELECT RegistrationProjectID FROM candidate
-            WHERE PSCID=:v_PSCID
-            AND CandID=:v_CandID",
-            array(
-                'v_PSCID'  => $values['PSCID'],
-                'v_CandID' => $values['CandID'],
-            )
-        );
-        $user         = \User::singleton();
-        $errorProject = "You do not have access to this candidate's project";
-        $user_list_of_projects = $user->getProjectIDs();
-        if (count($user_list_of_projects) == 1) {
-            //if there is only one project, autoselect first project from array of 1
-            $userProjectID = array_pop($user_list_of_projects);
-            if ($projectID != $userProjectID) {
-                return array('Project' => $errorProject);
-            }
-        } else if (count($user_list_of_projects) > 1) {
-            $projectMatch = 0;
-            foreach ($user_list_of_projects as &$userProjectID) {
-                if ($projectID == $userProjectID) {
-                    $projectMatch = 1;
-                }
-            }
-            if ($projectMatch == 0) {
-                return array('Project' => $errorProject);
-            }
-        }
-
         $numSessions = $db->pselectOne(
             "SELECT COUNT(*) FROM session 
             WHERE CandID=:v_CandID 
@@ -177,6 +147,36 @@ class AddSurvey extends \NDB_Form
             ) {
                 return array('Email' => 'Email is not valid.');
 
+            }
+        }
+
+        $projectID    = $db->pselectOne(
+            "SELECT RegistrationProjectID FROM candidate
+            WHERE PSCID=:v_PSCID
+            AND CandID=:v_CandID",
+            array(
+                'v_PSCID'  => $values['PSCID'],
+                'v_CandID' => $values['CandID'],
+            )
+        );
+        $user         = \User::singleton();
+        $errorProject = "You do not have access to this candidate's project";
+        $user_list_of_projects = $user->getProjectIDs();
+        if (count($user_list_of_projects) == 1) {
+            //if there is only one project, autoselect first project from array of 1
+            $userProjectID = array_pop($user_list_of_projects);
+            if ($projectID != $userProjectID) {
+                return array('Project' => $errorProject);
+            }
+        } else if (count($user_list_of_projects) > 1) {
+            $projectMatch = 0;
+            foreach ($user_list_of_projects as &$userProjectID) {
+                if ($projectID == $userProjectID) {
+                    $projectMatch = 1;
+                }
+            }
+            if ($projectMatch == 0) {
+                return array('Project' => $errorProject);
             }
         }
 

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -77,6 +77,36 @@ class AddSurvey extends \NDB_Form
               array('CandID' => $error);
         }
 
+        $projectID    = $db->pselectOne(
+            "SELECT RegistrationProjectID FROM candidate
+            WHERE PSCID=:v_PSCID
+            AND CandID=:v_CandID",
+            array(
+                'v_PSCID'  => $values['PSCID'],
+                'v_CandID' => $values['CandID'],
+            )
+        );
+        $user         = \User::singleton();
+        $errorProject = "You do not have access to this candidate's project";
+        $user_list_of_projects = $user->getProjectIDs();
+        if (count($user_list_of_projects) == 1) {
+            //if there is only one project, autoselect first project from array of 1
+            $userProjectID = array_pop($user_list_of_projects);
+            if ($projectID != $userProjectID) {
+                return array('Project' => $errorProject);
+            }
+        } else if (count($user_list_of_projects) > 1) {
+            $projectMatch = 0;
+            foreach ($user_list_of_projects as &$userProjectID) {
+                if ($projectID == $userProjectID) {
+                    $projectMatch = 1;
+                }
+            }
+            if ($projectMatch == 0) {
+                return array('Project' => $errorProject);
+            }
+        }
+
         $numSessions = $db->pselectOne(
             "SELECT COUNT(*) FROM session 
             WHERE CandID=:v_CandID 

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -77,19 +77,6 @@ class AddSurvey extends \NDB_Form
               array('CandID' => $error);
         }
 
-        $projectID = $db->pselect(
-            "SELECT ProjectID FROM session
-            WHERE CandID=:v_CandID",
-            array(
-                'v_CandID' => $values['CandID']
-            )
-        );
-        if (!\NDB_Factory::singleton()->user()->hasProject(reset($projectID[0]))) {
-            return array(
-                'Project' => "You do not have access to this candidate's project"
-            );
-        }
-
         $numSessions = $db->pselectOne(
             "SELECT COUNT(*) FROM session 
             WHERE CandID=:v_CandID 
@@ -106,6 +93,21 @@ class AddSurvey extends \NDB_Form
                 'VL' => "Visit ".
                             $values['VL'].
                             " does not exist for given candidate",
+            );
+        }
+
+        $projectID = $db->pselectOne(
+            "SELECT ProjectID FROM session
+            WHERE CandID=:v_CandID
+            AND Visit_Label=:v_VL",
+            array(
+                'v_CandID' => $values['CandID'],
+                'v_VL'     => $values['VL']
+            )
+        );
+        if (!\NDB_Factory::singleton()->user()->hasProject($projectID)) {
+            return array(
+                'Project' => "You are not affiliated with this session's project"
             );
         }
 

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -150,7 +150,7 @@ class AddSurvey extends \NDB_Form
             }
         }
 
-        $projectID    = $db->pselectOne(
+        $projectID = $db->pselectOne(
             "SELECT RegistrationProjectID FROM candidate
             WHERE PSCID=:v_PSCID
             AND CandID=:v_CandID",
@@ -159,28 +159,10 @@ class AddSurvey extends \NDB_Form
                 'v_CandID' => $values['CandID'],
             )
         );
-        $user         = \User::singleton();
-        $errorProject = "You do not have access to this candidate's project";
-        $user_list_of_projects = $user->getProjectIDs();
-        if (count($user_list_of_projects) == 1) {
-            //if there is only one project, autoselect first project from array of 1
-            $userProjectID = array_pop($user_list_of_projects);
-            if ($projectID != $userProjectID) {
-                return array('Project' => $errorProject);
-            }
-        } else if (count($user_list_of_projects) > 1) {
-            $projectMatch = 0;
-            foreach ($user_list_of_projects as &$userProjectID) {
-                if ($projectID == $userProjectID) {
-                    $projectMatch = 1;
-                }
-            }
-            if ($projectMatch == 0) {
-                return array('Project' => $errorProject);
-            }
-        }
 
-        return array();
+        return \NDB_Factory::singleton()->user()->hasProject($projectID) ?
+            array() :
+            array('Project' => "You do not have access to this candidate's project");
     }
 
     /**

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -151,12 +151,12 @@ class AddSurvey extends \NDB_Form
         }
 
         $projectID = $db->pselectOne(
-            "SELECT RegistrationProjectID FROM candidate
-            WHERE PSCID=:v_PSCID
-            AND CandID=:v_CandID",
+            "SELECT ProjectID FROM session
+            WHERE CandID=:v_CandID
+            AND Visit_Label=:v_VL",
             array(
-                'v_PSCID'  => $values['PSCID'],
                 'v_CandID' => $values['CandID'],
+                'v_VL'     => $values['VL']
             )
         );
 

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -77,16 +77,14 @@ class AddSurvey extends \NDB_Form
               array('CandID' => $error);
         }
 
-        $projectID = $db->pselectOne(
+        $projectID = $db->pselect(
             "SELECT ProjectID FROM session
-            WHERE CandID=:v_CandID
-            AND Visit_Label=:v_VL",
+            WHERE CandID=:v_CandID",
             array(
-                'v_CandID' => $values['CandID'],
-                'v_VL'     => $values['VL']
+                'v_CandID' => $values['CandID']
             )
         );
-        if (!\NDB_Factory::singleton()->user()->hasProject($projectID)) {
+        if (!\NDB_Factory::singleton()->user()->hasProject(reset($projectID[0]))) {
             return array(
                 'Project' => "You do not have access to this candidate's project"
             );

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -77,6 +77,21 @@ class AddSurvey extends \NDB_Form
               array('CandID' => $error);
         }
 
+        $projectID = $db->pselectOne(
+            "SELECT ProjectID FROM session
+            WHERE CandID=:v_CandID
+            AND Visit_Label=:v_VL",
+            array(
+                'v_CandID' => $values['CandID'],
+                'v_VL'     => $values['VL']
+            )
+        );
+        if (!\NDB_Factory::singleton()->user()->hasProject($projectID)) {
+            return array(
+                'Project' => "You do not have access to this candidate's project"
+            );
+        }
+
         $numSessions = $db->pselectOne(
             "SELECT COUNT(*) FROM session 
             WHERE CandID=:v_CandID 
@@ -150,19 +165,7 @@ class AddSurvey extends \NDB_Form
             }
         }
 
-        $projectID = $db->pselectOne(
-            "SELECT ProjectID FROM session
-            WHERE CandID=:v_CandID
-            AND Visit_Label=:v_VL",
-            array(
-                'v_CandID' => $values['CandID'],
-                'v_VL'     => $values['VL']
-            )
-        );
-
-        return \NDB_Factory::singleton()->user()->hasProject($projectID) ?
-            array() :
-            array('Project' => "You do not have access to this candidate's project");
+        return array();
     }
 
     /**

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -232,7 +232,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector(".error")
         )->getText();
         $this->assertContains(
-            "You do not have access to this candidate's project",
+            "Visit V1 does not exist for given candidate",
             $bodyText
         );
 

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -232,7 +232,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector(".error")
         )->getText();
         $this->assertContains(
-            "Visit V1 does not exist for given candidate",
+            "You do not have access to this candidate's project",
             $bodyText
         );
 


### PR DESCRIPTION
## Brief summary of changes

If a user attempts to create a survey for a candidate on a project they are not involved in, an error message will appear and the survey will not be created.

#### Testing instructions
1. Create a user account who isn't affiliated with at least one project and with "User Management" permissions
2. Log-in as this user and go to the survey accounts page.
3. Try to add a survey using a candidate who is on a project that the user is not on. An error message should appear.
4. Check that the survey was not added to the list. 

#### Link to related issue

* Resolves #6582 
