### PR TITLE
[Integration] changeUserProject helper function, candidate_profile tests

### DIFF
--- a/modules/candidate_profile/test/candidate_profileTest.php
+++ b/modules/candidate_profile/test/candidate_profileTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Candidate_profile automated integration tests
+ *
+ * PHP Version 7
+ *
+ * @category Test
+ * @package  Loris
+ * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+use Facebook\WebDriver\WebDriverBy;
+require_once __DIR__
+    . "/../../../test/integrationtests/LorisIntegrationTestWithCandidate.class.inc";
+/**
+ * CandidateProfileIntegrationTest
+ *
+ * @category Test
+ * @package  Loris
+ * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://github.com/aces/Loris
+ */
+class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
+{
+    /**
+     * Setup the tests and database data
+     *
+     * @return void
+     */
+    function setUp()
+    {
+        parent::setUp();
+        $this->setupConfigSetting("useEDC", "true");
+    }
+
+    /**
+     * Tear down the tests and delete database data
+     *
+     * @return void
+     */
+    function tearDown(): void
+    {
+        parent::tearDown();
+        $this->restoreConfigSetting("useEDC");
+    }
+
+    /**
+     * Tests that the page loads
+     *
+     * @return void
+     */
+    function testCandidateProfileDoespageLoad()
+    {
+        $this->safeGet($this->url . "/900000/");
+        $bodyText
+            = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
+            ->getText();
+        $this->assertContains("Candidate Profile", $bodyText);
+    }
+
+    /**
+     * Test that the page does not load if the user's study site does not
+     * match the candidate's
+     *
+     * @return void
+     */
+    function testCandidateProfileWithoutSitePermissions()
+    {
+        $this->resetStudySite();
+        $this->changeStudySite();
+        $this->setupPermissions(["data_entry"]);
+        $this->safeGet($this->url . "/900000/");
+        $bodyText
+            = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
+            ->getText();
+        $this->assertContains("Permission Denied", $bodyText);
+        $this->resetPermissions();
+
+        $this->resetStudySite();
+    }
+
+    /**
+     * Test that the page does not load if the user's project does not
+     * match the candidate's
+     *
+     * @return void
+     */
+    function testCandidateProfileWithoutProjectPermissions()
+    {
+        $this->resetProject();
+        $this->changeProject();
+        $this->setupPermissions(["data_entry"]);
+        $this->safeGet($this->url . "/900000/");
+        $bodyText
+            = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
+            ->getText();
+        $this->assertContains("Permission Denied", $bodyText);
+        $this->resetPermissions();
+
+        $this->resetProject();
+    }
+}

--- a/modules/candidate_profile/test/candidate_profileTest.php
+++ b/modules/candidate_profile/test/candidate_profileTest.php
@@ -33,9 +33,9 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
     {
         $this->safeGet($this->url . "/900000/");
         $bodyText
-            = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
+            = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Candidate Profile", $bodyText);
+        $this->assertContains("Candidate Profile 900000", $bodyText);
     }
 
     /**
@@ -51,7 +51,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->setupPermissions(["data_entry"]);
         $this->safeGet($this->url . "/900000/");
         $bodyText
-            = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
+            = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
         $this->assertContains("Permission Denied", $bodyText);
         $this->resetPermissions();
@@ -72,7 +72,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->setupPermissions(["data_entry"]);
         $this->safeGet($this->url . "/900000/");
         $bodyText
-            = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
+            = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
         $this->assertContains("Permission Denied", $bodyText);
         $this->resetPermissions();

--- a/modules/candidate_profile/test/candidate_profileTest.php
+++ b/modules/candidate_profile/test/candidate_profileTest.php
@@ -6,7 +6,7 @@
  *
  * @category Test
  * @package  Loris
- * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
+ * @author   Alexandra Livadas <alexandra.livadas@mail.mcgill.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
@@ -18,34 +18,12 @@ require_once __DIR__
  *
  * @category Test
  * @package  Loris
- * @author   Alexandra Livadas <alexandra.livadas@mcin.ca>
+ * @author   Alexandra Livadas <alexandra.livadas@mail.mcgill.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://github.com/aces/Loris
  */
 class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
 {
-    /**
-     * Setup the tests and database data
-     *
-     * @return void
-     */
-    function setUp()
-    {
-        parent::setUp();
-        $this->setupConfigSetting("useEDC", "true");
-    }
-
-    /**
-     * Tear down the tests and delete database data
-     *
-     * @return void
-     */
-    function tearDown(): void
-    {
-        parent::tearDown();
-        $this->restoreConfigSetting("useEDC");
-    }
-
     /**
      * Tests that the page loads
      *
@@ -89,8 +67,8 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
      */
     function testCandidateProfileWithoutProjectPermissions()
     {
-        $this->resetProject();
-        $this->changeProject();
+        $this->resetUserProject();
+        $this->changeUserProject();
         $this->setupPermissions(["data_entry"]);
         $this->safeGet($this->url . "/900000/");
         $bodyText
@@ -99,6 +77,6 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $this->assertContains("Permission Denied", $bodyText);
         $this->resetPermissions();
 
-        $this->resetProject();
+        $this->resetUserProject();
     }
 }

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -349,6 +349,38 @@ abstract class LorisIntegrationTest extends TestCase
     }
 
     /**
+     * Helper function to change the users Project
+     *
+     * @return void
+     */
+    function changeProject()
+    {
+        $this->DB->insert("Project", ["ProjectID" => 99, "Alias" => "BBQ"]);
+        $this->DB->update(
+            "user_project_rel",
+            ["ProjectID" => 99],
+            ["UserID" => 999990]
+        );
+    }
+
+    /**
+     * Helper function to reset the users Project
+     *
+     * @return void
+     */
+    function resetProject()
+    {
+        $this->DB->run('SET foreign_key_checks =0');
+        $this->DB->update(
+            "user_project_rel",
+            ["ProjectID" => 1],
+            ["UserID" => 999990]
+        );
+        $this->DB->delete("Project", ["ProjectID" => 99]);
+        $this->DB->run('SET foreign_key_checks =1');
+    }
+
+    /**
      * Helper function to create a subproject
      *
      * @param string $SubprojectID Name of the subproject

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -353,7 +353,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    function changeProject()
+    function changeUserProject()
     {
         $this->DB->insert("Project", ["ProjectID" => 99, "Alias" => "BBQ"]);
         $this->DB->update(
@@ -368,7 +368,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    function resetProject()
+    function resetUserProject()
     {
         $this->DB->run('SET foreign_key_checks =0');
         $this->DB->update(

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -19,6 +19,7 @@
             <directory>../modules/bvl_feedback/test/</directory>
             <directory>../modules/candidate_list/test/</directory>
             <directory>../modules/candidate_parameters/test/</directory>
+            <directory>../modules/candidate_profile/test/</directory>
             <directory>../modules/configuration/test/</directory>
             <directory>../modules/conflict_resolver/test/</directory>
             <directory>../modules/create_timepoint/test/</directory>


### PR DESCRIPTION
I added 2 helper functions, `changeProject` and `resetProject`, to the LorisIntegrationTest.class.inc class. These will allow us to test project permissions on modules. 

I also added initial integration tests for the `candidate_profile`module, **including a project permission test**.

#### Testing instructions

1. Check Travis or run `npm run tests:integration -- --filter CandidateProfileIntegrationTest`

#### Link to related issue

* Resolves #6911
