### PR TITLE
[Dashboard] User approval test plan

### DIFF
--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -75,9 +75,11 @@ class Module extends \Module
     {
         switch($type) {
         case "usertasks":
-            $factory = \NDB_Factory::singleton();
-            $DB      = $factory->database();
-            $baseURL = $factory->settings()->getBaseURL();
+            $factory  = \NDB_Factory::singleton();
+            $DB       = $factory->database();
+            $baseURL  = $factory->settings()->getBaseURL();
+            $site_arr = $user->getCenterIDs();
+
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
@@ -85,8 +87,12 @@ class Module extends \Module
                     $DB,
                     "SELECT COUNT(DISTINCT users.UserID) FROM users
                         LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
-                    WHERE users.Pending_approval='Y'
-                        AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
+                    WHERE
+                        users.Pending_approval='Y'
+                        AND (
+                            upr.CenterID IN (". implode(",", $site_arr).")
+                            OR upr.CenterID IS NULL
+                        )",
                     'user_accounts_multisite',
                     'upr.CenterID',
                     $baseURL . "/user_accounts/?pendingApproval=Y",

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -75,11 +75,9 @@ class Module extends \Module
     {
         switch($type) {
         case "usertasks":
-            $factory  = \NDB_Factory::singleton();
-            $DB       = $factory->database();
-            $baseURL  = $factory->settings()->getBaseURL();
-            $site_arr = $user->getCenterIDs();
-
+            $factory = \NDB_Factory::singleton();
+            $DB      = $factory->database();
+            $baseURL = $factory->settings()->getBaseURL();
             return [
                 new \LORIS\dashboard\TaskQueryWidget(
                     $user,
@@ -87,12 +85,8 @@ class Module extends \Module
                     $DB,
                     "SELECT COUNT(DISTINCT users.UserID) FROM users
                         LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
-                    WHERE
-                        users.Pending_approval='Y'
-                        AND (
-                            upr.CenterID IN (". implode(",", $site_arr).")
-                            OR upr.CenterID IS NULL
-                        )",
+                    WHERE users.Pending_approval='Y'
+                        AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
                     'user_accounts_multisite',
                     'upr.CenterID',
                     $baseURL . "/user_accounts/?pendingApproval=Y",

--- a/modules/user_accounts/test/TestPlan.md
+++ b/modules/user_accounts/test/TestPlan.md
@@ -81,9 +81,9 @@ When creating or editing a user: (subtest: edit_user)
 
 ### Widget registration on the dashboard page
 
-36. Verify that if a user has 'User Management / Survey Participant Management' permission, the number of pending
-    account approvals is displayed in the My Task panel of the dashboard page. This should be the number of entries
-    in the User Account page with the following Selection Filter: Site set to the user's site and Pending Approval
-    set to 'Yes'. The Site displayed will be 'All user sites'. Check that you are taken to that page (with the
-    Selection Filter correctly set) when you click on the task.
+36. Verify that if a user has `user_accounts_multisite` permission, the correct number of pending account approvals is displayed in the My Task panel of the dashboard page. This should be the number of entries in the User Account page with the following Selection Filter: Site set to all sites except Data Coordinating Center and Pending Approval set to 'Yes'. The Site displayed will be 'All'. Check that you are taken to that page (with the Selection Filter correctly set) when you click on the task.
     [Automate Test on Travis_CI]
+
+37. Verify that if a user has `user_accounts` without `user_accounts_multisite` permission, the correct number of pending account approvals is displayed in the My Task panel of the dashboard page. This should be the number of entries in the User Account page with the following Selection Filter: Site set to the user's site and Pending Approval set to 'Yes'. The Site displayed will be 'All User Sites'. Check that you are taken to that page (with the Selection Filter correctly set) when you click on the task.
+    [Automate Test on Travis_CI]
+


### PR DESCRIPTION
In Dashboard > My Tasks 
~~I updated the query executed for displaying the users with Site set to the current user's site and Pending Approval set to 'Yes'. Previously, the query was targeting users from all sites except Data Coordinating Center and Pending Approval set to 'Yes'.~~

I updated the test plan to indicate that pending users can belong to any sites except Data Coordinating Center.

 Resolves #6577
