### PR TITLE
[module_manager] refresh menu bar after enabling/disabling modules

### DIFF
--- a/modules/module_manager/jsx/modulemanager.js
+++ b/modules/module_manager/jsx/modulemanager.js
@@ -76,7 +76,19 @@ class ModuleManagerIndex extends Component {
           } else {
               const success = this.setModuleDisplayStatus(id, value);
               if (success === true) {
-                  swal.fire('Success!', 'Updated ' + id + ' status!', 'success');
+                swal.fire({
+                  title: 'Success!',
+                  text: 'Updated ' + id + ' status!' +
+                    'To apply changes the interface must be reloaded. proceed ?',
+                  type: 'success',
+                  showCancelButton: true,
+                  confirmButtonText: 'Reload the page',
+                  cancelButtonText: 'Continue',
+                }).then((status) => {
+                  if (status.value) {
+                    window.location.href = this.props.BaseURL + '/module_manager';
+                  }
+                });
               } else {
                   // If we get here something went very wrong, because somehow
                   // a module was toggled that isn't in the table.


### PR DESCRIPTION
## Brief summary of changes

Allows the enabling/disabling modules directly from the frontend to allow an option of refreshing the page and specifically when the swal is shown for the user confirming the changes.

#### Testing instructions (if applicable)

1. Visit the module_manager
2. Change the active of a module
3. Test the refresh option or the continue option.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
#6698