### PR TITLE
[media] hidden files do not display for superuser

### DIFF
--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -155,8 +155,7 @@ class Media extends \DataFrameworkMenu
     public function getDataProvisionerWithFilters() : \LORIS\Data\Provisioner
     {
         $provisioner = parent::getDataProvisionerWithFilters();
-        $factory     = \NDB_Factory::singleton();
-        $user        = $factory->user();
+        $user        = \NDB_Factory::singleton()->user();
         if ($user->hasPermission('superuser',)) {
             // We don't filter out hidden files.
             return $provisioner;

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -155,7 +155,12 @@ class Media extends \DataFrameworkMenu
     public function getDataProvisionerWithFilters() : \LORIS\Data\Provisioner
     {
         $provisioner = parent::getDataProvisionerWithFilters();
-
+        $factory     = \NDB_Factory::singleton();
+        $user        = $factory->user();
+        if ($user->hasPermission('superuser',)) {
+            // We don't filter out hidden files.
+            return $provisioner;
+        }
         return $provisioner->filter(new HideFileFilter());
     }
 

--- a/modules/media/php/media.class.inc
+++ b/modules/media/php/media.class.inc
@@ -156,7 +156,7 @@ class Media extends \DataFrameworkMenu
     {
         $provisioner = parent::getDataProvisionerWithFilters();
         $user        = \NDB_Factory::singleton()->user();
-        if ($user->hasPermission('superuser',)) {
+        if ($user->hasPermission('superuser')) {
             // We don't filter out hidden files.
             return $provisioner;
         }

--- a/modules/media/test/MediaTest.php
+++ b/modules/media/test/MediaTest.php
@@ -82,7 +82,7 @@ class MediaTest extends LorisIntegrationTest
         $this->_testFilter(self::$PSCID, self::$table, null, "MTL010");
         $this->_testFilter(self::$FileName, self::$table, null, "MTL010");
         $this->_testFilter(self::$VisitLabel, self::$table, "3 rows", "2");
-        $this->_testFilter(self::$Language, self::$table, "26", "2");
+        $this->_testFilter(self::$Language, self::$table, "27", "2");
         $this->_testFilter(self::$Instrument, self::$table, "4 rows", "2");
         //$this->_testFilter(self::$Site, self::$table, "12 rows", "2");rewirte later
 


### PR DESCRIPTION
## Brief summary of changes

Solves the bug found in #6950

#### Testing instructions (if applicable)

1. Hide file as superuser.
2. Refresh module.
3. Hidden file row should still be visible to superuser.
4. Hidden file row should be hidden from non-superusers.

#### Link(s) to related issue(s)

* Resolves #6950
