### PR TITLE
[MRI Violations] Tabs Navigation Fix

### DIFF
--- a/modules/mri_violations/php/mri_protocol_check_violations.class.inc
+++ b/modules/mri_violations/php/mri_protocol_check_violations.class.inc
@@ -70,10 +70,10 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
             implode(',', $siteClauseElements)
         );
 
-        $this->query    = " FROM mri_violations_log l 
+        $this->query    = " FROM mri_violations_log l
             LEFT JOIN mri_scan_type m
-            ON m.ID=l.Scan_type 
-            LEFT JOIN mri_protocol_checks_group mpcg 
+            ON m.ID=l.Scan_type
+            LEFT JOIN mri_protocol_checks_group mpcg
             ON (mpcg.MriProtocolChecksGroupID = l.MriProtocolChecksGroupID)
             LEFT JOIN candidate c ON (l.CandID=c.CandID)
             LEFT JOIN session s ON (
@@ -173,7 +173,6 @@ class Mri_Protocol_Check_Violations extends \NDB_Menu_Filter
                 "maxlength" => 64,
             ]
         );
-
     }
 
 

--- a/modules/mri_violations/php/resolved_violations.class.inc
+++ b/modules/mri_violations/php/resolved_violations.class.inc
@@ -218,7 +218,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 s.SubprojectID as Subproject,
                 minc_location as MincFile,
                 series_description as Series_Description,
-                'Could not identify scan type' as Problem, 
+                'Could not identify scan type' as Problem,
                 SeriesUID,
                 md5(concat_WS(':',
                               minc_location,
@@ -227,17 +227,17 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                               time_run
                    )
                 ) as hash,
-                mpvs.ID as join_id,                
+                mpvs.ID as join_id,
                 p.CenterID as Site,
                 violations_resolved.Resolved as Resolved
             FROM mri_protocol_violated_scans AS mpvs
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mpvs.ID 
+            ON (violations_resolved.ExtID=mpvs.ID
             AND violations_resolved.TypeTable='mri_protocol_violated_scans')
             LEFT JOIN candidate c
             ON (mpvs.CandID = c.CandID)
             LEFT JOIN session s
