### PR TITLE
[instrument_list] Remove from test plan ability to view another site's timepoint

### DIFF
--- a/modules/instrument_list/test/TestPlan.md
+++ b/modules/instrument_list/test/TestPlan.md
@@ -1,6 +1,6 @@
 # Instrument List Test Plan
 
-1. Verify that in order to access the module, the user must either have the `Across all sites access candidate profiles` permission, or be at the same site as the visit, or at the same site as one of the candidate's other visits.
+1. Verify that in order to access the module, the user must either have the `Across all sites access candidate profiles` permission, or be at the same site as the visit.
 2. Verify that in order to update the current `Stage` status, the user requires `Data entry` permissions, and must be at the proper site. Exception: if the current `Stage` status is `Approval`, then only the `Behavioural QC` permission is necessary to update the `Stage` status.
 3. Verify that each instrument in the list directs to the corresponding instrument page.
 4. Verify that the flags' values (Data Entry, Administration, Feedback, Double Data Entry Form, Double Data Entry Status) for each instrument in the list are showing up appropriately.


### PR DESCRIPTION
## Brief summary of changes

Update test plan to meet current functionality. Apparently, it used to be the case that a user was able to access a patient's timepoint at another site that the user is not affiliated with if the candidate has at least 1 timepoint at a site the user *is* affiliated with. That now has since changed (?) but the test plan wasn't updated.

#### Testing instructions (if applicable)

1. Test item 1 of test plan and verify that it is the case.