### PR TITLE
[candidate_profile] Show Consent Summary card iff useConsent Yes

### DIFF
--- a/modules/candidate_parameters/php/module.class.inc
+++ b/modules/candidate_parameters/php/module.class.inc
@@ -42,6 +42,10 @@ class Module extends \Module
                 return [];
             }
 
+            if (!\NDB_Factory::singleton()->settings()->consentEnabled()) {
+                return [];
+            }
+
             // The candidate getConsents only returns the types of
             // consents that the candidate has saved, we want to
             // summarize all of the types configured in the database.

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -164,5 +164,17 @@ class Settings
         return false;
     }
 
+    /**
+     * Determines whether the useConsent configuration setting is
+     * enabled
+     *
+     * @return bool True if the useConsent setting is enabled
+     */
+    function consentEnabled(): bool
+    {
+        return \NDB_Factory::singleton()->config()->settingEnabled(
+            'useConsent'
+        );
+    }
 
 }


### PR DESCRIPTION
## Brief summary of changes

Resolves https://github.com/aces/Loris/issues/6680

#### Testing instructions (if applicable)

1. In Configurations module,  set 'Use consent' config option to Yes.
2. Navigate to Candidate Profile page from non-admin account and see the consent card there as it should be.
3. Now, set 'Use Consent' config to 'No'
4. Refresh the candidate profile page and see that the consent card is no longer there

#### Link(s) to related issue(s)

* Resolves #6680 
