### PR TITLE
[Tools] PHPCS exclude list

### DIFF
--- a/test/run-php-linter.sh
+++ b/test/run-php-linter.sh
@@ -13,52 +13,43 @@ find docs modules htdocs php src tools \
 # php/
 # htdocs/
 # modules/
+# test/
+# tools/
 
-# Also run PHPCS on all tools/ scripts in this array
-declare -a tools_list=(
-    'assign_missing_instruments.php'
-    'configuration_check.php'
-    'config_to_db.php'
-    'data_integrity_check.php'
-    'delete_candidate.php'
-    'delete_ignored_conflicts.php'
-    'delete_timepoint.php'
-    'CouchDB_Confirm_Integrity.php'
-    'detect_duplicated_commentids.php'
-    'generate_project_statistics_csv.php'
-    'generic_includes.php'
-    'importers/CandidateImporter.php'
-    'importers/DataImporter.class.inc'
-    'importers/InstrumentImporter.php'
-    'importers/VisitImporter.php'
-    'importers/openScienceDataImporter.php'
-    'exporters/dataExtractor.php'
-    'mri_violations_resolver.php'
-    'populate_examiners_psc_rel.php'
-    'raisinbread_refresh.php'
-    'recreate_conflicts.php'
-    'resetpassword.php'
-    'detect_conflicts.php'
-    'setconfig.php'
-    'single_use/Cleanup_multiple_firstVisits.php'
-    'single_use/Convert_LorisMenuID_to_ModuleID.php'
-    'generate_tables_sql.php'
-    'lorisform_parser.php'
-    'populate_visit_windows.php'
-    'manage_modules.php'
-    'DB_date_zeros_removal.php'
-    'CouchDB_Import_MRI.php'
-    'CouchDB_Import_Demographics.php'
-    'CouchDB_Import_Instruments.php'
-    'CouchDB_MRI_Importer.php'
-)
+# except:
+ignored_files="
+    tools/single_use/Cleanup_Consent_Data.php,\
+    tools/single_use/Engine_Change_MyISAM_to_INNODB.php,\
+    tools/single_use/normalize_mri_protocol_range_data.php,\
+    tools/single_use/Update_scan_type_of_mri_violations_log_when_manual_caveat.php,\
+    tools/single_use/instrument_double_escape_report.php,\
+    tools/single_use/Normalize_protocol_split_rows.php,\
+    tools/single_use/migrate_sql_to_json.php,\
+    tools/single_use/data_dictionary_cleaner.php,\
+    tools/single_use/Normalize_Consent_Data.php,\
+    tools/single_use/remove_logged_passwords.php,\
+    tools/deprecated/create_candidates.php,\
+    tools/deprecated/excelDump.php,\
+    tools/data_integrity/fix_candidate_age.php,\
+    tools/data_integrity/score_instrument.php,\
+    tools/exporters/data_dictionary_builder.php,\
+    tools/exporters/DB_dump_table_data.php,\
+    tools/generate_tables_sql_and_testNames.php,\
+    tools/fix_timepoint_date_problems.php,\
+    tools/CouchDB_MRI_Importer.php,\
+    tools/CouchDB_Import_RadiologicalReview.php,\
+    tools/cleanup_mri_tables_for_19-0_release.php
+"
 
-vendor/bin/phpcs --standard=test/LorisCS.xml --extensions=php,inc \
+vendor/bin/phpcs \
+    --standard=test/LorisCS.xml \
+    --extensions=php,inc \
+    --ignore="$ignored_files" \
     php/ \
     htdocs/ \
     modules/ \
     test/ \
-    "${tools_list[@]/#/tools/}" \
+    tools/ \
     || exit $?;
 
 # Ensure strict typing is used in these files


### PR DESCRIPTION
Updated test/run-php-linter.sh to replace the tests and tools include list for an exclude list.
This allows PHPCS to run on all new tests/tools.