### PR TITLE
[Configuration] fix funny behaviour of “Reset button” for fields that have the “Add field” button.

### DIFF
--- a/modules/configuration/js/configuration_helper.js
+++ b/modules/configuration/js/configuration_helper.js
@@ -90,6 +90,11 @@ $(function () {
             }
         });
     });
+
+    // On form reset, to delete the elements added with the "Add field" button that were not submitted.
+    $('form').on('reset', function(e) {
+        $(".tab-pane.active").find("select[name^='add-']").parent().remove();
+    });
 });
 
 /*


### PR DESCRIPTION
## Brief summary of changes
Fix bug where the fields added with the “Add field” button were not properly reset when the “Reset button” of the form was clicked.
See more details on issue #7009 

#### Testing instructions

1. Go to: `MainMenu->Admin->Configuration->Satistics`
2. Add a new field using the button `“Add field”`
3. **Before submitting** the form click `“Reset”`
4. The fields should be now properly reset.

**Note:** The same functionality should be observed if done in other of the tabs (Study for example).

#### Link to related issue

* Resolves #7009 
