### PR TITLE
[Statistics] Behavioural Statistics > Double Data Entry - Site permission fix

### DIFF
--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -25,10 +25,60 @@ namespace LORIS\statistics;
  */
 class Statistics_DD_Site extends statistics_site
 {
-
     var $query_criteria = '';
     var $query_vars     = array();
+    /**
+     * Checking user's permission
+     *
+     * @param \User $user The user whose access is being checked
+     *
+     * @return bool
+     */
+    function _hasAccess(\User $user) : bool
+    {
+        //TODO: Create a permission specific to statistics
+        $hasAccessToAllProfiles = $user->hasAllPermissions(
+            array(
+                'access_all_profiles',
+                'data_entry',
+            )
+        );
 
+        $hasCenterPermission = false;
+
+        // TODO: There are no means of set permissions per site
+        // for a given user right now: (e.g.) The user X can have
+        // the permission data_entry on site Y but not on site Z.
+        // Currently, hasCenterPermission() function is only checking
+        // if the user have a given center AND a given permission
+        // not if it have the permission for this specific center.
+        // This logic will be implemented in hasCenterPermission()
+        // in near versions when the permission framework allow it.
+        // If a CenterID is passed in the request, check if the user has the
+        // data_entry permission at the site/center specified by CenterID.
+        if (!empty($_REQUEST['CenterID'])) {
+            $hasCenterPermission = $user->hasCenterPermission(
+                'data_entry',
+                intval($_REQUEST['CenterID'])
+            );
+        } else {
+            // For the short term the user we'll be granted access
+            // if at least have permission AND one of the centers
+            // The filter _checkCriteria() (please see bellow)
+            // takes care of restricting access to sites the user belongs to.
+            // When logic reimplemented on hasCenterPermission(),
+            // _checkCriteria() will take care of retriving information
+            // only for those centers the user has the specific permission.
+            // (please see notes about hasCenterPermission() above)
+            foreach ($user->getCenterIDs() as $centerID) {
+                if ($user->hasCenterPermission('data_entry', intval($centerID))) {
+                    $hasCenterPermission = true;
+                    break;
+                }
+            }
+        }
+        return $hasAccessToAllProfiles || $hasCenterPermission;
+    }
     /**
      * CheckCriteria function
      *
@@ -39,16 +89,53 @@ class Statistics_DD_Site extends statistics_site
      */
     function _checkCriteria($centerID, $projectID)
     {
+        // TODO: There are no means of set permissions per site
+        // for a given user right now: (e.g.) The user X can have
+        // the permission data_entry on site Y but not on site Z.
+        // Currently, hasCenterPermission() function is only checking
+        // if the user have a given center AND a given permission
+        // not if it have the permission for this specific center.
+        // This logic will be implemented in hasCenterPermission()
+        // in near versions when the permission framework allow it
+        // The filter _checkCriteria() takes care of restricting
+        // the user access only to the sites it belongs to.
+        // When logic reimplemented on hasCenterPermission(),
+        // _checkCriteria() will take care of retriving information
+        // only for those centers the user has the specific permission.
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
+        } else {
+            $list_of_permitted_sites = (array) null;
+            $currentUser = \User::singleton();
+            if ($currentUser->hasPermission('access_all_profiles')) {
+                $list_of_permitted_sites = array_keys(\Utility::getSiteList());
+            } else {
+                foreach ($currentUser->getCenterIDs() as $centerID) {
+                    if ($currentUser->hasCenterPermission(
+                        'data_entry',
+                        intval($centerID)
+                    )
+                    ) {
+                        array_push($list_of_permitted_sites, $centerID);
+                    }
+                }
+            }
+            $params    = array();
+            $centerIDs = array();
+            foreach ($list_of_permitted_sites as $key => $siteID) {
+                $params[]            = ":id$key";
+                $centerIDs["id$key"] = $siteID;
+            }
+            $this->query_criteria .=
+                " AND s.CenterID IN (" . implode(',', $params) . ")";
+            $this->query_vars     += $centerIDs;
         }
         if (!empty($projectID)) {
             $this->query_criteria   .= " AND s.ProjectID =:pid ";
             $this->query_vars['pid'] = $projectID;
         }
     }
