### PR TITLE
[Documentation] Updating main README with new install markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
 ([CentOS Readme also available](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 
-Please consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
+Please consult the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 
 #### Heroku
 
@@ -40,7 +40,7 @@ These dependencies are subject to change so be sure to verify your version of My
 
 ### Install Steps
 
-Consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information.
+Consult the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md) for more information.
 
 1. Set up LINUX user and group lorisadmin and create LORIS base directory:
 
@@ -66,7 +66,7 @@ Download the latest release from the [releases page](https://github.com/aces/Lor
 
 3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
 
-For more information, please read the [Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install).
+For more information, please read the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md).
 
  ```bash
  cd /var/www/$projectname/tools

--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ If you use MySQL 8, please read [this link](https://www.php.net/manual/en/mysqli
 ## Community
 
 ### Get in touch
-For questions and troubleshooting guidance beyond what is covered in our GitHub Wiki, please subscribe to the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) and email us there. 
+For questions and troubleshooting guidance beyond what is covered in our documentation, please subscribe to the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) and email us there. 
 
-### GitHub Issues
+### Support and GitHub Issues
+For troubleshooting specific installation issues or errors, please see the [Installation troubleshooting guide](), and then contact us via the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev).
 For bug reporting and new feature requests, please search and report via our GitHub Issues. 
 Please include details such as the version of LORIS you're using as well as information
 such as the OS you're using, your PHP and Apache versions, etc.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 * Try the LORIS demo instance at https://demo.loris.ca.
 
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
-([CentOS Readme also available](/docs/CentOS-install.md)).
+([CentOS Readme also available](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 
 Please consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 
@@ -40,7 +40,6 @@ These dependencies are subject to change so be sure to verify your version of My
 
 ### Install Steps
 
-<<<<<<< HEAD
 Consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information.
 
 1. Set up LINUX user and group lorisadmin and create LORIS base directory:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
 ([CentOS Readme also available](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 
-Please consult the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
+Please consult the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md) for more information. These installation instructions and more LORIS documentation for developers can also be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 
 #### Heroku
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you use MySQL 8, please read [this link](https://www.php.net/manual/en/mysqli
 For questions and troubleshooting guidance beyond what is covered in our documentation, please subscribe to the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev) and email us there. 
 
 ### Support and GitHub Issues
-For troubleshooting specific installation issues or errors, please see the [Installation troubleshooting guide](), and then contact us via the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev).
+For troubleshooting specific installation issues or errors, please see the [Installation troubleshooting guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Troubleshooting.md), and then contact us via the [LORIS Developers mailing list](http://www.bic.mni.mcgill.ca/mailman/listinfo/loris-dev).
 For bug reporting and new feature requests, please search and report via our GitHub Issues. 
 Please include details such as the version of LORIS you're using as well as information
 such as the OS you're using, your PHP and Apache versions, etc.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
 ([CentOS Readme also available](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 
-Please consult the [LORIS Wiki Setup Guide](https://github.com/aces/Loris/wiki/Setup) notes on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.
+Please consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 
 #### Heroku
 
@@ -40,7 +40,7 @@ These dependencies are subject to change so be sure to verify your version of My
 
 ### Install Steps
 
-Consult the [LORIS Wiki](https://github.com/aces/Loris/wiki/Setup) page on this [Install process](https://github.com/aces/Loris/wiki/Installing-Loris) for more information.
+Consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information.
 
 1. Set up LINUX user and group lorisadmin and create LORIS base directory:
 
@@ -66,7 +66,7 @@ Download the latest release from the [releases page](https://github.com/aces/Lor
 
 3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
 
-For more information, please read the [Installing Loris wiki page](https://github.com/aces/Loris/wiki/Installing-Loris).
+For more information, please read the [Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install).
 
  ```bash
  cd /var/www/$projectname/tools

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
 ([CentOS Readme also available](/docs/CentOS-install.md)).
 
-Please consult the LORIS Installation Markdowns for [Ubuntu](/docs/Ubuntu-install.md) or [CentOS](/docs/CentOS-install.md) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
+Please consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 
 #### Heroku
 
@@ -40,7 +40,8 @@ These dependencies are subject to change so be sure to verify your version of My
 
 ### Install Steps
 
-Consult the LORIS Installation Markdowns for either [Ubuntu](/docs/Ubuntu-install.md) or [CentOS](/docs/CentOS-install.md) for more information.
+<<<<<<< HEAD
+Consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information.
 
 1. Set up LINUX user and group lorisadmin and create LORIS base directory:
 
@@ -66,7 +67,7 @@ Download the latest release from the [releases page](https://github.com/aces/Lor
 
 3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
 
-For more information, please read the Installation Markdowns for either [Ubuntu](/docs/Ubuntu-install.md) or [CentOS](/docs/CentOS-install.md).
+For more information, please read the [Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install).
 
  ```bash
  cd /var/www/$projectname/tools

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 * Try the LORIS demo instance at https://demo.loris.ca.
 
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
-([CentOS Readme also available](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
+([CentOS Readme also available](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
 
 Please consult the [Ubuntu Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/Ubuntu/README.md) or [CentOS Installation guide](docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ LORIS (Longitudinal Online Research and Imaging System) is a self-hosted web app
 * Try the LORIS demo instance at https://demo.loris.ca.
 
 This Readme covers installation of LORIS version <b>23</b> on <b>Ubuntu</b>.
-([CentOS Readme also available](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install/CentOS/README.md)).
+([CentOS Readme also available](/docs/CentOS-install.md)).
 
-Please consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
+Please consult the LORIS Installation Markdowns for [Ubuntu](/docs/Ubuntu-install.md) or [CentOS](/docs/CentOS-install.md) for more information. Installation instructions and further information about LORIS for developers can be found on the [LORIS ReadTheDocs website](https://acesloris.readthedocs.io/en/latest/).
 
 #### Heroku
 
@@ -40,7 +40,7 @@ These dependencies are subject to change so be sure to verify your version of My
 
 ### Install Steps
 
-Consult the [LORIS Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install) for more information.
+Consult the LORIS Installation Markdowns for either [Ubuntu](/docs/Ubuntu-install.md) or [CentOS](/docs/CentOS-install.md) for more information.
 
 1. Set up LINUX user and group lorisadmin and create LORIS base directory:
 
@@ -66,7 +66,7 @@ Download the latest release from the [releases page](https://github.com/aces/Lor
 
 3. Run installer script to install core code, and libraries. The script will prompt for information and so that it can create directories automatically.
 
-For more information, please read the [Installation Markdowns](/docs/wiki/00_SERVER_INSTALL_AND_CONFIGURATION/01_LORIS_Install).
+For more information, please read the Installation Markdowns for either [Ubuntu](/docs/Ubuntu-install.md) or [CentOS](/docs/CentOS-install.md).
 
  ```bash
  cd /var/www/$projectname/tools


### PR DESCRIPTION
## Brief summary of changes

The main LORIS README.md now points to the new install markdowns for the 23 release. The README also points to the ReadTheDocs URL. 

#### Link(s) to related issue(s)

* Resolves #6709