### PR TITLE
[dev] Remove shellcheck from make checkstatic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ clean:
 
 # Perform static analysis checks
 checkstatic: phpdev
-	npm run lint:shell
 	npm run lint:php
 	vendor/bin/phan
 	npm run lint:javascript


### PR DESCRIPTION
PR #6053 added the "shellcheck" tool to our static analysis suite
to lint shell scripts. However, the PR added it to `make checkstatic`
prematurely.

1. The wrapper shell script does not run on MacOS because it depends
   on newer bash options.
2. The script requires a third party tool which is not managed by
   any of our dependency managers (npm, composer, etc) to be installed.

The result is that developers can no longer run `make checkstatic`
to check their code without running through hoops. This removes
it from the checkstatic target, since it currently prevents developers
from working on LORIS.