### PR TITLE
[Exceptions] Fix null user on ExceptionHandlingMiddleware

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -29,8 +29,7 @@ $client->initialize();
 // Middleware that happens on every request. This doesn't include
 // any authentication middleware, because that's done dynamically
 // based on the module router, depending on if the module is public.
-$middlewarechain = (new \LORIS\Middleware\ExceptionHandlingMiddleware())
-    ->withMiddleware(new \LORIS\Middleware\ContentLength())
+$middlewarechain = (new \LORIS\Middleware\ContentLength())
     ->withMiddleware(new \LORIS\Middleware\ResponseGenerator());
 
 $serverrequest = \Laminas\Diactoros\ServerRequestFactory::fromGlobals();

--- a/src/Middleware/ExceptionHandlingMiddleware.php
+++ b/src/Middleware/ExceptionHandlingMiddleware.php
@@ -14,10 +14,8 @@ use \Psr\Http\Server\RequestHandlerInterface;
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
-class ExceptionHandlingMiddleware implements MiddlewareInterface, MiddlewareChainer
+class ExceptionHandlingMiddleware implements MiddlewareInterface
 {
-    use MiddlewareChainerMixin;
-
     /**
      * Attempts a request and catches stray exceptions. When an exception occurs
      * hand this off to another Middleware to decoreate the page.
@@ -33,7 +31,7 @@ class ExceptionHandlingMiddleware implements MiddlewareInterface, MiddlewareChai
         RequestHandlerInterface $handler
     ) : ResponseInterface {
         try {
-            return $this->next->process($request, $handler);
+            return $handler->handle($request);
         } catch (\NotFound $e) {
             error_log($e->getMessage() . $e->getTraceAsString());
             $status = 404;

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -92,7 +92,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $modulename = $components[0];
         }
 
-        $factory = \NDB_Factory::singleton();
+        $factory  = \NDB_Factory::singleton();
         $ehandler = new \LORIS\Middleware\ExceptionHandlingMiddleware();
         if ($this->lorisinstance->hasModule($modulename)) {
             $uri    = $request->getURI();
@@ -135,7 +135,8 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         return $ehandler->process(
             $request,
             (new \LORIS\Middleware\PageDecorationMiddleware($this->user))
-                ->process($request,
+                ->process(
+                    $request,
                     new NoopResponder(new \LORIS\Http\Error($request, 404))
                 )
         );

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -93,6 +93,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
         }
 
         $factory = \NDB_Factory::singleton();
+        $ehandler = new \LORIS\Middleware\ExceptionHandlingMiddleware();
         if ($this->lorisinstance->hasModule($modulename)) {
             $uri    = $request->getURI();
             $suburi = $this->stripPrefix($modulename, $uri);
@@ -108,7 +109,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
             $module  = \Module::factory($modulename);
             $mr      = new ModuleRouter($module);
             $request = $request->withURI($suburi);
-            return $mr->handle($request);
+            return $ehandler->process($request, $mr);
         }
         // Legacy from .htaccess. A CandID goes to the timepoint_list
         // FIXME: This should all be one candidates module, not a bunch
@@ -125,17 +126,18 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                 ->withAttribute("CandID", $components[0]);
                 $module  = \Module::factory("timepoint_list");
                 $mr      = new ModuleRouter($module);
-                return $mr->handle($request);
+                return $ehandler->process($request, $mr);
             }
         }
 
         // Fall through to 404. We don't have any routes that go farther
         // than 1 level..
-        return (new \LORIS\Middleware\PageDecorationMiddleware(
-            $this->user
-        ))->process(
+        return $ehandler->process(
             $request,
-            new NoopResponder(new \LORIS\Http\Error($request, 404))
+            (new \LORIS\Middleware\PageDecorationMiddleware($this->user))
+                ->process($request,
+                    new NoopResponder(new \LORIS\Http\Error($request, 404))
+                )
         );
     }
 }


### PR DESCRIPTION
The ExceptionHandlingMiddleware uses the PageDecorationMiddleware,
and as such needs to be chained after all the prerequisites of the
PageDecorationMiddleware (ie. the lorisinstance and user) are added
to the request object.

This converts it from a MiddlewareChainer interface into a normal
middleware and explicitly adds it to the BaseRouter, instead of the
top level chain.

Replaces #6820.