### PR TITLE
[Behavioural QC] - Instruments filter fixes

### DIFF
--- a/modules/behavioural_qc/jsx/behavioural_qc_module.js
+++ b/modules/behavioural_qc/jsx/behavioural_qc_module.js
@@ -305,7 +305,7 @@ class DefaultPanel extends Component {
 }
 DefaultPanel.propTypes = {
   title: PropTypes.string,
-  children: PropTypes.string,
+  children: PropTypes.object,
 };
 
 class IncompleteCandidates extends Component {
@@ -468,7 +468,7 @@ class BehaviouralQCGraphics extends Component {
   }
 }
 BehaviouralQCGraphics.propTypes = {
-  percentCompleted: PropTypes.string,
+  percentCompleted: PropTypes.number,
   pscid: PropTypes.string,
   visit: PropTypes.string,
   instrument: PropTypes.string,

--- a/modules/behavioural_qc/php/behavioural_qc.class.inc
+++ b/modules/behavioural_qc/php/behavioural_qc.class.inc
@@ -34,15 +34,21 @@ class Behavioural_QC extends \NDB_Form
         $user     =& \User::singleton();
         $sanitize = array_map('htmlspecialchars', $_REQUEST);
 
-        $instrument   = $this->getTestNameusingMappedName(
-            $sanitize['instrument'] ?? null
-        );
-        $site_default =$this->getDefaultSite();
+        $instr = null;
+        if (isset($sanitize['instrument'])
+            && $sanitize['instrument'] != 'All Instruments'
+        ) {
+            $instr = $sanitize['instrument'];
+        }
+        $instrument = $this->getTestNameusingMappedName($instr);
+
+        $site_default = $this->getDefaultSite();
         //construct the instrument drop down..
         $this->tpl_data['visit_label'] = $sanitize['visit_label'] ?? null;
         $this->tpl_data['FieldName']   = $sanitize['FieldName'] ?? null;
         $this->tpl_data['project']     = $sanitize['project'] ?? null;
         $this->tpl_data['site']        = $sanitize['site'] ?? null;
+
         if (isset($sanitize['PSCID']) && !empty($sanitize['PSCID'])) {
             $this->tpl_data['PSCID'] = $sanitize['PSCID'];
         } elseif (isset($sanitize['candidate']) && !empty($sanitize['candidate'])) {
@@ -50,7 +56,8 @@ class Behavioural_QC extends \NDB_Form
         } else {
             $this->tpl_data['candidate'] = null;
         }
-        $this->tpl_data['test_name'] = $instrument;
+        $this->tpl_data['test_name']    = $instrument;
+        $this->tpl_data['test_name_id'] = $sanitize['instrument'];
 
         $candID = null;
         if (isset($sanitize['PSCID']) && !empty($sanitize['PSCID'])
@@ -231,12 +238,12 @@ class Behavioural_QC extends \NDB_Form
             }
         }
 
-        if (($project !=null)&&($project!='All Projects')) {
+        if (($project !=null)&&($project != 'All Projects')) {
             $where         .= " AND psr.ProjectID = :PID";
             $qparams['PID'] = $project;
         }
 
-        if (isset($test_name) && $test_name !='All Instruments'
+        if (isset($test_name) && $test_name != 'All Instruments'
             && $test_name!=null
         ) {
 
@@ -284,11 +291,11 @@ class Behavioural_QC extends \NDB_Form
     {
         $sanitize = array_map('htmlspecialchars', $_REQUEST);
         if (!empty($sanitize[$Filter])
-            && $sanitize[$Filter] !=='All Fields'
-            && (strtolower($sanitize[$Filter]) !=='any')
-            && ($sanitize[$Filter] !=='All Visits')
-            && $sanitize[$Filter] !=='all_flags'
-            && ($sanitize[$Filter] !=='All Instruments')
+            && $sanitize[$Filter] !== 'All Fields'
+            && (strtolower($sanitize[$Filter]) !== 'any')
+            && ($sanitize[$Filter] !== 'All Visits')
+            && $sanitize[$Filter] !== 'all_flags'
+            && ($sanitize[$Filter] !== 'All Instruments')
         ) {
             global $DB;
             if ($Filter == 'instrument') {
@@ -360,13 +367,13 @@ class Behavioural_QC extends \NDB_Form
         }
 
         //filter for testname
-        if (($test_name !=null)&&($test_name!='All Instruments')) {
+        if (($test_name !=null)&&($test_name != 'All Instruments')) {
             $where        .= " AND TableName LIKE CONCAT(:TN, '%')";
             $qparams['TN'] = $test_name;
         }
 
         //filter for visit
-        if (($visit_label !=null)&&($visit_label!='All Visits')) {
+        if (($visit_label !=null)&&($visit_label != 'All Visits')) {
             $where        .= " AND s.visit_label = :VL";
             $qparams['VL'] = $visit_label;
         }
@@ -505,13 +512,13 @@ class Behavioural_QC extends \NDB_Form
         $qparams = [];
 
         //filter for testname
-        if (($test_name !=null)&&($test_name!='All Instruments')) {
+        if (($test_name !=null)&&($test_name != 'All Instruments')) {
             $where        .= " AND f.test_name = :TN";
             $qparams['TN'] = $test_name;
         }
 
         //filter for visit
-        if (($visit_label !=null)&&($visit_label!='All Visits')) {
+        if (($visit_label !=null)&&($visit_label != 'All Visits')) {
             $where        .= " AND s.visit_label = :VL";
             $qparams['VL'] = $visit_label;
         }

--- a/modules/behavioural_qc/templates/form_behavioural_qc.tpl
+++ b/modules/behavioural_qc/templates/form_behavioural_qc.tpl
@@ -34,7 +34,7 @@
 							<label class="col-sm-12 col-md-4">Instruments:</label>
 							<div class="col-sm-12 col-md-8">
 								<select name="instrument" id="instrument" class="form-control input-sm">
-									<option value="{$instrumentvalue}" selected="selected">{$instrumentvalue}></option>
+									<option value="{$test_name_id}" selected="selected">{$test_name_id}</option>
 								</select>
 							</div>
 						</div>


### PR DESCRIPTION
This PR fixes a bunch of issues noticed on the Behavioural QC module:
- Console warning about type mismatch in React component
- A 500 error if the data table is filtered with Instrument set to All instrument
- The Instrument dropdown which did not keep track of the selected value 

#Blocking #6836
#Fixes  #6946