### PR TITLE
[Imaging browser] Fix loading error for t1-defaced and t2-defaced scan types

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -112,7 +112,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         $coalesce_desc = array();
 
         foreach ($scan_id_types as $id => $type) {
-            $pass[$id]          = $DB->quote($type);
+            $pass[$id]          = $DB->escape($type);
             $qc[$id]            = $DB->quote($type);
             $coalesce_desc[$id] = $DB->quote($pass[$id] . '.' . $qc[$id]);
             $case_desc[$id]     = "
@@ -155,8 +155,8 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               JOIN files_qcstatus USING (FileID)
               WHERE files.AcquisitionProtocolID= $key
                 AND files_qcstatus.QCStatus IN (1, 2)
-              GROUP BY files.SessionID) `$pass[$key]`
-                ON (`$pass[$key]`.SessionID=f.SessionID
+              GROUP BY files.SessionID) $pass[$key]
+                ON ($pass[$key].SessionID=f.SessionID
             ) ";
         }
 
@@ -210,7 +210,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               $left_joins
             WHERE
               s.Active = 'Y' AND
-              f.FileType='mnc'
+              f.FileType IN ('mnc', 'nii')
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label
             ",

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -33,10 +33,13 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
     /**
      * Create an ImagingBrowserRowProvisioner, which gets rows for
      * the imaging browser menu table.
+     *
+     * @throws \ConfigurationException
      */
     function __construct()
     {
         $config = \NDB_Config::singleton();
+        $DB     = \NDB_Factory::singleton()->database();
 
         // ===========================================================
         // Get the different scan types to be displayed in data table
@@ -92,7 +95,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         }
 
         $NewDataSubquery = "
-            CASE 
+            CASE
                 COALESCE(Max(fqc.QCLastChangeTime), 'new')
                 WHEN 'new' THEN {$acqpif}
                 WHEN ''    THEN {$acqpif}
@@ -109,9 +112,9 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         $coalesce_desc = array();
 
         foreach ($scan_id_types as $id => $type) {
-            $pass[$id]          = $type . 'pass';
-            $qc[$id]            = $type . 'QC';
-            $coalesce_desc[$id] = $pass[$id] . '.' . $qc[$id];
+            $pass[$id]          = $DB->quote($type);
+            $qc[$id]            = $DB->quote($type);
+            $coalesce_desc[$id] = $DB->quote($pass[$id] . '.' . $qc[$id]);
             $case_desc[$id]     = "
                 CASE
                     COALESCE($coalesce_desc[$id], '')
@@ -126,15 +129,15 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
                 WHEN 'Fail' THEN
                     IF(s.MRIQCPending='Y', 'Pending Fail', 'Fail')
                 WHEN 'Pass' THEN
-                    IF(s.MRIQCPending='Y', 'Pending Pass', 'Pass') 
+                    IF(s.MRIQCPending='Y', 'Pending Pass', 'Pass')
                 ELSE s.MRIQCStatus
-            END 
+            END
             ";
 
         $PendingNewquery = "
-            CASE 
+            CASE
                 WHEN s.MRIQCPending='Y' THEN 'P'
-                WHEN MAX(fqc.QCFirstChangeTime) IS NULL $newQueryCase THEN  'N'      
+                WHEN MAX(fqc.QCFirstChangeTime) IS NULL $newQueryCase THEN  'N'
             END";
 
         // ====================================================
@@ -146,14 +149,14 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         foreach ($case_desc as $key => $value) {
             $left_joins .= "
             LEFT JOIN (
-              SELECT files.SessionID, 
-                MIN(files_qcstatus.QCStatus+0) as $qc[$key] 
-              FROM files 
-              JOIN files_qcstatus USING (FileID) 
-              WHERE files.AcquisitionProtocolID= $key 
-                AND files_qcstatus.QCStatus IN (1, 2) 
-              GROUP BY files.SessionID) $pass[$key] 
-                ON ($pass[$key].SessionID=f.SessionID
+              SELECT files.SessionID,
+                MIN(files_qcstatus.QCStatus+0) as $qc[$key]
+              FROM files
+              JOIN files_qcstatus USING (FileID)
+              WHERE files.AcquisitionProtocolID= $key
+                AND files_qcstatus.QCStatus IN (1, 2)
+              GROUP BY files.SessionID) `$pass[$key]`
+                ON (`$pass[$key]`.SessionID=f.SessionID
             ) ";
         }
 
@@ -166,7 +169,8 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // $scan_types are set in the configuration module
         $modalities_subquery = '';
         foreach ($case_desc as $key => $value) {
-            $modalities_subquery = "$value as $scan_id_types[$key]_QC_Status";
+            $modalities_subquery = $value." as " .
+                $DB->quote("$scan_id_types[$key]_QC_Status");
         }
 
         // =================================================
@@ -174,7 +178,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         // =================================================
 
         parent::__construct(
-            "SELECT 
+            "SELECT
               p.Name as Site,
               c.PSCID as PSCID,
               c.CandID as DCCID,
@@ -189,24 +193,24 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               s.ID as sessionID,
               GROUP_CONCAT(DISTINCT modality.Scan_type) as sequenceType,
               $PendingNewquery as pending," .
-              ($modalities_subquery==''?'':"$modalities_subquery,") .
-              "s.CenterID as CenterID,
+            ($modalities_subquery==''?'':"$modalities_subquery,") .
+            "s.CenterID as CenterID,
               c.Entity_type as entityType,
               s.ProjectID
-            FROM psc AS p 
-              JOIN session s ON (s.CenterID=p.CenterID) 
-              JOIN candidate c ON (c.CandID=s.CandID) 
+            FROM psc AS p
+              JOIN session s ON (s.CenterID=p.CenterID)
+              JOIN candidate c ON (c.CandID=s.CandID)
               LEFT JOIN Project ON (s.ProjectID=Project.ProjectID)
-              JOIN files f ON (f.SessionID=s.ID) 
-              LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID) 
+              JOIN files f ON (f.SessionID=s.ID)
+              LEFT JOIN files_qcstatus fqc ON (fqc.FileID=f.FileID)
               JOIN parameter_file pf ON (f.FileID=pf.FileID)
               JOIN parameter_type pt USING (ParameterTypeID)
-              LEFT JOIN mri_scan_type modality ON 
+              LEFT JOIN mri_scan_type modality ON
                 (f.AcquisitionProtocolID=modality.ID)
-              $left_joins 
-            WHERE 
+              $left_joins
+            WHERE
               s.Active = 'Y' AND
-              f.FileType IN ('mnc', 'nii')
+              f.FileType='mnc'
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label
             ",


### PR DESCRIPTION
Adding 't1-defaced' or 't2-defaced' scan types to the imaging browser was causing an SQL error due to the hyphen in the name.

#### Brief summary of changes

- ~I replaced all hyphen occurrences in the array containing the scan type names with underscores. This does not change how the scan type name appears on the frontend.~ 
- I used Database->quote() to quote scan type names, or surrounded them with backticks if they needed to be interpreted as identifiers rather than string literals.
#### Testing instructions (if applicable)

1. Go to Admin>Configuration>Imaging types>
2. Add t1-defaced and/or t2-defaced scan types next to the tabulated scan types and save
3. Go to the imaging module front page
4. Observe the module loading properly, with t1-defaced/t2-defaced QC columns

#### Link(s) to related issue(s)

* Resolves #6616 
