### PR TITLE
[Examiner / Edit Examiner] fix various issues when establishing the Certification Status of the Examiner

### DIFF
--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -265,10 +265,7 @@ class EditExaminer extends \NDB_Form
             }
         }
 
-        $baseurl = \NDB_Factory::singleton()->settings()->getBaseURL();
-        $url     = "{$baseurl}/examiner/editExaminer/?identifier="
-               . $examinerID;
-        header("Location: " . $url, true, 303);
+        header("Refresh:0");
     }
 
     /**
@@ -307,7 +304,7 @@ class EditExaminer extends \NDB_Form
             'maxYear'        => $config->getSetting('endYear'),
         );
         $statusOptions = array(
-            null            => 'N/A',
+            null            => '',
             'not_certified' => 'Not Certified',
             'in_training'   => 'In Training',
             'certified'     => 'Certified',
@@ -381,35 +378,26 @@ class EditExaminer extends \NDB_Form
      */
     function _validateEditExaminer($values)
     {
-        $DB     = \Database::singleton();
         $errors = array();
 
-        // check that there is both a status and a date (neither can be null)
+        $instruments = $this->getCertificationInstruments();
         foreach ($values['certStatus'] as $instrumentID => $certificationStatus) {
-            if (empty($certificationStatus)
-                || empty($values['date_cert'][$instrumentID])
-            ) {
-                if (($certificationStatus == "certified")
-                    && empty($values['date_cert'][$instrumentID])
-                ) {
-                    $errors['certStatus[' . $instrumentID .']'] = 'Both certification
-                        status and date must be filled out';
-                }
-            }
-        }
 
-        // check if previously recorded certification are all present
-        // (can not delete, only change status)
-        $rows = $DB->pselect(
-            "SELECT c.testID
-              FROM certification c
-              WHERE c.examinerID=:EID",
-            array('EID' => $this->identifier)
-        );
-        foreach ($rows as $row) {
-            if ($values['certStatus'][$row['testID']] == "") {
-                $errors['certStatus['.$row['testID'].']']
-                    = 'You can not delete a status';
+            // mandatory to choose an option for the Certification Status.
+            if (empty($certificationStatus)) {
+                $errors['certStatus[' . $instrumentID .']'] = 'Please choose
+                    a Certification Status for the Instrument: '
+                    . $instruments[$instrumentID];
+            }
+
+            // if the option chosen is "Certified"
+            // the Certification Day must be specified.
+            if (($certificationStatus == "certified")
+                && empty($values['date_cert'][$instrumentID])
+            ) {
+                    $errors['certStatus[' . $instrumentID .']'] = 'Please choose
+                    a Certification Date for the Instrument: '
+                    . $instruments[$instrumentID];
             }
         }
         return $errors;

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -304,7 +304,7 @@ class EditExaminer extends \NDB_Form
             'maxYear'        => $config->getSetting('endYear'),
         );
         $statusOptions = array(
-            null            => '',
+            null            => 'N/A',
             'not_certified' => 'Not Certified',
             'in_training'   => 'In Training',
             'certified'     => 'Certified',
@@ -378,26 +378,31 @@ class EditExaminer extends \NDB_Form
      */
     function _validateEditExaminer($values)
     {
+        $DB     = \Database::singleton();
         $errors = array();
 
-        $instruments = $this->getCertificationInstruments();
+        // check that there is both a status and a date (neither can be null)
         foreach ($values['certStatus'] as $instrumentID => $certificationStatus) {
-
-            // mandatory to choose an option for the Certification Status.
-            if (empty($certificationStatus)) {
-                $errors['certStatus[' . $instrumentID .']'] = 'Please choose
-                    a Certification Status for the Instrument: '
-                    . $instruments[$instrumentID];
-            }
-
-            // if the option chosen is "Certified"
-            // the Certification Day must be specified.
             if (($certificationStatus == "certified")
                 && empty($values['date_cert'][$instrumentID])
             ) {
-                    $errors['certStatus[' . $instrumentID .']'] = 'Please choose
-                    a Certification Date for the Instrument: '
-                    . $instruments[$instrumentID];
+                  $errors['certStatus[' . $instrumentID .']'] = 'Both certification
+                  status and date must be filled out';
+            }
+        }
+
+        // check if previously recorded certification are all present
+        // (can not delete, only change status)
+        $rows = $DB->pselect(
+            "SELECT c.testID
+              FROM certification c
+              WHERE c.examinerID=:EID",
+            array('EID' => $this->identifier)
+        );
+        foreach ($rows as $row) {
+            if ($values['certStatus'][$row['testID']] == "") {
+                $errors['certStatus['.$row['testID'].']']
+                    = 'You can not delete a status';
             }
         }
         return $errors;

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -192,15 +192,15 @@ class EditExaminer extends \NDB_Form
                         'TID' => $testID,
                     )
                 );
-                if (empty($oldVals)) {
-                    throw new \LorisException(
-                        'Certification data could not be found'
-                    );
+
+                $oldVal  = null;
+                $oldDate = null;
+                if (!empty($oldVals)) {
+                    // since there is an ORDER BY in pselect
+                    // $oldVals[0] corresponds to the latest date
+                    $oldVal  = $oldVals[0]['new'] ?? null;
+                    $oldDate = $oldVals[0]['new_date'] ?? null;
                 }
-                // since there is an ORDER BY in pselect
-                // $oldVals[0] corresponds to the latest date
-                $oldVal  = $oldVals[0]['new'] ?? null;
-                $oldDate = $oldVals[0]['new_date'] ?? null;
 
                 $oldCertification = $DB->pselectRow(
                     "SELECT pass, date_cert, comment


### PR DESCRIPTION
## Brief summary of changes
- Light modification of the function that handles the validation `function _validateEditExaminer($values)`. Cleaning an unused if condition.
- Light modification of the function that handles the process of the form `function _process($values)`
- Reestablishing old code accidentally replaced by https://github.com/aces/Loris/commit/058fa91d174e66f3e847f82a1bb7dc8408c3b112#diff-e429062f89aabd1a9ed7a99166cf2e85R195
- Properly function of buttons “Save” and “Reset”

#### Testing instructions (if applicable)

1. Go to Clinical/Examiner.
2. Add a new Examiner.
3. Click on the new examiner's name to edit the new examiner.
4. Play around with the buttons "Save" and "Reset". The behaviour should be the intended one. The page should refresh after each action.
5. No error 500  should be shown when leaving one of the instruments as `certificated = N/A` for the first time. 
6. After changing from N/A to other estate for a given instrument will be not possible to go back to N/A and a message should be shown alerting this.

#### Link(s) to related issue(s)

* Resolves #6605 
* Use the solution given in #5738 to handle the refresh part.