### PR TITLE
[user_accounts] Remove DDC restriction for pending accounts in dashboard

### DIFF
--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -500,7 +500,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $this->_testMytaskPanelAndLink(
             ".pending-accounts",
-            "1",
+            "2",
             "- User Accounts"
         );
         $this->resetPermissions();

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -85,8 +85,7 @@ class Module extends \Module
                     $DB,
                     "SELECT COUNT(DISTINCT users.UserID) FROM users
                         LEFT JOIN user_psc_rel as upr ON (upr.UserID=users.ID)
-                    WHERE users.Pending_approval='Y'
-                        AND (upr.CenterID <> 1 OR upr.CenterID IS NULL)",
+                    WHERE users.Pending_approval='Y'",
                     'user_accounts_multisite',
                     'upr.CenterID',
                     $baseURL . "/user_accounts/?pendingApproval=Y",


### PR DESCRIPTION
## Brief summary of changes
This PR removes the restriction that DDC users are not included in pending account approval in the dashboard widget. 

#### Testing instructions (if applicable)

1. Request an account and choose Data Coordinating Center as site
2. Ensure that the number of `Pending account approvals` increases accordingly in the `My tasks` section of the dashboard
3. Ensure that when clicking on `Pending account approvals`, the user is included in the results
4. Repeat steps 2-3 after creating a new user from the `user_accounts` module with `Pending approval` set to `Yes`.

#### Link(s) to related issue(s)

* Resolves #6962