### PR TITLE
[survey_account] fix can't add survey to candidate in main branch

### DIFF
--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -208,7 +208,7 @@ class AddSurvey extends \NDB_Form
         }
         $battery = new \NDB_BVL_Battery();
         $battery->selectBattery(
-            strval(new \SessionID($SessionID))
+            (new \SessionID($SessionID))
         );
 
         $commentID = $battery->addInstrument($values['Test_name']);

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1445,7 +1445,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     /**
      * Gets the sessionID for the timepoint to which this instrument pertains
      *
-     * @return SessionID The sessionID
+     * @return ?SessionID The sessionID
      */
     function getSessionID(): ?SessionID
     {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1459,7 +1459,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         );
 
         if (empty($result)) {
-           return null;
+            return null;
         }
 
         return (new SessionID($result));

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1447,8 +1447,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @return SessionID The sessionID
      */
-    function getSessionID(): SessionID
+    function getSessionID(): ?SessionID
     {
+
         $query  = "SELECT SessionID FROM flag WHERE CommentID = :CID";
         $result = \NDB_Factory::singleton()->database()->pselectOne(
             $query,
@@ -1456,10 +1457,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'CID' => $this->getCommentID(),
             ]
         );
+
         if (empty($result)) {
-            throw new NotFound(
-                "No SessionID exists for CommentID: `{$this->getCommentID()}`"
-            );
+           return null;
         }
 
         return (new SessionID($result));

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -998,7 +998,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     }
 
     /**
-     * Test that getSessionID throws a NotFound exception if nothing was found in the
+     * Test that getSessionID will return null if nothing was found in the
      * database for the given commentID
      *
      * @covers NDB_BVL_Instrument::getSessionID
@@ -1009,8 +1009,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setUpMockDB();
         $this->_setTableData();
         $this->_instrument->commentID = 'commentID3';
-        $this->expectException('NotFound');
-        $this->_instrument->getSessionID();
+        $this->assertNull($this->_instrument->getSessionID());
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes

1. Fixing the SessionID type in addSurvey function.
According to @driusan 's commnet in https://github.com/aces/Loris/pull/5352#discussion_r450254444
"The semantics of this function shouldn't be changed to throw an exception. This isn't backwards compatible and is unrelated to using the SessionID class."
2. Fixing the return value of getSession.

#### Testing instructions (if applicable)

Add a new survey for a candidate.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
