### PR TITLE
[Statistics] fix behavioural tab without any project selection

### DIFF
--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -128,6 +128,8 @@ class Stats_Behavioural extends \NDB_Form
                 $suproject_query ="AND s.SubprojectID IN ($subprojList)";
             }
             $Visits = \Utility::getExistingVisitLabels($currentProject);
+        } else {
+            $Visits = \Utility::getExistingVisitLabels();
         }
 
         $this->tpl_data['Visits'] = $Visits ?? '';


### PR DESCRIPTION
## Brief summary of changes
When no project is selected the behavioural tab should show results for all projects for all visits. instead it was just displaying an empty row see images.

before:
![Screenshot from 2020-08-05 13-16-54](https://user-images.githubusercontent.com/15268287/89443198-f6a12200-d71d-11ea-8e39-b032a3f305e2.png)


after:
![Screenshot from 2020-08-05 13-14-21](https://user-images.githubusercontent.com/15268287/89443111-d5d8cc80-d71d-11ea-9d40-c9581066f3be.png)
