### PR TITLE
[Help Doc] Added help file for instrument data entry

### DIFF
--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -4,7 +4,8 @@
 
 Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
 
-The blue sidebar panel contains key flags to mark instrument administration and data entry status. It also allows the user to navigate to different pages if the instrument has multiple pages. It may also contain specific flags depending on the instrument. On mobile devices or in narrow browser windows, this sidebar panel is hidden but can be accessed by clicking the list icon in the top left-hand corner.
+In the left sidebar panel (on tablets, click the list icon) - you can set status flags for this instrument form.  The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set. 
+If a form has multiple pages, enter and save data on each subpage before returning to the Top page to set the status flags. 
 
 In the sidebar, the Data Entry status can be set to either `Complete` or `In Progress`. The status cannot be set to `Complete` if the Administration option is not set. If the Data Entry status is `In Progress`, the sidebar will display the option to delete all the instrument data. The sidebar also allows the user to specify the Administration status of the instrument. 
 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -3,9 +3,8 @@
 Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
 
 In the left sidebar panel (on tablets, click the list icon) - you can set status flags for this instrument form.  The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set. 
-If a form has multiple pages, enter and save data on each subpage before returning to the Top page to set the status flags. 
-
-In the sidebar, the Data Entry status can be set to either `Complete` or `In Progress`. The status cannot be set to `Complete` if the Administration option is not set. If the Data Entry status is `In Progress`, the sidebar will display the option to delete all the instrument data. The sidebar also allows the user to specify the Administration status of the instrument. 
+The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set.
+While the Data Entry status is `In Progress`, you may see in the sidebar the option to delete all the instrument data which will clear all data in the form. 
 
 Under the general information about the candidate at the top of the screen, the user can perform data entry for the instrument. Required values are specified with a red asterisk. If these values are not completed, an error message will appear when a user attempts to save the data. 
 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -2,6 +2,8 @@
 
 Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
 
-In the left sidebar panel (on tablets, click the list icon) - you can set status flags for this instrument form.  The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set. 
+
+If a form has multiple pages, enter and save data on each subpage, then return to the Top page and click "Save".  Scoring will be calculated only after Save is clicked.  After entering all data, use the status flags and "Send to DCC" in the left sidebar to complete the instrument form. 
+
 The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set.
 While the Data Entry status is `In Progress`, you may see in the sidebar the option to delete all the instrument data which will clear all data in the form. 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -1,5 +1,4 @@
-# Instrument
-
+# Instruments
 
 Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -5,7 +5,3 @@ Inside the instrument form, general information is shown at the top including da
 In the left sidebar panel (on tablets, click the list icon) - you can set status flags for this instrument form.  The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set. 
 The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set.
 While the Data Entry status is `In Progress`, you may see in the sidebar the option to delete all the instrument data which will clear all data in the form. 
-
-Under the general information about the candidate at the top of the screen, the user can perform data entry for the instrument. Required values are specified with a red asterisk. If these values are not completed, an error message will appear when a user attempts to save the data. 
-
-If the instrument has multiple pages, the user must save the data individually for each page. If the user has navigated to a page that is not the `Top` page of the instrument, they will be unable to alter any status flags in the sidebar. 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -2,7 +2,7 @@
 
 **Help for specific instruments can be found in the subsections below.**
 
