### PR TITLE
[instrument_builer] Blank line fix

### DIFF
--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -90,7 +90,7 @@ var Instrument = {
             for (element of elements[i].Elements) {
                 switch (element.Type) {
                     case "line":
-                        content += '<br>\n';
+                        content += 'static{@}{@}<br>\n';
                     case "select":
                         if (element.Options.AllowMultiple) {
                             content += "selectmultiple{@}"

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -88,10 +88,8 @@ var Instrument = {
                 content += "page{@}{@}" + elements[i].Description + "\n";
             }
             for (element of elements[i].Elements) {
+              console.log(element.Type);
                 switch (element.Type) {
-                    case "line":
-                      content += 'line{@}{@}' + element.Description + "\n";
-                        break;
                     case "select":
                         if (element.Options.AllowMultiple) {
                             content += "selectmultiple{@}"

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -89,6 +89,8 @@ var Instrument = {
             }
             for (element of elements[i].Elements) {
                 switch (element.Type) {
+                    case "line":
+                        content += '<br>\n';
                     case "select":
                         if (element.Options.AllowMultiple) {
                             content += "selectmultiple{@}"

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -90,7 +90,7 @@ var Instrument = {
             for (element of elements[i].Elements) {
                 switch (element.Type) {
                     case "line":
-                        content += 'static{@}{@}<br>\n';
+                      content += 'line{@}{@}' + element.Description + "\n";
                         break;
                     case "select":
                         if (element.Options.AllowMultiple) {
@@ -298,6 +298,14 @@ var Instrument = {
                                 value: "Header"
                             };
                             break;
+                      case "line":
+                          tempElement.Type = 'line';
+                          tempElement.Description = pieces[2];
+                          tempElement.selected = {
+                            id: 'line',
+                            value: 'Blank Line'
+                          };
+                          break;
                         default:
                             break;
                     }

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -91,6 +91,7 @@ var Instrument = {
                 switch (element.Type) {
                     case "line":
                         content += 'static{@}{@}<br>\n';
+                        break;
                     case "select":
                         if (element.Options.AllowMultiple) {
                             content += "selectmultiple{@}"

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -90,6 +90,10 @@ var Instrument = {
             for (element of elements[i].Elements) {
               console.log(element.Type);
                 switch (element.Type) {
+                    case "line":
+                      console.log('test');
+                      content += 'line{@}{@}' + element.Description + "\n";
+                      break;
                     case "select":
                         if (element.Options.AllowMultiple) {
                             content += "selectmultiple{@}"

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -88,10 +88,8 @@ var Instrument = {
                 content += "page{@}{@}" + elements[i].Description + "\n";
             }
             for (element of elements[i].Elements) {
-              console.log(element.Type);
                 switch (element.Type) {
                     case "line":
-                      console.log('test');
                       content += 'line{@}{@}' + element.Description + "\n";
                       break;
                     case "select":

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -90,7 +90,7 @@ var Instrument = {
             for (element of elements[i].Elements) {
                 switch (element.Type) {
                     case "line":
-                      content += 'line{@}{@}<br />'+"\n";
+                      content += 'static{@}{@}<br />'+"\n";
                       break;
                     case "select":
                         if (element.Options.AllowMultiple) {

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -90,7 +90,7 @@ var Instrument = {
             for (element of elements[i].Elements) {
                 switch (element.Type) {
                     case "line":
-                      content += 'line{@}{@}' + element.Description + "\n";
+                      content += 'line{@}{@}<br />'+"\n";
                       break;
                     case "select":
                         if (element.Options.AllowMultiple) {
@@ -275,20 +275,37 @@ var Instrument = {
                             };
                             break;
                         case "static":
-                            tempElement.Type = (pieces[1] === '') ? 'label' : 'score';
+                            if (pieces[1] === '') {
+                                if (pieces[2] === '<br />') {
+                                  tempElement.Type = 'line';
+                                } else {
+                                  tempElement.Type = 'label';
+                                }
+                            } else {
+                              tempElement.Type = 'score';
+                            }
+
                             if (tempElement.Type === 'score') {
                                 tempElement.Name = pieces[1];
                                 tempElement.selected = {
                                     id: "score",
                                     value: "Scored Field"
                                 };
-                            } else {
+                                tempElement.Description = pieces[2];
+                            }
+                            if (tempElement.Type === 'label') {
                                 tempElement.selected = {
                                     id: "label",
                                     value: "Label"
                                 };
+                                tempElement.Description = pieces[2];
                             }
-                            tempElement.Description = pieces[2];
+                            if (tempElement.Type === 'line') {
+                              tempElement.selected = {
+                                id: "line",
+                                value: "Blank line"
+                              };
+                            }
                             break;
                         case "header":
                             tempElement.Type = 'header';
@@ -298,14 +315,6 @@ var Instrument = {
                                 value: "Header"
                             };
                             break;
-                      case "line":
-                          tempElement.Type = 'line';
-                          tempElement.Description = pieces[2];
-                          tempElement.selected = {
-                            id: 'line',
-                            value: 'Blank Line'
-                          };
-                          break;
                         default:
                             break;
                     }

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -39,6 +39,7 @@ class LorisElement extends Component {
         break;
       case 'line':
         elementHtml = <div></div>;
+        break;
       case 'score':
         elementHtml = <StaticElement text={0} label={element.Description} />;
 

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -727,12 +727,19 @@ class AddElement extends Component {
           {} :
           this.props.element.Options
         ),
-        Description: Instrument.clone(this.props.element.Description),
+        Description: Instrument.clone(
+          this.props.element.Description === undefined ?
+          {} :
+          this.props.element.Description
+        ),
         Name: Instrument.clone(this.props.element.Name === undefined ?
           '' :
           this.props.element.Name
         ),
-        selected: Instrument.clone(this.props.element.selected),
+        selected: Instrument.clone(this.props.element.selected === undefined ?
+          {} :
+          this.props.element.selected
+        ),
       };
     } else {
       this.state = {
@@ -898,8 +905,9 @@ class AddElement extends Component {
 
     // Setup the desired element to be added
     switch (selected) {
-      case 'header':
       case 'line':
+        break;
+      case 'header':
       case 'label':
         questionName = '';
         break;
@@ -981,8 +989,9 @@ class AddElement extends Component {
     let buttons;
         // Set the inputs to display based on the desired element type
     switch (this.state.selected.id) {
-      case 'header':
       case 'line':
+        break;
+      case 'header':
       case 'label':
         questionInput = <QuestionText
           updateState={this.updateState}

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -524,6 +524,7 @@ class ListElements extends Component {
         newState.Options = {};
         newState.Name = '';
         newState.Description = '';
+        break;
       case 'textarea':
         textSize = 'large';
         // falls through

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -37,6 +37,8 @@ class LorisElement extends Component {
       case 'label':
         elementHtml = <p>{element.Description}</p>;
         break;
+      case 'line':
+        elementHtml = <div></div>;
       case 'score':
         elementHtml = <StaticElement text={0} label={element.Description} />;
 
@@ -896,6 +898,7 @@ class AddElement extends Component {
     // Setup the desired element to be added
     switch (selected) {
       case 'header':
+      case 'line':
       case 'label':
         questionName = '';
         break;
@@ -978,6 +981,7 @@ class AddElement extends Component {
         // Set the inputs to display based on the desired element type
     switch (this.state.selected.id) {
       case 'header':
+      case 'line':
       case 'label':
         questionInput = <QuestionText
           updateState={this.updateState}

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -520,6 +520,10 @@ class ListElements extends Component {
     let textSize = 'small';
     // Set the options for the desired type
     switch (newId) {
+      case 'line':
+        newState.Options = {};
+        newState.Name = '';
+        newState.Description = '';
       case 'textarea':
         textSize = 'large';
         // falls through


### PR DESCRIPTION
## Brief summary of changes
this is almost an exact replica of #5616 with the difference being that this would be backwards compatible with existing linst files havin `static{@}{@}<br />` encoding a blank line.

This functionality was removed 5 years ago in the following commit https://github.com/aces/Loris/commit/52b22d7fc66720e57ebc5f4d4564cdb288222409