### PR TITLE
[configuration] Add date_format as DataType in ConfigSettings

### DIFF
--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -42,8 +42,8 @@ INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType,
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'endYear', "End year for study recruitment or data collection", 1, 0, 'text', ID, 'End year', 6 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ageMin', 'Minimum candidate age in years (0+)', 1, 0, 'text', ID, 'Minimum candidate age', 7 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'ageMax', 'Maximum candidate age in years', 1, 0, 'text', ID, 'Maximum candidate age', 8 FROM ConfigSettings WHERE Name="study";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dobFormat', "Format of the Date of Birth", 1, 0, 'text', ID, 'DOB Format', 9 FROM ConfigSettings WHERE Name="study";
-INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dodFormat', 'Format of the Date of Death', 1, 0, 'text', ID, 'DOD Format', 10 FROM ConfigSettings WHERE Name="study";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dobFormat', "Format of the Date of Birth", 1, 0, 'date_format', ID, 'DOB Format', 9 FROM ConfigSettings WHERE Name="study";
+INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'dodFormat', 'Format of the Date of Death', 1, 0, 'date_format', ID, 'DOD Format', 10 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'useProband', "Enable for proband data collection", 1, 0, 'boolean', ID, 'Use proband', 11 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'useFamilyID', 'Enable if family members are recruited for the study', 1, 0, 'boolean', ID, 'Use family', 12 FROM ConfigSettings WHERE Name="study";
 INSERT INTO ConfigSettings (Name, Description, Visible, AllowMultiple, DataType, Parent, Label, OrderNumber) SELECT 'useExternalID', "Enable if data is used for blind data distribution, or from external data sources", 1, 0, 'boolean', ID, 'Use external ID', 13 FROM ConfigSettings WHERE Name="study";
@@ -182,8 +182,8 @@ INSERT INTO Config (ConfigID, Value) SELECT ID, "true" FROM ConfigSettings WHERE
 INSERT INTO Config (ConfigID, Value) SELECT ID, 0 FROM ConfigSettings WHERE Name="ImagingUploaderAutoLaunch";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "Modify this to your project's citation policy" FROM ConfigSettings WHERE Name="citation_policy";
 INSERT INTO Config (ConfigID, Value) SELECT ID, "" FROM ConfigSettings WHERE Name="CSPAdditionalHeaders";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "YMd" FROM ConfigSettings WHERE Name="dobFormat";
