### PR TITLE
Lower console.log from eslint error to warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "new-cap": ["error", {
       "capIsNewExceptions": ["DynamicTable"]
     }],
-    "no-console": ["error", {
+    "no-console": ["warn", {
       "allow": ["info", "warn", "error"]
     }]
   },


### PR DESCRIPTION
This changes console.log back from an eslint error to an
eslint warning. With the current settings console.log can't
be used (even in development) because `make dev` fails with
an error about console.log. Making it impossible to use
console.log in development just encourages people to misuse
other console levels, which won't be flagged by eslint.