### PR TITLE
[Test] unittests for User.class.inc, UserPermissions.class.inc

### DIFF
--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -836,14 +836,6 @@ class UserTest extends TestCase
             "examiners_psc_rel",
             $this->_eprInfo
         );
-        $this->_dbMock->setFakeTableData(
-            "permissions",
-            $this->_permissionsInfo
-        );
-        $this->_dbMock->setFakeTableData(
-            "user_perm_rel",
-            $this->_upermInfo
-        );
     }
 }
 


### PR DESCRIPTION
## Brief summary of changes

Unit tests for the User and UserPermissions libraries under `php/libraries`. This PR completes the coverage of these two libraries.

**Note:** The functions `getSiteNames` and `getCenterID` are deprecated and are not covered.

**TODO:**

- [x] Test for `hasCenterPermission`

#### Testing instructions (if applicable)

Run `npm run tests:unit -- --filter UserTest` or check out the Travis output.

