### PR TITLE
[New Profile] error 500 fix (regression from #6186)

### DIFF
--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -108,7 +108,7 @@ class New_Profile extends \NDB_Form
                 'candID' => $this->_candID,
                 'pscid'  => $this->_pscid
             ];
-            return (new \LORIS\Http\Response\JSON\Created(json_encode($result)))
+            return (new \LORIS\Http\Response\JSON\Created($result))
                 ->withHeader("Allow", "POST");
         }
 


### PR DESCRIPTION
Since #6186,  /new_profile/ triggers an error 500 on submission.
This PR fixes the regression.

* Resolves #6821
