### PR TITLE
[cand. profile/instr. list] Send to DCC/BVL Feedback sessionID fixes

### DIFF
--- a/modules/bvl_feedback/ajax/bvl_panel_ajax.php
+++ b/modules/bvl_feedback/ajax/bvl_panel_ajax.php
@@ -20,26 +20,24 @@ use \LORIS\StudyEntities\Candidate\CandID;
 
 $username = \User::singleton()->getUsername();
 
-if (isset($_POST['candID']) && (empty($_POST['sessionID']))) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread = \NDB_BVL_Feedback::Singleton($username, $candID);
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && (empty($_POST['commentID']))
-) {
-    $candID         = new CandID($_POST['candID']);
+if (isset($_POST['candID']) && !empty($_POST['candID'])) {
+    $candID    = new CandID($_POST['candID']);
+    $sessionID = null;
+    $commentID = null;
+
+    if (isset($_POST['sessionID']) && !empty($_POST['sessionID'])) {
+        $sessionID = new \SessionID($_POST['sessionID']);
+    }
+
+    if (isset($_POST['commentID']) && !empty($_POST['commentID'])) {
+        $commentID = $_POST['commentID'];
+    }
+
     $feedbackThread =& \NDB_BVL_Feedback::Singleton(
         $username,
         $candID,
-        new \SessionID($_POST['sessionID'])
-    );
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && isset($_POST['commentID'])
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =& \NDB_BVL_Feedback::Singleton(
-        $username,
-        $candID,
-        new \SessionID($_POST['sessionID']),
-        $_POST['commentID']
+        $sessionID,
+        $commentID
     );
 }
+

--- a/modules/bvl_feedback/ajax/bvl_panel_ajax.php
+++ b/modules/bvl_feedback/ajax/bvl_panel_ajax.php
@@ -30,7 +30,7 @@ if (isset($_POST['candID']) && (empty($_POST['sessionID']))) {
     $feedbackThread =& \NDB_BVL_Feedback::Singleton(
         $username,
         $candID,
-        $_POST['sessionID']
+        new \SessionID($_POST['sessionID'])
     );
 } elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
     && isset($_POST['commentID'])

--- a/modules/bvl_feedback/ajax/react_get_bvl_threads.php
+++ b/modules/bvl_feedback/ajax/react_get_bvl_threads.php
@@ -24,36 +24,29 @@ require_once __DIR__ . "/../../../vendor/autoload.php";
 
 $username = \User::singleton()->getUsername();
 
+if (isset($_POST['candID']) && !empty($_POST['candID'])) {
+    $candID    = new CandID($_POST['candID']);
+    $sessionID = null;
+    $commentID = null;
 
-if (isset($_POST['candID'])
-    && (!isset($_POST['sessionID']) || empty($_POST['sessionID']))
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =& \NDB_BVL_Feedback::Singleton($username, $candID);
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && !(isset($_POST['commentID']))
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =&
-        \NDB_BVL_Feedback::Singleton(
-            $username,
-            $candID,
-            new \SessionID($_POST['sessionID'])
-        );
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && isset($_POST['commentID'])
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =&
-        \NDB_BVL_Feedback::Singleton(
-            $username,
-            $candID,
-            new \SessionID($_POST['sessionID']),
-            $_POST['commentID']
-        );
+    if (isset($_POST['sessionID']) && !empty($_POST['sessionID'])) {
+        $sessionID = new \SessionID($_POST['sessionID']);
+    }
+
+    if (isset($_POST['commentID']) && !empty($_POST['commentID'])) {
+        $commentID = $_POST['commentID'];
+    }
+
+    $feedbackThread =& \NDB_BVL_Feedback::Singleton(
+        $username,
+        $candID,
+        $sessionID,
+        $commentID
+    );
 }
 
 $feedbackThreadList = $feedbackThread->getThreadList();
 echo json_encode($feedbackThreadList);
 
 exit();
+

--- a/modules/bvl_feedback/ajax/react_get_bvl_threads.php
+++ b/modules/bvl_feedback/ajax/react_get_bvl_threads.php
@@ -25,7 +25,9 @@ require_once __DIR__ . "/../../../vendor/autoload.php";
 $username = \User::singleton()->getUsername();
 
 
-if (isset($_POST['candID']) && !(isset($_POST['sessionID']))) {
+if (isset($_POST['candID'])
+    && (!isset($_POST['sessionID']) || empty($_POST['sessionID']))
+) {
     $candID         = new CandID($_POST['candID']);
     $feedbackThread =& \NDB_BVL_Feedback::Singleton($username, $candID);
 } elseif (isset($_POST['candID']) && isset($_POST['sessionID'])

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -186,7 +186,7 @@ class Instrument_List_ControlPanel extends \TimePoint
                 ['Submitted' => $submitted]
             );
 
-                // revert from approval (or the bin)
+            // revert from approval (or the bin)
             if ($currentStage == 'Approval') {
                 $this->setData(
                     [
@@ -713,9 +713,9 @@ class Instrument_List_ControlPanel extends \TimePoint
                     'In Progress',
                 ]
             )
-            && ! $config->settingEnabled("useScanDone")
+            && (!$config->settingEnabled("useScanDone")
             || $this->getData('Current_stage') == 'Screening'
-            || !empty($scanDone)
+            || !empty($scanDone))
         ) {
             return true;
         }

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -174,7 +174,7 @@ class Timepoint_List extends \NDB_Menu
 
                 // get the outcome data
                 $outcomeStage
-                    = $this->_determinePreviousStage($timePoint);
+                    = $this->_determinePreviousStage($sessionID);
 
                 $getStatusMethod = 'get'.$outcomeStage.'Status';
 

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -85,7 +85,9 @@ class BVL_Feedback_Panel
         $candidateObject         = Candidate::singleton($candidateID);
         $this->tpl_data['pscid'] = $candidateObject->getPSCID();
 
-        $this->tpl_data['sessionID'] = $feedbackProfile["SessionID"] ?? null;
+        $this->tpl_data['sessionID'] = isset($feedbackProfile["SessionID"]) ?
+            $feedbackProfile["SessionID"]->__toString() :
+            null;
 
         $feedbackObject = $this->feedbackThread->_feedbackObjectInfo;
         $this->tpl_data['commentID'] = $feedbackObject["CommentID"] ?? null;

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -86,7 +86,7 @@ class BVL_Feedback_Panel
         $this->tpl_data['pscid'] = $candidateObject->getPSCID();
 
         $this->tpl_data['sessionID'] = isset($feedbackProfile["SessionID"]) ?
-            $feedbackProfile["SessionID"]->__toString() :
+            strval($feedbackProfile["SessionID"]) :
             null;
 
         $feedbackObject = $this->feedbackThread->_feedbackObjectInfo;

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -215,7 +215,9 @@ class NDB_BVL_Feedback
             || isset($this->_feedbackObjectInfo['SessionID'])
         ) {
             $this->_feedbackCandidateProfileInfo['SessionID']
-                = $result[0]['SessionID'] ?? $this->_feedbackObjectInfo['SessionID'];
+                = isset($result[0]['SessionID']) ?
+                  new \SessionID($result[0]['SessionID']) :
+                  $this->_feedbackObjectInfo['SessionID'];
         }
     }
 


### PR DESCRIPTION
This PR completes the work done on #7036 to solve some errors introduced by #5352 (candidate profile/instrument list)

error 500 if $_POST['sessionID'] is an empty string (react_get_bvl_threads.php)
console warning: sessionID is of type object (BVL_Feedback_Panel.class.inc)
one omitted conversion of $_POST['sessionID'] to new \SessionID($_POST['sessionID']) (bvl_panel_ajax.php)

Resolves #7139
Resolves #7017 
Resolves #6987