### PR TITLE
[imaging_uploader] Fix bug with auto-filling compound visit labels

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -56,6 +56,8 @@ class UploadForm extends Component {
         let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
+        // visitLabel can contain underscores
+        // join the remaining elements of patientName and use as visitLabel
         ids.splice(0, 2);
         formData.visitLabel = ids.join('_');
       }
@@ -69,6 +71,8 @@ class UploadForm extends Component {
         let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
+        // visitLabel can contain underscores
+        // join the remaining elements of patientName and use as visitLabel
         ids.splice(0, 2);
         formData.visitLabel = ids.join('_');
       }

--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -53,10 +53,11 @@ class UploadForm extends Component {
         delete formData.visitLabel;
       } else if (typeof formData.mriFile !== 'undefined') {
         let patientName = formData.mriFile.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
-        let ids = patientName.split('_', 3);
+        let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
-        formData.visitLabel = ids[2];
+        ids.splice(0, 2);
+        formData.visitLabel = ids.join('_');
       }
     }
 
@@ -65,10 +66,11 @@ class UploadForm extends Component {
     if (field === 'mriFile') {
       if (value.name && formData.IsPhantom === 'N') {
         let patientName = value.name.replace(/\.[a-z]+\.?[a-z]+?$/i, '');
-        let ids = patientName.split('_', 3);
+        let ids = patientName.split('_');
         formData.candID = ids[1];
         formData.pSCID = ids[0];
-        formData.visitLabel = ids[2];
+        ids.splice(0, 2);
+        formData.visitLabel = ids.join('_');
       }
     }
 


### PR DESCRIPTION
## Brief summary of changes
For compound visit labels that contain underscores (EX: `Initial_MRI`), the auto-fill feature was not populating the full visit name due to how the file name was being spliced. This PR addresses that issue and ensures that full visit label is populated.

#### Testing instructions (if applicable)

1. Try attaching a file with visit label containing an underscore. (EX: `Initial_MRI`)
2. Try attaching a file with visit label that does not contain underscores. (EX: `V1`)
3. Repeat steps 1 & 2 for both cases where Phantom Scan = `yes` & `no`

#### Link(s) to related issue(s)

* Resolves #6569 
