### PR TITLE
Fix order of SQL in release upgrade patch

### DIFF
--- a/SQL/Release_patches/22.0_To_23.0_upgrade.sql
+++ b/SQL/Release_patches/22.0_To_23.0_upgrade.sql
@@ -41,36 +41,6 @@ INSERT INTO user_perm_rel
       (SELECT permID FROM permissions WHERE code='electrophysiology_browser_view_site')
     );
 
-SELECT 'Running: SQL/New_patches/2018-07-23-battery_manager_permissions.sql';
-
--- Add view permission for battery manager
-INSERT INTO permissions (code, description, categoryID)
-       VALUES (
-           'battery_manager_view',
-           'View Battery Manager',
-           (SELECT ID FROM permissions_category WHERE Description = 'Permission')
-       );
-
--- Add edit permission for battery manager
-INSERT INTO permissions (code, description, categoryID)
-       VALUES (
-           'battery_manager_edit',
-           'Add, activate, and deactivate entries in Test Battery',
-           (SELECT ID FROM permissions_category WHERE Description = 'Permission')
-       );
-
--- Give view permission to admin
-INSERT INTO user_perm_rel (userID, permID)
-SELECT ID, permID FROM users u JOIN permissions p
-WHERE UserID='admin' AND code = 'battery_manager_view';
-
--- Give edit permission to admin
-INSERT INTO user_perm_rel (userID, permID)
-SELECT ID, permID FROM users u JOIN permissions p
-WHERE UserID='admin' AND code = 'battery_manager_edit';
-
-INSERT INTO modules (Name, Active) VALUES ('battery_manager', 'Y');
-
 SELECT 'Running: SQL/New_patches/2019-02-08-multiple_mri_protocols.sql';
 
 -- ####################################################################################
@@ -478,3 +448,33 @@ AND EXISTS (
     AND pf.FileID = f.FileID
     AND pf.Value = mvl.Value
 );
+
+SELECT 'Running: SQL/New_patches/2018-07-23-battery_manager_permissions.sql';
+
+-- Add view permission for battery manager
+INSERT INTO permissions (code, description, categoryID)
+       VALUES (
+           'battery_manager_view',
+           'View Battery Manager',
+           (SELECT ID FROM permissions_category WHERE Description = 'Permission')
+       );
+
+-- Add edit permission for battery manager
+INSERT INTO permissions (code, description, categoryID)
+       VALUES (
+           'battery_manager_edit',
+           'Add, activate, and deactivate entries in Test Battery',
+           (SELECT ID FROM permissions_category WHERE Description = 'Permission')
+       );
+
+-- Give view permission to admin
+INSERT INTO user_perm_rel (userID, permID)
+SELECT ID, permID FROM users u JOIN permissions p
+WHERE UserID='admin' AND code = 'battery_manager_view';
+
+-- Give edit permission to admin
+INSERT INTO user_perm_rel (userID, permID)
+SELECT ID, permID FROM users u JOIN permissions p
+WHERE UserID='admin' AND code = 'battery_manager_edit';
+
+INSERT INTO modules (Name, Active) VALUES ('battery_manager', 'Y');


### PR DESCRIPTION
The modules table must be created before the battery_manager
attempts to insert into the module.

Resolves #6726