### PR TITLE
[electrophysiology_browser] Session page: Add Project Permissions check

### DIFF
--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -37,6 +37,7 @@ class Sessions extends \NDB_Page
     public $skipTemplate = true; // stops from looking for a smarty template
     protected $timepoint;
     protected $sessionID;
+    protected $candidate;
 
     /**
      * Determine whether the user has permission to view this page
@@ -47,29 +48,29 @@ class Sessions extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return ($user->hasPermission('electrophysiology_browser_view_allsites')
+        return (($user->hasPermission('electrophysiology_browser_view_allsites')
                 || ($user->hasCenter($this->timepoint->getCenterID())
                 && $user->hasPermission('electrophysiology_browser_view_site')
             )
-        );
+        ) && $user->hasProject($this->candidate->getProjectID()));
     }
 
     /**
-     * Handles a login request
+     * Load the required variables in order to check that the  user
+     * has access to the session.
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request
+     * @param \User                  $user    The user to load the resources for
+     * @param ServerRequestInterface $request The PSR15 Request being handled
      *
-     * @return ResponseInterface The outgoing PSR7 response
+     * @return ResponseInterface
      */
-    public function handle(ServerRequestInterface $request) : ResponseInterface
-    {
-        $path       = $request->getUri()->getPath();
-        $parameters = $request->getQueryParams();
-        $user       = $request->getAttribute('user');
+    public function loadResources(
+        \User $user, ServerRequestInterface $request
+    ) : ResponseInterface {
 
+        $path    = $request->getUri()->getPath();
         $matches = [];
 
-        // check that the session ID is of type integer
         if (preg_match('#/sessions/(\d+)#', $path, $matches) !== 1) {
             return (new \LORIS\Middleware\PageDecorationMiddleware($user))
                 ->process(
@@ -82,6 +83,26 @@ class Sessions extends \NDB_Page
 
         $this->timepoint = \NDB_Factory::singleton()->timepoint($session_id);
         $this->sessionID = $session_id;
+
+        $candID          = $this->timepoint->getCandID();
+        $this->candidate = \Candidate::singleton($candID);
+
+        parent::loadResources($user, $request);
+        return (new \LORIS\Http\Response())
+            ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
+    }
+
+    /**
+     * Handles a login request
+     *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
+     * @return ResponseInterface The outgoing PSR7 response
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $parameters = $request->getQueryParams();
+        $user       = $request->getAttribute('user');
 
         if (!$this->_hasAccess($user)) {
             return (new \LORIS\Middleware\PageDecorationMiddleware($user))

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -76,14 +76,9 @@ class Sessions extends \NDB_Page
             throw new \DomainException("Invalid session");
         }
         $session_id = intval($matches[1]);
-        try {
-            $this->timepoint = \NDB_Factory::singleton()->timepoint(
-                $session_id
-            );
-            $this->sessionID = $session_id;
-        } catch(\LorisException $e) {
-            throw $e;
-        }
+
+        $this->timepoint = \NDB_Factory::singleton()->timepoint($session_id);
+        $this->sessionID = $session_id;
 
         $candID          = $this->timepoint->getCandID();
         $this->candidate = \Candidate::singleton($candID);

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -79,18 +79,9 @@ class Sessions extends \NDB_Page
         }
 
         $session_id = intval($matches[1]);
-        try {
-            $this->timepoint = \NDB_Factory::singleton()->timepoint(
-                $session_id
-            );
-            $this->sessionID = $session_id;
-        } catch(\LorisException $e) {
-            return (new \LORIS\Middleware\PageDecorationMiddleware($user))
-                ->process(
-                    $request,
-                    new \LORIS\Http\StringStream("Session not found")
-                )->withStatus(404);
-        }
+
+        $this->timepoint = \NDB_Factory::singleton()->timepoint($session_id);
+        $this->sessionID = $session_id;
 
         if (!$this->_hasAccess($user)) {
             return (new \LORIS\Middleware\PageDecorationMiddleware($user))

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -77,8 +77,14 @@ class Sessions extends \NDB_Page
         }
         $session_id = intval($matches[1]);
 
-        $this->timepoint = \NDB_Factory::singleton()->timepoint($session_id);
-        $this->sessionID = $session_id;
+        try {
+            $this->timepoint = \NDB_Factory::singleton()->timepoint(
+                $session_id
+            );
+            $this->sessionID = $session_id;
+        } catch(\LorisException $e) {
+            throw new \NotFound("Session not found");
+        }
 
         $candID          = $this->timepoint->getCandID();
         $this->candidate = \Candidate::singleton($candID);

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -60,7 +60,7 @@ class Sessions extends \NDB_Page
      * @param \User                  $user    The user to load the resources for
      * @param ServerRequestInterface $request The PSR15 Request being handled
      *
-     * @throws \DomainException If the session id is non-numerical
+     * @throws \NotFound If the session id is non-numerical
      * @throws \LorisException  If the session is not found
      *
      * @return void
@@ -73,7 +73,7 @@ class Sessions extends \NDB_Page
         $matches = [];
 
         if (preg_match('#/sessions/(\d+)#', $path, $matches) !== 1) {
-            throw new \DomainException("Invalid session");
+            throw new \NotFound("Invalid session");
         }
         $session_id = intval($matches[1]);
 

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -50,9 +50,8 @@ class Sessions extends \NDB_Page
     {
         return (($user->hasPermission('electrophysiology_browser_view_allsites')
                 || ($user->hasCenter($this->timepoint->getCenterID())
-                && $user->hasPermission('electrophysiology_browser_view_site')
-            )
-        ) && $user->hasProject($this->candidate->getProjectID()));
+                && $user->hasPermission('electrophysiology_browser_view_site'))
+            ) && $user->hasProject($this->candidate->getProjectID()));
     }
 
     /**

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -60,7 +60,8 @@ class Sessions extends \NDB_Page
      * @param \User                  $user    The user to load the resources for
      * @param ServerRequestInterface $request The PSR15 Request being handled
      *
-     * @throws \LorisException If the session is non-numerical or does not exist
+     * @throws \DomainException If the session id is non-numerical
+     * @throws \LorisException  If the session is not found
      *
      * @return void
      */
@@ -72,7 +73,7 @@ class Sessions extends \NDB_Page
         $matches = [];
 
         if (preg_match('#/sessions/(\d+)#', $path, $matches) !== 1) {
-            throw new \LorisException("Invalid session");
+            throw new \DomainException("Invalid session");
         }
         $session_id = intval($matches[1]);
         try {
@@ -81,7 +82,7 @@ class Sessions extends \NDB_Page
             );
             $this->sessionID = $session_id;
         } catch(\LorisException $e) {
-            throw new \LorisException("Session not found");
+            throw $e;
         }
 
         $candID          = $this->timepoint->getCandID();

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -1,5 +1,4 @@
 <?php declare(strict_types=1);
-
 /**
  * This class features the code for the menu portion of the LORIS
  * electrophysiology browser module.
@@ -61,34 +60,34 @@ class Sessions extends \NDB_Page
      * @param \User                  $user    The user to load the resources for
      * @param ServerRequestInterface $request The PSR15 Request being handled
      *
-     * @return ResponseInterface
+     * @throws \LorisException If the session is non-numerical or does not exist
+     *
+     * @return void
      */
     public function loadResources(
         \User $user, ServerRequestInterface $request
-    ) : ResponseInterface {
+    ) : void {
 
         $path    = $request->getUri()->getPath();
         $matches = [];
 
         if (preg_match('#/sessions/(\d+)#', $path, $matches) !== 1) {
-            return (new \LORIS\Middleware\PageDecorationMiddleware($user))
-                ->process(
-                    $request,
-                    new \LORIS\Http\StringStream("Invalid session")
-                )->withStatus(404);
+            throw new \LorisException("Invalid session");
         }
-
         $session_id = intval($matches[1]);
-
-        $this->timepoint = \NDB_Factory::singleton()->timepoint($session_id);
-        $this->sessionID = $session_id;
+        try {
+            $this->timepoint = \NDB_Factory::singleton()->timepoint(
+                $session_id
+            );
+            $this->sessionID = $session_id;
+        } catch(\LorisException $e) {
+            throw new \LorisException("Session not found");
+        }
 
         $candID          = $this->timepoint->getCandID();
         $this->candidate = \Candidate::singleton($candID);
 
         parent::loadResources($user, $request);
-        return (new \LORIS\Http\Response())
-            ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
     }
 
     /**

--- a/modules/electrophysiology_browser/php/sessions.class.inc
+++ b/modules/electrophysiology_browser/php/sessions.class.inc
@@ -50,7 +50,7 @@ class Sessions extends \NDB_Page
         return (($user->hasPermission('electrophysiology_browser_view_allsites')
                 || ($user->hasCenter($this->timepoint->getCenterID())
                 && $user->hasPermission('electrophysiology_browser_view_site'))
-            ) && $user->hasProject($this->candidate->getProjectID()));
+            ) && $user->hasProject($this->timepoint->getProject()->getId()));
     }
 
     /**
@@ -85,9 +85,6 @@ class Sessions extends \NDB_Page
         } catch(\LorisException $e) {
             throw new \NotFound("Session not found");
         }
-
-        $candID          = $this->timepoint->getCandID();
-        $this->candidate = \Candidate::singleton($candID);
 
         parent::loadResources($user, $request);
     }

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -347,7 +347,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
             } else {
                 $_REQUEST['subtest'] = $pagename;
             }
-
+            $page->loadResources($user, $request);
             if ($page->_hasAccess($user) !== true) {
                 return (new \LORIS\Middleware\PageDecorationMiddleware(
                     $user

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -710,6 +710,22 @@ class NDB_Page implements RequestHandlerInterface
     }
 
     /**
+     * This function can be overridden in a module's page to load the necessary
+     * resources to check the permissions of a user.
+     *
+     * @param User                   $user    The user to load the resources for
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface
+     */
+    public function loadResources(
+        \User $user, ServerRequestInterface $request
+    ) : ResponseInterface {
+        return (new \LORIS\Http\Response())
+            ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
+    }
+
+    /**
      * Displays the form
      *
      * @return string of the content to be inserted into the template

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -716,13 +716,11 @@ class NDB_Page implements RequestHandlerInterface
      * @param User                   $user    The user to load the resources for
      * @param ServerRequestInterface $request The PSR15 Request being handled
      *
-     * @return ResponseInterface
+     * @return void
      */
     public function loadResources(
         \User $user, ServerRequestInterface $request
-    ) : ResponseInterface {
-        return (new \LORIS\Http\Response())
-            ->withBody(new \LORIS\Http\StringStream($this->display() ?? ""));
+    ) : void {
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

When a user tries to access the individual session page for a project they are not affiliated with (by altering the URL), a "permission denied" message should appear.

#### Testing instructions (if applicable)

1. Create a user and give them `View all-sites Electrophysiology Browser pages` permission.
2. Assign the user project "Pumpernickel" and site "Ottawa"
3. Navigate to the EEG browser page as that user.
4. Copy either the "all-types" or "raw" link from one of the rows.
5. As an admin, change the user to a different project (anything other than Pumpernickel)
6. Go back to the user account and to the EEG Browser page.
7. Note that there are no sessions listed (on the test VM)
8. Paste the copied URL.
9. There should be a "Permission denied" message and no data should be displayed.  

#### Links to related issues

* Resolves #6558
* Related to issue #6557 and associated PR #6639 