### PR TITLE
[API] Project /images endpoint broken  

### DIFF
--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -69,18 +69,16 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
             'Visit'      => $this->_visitlabel,
             'Visit_date' => $this->_visitdate,
             'Site'       => $this->_centername,
-            'File'       => $this->_filename,
             'InsertTime' => $this->_inserttime,
             'ScanType'   => $this->_scantype,
             'QC_status'  => $this->_qcstatus,
             'Selected'   => $this->_selected,
         );
 
-        $filename = basename($obj['File']);
         $candid   = $obj['Candidate'];
         $visit    = $obj['Visit'];
 
-        $obj['Link']       = "/candidates/$candid/$visit/images/$filename";
+        $obj['Link']       = "/candidates/$candid/$visit/images/";
         $obj['InsertTime'] = date('c', (int) $obj['InsertTime']);
 
         return json_encode($obj);

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -29,7 +29,6 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
     private $_visitdate;
     private $_centerid;
     private $_centername;
-    private $_filename;
     private $_inserttime;
     private $_scantype;
     private $_qcstatus;
@@ -49,7 +48,6 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
         $this->_visitdate  = $row['Visit_date'] ?? null;
         $this->_centerid   = $row['CenterID'] ?? null;
         $this->_centername = $row['Site'] ?? null;
-        $this->_filename   = $row['File'] ?? null;
         $this->_inserttime = $row['InsertTime'] ?? null;
         $this->_scantype   = $row['ScanType'] ?? null;
         $this->_qcstatus   = $row['QC_status'] ?? null;

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -29,6 +29,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
     private $_visitdate;
     private $_centerid;
     private $_centername;
+    private $_filename;
     private $_inserttime;
     private $_scantype;
     private $_qcstatus;
@@ -48,6 +49,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
         $this->_visitdate  = $row['Visit_date'] ?? null;
         $this->_centerid   = $row['CenterID'] ?? null;
         $this->_centername = $row['Site'] ?? null;
+        $this->_filename   = $row['File'] ?? null;
         $this->_inserttime = $row['InsertTime'] ?? null;
         $this->_scantype   = $row['ScanType'] ?? null;
         $this->_qcstatus   = $row['QC_status'] ?? null;
@@ -72,11 +74,11 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
             'QC_status'  => $this->_qcstatus,
             'Selected'   => $this->_selected,
         );
-
+        $filename = basename($this->_filename);
         $candid = $obj['Candidate'];
         $visit  = $obj['Visit'];
 
-        $obj['Link']       = "/candidates/$candid/$visit/images/";
+        $obj['Link']       = "/candidates/$candid/$visit/images/$filename";
         $obj['InsertTime'] = date('c', (int) $obj['InsertTime']);
 
         return json_encode($obj);

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -73,8 +73,8 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
             'Selected'   => $this->_selected,
         );
 
-        $candid   = $obj['Candidate'];
-        $visit    = $obj['Visit'];
+        $candid = $obj['Candidate'];
+        $visit  = $obj['Visit'];
 
         $obj['Link']       = "/candidates/$candid/$visit/images/";
         $obj['InsertTime'] = date('c', (int) $obj['InsertTime']);

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -63,7 +63,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
      */
     public function toJSON() : string
     {
-        $obj = array(
+        $obj      = array(
             'Candidate'  => $this->_candid,
             'PSCID'      => $this->_pscid,
             'Visit'      => $this->_visitlabel,
@@ -75,8 +75,8 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
             'Selected'   => $this->_selected,
         );
         $filename = basename($this->_filename);
-        $candid = $obj['Candidate'];
-        $visit  = $obj['Visit'];
+        $candid   = $obj['Candidate'];
+        $visit    = $obj['Visit'];
 
         $obj['Link']       = "/candidates/$candid/$visit/images/$filename";
         $obj['InsertTime'] = date('c', (int) $obj['InsertTime']);

--- a/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
@@ -49,6 +49,7 @@ class ProjectImagesRowProvisioner extends DBRowProvisioner
                s.CenterID as CenterID,
                p.Name as Site,
                f.InsertTime as InsertTime,
+               f.File as File,
                mst.Scan_type as ScanType,
                qc.QCStatus as QC_status,
                qc.Selected as Selected

--- a/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
@@ -48,7 +48,6 @@ class ProjectImagesRowProvisioner extends DBRowProvisioner
                s.Date_visit as Visit_date,
                s.CenterID as CenterID,
                p.Name as Site,
-               f.File as File,
                f.InsertTime as InsertTime,
                mst.Scan_type as ScanType,
                qc.QCStatus as QC_status,

--- a/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
@@ -48,6 +48,7 @@ class ProjectImagesRowProvisioner extends DBRowProvisioner
                s.Date_visit as Visit_date,
                s.CenterID as CenterID,
                p.Name as Site,
+               f.File as File,
                f.InsertTime as InsertTime,
                mst.Scan_type as ScanType,
                qc.QCStatus as QC_status,


### PR DESCRIPTION
## Brief summary of changes
Fixing 500 error. 
remove "file" column from projectimagesrow, since #6516.
"PHP Fatal error: Uncaught TypeError: basename() expects parameter 1 to be string, null given in /var/www/Loris/modules/api/php/models/projectimagesrow.class.inc:79"

#### Testing instructions (if applicable)
Test  "/api/v0.0.3/projects/Rye/images" on a loris instence with Rasinbread data set .
It will show the result.
<img width="916" alt="屏幕快照 2020-06-03 11 31 13" src="https://user-images.githubusercontent.com/9876007/83656662-c9a18900-a58d-11ea-9acf-cfd7e543ae44.png">

#### Link(s) to related issue(s)
https://github.com/aces/Loris/issues/6572
