### PR TITLE
[Core] Require correct types for lorisform->addSelect

### DIFF
--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -187,8 +187,12 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addSelect(string $name, string $label, array $options, array $attribs=array())
-    {
+    function addSelect(
+        string $name,
+        string $label,
+        array $options,
+        array $attribs=array()
+    ) {
         $attribs = array_merge(
             array('class' => 'form-control input-sm'),
             $attribs

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -187,7 +187,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @return void
      */
-    function addSelect($name, $label, $options, $attribs=array())
+    function addSelect(string $name, string $label, array $options, array $attribs=array())
     {
         $attribs = array_merge(
             array('class' => 'form-control input-sm'),


### PR DESCRIPTION
Since the type is currently only enforced by PHPDocs and not
PHP, incorrect types can be passed by addSelect. This enforces
the types from the PHP side of things.

(Currently when a string is passed instead of an array in some
instruments, the array_merge call generates a PHP warning which
breaks endpoints which use the instrument in a JSON context. This
change makes the invalid instruments die with a type error instead,
forcing them to be fixed.)