### PR TITLE
[SQL Cleanup Patch] Remove violated_scans_edit permission

### DIFF
--- a/SQL/0000-00-01-Permission.sql
+++ b/SQL/0000-00-01-Permission.sql
@@ -68,7 +68,6 @@ INSERT INTO `permissions` VALUES
     (17,'conflict_resolver','Resolving conflicts','2'),
     (18,'data_dict_view','View Data Dictionary (Parameter type descriptions)','2'),
     (19,'violated_scans_view_allsites','Violated Scans: View all-sites Violated Scans','2'),
-    (20,'violated_scans_edit','Violated Scans: Edit MRI protocol table','2'),
     (22,'config','Edit configuration settings','2'),
     (23,'imaging_browser_view_site','View own-site Imaging Browser pages','2'),
     (24,'imaging_browser_view_allsites', 'View all-sites Imaging Browser pages', '2'),

--- a/SQL/Cleanup_patches/2020-06-18-remove_violated_scans_edit_permission.sql
+++ b/SQL/Cleanup_patches/2020-06-18-remove_violated_scans_edit_permission.sql
@@ -1,0 +1,3 @@
+DELETE FROM user_perm_rel WHERE permID IN (SELECT permID from permissions where code='violated_scans_edit');
+
+DELETE FROM permissions where code='violated_scans_edit';

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -36,8 +36,6 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
      */
     function _hasAccess(\User $user) : bool
     {
-        $this->tpl_data['violated_scans_modifications']
-            = $user->hasPermission('violated_scans_edit');
         return $user->hasAnyPermission(
             array(
                 'violated_scans_view_allsites',

--- a/raisinbread/RB_files/RB_permissions.sql
+++ b/raisinbread/RB_files/RB_permissions.sql
@@ -20,7 +20,6 @@ INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (17,'conflict_resolver','Resolving conflicts',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (18,'data_dict_view','View Data Dictionary (Parameter type descriptions)',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (19,'violated_scans_view_allsites','Violated Scans: View all-sites Violated Scans',2);
-INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (20,'violated_scans_edit','Violated Scans: Edit MRI protocol table',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (22,'config','Edit configuration settings',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (23,'imaging_browser_view_site','View own-site Imaging Browser pages',2);
 INSERT INTO `permissions` (`permID`, `code`, `description`, `categoryID`) VALUES (24,'imaging_browser_view_allsites','View all-sites Imaging Browser pages',2);

--- a/raisinbread/RB_files/RB_user_perm_rel.sql
+++ b/raisinbread/RB_files/RB_user_perm_rel.sql
@@ -20,7 +20,6 @@ INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,16);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,17);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,18);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,19);
-INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,20);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,21);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,22);
 INSERT INTO `user_perm_rel` (`userID`, `permID`) VALUES (1,23);


### PR DESCRIPTION
A patch was created to Remove the unused permission `violated_scans_edit` from the database.

* Resolves #6723
