### PR TITLE
Add callback for updates of filters in FilterableDataTable

### DIFF
--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -29,6 +29,7 @@ class FilterableDataTable extends Component {
     };
     this.updateFilter = this.updateFilter.bind(this);
     this.clearFilter = this.clearFilter.bind(this);
+    this.validFilters = this.validFilters.bind(this);
   }
 
   /**
@@ -38,6 +39,9 @@ class FilterableDataTable extends Component {
    */
   updateFilter(filter) {
     this.setState({filter});
+    if (this.props.updateFilterCallback) {
+        this.props.updateFilterCallback(filter);
+    }
   }
 
   /**
@@ -49,17 +53,46 @@ class FilterableDataTable extends Component {
   }
 
   /**
+   * Returns the filter state, with filters that are
+   * set to an invalid option removed from the returned
+   * filters
+   *
+   * @return {object}
+   */
+  validFilters() {
+      let filters = {};
+      this.props.fields.forEach((field) => {
+        const filtername = field.filter.name;
+        const filterval = this.state.filter[filtername];
+        if (!this.state.filter[filtername]) {
+            return;
+        }
+
+        if (field.filter.type !== 'select') {
+            return;
+        }
+
+        if (!(filterval.value in field.filter.options)) {
+            return;
+        }
+        filters[filtername] = filterval;
+      });
+      return filters;
+  }
+
+  /**
    * Renders the React component.
    *
    * @return {JSX} - React markup for the component
    */
   render() {
+    const filters = this.validFilters();
     const filter = (
       <Filter
         name={this.props.name + '_filter'}
         id={this.props.name + '_filter'}
         columns={this.props.columns}
-        filter={this.state.filter}
+        filter={filters}
         fields={this.props.fields}
         updateFilter={this.updateFilter}
         clearFilter={this.clearFilter}
@@ -70,7 +103,7 @@ class FilterableDataTable extends Component {
       <DataTable
         data={this.props.data}
         fields={this.props.fields}
-        filter={this.state.filter}
+        filter={filters}
         actions={this.props.actions}
         getFormattedCell={this.props.getFormattedCell}
         getMappedCell={this.props.getMappedCell}
@@ -125,6 +158,7 @@ FilterableDataTable.propTypes = {
   columns: PropTypes.number,
   getFormattedCell: PropTypes.func,
   actions: PropTypes.array,
+  updateFilterCallback: PropTypes.func,
 };
 
 export default FilterableDataTable;

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -62,6 +62,9 @@ class FilterableDataTable extends Component {
   validFilters() {
       let filters = {};
       this.props.fields.forEach((field) => {
+        if (!field.filter) {
+            return;
+        }
         const filtername = field.filter.name;
         const filterval = this.state.filter[filtername];
         if (!filterval) {

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -69,6 +69,7 @@ class FilterableDataTable extends Component {
         }
 
         if (field.filter.type !== 'select') {
+            filters[filtername] = filterval;
             return;
         }
 

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -64,7 +64,7 @@ class FilterableDataTable extends Component {
       this.props.fields.forEach((field) => {
         const filtername = field.filter.name;
         const filterval = this.state.filter[filtername];
-        if (!this.state.filter[filtername]) {
+        if (!filterval) {
             return;
         }
 


### PR DESCRIPTION
This adds a callback for updating filters in a FilterableDataTable.
This is intended to make it possible to add features such as context
sensitive filters, where the option selected for filter A might affect
the options available in filter B (for instance, selecting a project filter
affecting which subprojects are available in a subproject filter.)

Since changing the options might result in filter B being in an invalid
state (if the option that was selected is no longer valid when A
changes) the FilterableDataTable also removes invalid choices from being
passed down to the DataTable or Filter components upon rendering.