### PR TITLE
[Documentation] Behaviour Feedback widgets description

### DIFF
--- a/modules/bvl_feedback/README.md
+++ b/modules/bvl_feedback/README.md
@@ -1,0 +1,15 @@
+# Behavioural Feedback
+
+
+## Purpose
+
+The Feedback module allows users to flag and comment on any database field particularly for behavioural data entry. 
+Two default feedback types exist: input and scoring errors. Additional feedback types can be added to feedback_bvl_type table.
+
+## Behavioral Feedback Notifications
+
+The Dashboard Widget tracks issues and corrections to behavioural/clinical data points. Notification are clickable and redirect to the instrument with new changes or feedback.
+
+## Permissions
+
+The `bvl_feedback` permission is required to access the behavioural feedback module.

--- a/modules/bvl_feedback/README.md
+++ b/modules/bvl_feedback/README.md
@@ -15,9 +15,12 @@ Two default feedback types exist: input and scoring errors. Additional feedback 
 
 ## Interactions with LORIS
 
-The Feedback module registers widgets on the dashboard.
+Note that Feedback is also displayed in the Behavioural QC module. 
+
+Behavioural feedback is accessed via a pencil icon in the top menu bar which is visible only when in certain behavioural/clinical modules.
+Behavioural Feedback status data is also accessible and the module is linked in many places in LORIS at 3 levels : Candidate, Timepoint, and Instrument.  
+Links appear in the respective modules : candidate profile and candidate dashboard, timepoint list, and instrument, as well as from the sidebar in each instrument form. 
 
 ### Dashboard Widget
 
-The Dashboard Widget `Behavioural Feedback Notifications` tracks issues and corrections to behavioural/clinical data points on 3 different levels: 
-Profile, Visit and Instrument.
+The Dashboard Widget `Behavioural Feedback Notifications` displays feedback outstanding on behavioural/clinical data

--- a/modules/bvl_feedback/README.md
+++ b/modules/bvl_feedback/README.md
@@ -3,13 +3,21 @@
 
 ## Purpose
 
-The Feedback module allows users to flag and comment on any database field particularly for behavioural data entry. 
-Two default feedback types exist: input and scoring errors. Additional feedback types can be added to feedback_bvl_type table.
-
-## Behavioral Feedback Notifications
-
-The Dashboard Widget tracks issues and corrections to behavioural/clinical data points. Notification are clickable and redirect to the instrument with new changes or feedback.
+The Feedback module allows users to flag and comment on  behavioural database fields.
 
 ## Permissions
 
 The `bvl_feedback` permission is required to access the behavioural feedback module.
+
+## Configurations
+
+Two default feedback types exist: input and scoring errors. Additional feedback types can be added to feedback_bvl_type table.
+
+## Interactions with LORIS
+
+The Feedback module registers widgets on the dashboard.
+
+### Dashboard Widget
+
+The Dashboard Widget `Behavioural Feedback Notifications` tracks issues and corrections to behavioural/clinical data points on 3 different levels: 
+Profile, Visit and Instrument.

--- a/modules/bvl_feedback/test/TestPlan.md
+++ b/modules/bvl_feedback/test/TestPlan.md
@@ -28,3 +28,8 @@
 8. Click on the pencil button and 'Add a thread entry'. Click on 'Send'. Click on the chevron next to the status. You should be able to see the original text box thread entry and the one you just entered.
 9. Click on 'opened' and choose a different status. Status should be updated.
 
+### Widget registration on the dashboard page
+
+10. Verify that if a user has the 'bvl_feedback' permission, the latest Behavioural Feedback Notifications are displayed (4 at most) in the Behavioural Feedback panel. Clicking on a feedback thread will take you to the proper page.
+11. Check that if a document notification occurred since the last login, it is labeled as 'New' in the Behavioural Feedback panel.
+12. Check that a 'New' notification is not labeled 'New' anymore after login in again.


### PR DESCRIPTION
Tentative to update the documentation of the bvl_feedback module:
- creation of a basic README
- update of the Test Plan to mention the Behavioral Feedback Notifications widget.

* Resolves #6630