### PR TITLE
[electrophysiology browser] Check if user is affiliated with site when opening individual scan sessions

### DIFF
--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -48,7 +48,7 @@ class Sessions extends \NDB_Page
     function _hasAccess(\User $user) : bool
     {
         return ($user->hasPermission('electrophysiology_browser_view_allsites')
-                || ($user->hasCenter($this->timepoint->getCenterID())
+                || ($user->hasStudySite() || $user->hasCenter($this->timepoint->getCenterID())
                 && $user->hasPermission('electrophysiology_browser_view_site')
             )
         );

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -48,9 +48,10 @@ class Sessions extends \NDB_Page
     function _hasAccess(\User $user) : bool
     {
         return ($user->hasPermission('electrophysiology_browser_view_allsites')
-                || ($user->hasStudySite() || $user->hasCenter($this->timepoint->getCenterID())
+                || ($user->hasStudySite()
+                || $user->hasCenter($this->timepoint->getCenterID())
                 && $user->hasPermission('electrophysiology_browser_view_site')
-            )
+                    )
         );
     }
 

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -19,7 +19,6 @@ use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 use LORIS\electrophysiology_browser\Models\ElectrophysioFile;
 
-
 /**
  * Provides the PHP code for the menu filter for the electrophysiology browser
  *
@@ -49,10 +48,7 @@ class Sessions extends \NDB_Page
     {
         return ($user->hasPermission('electrophysiology_browser_view_allsites')
                 || ($user->hasStudySite()
-                || $user->hasCenter($this->timepoint->getCenterID())
-                && $user->hasPermission('electrophysiology_browser_view_site')
-                    )
-        );
+                && $user->hasPermission('electrophysiology_browser_view_site') ) );
     }
 
     /**


### PR DESCRIPTION
*Brief summary of changes*

The `_hasAccess` method is being called by `Module.class.inc` [here](https://github.com/aces/Loris/blob/23.0-release/php/libraries/Module.class.inc#L351). This is causing an error because because `$this.timepoint` is not initialised before the method call in the module class, which leads to calling `getCenterID` on null: https://github.com/aces/Loris/blob/a5304c762454fa8241ce0699af94b2da15f8879d/modules/electrophysiology_browser/php/sessions.class.inc#L51  

I added `hasStudySite` as part of the `_hasAccess` method to verify the user is affiliated with the study site of the scan session, and removed `$user->hasCenter($this->timepoint->getCenterID()`, to follow the same logic check as some of the other mdules. 


#### Testing instructions (if applicable)

1. Assign your user "view own site EEG pages" only
2. Go to the EEG front page, click on one of the hyperlinks under the "Links" column
3. Observe session loading successfully

#### Link(s) to related issue(s)

* Resolves #6557 
