### PR TITLE
[API] Correct variables named filename that are actually paths

### DIFF
--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -49,7 +49,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
         $this->_visitdate  = $row['Visit_date'] ?? null;
         $this->_centerid   = $row['CenterID'] ?? null;
         $this->_centername = $row['Site'] ?? null;
-        $this->_filename   = $row['File'] ?? null;
+        $this->_path       = $row['Path'] ?? null;
         $this->_inserttime = $row['InsertTime'] ?? null;
         $this->_scantype   = $row['ScanType'] ?? null;
         $this->_qcstatus   = $row['QC_status'] ?? null;
@@ -73,6 +73,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
             'ScanType'   => $this->_scantype,
             'QC_status'  => $this->_qcstatus,
             'Selected'   => $this->_selected,
+            'Path'       => $this->_path,
         ];
         $filename = basename($this->_filename);
         $candid   = $obj['Candidate'];
@@ -80,6 +81,7 @@ class ProjectImagesRow implements \LORIS\Data\DataInstance
 
         $obj['Link']       = "/candidates/$candid/$visit/images/$filename";
         $obj['InsertTime'] = date('c', (int) $obj['InsertTime']);
+        $obj['File']       = $filename;
 
         return $obj;
     }

--- a/modules/api/php/models/projectrecordingsrow.class.inc
+++ b/modules/api/php/models/projectrecordingsrow.class.inc
@@ -46,7 +46,7 @@ class ProjectRecordingsRow implements \LORIS\Data\DataInstance
         $this->_visitdate  = $row['Visit_date'] ?? null;
         $this->_centerid   = $row['CenterID'] ?? null;
         $this->_centername = $row['Site'] ?? null;
-        $this->_filename   = $row['File'] ?? null;
+        $this->_path       = $row['Path'] ?? null;
         $this->_modality   = $row['Modality'] ?? null;
         $this->_inserttime = $row['InsertTime'] ?? null;
     }
@@ -64,6 +64,7 @@ class ProjectRecordingsRow implements \LORIS\Data\DataInstance
             'Visit'      => $this->_visitlabel,
             'Visit_date' => $this->_visitdate,
             'Site'       => $this->_centername,
+            'Path'       => $this->_path,
             'File'       => $this->_filename,
             'Modality'   => $this->_modality,
             'InsertTime' => $this->_inserttime,
@@ -76,6 +77,7 @@ class ProjectRecordingsRow implements \LORIS\Data\DataInstance
         $obj['Link'] = "/candidates/$candid/$visit/electrophysiology/$filename";
 
         $obj['InsertTime'] = date('c', (int) $obj['InsertTime']);
+        $obj['File']       = $filename;
 
         return $obj;
     }

--- a/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectimagesrowprovisioner.class.inc
@@ -49,7 +49,7 @@ class ProjectImagesRowProvisioner extends DBRowProvisioner
                s.CenterID as CenterID,
                p.Name as Site,
                f.InsertTime as InsertTime,
-               f.File as File,
+               f.File as Path,
                mst.Scan_type as ScanType,
                qc.QCStatus as QC_status,
                qc.Selected as Selected

--- a/modules/api/php/provisioners/projectrecordingsrowprovisioner.class.inc
+++ b/modules/api/php/provisioners/projectrecordingsrowprovisioner.class.inc
@@ -46,7 +46,7 @@ class ProjectRecordingsRowProvisioner extends DBRowProvisioner
                s.Date_visit as Visit_date,
                s.CenterID as CenterID,
                p.Name as Site,
-               f.FilePath as File,
+               f.FilePath as Path,
                pm.PhysiologicalModality as Modality,
                f.InsertTime as InsertTime
              FROM

--- a/modules/api/php/views/visit/dicoms.class.inc
+++ b/modules/api/php/views/visit/dicoms.class.inc
@@ -53,6 +53,7 @@ class Dicoms
     {
         return [
             'Tarname'    => $dicom->getTarname(),
+            'Path'       => $dicom->getArchiveLocation(),
             'SeriesInfo' => array_map(
                 [
                     'self',

--- a/modules/api/php/views/visit/images.class.inc
+++ b/modules/api/php/views/visit/images.class.inc
@@ -57,6 +57,7 @@ class Images
                 return [
                     'OutputType'      => $image->getOutputType(),
                     'Filename'        => $image->getFilename(),
+                    'Path'            => $image->getFilelocation(),
                     'AcquisitionType' => $image->getAcquisitionprotocol(),
                 ];
             },

--- a/modules/api/php/views/visit/recordings.class.inc
+++ b/modules/api/php/views/visit/recordings.class.inc
@@ -56,6 +56,7 @@ class Recordings
                 return [
                     'OutputType'          => $recording->getOutputType(),
                     'Filename'            => $recording->getFilename(),
+                    'Path'                => $recording->getFilelocation(),
                     'AcquisitionModality' => $recording->getAcquisitionmodality(),
                 ];
             },


### PR DESCRIPTION
## Brief summary of changes

Some endpoints were displaying the filename and others the path, but the variable was called filename in those endpoints. For consistency, the path is used everywhere and both the filename and path are displayed.

#### Testing instructions

1. Go to <hostname>/api/v0.0.3/candidates/400162/V6/dicoms
Path should be in the attributes.

![dicoms](https://user-images.githubusercontent.com/32504294/90050524-4d6da500-dca4-11ea-9c80-44903dfe06a6.png)

2. Go to <hostname>/api/v0.0.3/candidates/400162/V6/images
Path should be in the attributes.

![Screenshot from 2020-08-12 14-00-11](https://user-images.githubusercontent.com/32504294/90050436-2d3de600-dca4-11ea-8bc8-09fd598306e6.png)

3. Go to <hostname>/api/v0.0.3/candidates/400162/V6/recordings
Path should be in the attributes.

![recordings](https://user-images.githubusercontent.com/32504294/90053328-4fd1fe00-dca8-11ea-8527-ff1c07bbcb4b.png)

4. Go to <hostname>/api/v0.0.3/projects/pumpernickel/images
Path should be in the attributes.

![images_projects](https://user-images.githubusercontent.com/32504294/90053455-860f7d80-dca8-11ea-99b9-8e7a64e35cc8.png)

5. Go to <hostname>/api/v0.0.3/projects/pumpernickel/recordings
Path should be in the attributes.

![recordings_project](https://user-images.githubusercontent.com/32504294/90053485-90ca1280-dca8-11ea-89fe-fb9a8fd69c9b.png)
