### PR TITLE
[instrument_builder] Loading existing instrument corrupts Date element

### DIFF
--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -121,9 +121,18 @@ var Instrument = {
                         // Add dropdown and special naming when no date format is set
                         // (i.e when addDateElement() is used)
                         if (!element.Options.dateFormat) {
+                          if (elName === '' || !elName.includes('_date')) {
                             elName = elName + "_date";
-                            dropdown = "select{@}" + elName + "_status" +
+                          }
+                          console.log(element.Description);
+                          if (!element.Description) {
+                            element.Description = '';
+                          }
+                          dropdown = "select{@}" + elName + "_status" +
                             "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
+                        }
+                        if (!element.Options.dateFormat) {
+                          element.Options.dateFormat = 'Date';
                         }
 
                         content += 'date{@}';

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -120,7 +120,7 @@ var Instrument = {
 
                         // Add dropdown and special naming when no date format is set
                         // (i.e when addDateElement() is used)
-                        if (element.Options.dateFormat === "") {
+                        if (!element.Options.dateFormat) {
                             elName = elName + "_date";
                             dropdown = "select{@}" + elName + "_status" +
                             "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -124,14 +124,13 @@ var Instrument = {
                           if (elName === '' || !elName.includes('_date')) {
                             elName = elName + "_date";
                           }
-                          console.log(element.Description);
                           if (!element.Description) {
+                            // Prevents undefined being added to linst file.
                             element.Description = '';
                           }
                           dropdown = "select{@}" + elName + "_status" +
                             "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
-                        }
-                        if (!element.Options.dateFormat) {
+                          // Makes the date be the default 'Date' if undefined.
                           element.Options.dateFormat = 'Date';
                         }
 

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -121,9 +121,9 @@ var Instrument = {
                         // Add dropdown and special naming when no date format is set
                         // (i.e when addDateElement() is used)
                         if (!element.Options.dateFormat) {
-                          if (!element.Description) {
-                            // Prevents undefined being added to linst file.
-                            element.Description = '';
+                          if (!elName.includes('_date')) {
+                            // prevents double _date if load & save linst file.
+                            elName = elName + "_date";
                           }
                           dropdown = "select{@}" + elName + "_status" +
                             "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -121,9 +121,6 @@ var Instrument = {
                         // Add dropdown and special naming when no date format is set
                         // (i.e when addDateElement() is used)
                         if (!element.Options.dateFormat) {
-                          if (elName === '' || !elName.includes('_date')) {
-                            elName = elName + "_date";
-                          }
                           if (!element.Description) {
                             // Prevents undefined being added to linst file.
                             element.Description = '';


### PR DESCRIPTION
## Brief summary of changes

When loading an existing instrument and resaving the linst into a new file, the Date element's status field is lost and "undefined" is concatenated to the end of the date element line. This PR fixes the foregoing problem.

#### Testing instructions (if applicable)

1. Go to 'Instrument Builder module', Build tab and build an instrument with date elements
2. Click on 'Save' tab and save the instrument.
3. Read the linst file and see the output.
4. Refresh the instrument builder, and go to the 'Load' tab. Load the instrument linst file that you just created.
5. You can add extra fields to the build if you like, but without editing the date fields, resave the instrument.
6. Read the linst file and notice no changes made to the otherwise untouched file.

#### Link(s) to related issue(s)

* Resolves https://github.com/aces/Loris/issues/6669