### PR TITLE
[Core: Middleware] Fix crash when a PSR Request's User attribute is null

### DIFF
--- a/src/Middleware/ExceptionHandlingMiddleware.php
+++ b/src/Middleware/ExceptionHandlingMiddleware.php
@@ -44,7 +44,7 @@ class ExceptionHandlingMiddleware implements MiddlewareInterface, MiddlewareChai
 
         // Decorate the request.
         return (new \LORIS\Middleware\PageDecorationMiddleware(
-            $request->getAttribute('user')
+            $request->getAttribute('user') ?? \NDB_Factory::singleton()->user()
         ))->process(
             $request,
             new \LORIS\Router\NoopResponder(


### PR DESCRIPTION
## Brief summary of changes

The middleware added in #6076 will crash when the request's user object is equal to null.

I'm not sure why this case occurs, but given that it does, this adds a fallback to the Factory user singleton so that the application can continue to work.

#### Testing instructions (if applicable)

1. On `aces/master`, login and go to My Preferences. It will crash.
2. Do the same on this branch. It should load.