### PR TITLE
[Module Manager] Fix punctuation in reload prompt

### DIFF
--- a/modules/module_manager/jsx/modulemanager.js
+++ b/modules/module_manager/jsx/modulemanager.js
@@ -78,8 +78,8 @@ class ModuleManagerIndex extends Component {
               if (success === true) {
                 swal.fire({
                   title: 'Success!',
-                  text: 'Updated ' + id + ' status!' +
-                    'To apply changes the interface must be reloaded. proceed ?',
+                  text: 'Updated ' + id + ' status! ' +
+                    'To apply changes the interface must be reloaded. Proceed?',
                   type: 'success',
                   showCancelButton: true,
                   confirmButtonText: 'Reload the page',


### PR DESCRIPTION
The alert prompting the user to reload the page in
the module manager had incorrect spacing and punctuation
in the message shown to the user. This corrects it.