-INSERT INTO Config (ConfigID, Value) SELECT ID, "YMd"  FROM ConfigSettings WHERE Name="dodFormat";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "Ymd" FROM ConfigSettings WHERE Name="dobFormat";
+INSERT INTO Config (ConfigID, Value) SELECT ID, "Ymd"  FROM ConfigSettings WHERE Name="dodFormat";
 
 
 INSERT INTO Config (ConfigID, Value) SELECT ID, "/data/%PROJECTNAME%/data/" FROM ConfigSettings WHERE Name="imagePath";

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -8,7 +8,7 @@ CREATE TABLE `ConfigSettings` (
     `Description` varchar(255) DEFAULT NULL,
     `Visible` tinyint(1) DEFAULT '0',
     `AllowMultiple` tinyint(1) DEFAULT '0',
-    `DataType` ENUM('text', 'boolean', 'email', 'instrument', 'textarea', 'scan_type', 'lookup_center', 'path', 'web_path') DEFAULT NULL,
+    `DataType` ENUM(enum('text','boolean','email','instrument','textarea','scan_type','date_format','lookup_center','path','web_path') DEFAULT NULL,
     `Parent` int(11) DEFAULT NULL,
     `Label` varchar(255) DEFAULT NULL,
     `OrderNumber` int(11) DEFAULT NULL,

--- a/SQL/0000-00-03-ConfigTables.sql
+++ b/SQL/0000-00-03-ConfigTables.sql
@@ -8,7 +8,7 @@ CREATE TABLE `ConfigSettings` (
     `Description` varchar(255) DEFAULT NULL,
     `Visible` tinyint(1) DEFAULT '0',
     `AllowMultiple` tinyint(1) DEFAULT '0',
-    `DataType` ENUM(enum('text','boolean','email','instrument','textarea','scan_type','date_format','lookup_center','path','web_path') DEFAULT NULL,
+    `DataType` ENUM('text','boolean','email','instrument','textarea','scan_type','date_format','lookup_center','path','web_path') DEFAULT NULL,
     `Parent` int(11) DEFAULT NULL,
     `Label` varchar(255) DEFAULT NULL,
     `OrderNumber` int(11) DEFAULT NULL,

--- a/SQL/New_patches/2020_06_16_Add_Date_Format_to_ConfigSettings_DataType.sql
+++ b/SQL/New_patches/2020_06_16_Add_Date_Format_to_ConfigSettings_DataType.sql
@@ -1,0 +1,11 @@
+-- Add date_format option to DataType
+ALTER TABLE ConfigSettings
+	MODIFY COLUMN `DataType` enum('text','boolean','email','instrument','textarea','scan_type','date_format','lookup_center','path','web_path') DEFAULT NULL;
+
+-- Update DataType of dobFormat
+UPDATE ConfigSettings
+	SET DataType='date_format' WHERE Name='dobFormat';
+
+-- Update DataType of dodFormat
+UPDATE ConfigSettings
+	SET DataType='date_format' WHERE Name='dodFormat';

--- a/SQL/New_patches/2020_06_16_Add_Date_Format_to_ConfigSettings_DataType.sql
+++ b/SQL/New_patches/2020_06_16_Add_Date_Format_to_ConfigSettings_DataType.sql
@@ -9,3 +9,20 @@ UPDATE ConfigSettings
 -- Update DataType of dodFormat
 UPDATE ConfigSettings
 	SET DataType='date_format' WHERE Name='dodFormat';
+
+-- Convert old date casing combos to supported format
+UPDATE Config SET Value='Ymd' 
+	WHERE Value IN ('YMD', 'YMd', 'YmD', 'yMD', 'yMd', 'ymD', 'ymd') 
+	AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dobFormat');
+
+UPDATE Config SET Value='Ymd' 
+        WHERE Value IN ('YMD', 'YMd', 'YmD', 'yMD', 'yMd', 'ymD', 'ymd') 
+        AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dodFormat');
+
+UPDATE Config SET Value='Ym'
+	WHERE Value IN ('YM', 'ym', 'yM')
+	AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dobFormat');
+
+UPDATE Config SET Value='Ym'
+        WHERE Value IN ('YM', 'ym', 'yM')
+        AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dodFormat');

--- a/SQL/New_patches/2020_06_16_Add_Date_Format_to_ConfigSettings_DataType.sql
+++ b/SQL/New_patches/2020_06_16_Add_Date_Format_to_ConfigSettings_DataType.sql
@@ -12,17 +12,17 @@ UPDATE ConfigSettings
 
 -- Convert old date casing combos to supported format
 UPDATE Config SET Value='Ymd' 
-	WHERE Value IN ('YMD', 'YMd', 'YmD', 'yMD', 'yMd', 'ymD', 'ymd') 
+	WHERE LOWER(Value)='ymd'
 	AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dobFormat');
 
 UPDATE Config SET Value='Ymd' 
-        WHERE Value IN ('YMD', 'YMd', 'YmD', 'yMD', 'yMd', 'ymD', 'ymd') 
+        WHERE LOWER(Value)='ymd'
         AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dodFormat');
 
 UPDATE Config SET Value='Ym'
-	WHERE Value IN ('YM', 'ym', 'yM')
+	WHERE LOWER(Value)='ym'
 	AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dobFormat');
 
 UPDATE Config SET Value='Ym'
-        WHERE Value IN ('YM', 'ym', 'yM')
+        WHERE LOWER(Value)='ym'
         AND ConfigID=(SELECT ID FROM ConfigSettings WHERE Name='dodFormat');

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -578,7 +578,7 @@ function editCandidateDOD(\Database $db): void
     if (!empty($dod)) {
         $config    = \NDB_Config::singleton();
         $dodFormat = $config->getSetting('dodFormat');
-        if ($dobFormat === 'Ym') {
+        if ($dodFormat === 'Ym') {
             $strippedDate = $dod->format('Y-m-01');
         } else {
             $dodString = $dod->format('Y-m-d');

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -544,7 +544,7 @@ function editCandidateDOB(\Database $db): void
     if (!empty($dob)) {
         $config    = \NDB_Config::singleton();
         $dobFormat = $config->getSetting('dobFormat');
-        if ($dobFormat === 'YM' || $dobFormat === 'Ym') {
+        if ($dobFormat === 'Ym') {
             $strippedDate = date("Y-m", strtotime($dob))."-01";
         }
         $db->update(
@@ -578,7 +578,7 @@ function editCandidateDOD(\Database $db): void
     if (!empty($dod)) {
         $config    = \NDB_Config::singleton();
         $dodFormat = $config->getSetting('dodFormat');
-        if ($dodFormat === 'YM' || $dobFormat === 'Ym') {
+        if ($dobFormat === 'Ym') {
             $strippedDate = $dod->format('Y-m-01');
         } else {
             $dodString = $dod->format('Y-m-d');

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -544,7 +544,7 @@ function editCandidateDOB(\Database $db): void
     if (!empty($dob)) {
         $config    = \NDB_Config::singleton();
         $dobFormat = $config->getSetting('dobFormat');
-        if ($dobFormat === 'YM') {
+        if ($dobFormat === 'YM' || $dobFormat === 'Ym') {
             $strippedDate = date("Y-m", strtotime($dob))."-01";
         }
         $db->update(
@@ -578,7 +578,7 @@ function editCandidateDOD(\Database $db): void
     if (!empty($dod)) {
         $config    = \NDB_Config::singleton();
         $dodFormat = $config->getSetting('dodFormat');
-        if ($dodFormat === 'YM') {
+        if ($dodFormat === 'YM' || $dobFormat === 'Ym') {
             $strippedDate = $dod->format('Y-m-01');
         } else {
             $dodString = $dod->format('Y-m-d');

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -61,6 +61,12 @@ class Configuration extends \NDB_Form
             $scan_types[$val] = $val;
         }
 
+        $date_format = array(
+          ''    => '',
+          'Ymd' => 'Ymd',
+          'Ym'  => 'Ym'
+        );
+
         $instruments     = \Utility::getAllInstruments();
         $instruments[''] = '';
 
@@ -69,6 +75,7 @@ class Configuration extends \NDB_Form
         $this->tpl_data['instruments']     = $instruments;
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
         $this->tpl_data['scan_types']      = $scan_types;
+        $this->tpl_data['date_format']     = $date_format;        
         $this->tpl_data['lookup_center']   = [
             ''            => '',
             'PatientID'   => 'PatientID',

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -61,11 +61,11 @@ class Configuration extends \NDB_Form
             $scan_types[$val] = $val;
         }
 
-        $date_format = array(
-          ''    => '',
-          'Ymd' => 'Ymd',
-          'Ym'  => 'Ym'
-        );
+        $date_format = [
+            ''    => '',
+            'Ymd' => 'Ymd',
+            'Ym'  => 'Ym'
+        ];
 
         $instruments     = \Utility::getAllInstruments();
         $instruments[''] = '';
@@ -75,7 +75,7 @@ class Configuration extends \NDB_Form
         $this->tpl_data['instruments']     = $instruments;
         $this->tpl_data['sandbox']         = $config->getSetting("sandbox");
         $this->tpl_data['scan_types']      = $scan_types;
-        $this->tpl_data['date_format']     = $date_format;        
+        $this->tpl_data['date_format']     = $date_format;
         $this->tpl_data['lookup_center']   = [
             ''            => '',
             'PatientID'   => 'PatientID',

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -63,8 +63,8 @@ class Configuration extends \NDB_Form
 
         $date_format = [
             ''    => '',
-            'Ymd' => 'Ymd',
-            'Ym'  => 'Ym'
+            'Ymd' => 'Ymd (EX: 2015-12-28)',
+            'Ym'  => 'Ym (EX: 2015-12)'
         ];
 
         $instruments     = \Utility::getAllInstruments();

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -28,6 +28,14 @@
     </select>
 {/function}
 
+{function name=createDateFormat}
+    <select class="form-control" name="{$k}" {if $d eq "Yes"}disabled{/if}>
+        {foreach from=$date_format key=name item=label}
+            <option {if $v eq $name}selected{/if} value="{$name}">{$label}</option>
+        {/foreach}
+    </select>
+{/function}
+
 {function name=createLookUpCenterNameUsing}
     <select class="form-control" name="{$k}" {if $d eq "Yes"}disabled{/if}>
         {foreach from=$lookup_center key=name item=label}
@@ -80,6 +88,8 @@
             {call createInstrument k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'scan_type'}
             {call createScanType k=$k v=$v d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'date_format'}
+            {call createDateFormat k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'email'}
             {call createEmail k=$k v=$v d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}
@@ -106,6 +116,8 @@
             {call createInstrument k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'scan_type'}
             {call createScanType k=$id d=$node['Disabled']}
+        {elseif $node['DataType'] eq 'date_format'}
+            {call createDateFormat k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'email'}
             {call createEmail k=$id d=$node['Disabled']}
         {elseif $node['DataType'] eq 'textarea'}


### PR DESCRIPTION
## Brief summary of changes
Quick fix for candidate parameter tabs `Date of Birth` and `Date of Death`. Altering the DOB format or the DOD format fields in the configuration module to either `YM` or `Ym` should result in the dates in cand param being saved with `YYYY-MM-01` as the day of the month rather than whatever the user entered. 

**Edit:**
This PR now adds a new dataType to ConfigSettings: `date_format`. Fields such as DOB and DOD format will now have a dropdown in which users that select what format they prefer. This should also resolve the ambiguity in candidate parameters that is discussed in the thread below.

#### Testing instructions (if applicable)

1. See test plan steps 35 & 40

#### Link(s) to related issue(s)

* Resolves #6678
