### PR TITLE
[Instrument] Add method for loading multiple instruments data at once

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2122,14 +2122,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "SELECT Data FROM flag WHERE CommentID=:CID",
                 ['CID' => $this->getCommentID()]
             );
-
             $this->instanceData = json_decode($jsondata, true) ?? [];
         } else {
             $defaults = $db->pselectRow(
                 "SELECT * FROM $this->table WHERE CommentID=:CID",
                 ['CID' => $this->getCommentID()]
             );
-
             $this->instanceData = $defaults ?? [];
         }
         return $this->instanceData;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2173,8 +2173,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * Loads multiple instruments representing multiple commentIDs from the
      * database in bulk. This function must be called on an instrument instantiated
      * as \NDB_BVL_Instrument::factory('instrumentname') without a comment ID, and
-     * will return an array of copies of the instrument type with the data for the given
-     * commentIDs loaded.
+     * will return an array of copies of the instrument type with the data for
+     * the given commentIDs loaded.
      *
      * @param $commentIDs string[] A list of commentIDs to load in bulk.
      *

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2168,6 +2168,82 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
+     * Loads multiple instruments representing multiple commentIDs from the
+     * database in bulk. This function must be called on an instrument instantiated
+     * as \NDB_BVL_Instrument::factory('instrumentname') without a comment ID, and
+     * will an array of copies of the instrument type with the data for the given
+     * commentIDs loaded.
+     *
+     * @param $commentIDs string[] A list of commentIDs to load in bulk.
+     *
+     * @return \NDB_BVL_Instrument[]
+     */
+    function bulkLoadInstanceData(iterable $commentIDs): array
+    {
+        if ($this->commentID !== null && $this->commentID !== '') {
+            throw new \LogicException(
+                "Must bulk load from instrument loaded without commentID"
+            );
+        }
+        $db = \Database::singleton();
+
+        $prepBindings = [];
+        $prepValues   = [];
+
+        $i = 0;
+        foreach ($commentIDs as $commentID) {
+            $i++;
+
+            $prepBindings[]      = ":cid$i";
+            $prepValues["cid$i"] = $commentID;
+        }
+
+        if ($this->jsonData) {
+            // We filter out if Data is null for 2 reasons.
+            // 1. Otherwise getInstanceData will re-query the database since
+            //    $newinst->instanceData is null and commentID is set
+            // 2. The Data column being null in the flag table is equivalent
+            //    to there not being a row in the table in the non-JSON
+            //    case (where it will also not get returned because there's
+            //    no row in the table.)
+            $jsondata = $db->pselect(
+                "SELECT CommentID, Data FROM flag WHERE Data IS NOT NULL" .
+                " AND CommentID IN ("
+                . join(',', $prepBindings) . ')',
+                $prepValues,
+            );
+            return array_map(
+                function ($row) {
+                    $newinst = clone $this;
+
+                    $newinst->commentID    = $row['CommentID'];
+                    $newinst->instanceData = json_decode($row['Data'], true);
+
+                    return $newinst;
+                },
+                $jsondata
+            );
+        } else {
+            $defaults = $db->pselect(
+                "SELECT * FROM $this->table WHERE CommentID IN ("
+                . join(',', $prepBindings) . ')',
+                $prepValues,
+            );
+            return array_map(
+                function ($row) {
+                    $newinst = clone $this;
+
+                    $newinst->commentID    = $row['CommentID'];
+                    $newinst->instanceData = $row;
+
+                    return $newinst;
+                },
+                $defaults
+            );
+        }
+    }
+
+    /**
      * Calculates the candidate's age at the time of this instrument.
      * If Date_taken is passed, this function  will calculate the age as of
      * the value of that argument. This is used, for instance, in

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2209,8 +2209,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             //    case (where it will also not get returned because there's
             //    no row in the table.)
             $jsondata = $db->pselect(
-                "SELECT CommentID, Data FROM flag WHERE Data IS NOT NULL" .
-                " AND CommentID IN ("
+                "SELECT CommentID, Data FROM flag WHERE CommentID IN ("
                 . join(',', $prepBindings) . ')',
                 $prepValues,
             );
@@ -2219,7 +2218,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     $newinst = clone $this;
 
                     $newinst->commentID    = $row['CommentID'];
-                    $newinst->instanceData = json_decode($row['Data'], true);
+                    $newinst->instanceData = json_decode(
+                        $row['Data'],
+                        true,
+                    ) ?? [];
 
                     return $newinst;
                 },

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2201,13 +2201,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         }
 
         if ($this->jsonData) {
-            // We filter out if Data is null for 2 reasons.
-            // 1. Otherwise getInstanceData will re-query the database since
-            //    $newinst->instanceData is null and commentID is set
-            // 2. The Data column being null in the flag table is equivalent
-            //    to there not being a row in the table in the non-JSON
-            //    case (where it will also not get returned because there's
-            //    no row in the table.)
             $jsondata = $db->pselect(
                 "SELECT CommentID, Data FROM flag WHERE CommentID IN ("
                 . join(',', $prepBindings) . ')',

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2173,7 +2173,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * Loads multiple instruments representing multiple commentIDs from the
      * database in bulk. This function must be called on an instrument instantiated
      * as \NDB_BVL_Instrument::factory('instrumentname') without a comment ID, and
-     * will an array of copies of the instrument type with the data for the given
+     * will return an array of copies of the instrument type with the data for the given
      * commentIDs loaded.
      *
      * @param $commentIDs string[] A list of commentIDs to load in bulk.

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2122,12 +2122,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 "SELECT Data FROM flag WHERE CommentID=:CID",
                 ['CID' => $this->getCommentID()]
             );
+
             $this->instanceData = json_decode($jsondata, true) ?? [];
         } else {
             $defaults = $db->pselectRow(
                 "SELECT * FROM $this->table WHERE CommentID=:CID",
                 ['CID' => $this->getCommentID()]
             );
+
             $this->instanceData = $defaults ?? [];
         }
         return $this->instanceData;


### PR DESCRIPTION
There is currently no mechanism to load the data from multiple
instrument instances at the same time efficiently and work with them
in PHP. (ie. to work the the data from multiple commentIDs for a single
instrument type in batch in a script) other than directly querying SQL.
However, this has other drawbacks such as the fact that you only know
whether the instrument data should be loaded from the flag.Data column
or a separate table once the instrument is instantiated.

This adds a bulkLoadInstanceData function which will load the data from
multiple commentIDs at the same time in a single SQL query and return an
array of \NDB_BVL_Instruments with the data loaded.

In my non-scientific benchmarking where I loaded all the data from a single
instrument type on my sandbox multiple times, and printed the value of a single
field this (unsurprisingly) resulted in significant performance gains.

The naive way where factory is called multiple times took approximately
12 seconds:

```
foreach($commentIDs as $cid) {
    $inst = \NDB_BVL_Instrument::factory('adi_r_proband', $cid);
    print $inst->getFieldValue('informant_relation');
}
```

The slightly smarter way where we avoid the overhead of re-parsing the
instrument took approximately 1.2 seconds:

```
$inst = \NDB_BVL_Instrument::factory('adi_r_proband');
foreach($commentIDs as $cid) {
    // note: must hack NDB_BVL_Instrument to make instanceData
    // public for this to work.
    $inst->instanceData = null;
    $inst->commentID = $cid;
    print $inst->getFieldValue('informant_relation');
}
```

The new function took approximately 0.2s:

```
$inst = \NDB_BVL_Instrument::factory('adi_r_proband');
$data = $inst->bulkLoadInstanceData($commentIDs);
foreach($data as $i) {
    print $i->getFieldValue('informant_relation');
}
```