-Once inside a time-point, users will see some general information about the candidate across the top of the screen, such as date of birth, sex, visit label, and subproject(cohort).
+Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
 
 The blue sidebar panel contains key flags to mark instrument administration and data entry status. It also allows the user to navigate to different pages if the instrument has multiple pages. It may also contain specific flags depending on the instrument. On mobile devices or in narrow browser windows, this sidebar panel is hidden but can be accessed by clicking the list icon in the top left-hand corner.
 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -10,25 +10,3 @@ In the sidebar, the Data Entry status can be set to either `Complete` or `In Pro
 Under the general information about the candidate at the top of the screen, the user can perform data entry for the instrument. Required values are specified with a red asterisk. If these values are not completed, an error message will appear when a user attempts to save the data. 
 
 If the instrument has multiple pages, the user must save the data individually for each page. If the user has navigated to a page that is not the `Top` page of the instrument, they will be unable to alter any status flags in the sidebar. 
-
-## Medical History
-
-This instrument contains 4 pages of data entry. The required information is on the Top page and is marked with a red asterisk. 
-
-If the user navigates to a page other than the `Top` page, the Administration and Data Entry options in the sidebar cannot be edited.
-
-## BMI Calculator
-
-The BMI Calculator instrument has one page of data entry. The required information is marked with a red asterisk.
-
-Along with the Administration and Data Entry options, the sidebar for this instrument includes the option to specify the Validity of the instrument. If the Data Entry status is set to `Complete`, the Validity option cannot be edited.
-
-## Radiology Review
-
-The Radiology Review instrument has one page of data entry. The required information is marked with a red asterisk.
-
-## AOSI
-
-The AOSI instrument has three pages of data entry. The required information is marked with a red asterisk.
-
-Along with the Administration and Data Entry options, the sidebar for this instrument includes the option to specify the Validity of the instrument. If the Data Entry status is set to `Complete`, the Validity option cannot be edited. If the Adminisitration or Validity options are not set by the user, the Data Entry status cannot be changed to `Complete`.

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -1,6 +1,5 @@
 # Instrument
 
-**Help for specific instruments can be found in the subsections below.**
 
 Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
 

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -1,0 +1,35 @@
+# Instrument
+
+**Help for specific instruments can be found in the subsections below.**
+
+Once inside a time-point, users will see some general information about the candidate across the top of the screen, such as date of birth, sex, visit label, and subproject(cohort).
+
+The blue sidebar panel contains key flags to mark instrument administration and data entry status. It also allows the user to navigate to different pages if the instrument has multiple pages. It may also contain specific flags depending on the instrument. On mobile devices or in narrow browser windows, this sidebar panel is hidden but can be accessed by clicking the list icon in the top left-hand corner.
+
+In the sidebar, the Data Entry status can be set to either `Complete` or `In Progress`. The status cannot be set to `Complete` if the Administration option is not set. If the Data Entry status is `In Progress`, the sidebar will display the option to delete all the instrument data. The sidebar also allows the user to specify the Administration status of the instrument. 
+
+Under the general information about the candidate at the top of the screen, the user can perform data entry for the instrument. Required values are specified with a red asterisk. If these values are not completed, an error message will appear when a user attempts to save the data. 
+
+If the instrument has multiple pages, the user must save the data individually for each page. If the user has navigated to a page that is not the `Top` page of the instrument, they will be unable to alter any status flags in the sidebar. 
+
+## Medical History
+
+This instrument contains 4 pages of data entry. The required information is on the Top page and is marked with a red asterisk. 
+
+If the user navigates to a page other than the `Top` page, the Administration and Data Entry options in the sidebar cannot be edited.
+
+## BMI Calculator
+
+The BMI Calculator instrument has one page of data entry. The required information is marked with a red asterisk.
+
+Along with the Administration and Data Entry options, the sidebar for this instrument includes the option to specify the Validity of the instrument. If the Data Entry status is set to `Complete`, the Validity option cannot be edited.
+
+## Radiology Review
+
+The Radiology Review instrument has one page of data entry. The required information is marked with a red asterisk.
+
+## AOSI
+
+The AOSI instrument has three pages of data entry. The required information is marked with a red asterisk.
+
+Along with the Administration and Data Entry options, the sidebar for this instrument includes the option to specify the Validity of the instrument. If the Data Entry status is set to `Complete`, the Validity option cannot be edited. If the Adminisitration or Validity options are not set by the user, the Data Entry status cannot be changed to `Complete`.

--- a/modules/instruments/help/instruments.md
+++ b/modules/instruments/help/instruments.md
@@ -1,8 +1,6 @@
 # Instruments
 
 Inside the instrument form, general information is shown at the top including date of birth, sex, visit label, and subproject(cohort).
-
-
 If a form has multiple pages, enter and save data on each subpage, then return to the Top page and click "Save".  Scoring will be calculated only after Save is clicked.  After entering all data, use the status flags and "Send to DCC" in the left sidebar to complete the instrument form. 
 
 The Data Entry flag can only be set to Complete after the Administration and Validity flags have been set.


### PR DESCRIPTION
I added a markdown file under `modules/instruments/help/` so that Help instructions for the user will render when they are completing instrument data entry. 

Here is a screenshot of how the markdown renders in the frontend. 
<img width="1440" alt="Screen Shot 2020-08-12 at 2 43 56 PM" src="https://user-images.githubusercontent.com/35467361/90054749-447fd200-dcaa-11ea-9de6-ed01e57dc43f.png">

#### Testing instructions (if applicable)
1. Checkout this branch and go to the LORIS frontend.
2. Navigate to `Candidate`->`Access Profile` and choose any candidate with associated instruments.
3. Navigate to the Data Entry page for any of the timepoint's instruments.
4. Go to the top of the page and click on the `?`
5. View the markdown.

#### Link to related issue

* Resolves #6906
