### PR TITLE
[Raisinbread] Fixing help_editor module to display RB instrument instructions

### DIFF
--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -32,20 +32,28 @@ try {
     include_once "helpfile.class.inc";
 
     if (!empty($moduleName)) {
-        $helpID = \LORIS\help_editor\HelpFile::hashToID(
-            md5($subpageName ?? $moduleName)
-        );
-    }
+        try {
+            $helpID = \LORIS\help_editor\HelpFile::hashToID(
+                md5($subpageName ?? $moduleName)
+            );
+            $help_file       = \LORIS\help_editor\HelpFile::factory($helpID);
+            $data            = $help_file->toArray();
+            $data['content'] = trim($data['content']);
 
-    $help_file       = \LORIS\help_editor\HelpFile::factory($helpID);
-    $data            = $help_file->toArray();
-    $data['content'] = trim($data['content']);
-
-    if (empty($data['updated'])) {
-        $data['updated'] = "-";
-        // if document was never updated should display date created
-        if (!empty($data['created'])) {
-            $data['updated'] = $data['created'];
+            if (empty($data['updated'])) {
+                $data['updated'] = "-";
+                // if document was never updated should display date created
+                if (!empty($data['created'])) {
+                    $data['updated'] = $data['created'];
+                }
+            }
+        } catch (\NotFound $e) {
+            // Send data with empty strings so that the content can be edited
+            $data = [
+                'content' => '',
+                'topic'   => '',
+                'updated' => '-'
+            ];
         }
     }
     print json_encode($data);

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -33,11 +33,11 @@ try {
 
     if (!empty($moduleName)) {
         try {
-            $helpID          = \LORIS\help_editor\HelpFile::hashToID(
+            $helpID    = \LORIS\help_editor\HelpFile::hashToID(
                 md5($subpageName ?? $moduleName)
             );
-            $help_file       = \LORIS\help_editor\HelpFile::factory($helpID);
-            $data            = $help_file->toArray();
+            $help_file = \LORIS\help_editor\HelpFile::factory($helpID);
+            $data      = $help_file->toArray();
 
         } catch (\NotFound $e) {
             // Send data with empty strings so that the content can be edited

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -38,15 +38,7 @@ try {
             );
             $help_file       = \LORIS\help_editor\HelpFile::factory($helpID);
             $data            = $help_file->toArray();
-            $data['content'] = trim($data['content']);
 
-            if (empty($data['updated'])) {
-                $data['updated'] = "-";
-                // if document was never updated should display date created
-                if (!empty($data['created'])) {
-                    $data['updated'] = $data['created'];
-                }
-            }
         } catch (\NotFound $e) {
             // Send data with empty strings so that the content can be edited
             $data = [
@@ -54,6 +46,16 @@ try {
                 'topic'   => '',
                 'updated' => '-'
             ];
+        }
+        
+        $data['content'] = trim($data['content']);
+
+        if (empty($data['updated'])) {
+            $data['updated'] = "-";
+            // if document was never updated should display date created
+            if (!empty($data['created'])) {
+                $data['updated'] = $data['created'];
+            }
         }
     }
     print json_encode($data);

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -43,7 +43,7 @@ try {
             $data = [
                 'content' => '',
                 'topic'   => '',
-                'updated' => '-'
+                'updated' => ''
             ];
         }
 

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -33,7 +33,7 @@ try {
 
     if (!empty($moduleName)) {
         try {
-            $helpID = \LORIS\help_editor\HelpFile::hashToID(
+            $helpID          = \LORIS\help_editor\HelpFile::hashToID(
                 md5($subpageName ?? $moduleName)
             );
             $help_file       = \LORIS\help_editor\HelpFile::factory($helpID);

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -47,14 +47,15 @@ try {
                 'updated' => '-'
             ];
         }
-        
+
         $data['content'] = trim($data['content']);
 
         if (empty($data['updated'])) {
-            $data['updated'] = "-";
             // if document was never updated should display date created
-            if (!empty($data['created'])) {
+            if (!empty($data['created']) && isset($data['created'])) {
                 $data['updated'] = $data['created'];
+            } else {
+                $data['updated'] = "-";
             }
         }
     }

--- a/modules/help_editor/help/help_editor.md
+++ b/modules/help_editor/help/help_editor.md
@@ -1,6 +1,6 @@
 # Help Editor
 
-This module displays existing help content for LORIS instrument pages
+This module displays existing help content for LORIS instrument pages.
 
 Use the *Selection Filter* section to search by Topic or Content keywords.
 

--- a/modules/help_editor/help/help_editor.md
+++ b/modules/help_editor/help/help_editor.md
@@ -1,7 +1,10 @@
 # Help Editor
 
-This module displays existing help content for LORIS modules and pages. 
+This module displays existing help content for LORIS instrument pages
 
 Use the *Selection Filter* section to search by Topic or Content keywords.
 
-Click on the blue link in any *Topic* or *Parent Topic* column to edit the content within. Make your edits within the Edit Help Content page, and click **Save**. 
+Click on the blue link in any *Topic* or *Parent Topic* column to edit the content within. Make your edits within the Edit Help Content page, and click **Save**.
+
+To add new help content for an instrument, navigate to the instrument's page from any candidate and any session. Click on the `?` icon in the navigation bar at the top
+ of the page. In the help pop-up box, click the `Edit` button. This will take you to the *Edit Help Content* page where you can save help content for that instrument.

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -73,10 +73,10 @@ class Edit_Help_Content extends \NDB_Form
             && $_REQUEST['subsection'] != 'undefined'
         ) {
             try {
-                $helpID = HelpFile::hashToID(md5($_REQUEST['subsection']));
+                $helpID   = HelpFile::hashToID(md5($_REQUEST['subsection']));
                 $parentID = HelpFile::hashToID(md5($_GET['section']));
             } catch (\NotFound $e) {
-                $helpID = '';
+                $helpID   = '';
                 $parentID = '';
             }
         }

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -59,17 +59,21 @@ class Edit_Help_Content extends \NDB_Form
         if (isset($_REQUEST['helpID'])) {
             $helpID = htmlspecialchars($_REQUEST['helpID']);
         }
-        if (isset($_GET['parentID'])) {
-            $parentID = htmlspecialchars($_GET['parentID']);
-        }
-        if (!empty($_REQUEST['section'])) {
-            $helpID = HelpFile::hashToID(md5($_REQUEST['section']));
+        if (isset($_REQUEST['section']) && !empty($_REQUEST['section'])) {
+            try {
+                $helpID = HelpFile::hashToID(md5($_REQUEST['section']));
+            } catch (\NotFound $e) {
+                $helpID = '';
+            }
         }
         if (!empty($_REQUEST['section'])
             && $_REQUEST['subsection'] != 'undefined'
         ) {
-            $helpID   = HelpFile::hashToID(md5($_REQUEST['subsection']));
-            $parentID = HelpFile::hashToID(md5($_GET['section']));
+            try {
+                $helpID = HelpFile::hashToID(md5($_REQUEST['subsection']));
+            } catch (\NotFound $e) {
+                $helpID = '';
+            }
         }
         $this->tpl_data['section']    = $safeSection;
         $this->tpl_data['subsection'] = $safeSubsection;
@@ -128,11 +132,10 @@ class Edit_Help_Content extends \NDB_Form
         $this->addBasicTextArea(
             'content',
             'Content',
-            [],
-            array(
+            [
                 'cols' => 140,
                 'rows' => 30,
-            )
+            ]
         );
 
     }

--- a/modules/help_editor/php/edit_help_content.class.inc
+++ b/modules/help_editor/php/edit_help_content.class.inc
@@ -59,7 +59,10 @@ class Edit_Help_Content extends \NDB_Form
         if (isset($_REQUEST['helpID'])) {
             $helpID = htmlspecialchars($_REQUEST['helpID']);
         }
-        if (isset($_REQUEST['section']) && !empty($_REQUEST['section'])) {
+        if (isset($_GET['parentID'])) {
+            $parentID = htmlspecialchars($_GET['parentID']);
+        }
+        if (!empty($_REQUEST['section'])) {
             try {
                 $helpID = HelpFile::hashToID(md5($_REQUEST['section']));
             } catch (\NotFound $e) {
@@ -71,8 +74,10 @@ class Edit_Help_Content extends \NDB_Form
         ) {
             try {
                 $helpID = HelpFile::hashToID(md5($_REQUEST['subsection']));
+                $parentID = HelpFile::hashToID(md5($_GET['section']));
             } catch (\NotFound $e) {
                 $helpID = '';
+                $parentID = '';
             }
         }
         $this->tpl_data['section']    = $safeSection;

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -277,6 +277,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         // Sets up page variables such as $this->commentID and $this->form
         $obj->setup($commentID, $page);
+        // Set page name to testName
+        $obj->name = $instrument;
 
         if (!empty($commentID)) {
             $obj->setupCandidateInfoTables();

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -275,10 +275,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $obj->displayAllFields = true;
         }
 
-        // Sets up page variables such as $this->commentID and $this->form
-        $obj->setup($commentID, $page);
         // Set page name to testName
         $obj->name = $instrument;
+        // Sets up page variables such as $this->commentID and $this->form
+        $obj->setup($commentID, $page);
 
         if (!empty($commentID)) {
             $obj->setupCandidateInfoTables();

--- a/raisinbread/RB_files/RB_help.sql
+++ b/raisinbread/RB_files/RB_help.sql
@@ -1,6 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `help`;
 LOCK TABLES `help` WRITE;
-INSERT INTO `help` (`helpID`, `parentID`, `hash`, `topic`, `content`, `created`, `updated`) VALUES (123,12,'810dc6911c825b55eff684098f2beb19','bmi','The BMI calculator instrument can calculate the BMI and BMI Classification of a visitor. The two required fields for this instrument are the Date of Administration of the instrument and the Examiner name. The height and weight of the visitor must then be entered in either standard or metric units. The instrument will not accept an entry where the height and weight are given in both units. After this information is given, the instrument will calculate the BMI and BMI Classification of the visitor.',NULL,NULL);
+INSERT INTO `help` (`helpID`, `parentID`, `hash`, `topic`, `content`, `created`, `updated`) VALUES (123,-1,'810dc6911c825b55eff684098f2beb19','bmi','The BMI calculator instrument can calculate the BMI and BMI Classification of a visitor. The two required fields for this instrument are the Date of Administration of the instrument and the Examiner name. The height and weight of the visitor must then be entered in either standard or metric units. The instrument will not accept an entry where the height and weight are given in both units. After this information is given, the instrument will calculate the BMI and BMI Classification of the visitor.','2020-09-01 01:03:09',NULL);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_help.sql
+++ b/raisinbread/RB_files/RB_help.sql
@@ -1,6 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `help`;
 LOCK TABLES `help` WRITE;
-INSERT INTO `help` (`helpID`, `parentID`, `hash`, `topic`, `content`, `created`, `updated`) VALUES (123,-1,'810dc6911c825b55eff684098f2beb19','bmi','The BMI calculator instrument can calculate the BMI and BMI Classification of a visitor. The two required fields for this instrument are the Date of Administration of the instrument and the Examiner name. The height and weight of the visitor must then be entered in either standard or metric units. The instrument will not accept an entry where the height and weight are given in both units. After this information is given, the instrument will calculate the BMI and BMI Classification of the visitor.','2020-09-01 01:03:09',NULL);
+INSERT INTO `help` (`helpID`, `hash`, `topic`, `content`, `created`, `updated`) VALUES (123,'810dc6911c825b55eff684098f2beb19','bmi','The BMI calculator instrument can calculate the BMI and BMI Classification of a visitor. The two required fields for this instrument are the Date of Administration of the instrument and the Examiner name. The height and weight of the visitor must then be entered in either standard or metric units. The instrument will not accept an entry where the height and weight are given in both units. After this information is given, the instrument will calculate the BMI and BMI Classification of the visitor.','2020-09-01 01:03:09',NULL);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_help.sql
+++ b/raisinbread/RB_files/RB_help.sql
@@ -1,5 +1,6 @@
 SET FOREIGN_KEY_CHECKS=0;
 TRUNCATE TABLE `help`;
 LOCK TABLES `help` WRITE;
+INSERT INTO `help` (`helpID`, `parentID`, `hash`, `topic`, `content`, `created`, `updated`) VALUES (123,12,'810dc6911c825b55eff684098f2beb19','bmi','The BMI calculator instrument can calculate the BMI and BMI Classification of a visitor. The two required fields for this instrument are the Date of Administration of the instrument and the Examiner name. The height and weight of the visitor must then be entered in either standard or metric units. The instrument will not accept an entry where the height and weight are given in both units. After this information is given, the instrument will calculate the BMI and BMI Classification of the visitor.',NULL,NULL);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
**Edited** 
This PR aimed to add data to the `help` table in Raisinbread so that the data would generate in the Help Editor module. This will allow the `Help Editor` module to be manually tested.

It was found that there is a bug in this module that causes it not to save/display this information. This issue is resolved in this PR. 

Here is a screenshot of the `Help Editor` module with the new data:
<img width="1436" alt="Screen Shot 2020-08-12 at 6 11 24 PM" src="https://user-images.githubusercontent.com/35467361/90073939-2aed8300-dcc8-11ea-8eec-be5a01043218.png">

#### Testing instructions (if applicable)
With a fresh RB install:
1. Navigate to `Help Editor` in the frontend and see that data loads for instructions for the BMI instrument.

#### Link to related issue

* Resolves #5691
