### PR TITLE
[api] Fix value in "Sex" field of candidate API

### DIFF
--- a/raisinbread/test/api/LorisApiCandidatesTest.php
+++ b/raisinbread/test/api/LorisApiCandidatesTest.php
@@ -175,7 +175,7 @@ class LorisApiCandidatesTest extends LorisApiAuthenticatedTest
         );
         $this->assertSame(
             gettype($candidatesCandidArray['Meta']['Sex']),
-            'array'
+            'string'
         );
         $this->assertSame(
             gettype($candidatesCandidArray['Visits']),

--- a/src/StudyEntities/Candidate/Sex.php
+++ b/src/StudyEntities/Candidate/Sex.php
@@ -23,7 +23,7 @@ namespace LORIS\StudyEntities\Candidate;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Sex
+class Sex implements \JsonSerializable
 {
     /* @var string */
     public $value;
@@ -70,6 +70,17 @@ class Sex
      * @return string
      */
     public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Implements the JSONSerializeable interface by converting
+     * the value to a string.
+     *
+     * @return string
+     */
+    public function jsonSerialize() : string
     {
         return $this->value;
     }


### PR DESCRIPTION
The "Sex" attribute in the single candidate portion of the API
was incorrectly being serialized as an object with a "value" key instead
of a string.

This fixes it by implementing to JSONSerializable interface to
serialize Sex objects as strings.

Fixes #6951
Fixes #6995
Fixes #7008