### PR TITLE
[Tests] Integration tests Fix

### DIFF
--- a/test/dockerized-integration-tests.sh
+++ b/test/dockerized-integration-tests.sh
@@ -9,4 +9,5 @@ else
 fi
 
 # Core integration tests
-docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml
+docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisCoreIntegrationTests $*
+docker-compose run -T -e HEADLESS=true --rm ${CONTAINER} vendor/bin/phpunit --configuration test/phpunit.xml --testsuite LorisModuleIntegrationTests $*


### PR DESCRIPTION
Fix a regression introduced in #5635 which prevents integration tests to be run with `npm run tests:integration`

* Resolves #6781
