### PR TITLE
[User Accounts] Typo in permission name

### DIFF
--- a/modules/user_accounts/php/user_accounts.class.inc
+++ b/modules/user_accounts/php/user_accounts.class.inc
@@ -46,7 +46,7 @@ class User_Accounts extends \DataFrameworkMenu
      */
     public function allSitePermissionNames() : ?array
     {
-        return ['user_account_multisite'];
+        return ['user_accounts_multisite'];
     }
 
     /**


### PR DESCRIPTION
I fixed a typo in /php/libraries/UserPermissions.class.inc:126. The permission user_accounts_multisite
is mispelled.

* Resolves #6655