### PR TITLE
[Candidate parameters] Titles cut off in Candidate Info

### DIFF
--- a/modules/candidate_profile/jsx/CandidateInfo.js
+++ b/modules/candidate_profile/jsx/CandidateInfo.js
@@ -166,7 +166,7 @@ export class CandidateInfo extends Component {
 
             return (
                 <div style={cardStyle} key={label}>
-                    <dt style={{whiteSpace: 'nowrap'}}>{label}</dt>
+                    <dt>{label}</dt>
                     <dd style={valueStyle}>{value}</dd>
                 </div>
             );


### PR DESCRIPTION
Additional fields can show up in the Candidate Info card in the Candidate Profile page, but those with long titles overlap and are not readable. Removing White-space:nowrap on the container solved the problem.

<img src="https://user-images.githubusercontent.com/32041423/84726505-02ad0680-af5b-11ea-9d3f-a921ea929f46.png" width="400" />

* Resolves #6679