### PR TITLE
[candidate_parameters] Candidate information fields disabled without edit permission

### DIFF
--- a/modules/candidate_parameters/jsx/CandidateInfo.js
+++ b/modules/candidate_parameters/jsx/CandidateInfo.js
@@ -123,7 +123,9 @@ class CandidateInfo extends Component {
     }
     let reasonDisabled = true;
     let reasonRequired = false;
-    if (this.state.formData.flaggedCaveatemptor === 'true') {
+    if (this.state.formData.flaggedCaveatemptor === 'true'
+      && loris.userHasPermission('candidate_parameter_edit')
+    ) {
       reasonDisabled = false;
       reasonRequired = true;
     }
@@ -141,7 +143,9 @@ class CandidateInfo extends Component {
       }
     }
 
-    if (this.state.formData.flaggedReason === reasonKey) {
+    if (this.state.formData.flaggedReason === reasonKey
+      && loris.userHasPermission('candidate_parameter_edit')
+    ) {
       otherRequired = true;
       otherDisabled = false;
     }


### PR DESCRIPTION
#### Testing instructions (if applicable)

1. Access a candidate profile with  `true` selected for `Caveat Emptor Flag for Candidate` and `other` selected for `Reason for Caveat Emptor Flag` in the Candidate Information tab.
2. Without edit permission, all fields should be disabled. 
3. With edit permission, all fields should be enabled (`Reason for Caveat Emptor Flag` enabled if `true` selected for `Caveat Emptor Flag for Candidate`, and `If Other, please specify` enabled when `other` selected).

#### Link(s) to related issue(s)

* Resolves #6984