### PR TITLE
[eslint] Fix prefer-rest-params warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
     }],
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
-    "prefer-rest-params": "warn",
+    "prefer-rest-params": "error",
     "array-callback-return": 0,
     "require-jsdoc": "warn",
     "no-implicit-globals": 0,

--- a/htdocs/js/loris.js
+++ b/htdocs/js/loris.js
@@ -4,10 +4,10 @@ let LorisHelper = function(configParams, userPerms, studyParams) {
   'use strict';
   let lorisObj = configParams;
 
-    // Filters will only get applied on a POST, so
-    // on click we need to fake a form which posts
-    // to the module in order to get filters applied
-    // when there's a link to a filtered menu
+  // Filters will only get applied on a POST, so
+  // on click we need to fake a form which posts
+  // to the module in order to get filters applied
+  // when there's a link to a filtered menu
   lorisObj.loadFilteredMenuClickHandler = function(module, filters) {
     return function(e) {
       e.preventDefault();
@@ -30,6 +30,7 @@ let LorisHelper = function(configParams, userPerms, studyParams) {
       form.appendTo('body').submit();
     };
   };
+
   lorisObj.getCookie = function(cName) {
     'use strict';
     let cookies = document.cookie.split('; ');
@@ -44,6 +45,7 @@ let LorisHelper = function(configParams, userPerms, studyParams) {
     }
     return undefined;
   };
+
   lorisObj.userHasPermission = function(permname) {
     'use strict';
     if (userPerms.indexOf(permname) >= 0 ||
@@ -56,9 +58,8 @@ let LorisHelper = function(configParams, userPerms, studyParams) {
 
   lorisObj.debounce = function(fn, delay) {
     let timer = null;
-    return function() {
-      let context = this;
-      let args = arguments;
+    return function(...args) {
+      const context = this;
       clearTimeout(timer);
       timer = setTimeout(function() {
         fn.apply(context, args);
@@ -66,10 +67,11 @@ let LorisHelper = function(configParams, userPerms, studyParams) {
     };
   };
 
-    // Returns config settings from whitelist passed in main.php (study options)
+  // Returns config settings from whitelist passed in main.php (study options)
   lorisObj.config = function(param) {
     'use strict';
     return studyParams[param];
   };
+
   return lorisObj;
 };


### PR DESCRIPTION
This PR:
* resolves all eslint prefer-rest-params warnings
* raises prefer-rest-params severity to error

## To test
### Step 1
```
rm -R nodes_modules/
npm install
```

### Step 2
```
make checkstatic
```
No warnings `Use the rest parameters instead of 'arguments'  prefer-rest-params` should be printed.

### Step 3
```
git checkout master htdocs/js/loris.js
make checkstatic
```
An error `Use the rest parameters instead of 'arguments'  prefer-rest-params` should be printed.

* resolves #6750 (partially)