### PR TITLE
[Instrument] Allow fields to have value "0"

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1427,21 +1427,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
     /**
      * Get a the value of $field from the instrument table.
-     * Used specifically by electronic instruments to check if file
-     * is already uploaded.
      *
      * @param string $field The field to get from this instrument
      *
-     * @return string|false The value of the field, or false if it's empty.
+     * @return string The value of the field, or false if it's empty.
      */
     function getFieldValue(string $field)
     {
         $allValues = self::loadInstanceData($this);
 
-        if (!empty($allValues[$field])) {
-            return $allValues[$field];
+        if (!array_key_exists($field, $allValues)) {
+            throw new \OutOfBoundsException("Invalid field for instrument");
         }
-        return false;
+        return $allValues[$field];
     }
 
 


### PR DESCRIPTION
The instrument getFieldValue function was doing a "!empty" check
to see if the field is valid. This catches values such as "0"
incorrectly and converts them to false.

This changes it to array_key_exists to properly verify that the
field is valid. At the same time, it converts the "false" error
code return for an invalid field to an exception, since callers
shouldn't be requesting the value of fields that don't exist on
an instrument, and it indicates a programming error that is more
likely to be caught this way.