-            ON (SUBSTRING_INDEX(mpvs.PatientName,'_',-1) = s.Visit_label 
+            ON (SUBSTRING_INDEX(mpvs.PatientName,'_',-1) = s.Visit_label
                 AND mpvs.CandID = s.CandID
             )
             LEFT JOIN psc p
@@ -258,10 +258,10 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 p.CenterID as Site,
                 violations_resolved.Resolved as Resolved
             FROM mri_violations_log AS mrl
-            LEFT JOIN mri_scan_type 
+            LEFT JOIN mri_scan_type
             ON (mri_scan_type.ID=mrl.Scan_type)
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=mrl.LogID 
+            ON (violations_resolved.ExtID=mrl.LogID
             AND violations_resolved.TypeTable='mri_violations_log')
             LEFT JOIN candidate c
             ON (mrl.CandID=c.CandID)
@@ -277,7 +277,7 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 null,
                 MincFile,
                 null,
-                Reason, 
+                Reason,
                 SeriesUID,
                 md5(concat_WS(':',MincFile,PatientName,SeriesUID,TimeRun))
                    as hash,
@@ -286,10 +286,10 @@ class Resolved_Violations extends \NDB_Menu_Filter_Form
                 violations_resolved.Resolved as Resolved
             FROM MRICandidateErrors
             LEFT JOIN violations_resolved
-            ON (violations_resolved.ExtID=MRICandidateErrors.ID 
+            ON (violations_resolved.ExtID=MRICandidateErrors.ID
             AND violations_resolved.TypeTable='MRICandidateErrors')
             WHERE Resolved <> '0')
-            as v LEFT JOIN psc site ON (site.CenterID = v.Site) 
+            as v LEFT JOIN psc site ON (site.CenterID = v.Site)
             LEFT JOIN Project as pjct ON (v.Project = pjct.ProjectID)
             LEFT JOIN subproject as subpjct
                  ON (v.Subproject = subpjct.SubprojectID)

--- a/modules/mri_violations/templates/menu_mri_protocol_check_violations.tpl
+++ b/modules/mri_violations/templates/menu_mri_protocol_check_violations.tpl
@@ -57,7 +57,19 @@
         </div>
     </div>
 </div>
- <div class="dynamictable" id="datatable"></div>
+
+<div id="tabs" style="background: white">
+    <ul class="nav nav-tabs">
+        <li class="statsTab active"><a class="statsTabLink">Protocol violations</a></li>
+        <li class="statsTab"><a class="statsTabLink" id="onLoad" href="{$baseurl}/mri_violations/mri_protocol_violations/">Resolved violations</a></li>
+    </ul>
+    <div class="tab-content" style="margin: 14px;">
+        <div class="tab-pane active">
+            <div class="dynamictable" id="datatable"></div>
+        </div>
+    </div>
+</div>
+
 <script>
 loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
 var hasWritePermission = {json_encode($hasWritePermission)};

--- a/modules/mri_violations/templates/menu_mri_protocol_violations.tpl
+++ b/modules/mri_violations/templates/menu_mri_protocol_violations.tpl
@@ -73,15 +73,15 @@
         <li class="statsTab"><a class="statsTabLink" id="onLoad" href="{$baseurl}/mri_violations/mri_protocol_check_violations/">Protocol violations</a></li>
         <li class="statsTab active"><a class="statsTabLink">Resolved violations</a></li>
     </ul>
-    <div class="tab-content">
+    <div class="tab-content" style="margin: 14px;">
         <div class="tab-pane active">
 
             <!-- Mri- protocol table  -->
-            <div id='hide' style="font-weight: bold" class="toggle_mri_tbl">
+            <div id='hide' style="font-weight: bold; padding:10px" class="toggle_mri_tbl">
                 <span class="glyphicon glyphicon-minus"></span> Hide mri-protocol Table
             </div>
 
-            <div id='show' style="font-weight: bold" class="toggle_mri_tbl">
+            <div id='show' style="font-weight: bold; padding:10px" class="toggle_mri_tbl">
                 <span class="glyphicon glyphicon-plus"></span> Show mri-protocol Table
             </div>
 
@@ -103,10 +103,10 @@
                     {else}
                         {assign var=rowBorder value=''}
                     {/if}
-                    
+
                     {foreach from=$mpgroup item=protocol}
                         <tr>
-                        {foreach from=$protocol key=k item=v}   
+                        {foreach from=$protocol key=k item=v}
                             <td id="row_{$protocol.ID}_td_{$k}" class='description' nowrap {$rowBorder}>
                                 {$v}
                             </td>
@@ -124,8 +124,8 @@
                     <td align="right" id="pageLinks"></td>
                 </tr>
             </table>
-          <div class="dynamictable" id="datatable"></div> 
-             
+          <div class="dynamictable" id="datatable"></div>
+
       </div>
     </div>
 </div>
@@ -136,7 +136,7 @@ var table = RDynamicDataTable({
      "DataURL" : "{$baseurl}/mri_violations/mri_protocol_violations/?format=json",
      "getFormattedCell" : formatColumn,
      "freezeColumn" : "PatientName"
-     
+
   });
 ReactDOM.render(table, document.getElementById("datatable"));
 


### PR DESCRIPTION
/mri_violations/mri_protocol_violations/ contains two tabs under the menu filter.
Clicking the first tab takes the user to /mri_violations/ which removes both tabs.

This PR adds the same tabs in /mri_violations to allow the users to alternate between them.

![Screenshot from 2020-06-30 16-28-01](https://user-images.githubusercontent.com/32041423/86173992-d9f64680-baee-11ea-9f8d-692620f70340.png)

* Resolves #6689
