### PR TITLE
[Test/Tools] Option in run-php-linter.sh to auto fix PHPCS

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint:javascript": "./test/run-js-linter.sh",
     "lintfix:javascript": "eslint --fix --ext .js, jsx modules",
     "lint:php": "./test/run-php-linter.sh",
+    "lintfix:php": "./test/run-php-linter.sh -f",
     "tests:static": "make checkstatic",
     "lint:shell": "./test/run-shell-linter.sh",
     "tests:unit": "./test/dockerized-unit-tests.sh",

--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+has_param() {
+    local param="$1"
+    shift
+    for arg; do
+        if [[ $arg == "$param" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+join_by() {
+    local d=$1; shift;
+    local f=$1; shift;
+    printf %s "$f" "${@/#/$d}";
+}
+
+fix=false
+if has_param '-f' "$@"; then
+    echo "Fix mode set to true"
+    fix=true
+fi
+
 # Run PHP -l on everything to ensure there's no syntax
 # errors.
 find docs modules htdocs php src tools \
@@ -17,34 +40,40 @@ find docs modules htdocs php src tools \
 # tools/
 
 # except:
-ignored_files="
-    tools/single_use/Cleanup_Consent_Data.php,\
-    tools/single_use/Engine_Change_MyISAM_to_INNODB.php,\
-    tools/single_use/normalize_mri_protocol_range_data.php,\
-    tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php,\
-    tools/single_use/instrument_double_escape_report.php,\
-    tools/single_use/Normalize_protocol_split_rows.php,\
-    tools/single_use/migrate_sql_to_json.php,\
-    tools/single_use/data_dictionary_cleaner.php,\
-    tools/single_use/Normalize_Consent_Data.php,\
-    tools/single_use/remove_logged_passwords.php,\
-    tools/single_use/cleanup_mri_tables_for_19-0_release.php,\
-    tools/deprecated/create_candidates.php,\
-    tools/deprecated/excelDump.php,\
-    tools/generate_tables_sql_and_testNames.php,\
+declare -a ignored_files=(
+    tools/single_use/Cleanup_Consent_Data.php
+    tools/single_use/Engine_Change_MyISAM_to_INNODB.php
+    tools/single_use/normalize_mri_protocol_range_data.php
+    tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php
+    tools/single_use/instrument_double_escape_report.php
+    tools/single_use/cleanup_mri_tables_for_19-0_release.php
+    tools/single_use/Normalize_protocol_split_rows.php
+    tools/single_use/migrate_sql_to_json.php
+    tools/single_use/data_dictionary_cleaner.php
+    tools/single_use/Normalize_Consent_Data.php
+    tools/single_use/remove_logged_passwords.php
+    tools/deprecated/create_candidates.php
+    tools/deprecated/excelDump.php
+    tools/generate_tables_sql_and_testNames.php
     tools/fix_timepoint_date_problems.php
-"
+)
 
-vendor/bin/phpcs \
-    --standard=test/LorisCS.xml \
-    --extensions=php,inc \
-    --ignore="$ignored_files" \
-    php/ \
-    htdocs/ \
-    modules/ \
-    test/ \
-    tools/ \
-    || exit $?;
+declare -a params=(
+    --standard=test/LorisCS.xml
+    --extensions=php,inc
+    --ignore=$(join_by ',' "${ignored_files[@]}")
+    php/
+    htdocs/
+    modules/
+    test/
+    tools/
+)
+
+if [ "$fix" = true ] ; then
+    vendor/bin/phpcbf $(join_by ' ' "${params[@]}") || exit $?;
+else
+    vendor/bin/phpcs $(join_by ' ' "${params[@]}") || exit $?;
+fi
 
 # Ensure strict typing is used in these files
 declare -a strict_libraries=(
@@ -52,10 +81,31 @@ declare -a strict_libraries=(
     'OutputWrapper.class.inc'
 )
 
-vendor/bin/phpcs --standard=test/StrictTypesCS.xml --extensions=php,inc "${strict_libraries[@]/#/php/libraries/}" || exit $?;
+declare -a params=(
+    '--standard=test/StrictTypesCS.xml'
+    '--extensions=php,inc'
+    "${strict_libraries[@]/#/php/libraries/}"
+)
+
+if [ "$fix" = true ] ; then
+    vendor/bin/phpcbf $(join_by ' ' "${params[@]}") || exit $?;
+else
+    vendor/bin/phpcs $(join_by ' ' "${params[@]}") || exit $?;
+fi
 
 # Run PHPCS on src/ directory using a different ruleset conforming to PSR2.
-vendor/bin/phpcs --standard=test/SrcCS.xml --extensions=php/php src/ || exit $?;
+
+declare -a params=(
+    '--standard=test/SrcCS.xml'
+    '--extensions=php/php'
+    'src/'
+)
+
+if [ "$fix" = true ] ; then
+    vendor/bin/phpcbf $(join_by ' ' "${params[@]}") || exit $?;
+else
+    vendor/bin/phpcs $(join_by ' ' "${params[@]}") || exit $?;
+fi
 
 vendor/bin/phpmd php/,modules/,src/ text 'test/LorisPHPMD.xml' || exit $?;
 


### PR DESCRIPTION
PHPCBF can auto-fix minor PHPCS lint issues (trailing spaces, indent spaces, short arrays notation), which can be convenient.
An es-lint auto-fixer script already exists on the js side (npm lintfix:javascript).
I extended run-php-linter.sh to automatically solve hundred of errors for a recent PR (#6786).

This PR:

- add a -f flag to `run-php-linter.sh`, to run PHPCBF in place of PHPCS with the defined rules.
- add a npm script `lintfix:php`

## To test
- make sure `npm run lintfix:php` run `PHPCBF and fixes fixable errors in php files.
- make sure run-php-linter.sh (make checkstatic) stills works as intended.

Resolves #6826