### PR TITLE
[Help editor] Test plan update

### DIFF
--- a/modules/help_editor/test/TestPlan.md
+++ b/modules/help_editor/test/TestPlan.md
@@ -22,17 +22,15 @@
     [Automation Testing]
 12. Test clear filter button.
     [Automation Testing]
-13. Test links to topics, both parent and subtopic.
+13. Ensure permission for Edit Help is working properly.
     [Manual Testing]
-14. Ensure permission for Edit Help is working properly.
+14. Sort all header columns.
     [Manual Testing]
-15. Sort all header columns.
+15. Check multiple pages links.
     [Manual Testing]
-16. Check multiple pages links.
-    [Manual Testing]
-17. Test Reset Button - In the Help Editor, add content and click on Reset. Make sure that none of the recent changes were
+16. Test Reset Button - In the Help Editor, add content and click on Reset. Make sure that none of the recent changes were
     saved and the page reloads with the default content.
     [Manual Testing]
-18. Test Preview Button - In the Help Editor, update title and content, and click on the Preview button. Make sure
+17. Test Preview Button - In the Help Editor, update title and content, and click on the Preview button. Make sure
     the recent changes are visible in the Help side panel. Continue updating the content and clicking the 'Preview' button. The latest help content should show in the side panel.
     [Manual Testing]


### PR DESCRIPTION
Small changes in the test plan to remove the reference to parents and subtopics (not relevant anymore).

* Resolves #5784
