### PR TITLE
[candidate_parameters] Fix access to module

### DIFF
--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -14,13 +14,17 @@
  */
 use \LORIS\StudyEntities\Candidate\CandID;
 
-$user = \NDB_Factory::singleton()->user();
-if (!$user->hasAnyPermission(
-    array(
-        'candidate_parameter_edit',
-        'candidate_parameter_view'
-    )
-)
+$user      = \NDB_Factory::singleton()->user();
+$candID    = new CandID($_GET['candID']);
+$candidate = \Candidate::singleton($candID);
+
+if (!$user->hasPermission('access_all_profiles')
+    && !($user->hasAnyPermission(
+        array(
+            'candidate_parameter_edit',
+            'candidate_parameter_view'
+        )
+    ) && $user->hasCenter($candidate->getCenterID()))
 ) {
     header("HTTP/1.1 403 Forbidden");
     exit;

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -11,7 +11,9 @@
  * @link     https://www.github.com/aces/Loris/
  */
 namespace LORIS\candidate_parameters;
-use \Loris\StudyEntities\Candidate\CandID;
+use \LORIS\StudyEntities\Candidate\CandID;
+use \LORIS\StudyEntities\Candidate;
+
 
 /**
  * Main class for candidate_parameters module
@@ -31,6 +33,7 @@ use \Loris\StudyEntities\Candidate\CandID;
  */
 class Candidate_Parameters extends \NDB_Form
 {
+
     /**
      * Check user permissions
      *
@@ -40,12 +43,18 @@ class Candidate_Parameters extends \NDB_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasAnyPermission(
-            array(
-                'candidate_parameter_view',
-                'candidate_parameter_edit',
-            )
-        );
+        $candidate =& \Candidate::singleton(new CandID($this->identifier));
+
+        // User must either have 'access_all_profiles' permission, or
+        // one of the candidate_parameter permissions AND have the candidate's site.
+        return $user->hasPermission('access_all_profiles') ||
+            ($user->hasAnyPermission(
+                array(
+                    'candidate_parameter_view',
+                    'candidate_parameter_edit',
+                ))
+                && $user->hasCenter($candidate->getCenterID())
+            );
     }
 
     /**

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -12,8 +12,6 @@
  */
 namespace LORIS\candidate_parameters;
 use \LORIS\StudyEntities\Candidate\CandID;
-use \LORIS\StudyEntities\Candidate;
-
 
 /**
  * Main class for candidate_parameters module
@@ -33,7 +31,6 @@ use \LORIS\StudyEntities\Candidate;
  */
 class Candidate_Parameters extends \NDB_Form
 {
-
     /**
      * Check user permissions
      *

--- a/modules/candidate_parameters/php/candidate_parameters.class.inc
+++ b/modules/candidate_parameters/php/candidate_parameters.class.inc
@@ -52,7 +52,8 @@ class Candidate_Parameters extends \NDB_Form
                 array(
                     'candidate_parameter_view',
                     'candidate_parameter_edit',
-                ))
+                )
+            )
                 && $user->hasCenter($candidate->getCenterID())
             );
     }


### PR DESCRIPTION
## Brief summary of changes

This PR changes the access to the candidate_parameters module so that anyone with `access_all_profiles` permission can view the module (even without `candidate_parameter_view` or `candidate_parameter_edit` permissions). It also ensures that users with either `candidate_parameter_view` or `candidate_parameter_edit`, but without `access_all_profiles` can only access the module for candidates belonging to the same site(s) as themselves. 

#### Testing instructions (if applicable)

1. Make user with only one site
2. From admin account, get link for candidate parameters of a candidate from a **different** site than the user's.
3. Navigate to this link from the user's account with the permission `access_all_profiles`. Make sure that you can access the page with this permission, with or without the `candidate_parameter_view` and `candidate_parameter_edit` permissions.
4. Navigate to the link again but with the permission `candidate_parameter_view` and _without_ the `access_all_profiles` permission. Make sure that you are not able to access the page. You should get the "You do not have access to this page" message, but _not_ an error.
5. Repeat step 4 but with the `candidate_parameter_edit` permission instead. 
6. Repeat step 4 but with none of the mentioned permissions. 
7. Try navigating to a candidate that does belong to the **same site as the user**. Make sure that you can access the candidate parameters page with any combination of the permissions `candidate_parameter_view`, `candidate_parameter_edit`, and `access_all_profiles`. Without these permissions you should not be able to access the page, and also not get an error. 

#### Link(s) to related issue(s)

* Resolves #6589
