### PR TITLE
[Lint] Fix PHP Deprecated warning

### DIFF
--- a/tools/exporters/dataExtractor.php
+++ b/tools/exporters/dataExtractor.php
@@ -277,7 +277,7 @@ function writeToCsv(SplFileInfo $file, array $headers, array $data): void
     } catch (RuntimeException $e) {
         throw new InvalidArgumentException(
             'Could not open ' . $file->getRealPath() . ' for writing.' .
-            $e-getMessage()
+            $e->getMessage()
         );
     }
     // Write CSV headers


### PR DESCRIPTION
Fix the warning:

```
PHP Deprecated:  The behavior of unparenthesized expressions containing both
'.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher precedence
in tools/exporters/dataExtractor.php on line 279
```

when running `make checkstatic`.

As a bonus, also fix that line of the script, which was broken.