### PR TITLE
Empty string when MINCToolsPath not configured

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -113,14 +113,13 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $mincpath = \NDB_Factory::singleton()->config()
-            ->getSetting('MINCToolsPath') ?? '';
+            ->getSetting('MINCToolsPath');
 
-        if (!$mincpath) {
-            error_log(
-                'Invalid MINCToolsPath configuration setting:' .
+        if ($mincpath === null) {
+            return new \LORIS\Http\Response\JSON\InternalServerError(
+                'Invalid MINCToolsPath configuration setting: ' .
                 'MINCToolsPath is null'
             );
-            return new \LORIS\Http\Response\JSON\NotFound();
         }
 
         $minctooldir = new \SPLFileInfo($mincpath);

--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -115,6 +115,14 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $mincpath = \NDB_Factory::singleton()->config()
             ->getSetting('MINCToolsPath') ?? '';
 
+        if (!$mincpath) {
+            error_log(
+                'Invalid MINCToolsPath configuration setting:' .
+                'MINCToolsPath is null'
+            );
+            return new \LORIS\Http\Response\JSON\NotFound();
+        }
+
         $minctooldir = new \SPLFileInfo($mincpath);
         if (!$minctooldir->isDir() || !$minctooldir->isReadable()) {
             return new \LORIS\Http\Response\JSON\InternalServerError(

--- a/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/image/format/raw.class.inc
@@ -113,7 +113,7 @@ class Raw extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $mincpath = \NDB_Factory::singleton()->config()
-            ->getSetting('MINCToolsPath');
+            ->getSetting('MINCToolsPath') ?? '';
 
         $minctooldir = new \SPLFileInfo($mincpath);
         if (!$minctooldir->isDir() || !$minctooldir->isReadable()) {


### PR DESCRIPTION
## Brief summary of changes
`\NDB_Factory::singleton()->config()->getSetting('MINCToolsPath')` returns null, which creates an error when trying to execute `new \SPLFileInfo($mincpath)`. 

Setting `$mincpath` to an empty string when null solves the problem.

#### Testing instructions

1. Go to <hostname>/api/v0.0.3/candidates//587630/V1/images/demo_587630_V1_t1_001.mnc/format/raw.
2. The message `{"error":"Invalid MINCToolsPath configuration setting."}` should be displayed.

#### Link(s) to related issue(s)

* Resolves #6827
