### PR TITLE
[eslint] Option to compile without  eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
     "tests:unit:debug": "DEBUG=true ./test/dockerized-unit-tests.sh",
     "tests:integration": "./test/dockerized-integration-tests.sh",
     "tests:integration:debug": "DEBUG=true ./test/dockerized-integration-tests.sh",
-    "compile": "webpack",
-    "watch": "webpack --watch"
+    "compile": "webpack --mode=development",
+    "compile-production": "webpack --mode=production",
+    "watch": "webpack --watch --mode=development"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ const optimization = {
     }),
   ],
 };
+
 const resolve = {
   alias: {
     util: path.resolve(__dirname, './htdocs/js/util'),
@@ -44,6 +45,7 @@ const resolve = {
   },
   extensions: ['*', '.js', '.jsx', '.json'],
 };
+
 const mod = {
   rules: [
     {
@@ -52,12 +54,6 @@ const mod = {
       use: [
         {
           loader: 'babel-loader?cacheDirectory',
-        },
-        {
-          loader: 'eslint-loader',
-          options: {
-            cache: true,
-          },
         },
       ],
       enforce: 'pre',
@@ -277,4 +273,22 @@ if (fs.existsSync('./project/webpack-project.config.js')) {
   }
 }
 
-module.exports = config;
+module.exports = (env, options) => {
+  if (options.mode == 'production') {
+    config[0].module.rules.push({
+      test: /\.(js|jsx)$/,
+      exclude: /node_modules/,
+      use: [
+        {
+          loader: 'eslint-loader',
+          options: {
+            cache: true,
+          },
+        },
+      ],
+      enforce: 'pre',
+    });
+  }
+
+  return config;
+};


### PR DESCRIPTION
This PR add a new command: `npm run compile-production`, to compile jsx files with eslint. `npm run compile` now runs on dev mode and have eslint disabled.