### PR TITLE
[API] Users get candidates from own projects only in endpoint /candidates that list all candidates

### DIFF
--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -79,6 +79,17 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
     }
 
     /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always true
+     */
+    public function useProjectFilter() : bool
+    {
+        return true;
+    }
+
+    /**
      * Handles a request starts with /candidates
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
@@ -153,6 +164,12 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $provisioner = (new \LORIS\api\Provisioners\CandidatesProvisioner())
             ->filter($filter);
+
+        if ($this->useProjectFilter()) {
+            $provisioner = $provisioner->filter(
+                new \LORIS\Data\Filters\UserProjectMatch()
+            );
+        }
 
         $candidates = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -152,11 +152,8 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
         );
 
         $provisioner = (new \LORIS\api\Provisioners\CandidatesProvisioner())
-            ->filter($filter);
-
-        $provisioner = $provisioner->filter(
-            new \LORIS\Data\Filters\UserProjectMatch()
-        );
+            ->filter($filter)
+            ->filter(new \LORIS\Data\Filters\UserProjectMatch());
 
         $candidates = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)

--- a/modules/api/php/endpoints/candidates.class.inc
+++ b/modules/api/php/endpoints/candidates.class.inc
@@ -79,17 +79,6 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
     }
 
     /**
-     * Tells the base class that this page's provisioner can support
-     * the UserProjectMatch filter.
-     *
-     * @return bool always true
-     */
-    public function useProjectFilter() : bool
-    {
-        return true;
-    }
-
-    /**
      * Handles a request starts with /candidates
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
@@ -165,11 +154,9 @@ class Candidates extends Endpoint implements \LORIS\Middleware\ETagCalculator
         $provisioner = (new \LORIS\api\Provisioners\CandidatesProvisioner())
             ->filter($filter);
 
-        if ($this->useProjectFilter()) {
-            $provisioner = $provisioner->filter(
-                new \LORIS\Data\Filters\UserProjectMatch()
-            );
-        }
+        $provisioner = $provisioner->filter(
+            new \LORIS\Data\Filters\UserProjectMatch()
+        );
 
         $candidates = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)

--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -81,4 +81,18 @@ class CandidatesRow implements \LORIS\Data\DataInstance
         }
         return intval($this->_centerid);
     }
+
+    /**
+     * Returns the ProjectID for this row, for filters such as
+     * \LORIS\Data\Filters\UserProjectMatch to match against.
+     *
+     * @return string ProjectID
+     */
+    public function getProjectID(): int
+    {
+        if ($this->_projectname === null) {
+            throw new \Exception('ProjectID is null');
+        }
+        return intval($this->_projectname);
+    }
 }

--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -24,6 +24,7 @@ class CandidatesRow implements \LORIS\Data\DataInstance
 {
     private $_candid;
     private $_projectname;
+    private $_projectid;
     private $_pscid;
     private $_sitename;
     private $_edc;
@@ -40,6 +41,7 @@ class CandidatesRow implements \LORIS\Data\DataInstance
     {
         $this->_candid      = $row['CandID'] ?? null;
         $this->_projectname = $row['ProjectName'] ?? null;
+        $this->_projectid   = $row['ProjectID'] ?? null;
         $this->_pscid       = $row['PSCID'] ?? null;
         $this->_sitename    = $row['SiteName'] ?? null;
         $this->_edc         = $row['EDC'] ?? null;
@@ -56,13 +58,14 @@ class CandidatesRow implements \LORIS\Data\DataInstance
     public function jsonSerialize() : array
     {
         $obj = [
-            'CandID'  => $this->_candid,
-            'Project' => $this->_projectname,
-            'PSCID'   => $this->_pscid,
-            'Site'    => $this->_sitename,
-            'EDC'     => $this->_edc,
-            'DoB'     => $this->_dob,
-            'Sex'     => $this->_sex,
+            'CandID'    => $this->_candid,
+            'Project'   => $this->_projectname,
+            'ProjectID' => $this->_projectid,
+            'PSCID'     => $this->_pscid,
+            'Site'      => $this->_sitename,
+            'EDC'       => $this->_edc,
+            'DoB'       => $this->_dob,
+            'Sex'       => $this->_sex,
         ];
 
         return $obj;
@@ -86,13 +89,13 @@ class CandidatesRow implements \LORIS\Data\DataInstance
      * Returns the ProjectID for this row, for filters such as
      * \LORIS\Data\Filters\UserProjectMatch to match against.
      *
-     * @return string ProjectID
+     * @return integer ProjectID
      */
     public function getProjectID(): int
     {
-        if ($this->_projectname === null) {
+        if ($this->_projectid === null) {
             throw new \Exception('ProjectID is null');
         }
-        return intval($this->_projectname);
+        return intval($this->_projectid);
     }
 }

--- a/modules/api/php/provisioners/candidatesprovisioner.class.inc
+++ b/modules/api/php/provisioners/candidatesprovisioner.class.inc
@@ -41,6 +41,7 @@ class CandidatesProvisioner extends DBRowProvisioner
              SELECT 
                c.CandID as CandID,
                p.Name as ProjectName,
+               c.RegistrationProjectID as ProjectID,
                c.PSCID as PSCID,
                c.RegistrationCenterID as CenterID,
                s.Name as SiteName,


### PR DESCRIPTION
## Brief summary of changes
The list of candidates returned by the /candidates endpoint is filtered for projects that the user has access to. Only candidates from projects a user has access to is returned.

#### Testing instructions
1- Login your VM with admin
2- Make sure one of the users don't have access to all projects. 
3- Login as the user that don't have access to all projects.
4- Go to <hostname>/api/v0.0.3/candidates
5- Make sure only the projects the user has access to appear in the list displayed on the page

#### Link(s) to related issue(s)

* Resolves #6931 
