### PR TITLE
[Instrument] Fix GUIDelimiter class variable name

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -73,10 +73,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
     /**
      * String to separate the group elements
-     *
-     * @access public
      */
-    public $GUIDelimiter = "</td>\n<td>";
+    var $_GUIDelimiter = "</td>\n<td>";
 
     /**
      * Commonly used level of indentation


### PR DESCRIPTION
The variable was incorrectly renamed in a PR which was just
supposed to add access modifiers to variables. This old name
is used all over the place by instruments, so this restores
the name to prevent warnings from LORIS.

The keyword needs to remain `var` to prevent PHPCS from
complaining about the underscore.