### PR TITLE
Add name of pre-GitHub contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ LORIS is made by staff developers at the [McGill Centre for Integrative Neurosci
 
 Visit [the LORIS website](https://loris.ca) for the history of LORIS and our **Technical Papers**.
 
-The original (pre-GitHub) LORIS development team from 1999-2010 included: Dario Vins, Alex Zijdenbos, Jonathan Harlap, Matt Charlet, Andrew Corderey, Sebastian Muehlboeck, and Samir Das.
+The original (pre-GitHub) LORIS development team from 1999-2010 included: Dario Vins, Alex Zijdenbos, Jonathan Harlap, Matt Charlet, Andrew Corderey, Sebastian Muehlboeck, James McKinney, and Samir Das.


### PR DESCRIPTION
For whatever reason I was reminiscing about the NIH MRI study of normal brain development this morning, and wondering what happened to that software project I contributed to in 2004. It was wonderful to see the great progress that has been made! I also see you recently corrected one of my stranger contributions of "There can only be one" #6416.

Anyway, I don't know if there is a logic to the order or inclusion of past contributor names, but I put myself before-last, as I find going last carries an extra "oomph" that Samir deserves :)