### PR TITLE
[LINST] Remove '_date' only for Standard Format

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -576,7 +576,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         // Set date format
                         $dateFormat = isset($pieces[5]) ? trim($pieces[5]) : "";
 
-                        if (isset($dateFormat) && $dateFormat != "" && $dateFormat !== "Date") {
+                        if (isset($dateFormat) && $dateFormat != ""
+                            && $dateFormat !== "Date"
+                        ) {
                             if ($dateFormat === 'MonthYear') {
                                 // Shows date without day of month
                                 $this->addMonthYear(

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -559,13 +559,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $this->LinstQuestions[$pieces[1]] = ['type' => 'textarea'];
                     break;
                 case 'date':
-                    if (strpos($pieces[1], "_date") !== false) {
-                        $pieces[1] = substr(
-                            $pieces[1],
-                            0,
-                            strpos($pieces[1], "_date")
-                        );
-                    }
                     if ($addElements) {
                         if ($pieces[3] == 1900 && $pieces[4] == 2100) {
                             $dateOptions = null;
@@ -600,6 +593,20 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                 );
                             }
                         } else {
+                            // addDateElement appends '_date' to the field name so
+                            // remove it first here
+                            if (strpos($pieces[1], "_date") !== false) {
+                                $pieces[1] = substr(
+                                    $pieces[1],
+                                    0,
+                                    strpos($pieces[1], "_date")
+                                );
+                            } else {
+                                throw new \LorisException(
+                                    "Standard Date format field $pieces[1] must end"
+                                      . " with '_date'."
+                                );
+                            }
                             // Shows standard date
                             $this->addDateElement(
                                 $pieces[1],

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -576,7 +576,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         // Set date format
                         $dateFormat = isset($pieces[5]) ? trim($pieces[5]) : "";
 
-                        if (isset($dateFormat) && $dateFormat != "") {
+                        if (isset($dateFormat) && $dateFormat != "" && $dateFormat !== "Date") {
                             if ($dateFormat === 'MonthYear') {
                                 // Shows date without day of month
                                 $this->addMonthYear(
@@ -595,7 +595,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         } else {
                             // addDateElement appends '_date' to the field name so
                             // remove it first here
-                            if (strpos($pieces[1], "_date") !== false) {
+                            if (substr($pieces[1], -5) == "_date") {
                                 $pieces[1] = substr(
                                     $pieces[1],
                                     0,

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -149,7 +149,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
                        . "'option_1'=>'Option 1'{-}'option_2'=>'Option 2'{-}"
                        . "'option_3'=>'Option 3'{-}'option_4'=>'Option 4'{-}"
                        . "'not_answered'=>'Not Answered'\n";
-        $instrument .= "date{@}FieldName{@}Field Description{@}2003{@}2014\n";
+        $instrument .= "date{@}FieldName_date{@}Field Description{@}2003{@}2014\n";
         $instrument .= "select{@}date_status{@}{@}NULL=>''{-}"
                        . "'not_answered'=>'Not Answered'\n";
         $instrument .= "numeric{@}FieldName{@}Field Description{@}0{@}20\n";
@@ -250,7 +250,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
                 ],
                 [
                     'Type'        => "date",
-                    "Name"        => "FieldName",
+                    "Name"        => "FieldName_date",
                     "Description" => "Field Description",
                     "Options"     => [
                         "MinDate"         => "2003-01-01",


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the removal of '_date' by only allowing it to happen for Standard Date formats. 

Currently, all date elements (standard, basic, and month/year) in linst instruments have their field names redefined as the substring appearing before '_date'. For example, if a date element is called 'enrolment_date_v2', the instrument field name becomes `enrolment`. The issue with this is that on saving the instrument, the save function will try to update a field called 'enrolment' in the instrument table which does not exist.

Now, the reason why this functionality existed in the first place is because the Standard Date format requires a field name ending  with '_date'. Linst Standard Date formats are created by calling the `NDB_BVL_Instrument` class addDateElement() function which auto appends '_date' to the date element name. In order to avoid '_date' appearing twice, the `NDB_BVL_Instrument_LINST class` removes '_date' from the element name before calling addDateElement().

Basic Date and Month/Year formats call the NDB_Page class addBasicDate() function and the NDB_BVL_Instrument class addMonthYear) function respectively, both of which do not seem to auto append '_date' to the field name.

In this PR, if a Standard Date format field name does not already end with '_date' , a LorisException is thrown.

#### Testing instructions (if applicable)

1. Add a Standard Date field to the $loris/project/instruments/bmi.linst. You can add to the end of the file:
```
date{@}completion_date{@}Date of completion{@}{@}{@}BasicDate
```
2. Add the date field to the `bmi` SQL table. You can run in mysql:
```
alter table bmi add column completion_date date DEFAULT NULL;
``` 
3. On main branch, fill out the date field and click 'Save Data' on the bmi instrument front-end for any candidate. You will get the 'Something went wrong.' page. Check your apache error log, and you should see errors 
```
Column not found: 1054 Unknown column 'completion' in 'field list'
Update statement did not execute successfully
```
'Inspect' the HTML date element on the browser, and notice that the input name is 'completion' instead of 'completion_date'.
4. On this PR branch, repeat the above step and you will get no errors (except for maybe 'Error running scoring algorithm' which is a separate issue I think is unrelated to this PR)
5. On this PR branch still, modify the last line of the bmi.list file to be:
```
date{@}completion_date{@}Date of completion{@}{@}{@}
``` 
This now changes the date element from a Basic Date format to a Standard Date format. A standard date format date field requires a not_answered '_status' field so run in mysql:
```
alter table bmi add column completion_date_status enum('not_answered') default NULL;
```
6. Refresh the instrument page, fill out the date field and click 'Save Data' again. You will get no errors. Inspect the HTML date element, and notice that the field name is `completion_date` and not `completion_date_date`
7. After finishing testing, you can delete the columns you had added. Run in mysql:
```
alter table bmi drop column completion_date;
alter table bmi drop column completion_date_status;
```