### PR TITLE
[imaging browser] Display different scan type columns

### DIFF
--- a/modules/imaging_browser/php/imaging_browser.class.inc
+++ b/modules/imaging_browser/php/imaging_browser.class.inc
@@ -132,7 +132,7 @@ class Imaging_Browser extends \DataFrameworkMenu
         );
 
         // get list of scan types
-        $all_scan_types = \Utility::getScanTypeList();
+        $all_scan_types = \Utility::getScanTypeList(false);
 
         // get list of scan types that should be present in the data table
         // Get the intersection between all the scan types and those

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1011,7 +1011,7 @@ class Utility
     {
         $DB    = \Database::singleton();
         $query = "SELECT ID, Scan_type
-             FROM mri_scan_type mri\n";
+             FROM mri_scan_type mri ";
         if ($join_files) {
             $query .= "JOIN files f ON (f.AcquisitionProtocolID=mri.ID)";
         }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -236,7 +236,7 @@ class Utility
         if (!is_null($projectID)) {
             $subprojects = $DB->pselect(
                 "SELECT * FROM subproject
-                JOIN project_subproject_rel USING (SubprojectID) 
+                JOIN project_subproject_rel USING (SubprojectID)
                 WHERE ProjectID=:pID",
                 array('pID' => $projectID)
             );
@@ -575,7 +575,7 @@ class Utility
 
         $instruments   = array();
         $instruments_q = $DB->pselect(
-            "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true 
+            "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true
              ORDER BY Full_name",
             array()
         );
@@ -1001,20 +1001,21 @@ class Utility
     /**
      * Get the list of MRI scan type available in the database
      *
+     * @param bool $join_files Whether to perform an inner join on the files table
+     *
      * @return array Array of MRI scan types which exist in the database table
      *               mri_scan_type joined to the files table
      *               array($scan_type_id => $scan_type)
      */
-    static function getScanTypeList(): array
+    static function getScanTypeList($join_files = true): array
     {
         $DB = \Database::singleton();
-
-        $scan_types_DB = $DB->pselect(
-            "SELECT ID, Scan_type 
-             FROM mri_scan_type mri
-                JOIN files f ON (f.AcquisitionProtocolID=mri.ID)",
-            array()
-        );
+        $query = "SELECT ID, Scan_type
+             FROM mri_scan_type mri\n";
+        if ($join_files) {
+            $query .= "JOIN files f ON (f.AcquisitionProtocolID=mri.ID)";
+        }
+        $scan_types_DB = $DB->pselect($query, array());
 
         $scan_types = array();
         foreach ($scan_types_DB as $scan_type) {

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -1009,7 +1009,7 @@ class Utility
      */
     static function getScanTypeList($join_files = true): array
     {
-        $DB = \Database::singleton();
+        $DB    = \Database::singleton();
         $query = "SELECT ID, Scan_type
              FROM mri_scan_type mri\n";
         if ($join_files) {


### PR DESCRIPTION
## Brief summary of changes

- Currently, the function `Utilities::getScanTypeList` has an inner join `JOIN files f ON (f.AcquisitionProtocolID=mri.ID)` which excludes scan types that are NOT of the following: fMRI, t1, t2, dwi25, dwi65 and fieldmapDWI, from being returned through the function because the files.AcquisitionProtocolID only has the scan type IDs for the aforementioned scan types. This results in a lot (the majority) of scan types not appearing when attempting to add them through Configuration>Imaging Modules.
- I added an optional boolean paramater, `join_files` to `Utilities::getScanTypeList` that allows disabling its inner join, which results in all the scan types to be returned. 
- passing `false` to the function call in the imaging module class gets us all the scan types, allowing all the scan types to be displayed on the front page.

- `getScanTypeList` is only called twice throughout the code base, the proposed modifications do not change its default behaviour, so outside of the function call that is modified through this PR, there should not be any side effects observed with the one other call.

#### Testing instructions (if applicable)

1. Navigate to  Configuration>Imaging Modules>
2. Add different scan type fields
3. Navigate to the imaging browser front page
4. observe the added fields 

#### Link(s) to related issue(s)

* Resolves #6619