-
     /**
      * Notexcluded function
      *

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -36,7 +36,7 @@ class Statistics_DD_Site extends statistics_site
      */
     function _hasAccess(\User $user) : bool
     {
-        //TODO: Create a permission specific to statistics
+        // TODO (#6742): Create a permission specific to statistics
         $hasAccessToAllProfiles = $user->hasAllPermissions(
             array(
                 'access_all_profiles',
@@ -46,14 +46,9 @@ class Statistics_DD_Site extends statistics_site
 
         $hasCenterPermission = false;
 
-        // TODO: There are no means of set permissions per site
-        // for a given user right now: (e.g.) The user X can have
-        // the permission data_entry on site Y but not on site Z.
-        // Currently, hasCenterPermission() function is only checking
-        // if the user have a given center AND a given permission
-        // not if it have the permission for this specific center.
-        // This logic will be implemented in hasCenterPermission()
-        // in near versions when the permission framework allow it.
+        // TODO (#6742): There are no means of setting permissions per site
+        // for a given user right now (see #6742 for more info)
+
         // If a CenterID is passed in the request, check if the user has the
         // data_entry permission at the site/center specified by CenterID.
         if (!empty($_REQUEST['CenterID'])) {
@@ -62,14 +57,8 @@ class Statistics_DD_Site extends statistics_site
                 intval($_REQUEST['CenterID'])
             );
         } else {
-            // For the short term the user we'll be granted access
-            // if at least have permission AND one of the centers
-            // The filter _checkCriteria() (please see bellow)
-            // takes care of restricting access to sites the user belongs to.
-            // When logic reimplemented on hasCenterPermission(),
-            // _checkCriteria() will take care of retriving information
-            // only for those centers the user has the specific permission.
-            // (please see notes about hasCenterPermission() above)
+            // FIXME (#6742): For the short term the user will be granted access
+            // if they have permission for a minimum of one of the centers
             foreach ($user->getCenterIDs() as $centerID) {
                 if ($user->hasCenterPermission('data_entry', intval($centerID))) {
                     $hasCenterPermission = true;
@@ -79,6 +68,7 @@ class Statistics_DD_Site extends statistics_site
         }
         return $hasAccessToAllProfiles || $hasCenterPermission;
     }
+
     /**
      * CheckCriteria function
      *
@@ -89,19 +79,14 @@ class Statistics_DD_Site extends statistics_site
      */
     function _checkCriteria($centerID, $projectID)
     {
-        // TODO: There are no means of set permissions per site
-        // for a given user right now: (e.g.) The user X can have
-        // the permission data_entry on site Y but not on site Z.
-        // Currently, hasCenterPermission() function is only checking
-        // if the user have a given center AND a given permission
-        // not if it have the permission for this specific center.
-        // This logic will be implemented in hasCenterPermission()
-        // in near versions when the permission framework allow it
-        // The filter _checkCriteria() takes care of restricting
-        // the user access only to the sites it belongs to.
+        // TODO (#6743): _checkCriteria takes care of restricting data access
+        // to sites the user belongs to.
         // When logic reimplemented on hasCenterPermission(),
-        // _checkCriteria() will take care of retriving information
+        // _checkCriteria() will take care of retrieving information
         // only for those centers the user has the specific permission.
+
+        // TODO (#6743): There are no means of setting permissions per site
+        // for a given user right now (see #6743 for more info)
         if (!empty($centerID)) {
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
@@ -136,6 +121,7 @@ class Statistics_DD_Site extends statistics_site
             $this->query_vars['pid'] = $projectID;
         }
     }
+
     /**
      * Notexcluded function
      *

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -37,12 +37,10 @@ class Statistics_DD_Site extends statistics_site
     function _hasAccess(\User $user) : bool
     {
         // TODO (#6742): Create a permission specific to statistics
-        $hasAccessToAllProfiles = $user->hasAllPermissions(
-            array(
-                'access_all_profiles',
-                'data_entry',
-            )
-        );
+        $hasAccessToAllProfiles = $user->hasPermission('access_all_profiles');
+        if ($hasAccessToAllProfiles) {
+            return true;
+        }
 
         $hasCenterPermission = false;
 
@@ -91,20 +89,12 @@ class Statistics_DD_Site extends statistics_site
             $this->query_criteria   .= " AND s.CenterID =:cid ";
             $this->query_vars['cid'] = $centerID;
         } else {
-            $list_of_permitted_sites = (array) null;
-            $currentUser = \User::singleton();
+            $list_of_permitted_sites = [];
+            $currentUser = \NDB_Factory::singleton()->user();
             if ($currentUser->hasPermission('access_all_profiles')) {
                 $list_of_permitted_sites = array_keys(\Utility::getSiteList());
             } else {
-                foreach ($currentUser->getCenterIDs() as $centerID) {
-                    if ($currentUser->hasCenterPermission(
-                        'data_entry',
-                        intval($centerID)
-                    )
-                    ) {
-                        array_push($list_of_permitted_sites, $centerID);
-                    }
-                }
+                $list_of_permitted_sites = $currentUser->getCenterIDs();
             }
             $params    = array();
             $centerIDs = array();
@@ -178,13 +168,13 @@ class Statistics_DD_Site extends statistics_site
             "SELECT count(s.CandID)  FROM session s, candidate c,
                 flag f, $safe_instrument i
              WHERE
-                s.ID=f.SessionID AND f.CommentID=i.CommentID 
-                AND s.CandID=c.CandID  
-                AND s.Active='Y' 
+                s.ID=f.SessionID AND f.CommentID=i.CommentID
+                AND s.CandID=c.CandID
+                AND s.Active='Y'
                 AND s.CenterID <> '1'
                 AND s.Current_stage <> 'Recycling Bin'
                 $this->query_criteria
-                AND f.Data_entry='Complete' AND f.Administration='All' 
+                AND f.Data_entry='Complete' AND f.Administration='All'
                 AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID",
             $this->query_vars
         );
@@ -205,10 +195,10 @@ class Statistics_DD_Site extends statistics_site
         $safe_instrument = $DB->escape($instrument);
         $result          = $DB->pselect(
             "SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID,
-                lower(s.Visit_label) as Visit_label 
+                lower(s.Visit_label) as Visit_label
                 FROM session s, candidate c, flag f, $safe_instrument i
-                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID AND 
-                s.CandID=c.CandID  AND s.Active='Y' 
+                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID AND
+                s.CandID=c.CandID  AND s.Active='Y'
                 AND s.CenterID <> '1'
                 $this->query_criteria
                 AND s.Current_stage <> 'Recycling Bin'


### PR DESCRIPTION
### Description of the issue
In Statistics / Behavioural Statistics / Double Data Entry Statistics, users were allowed to see the double data entry breakdown per participant from sites they don't have access to. 
### Brief summary of changes
The `_hasAccess` function was incorpoerate to this class (same functionality that the one in #5591)

The function `_checkCriteria` was modified for only retrieve data from the sites(centers) the user have access to.

Note: In future developments the capacity of setting permissions per site per user could be desirable. A note in rapport was included in the codeset. In this case the proposed function `_hasAccess` should be updated accordingly .

#### Testing instructions (if applicable)
A user with permission 'data_entry' should be now able to access the 'breakdown per participant' for the double data entry page only for the sites it have access to.

#### Links to related PRs
#5950
#5591
Duplicates of #5966 (rebased on 23.0)