### PR TITLE
[instrument_builder] Let mindate and maxdate options be removable

### DIFF
--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -324,10 +324,10 @@ class DateOptions extends Component {
     // Keep track of the inputed years
   onChange(e) {
     let options = Instrument.clone(this.props.element.Options);
-    if (e.target.id === 'datemin' && e.target.value.length > 0) {
-      options.MinDate = e.target.value + '-01-01';
-    } else if (e.target.id === 'datemax' && e.target.value.length > 0) {
-      options.MaxDate = e.target.value + '-12-31';
+    if (e.target.id === 'datemin') {
+      options.MinDate = e.target.value;
+    } else if (e.target.id === 'datemax') {
+      options.MaxDate = e.target.value;
     } else if (e.target.id === 'dateFormat') {
       options.dateFormat = e.target.value;
     }
@@ -336,8 +336,8 @@ class DateOptions extends Component {
   // Render the HTML
   render() {
     // Truncate off the month and day from the date to only have the year.
-    let minYear = this.props.element.Options.MinDate.split('-')[0];
-    let maxYear = this.props.element.Options.MaxDate.split('-')[0];
+    let minYear = this.props.element.Options.MinDate;
+    let maxYear = this.props.element.Options.MaxDate;
 
     let dateOptionsClass = 'options form-group';
     let errorMessage = '';

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -335,7 +335,6 @@ class DateOptions extends Component {
   }
   // Render the HTML
   render() {
-    // Truncate off the month and day from the date to only have the year.
     let minYear = this.props.element.Options.MinDate;
     let maxYear = this.props.element.Options.MaxDate;
 


### PR DESCRIPTION
## Brief summary of changes

This PR allows the Start year and End year values for Date elements be emptied

#### Testing instructions (if applicable)

1. On branch 23.0-release, add a Date element and notice that once you enter a value for both Start year and End year, you are not able to make the fields empty
2. Save the instrument with one Date element without min/max values, and another Date element with min/max values.
3. On this PR's branch, add a Date element and notice that you can make it empty after inserting a value. Make sure you run `make dev` after changing branches.
4. Save the instrument with the same elements as step 2.
5. Compare the two saved linst files and see that they are identical. This PR should only affect the front-end instrument builder. Please report if otherwise.

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/Loris/issues/6567
