### PR TITLE
[Raisinbread] Add missing tables to 9999-99-99-drop_tables

### DIFF
--- a/SQL/9999-99-99-drop_tables.sql
+++ b/SQL/9999-99-99-drop_tables.sql
@@ -149,6 +149,7 @@ DROP TABLE IF EXISTS `mri_scan_type`;
 DROP TABLE IF EXISTS `mri_scanner`;
 DROP TABLE IF EXISTS `mri_processing_protocol`;
 DROP TABLE IF EXISTS `ImagingFileTypes`;
+DROP TABLE IF EXISTS `mri_upload_rel`;
 
 DROP TABLE IF EXISTS `tarchive_files`;
 DROP TABLE IF EXISTS `tarchive_series`;
@@ -173,5 +174,8 @@ DROP TABLE IF EXISTS `psc`;
 DROP TABLE IF EXISTS `visit_project_subproject_rel`;
 DROP TABLE IF EXISTS `visit`;
 DROP TABLE IF EXISTS `project_subproject_rel`;
+DROP TABLE IF EXISTS `consent_group`;
+DROP TABLE IF EXISTS `hrrt_archive_files`;
+DROP TABLE IF EXISTS `hrrt_archive`;
 DROP TABLE IF EXISTS `Project`;
 DROP TABLE IF EXISTS `subproject`;


### PR DESCRIPTION
## Brief summary of changes
This PR adds 4 tables to `9999-99-99-drop_tables.sql` that were missing. This prevents an error when dropping tables for foreign key constraint fail.

#### Testing instructions (if applicable)

1. After sourcing RB dataset, run the drop table patches. Make sure that no error is thrown, and that all tables have been dropped from database.
2. Make sure there are no errors when sourcing raisinbread

#### Link(s) to related issue(s)

* Resolves #6920
