### PR TITLE
JSON data toolkit

### DIFF
--- a/php/libraries/JSONToolkit.class.inc
+++ b/php/libraries/JSONToolkit.class.inc
@@ -1,0 +1,481 @@
+<?php
+/**
+ * File implements the JSONToolkit class
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package  Behavioural
+ * @author   Camille Beaudoin <camille.beaudoin@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+namespace LORIS;
+
+/**
+ * JSON data toolkit class.
+ *
+ * This class provides a toolkit for accessing and manipulating
+ * JSON instrument data.
+ *
+ * PHP version 7
+ *
+ * @category Behavioural
+ * @package  Main
+ * @author   Camille Beaudoin <camille.beaudoin@mcin.ca>
+ * @license  GPLv3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
+ * @link     https://www.github.com/aces/Loris-Trunk/
+ */
+
+
+class JSONToolkit
+{
+    var $instrName;
+    var $flagData;
+    var $metadataFields = array(
+        'Date_taken',
+        'Examiner',
+        'Candidate_Age',
+        'Window_Difference'
+    );
+
+    /**
+     * JSONToolkit constructor.
+     *
+     * @param string $instrumentName Name of instrument whose data to manipulate
+     * @throws \LorisException
+     */
+    function __construct(string $instrumentName)
+    {
+        $db = \Database::singleton();
+
+        $checkInstrument = $db->pselect(
+            "SELECT Test_name FROM test_battery WHERE Test_name=:tbln",
+            array("tbln" => $instrumentName)
+        );
+        if (empty($checkInstrument)) {
+            throw new \Exception("The instrument ". $instrumentName . "was not found in the database.");
+        }
+
+        $queryData = $db->pselectWithIndexKey(
+            "SELECT CommentID, Data FROM flag WHERE Test_name =:tbln",
+            array("tbln" => $instrumentName),
+            'CommentID'
+        );
+
+        $this->instrName = $instrumentName;
+        $this->flagData = $queryData;
+    }
+
+    /**
+     * Select list of CommentIDs where a field has certain value
+     *
+     * @param array $conditionArray     The array of conditions to meet for selection
+     *                                  Given as field => value, checks if the value at field === value
+     * @return array                    List of commentIDs
+     */
+    public function selectCMIDs(array $conditionArray) : array
+    {
+        // Function specifying what to select
+        $fn = function(& $cmids, $cmid, $instrData) {
+            $cmids[] = $cmid;
+        };
+        return $this->genericSelect($conditionArray, $fn);
+    }
+
+    /**
+     * Select all data where a field has certain value
+     *
+     * @param array $conditionArray     Array of conditions to meet for selection
+     *                                  Given as field => value, checks if the value at field === value
+     * @return array                    Array of instrument data with CommentID as key
+     */
+    public function selectAll(array $conditionArray) : array
+    {
+        // Function specifying what to select
+        $fn = function(& $results, $cmid, $instrData) {
+            $results[$cmid] = $instrData;
+        };
+        return $this->genericSelect($conditionArray, $fn);
+    }
+
+    /**
+     * Select value of $selected when $field has $val
+     *
+     * @param string $selected          Name of field to return values of
+     * @param array $conditionArray     Array of conditions to meet for selection
+     *                                  Given as field => value, checks if the value at field === value
+     * @return array                    Array of values for $selected
+     *                                  CommentID as key
+     */
+    public function selectField(
+        string $selected,
+        array $conditionArray
+    ) : array {
+        // Function specifying what to select
+        $fn = function(& $results, $cmid, $instrData) use($selected) {
+            if(key_exists($selected, $instrData)) {
+                $results[$cmid] = $instrData[$selected];
+            }
+        };
+        return $this->genericSelect($conditionArray, $fn);
+    }
+
+    /**
+     * Generic method for selecting values that meet conditions
+     * Customization through function parameter
+     *
+     * @param array $conditionArray     Array of conditions to meet for selection
+     *                                  Given as field => value, checks if the value at field === value
+     * @param callable $fn              Function that specifies how the return array is constructed
+     *
+     * @return array                    Array of values that meet conditions, constructed by $fn
+     *                                  CommentID as key.
+     */
+    public function genericSelect(
+        array $conditionArray,
+        callable $fn
+    ) : array {
+        $results = array();
+        foreach ($this->flagData as $cmid => $data) {
+            if (is_null($data['Data'])) {
+                continue;
+            }
+
+            // array of instrument data
+            $instrData = json_decode($data['Data'], true);
+
+            // perform operation from anonymous function if conditions are met
+            if ($this->checkConditions($instrData, $conditionArray)) {
+                $fn($results, $cmid, $instrData);
+            }
+        }
+        return $results;
+    }
+
+    /**
+     * Renames field of instrument
+     *
+     * @param string $oldName   Name of field to rename
+     * @param string $newName   What the field will be renamed as
+     *
+     * @return int              Return number of fields altered
+     * @throws \DatabaseException
+     */
+    public function rename(
+        string $oldName,
+        string $newName
+    ) : int {
+        // Function specifying rename operation
+        $fn = function($instrData, $oldName) use($newName) {
+            // Make sure a field $newName does not already exist
+            if(!key_exists($newName, $instrData)) {
+                // rename field in array
+                $fieldNames = array_keys($instrData);
+                $fieldNames[array_search($oldName, $fieldNames)] = $newName;
+                $instrData = array_combine($fieldNames, $instrData);
+                return $instrData;
+            } else {
+                // return null if no change is made
+                return null;
+            }
+        };
+
+        return $this->genericOperation(
+            $oldName,
+            $fn
+        );
+    }
+
+    /**
+     * Drop field from instrument data
+     *
+     * @param string $field     Name of field to be dropped
+     *
+     * @return int              Return number of fields altered
+     * @throws \DatabaseException
+     */
+    public function drop(string $field) : int
+    {
+        // Function specifying drop operation
+        $fn = function($instrData, $field) {
+            unset($instrData[$field]);
+            return $instrData;
+        };
+        return $this->genericOperation($field, $fn);
+    }
+
+    /**
+     * Generic method for performing operations directly on flag table
+     * Customization through function parameter
+     *
+     * @param string $field A field to check for before performing operation
+     * @param callable $fn Function that specifies how the return array is constructed
+     *
+     * @return int              Number of fields altered
+     * @throws \DatabaseException
+     */
+    public function genericOperation(
+        string $field,
+        callable $fn
+    ) : int {
+
+        // Do not modify if metadata field
+        if($this->checkMetaData($field)) {
+            throw new \Exception("Modification of metadata field forbidden.");
+        }
+
+        $dataAltered = 0;
+
+        foreach ($this->flagData as $cmid => $data) {
+            // Continue if data is empty
+            if (is_null($data['Data'])) {
+                continue;
+            }
+
+            // Array of instrument data
+            $instrData = json_decode($data['Data'], true);
+
+            // Only operate if field exists
+            if (key_exists($field, $instrData)) {
+
+                // set instrument data using function parameter
+                $instrData = $fn($instrData, $field);
+
+                if (!isset($instrData)) {
+                    continue;
+                }
+
+                $instrument = \NDB_BVL_Instrument::factory($this->instrName, $cmid, '', true);
+
+                // Unset metadata fields for validation
+                $validationData = $instrData;
+                foreach ($this->metadataFields as $meta) {
+                    unset($validationData[$meta]);
+                }
+
+                // If valid, save values
+                if ($instrument->form->validate($validationData)) {
+                    // update values
+                    $newData = json_encode($instrData);
+
+                    // Update flagData variable
+                    $this->flagdata[$cmid]['Data'] = $newData;
+
+                    // Update database
+                    $db = \Database::singleton();
+                    $db->unsafeupdate(
+                        "flag",
+                        array("Data" => $newData),
+                        array("CommentID" => $cmid)
+                    );
+                    $dataAltered++;
+                    $instrument->score();
+                } else {
+                    throw new \Exception("Operation can not be performed due to a validation error for CommentID $cmid.");
+                }
+            }
+        }
+
+        if($dataAltered) {
+            $this->resetFlag();
+        }
+        return $dataAltered;
+    }
+
+    /**
+     * Alter value of a field
+     * (Alter value of $field to $newVal if the
+     * $conditionalField has value $conditionalValue)
+     *
+     * @param string $field             The name of field whos data will be changed.
+     * @param string $newVal            The value that the field will be changed to.
+     * @param array $conditionArray     The array of conditions to meet for modification
+     *                                  Given as field => value, checks if the value at field === value
+     *
+     * @return int                      Return number of fields altered
+     * @throws \DatabaseException
+     * @throws \LorisException
+     * @throws \NotFound
+     */
+    public function modify(
+        string $field,
+        string $newVal,
+        array $conditionArray
+    ) : int {
+        // Simple modification function, setting field to new value
+        $fn = function($value) use($newVal) {
+            return $newVal === 'null' ? null : $newVal;
+        };
+        return $this->customModify(
+            $fn,
+            $field,
+            $conditionArray
+        );
+    }
+
+    /**
+     * Alter value of a field using given operation
+     *
+     * @param callable $fn                  Function containing the operation to be done
+     *                                      on the specified field
+     * @param string $field                 The name of the field to modify
+     * @param array|null $conditionArray    The array of conditions to meet for modification
+     *                                      Given as field => value, checks if the value at field === value
+     *
+     * @return int                          Return number of fields altered
+     * @throws \DatabaseException
+     * @throws \LorisException
+     * @throws \NotFound
+     *
+     */
+    public function customModify(
+        callable $fn,
+        string $field,
+        ?array $conditionArray = null
+    ) : int {
+
+        // Do not modify if metadata field
+        if($this->checkMetaData($field)) {
+            throw new  \Exception("Modification of metadata field forbidden.");
+        }
+
+        $dataAltered = 0;
+        foreach ($this->flagData as $cmid => $data) {
+            // Continue if data is empty
+            if (is_null($data['Data'])) {
+                continue;
+            }
+
+            // Array of instrument data
+            $instrData = json_decode($data['Data'], true);
+
+            // Continue if field does not exist
+            if (!key_exists($field, $instrData)) {
+                continue;
+            }
+
+            // If conditions given, check if conditions are met
+            if (isset($conditionArray) && !$this->checkConditions($instrData, $conditionArray)) {
+                continue;
+            }
+
+            $oldVal = $instrData[$field];
+            $newVal = $fn($instrData[$field]);
+
+            // If field already has the new value, continue
+            if($newVal === $oldVal) {
+                continue;
+            }
+
+            // set new value
+            $instrData[$field] = $newVal;
+
+            $instrument = \NDB_BVL_Instrument::factory($this->instrName, $cmid, '', true);
+
+            // Unset metadata fields before validating
+            $validationData = $instrData;
+            foreach ($this->metadataFields as $meta) {
+                unset($validationData[$meta]);
+            }
+
+            // if validated, save values
+            if ($instrument->form->validate($validationData)) {
+                $instrument->_saveValues($instrData);
+                $dataAltered++;
+                $instrument->score();
+            } else {
+                throw new \Exception("Operation can not be performed due to a validation error for CommentID $cmid.");
+            }
+        }
+        // If any data was altered, reset the flag data variable
+        if($dataAltered) {
+            $this->resetFlag();
+        }
+        return $dataAltered;
+    }
+
+
+    /**
+     * Check if there is a status field in
+     * an instrument's data for a given fieldname
+     * (e.g. $field "name" given: search for "name_status")
+     *
+     * @param string $field     Name of the field to check for relative status field
+     *
+     * @return bool             Return true if status field found
+     */
+    public function checkStatusField(string $field) : bool
+    {
+        foreach ($this->flagData as $cmid => $data) {
+            if (is_null($data['Data'])) {
+                continue;
+            }
+
+            // Array of instrument data
+            $instrData = json_decode($data['Data'], true);
+
+            // Check for status field
+            if (isset($instrData[$field . "_status"])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether all conditions are met in an array of data
+     *
+     * @param array $data               The array of data to parse through for conditions
+     * @param array $conditionArray     The conditions to check for in the data
+     *                                  Given as field => value, checks if the value at field === value
+     *
+     * @return bool                     Return true if all conditions met
+     */
+    public function checkConditions(
+        array $data,
+        array $conditionArray
+    ) : bool {
+        $pass = true;
+
+        foreach($conditionArray as $field => $value) {
+            if (!key_exists($field, $data)) {
+                // if the field does not exist in the data, condition not met
+                $pass = false;
+            } elseif ($data[$field] != $value &&
+                !($value === 'null' && empty($data[$field]))
+            ) {
+                // if the value does not match the data value, condition not met
+                // including null option
+                $pass = false;
+            }
+        }
+        return $pass;
+    }
+
+    /**
+     * Checks whether the field passed is a metadata field
+     *
+     * @param string $field     The field to check
+     *
+     * @return bool             Return true if metadata field
+     */
+    public function checkMetaData(string $field) : bool
+    {
+        return in_array($field, $this->metadataFields);
+    }
+
+    /**
+     * Resets flagData variable with query to DB
+     */
+    public function resetFlag() : void
+    {
+        $db = \Database::singleton();
+        $queryData = $db->pselectWithIndexKey(
+            "SELECT CommentID, Data FROM flag WHERE Test_name =:tbln",
+            array("tbln" => $this->instrName),
+            'CommentID'
+        );
+        $this->flagData = $queryData;
+    }
+}

--- a/php/libraries/JSONToolkit.class.inc
+++ b/php/libraries/JSONToolkit.class.inc
@@ -32,12 +32,12 @@ class JSONToolkit
 {
     var $instrName;
     var $flagData;
-    var $metadataFields = array(
+    var $metadataFields = [
         'Date_taken',
         'Examiner',
         'Candidate_Age',
         'Window_Difference'
-    );
+    ];
 
     /**
      * JSONToolkit constructor.
@@ -52,7 +52,7 @@ class JSONToolkit
 
         $checkInstrument = $db->pselect(
             "SELECT Test_name FROM test_battery WHERE Test_name=:tbln",
-            array("tbln" => $instrumentName)
+            ["tbln" => $instrumentName]
         );
         if (empty($checkInstrument)) {
             throw new \Exception(
@@ -62,7 +62,7 @@ class JSONToolkit
 
         $queryData = $db->pselectWithIndexKey(
             "SELECT CommentID, Data FROM flag WHERE Test_name =:tbln",
-            array("tbln" => $instrumentName),
+            ["tbln" => $instrumentName],
             'CommentID'
         );
 
@@ -151,7 +151,7 @@ class JSONToolkit
         array $conditionArray,
         callable $fn
     ) : array {
-        $results = array();
+        $results = [];
         foreach ($this->flagData as $cmid => $data) {
             if (is_null($data['Data'])) {
                 continue;
@@ -287,8 +287,8 @@ class JSONToolkit
                     $db = \Database::singleton();
                     $db->unsafeupdate(
                         "flag",
-                        array("Data" => $newData),
-                        array("CommentID" => $cmid)
+                        ["Data" => $newData],
+                        ["CommentID" => $cmid]
                     );
                     $dataAltered++;
                     $instrument->score();
@@ -515,7 +515,7 @@ class JSONToolkit
         $db        = \Database::singleton();
         $queryData = $db->pselectWithIndexKey(
             "SELECT CommentID, Data FROM flag WHERE Test_name =:tbln",
-            array("tbln" => $this->instrName),
+            ["tbln" => $this->instrName],
             'CommentID'
         );
         $this->flagData = $queryData;

--- a/php/libraries/JSONToolkit.class.inc
+++ b/php/libraries/JSONToolkit.class.inc
@@ -43,6 +43,7 @@ class JSONToolkit
      * JSONToolkit constructor.
      *
      * @param string $instrumentName Name of instrument whose data to manipulate
+     *
      * @throws \LorisException
      */
     function __construct(string $instrumentName)
@@ -54,7 +55,9 @@ class JSONToolkit
             array("tbln" => $instrumentName)
         );
         if (empty($checkInstrument)) {
-            throw new \Exception("The instrument ". $instrumentName . "was not found in the database.");
+            throw new \Exception(
+                "The instrument $instrumentName was not found in the database."
+            );
         }
 
         $queryData = $db->pselectWithIndexKey(
@@ -64,20 +67,26 @@ class JSONToolkit
         );
 
         $this->instrName = $instrumentName;
-        $this->flagData = $queryData;
+        $this->flagData  = $queryData;
     }
 
     /**
      * Select list of CommentIDs where a field has certain value
      *
-     * @param array $conditionArray     The array of conditions to meet for selection
-     *                                  Given as field => value, checks if the value at field === value
-     * @return array                    List of commentIDs
+     * @param array $conditionArray The array of conditions to meet for selection
+     *                              Given as field => value, checks if the value
+     *                              at field === value
+     *
+     * @return array                 List of commentIDs
      */
     public function selectCMIDs(array $conditionArray) : array
     {
-        // Function specifying what to select
-        $fn = function(& $cmids, $cmid, $instrData) {
+        /*
+         * Function specifying what to select
+         *
+         * @SupressWarnings("unused")
+         */
+        $fn = function (& $cmids, $cmid, $instrData) {
             $cmids[] = $cmid;
         };
         return $this->genericSelect($conditionArray, $fn);
@@ -86,14 +95,16 @@ class JSONToolkit
     /**
      * Select all data where a field has certain value
      *
-     * @param array $conditionArray     Array of conditions to meet for selection
-     *                                  Given as field => value, checks if the value at field === value
-     * @return array                    Array of instrument data with CommentID as key
+     * @param array $conditionArray Array of conditions to meet for selection
+     *                              Given as field => value, checks if the
+     *                              value at field === value
+     *
+     * @return array                 Array of instrument data with CommentID as key
      */
     public function selectAll(array $conditionArray) : array
     {
         // Function specifying what to select
-        $fn = function(& $results, $cmid, $instrData) {
+        $fn = function (& $results, $cmid, $instrData) {
             $results[$cmid] = $instrData;
         };
         return $this->genericSelect($conditionArray, $fn);
@@ -102,19 +113,21 @@ class JSONToolkit
     /**
      * Select value of $selected when $field has $val
      *
-     * @param string $selected          Name of field to return values of
-     * @param array $conditionArray     Array of conditions to meet for selection
-     *                                  Given as field => value, checks if the value at field === value
-     * @return array                    Array of values for $selected
-     *                                  CommentID as key
+     * @param string $selected       Name of field to return values of
+     * @param array  $conditionArray Array of conditions to meet for selection
+     *                               Given as field => value, checks if the
+     *                               value at field === value
+     *
+     * @return array                  Array of values for $selected
+     *                                CommentID as key
      */
     public function selectField(
         string $selected,
         array $conditionArray
     ) : array {
         // Function specifying what to select
-        $fn = function(& $results, $cmid, $instrData) use($selected) {
-            if(key_exists($selected, $instrData)) {
+        $fn = function (& $results, $cmid, $instrData) use ($selected) {
+            if (key_exists($selected, $instrData)) {
                 $results[$cmid] = $instrData[$selected];
             }
         };
@@ -125,12 +138,14 @@ class JSONToolkit
      * Generic method for selecting values that meet conditions
      * Customization through function parameter
      *
-     * @param array $conditionArray     Array of conditions to meet for selection
-     *                                  Given as field => value, checks if the value at field === value
-     * @param callable $fn              Function that specifies how the return array is constructed
+     * @param array    $conditionArray Array of conditions to meet for selection
+     *                                 Given as field => value, checks if the
+     *                                 value at field === value
+     * @param callable $fn             Function that specifies how the return array
+     *                                 is constructed
      *
-     * @return array                    Array of values that meet conditions, constructed by $fn
-     *                                  CommentID as key.
+     * @return array                   Array of values that meet conditions,
+     *                                 constructed by $fn. CommentID as key.
      */
     public function genericSelect(
         array $conditionArray,
@@ -156,10 +171,10 @@ class JSONToolkit
     /**
      * Renames field of instrument
      *
-     * @param string $oldName   Name of field to rename
-     * @param string $newName   What the field will be renamed as
+     * @param string $oldName Name of field to rename
+     * @param string $newName What the field will be renamed as
      *
-     * @return int              Return number of fields altered
+     * @return int            Number of fields altered
      * @throws \DatabaseException
      */
     public function rename(
@@ -167,9 +182,9 @@ class JSONToolkit
         string $newName
     ) : int {
         // Function specifying rename operation
-        $fn = function($instrData, $oldName) use($newName) {
+        $fn = function ($instrData, $oldName) use ($newName) {
             // Make sure a field $newName does not already exist
-            if(!key_exists($newName, $instrData)) {
+            if (!key_exists($newName, $instrData)) {
                 // rename field in array
                 $fieldNames = array_keys($instrData);
                 $fieldNames[array_search($oldName, $fieldNames)] = $newName;
@@ -190,7 +205,7 @@ class JSONToolkit
     /**
      * Drop field from instrument data
      *
-     * @param string $field     Name of field to be dropped
+     * @param string $field Name of field to be dropped
      *
      * @return int              Return number of fields altered
      * @throws \DatabaseException
@@ -198,7 +213,7 @@ class JSONToolkit
     public function drop(string $field) : int
     {
         // Function specifying drop operation
-        $fn = function($instrData, $field) {
+        $fn = function ($instrData, $field) {
             unset($instrData[$field]);
             return $instrData;
         };
@@ -209,10 +224,11 @@ class JSONToolkit
      * Generic method for performing operations directly on flag table
      * Customization through function parameter
      *
-     * @param string $field A field to check for before performing operation
-     * @param callable $fn Function that specifies how the return array is constructed
+     * @param string   $field A field to check for before performing operation
+     * @param callable $fn    Function that specifies how the return array is
+     *                        constructed.
      *
-     * @return int              Number of fields altered
+     * @return int            Number of fields altered
      * @throws \DatabaseException
      */
     public function genericOperation(
@@ -221,7 +237,7 @@ class JSONToolkit
     ) : int {
 
         // Do not modify if metadata field
-        if($this->checkMetaData($field)) {
+        if ($this->checkMetaData($field)) {
             throw new \Exception("Modification of metadata field forbidden.");
         }
 
@@ -246,7 +262,12 @@ class JSONToolkit
                     continue;
                 }
 
-                $instrument = \NDB_BVL_Instrument::factory($this->instrName, $cmid, '', true);
+                $instrument = \NDB_BVL_Instrument::factory(
+                    $this->instrName,
+                    $cmid,
+                    '',
+                    true
+                );
 
                 // Unset metadata fields for validation
                 $validationData = $instrData;
@@ -272,12 +293,15 @@ class JSONToolkit
                     $dataAltered++;
                     $instrument->score();
                 } else {
-                    throw new \Exception("Operation can not be performed due to a validation error for CommentID $cmid.");
+                    throw new \Exception(
+                        "Operation can not be performed due to ".
+                        "a validation error for CommentID $cmid."
+                    );
                 }
             }
         }
 
-        if($dataAltered) {
+        if ($dataAltered) {
             $this->resetFlag();
         }
         return $dataAltered;
@@ -288,10 +312,11 @@ class JSONToolkit
      * (Alter value of $field to $newVal if the
      * $conditionalField has value $conditionalValue)
      *
-     * @param string $field             The name of field whos data will be changed.
-     * @param string $newVal            The value that the field will be changed to.
-     * @param array $conditionArray     The array of conditions to meet for modification
-     *                                  Given as field => value, checks if the value at field === value
+     * @param string $field          The name of field whos data will be changed.
+     * @param string $newVal         The value that the field will be changed to.
+     * @param array  $conditionArray The array of conditions to meet for modification
+     *                               Given as field => value, checks if the value at
+     *                               field === value
      *
      * @return int                      Return number of fields altered
      * @throws \DatabaseException
@@ -303,8 +328,12 @@ class JSONToolkit
         string $newVal,
         array $conditionArray
     ) : int {
-        // Simple modification function, setting field to new value
-        $fn = function($value) use($newVal) {
+        /*
+         * Simple modification function, setting field to new value
+         *
+         * @SupressWarnings("unused")
+         */
+        $fn = function ($value) use ($newVal) {
             return $newVal === 'null' ? null : $newVal;
         };
         return $this->customModify(
@@ -317,17 +346,17 @@ class JSONToolkit
     /**
      * Alter value of a field using given operation
      *
-     * @param callable $fn                  Function containing the operation to be done
-     *                                      on the specified field
-     * @param string $field                 The name of the field to modify
-     * @param array|null $conditionArray    The array of conditions to meet for modification
-     *                                      Given as field => value, checks if the value at field === value
+     * @param callable   $fn             Function containing the operation to be done
+     *                                   on the specified field
+     * @param string     $field          The name of the field to modify
+     * @param array|null $conditionArray The array of conditions to meet for
+     *                                   modification. Given as field => value,
+     *                                   checks if the value a field === value.
      *
      * @return int                          Return number of fields altered
      * @throws \DatabaseException
      * @throws \LorisException
      * @throws \NotFound
-     *
      */
     public function customModify(
         callable $fn,
@@ -336,7 +365,7 @@ class JSONToolkit
     ) : int {
 
         // Do not modify if metadata field
-        if($this->checkMetaData($field)) {
+        if ($this->checkMetaData($field)) {
             throw new  \Exception("Modification of metadata field forbidden.");
         }
 
@@ -356,7 +385,9 @@ class JSONToolkit
             }
 
             // If conditions given, check if conditions are met
-            if (isset($conditionArray) && !$this->checkConditions($instrData, $conditionArray)) {
+            if (isset($conditionArray)
+                && !$this->checkConditions($instrData, $conditionArray)
+            ) {
                 continue;
             }
 
@@ -364,14 +395,19 @@ class JSONToolkit
             $newVal = $fn($instrData[$field]);
 
             // If field already has the new value, continue
-            if($newVal === $oldVal) {
+            if ($newVal === $oldVal) {
                 continue;
             }
 
             // set new value
             $instrData[$field] = $newVal;
 
-            $instrument = \NDB_BVL_Instrument::factory($this->instrName, $cmid, '', true);
+            $instrument = \NDB_BVL_Instrument::factory(
+                $this->instrName,
+                $cmid,
+                '',
+                true
+            );
 
             // Unset metadata fields before validating
             $validationData = $instrData;
@@ -385,11 +421,14 @@ class JSONToolkit
                 $dataAltered++;
                 $instrument->score();
             } else {
-                throw new \Exception("Operation can not be performed due to a validation error for CommentID $cmid.");
+                throw new \Exception(
+                    "Operation can not be performed due to a ".
+                    "validation error for CommentID $cmid."
+                );
             }
         }
         // If any data was altered, reset the flag data variable
-        if($dataAltered) {
+        if ($dataAltered) {
             $this->resetFlag();
         }
         return $dataAltered;
@@ -401,7 +440,7 @@ class JSONToolkit
      * an instrument's data for a given fieldname
      * (e.g. $field "name" given: search for "name_status")
      *
-     * @param string $field     Name of the field to check for relative status field
+     * @param string $field Name of the field to check for relative status field
      *
      * @return bool             Return true if status field found
      */
@@ -426,9 +465,10 @@ class JSONToolkit
     /**
      * Checks whether all conditions are met in an array of data
      *
-     * @param array $data               The array of data to parse through for conditions
-     * @param array $conditionArray     The conditions to check for in the data
-     *                                  Given as field => value, checks if the value at field === value
+     * @param array $data           The array of data to parse through for conditions
+     * @param array $conditionArray The conditions to check for in the data
+     *                              Given as field => value, checks if the
+     *                              value at field === value
      *
      * @return bool                     Return true if all conditions met
      */
@@ -438,12 +478,12 @@ class JSONToolkit
     ) : bool {
         $pass = true;
 
-        foreach($conditionArray as $field => $value) {
+        foreach ($conditionArray as $field => $value) {
             if (!key_exists($field, $data)) {
                 // if the field does not exist in the data, condition not met
                 $pass = false;
-            } elseif ($data[$field] != $value &&
-                !($value === 'null' && empty($data[$field]))
+            } elseif ($data[$field] != $value
+                && !($value === 'null' && empty($data[$field]))
             ) {
                 // if the value does not match the data value, condition not met
                 // including null option
@@ -456,7 +496,7 @@ class JSONToolkit
     /**
      * Checks whether the field passed is a metadata field
      *
-     * @param string $field     The field to check
+     * @param string $field The field to check
      *
      * @return bool             Return true if metadata field
      */
@@ -467,10 +507,12 @@ class JSONToolkit
 
     /**
      * Resets flagData variable with query to DB
+     *
+     * @return void
      */
     public function resetFlag() : void
     {
-        $db = \Database::singleton();
+        $db        = \Database::singleton();
         $queryData = $db->pselectWithIndexKey(
             "SELECT CommentID, Data FROM flag WHERE Test_name =:tbln",
             array("tbln" => $this->instrName),

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1202,8 +1202,8 @@ class LorisForm
             }
             $values = $this->getSubmitValues();
         }
-
         $errors = [];
+
         foreach ($this->form as $elName => $el) {
             if ($el['type'] === 'group') {
                 if (isset($el['required'])) {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1187,13 +1187,13 @@ class LorisForm
     /**
      * Reimplements the HTML_QuickForm validate API.
      *
-     * @param array|null $values    Optional array of values to validate
+     * @param array|null $vals Optional array of values to validate
      *
      * @return bool true if all registered rules passed
      */
     function validate(?array $vals = null)
     {
-        if(isset($vals)) {
+        if (isset($vals)) {
             $this->setDefaults($vals);
             $values = $vals;
         } else {

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1187,14 +1187,22 @@ class LorisForm
     /**
      * Reimplements the HTML_QuickForm validate API.
      *
+     * @param array|null $values    Optional array of values to validate
+     *
      * @return bool true if all registered rules passed
      */
-    function validate()
+    function validate(?array $vals = null)
     {
-        if (!$this->isSubmitted()) {
-            return false;
+        if(isset($vals)) {
+            $this->setDefaults($vals);
+            $values = $vals;
+        } else {
+            if (!$this->isSubmitted()) {
+                return false;
+            }
+            $values = $this->getSubmitValues();
         }
-        $values = $this->getSubmitValues();
+
         $errors = [];
         foreach ($this->form as $elName => $el) {
             if ($el['type'] === 'group') {

--- a/tools/JSON_data.php
+++ b/tools/JSON_data.php
@@ -1,0 +1,363 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Tools for viewing and manipulating instrument JSON data
+ *
+ * PHP version 7
+ *
+ * @category Main
+ * @package  Loris
+ * @author   Camille Beaudoin  <camille.beaudoin@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+require_once __DIR__ . "/../vendor/autoload.php";
+require_once "generic_includes.php";
+require_once "JSONToolkit.class.inc";
+
+use LORIS\JSONToolkit;
+
+// Help message
+if(count($argv) <  3 || $argv[1] === 'help') {
+    showHelp();
+}
+
+// Get test name from argument
+$test_name = $argv[1];
+if (!is_file(__DIR__."/../project/instruments/NDB_BVL_Instrument_$test_name.class.inc")
+    && !is_file(__DIR__."/../project/instruments/$test_name.linst")) {
+    throw new Exception(
+        "Included file does not exist (".__DIR__."/../project/instruments/NDB_BVL_Instrument_$test_name.class.inc)"
+    );
+}
+
+$action = strtolower($argv[2]);
+
+// instantiate toolkit
+$toolkit = new JSONToolkit($test_name);
+
+switch ($action) {
+    case 'select':
+        if (count($argv) !== 5) {
+            showHelp();
+        }
+        $field = $argv[3];
+        $val = $argv[4];
+
+        $conditions = array($field => $val);
+        // Execute action, set array of commentIDs
+        $cmids = $toolkit->selectCMIDs($conditions);
+        print_r("\n#########################################################\n");
+        print_r("The following is a list of CommentIDs where the field\n".
+            "$field has the value $val in the instrument $test_name:\n");
+        print_r("#########################################################\n");
+        print_r($cmids);
+        break;
+
+    case 'selectall':
+        if (count($argv) !== 5) {
+            showHelp();
+        }
+        $field = $argv[3];
+        $val = $argv[4];
+
+        $conditions = array($field => $val);
+
+        // Perform action, set results array
+        $results = $toolkit->selectAll($conditions);
+        print_r("\n#########################################################\n");
+        print_r("The following is a list of CommentIDs and full data\n".
+            "where the field $field has the value $val \n".
+            "in the instrument $test_name:\n");
+        print_r("#########################################################\n");
+        print_r($results);
+        break;
+
+    case 'selectfield':
+        if (count($argv) !== 6) {
+            showHelp();
+        }
+        $selected = $argv[3];
+        $field = $argv[4];
+        $val = $argv[5];
+
+        $conditions = array($field => $val);
+
+        // Perform action, set results array
+        $results = $toolkit->selectField($selected, $conditions);
+        print_r("\n#########################################################\n");
+        print_r("The following is a list of CommentIDs and values for \n".
+            "field $selected where the field $field has the value \n".
+            "$val in the instrument $test_name:\n");
+        print_r("#########################################################\n");
+
+        print_r($results);
+        break;
+
+    case 'rename':
+        if (count($argv) != 5) {
+            showHelp();
+        }
+        $oldName = $argv[3];
+        $newName = $argv[4];
+
+        // Do not rename if metadata field
+        if($toolkit->checkMetaData($oldName) || $toolkit->checkMetaData($newName)) {
+            metaDataMessage();
+        }
+
+        // Execute command & get number of changes
+        $fieldsChanged = $toolkit->rename($oldName, $newName);
+        if($fieldsChanged) {
+            print_r("\n#########################################################\n");
+            print_r("The command was performed with $fieldsChanged changes made.\n");
+            print_r("#########################################################\n");
+        } else {
+            print_r("\n#########################################################\n");
+            print_r("No changes were made in the database. The field $oldName may not \n".
+                "exist or there may already be a field named $newName \n");
+            print_r("#########################################################\n");
+
+        }
+
+        // Check for status field
+        if($toolkit->checkStatusField($oldName)) {
+            print_r("*** A status field " . $oldName . "_status has been detected. ***\n");
+        }
+        break;
+
+    case 'drop':
+        if (count($argv) != 4) {
+            showHelp();
+        }
+
+        $field = $argv[3];
+
+        // Do not drop if metadata field
+        if($toolkit->checkMetaData($field)) {
+            metaDataMessage();
+        }
+
+        // Execute command & get number of changes
+        $fieldsChanged = $toolkit->drop($field);
+        if($fieldsChanged) {
+            print_r("\n#########################################################\n");
+            print_r("The command was performed with $fieldsChanged changes made.\n");
+            print_r("#########################################################\n");
+        } else {
+            print_r("\n#########################################################\n");
+            print_r("No changes were made in the database. The field $field was not found.\n");
+            print_r("#########################################################\n");
+        }
+
+        // Check for status field
+        if($toolkit->checkStatusField($field)) {
+            print_r("*** A status field " . $field . "_status has been detected. ***\n");
+        }
+        break;
+
+    case 'modify':
+        if (count($argv) !== 7) {
+            showHelp();
+        }
+
+        $field = $argv[3];
+        $newVal = $argv[4];
+        $conditionalField = $argv[5];
+        $conditionalVal = $argv[6];
+
+        // Do not modify if metadata field
+        if($toolkit->checkMetaData($field)) {
+            metaDataMessage();
+        }
+
+        $conditions = array($conditionalField => $conditionalVal);
+
+        // Execute command & get number of fields changed
+        $fieldsChanged = $toolkit->modify(
+            $field,
+            $newVal,
+            $conditions
+        );
+
+        if($fieldsChanged) {
+            print_r("\n#########################################################\n");
+            print_r("The command was performed with $fieldsChanged changes made.\n");
+            print_r("#########################################################\n");
+        } else {
+            print_r("\n#########################################################\n");
+            print_r("No changes were made in the database. Possible reasons include field \n".
+                "$field and/or $conditionalField do not exist, the field $conditionalField \n".
+                "never has the value $conditionalVal, or the field $field already has the value $newVal\n");
+            print_r("#########################################################\n");
+
+        }
+
+        // Check for status field
+        if($toolkit->checkStatusField($field)) {
+            print_r("*** A status field $field" . "_status has been detected. ***\n");
+        }
+        break;
+
+    case 'custommodify':
+        if (count($argv) < 6 || count($argv) > 8) {
+            showHelp();
+        }
+
+        $field = $argv[3];
+        $operation = $argv[4];
+        $opVal = $argv[5];
+        $fn;
+
+        // Do not modify if metadata field
+        if($toolkit->checkMetaData($field)) {
+            metaDataMessage();
+        }
+
+        // Set anonymous function
+        if ($operation === 'add') {
+            $fn = function ($val) use($opVal) {
+                // if value is null don't alter
+                if (!isset($val)) {
+                    return $val;
+                }
+                if (!is_numeric($val) || !is_numeric($opVal)) {
+                    throw new Exception("Non-numeric value given for addition operation");
+                }
+                return $val + $opVal;
+            };
+
+        } elseif ($operation === 'multiply') {
+            $fn = function ($val) use($opVal) {
+                // if value is null don't alter
+                if (!isset($val)) {
+                    return $val;
+                }
+                if (!is_numeric($val) || !is_numeric($opVal)) {
+                    throw new Exception("Non-numeric value given for multiplication operation");
+                }
+                return $val * $opVal;
+            };
+
+        } elseif ($operation === 'divide') {
+            $fn = function ($val) use($opVal) {
+                // if value is null don't alter
+                if (!isset($val)) {
+                    return $val;
+                }
+                if (!is_numeric($val) || !is_numeric($opVal)) {
+                    throw new Exception("Non-numeric value given for division operation");
+                }
+                return $val / $opVal;
+            };
+
+        } elseif ($operation === 'concat') {
+            $fn = function ($val) use($opVal) {
+                return $val . $opVal;
+            };
+
+        } else {
+            showHelp();
+        }
+
+        // if conditional values are set, include as parameters
+        // Otherwise, do not
+        if(isset($argv[6]) && isset($argv[7])) {
+            $conditionalField = $argv[6];
+            $conditionalVal = $argv[7];
+            $conditions = array($conditionalField => $conditionalVal);
+
+            // Execute action and get number of changes
+            $fieldsChanged = $toolkit->customModify(
+                $fn,
+                $field,
+                $conditions
+            );
+
+        } else {
+            // Execute action and get number of changes
+            $fieldsChanged = $toolkit->customModify(
+                $fn,
+                $field
+            );
+        }
+        // Print how many changes made (if any)
+        if($fieldsChanged) {
+            print_r("\n#########################################################\n");
+            print_r("The command was performed with $fieldsChanged changes made.\n");
+            print_r("#########################################################\n");
+
+        } else {
+            print_r("\n#########################################################\n");
+            print_r("No changes were made in the database. \n");
+            print_r("#########################################################\n");
+        }
+
+        // check for status field
+        if($toolkit->checkStatusField($field)) {
+            print_r("*** A status field  $field"."_status has been detected. ***\n");
+        }
+        break;
+
+    default:
+        print_r("\n#########################################################\n");
+        print_r("Action $action not recognized.\n");
+        print_r("#########################################################\n");
+        showHelp();
+}
+
+/*
+ * Prints the usage and example help text and stop program
+ */
+function showHelp()
+{
+
+    echo <<<USAGE
+*** Usage Info ***
+
+php JSON_data.php [instrument] [action] [parameters]
+php JSON_data.php help
+
+ACTIONS
+Select:         php JSON_data.php [tbl] select [field] [value]
+                -   Select CommentIDs for instrument [tbl] where [field] has value [value]
+SelectAll:      php JSON_data.php [tbl] selectAll [field] [value]
+                -   Select full data for instrument [tbl] where [conField] has value [value]
+SelectField:    php JSON_data.php [tbl] select [field] [conField] [value]
+                -   Select CommentIDs and the value of [field] for instrument [tbl] where 
+                    [conField] has value [value]                    
+Rename:         php JSON_data.php [tbl] rename [oldName] [newName]
+                -   Rename the field [oldName] to [newName] in instrument [tbl]
+                
+Drop:           php JSON_data.php [tbl] drop [field]
+                -   Drop [field] for instrument [instr]. NOTE: data will be lost for this field
+                
+Modify:         php JSON_data.php [tbl] modify [field] [newVal] [conField] [conVal] 
+                -   Set [field] to [newVal] where [conField] has value [conVal] for instrument [tbl]
+                
+customModify:   php JSON_data.php [tbl] customModify [field] [operation] [opVal]
+                -   Perform [operation]* with value [opVal] on [field] in instrument [tbl]
+                
+                php JSON_data.php [tbl] customModify [field] [operation] [opVal] [conField] [conVal]
+                -   Perform [operation]* with value [opVal] on [field] in instrument [tbl] 
+                    when [conField] has value [conVal]
+                    
+                * [operation] may be one of the following:
+                    add         Add [opVal] to field
+                    multiply    Multiple field by [opVal]
+                    divide      Divide field by [opVal]
+                    concat      Concatenate field with [opVal]
+
+USAGE;
+    die();
+}
+
+function metaDataMessage() {
+    print_r("#########################################################\n");
+    print_r("Can not alter metadata values:\n");
+    print_r("Date_taken \nExaminer \nCandidate_Age \nWindow_Difference\n");
+    print_r("#########################################################\n");
+    die();
+}
+?>


### PR DESCRIPTION
This PR creates a toolkit for manipulating and interacting with instrument JSON data, intended for future instruments that will not have their own SQL tables. 
Operations include:
- Renaming fields
- Dropping fields
- Selecting specified data
- Modifying fields

This includes a library with functions to interact with the instrument data as well as a tools script to perform operations directly.

Needs work:
- functionality blocked until issue #6746 is solved as it prevents saving for modification of instruments that have a Data_entry_completion_status field in the flag data
- Score check not working
- PHP notices printed from validation check (although the validation check does seem to be functional)