### PR TITLE
[Candidate] Allow null Sex for scanner candidates

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -102,7 +102,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         foreach ($row as $key=>$value) {
             switch ($key){
             case 'Sex':
-                $this->candidateInfo[$key] = new Sex($value);
+                $this->candidateInfo[$key] = empty($value) ? null : new Sex($value);
                 break;
             case 'EntityType':
                 $this->candidateInfo[$key] = new EntityType($value);


### PR DESCRIPTION
## Brief summary of changes

Currently, the default value for "Sex" when a scanner is created is NULL. This causes an error when the candidate profile is visited from the family tab (as described in issue #6990). This PR makes it so that a Sex value is not required when selecting a Candidate to accommodate these Scanner candidates.

#### Testing instructions (if applicable)

1. Make sure that you can visit the candidate profile of a candidate with entity type `scanner`
2. Follow the procedure in the description of https://github.com/aces/loris/issues/6990 and make sure that you do not encounter the error.

#### Link(s) to related issue(s)

* Resolves #6990
