### PR TITLE
[Data Tables] Add ability for data tables to stream data

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,11 @@
     "@babel/preset-react",
     "@babel/preset-env"
   ],
-  "plugins": ["@babel/plugin-proposal-object-rest-spread"]
+  "plugins": ["@babel/plugin-proposal-object-rest-spread",
+     ["@babel/plugin-transform-runtime",
+      {
+        "regenerator": true
+      }
+    ]
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ changes in the following format: PR #1234***
 ##LORIS 24.0 (Release Date: ??)
 ### Core
 #### Features
-- *Add item here*
+- Data tables may now stream data as they're loading rather than waiting
+  until all data has loaded. (PR #6853)
+
 #### Updates and Improvements
 - Module-specific permissions added for Survey Accounts, Imaging Behavioural
 Quality Control, and Behavioural Quality Control. (PR #6041)

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -61,4 +61,17 @@ foreach ($headers as $name => $values) {
 }
 
 // Include the body.
-print $response->getBody();
+$bodystream = $response->getBody();
+
+// First we need to disable any output buffering so that
+// it streams to the output instead of into the buffer
+// and uses up all the memory for large chunks of data.
+for ($i = ob_get_level(); $i != 0; $i = ob_get_level()) {
+    ob_end_clean();
+}
+ob_implicit_flush();
+
+while ($bodystream->eof() == false) {
+    // 64k oughta be enough for anybody.
+    print $bodystream->read(1024*64);
+}

--- a/jslib/fetchDataStream.js
+++ b/jslib/fetchDataStream.js
@@ -1,0 +1,96 @@
+/**
+ * Process as many rows as possible from a data stream.
+ *
+ * @param {binary} data - a chunk of data read from the data stream
+ * @param {function} rowcb - The row callback function
+ * @param {function} endstreamcb - The stream termination callback
+ * function
+ *
+ * @return {object} An object containing keys "remainder" which is
+ * a slice of any unprocessed data, and a key "eos" which is a boolean
+ * indicating whether the end of the stream has been reached.
+ */
+async function processLines(data, rowcb, endstreamcb) {
+    const utf8Decoder = new TextDecoder('utf-8');
+    let row = [];
+    let colStart = -1;
+    let rowStart = 0;
+    for (let i = 0; i < data.length; i++) {
+        switch (data[i]) {
+            case 0x1e: // end of column
+                const rowdata = data.slice(colStart+1, i);
+                const encoded = utf8Decoder.decode(rowdata);
+                colStart = i;
+                row.push(encoded);
+                continue;
+            case 0x1f: // end of row
+                const rowdata2 = data.slice(colStart+1, i);
+                const encoded2 = utf8Decoder.decode(rowdata2);
+                row.push(encoded2);
+
+                rowcb(row);
+
+                rowStart = i+1;
+                colStart = i;
+                row = [];
+                continue;
+            case 0x04: // end of stream
+                rowcb(row);
+                endstreamcb(row);
+                return {remainder: [], eos: true};
+        }
+    }
+    return {remainder: data.slice(rowStart), eos: false};
+};
+
+/**
+ * fetchDataStream fetches a data stream from dataURL where
+ * rows are denoted by the byte 0x1f, columns by 0x1e, and
+ * the stream is terminated by 0x04.
+ *
+ * @param {string} dataURL   - the URL of the stream to fetch
+ * @param {function} rowcb   - A callback to call for each row
+ * @param {function} chunkcb - A callback to call for each chunk
+ *                             read from the stream.
+ * @param {function} endstreamcb - A callback to call when the final
+ *                             byte is read from the stream.
+ */
+async function fetchDataStream(dataURL, rowcb, chunkcb, endstreamcb) {
+    const response = await fetch(
+        dataURL,
+        {credentials: 'same-origin'},
+    );
+
+    const reader = response.body.getReader();
+
+    let remainder = [];
+    let doneLoop = false;
+    while (!doneLoop) {
+        await reader.read().then(({done, value}) => {
+            let combined;
+            if (remainder.length == 0) {
+                combined = value;
+            } else {
+                combined = new Uint8Array(
+                    value.length + remainder.length
+                );
+                for (let i = 0; i < remainder.length; i++) {
+                    combined[i] = remainder[i];
+                }
+                for (let i = 0; i < value.length; i++) {
+                    combined[i+remainder.length] = value[i];
+                }
+            }
+            return processLines(combined, rowcb, endstreamcb);
+        }).then(({remainder: rem, eos}) => {
+            chunkcb(eos);
+            doneLoop = eos;
+            remainder = rem;
+        }).catch((err) => {
+            console.error(err);
+            doneLoop = true;
+        });
+    };
+};
+
+export default fetchDataStream;

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -540,6 +540,8 @@ class DataTable extends Component {
       </select>
     );
 
+    const loading = this.props.loading ? 'Loading...' : '';
+
     let header = this.props.hide.rowsPerPage === true ? '' : (
       <div className="table-header">
         <div className="row">
@@ -556,6 +558,7 @@ class DataTable extends Component {
             }}>
               {rows.length} rows displayed of {filteredCount}.
               (Maximum rows per page: {rowsPerPageDropdown})
+              {loading}
             </div>
             <div style={{
               order: '2',

--- a/jsx/FilterableDataTable.js
+++ b/jsx/FilterableDataTable.js
@@ -118,6 +118,7 @@ class FilterableDataTable extends Component {
         fields={this.props.fields}
         filter={filters}
         actions={this.props.actions}
+        loading={this.props.loading}
         getFormattedCell={this.props.getFormattedCell}
         getMappedCell={this.props.getMappedCell}
         folder={this.props.folder}

--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -29,7 +29,7 @@ class DataDictIndex extends Component {
       error: false,
       isLoaded: false,
       isLoading: false,
-      fieldOptions: {'sourceFrom': {'abc': 'def'}},
+      fieldOptions: {'sourceFrom': {}},
     };
 
     this.fetchData = this.fetchData.bind(this);
@@ -74,6 +74,9 @@ class DataDictIndex extends Component {
                         row.push(encoded);
                         continue;
                     case 0x1f: // end of row
+                        const rowdata2 = data.slice(colStart+1, i);
+                        const encoded2 = utf8Decoder.decode(rowdata2);
+                        row.push(encoded2);
                         this.state.data.push(row);
                         rowStart = i+1;
                         colStart = i;

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -1,0 +1,29 @@
+<?php
+namespace LORIS\datadict;
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+
+/**
+ * Return the dynamic field options for the data dictionary filter
+ * as a JSON object.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link    https://github.com/aces/Loris
+ */
+class Fields extends \NDB_Page
+{
+    /**
+     * Returns a list of instruments to use as the "Source From"
+     * filter options as JSON.
+     *
+     * @param ServerRequestInterface $request The incoming request
+     *
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        return new \LORIS\Http\Response\JSON\OK(
+            ['sourceFrom' => \Utility::getAllInstruments()]
+        );
+    }
+}

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -35,11 +35,11 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
     private $_loadingUI
         =  [
             'Data Dictionary'    => '#bc2 > a:nth-child(2) > div',
-            'Source From'        => '#dynamictable > thead > tr > th:nth-child(2)',
-            'Name'               => '#dynamictable > thead > tr > th:nth-child(3)',
-            'Source Field'       => '#dynamictable > thead > tr > th:nth-child(4)',
-            'Description'        => '#dynamictable > thead > tr > th:nth-child(5)',
-            'Description Status' => '#dynamictable > thead > tr > th:nth-child(6)',
+            'Source From'        => '.col-xs-12:nth-child(2) .col-sm-3',
+            'Name'               => '.col-xs-12:nth-child(3) .col-sm-3',
+            'Source Field'       => '.col-xs-12:nth-child(4) .col-sm-3',
+            'Description'        => '.col-xs-12:nth-child(5) .col-sm-3',
+            'Description Status' => '.col-xs-12:nth-child(6) .col-sm-3',
         ];
 
     /**
@@ -106,7 +106,6 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
     function testPageUIs()
     {
         $this->safeGet($this->url . "/datadict/");
-        sleep(3);
         foreach ($this->_loadingUI as $key => $value) {
             $text = $this->safeFindElement(
                 WebDriverBy::cssSelector($value)

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -106,6 +106,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
     function testPageUIs()
     {
         $this->safeGet($this->url . "/datadict/");
+        sleep(3);
         foreach ($this->_loadingUI as $key => $value) {
             $text = $this->safeFindElement(
                 WebDriverBy::cssSelector($value)

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -35,11 +35,11 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
     private $_loadingUI
         =  [
             'Data Dictionary'    => '#bc2 > a:nth-child(2) > div',
-            'Source From'        => '.col-xs-12:nth-child(2) .col-sm-3',
-            'Name'               => '.col-xs-12:nth-child(3) .col-sm-3',
-            'Source Field'       => '.col-xs-12:nth-child(4) .col-sm-3',
-            'Description'        => '.col-xs-12:nth-child(5) .col-sm-3',
-            'Description Status' => '.col-xs-12:nth-child(6) .col-sm-3',
+            'Source From'        => '.col-xs-12:nth-child(3) .col-sm-3',
+            'Name'               => '.col-xs-12:nth-child(4) .col-sm-3',
+            'Source Field'       => '.col-xs-12:nth-child(5) .col-sm-3',
+            'Description'        => '.col-xs-12:nth-child(6) .col-sm-3',
+            'Description Status' => '.col-xs-12:nth-child(7) .col-sm-3',
         ];
 
     /**
@@ -114,4 +114,3 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
         }
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "test": "test"
   },
   "dependencies": {
+    "@babel/plugin-transform-runtime": "^7.10.5",
+    "@babel/runtime": "^7.10.5",
     "@fortawesome/fontawesome-free": "^5.11.2",
     "copy-webpack-plugin": "^5.1.1",
     "prop-types": "^15.7.2",

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -14,6 +14,9 @@
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
 
+use \Psr\Http\Message\ServerRequestInterface;
+use \Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 /**
  * A DataFrameworkMenu is a type of menu (filterable data table)
  * where the data comes from the LORIS data framework, and the
@@ -147,6 +150,38 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
                 'fieldOptions' => $this->getFieldOptions(),
             ]
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param ServerRequestInterface $request The PSR15 Request being handled
+     *
+     * @return ResponseInterface The PSR15 response for the page.
+     */
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        if (($request->getQueryParams()['format'] ?? '') === 'binary') {
+            return (new \LORIS\Http\Response())
+                ->withHeader("Content-Type", "application/octet-stream")
+                ->withBody($this->toBinaryStream());
+        }
+        return parent::handle($request);
+    }
+
+    /**
+     * Return a PSR7 StreamInterface which streams the data for this table
+     * as a binary stream
+     *
+     * @return StreamInterface Stream of the table data
+     */
+    public function toBinaryStream(): StreamInterface
+    {
+        $table = (new \LORIS\Data\Table())
+            ->withDataFrom($this->getDataProvisionerWithFilters());
+        $rows  = $table->getRows(\NDB_Factory::singleton()->user());
+        return new \LORIS\Http\DataIteratorBinaryStream($rows);
+
     }
 }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -687,14 +687,14 @@ class NDB_Page implements RequestHandlerInterface
         // Format should be deprecated and getting the page in different formats
         // should be a different endpoint or use HTTP content negotiation headers.
         $get = $request->getQueryParams();
-        if (isset($get['format'])) {
+        if (isset($get['format']) && $get['format'] === 'json') {
             $this->format = $get['format'];
             return $handler->handle($request)
                 ->withHeader("Content-Type", "application/json");
         }
+
         return (new \LORIS\Middleware\PageDecorationMiddleware($user))
-            ->process($request, $handler)
-            ->withHeader("Content-Type", "text/html");
+            ->process($request, $handler);
     }
 
     /**

--- a/src/Http/DataIteratorBinaryStream.php
+++ b/src/Http/DataIteratorBinaryStream.php
@@ -187,7 +187,7 @@ class DataIteratorBinaryStream implements StreamInterface
             $this->eof = true;
             return chr(0x04);
         }
-        $rowArray        = array_values(json_decode($row->toJSON(), true));
+        $rowArray        = array_values(json_decode(json_encode($row), true));
         $rowVal          = join(chr(0x1e), $rowArray) . chr(0x1f);
         $this->position += strlen($rowVal);
         return $rowVal;

--- a/src/Http/DataIteratorBinaryStream.php
+++ b/src/Http/DataIteratorBinaryStream.php
@@ -1,0 +1,231 @@
+<?php
+namespace LORIS\Http;
+
+use \Psr\Http\Message\StreamInterface;
+
+/**
+ * A DataIteratorBinaryStream takes a Traversable of data
+ * from a LORIS DataProvisioner and returns it over a stream
+ * as it's read.
+ */
+class DataIteratorBinaryStream implements StreamInterface
+{
+    protected $position;
+    protected $eof;
+    protected $rowgen;
+
+    public function __construct(\Traversable $data)
+    {
+        $this->position = 0;
+        $this->rows     = $data;
+        $this->rowgen   = $this->rowGenerator();
+        $this->eof      = false;
+    }
+    /**
+     * Reads all data from the stream into a string, from the beginning to end.
+     *
+     * This method MUST attempt to seek to the beginning of the stream before
+     * reading data and read the stream until the end is reached.
+     *
+     * Warning: This could attempt to load a large amount of data into memory.
+     *
+     * This method MUST NOT raise an exception in order to conform with PHP's
+     * string casting operations.
+     *
+     * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
+     * @return string
+     */
+    public function __toString()
+    {
+        return "";
+    }
+
+    /**
+     * Closes the stream and any underlying resources.
+     *
+     * @return void
+     */
+    public function close()
+    {
+    }
+
+    /**
+     * Separates any underlying resources from the stream.
+     *
+     * After the stream has been detached, the stream is in an unusable state.
+     *
+     * @return resource|null Underlying PHP stream, if any
+     */
+    public function detach()
+    {
+        return null;
+    }
+
+    /**
+     * Get the size of the stream if known.
+     *
+     * @return int|null Returns the size in bytes if known, or null if unknown.
+     */
+    public function getSize()
+    {
+        return null;
+    }
+
+    /**
+     * Returns the current position of the file read/write pointer
+     *
+     * @return int Position of the file pointer
+     * @throws \RuntimeException on error.
+     */
+    public function tell()
+    {
+        return $this->position;
+    }
+
+    /**
+     * Returns true if the stream is at the end of the stream.
+     *
+     * @return bool
+     */
+    public function eof()
+    {
+        return $this->eof;
+    }
+
+    /**
+     * Returns whether or not the stream is seekable.
+     *
+     * @return bool
+     */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /**
+     * Seek to a position in the stream.
+     *
+     * @see http://www.php.net/manual/en/function.fseek.php
+     * @param int $offset Stream offset
+     * @param int $whence Specifies how the cursor position will be calculated
+     *     based on the seek offset. Valid values are identical to the built-in
+     *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
+     *     offset bytes SEEK_CUR: Set position to current location plus offset
+     *     SEEK_END: Set position to end-of-stream plus offset.
+     * @throws \RuntimeException on failure.
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new \RuntimeException("Can not seek");
+    }
+
+    /**
+     * Seek to the beginning of the stream.
+     *
+     * If the stream is not seekable, this method will raise an exception;
+     * otherwise, it will perform a seek(0).
+     *
+     * @see seek()
+     * @see http://www.php.net/manual/en/function.fseek.php
+     * @throws \RuntimeException on failure.
+     */
+    public function rewind()
+    {
+        throw new \RuntimeException("Stream not seekable");
+    }
+
+    /**
+     * Returns whether or not the stream is writable.
+     *
+     * @return bool
+     */
+    public function isWritable()
+    {
+        return false;
+    }
+
+    /**
+     * Write data to the stream.
+     *
+     * @param string $string The string that is to be written.
+     * @return int Returns the number of bytes written to the stream.
+     * @throws \RuntimeException on failure.
+     */
+    public function write($string)
+    {
+        throw new \RuntimeException("Stream not writable");
+    }
+
+    /**
+     * Returns whether or not the stream is readable.
+     *
+     * @return bool
+     */
+    public function isReadable()
+    {
+        return true;
+    }
+
+    /**
+     * Read data from the stream.
+     *
+     * @param int $length Read up to $length bytes from the object and return
+     *     them. Fewer than $length bytes may be returned if underlying stream
+     *     call returns fewer bytes.
+     * @return string Returns the data read from the stream, or an empty string
+     *     if no bytes are available.
+     * @throws \RuntimeException if an error occurs.
+     */
+    public function read($length)
+    {
+        if ($this->eof) {
+            return "";
+        }
+        $this->rowgen->next();
+        $row = $this->rowgen->current();
+        if (!$this->rowgen->valid()) {
+            $this->eof = true;
+            return chr(0x04);
+        }
+        $rowArray        = array_values(json_decode($row->toJSON(), true));
+        $rowVal          = join(chr(0x1e), $rowArray) . chr(0x1f);
+        $this->position += strlen($rowVal);
+        return $rowVal;
+    }
+
+    /**
+     * Returns the remaining contents in a string
+     *
+     * @return string
+     * @throws \RuntimeException if unable to read.
+     * @throws \RuntimeException if error occurs while reading.
+     */
+    public function getContents()
+    {
+        return "";
+    }
+
+    /**
+     * Get stream metadata as an associative array or retrieve a specific key.
+     *
+     * The keys returned are identical to the keys returned from PHP's
+     * stream_get_meta_data() function.
+     *
+     * @see http://php.net/manual/en/function.stream-get-meta-data.php
+     * @param string $key Specific metadata to retrieve.
+     * @return array|mixed|null Returns an associative array if no key is
+     *     provided. Returns a specific key value if a key is provided and the
+     *     value is found, or null if the key is not found.
+     */
+    public function getMetadata($key = null)
+    {
+        return null;
+    }
+
+    private function rowGenerator()
+    {
+        foreach ($this->rows as $row) {
+            yield $row;
+        }
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ const resolve = {
   alias: {
     util: path.resolve(__dirname, './htdocs/js/util'),
     jsx: path.resolve(__dirname, './jsx'),
+    jslib: path.resolve(__dirname, './jslib'),
     Breadcrumbs: path.resolve(__dirname, './jsx/Breadcrumbs'),
     DataTable: path.resolve(__dirname, './jsx/DataTable'),
     DynamicDataTable: path.resolve(__dirname, './jsx/DynamicDataTable'),


### PR DESCRIPTION
This is a proof of concept. It loads the data for the data dictionary
module from a binary stream rather than a JSON object and displays the
data in the table as it is loading. The stream consists of rows separated
by the byte 0x1f, and columns separated by 0x1e. The entire stream is
terminated with the byte 0x04.

FieldOptions are moved to a different endpoint rather than crammed
into the JSON since there is no longer any JSON to cram it into.