### PR TITLE
[Imaging Uploader] Fix grammar of alert messages

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -164,7 +164,7 @@ class UploadForm extends Component {
     if (mriFile.status === 'Failure') {
       swal({
         title: 'Are you sure?',
-        text: 'A file with this name already exists!\n Would you like to override existing file?',
+        text: 'A file with this name already exists!\n Would you like to overwrite the existing file?',
         type: 'warning',
         showCancelButton: true,
         confirmButtonText: 'Yes, I am sure!',
@@ -173,7 +173,7 @@ class UploadForm extends Component {
         if (isConfirm) {
           this.uploadFile(true);
         } else {
-          swal('Cancelled', 'Your imaginary file is safe :)', 'error');
+          swal('Cancelled', 'Your upload has been cancelled.', 'error');
         }
       }.bind(this));
     }
@@ -182,8 +182,8 @@ class UploadForm extends Component {
     if (mriFile.status === 'Not Started') {
       swal({
         title: 'Are you sure?',
-        text: 'A file with this name has been uploaded but has not yet started the MRI pipeline.' +
-          '\n Would you like to override the existing file?',
+        text: 'A file with this name has been uploaded but has not yet been processed by the MRI pipeline.' +
+          '\n Would you like to overwrite the existing file?',
         type: 'warning',
         showCancelButton: true,
         confirmButtonText: 'Yes, I am sure!',


### PR DESCRIPTION
I noticed some problems in the phrasing of some error messages based on @jesscall's [comment](https://github.com/aces/Loris/issues/6620#issuecomment-638261560) in another issue.

This removes a debug message and also fixes grammer.