### PR TITLE
[issue_tracker] Widgets not described in test plan

### DIFF
--- a/modules/issue_tracker/test/issue_tracker_test_plan.md
+++ b/modules/issue_tracker/test/issue_tracker_test_plan.md
@@ -35,3 +35,16 @@ Permissions [Automation Testing]
 2. Remove reporter permission
 3. Remove developer permission
 4. Test that the module behaves correctly as described above. 
+
+**Test the Issue Tracker Dashboard widget**
+1. The dashboard widget named My Tasks, should display the correct number of assigned issues.
+2. Check if the number changes when a new issue has been assigned to you or removed.
+3. Verify clicking on Your assigned issues, will redirect you to the issue tracker module and where all issues contain you as the assignee.
+
+**Test the Issue Tracker Candidate Dashboard widget**
+1. Find an issue with a PSCID assigned to it.
+2. Visit the Candidate Dashboard for the foregoing candidate.
+3. View the Open Issues widget and verify all issues of the candidate exist in the widget.
+4. The number of comments an issue has should be displayed correctly in the widget.
+5. The links should redirect the user to the correct issue.
+6. Create or assign an issue to a PSCID and see if the foregoing works correctly for the new issue.


### PR DESCRIPTION
## Brief summary of changes

Update the test plan to include instructions for the Issue Tracker Dashboard widget and the Issue Tracker Candidate Dashboard widget.

#### Testing instructions (if applicable)

1. View the new test plan instructions.
2. follow the instructions.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
#6438