### PR TITLE
[imaging_browser] Fix inefficient query for first acquisition date

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -206,7 +206,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               $left_joins 
             WHERE 
               s.Active = 'Y' AND
-              f.FileType='mnc'
+              f.FileType='mnc' AND
               pt.Name='acquisition_date'
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label

--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -207,6 +207,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
             WHERE 
               s.Active = 'Y' AND
               f.FileType='mnc'
+              pt.Name='acquisition_date'
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label
             ",


### PR DESCRIPTION
The mri_acquisition_date table dropped in LORIS 22.0, and replaced by
a JOIN to the `parameter_file` table in order to look up the header
directly. However, ths query is missing a clause to restrict it to
only look up the `acquisition_date` header, resulting in an
unconditional join to `parameter_file`. Due to the size of the table
in existing projects, this can make the imaging browser menu page
take minutes to load.

This adds a where clause to restrict it to joining the `acquisition_date`
header, making the load time of the module usable again.