### PR TITLE
[Install] Guideline and PHP version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ sudo a2ensite $projectname
 sudo service apache2 reload
 ```
     
-6. Go to http://localhost/installdb.php and follow the instructions to finalize LORIS installation, then restart apache.
+6. Open your browser and go to: `<loris-url>/installdb.php`. This web page will prompt you for your mysql connection information. Follow the instructions to finalize LORIS installation, then restart apache.
 
 If you use MySQL 8, please read [this link](https://www.php.net/manual/en/mysqli.requirements.php) and also [this](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password-compatible-connectors).
 

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -10,9 +10,9 @@ For further details on the install process, please see the LORIS GitHub Wiki Cen
 # System Requirements - Install dependencies
 
 Default dependencies installed by CentOS 7.x may not meet the version requirements for LORIS deployment or development:
-* MariaDB 10.3 is supported for LORIS 23.*   
+* MariaDB 10.3 is supported for LORIS 23.   
 
-* PHP 7.3 is supported for LORIS 23.*
+* PHP 7.3 (or higher) is supported for LORIS 23. PHP 7.4 is recommended.
 
 In addition to the above, the following packages should be installed with `yum` and may also differ from the packages referenced in the main (Ubuntu) [LORIS Readme](../../../../../README.md). Detailed command examples are provided below (`sudo` privilege may be required depending on your system).
  * Apache 2.4 or higher  
@@ -31,7 +31,7 @@ sudo yum install httpd
 sudo systemctl enable httpd
 sudo systemctl start httpd
 ```
-## PHP 7.3
+## PHP 7.4
 ```bash
 sudo yum install epel-release
 sudo yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
@@ -39,9 +39,10 @@ sudo yum install yum-utils
 sudo yum update
 
 # By default, the repository for PHP 5.4 is enabled
+# Make sure to have only one repository for PHP enabled
 sudo yum-config-manager --disable remi-php54
-sudo yum-config-manager --enable remi-php73
-sudo yum install php php-pdo php-pdo_mysql php73-php-fpm php73-php-gd php73-php-json php73-php-mbstring php73-php-mysqlnd php73-php-xml php73-php-xmlrpc php73-php-opcache php73-php-mysql
+sudo yum-config-manager --enable remi-php74
+sudo yum install php php-pdo php-pdo_mysql php-fpm php-gd php-json php-mbstring php-mysqlnd php-xml php-xmlrpc php-opcache
 ```
 ## MariaDB
 
