### PR TITLE
[Imaging Browser] Fix menu loading

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -208,8 +208,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
               $left_joins
             WHERE
               s.Active = 'Y' AND
-              f.FileType IN ('mnc', 'nii') AND
-              pt.Name='acquisition_date'
+              f.FileType IN ('mnc', 'nii')
             GROUP BY s.ID
             ORDER BY c.PSCID, s.Visit_label
             ",


### PR DESCRIPTION
The query was updated for the imaging browser to use an
AcquisitionDate column from the file table instead of a
join to the parameter_type table. However, a leftover
clause in the WHERE part of the SQL statement is referencing
the no longer joined table, causing the page to crash on
accessing the menu.

This removes the invalid clause.