### PR TITLE
[DQT beta] fix console warnings

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -2233,7 +2233,7 @@ class RadioElement extends React.Component {
 }
 RadioElement.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   options: PropTypes.object.isRequired,
   disabled: PropTypes.bool,
   required: PropTypes.bool,

--- a/modules/dqt/jsx/react.app.js
+++ b/modules/dqt/jsx/react.app.js
@@ -47,7 +47,7 @@ class DataQueryApp extends Component {
         show: false,
       },
       ActiveTab: 'Info',
-      rowData: {},
+      rowData: [],
       filter: {
         type: 'group',
         activeOperator: 0,
@@ -685,7 +685,7 @@ class DataQueryApp extends Component {
 
     // Reset the rowData and sessiondata
     this.setState({
-      rowData: {},
+      rowData: [],
       sessiondata: {},
       loading: true,
     });
@@ -962,7 +962,7 @@ class DataQueryApp extends Component {
       grouplevel: displayID,
       ...(rowdata.rowdata.length > 0
         ? {rowData: rowdata}
-        : {rowData: {}}),
+        : {rowData: []}),
     });
   }
 

--- a/modules/dqt/jsx/react.app.js
+++ b/modules/dqt/jsx/react.app.js
@@ -961,7 +961,7 @@ class DataQueryApp extends Component {
     this.setState({
       grouplevel: displayID,
       ...(rowdata.rowdata.length > 0
-        ? {rowData: rowdata}
+        ? {rowData: rowdata.rowdata}
         : {rowData: []}),
     });
   }

--- a/modules/dqt/jsx/react.app.js
+++ b/modules/dqt/jsx/react.app.js
@@ -961,7 +961,7 @@ class DataQueryApp extends Component {
     this.setState({
       grouplevel: displayID,
       ...(rowdata.rowdata.length > 0
-        ? {rowData: rowdata.rowdata}
+        ? {rowData: rowdata}
         : {rowData: []}),
     });
   }

--- a/modules/dqt/jsx/react.tabs.js
+++ b/modules/dqt/jsx/react.tabs.js
@@ -1085,7 +1085,9 @@ class ManageSavedQueryRow extends Component {
             if (this.props.Query.Fields[instrument].hasOwnProperty(field)
               && field !== 'allVisits'
             ) {
-              fields.push(<li key={instrument}>{instrument},{field}</li>);
+              fields.push(
+                <li key={instrument + field}>{instrument},{field}</li>
+              );
             }
           }
         }

--- a/modules/dqt/jsx/react.tabs.js
+++ b/modules/dqt/jsx/react.tabs.js
@@ -531,6 +531,9 @@ ViewDataTabPane.propTypes = {
   Data: PropTypes.array,
   runQuery: PropTypes.func.isRequired,
 };
+ViewDataTabPane.defaultProps = {
+  Data: [],
+};
 
 /**
  * ScatterplotGraph Component

--- a/modules/dqt/jsx/react.tabs.js
+++ b/modules/dqt/jsx/react.tabs.js
@@ -528,6 +528,7 @@ class ViewDataTabPane extends Component {
 }
 
 ViewDataTabPane.propTypes = {
+  Data: PropTypes.array,
   runQuery: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
## Brief summary of changes

Fixes the warning in browser console:
```
Warning: Encountered two children with the same key, `demographics`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

also

```
react.development.js:1641 Warning: Failed prop type: The prop label is marked as required in RadioElement, but its value is undefined.
in RadioElement (created by ViewDataTabPane)
in ViewDataTabPane (created by DataQueryApp)
```

and lastly solves
```
When clicking Run Query:
react_devtools_backend.js:2273 Warning: Failed prop type: Invalid prop Data of type object supplied to StaticDataTable, expected array.
in StaticDataTable (created by ViewDataTabPane)
in ViewDataTabPane (created by DataQueryApp)
in div (created by StepperPanel)
in StepperPanel (created by DataQueryApp)
in div (created by DataQueryApp)
in div (created by DataQueryApp)
in DataQueryApp
in div (created by StepperPanel)
in StepperPanel (created by DataQueryApp)
in div (created by DataQueryApp)
in div (created by DataQueryApp)
in DataQueryApp
```