### PR TITLE
[User accounts] Add password validation rule for user name

### DIFF
--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -9,6 +9,8 @@ namespace LORIS\my_preferences;
 class My_Preferences extends \NDB_Form
 {
     private const PASSWORD_ERROR_IS_EMAIL  = 'Your password cannot be your email.';
+    private const PASSWORD_ERROR_IS_USER   = 'Your password cannot be ' .
+                                        'your user name.';
     private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match.';
     private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are ' .
                                         'identical: please choose another one';
@@ -383,6 +385,11 @@ class My_Preferences extends \NDB_Form
 
         if ($values['Email'] === $plaintext) {
             $errors['Password_Group'] = self::PASSWORD_ERROR_IS_EMAIL;
+        }
+
+        // Make sure the user is not using their username as their password.
+        if ($this->identifier === $plaintext) {
+            $errors['Password_Group'] = self::PASSWORD_ERROR_IS_USER;
         }
 
         // Ensure that the password and confirm password fields match.

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -26,6 +26,8 @@ use \Psr\Http\Message\ResponseInterface;
 class Edit_User extends \NDB_Form
 {
     private const PASSWORD_ERROR_IS_EMAIL  = 'Your password cannot be your email.';
+    private const PASSWORD_ERROR_IS_USER   = 'Your password cannot be ' .
+                                        'your user name.';
     private const PASSWORD_ERROR_NO_MATCH  = 'The passwords do not match.';
     private const PASSWORD_ERROR_NO_CHANGE = 'New and old passwords are ' .
                                         'identical: please choose another one';
@@ -1094,6 +1096,16 @@ class Edit_User extends \NDB_Form
         ) {
             $errors['Password_Group'] = self::PASSWORD_ERROR_IS_EMAIL;
         }
+
+        // Make sure the user is not using their username as their password.
+        if ((isset($values['UserID'])
+            && $values['UserID'] === $values['Password_hash'])
+            || (!empty($this->identifier)
+            && $this->identifier === $values['Password_hash'])
+        ) {
+            $errors['Password_Group'] = self::PASSWORD_ERROR_IS_USER;
+        }
+
         if (!is_null($this->identifier)) {
             $pass = $DB->pselectOne(
                 "SELECT COALESCE(Password_hash) "


### PR DESCRIPTION
The PR adds a password validation rule for username.
Side note, I wonder if the use of COALESCE [here](https://github.com/aces/Loris/pull/6705/files#diff-324943431518887444da99607e70a4e4R1111) is necessary?

* Resolves #6699
* Related to #6615