### PR TITLE
[imaging_browser] ViewSession subpage: Add Project Permission checks

### DIFF
--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -55,17 +55,19 @@ class ViewSession extends \NDB_Form
         $candidate = \Candidate::singleton($candid);
 
         if ($candidate->getData('Entity_type') == 'Scanner') {
-            return $user->hasPermission('imaging_browser_phantom_allsites')
+            return ($user->hasPermission('imaging_browser_phantom_allsites')
                 || $user->hasCenterPermission(
                     'imaging_browser_phantom_ownsite',
                     \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
-                );
+                ))
+                && ($user->hasProject($candidate->getProjectID()));
         } elseif ($candidate->getData('Entity_type') == 'Human') {
-            return $user->hasPermission('imaging_browser_view_allsites')
+            return ($user->hasPermission('imaging_browser_view_allsites')
                 || $user->hasCenterPermission(
                     'imaging_browser_view_site',
                     \TimePoint::singleton($_REQUEST['sessionID'])->getCenterID()
-                );
+                ))
+                && $user->hasProject($candidate->getProjectID());
         }
 
         return false;


### PR DESCRIPTION
## Brief summary of changes

If a user tries to access an individual session (by changing the sessionID in the URL), they are no longer able to access sessions for projects they are not affiliated with. 

#### Testing instructions (if applicable)

1. Grant a user "view all sites Imaging browser browser pages" permission
2. Navigate to the imaging browser front page
3. Click on one of the hyperlinks under the "Links" column
4. Modify the `sessionID` number in the URL to a session belonging to a project the user is not affiliated with.
5. The "You do not have access to this page." message should appear. 

#### Links to related issue

* Resolves #6618
