### PR TITLE
[Core] Fix fatal error caused by exception handling middleware

### DIFF
--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -132,13 +132,10 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
         // Fall through to 404. We don't have any routes that go farther
         // than 1 level..
-        return $ehandler->process(
-            $request,
-            (new \LORIS\Middleware\PageDecorationMiddleware($this->user))
+        return (new \LORIS\Middleware\PageDecorationMiddleware($this->user))
                 ->process(
                     $request,
                     new NoopResponder(new \LORIS\Http\Error($request, 404))
-                )
-        );
+                );
     }
 }


### PR DESCRIPTION
The second argument to the "process" function is a RequestHandler,
but was incorrectly passed a response directly in the case where
the BaseRouter got a 404 error.

This is not a case that should generate any exceptions, since it's
not dependent on any user data (other than the URL from the request
object, which is just used for the error page).

Remove the ExceptionHandlingMiddleware to fix this case.

Fixes the error:

```
Fatal error:  Uncaught TypeError: Argument 2 passed to LORIS\\Middleware\\ExceptionHandlingMiddleware::process() must implement interface Psr\\Http\\Server\\RequestHandlerInterface, instance of LORIS\\Http\\Error given, called in /var/www/loris/src/Router/BaseRouter.php on line 140 and defined in /var/www/loris/src/Middleware/ExceptionHandlingMiddleware.php:29\nStack trace:\n#0 /var/www/loris/src/Router/BaseRouter.php(140): LORIS\\Middleware\\ExceptionHandlingMiddleware->process(Object(Laminas\\Diactoros\\ServerRequest), Object(LORIS\\Http\\Error))\n#1 /var/www/loris/src/Middleware/ResponseGenerator.php(50): LORIS\\Router\\BaseRouter->handle(Object(Laminas\\Diactoros\\ServerRequest))\n#2 /var/www/loris/src/Middleware/ContentLength.php(52): LORIS\\Middleware\\ResponseGenerator->process(Object(Laminas\\Diactoros\\ServerRequest), Object(LORIS\\Router\\BaseRouter))\n#3 /var/www/loris/htdocs/index.php(48): LORIS\\Middleware\\ContentLength->process(Object(Laminas\\Diactoros\\ServerRequest), Object(LORIS\\Router\\BaseRouter))\n#4 {main}\n  thrown in /var/www/loris/src/Middleware/ExceptionHandlingMiddleware.php on line 29, referer: [...]
```
