### PR TITLE
[Genomic Browser] Subproject Column label

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -35,7 +35,7 @@ class StaticDataTable extends Component {
     this.downloadCSV = this.downloadCSV.bind(this);
     this.countFilteredRows = this.countFilteredRows.bind(this);
     this.toCamelCase = this.toCamelCase.bind(this);
-    this.getSortedRows = this.getSortedRows.bind(this);
+    this.getSortedRows = this.getSortedRows.bind(this);//
     this.hasFilterKeyword = this.hasFilterKeyword.bind(this);
   }
 
@@ -131,14 +131,9 @@ class StaticDataTable extends Component {
     });
   }
 
-  downloadCSV() {
-    // Include only filtered data if filters were applied
-    let csvData = this.props.Data;
-    if (this.props.Filter && this.props.FilteredData.length > 0) {
-      csvData = this.props.FilteredData;
-    }
-
+  downloadCSV(csvData) {
     let csvworker = new Worker(loris.BaseURL + '/js/workers/savecsv.js');
+
     csvworker.addEventListener('message', function(e) {
       let dataURL;
       let dataDate;
@@ -155,17 +150,14 @@ class StaticDataTable extends Component {
         document.body.removeChild(link);
       }
     });
-
-    const parseCsvData = (csvData) => {
+    const correctReactLinks = (csvData) => {
       for (const index in csvData) {
         if (csvData.hasOwnProperty(index)) {
           for (const indexChild in csvData[index]) {
-            if (csvData[index].hasOwnProperty(indexChild) || indexChild == null) {
-              // if value is null, replace value by an empty string
+            if (csvData[index].hasOwnProperty(indexChild)
+              || indexChild == null) {
               if (csvData[index][indexChild] == null) {
                 csvData[index][indexChild] = [''];
-
-              // if value is a link tag (<a href='#'>link</a>), replace value by href content
               } else if (csvData[index][indexChild].type === 'a') {
                 csvData[index][indexChild] = [
                   csvData[index][indexChild].props['href'],
@@ -177,8 +169,7 @@ class StaticDataTable extends Component {
       }
       return csvData;
     };
-
-    const csvDownload = parseCsvData([...csvData]);
+    const csvDownload = correctReactLinks([...csvData]);
     csvworker.postMessage({
       cmd: 'SaveFile',
       data: csvDownload,
@@ -410,6 +401,7 @@ class StaticDataTable extends Component {
     let matchesFound = 0; // Keeps track of how many rows where displayed so far across all pages
     let filteredRows = this.countFilteredRows();
     let currentPageRow = (rowsPerPage * (this.state.PageNumber - 1));
+    let filteredData = [];
     let useKeyword = false;
 
     if (this.props.Filter.keyword) {
@@ -440,7 +432,7 @@ class StaticDataTable extends Component {
 
         if (this.hasFilterKeyword(this.props.Headers[j], data)) {
           filterMatchCount++;
-          this.props.FilteredData.push(this.props.Data[index[i].RowIdx]);
+          filteredData.push(this.props.Data[index[i].RowIdx]);
         }
 
         if (useKeyword === true) {
@@ -504,6 +496,12 @@ class StaticDataTable extends Component {
       </select>
     );
 
+    // Include only filtered data if filters were applied
+    let csvData = this.props.Data;
+    if (this.props.Filter && filteredData.length > 0) {
+      csvData = filteredData;
+    }
+
     let header = this.state.Hide.rowsPerPage === true ? '' : (
       <div className="table-header panel-heading">
         <div className="row">
@@ -534,7 +532,7 @@ class StaticDataTable extends Component {
             <div className="col-xs-6">
               <button
                 className="btn btn-primary downloadCSV"
-                onClick={this.downloadCSV}
+                onClick={this.downloadCSV.bind(null, csvData)}
               >
                 Download Table as CSV
               </button>
@@ -571,7 +569,6 @@ class StaticDataTable extends Component {
 StaticDataTable.propTypes = {
   Headers: PropTypes.array.isRequired,
   Data: PropTypes.array.isRequired,
-  FilteredData: PropTypes.array,
   RowNumLabel: PropTypes.string,
   // Function of which returns a JSX element for a table cell, takes
   // parameters of the form: func(ColumnName, CellData, EntireRowData)
@@ -583,7 +580,6 @@ StaticDataTable.propTypes = {
 StaticDataTable.defaultProps = {
   Headers: [],
   Data: {},
-  FilteredData: [],
   RowNumLabel: 'No.',
   Filter: {},
   Hide: {

--- a/modules/genomic_browser/jsx/profileColumnFormatter.js
+++ b/modules/genomic_browser/jsx/profileColumnFormatter.js
@@ -27,11 +27,6 @@ function formatColumn(column, cell, rowData, rowHeaders) {
       );
       break;
     }
-    case 'Subproject':
-      reactElement = (
-        <td>{loris.subprojectList[cell]}</td>
-      );
-      break;
     case 'File':
       if (cell === 'Y') {
         reactElement = (

--- a/modules/genomic_browser/php/genomic_browser.class.inc
+++ b/modules/genomic_browser/php/genomic_browser.class.inc
@@ -98,7 +98,7 @@ class Genomic_Browser extends \NDB_Menu_Filter
             'LPAD(candidate.CandID, 6, "0") AS DCCID',
             'candidate.PSCID',
             'candidate.Sex',
-            'cohort.SubprojectID as Subproject',
+            'subproj.title as Subproject',
             'DATE_FORMAT(candidate.DoB,\'%Y-%m-%d\') AS DoB',
             'candidate.ExternalID as externalID',
             "$file_subquery as File",
@@ -127,6 +127,8 @@ class Genomic_Browser extends \NDB_Menu_Filter
             LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID
                 from session s GROUP BY s.CandID) AS cohort
                 ON (cohort.CandID=candidate.CandID)
+            LEFT JOIN subproject AS subproj
+                ON (cohort.SubprojectID = subproj.SubprojectID)
             LEFT JOIN psc ON (psc.CenterID= candidate.RegistrationCenterID)
             WHERE
             candidate.Entity_type = 'Human' AND candidate.Active = 'Y' ";

--- a/modules/genomic_browser/php/snp_browser.class.inc
+++ b/modules/genomic_browser/php/snp_browser.class.inc
@@ -68,7 +68,7 @@ class SNP_Browser extends \NDB_Menu_Filter
             'LPAD(candidate.CandID, 6, "0") AS DCCID',
             'candidate.PSCID',
             'candidate.Sex',
-            'cohort.SubprojectID as Subproject',
+            'subproj.title as Subproject',
             'DATE_FORMAT(candidate.DoB,\'%Y-%m-%d\') AS DoB',
             'candidate.ExternalID as externalID',
             'SNP.Chromosome as Chromosome',
@@ -132,8 +132,10 @@ class SNP_Browser extends \NDB_Menu_Filter
         // If a candidate has no SNP records, they will not appear.
         $this->query = " FROM candidate
             LEFT JOIN (select s.CandID, min(s.subprojectID) as SubprojectID
-                    from session s GROUP BY s.CandID) AS cohort
-            ON (cohort.CandID = candidate.CandID)
+                from session s GROUP BY s.CandID) AS cohort
+                ON (cohort.CandID = candidate.CandID)
+            LEFT JOIN subproject AS subproj
+                ON (cohort.SubprojectID = subproj.SubprojectID)
             LEFT JOIN psc ON (psc.CenterID = candidate.RegistrationCenterID)
             JOIN SNP_candidate_rel ON (candidate.CandID = SNP_candidate_rel.CandID)
             LEFT JOIN SNP ON (SNP.SNPID = SNP_candidate_rel.SNPID)


### PR DESCRIPTION
In Genomic Browser > Profile and SNP screens, I added a parsing logic on the csv colums to allow special treatment of data (inspired by what is already implemented on the data table with [profileColumnFormatters](https://github.com/aces/Loris/blob/23.0-release/modules/genomic_browser/jsx/profileColumnFormatter.js)) and applied a Formatter on SNP > Subproject int he data table.

[Testing card](https://github.com/aces/Loris/projects/19#card-21296727)

* Resolves #6295