### PR TITLE
[Documentation] Doc Repo Test plan and README update

### DIFF
--- a/modules/document_repository/README.md
+++ b/modules/document_repository/README.md
@@ -6,8 +6,8 @@
 
 ## Intended Users
 
- LORIS users can view, download, upload, and delete files, as well as edit information pertaining to those files.
- This module is used primarily by study coordinators/administrators who share study protocols and manuals, as well as data entry staff who consult these documents.
+LORIS users can view, download, upload, and delete files, as well as edit information pertaining to those files.
+This module is used primarily by study coordinators/administrators who share study protocols and manuals, as well as data entry staff who consult these documents.
 
 ## Scope
 
@@ -33,5 +33,12 @@ post_max_size = 1024M           // Maximum size of POST data that PHP will accep
 
 - A mail server is required to send out email notification regarding the Document Repository updates.
 
-- Interactions: Notifications from the Document Repository module are visible on the Dashboard panel.
-  
+## Interactions with LORIS
+
+Users can enable notifications for the document_repository in the My Preferences module. Once activated, users receive an email each time one of the following event occurs:
+* Addition, deletion or modification of a file (by another user)
+* Addition of a category (by another user)
+
+### Dashboard Widget
+
+The `Document Repository Notifications` panel is displayed on the dashboard and displays the last 4 recently-uploaded documents for projects/sites relevant to the current user. A document status is `New` if it was created after current user's last login date.

--- a/modules/document_repository/test/TestPlan.md
+++ b/modules/document_repository/test/TestPlan.md
@@ -37,3 +37,14 @@
 16. Try uploading a file that exceeds the max upload limit. Ensure that an error message occurs
     when the server has detected that the file is too large.
     [Manual Testing]
+
+### Widget registration on the dashboard page
+
+17. Verify that if a user has the 'View and upload files in Document Repository' or 'Delete files in Document Repository' 
+    permission, the latest documents to have been edited or uploaded in the document repository are displayed (4 at most) 
+    in the Document Repository panel. Clicking on a document will display it in the browser. Clicking on the Document
+    Repository button takes you to the Document Repository page.
+    [Automate Test]
+18. Check that if a document notification occurred since the last login, it is labeled as 'New' in the Document Repository panel. [Automate Test]
+19. Check that a 'New' notification is not labeled 'New' anymore after login in again. [Manual Test]
+


### PR DESCRIPTION
Tentative to update the documentation of the document_repo module:
- update of the README
- update of the Test Plan to mention the Document Repository Notifications widget.

* Resolves #6631