@@ -104,8 +105,7 @@ Download the latest release from the [releases page](https://github.com/aces/Lor
 wget https://github.com/aces/Loris/archive/v$VERSION.tar.gz
 tar -zxf Loris-%VERSION%.tar.gz
 cp -r Loris-%VERSION%/ /var/www/loris
-chown -R lorisadmin /var/www/loris
-
+chown -R lorisadmin:apache /var/www/loris
 ```
 
 Alternatively the latest development branch can be obtained by forking the [LORIS repository](http://github.com/aces/Loris) for development purposes. We do not support unstable dev branches. 

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md
@@ -37,7 +37,11 @@ sudo yum install epel-release
 sudo yum install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
 sudo yum install yum-utils
 sudo yum update
-sudo yum --enablerepo=remi-php73 install php php-pdo php-pdo_mysql php73-php-fpm php73-php-gd php73-php-json php73-php-mbstring php73-php-mysqlnd php73-php-xml php73-php-xmlrpc php73-php-opcache php73-php-mysql
+
+# By default, the repository for PHP 5.4 is enabled
+sudo yum-config-manager --disable remi-php54
+sudo yum-config-manager --enable remi-php73
+sudo yum install php php-pdo php-pdo_mysql php73-php-fpm php73-php-gd php73-php-json php73-php-mbstring php73-php-mysqlnd php73-php-xml php73-php-xmlrpc php73-php-opcache php73-php-mysql
 ```
 ## MariaDB
 
@@ -56,7 +60,7 @@ gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 ```
 
-Install PGP key with:
+Install GPG key with:
 ```
 sudo rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 ```
@@ -100,6 +104,8 @@ Download the latest release from the [releases page](https://github.com/aces/Lor
 wget https://github.com/aces/Loris/archive/v$VERSION.tar.gz
 tar -zxf Loris-%VERSION%.tar.gz
 cp -r Loris-%VERSION%/ /var/www/loris
+chown -R lorisadmin /var/www/loris
+
 ```
 
 Alternatively the latest development branch can be obtained by forking the [LORIS repository](http://github.com/aces/Loris) for development purposes. We do not support unstable dev branches. 
@@ -108,27 +114,23 @@ Alternatively the latest development branch can be obtained by forking the [LORI
 
 A sample apache configuration file is in `docs/config/apache2-site`. 
 The install script will ask if you want to automatically create/install apache config files.
-It is recommended to perform this step **manually** --: copy our sample file to the apache configuration directory (`/etc/httpd/conf.d/`) and add the `.conf` file extension:
+It is recommended to perform this step **manually** --: copy our sample file to the apache configuration directory (`/etc/httpd/conf.d/`) and adjust the parameters according to your configuration:
 
 ```bash
 cd /var/www/loris
-cp docs/config/apache-site /etc/httpd/conf.d/apache-site.conf
+cp docs/config/apache2-site /etc/httpd/conf.d/loris.conf
 ```
 
 Customize and Verify your settings: 
-* Paths and settings in `/etc/httpd/conf.d/apache-site.conf` should be populated appropriately for your server. Replace placeholders such as `%LORISROOT%` with `/var/www/loris`, `%PROJECTNAME%` with `loris`, `%LOGDIRECTORY%` with `/var/log/httpd/loris-error.log`   
+ * Paths and settings in `/etc/httpd/conf.d/loris.conf` should be populated appropriately for your server. 
+   Replace placeholders such as:
 
- * DocumentRoot should point to `/var/www/loris/htdocs`  
- 
- * The `smarty/templates_c/` directory must be writable by Apache (e.g. by running: `sudo chgrp -R httpd   
-/var/www/loris/smarty/templates_c` and `sudo chmod 775 /var/www/loris/smarty/templates_c`).
-
-Create the Apache configuration `/etc/httpd/conf.d/loris.conf` for your LORIS environment. You can find an example in `loris/docs/config/apache2-site` for setup of `<VirtualHost>` in the loris.conf file you will create. Adjust the parameters according to your configuration.
 ```
 - %LORISROOT%    i.e. /var/www/loris
 - %PROJECTNAME%  i.e loris
 - %LOGDIRECTORY%  .i.e /var/log/httpd
 ```
+ * DocumentRoot should point to `/var/www/loris/htdocs`
 
 Finally, restart apache:
 ```bash

--- a/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
+++ b/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md
@@ -18,7 +18,7 @@ LORIS requires a LAMP stack in order to run, specifically:
 
 * MySQL 5.7 (or MariaDB 10.3) (or higher)  
 
-* PHP 7.3 (or higher)  
+* PHP 7.3 (or higher) - PHP 7.4 recommended
 
 Additionally, the following package manager are required to build LORIS:  
 
@@ -44,19 +44,19 @@ The following Ubuntu packages are required and should be installed using
 
 * software-properties-common  
 
-* php7.3-mysql  
+* php7.4-mysql  
 
-* php7.3-xml  
+* php7.4-xml  
 
-* php7.3-mbstring  
+* php7.4-mbstring  
 
-* php7.3-gd  
+* php7.4-gd  
 
-* php7.3-zip  
+* php7.4-zip  
 
-* php7.3-curl (for development instances only)  
+* php7.4-curl (for development instances only)  
 
-* libapache2-mod-php7.3  
+* libapache2-mod-php7.4  
 
 
 ## Getting the source code
@@ -154,7 +154,7 @@ cd /var/www/loris/tools/
 
 ## Configuring the database
 
-The install script will tell you to navigate to <loris-url>/installdb.php.
+Open your browser and go to: `<loris-url>/installdb.php`.
 
 MySQL (or MariaDB) must be installed and a root or admin-level MySQL user must
 be created before continuing. (This is not the same as a unix root credential.)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -115,7 +115,7 @@ echo ""
 
 mkdir -p ../smarty/templates_c
 # Setting 770 permissions for templates_c
-chmod 770 ../smarty/templates_c
+sudo chmod 770 ../smarty/templates_c
 
 # Detecting distribution
 if ! os_distro=$(hostnamectl 2>/dev/null)


### PR DESCRIPTION
Overall, the CentOS install works relatively well, except for some problems with permissions:
* sudo is required in the install.sh tool L118

Some typos were also found in the install README (loris/docs/config/apache-site instead of loris/docs/config/apache2-site), and steps added. 

Also updated the references of php7.3 to php7.4 across the documentation (Ubuntu/CentOS).

* Resolves #6703
* Resolves #6722
* Related to #4824
