### PR TITLE
[timepoint_list] Clarify ambiguous parts of test plan for timepoint_list

### DIFF
--- a/modules/timepoint_list/test/TestPlan.md
+++ b/modules/timepoint_list/test/TestPlan.md
@@ -10,11 +10,11 @@
     - For a candidate of the same site as your user, there should be up to 3 additional buttons:
         1. "Create time point" (links to create_timepoint module for that candidate) if your user has permission `data_entry`
         2. "Candidate Info" (links to candidate_parameters module for that candidate) if your user has permission `data_entry`
-        3. "View Imaging Datasets" (links to the imaging_browser module for that candidate
+        3. "View Imaging Datasets" (links to the imaging_browser module menu page filtered for that candidate)
 3.  **Button links**
     - Ensure the "View Imaging datasets" button points to correct place. (imaging_browser module for that candidate)
     - Ensure the "Create time point" button points to correct place. (create_timepoint module for that candidate)
     - Ensure the "Candidate Info" button points to correct place. (candidate_parameters module for that candidate)
 5.  **Datatable content**
     - Visit Label: Ensure correct visits are shown and links point to correct place. (instrument_list for that specific timepoint)
-    - Imaging Scan Done: If 'yes', ensure links point to correct place (imaging_browser for that candidate and visit_label)
+    - Imaging Scan Done: If 'yes', ensure links point to correct place (imaging_browser session page for that visit)


### PR DESCRIPTION
The timepoint_list test plan refers to links to imaging browser but uses very similar terminology to refer to linking to different places. This specifies where the links should go more precisely to avoid confusion.