### PR TITLE
[module_manager] remove extra padding on selectelement for dynamictable

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -445,7 +445,7 @@ class SelectElement extends Component {
     // Add error message
     if (this.props.hasError || (this.props.required && this.props.value === '')) {
       errorMessage = <span>{this.props.errorMessage}</span>;
-      elementClass = 'row form-group has-error';
+      elementClass = elementClass + ' has-error';
     }
 
     let newOptions = {};
@@ -485,7 +485,7 @@ class SelectElement extends Component {
           {requiredHTML}
         </label>
       );
-      inputClass = this.props.noMargins ? '' : 'col-sm-9';
+      inputClass = 'col-sm-9';
     }
 
     return (

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -430,7 +430,7 @@ class SelectElement extends Component {
     let errorMessage = null;
     let emptyOptionHTML = null;
     let requiredHTML = null;
-    let elementClass = 'row form-group';
+    let elementClass = this.props.noMargins ? '' : 'row form-group';
 
     // Add required asterisk
     if (required) {
@@ -477,7 +477,7 @@ class SelectElement extends Component {
     // and retain formatting. If label prop is not provided at all, the input
     // element will take up the whole row.
     let label = null;
-    let inputClass = 'col-sm-12';
+    let inputClass = this.props.noMargins ? '' : 'col-sm-12';
     if (this.props.label && this.props.label != '') {
       label = (
         <label className="col-sm-3 control-label" htmlFor={this.props.label}>
@@ -485,11 +485,11 @@ class SelectElement extends Component {
           {requiredHTML}
         </label>
       );
-      inputClass = 'col-sm-9';
+      inputClass = this.props.noMargins ? '' : 'col-sm-9';
     }
 
     return (
-      <div className={this.props.dynamicTable ? '' : elementClass}>
+      <div className={elementClass}>
         {label}
         <div className={inputClass}>
           <select
@@ -528,7 +528,7 @@ SelectElement.propTypes = {
   hasError: PropTypes.bool,
   errorMessage: PropTypes.string,
   onUserInput: PropTypes.func,
-  dynamicTable: PropTypes.bool,
+  noMargins: PropTypes.bool,
 };
 
 SelectElement.defaultProps = {
@@ -546,7 +546,7 @@ SelectElement.defaultProps = {
   onUserInput: function() {
     console.warn('onUserInput() callback is not set');
   },
-  dynamicTable: false,
+  noMargins: false,
 };
 
 /**

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -489,7 +489,7 @@ class SelectElement extends Component {
     }
 
     return (
-      <div className={elementClass}>
+      <div className={this.props.dynamicTable ? '' : elementClass}>
         {label}
         <div className={inputClass}>
           <select
@@ -528,6 +528,7 @@ SelectElement.propTypes = {
   hasError: PropTypes.bool,
   errorMessage: PropTypes.string,
   onUserInput: PropTypes.func,
+  dynamicTable: PropTypes.bool,
 };
 
 SelectElement.defaultProps = {
@@ -545,6 +546,7 @@ SelectElement.defaultProps = {
   onUserInput: function() {
     console.warn('onUserInput() callback is not set');
   },
+  dynamicTable: false,
 };
 
 /**

--- a/modules/module_manager/jsx/modulemanager.js
+++ b/modules/module_manager/jsx/modulemanager.js
@@ -121,6 +121,7 @@ class ModuleManagerIndex extends Component {
               options={{'Y': 'Yes', 'N': 'No'}}
               value={cell}
               onUserInput={this.toggleActive}
+              dynamicTable={true}
             /></td>;
     }
     cell = this.mapColumn(column, cell);
@@ -164,7 +165,6 @@ class ModuleManagerIndex extends Component {
         fields={fields}
         getFormattedCell={this.formatColumn}
       />
-
     );
   }
 }

--- a/modules/module_manager/jsx/modulemanager.js
+++ b/modules/module_manager/jsx/modulemanager.js
@@ -121,7 +121,7 @@ class ModuleManagerIndex extends Component {
               options={{'Y': 'Yes', 'N': 'No'}}
               value={cell}
               onUserInput={this.toggleActive}
-              dynamicTable={true}
+              noMargins={true}
             /></td>;
     }
     cell = this.mapColumn(column, cell);


### PR DESCRIPTION
## Brief summary of changes

Resolves the unnecessary padding to SelectElement components used inside the DynamicTable component.

#### Testing instructions (if applicable)

1. Visit the module_manager module.
2. Observe the fix for the UI carousel scrollers.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
#6697