### PR TITLE
[imaging_qc] Fix bugs in query that were leading to module not loading correctly

### DIFF
--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -129,9 +129,9 @@ class Imaging_QC extends \NDB_Menu_Filter
               ELSE 'Complete'
            END AS mri_parameter_form,
            CASE
-              WHEN m.".$scan_done." IS NULL THEN ''
-              WHEN (m.".$scan_done." = 'Complete'
-              OR m.".$scan_done." = 'Partial') THEN 'Yes'
+              WHEN m.`".$scan_done."` IS NULL THEN ''
+              WHEN (m.`".$scan_done."` = 'Complete'
+              OR m.`".$scan_done."` = 'Partial') THEN 'Yes'
               ELSE 'No'
            END as scan_done,
            CASE

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -268,7 +268,11 @@ class Imaging_QC extends \NDB_Menu_Filter
         $acq_IDs    = [];
         foreach ($scan_types as $scan_type) {
             // Only include scan types that appear in the MRI Parameter Form
-            $scanTypeInMRIPF = $db->columnExists('mri_parameter_form', $scan_type . "_Scan_done");
+            $scanTypeInMRIPF = $db->columnExists(
+                'mri_parameter_form',
+                $scan_type .
+                "_Scan_done"
+            );
 
             if (!$scanTypeInMRIPF) {
                 unset($scan_types[$scan_type]);

--- a/modules/imaging_qc/php/imaging_qc.class.inc
+++ b/modules/imaging_qc/php/imaging_qc.class.inc
@@ -267,6 +267,14 @@ class Imaging_QC extends \NDB_Menu_Filter
         $scans_done = [];
         $acq_IDs    = [];
         foreach ($scan_types as $scan_type) {
+            // Only include scan types that appear in the MRI Parameter Form
+            $scanTypeInMRIPF = $db->columnExists('mri_parameter_form', $scan_type . "_Scan_done");
+
+            if (!$scanTypeInMRIPF) {
+                unset($scan_types[$scan_type]);
+                continue;
+            }
+
             $query_params        = ['scan_type' => $scan_type];
             $acq_IDs[$scan_type] = $db->pselectOne(
                 "SELECT ID FROM mri_scan_type WHERE Scan_type=:scan_type",


### PR DESCRIPTION
## Brief summary of changes
This PR does two things:

1. Escapes field name in query
2. Only includes in the query scan_types that also appear in the MRI Parameter Form

**How to test:**
1. In `Configuration -> Imaging Modules -> Tabulated Scan Types`; add scan types that don't also appear in the MRI Parameter Form. 
2. Ensure the module will still load. 
3. Ensure that scan types not in MRI PF do not appear in the `imaging_qc` table. (EX: t1-defaced)

#### Link(s) to related issue(s)

* Resolves #6967
