### PR TITLE
[Test] unittests for NDB_BVL_Instrument library

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1941,7 +1941,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $group,
             $name . "_date_group",
             $label,
-            $this->GUIDelimiter,
+            $this->_GUIDelimiter,
             false
         );
         unset($group);

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1941,7 +1941,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $group,
             $name . "_date_group",
             $label,
-            $this->_GUIDelimiter,
+            $this->GUIDelimiter,
             false
         );
         unset($group);

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -260,6 +260,53 @@ class NDB_BVL_Instrument_Test extends TestCase
                 ]
             ]
         );
+
+        $textRules = $this->_instrument->XINRules['FieldName'];
+        $textAreaRules = $this->_instrument->XINRules['FieldName2'];
+        $this->assertEquals(
+            $textRules,
+            [
+                'message' => 'This field is required.',
+                'group' => 'FieldName_group',
+                'rules' => ['FieldName_status{@}=={@}', 'Option']
+            ]
+        );
+        $this->assertEquals(
+            $textAreaRules,
+            [
+                'message' => 'This field is required.',
+                'group' => 'FieldName2_group',
+                'rules' => ['FieldName2_status{@}=={@}', 'Option']
+            ]
+        );
+    }
+
+    /**
+     * Test that addTextAreaElementRD adds a group element to the instrument
+     *
+     * @covers NDB_BVL_Instrument::addTextAreaElementRD
+     * @return void
+     */
+    function testAddTextAreaElement()
+    {
+        $this->_instrument->addTextAreaElementRD(
+            "FieldName1", "Field Description1", array("value" => "Option")
+        );
+        $json = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
+        $this->assertEquals(
+            $outArray['Elements'][0],
+            ['Type' => "Group", 'Error' => "Unimplemented"]
+        );
+        $textRules = $this->_instrument->XINRules['FieldName1'];
+        $this->assertEquals(
+            $textRules,
+            [
+                'message' => 'You must specify or select from the drop-down',
+                'group' => 'FieldName1_group',
+                'rules' => ['FieldName1_status{@}=={@}', 'Option']
+            ]
+        );
     }
 
     /**
@@ -548,5 +595,110 @@ class NDB_BVL_Instrument_Test extends TestCase
             ]
         );
     }
+
+    /**
+     * Test that setup correctly sets the commentID and page values of the
+     * instrument and that getCommentID returns the commentID value.
+     *
+     * @covers NDB_BVL_Instrument::setup
+     * @covers NDB_BVL_Instrument::getCommentID
+     * @return void
+     */
+    function testSetup()
+    {
+        $this->_instrument->setup("commentID", "page");
+        $this->assertEquals("commentID", $this->_instrument->getCommentID());
+        $this->assertEquals("page", $this->_instrument->page);
+
+    }
+
+    /**
+     * Test that calculateAgeMonths returns the correct number of months
+     * for the given age array.
+     *
+     * @covers NDB_BVL_Instrument::calculateAgeMonths
+     * @return void
+     */
+    function testCalculateAgeMonths()
+    {
+        $age = array('year' => 3, 'mon' => 4, 'day' => 23);
+        $months = $this->_instrument->calculateAgeMonths($age);
+        $this->assertEquals(40.8, $months);
+    }
+
+    /**
+     * Test that calculateAgeDays returns the correct number of days
+     * for the given age array
+     *
+     * @covers NDB_BVL_Instrument::calculateAgeDays
+     * @return void
+     */
+    function testCalculateAgeDays()
+    {
+        $age = array('year' => 3, 'mon' => 4, 'day' => 23);
+        $days = $this->_instrument->calculateAgeDays($age);
+        $this->assertEquals(1238, $days);
+    }
+
+    /**
+     * Test that addYesNoElement adds an element to the instrument with
+     * yes/no options
+     *
+     * @covers NDB_BVL_Instrument::addYesNoElement
+     * @return void
+     */
+    function testAddYesNoElement()
+    {
+        $this->_instrument->addYesNoElement("field1", "label1");
+        $json = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
+        $this->assertEquals(
+            $outArray['Elements'][0],
+            array('Type' => 'select',
+                  'Name' => 'field1',
+                  'Description' => 'label1',
+                  'Options' => array('Values' => array('' => '',
+                                                       'yes' => 'Yes',
+                                                       'no' => 'No'),
+                                     'RequireResponse' => true)
+            )
+        );
+    }
+
+    /**
+     * Test that addYesNoElement adds an element and registers a XIN rule
+     * if specified.
+     *
+     * @covers NDB_BVL_Instrument::addYesNoElementWithRules
+     * @return void
+     */
+    function testAddYesNoElementWithRules()
+    {
+        $this->_instrument->addYesNoElement(
+            "field1", "label1", ["rule1"], "Rule message"
+        );
+        $json = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
+        $this->assertEquals(
+            $outArray['Elements'][0],
+            array('Type' => 'select',
+                'Name' => 'field1',
+                'Description' => 'label1',
+                'Options' => array('Values' => array('' => '',
+                    'yes' => 'Yes',
+                    'no' => 'No'),
+                    'RequireResponse' => true)
+            )
+        );
+        $rules = $this->_instrument->XINRules["field1"];
+        $this->assertEquals(
+            $rules,
+            array('message' => 'Rule message',
+                  'group' => '',
+                  'rules' => ['rule1']
+            )
+        );
+    }
+
 }
 ?>

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Unit test for NDB_BVL_Instrument class
+ *
+ * PHP Version 7
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
 namespace Loris\Tests;
 set_include_path(get_include_path().":" .  __DIR__  . "/../../php/libraries:");
 use PHPUnit\Framework\TestCase;
