### PR TITLE
[MRI Violations] Add help text to MRI Resolved Violations

### DIFF
--- a/modules/mri_violations/help/resolved_violations.md
+++ b/modules/mri_violations/help/resolved_violations.md
@@ -1,0 +1,3 @@
+# MRI Resolved Violations  
+
+This page displays scans that have been resolved from MRI Violation. Use the Selection Filter section to narrow down your search in the data results table below.  

--- a/modules/mri_violations/help/resolved_violations.md
+++ b/modules/mri_violations/help/resolved_violations.md
@@ -1,3 +1,3 @@
-# MRI Resolved Violations  
+# MRI Resolved Violations
 
-This page displays scans that have been resolved from MRI Violation. Use the Selection Filter section to narrow down your search in the data results table below.  
+This page displays all violated scans that have been updated to any resolution status other than **Unresolved**. Use the Selection Filter section to narrow down your search in the data results table below.


### PR DESCRIPTION
## Brief summary of changes
The help text for MRI Resolved Violations was missing. The screenshot below shows the help text that I added.
![image](https://user-images.githubusercontent.com/42322196/96934367-15e35c00-1490-11eb-8d45-919fede8ee12.png)

- [x] Have you updated related documentation?

#### Link(s) to related issue(s)

* Resolves #7021  (Reference the issue this fixes, if any.)
