### PR TITLE
[Test/Tools] Fix scripts issue with PR #6786

### DIFF
--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -7,7 +7,7 @@ find docs modules htdocs php src tools \
     -name '*.class.inc' \
     -print0 -o -name '*.php' -print0 \
     |xargs -0 -n1 php -l \
-    >/dev/null  
+    >/dev/null
 
 # Run PHPCS on all .php and .inc files in folders:
 # php/
@@ -49,8 +49,6 @@ declare -a tools_list=(
 
 # And on all PHP files in this array
 declare -a test_list=(
-    'integrationtests/LorisIntegrationTest.class.inc'
-    'integrationtests/LorisIntegrationTestWithCandidate.class.inc'
     'unittests/Database_Test.php'
 )
 
@@ -60,6 +58,7 @@ vendor/bin/phpcs --standard=test/LorisCS.xml --extensions=php,inc \
     modules/ \
     "test/integrationtests/" \
     "${tools_list[@]/#/tools/}" \
+    "${test_list[@]/#/test/}" \
     || exit $?;
 
 # Ensure strict typing is used in these files


### PR DESCRIPTION
PR #6786 was merged with an issue which removes Database_test.php from the list of scripts PHPCS runs onto.
This PR fixes this issue.