@@ -6,25 +17,45 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../../php/libraries/NDB_BVL_Instrument.class.inc';
 require_once 'Smarty_hook.class.inc';
 require_once 'NDB_Config.class.inc';
-
-class NDB_BVL_Instrument_ToJSON_Test extends TestCase
+/**
+ * Unit test for NDB_BVL_Instrument class
+ *
+ * PHP Version 7
+ *
+ * @category Tests
+ * @package  Main
+ * @author   Dave MacFarlane <david.macfarlane2@mcgill.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+class NDB_BVL_Instrument_Test extends TestCase
 {
+    private $_instrument;
     /**
      * Set up sets a fake $_SESSION object that we can use for
      * assertions
+     *
+     * @return void
      */
-    function setUp() {
+    function setUp()
+    {
         global $_SESSION;
-        if(!defined("UNIT_TESTING")) {
+        if (!defined("UNIT_TESTING")) {
             define("UNIT_TESTING", true);
         }
         date_default_timezone_set("UTC");
-        $this->Session = $this->getMockBuilder(\stdClass::class)->setMethods(array('getProperty', 'setProperty', 'getUsername', 'isLoggedIn'))->getMock();
-        $this->MockSinglePointLogin = $this->getMockBuilder('SinglePointLogin')->getMock();
-        $this->Session->method("getProperty")->willReturn($this->MockSinglePointLogin);
+        $this->session = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(
+                array('getProperty', 'setProperty', 'getUsername', 'isLoggedIn')
+            )
+            ->getMock();
+        $this->mockSinglePointLogin = $this->getMockBuilder('SinglePointLogin')
+            ->getMock();
+        $this->session->method("getProperty")
+            ->willReturn($this->mockSinglePointLogin);
 
         $_SESSION = array(
-            'State' => $this->Session
+            'State' => $this->session
         );
 
         $factory = \NDB_Factory::singleton();
@@ -37,30 +68,41 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         \NDB_Factory::$testdb = $mockdb;
         \NDB_Factory::$config = $mockconfig;
 
-        $this->QuickForm = new \LorisForm(); //$this->getMock("HTML_Quickform");
-        $this->Client = new \NDB_Client;
-        $this->Client->makeCommandLine();
-        $this->Client->initialize(__DIR__ . "/../../project/config.xml");
+        $this->quickForm = new \LorisForm();
 
-        $this->i = $this->getMockBuilder(\NDB_BVL_Instrument::class)->disableOriginalConstructor()->setMethods(array("getFullName", "getSubtestList"))->getMock();
-        $this->i->method('getFullName')->willReturn("Test Instrument");
-        $this->i->method('getSubtestList')->willReturn(array());
-        $this->i->form = $this->QuickForm;
-        $this->i->testName = "Test";
+        $this->_instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array("getFullName", "getSubtestList"))->getMock();
+        $this->_instrument->method('getFullName')->willReturn("Test Instrument");
+        $this->_instrument->method('getSubtestList')->willReturn(array());
+        $this->_instrument->form = $this->quickForm;
+        $this->_instrument->testName = "Test";
     }
 
     /**
      * Helper function to use for creating stubs that stub out everything except
      * the method being tested
+     *
+     * @param $methods The method being tested
+     *
+     * @return array
      */
-    function _getAllMethodsExcept($methods) {
+    function _getAllMethodsExcept($methods)
+    {
         $AllMethods = get_class_methods('NDB_BVL_Instrument');
 
         return array_diff($AllMethods, $methods);
     }
 
-    function testMetaData() {
-        $json = $this->i->toJSON();
+    /**
+     * Test that the toJSON method returns the correct metadata
+     *
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testMetaData()
+    {
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $ExpectedMeta = [
             'InstrumentVersion' => "1l",
@@ -72,14 +114,34 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $this->assertEquals($ExpectedMeta, $outArray['Meta']);
     }
 
-    function testSelectElement() {
+    /**
+     * Test that addSelect and addElement add the correct information
+     * and that toJSON returns this data
+     *
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testSelectElement()
+    {
         $value = array('value' => "Option");
         $not_answered = array('value' => 'Option', 'not_answered' => 'Not Answered');
-        $this->i->addSelect("FieldName", "Field Description", $value);
-        $this->i->addSelect("FieldName2", "Field Description 2", $not_answered);
-        $this->i->form->addElement('select', "multiselect1", "Test Question", $value, array("multiple" => 'multiple'));
-        $this->i->form->addElement('select', "multiselect2", "Test Question", $not_answered, array('multiple' => "multiple"));
-        $json = $this->i->toJSON();
+        $this->_instrument->addSelect("FieldName", "Field Description", $value);
+        $this->_instrument->addSelect(
+            "FieldName2", "Field Description 2", $not_answered
+        );
+        $this->_instrument->form->addElement(
+            'select',
+            "multiselect1",
+            "Test Question",
+            $value, array("multiple" => 'multiple')
+        );
+        $this->_instrument->form->addElement(
+            'select',
+            "multiselect2",
+            "Test Question",
+            $not_answered, array('multiple' => "multiple")
+        );
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $selectElement = $outArray['Elements'][0];
         $selectElement2 = $outArray['Elements'][1];
@@ -87,7 +149,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $multiselectElement = $outArray['Elements'][2];
         $multiselectElement2 = $outArray['Elements'][3];
 
-        $this->assertEquals($selectElement,
+        $this->assertEquals(
+            $selectElement,
             [
                 'Type' => "select",
                 "Name" => "FieldName",
@@ -101,7 +164,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
             ]
         );
 
-        $this->assertEquals($selectElement2,
+        $this->assertEquals(
+            $selectElement2,
             [
                 'Type' => "select",
                 "Name" => "FieldName2",
@@ -115,7 +179,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
             ]
         );
 
-        $this->assertEquals($multiselectElement,
+        $this->assertEquals(
+            $multiselectElement,
             [
                 'Type' => "select",
                 "Name" => "multiselect1",
@@ -130,7 +195,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
             ]
         );
 
-        $this->assertEquals($multiselectElement2,
+        $this->assertEquals(
+            $multiselectElement2,
             [
                 'Type' => "select",
                 "Name" => "multiselect2",
@@ -147,15 +213,30 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
     }
 
 
-    function testTextElement() {
-        $this->i->addTextElement("FieldName", "Field Description for Text", array("value" => "Option"));
-        $this->i->addTextAreaElement("FieldName2", "Field Description2 for Text", array("value" => "Option"));
-        $json = $this->i->toJSON();
+    /**
+     * Test that addTextElement and addTextAreaElement adds the correct data to
+     * the instrument
+     *
+     * @covers NDB_BVL_Instrument::addTextElement
+     * @covers NDB_BVL_Instrument::addTextAreaElement
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testTextElement()
+    {
+        $this->_instrument->addTextElement(
+            "FieldName", "Field Description for Text", array("value" => "Option")
+        );
+        $this->_instrument->addTextAreaElement(
+            "FieldName2", "Field Description2 for Text", array("value" => "Option")
+        );
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $textElement = $outArray['Elements'][0];
         $textareaElement = $outArray['Elements'][1];
 
-        $this->assertEquals($textElement,
+        $this->assertEquals(
+            $textElement,
             [
                 'Type'        => "text",
                 "Name"        => "FieldName",
@@ -167,7 +248,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
             ]
         );
 
-        $this->assertEquals($textareaElement,
+        $this->assertEquals(
+            $textareaElement,
             [
                 'Type'        => "text",
                 "Name"        => "FieldName2",
@@ -180,8 +262,18 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         );
     }
 
-    function testDateElement() {
-        $this->i->addBasicDate(
+    /**
+     * Test that addBasicDate (from NDB_Page) and addDateElement
+     * adds the correct date to the instrument object
+     *
+     * @covers NDB_Page::addBasicDate
+     * @covers NDB_Page::addDateElement
+     * @covers NDB_Page::toJSON
+     * @return void
+     */
+    function testDateElement()
+    {
+        $this->_instrument->addBasicDate(
             "FieldName",
             "Field Description",
             [
@@ -191,7 +283,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
                 "addEmptyOption" => false,
             ]
         );
-        $this->i->addBasicDate(
+        $this->_instrument->addBasicDate(
             "FieldName2",
             "Field Description",
             [
@@ -202,7 +294,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
             ]
         );
 
-        $this->i->addDateElement(
+        $this->_instrument->addDateElement(
             "FieldName3",
             "Field Description",
             [
@@ -212,7 +304,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
                 "addEmptyOption" => false,
             ]
         );
-        $this->i->addDateElement(
+        $this->_instrument->addDateElement(
             "FieldName4",
             "Field Description",
             [
@@ -222,7 +314,7 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
                 "addEmptyOption" => true,
             ]
         );
-        $json = $this->i->toJSON();
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $dateElement = $outArray['Elements'][0];
         $dateElement2 = $outArray['Elements'][1];
@@ -258,13 +350,22 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $this->assertEquals($dateElement4, $expectedResult);
     }
 
-    function testNumericElement() {
-        $this->i->addNumericElement("TestElement", "Test Description");
-        $json = $this->i->toJSON();
+    /**
+     * Test that addNumericElement adds the correct data to the instrument
+     *
+     * @covers NDB_BVL_Instrument::addNumericElement
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testNumericElement()
+    {
+        $this->_instrument->addNumericElement("TestElement", "Test Description");
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $numericElement = $outArray['Elements'][0];
 
-        $this->assertEquals($numericElement,
+        $this->assertEquals(
+            $numericElement,
             [
                 "Type" => "numeric",
                 "Name" => "TestElement",
@@ -277,29 +378,40 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
 
     }
 
-    function testScoreElement() {
-        $this->i->addScoreColumn(
+    /**
+     * Test that addScoreColumn (from NDB_Page) adds the data to the
+     * instrument object
+     *
+     * @covers NDB_Page::addScoreColumn
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testScoreElement()
+    {
+        $this->_instrument->addScoreColumn(
             "FieldName",
             "Field Description",
             "45"
         );
-        $this->i->addScoreColumn(
+        $this->_instrument->addScoreColumn(
             "FieldName2",
             null
         );
-        $json = $this->i->toJSON();
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $scoreElement = $outArray['Elements'][0];
         $scoreElement2 = $outArray['Elements'][1];
 
-        $this->assertEquals($scoreElement,
+        $this->assertEquals(
+            $scoreElement,
             [
                 'Type'        => "score",
                 "Name"        => "FieldName",
                 "Description" => "Field Description",
             ]
         );
-        $this->assertEquals($scoreElement2,
+        $this->assertEquals(
+            $scoreElement2,
             [
                 'Type'        => "score",
                 "Name"        => "FieldName2",
@@ -308,26 +420,39 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
 
     }
 
-    function testHeaderElement() {
+    /**
+     * Test that when a header element is added, the toJSON method returns the
+     * element in the correct format
+     *
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testHeaderElement()
+    {
         // Since QuickForm arbitrarily decides to split things into "sections"
         // when there's a header, the header test adds 2 headers to ensure that
         // the JSON serialization was done according to spec, and not according
         // to QuickForm's whims.
         // The first "section" has no elements, and the second one, to make sure
         // that the serialization won't die on a 0 element "section"
-        $this->i->form->addElement("header", null, "I am your test header");
-        $this->i->form->addElement("header", null, "I am another test header");
-        $this->i->addScoreColumn(
+        $this->_instrument->form->addElement(
+            "header", null, "I am your test header"
+        );
+        $this->_instrument->form->addElement(
+            "header", null, "I am another test header"
+        );
+        $this->_instrument->addScoreColumn(
             "FieldName2",
             "Field Description",
             "45"
         );
-        $json = $this->i->toJSON();
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $headerElement = $outArray['Elements'][0];
         $headerElement2= $outArray['Elements'][1];
 
-        $this->assertEquals($headerElement,
+        $this->assertEquals(
+            $headerElement,
             [
                 'Type'        => "header",
                 "Description" => "I am your test header",
@@ -336,7 +461,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
                 ]
             ]
         );
-        $this->assertEquals($headerElement2,
+        $this->assertEquals(
+            $headerElement2,
             [
                 'Type'        => "header",
                 "Description" => "I am another test header",
@@ -349,13 +475,23 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $this->assertEquals(count($outArray['Elements']), 3);
     }
 
-    function testLabelElement() {
-        $this->i->addLabel("I am a label");
-        $json = $this->i->toJSON();
+    /**
+     * Test that addLabel (from NDB_Page) adds the label element
+     * to the instrument object
+     *
+     * @covers NDB_Page::addLabel
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testLabelElement()
+    {
+        $this->_instrument->addLabel("I am a label");
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $labelElement = $outArray['Elements'][0];
 
-        $this->assertEquals($labelElement,
+        $this->assertEquals(
+            $labelElement,
             [
                 'Type'        => "label",
                 "Description" => "I am a label"
@@ -364,25 +500,37 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
         $this->assertEquals(count($outArray['Elements']), 1);
     }
 
-    function testPageGroup() {
-        $this->i = $this->getMockBuilder(\NDB_BVL_Instrument::class)->disableOriginalConstructor()->setMethods(array("getFullName", "getSubtestList", '_setupForm'))->getMock();
-        $this->i->method('getFullName')->willReturn("Test Instrument");
-        $this->i->method('getSubtestList')->willReturn(
+    /**
+     * Test that toJSON gets the subtest list and full name elements of
+     * the instrument
+     *
+     * @covers NDB_BVL_Instrument::toJSON
+     * @return void
+     */
+    function testPageGroup()
+    {
+        $this->_instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
+            ->disableOriginalConstructor()
+            ->setMethods(
+                array("getFullName", "getSubtestList", '_setupForm')
+            )->getMock();
+        $this->_instrument->method('getFullName')->willReturn("Test Instrument");
+        $this->_instrument->method('getSubtestList')->willReturn(
             array(
                 array('Name' => 'Page 1', 'Description' => 'The first page'),
                 array('Name' => 'Page 2', 'Description' => 'The second page'),
             )
         );
 
-        $this->i->form = $this->QuickForm;
-        $this->i->testName = "Test";
+        $this->_instrument->form = $this->quickForm;
+        $this->_instrument->testName = "Test";
 
-
-        $json = $this->i->toJSON();
+        $json = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
         $page1 = $outArray['Elements'][0];
         $page2 = $outArray['Elements'][1];
-        $this->assertEquals($page1,
+        $this->assertEquals(
+            $page1,
             [
                 'Type' => 'ElementGroup',
                 'GroupType' => 'Page',
@@ -390,7 +538,8 @@ class NDB_BVL_Instrument_ToJSON_Test extends TestCase
                 'Description' => 'The first page'
             ]
         );
-        $this->assertEquals($page2,
+        $this->assertEquals(
+            $page2,
             [
                 'Type' => 'ElementGroup',
                 'GroupType' => 'Page',

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -287,7 +287,7 @@ class NDB_BVL_Instrument_Test extends TestCase
      * @covers NDB_BVL_Instrument::addTextAreaElementRD
      * @return void
      */
-    function testAddTextAreaElement()
+    function testAddTextAreaElementRD()
     {
         $this->_instrument->addTextAreaElementRD(
             "FieldName1", "Field Description1", array("value" => "Option")
@@ -298,6 +298,38 @@ class NDB_BVL_Instrument_Test extends TestCase
             $outArray['Elements'][0],
             ['Type' => "Group", 'Error' => "Unimplemented"]
         );
+        $groupEl = $this->_instrument->form->form['FieldName1_group'];
+        $this->assertEquals(
+            $groupEl,
+            [
+                'type' => 'group',
+                'name' => 'FieldName1_group',
+                'elements' => [
+                    ['label' => null,
+                     'name' => 'FieldName1',
+                     'type' => 'textarea',
+                     'html' => $this->_instrument->form
+                         ->renderElement($groupEl['elements'][0])
+                    ],
+                    ['label' => '',
+                     'name' => 'FieldName1_status',
+                     'class' => 'form-control input-sm',
+                     'type' => 'select',
+                     'options' => ['' => '',
+                                   '88_refused' => '88 Refused',
+                                   '99_do_not_know' => '99 Do not know',
+                                   'not_answered' => 'Not Answered'
+                                  ],
+                     'html' => $this->_instrument->form
+                         ->renderElement($groupEl['elements'][1])
+                    ],
+                ],
+                'label' => 'Field Description1',
+                'delimiter' => ' ',
+                'options' => false,
+                'html' => $this->_instrument->form->groupHTML($groupEl)
+            ]
+        );
         $textRules = $this->_instrument->XINRules['FieldName1'];
         $this->assertEquals(
             $textRules,
@@ -305,6 +337,67 @@ class NDB_BVL_Instrument_Test extends TestCase
                 'message' => 'You must specify or select from the drop-down',
                 'group' => 'FieldName1_group',
                 'rules' => ['FieldName1_status{@}=={@}', 'Option']
+            ]
+        );
+    }
+
+    /**
+     * Test that addHourMinElement returns a group element with the correct
+     * data and sets an appropriate XINRule
+     *
+     * @covers NDB_BVL_Instrument::addHourMinElement
+     * @return void
+     */
+    function testAddHourMinElement()
+    {
+        $this->_instrument->addHourMinElement(
+            "hourMinField", "hourMinLabel", ["value" => "Option"], "Rule_message"
+        );
+        $json = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
+        $this->assertEquals(
+            $outArray['Elements'][0],
+            ['Type' => "Group", 'Error' => "Unimplemented"]
+        );
+        $groupEl = $this->_instrument->form->form['hourMinField_group'];
+        $this->assertEquals(
+            $groupEl,
+            [
+                'type' => 'group',
+                'name' => 'hourMinField_group',
+                'elements' => [
+                    ['label' => null,
+                     'name' => 'hourMinField',
+                     'type' => 'time',
+                     'html' => $this->_instrument->form
+                         ->renderElement($groupEl['elements'][0])
+                    ],
+                    ['label' => '',
+                     'name' => 'hourMinField_status',
+                     'class' => 'form-control input-sm',
+                     'type' => 'select',
+                     'options' => [null => '',
+                                   'dnk' => 'DNK',
+                                   'refusal' => 'Refusal',
+                                   'not_answered' => 'Not Answered',
+                                  ],
+                     'html' => $this->_instrument->form
+                         ->renderElement($groupEl['elements'][1])
+                    ]
+                ],
+                'label' => 'hourMinLabel',
+                'delimiter' => ' ',
+                'options' => false,
+                'html' => $this->_instrument->form->groupHTML($groupEl)
+            ]
+        );
+        $rules = $this->_instrument->XINRules['hourMinField'];
+        $this->assertEquals(
+            $rules,
+            [
+                'message' => 'Rule_message',
+                'group' => 'hourMinField_group',
+                'rules' => ['Option', 'hourMinField_status{@}=={@}']
             ]
         );
     }
@@ -398,6 +491,103 @@ class NDB_BVL_Instrument_Test extends TestCase
     }
 
     /**
+     * Test that addMonthYear creates a date element with the correct data
+     * and that it adds the element name to the monthYearFields array.
+     *
+     * @covers NDB_BVL_Instrument::addMonthYear
+     * @return void
+     */
+    function testMonthYearElement()
+    {
+        $this->_instrument->addMonthYear("Field1", "Label 1", ['value' => 'Option']);
+        $this->assertEquals(
+            $this->_instrument->form->form["Field1"],
+            [
+                'label' => 'Label 1',
+                'name' => 'Field1',
+                'type' => 'date',
+                'options' => ['value' => 'Option',
+                              'format' => 'YM']
+            ]
+        );
+        $this->assertEquals($this->_instrument->monthYearFields[0], "Field1");
+    }
+
+    /**
+     * Test that addCustomDateElement creates a group element with
+     * the correct data and sets a XINRule
+     *
+     * @covers NDB_BVL_Instrument::addCustomDateElement
+     * @return void
+     */
+    function testAddCustomDateElement()
+    {
+        $this->_instrument->addCustomDateElement(
+            "CustomName", "Date Label", array("value" => "Option")
+        );
+        $json = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
+        $this->assertEquals(
+            $outArray['Elements'][0],
+            ['Type' => "Group", 'Error' => "Unimplemented"]
+        );
+        $groupEl = $this->_instrument->form->form['CustomName_date_group'];
+        $this->assertEquals(
+            $groupEl,
+            [
+                'type' => 'group',
+                'name' => 'CustomName_date_group',
+                'elements' => [
+                    [
+                        'label' => null,
+                        'name' => 'CustomName_date',
+                        'class' => 'form-control input-sm',
+                        'type' => 'date',
+                        'html' => $this->_instrument->form
+                            ->renderElement($groupEl['elements'][0]),
+                        'options' => ['value' => 'Option']
+                    ],
+                    [
+                        'label' => null,
+                        'name' => 'CustomName_date_status',
+                        'class' => 'form-control input-sm',
+                        'type' => 'select',
+                        'options' => [
+                            null => '',
+                            '88_refused' => "88 Refused",
+                            '99_do_not_know' => "99 Do not know",
+                            'not_answered'   => "Not Answered"
+                        ],
+                        'html' => $this->_instrument->form
+                            ->renderElement($groupEl['elements'][1])
+                    ]
+                ],
+                'label' => 'Date Label',
+                'delimiter' => "</td>\n<td>",
+                'options' => false,
+                'html' => $this->_instrument->form->groupHTML($groupEl)
+            ]
+        );
+        $rule1 = $this->_instrument->XINRules['CustomName_date'];
+        $this->assertEquals(
+            $rule1,
+            [
+                'message' => "You must specify or select from the drop-down",
+                'group' => 'CustomName_date_group',
+                'rules' => ['CustomName_date_status{@}=={@}']
+            ]
+        );
+        $rule2 = $this->_instrument->XINRules['CustomName_date_status'];
+        $this->assertEquals(
+            $rule2,
+            [
+                'message' => "You must specify or select from the drop-down",
+                'group' => 'CustomName_date_group',
+                'rules' => ['CustomName_date{@}=={@}']
+            ]
+        );
+    }
+    /**
      * Test that addNumericElement adds the correct data to the instrument
      *
      * @covers NDB_BVL_Instrument::addNumericElement
@@ -422,7 +612,73 @@ class NDB_BVL_Instrument_Test extends TestCase
                 ]
             ]
         );
+    }
 
+    /**
+     * Test that addNumericElementRD correctly creates a group element
+     * and sets a XINRule with the proper data
+     *
+     * @covers NDB_BVL_Instrument::addNumericElementRD
+     * @return void
+     */
+    function testNumericElementRD()
+    {
+        $this->_instrument->addNumericElementRD("TestElement", "Test Description");
+        $json = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
+        $numericElement = $outArray['Elements'][0];
+        $this->assertEquals(
+            $numericElement,
+            ['Type' => "Group", 'Error' => "Unimplemented"]
+        );
+        $groupEl = $this->_instrument->form->form['TestElement_group'];
+        $this->assertEquals(
+            $groupEl,
+            [
+                'type' => 'group',
+                'name' => 'TestElement_group',
+                'elements' => [
+                    [
+                        'type' => 'text',
+                        'name' => 'TestElement',
+                        'label' => 'Test Description',
+                        'class' => 'form-control input-sm',
+                        'numeric' => true,
+                        'numericMsg' => 'Numbers only, please',
+                        'html' => $this->_instrument->form
+                            ->renderElement($groupEl['elements'][0])
+                    ],
+                    [
+                        'type' => 'select',
+                        'name' => 'TestElement_status',
+                        'label' => null,
+                        'class' => 'form-control input-sm not-answered',
+                        'options' => [
+                            '' => '',
+                            '88_refused' => '88 Refused',
+                            '99_do_not_know' => '99 Do not know',
+                            'not_answered' => 'Not Answered'
+                        ],
+                        'html' => $this->_instrument->form
+                            ->renderElement($groupEl['elements'][1])
+                    ]
+                ],
+                'label' => 'Test Description',
+                'delimiter' => ' ',
+                'options' => false,
+                'numeric' => [0],
+                'html' => $this->_instrument->form->groupHTML($groupEl)
+            ]
+        );
+        $rule = $this->_instrument->XINRules['TestElement'];
+        $this->assertEquals(
+            $rule,
+            [
+                'message' => 'This field is required',
+                'group' => 'TestElement_group',
+                'rules' => ['TestElement_status{@}=={@}']
+            ]
+        );
     }
 
     /**

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1000,7 +1000,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $this->_setUpMockDB();
         $this->_setTableData();
-        $this->_instrument->commentID = 'commentID2';
+        $this->_instrument->commentID = 'commentID3';
         $this->assertEquals(-1, $this->_instrument->getSessionID());
     }
 
@@ -1031,7 +1031,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $this->_setUpMockDB();
         $this->_setTableData();
-        $this->_instrument->commentID = 'commentID2';
+        $this->_instrument->commentID = 'commentID3';
         $this->assertEquals("", $this->_instrument->getVisitLabel());
     }
 
@@ -1060,7 +1060,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $this->_setUpMockDB();
         $this->_setTableData();
-        $this->_instrument->commentID = 'commentID2';
+        $this->_instrument->commentID = 'commentID3';
         $this->assertEquals(null, $this->_instrument->getSubprojectID());
     }
 
@@ -1152,7 +1152,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->commentID = 'commentID1';
         $this->_instrument->table = 'medical_history';
         $this->assertEquals(
-            'Test Examiner',
+            'Test Examiner1',
             $this->_instrument->getFieldValue('Examiner')
         );
     }
@@ -1563,6 +1563,60 @@ class NDB_BVL_Instrument_Test extends TestCase
     }
 
     /**
+     * Test that nullScores sets the value for the given key-value pair
+     * to null in the instrument table
+     *
+     * @covers NDB_BVL_Instrument::_nullScores
+     * @return void
+     */
+    function testNullScores()
+    {
+        $this->_setUpMockDB();
+        $this->_setTableData();
+        $this->_instrument->commentID = 'commentID1';
+        $this->_instrument->table = 'medical_history';
+        $this->_instrument->_nullScores(['Examiner' => 'Test Examiner1']);
+        $data = \NDB_BVL_Instrument::loadInstanceData($this->_instrument);
+        $this->assertEquals(null, $data['Examiner']);
+    }
+
+    /**
+     * Test that diff returns an array highlighting the differences between
+     * two instruments
+     *
+     * @covers NDB_BVL_Instrument::diff
+     * @return void
+     */
+    function testDiff()
+    {
+        $this->_setUpMockDB();
+        $this->_setTableData();
+        $this->_instrument->commentID = 'commentID1';
+        $this->_instrument->table = 'medical_history';
+        $otherInstrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array("getFullName", "getSubtestList"))->getMock();
+        $otherInstrument->commentID = 'commentID2';
+        $otherInstrument->table = 'medical_history';
+        $this->assertEquals(
+            $this->_instrument->diff($otherInstrument),
+            [
+                [
+                    'TableName' => 'medical_history',
+                    'ExtraKeyColumn' => null,
+                    'ExtraKey1' => ' ',
+                    'ExtraKey2' => ' ',
+                    'FieldName' => 'Examiner',
+                    'CommentId1' => 'commentID1',
+                    'Value1' => 'Test Examiner1',
+                    'CommentId2' => 'commentID2',
+                    'Value2' => 'Test Examiner2'
+                ]
+            ]
+        );
+    }
+
+    /**
      * Private function to set fake table data to be tested
      *
      * @return void
@@ -1582,7 +1636,13 @@ class NDB_BVL_Instrument_Test extends TestCase
                     'CommentID' => 'commentID1',
                     'Test_name' => 'Test_name1',
                     'UserID'    => '456'
-                ]
+                ],
+                [
+                    'SessionID' => '234',
+                    'CommentID' => 'commentID2',
+                    'Test_name' => 'Test_name2',
+                    'UserID'    => '457'
+                ],
             ]
         );
         $this->_DB->setFakeTableData(
@@ -1593,6 +1653,12 @@ class NDB_BVL_Instrument_Test extends TestCase
                     'DoB' => '1999-01-01',
                     'DoD' => '2016-01-01',
                     'PSCID' => '345'
+                ],
+                [
+                    'CandID' => 2,
+                    'DoB' => '1999-01-01',
+                    'DoD' => '2016-01-01',
+                    'PSCID' => '346'
                 ]
             ]
         );
@@ -1603,6 +1669,11 @@ class NDB_BVL_Instrument_Test extends TestCase
                     'ID' => '123',
                     'CandID' => 1,
                     'SubprojectID' => '12'
+                ],
+                [
+                    'ID' => '234',
+                    'CandID' => 2,
+                    'SubprojectID' => '12'
                 ]
             ]
         );
@@ -1612,10 +1683,17 @@ class NDB_BVL_Instrument_Test extends TestCase
                 [
                     'CommentID' => 'commentID1',
                     'UserID' => '456',
-                    'Examiner' => 'Test Examiner',
+                    'Examiner' => 'Test Examiner1',
                     'Date_taken' => '2010-05-05 00:00:01',
                     'Data_entry_completion_status' => 'Incomplete'
-                ]
+                ],
+                [
+                    'CommentID' => 'commentID2',
+                    'UserID' => '457',
+                    'Examiner' => 'Test Examiner2',
+                    'Date_taken' => '2010-05-05 00:00:01',
+                    'Data_entry_completion_status' => 'Incomplete'
+                ],
             ]
         );
         $this->_DB->setFakeTableData(


### PR DESCRIPTION
Unit tests for the NDB_BVL_Instrument library under `php/libraries`. This PR aims to complete coverage for this library.

#### Testing instructions

1. Run `npm run tests:unit -- --filter NDB_BVL_Instrument_Test` or check out the Travis output
