### PR TITLE
[Core] Fix warnings about continue in a switch being equivalent to a break

### DIFF
--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -166,7 +166,7 @@ foreach ($instruments AS $instrument) {
 
                 // Skip lines that contains only label or notes where bit[1] is empty.
                 if (empty($bits[1])) {
-                    continue;
+                    continue 2;
                 }
 
                 print "\tInserting $table $bits[1]\n";
@@ -175,7 +175,7 @@ foreach ($instruments AS $instrument) {
                 $Name = $table . "_" . $bits[1];
                 if (in_array($Name, $parameterNames, true)) {
                     // this specific table_field combination was already inserted, skip.
-                    continue;
+                    continue 2;
                 }
                 $parameterCount++;
                 $query_params = array(

--- a/tools/generate_tables_sql.php
+++ b/tools/generate_tables_sql.php
@@ -71,13 +71,12 @@ foreach($instruments AS $instrument){
             //no SQL need be generated.
             case "title":
             case "header":
-                continue;
-            break;
+                break;
 
             //generate specific column definitions for specific types of HTML elements
             default:
                 if((array_key_exists(1,$bits) ? $bits[1] : "") == "") {
-                    continue;
+                    continue 2;
                 }
                 if($bits[0]=="select"){
                     $bits[0]=enumizeOptions(

--- a/tools/generate_tables_sql_and_testNames.php
+++ b/tools/generate_tables_sql_and_testNames.php
@@ -52,19 +52,18 @@ foreach($instruments AS $instrument){
             break;
             case "page":
                 $pages[] = $bits[2];
-                continue;
+                break;
 
             //no SQL need be generated.
             case "title":
                 $title = $bits[1];
             case "header":
-                continue;
-            break;
+                break;
 
             //generate specific column definitions for specific types of HTML elements
             default:
                 if($bits[1] == "") {
-                    continue;
+                    continue 2;
                 }
                 if($bits[0]=="select"){
                     $bits[0]=enumizeOptions($bits[3], isset($tablename) ? $tablename : null, $bits[1]);
@@ -83,8 +82,8 @@ foreach($instruments AS $instrument){
                 $bits[2]=htmlspecialchars($bits[2]);
                 $output.="`$bits[1]` $bits[0] default NULL,\n";
         }
-
     }
+
     $output.="PRIMARY KEY  (`CommentID`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8;\n";
     print "Filename: $filename\n";
     $fp=fopen($filename, "w");


### PR DESCRIPTION
Fix warnings when running `make checkstatic`:

```
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/generate_tables_sql.php on line 74
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/generate_tables_sql.php on line 80
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/exporters/data_dictionary_builder.php on line 169
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/exporters/data_dictionary_builder.php on line 178
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/generate_tables_sql_and_testNames.php on line 55
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/generate_tables_sql_and_testNames.php on line 61
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in tools/generate_tables_sql_and_testNames.php on line 67
```

All the instances were in a switch that was the last thing in a loop, so breaking out of the switch or continuing the loop were equivalent, but I tried to update the code to be whichever seemed to be what the statement was semantically trying to do.