### PR TITLE
[document_repository] Permission to access module

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -215,9 +215,46 @@ class DocIndex extends React.Component {
 
     let tabList = [
       {id: 'browse', label: 'Browse'},
-      {id: 'upload', label: 'Upload'},
-      {id: 'category', label: 'Category'},
     ];
+    let uploadDoc;
+    let uploadCategory;
+    if (loris.userHasPermission('document_repository_view')) {
+      tabList.push(
+        {
+          id: 'upload',
+          label: 'Upload',
+        },
+      );
+      tabList.push(
+        {
+          id: 'category',
+          label: 'Category',
+        },
+      );
+
+      uploadDoc = (
+        <TabPane TabId={tabList[1].id}>
+          <DocUploadForm
+            dataURL={`${loris.BaseURL}/document_repository/?format=json`}
+            action={`${loris.BaseURL}/document_repository/Files`}
+            maxUploadSize={this.state.data.maxUploadSize}
+            refreshPage={this.fetchData}
+            category={this.state.newCategory}
+          />
+        </TabPane>
+      );
+
+      uploadCategory = (
+        <TabPane TabId={tabList[2].id}>
+          <DocCategoryForm
+            dataURL={`${loris.BaseURL}/document_repository/?format=json`}
+            action={`${loris.BaseURL}/document_repository/UploadCategory`}
+            refreshPage={this.fetchData}
+            newCategoryState={this.newCategoryState}
+          />
+        </TabPane>
+      );
+    }
     const parentTree = this.state.global ? null : (
       <div>
         <ParentTree
@@ -286,23 +323,8 @@ class DocIndex extends React.Component {
         <TabPane TabId={tabList[0].id}>
           {treeTable}
         </TabPane>
-        <TabPane TabId={tabList[1].id}>
-          <DocUploadForm
-            dataURL={`${loris.BaseURL}/document_repository/?format=json`}
-            action={`${loris.BaseURL}/document_repository/Files`}
-            maxUploadSize={this.state.data.maxUploadSize}
-            refreshPage={this.fetchData}
-            category={this.state.newCategory}
-          />
-        </TabPane>
-        <TabPane TabId={tabList[2].id}>
-          <DocCategoryForm
-            dataURL={`${loris.BaseURL}/document_repository/?format=json`}
-            action={`${loris.BaseURL}/document_repository/UploadCategory`}
-            refreshPage={this.fetchData}
-            newCategoryState={this.newCategoryState}
-          />
-        </TabPane>
+        {uploadDoc}
+        {uploadCategory}
       </Tabs>
     );
   }

--- a/modules/document_repository/php/module.class.inc
+++ b/modules/document_repository/php/module.class.inc
@@ -36,7 +36,12 @@ class Module extends \Module
     public function hasAccess(\User $user) : bool
     {
         return parent::hasAccess($user) &&
-            $user->hasPermission('document_repository_view');
+            $user->hasAnyPermission(
+                array(
+                    'document_repository_view',
+                    'document_repository_delete',
+                )
+            );
     }
 
     /**

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -36,12 +36,7 @@ class UploadCategory extends \NDB_Page
      */
     function _hasAccess(\User $user) : bool
     {
-        return $user->hasAnyPermission(
-            array(
-                'document_repository_view',
-                'document_repository_delete',
-            )
-        );
+        return $user->hasPermission('document_repository_view');
     }
 
 


### PR DESCRIPTION
## Brief summary of changes

- Changed the permission in module.class.inc to be able to access the module when you have only the permission to delete files
- When you only have permission to delete files, the tabs upload and category disappear (However, I was unable to forbid the user uploading a file or a category when they only have delete permission... Hiding the tabs should resolve it however I am not completely sure of it).

#### Testing instructions (if applicable)

1. Check that if you only have delete permission, you can view the module.
2. Check that if you only have delete permission, you cannot access the upload and category tabs.

#### Link(s) to related issue(s)

* Resolves #6373 
