### PR TITLE
[API] fix POST to candidates type error

### DIFF
--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -12,6 +12,7 @@
  */
 namespace LORIS\api\Endpoints;
 
+use LORIS\StudyEntities\Candidate\Sex;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
 use \LORIS\api\Endpoint;
@@ -203,12 +204,14 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $pscid = $data['Candidate']['PSCID'] ?? null;
 
+        $sex = new Sex($data['Candidate']['Sex']);
+
         try {
             $candid = \Candidate::createNew(
                 $centerid,
                 $data['Candidate']['DoB'],
                 $data['Candidate']['EDC'],
-                $data['Candidate']['Sex'],
+                $sex,
                 $pscid,
                 $project->getId()
             );


### PR DESCRIPTION
## Brief summary of changes

Fix for `PHP Fatal error:  Uncaught TypeError: Argument 4 passed to Candidate::createNew() must be an instance of LORIS\\StudyEntities\\Candidate\\Sex, string given, called in /var/www/loris/modules/api/php/endpoints/candidates.class.inc on line 213`

#### Testing instructions (if applicable)

1. Use the API to POST a new candidate.
