### PR TITLE
[Candidate List] Test plan update

### DIFF
--- a/modules/candidate_list/test/TestPlan.md
+++ b/modules/candidate_list/test/TestPlan.md
@@ -31,5 +31,5 @@
 Incorrect PSCID/DCCID combinations in the filter form should not give such an error.
 It should return that no results were found.
 16. Enter correct PSCID/DCCID combination and ensure that it loads correct timepoint_list page
-17. Remove access_all_profiles permission and ensure that PSCID links are not clickable.
+17. Remove access_all_profiles permission and ensure that PSCID links are clickable.
 18. Change useEDC config variable to _no_ from the Configuration Module and ensure filters are removed from menu.


### PR DESCRIPTION
Test plan update: 
PSCID links should be clickable in the search result table without the access_all_profiles permission.

* Resolves #6694
