### PR TITLE
[ddocument_repository] fix can't delete file issue

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -189,13 +189,13 @@ class DocIndex extends React.Component {
         function click() {
           swal.fire({
             title: 'Are you sure?',
-            text: 'Your will not be able to recover this file!',
-            type: 'warning',
+            text: "You won't be able to revert this!",
+            icon: 'warning',
             showCancelButton: true,
-            confirmButtonClass: 'btn-danger',
-            confirmButtonText: 'Yes, delete it!',
-            closeOnConfirm: false,
-          }, function() {
+            confirmButtonColor: '#3085d6',
+            cancelButtonColor: '#d33',
+            confirmButtonText: 'Yes, delete it!'
+          }).then((result) => {
             let deleteurl = loris.BaseURL + '/document_repository/Files/' + id;
               fetch(deleteurl, {
               method: 'DELETE',


### PR DESCRIPTION
## Brief summary of changes
fix sweet alert 2, can't delete issue.
#### Testing instructions (if applicable)

upload a file and delete it.

#### Link(s) to related issue(s)
https://github.com/aces/Loris/issues/7003
https://github.com/aces/Loris/issues/7004