### PR TITLE
[imaging Browser] Fix wrong data being displayed under QC columns

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -169,8 +169,8 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // $scan_types are set in the configuration module
         $modalities_subquery = '';
         foreach ($case_desc as $key => $value) {
-            $modalities_subquery .= $value ." as " .
-                $DB->quote("$scan_id_types[$key]_QC_Status") . ",";
+            $modalities_subquery .= "$value as " .
+                $DB->quote("$scan_id_types[$key]_QC_Status").",";
         }
 
         // =================================================

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -169,8 +169,8 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // $scan_types are set in the configuration module
         $modalities_subquery = '';
         foreach ($case_desc as $key => $value) {
-            $modalities_subquery = $value." as " .
-                $DB->quote("$scan_id_types[$key]_QC_Status");
+            $modalities_subquery .= $value ." as " .
+                $DB->quote("$scan_id_types[$key]_QC_Status") . ",";
         }
 
         // =================================================
@@ -192,9 +192,9 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               GROUP_CONCAT(DISTINCT OutputType) as Links,
               s.ID as sessionID,
               GROUP_CONCAT(DISTINCT modality.Scan_type) as sequenceType,
-              $PendingNewquery as pending," .
-            ($modalities_subquery==''?'':"$modalities_subquery,") .
-            "s.CenterID as CenterID,
+              $PendingNewquery as pending,
+              $modalities_subquery
+              s.CenterID as CenterID,
               c.Entity_type as entityType,
               s.ProjectID
             FROM psc AS p


### PR DESCRIPTION
 Wrong data ("Human") is currently appearing under the QC columns of some scan types. This is due to a bug in how the `modalities_subquery` values are being assigned.

#### Brief summary of changes

- I changed the modalities subquery reassignment under the for loop to a concatenation. 

Note: for the file changes, the linter automatically removed some whitespace at the end of some lines after saving.


#### Testing instructions (if applicable)

1. Having 2+ scan type columns (you can add more through admin>configuration>imaging modules>tabulated scan types, go to the front page
2. Observe no "Human" values under the QC statuses of the different scan types.

#### Link(s) to related issue(s)

* Resolves #6652 
