### PR TITLE
Fixed imaging uploader that would not automatically start when overwriting a file

### DIFF
--- a/modules/imaging_uploader/jsx/UploadForm.js
+++ b/modules/imaging_uploader/jsx/UploadForm.js
@@ -194,13 +194,13 @@ class UploadForm extends Component {
         showCancelButton: true,
         confirmButtonText: 'Yes, I am sure!',
         cancelButtonText: 'No, cancel it!',
-      }, function(isConfirm) {
-        if (isConfirm) {
+      }).then((result) => {
+        if (result.value) {
           this.uploadFile(true);
         } else {
           swal.fire('Cancelled', 'Your upload has been cancelled.', 'error');
         }
-      }.bind(this));
+      });
     }
 
     // Pipeline has not been triggered yet
@@ -214,13 +214,13 @@ class UploadForm extends Component {
         showCancelButton: true,
         confirmButtonText: 'Yes, I am sure!',
         cancelButtonText: 'No, cancel it!',
-      }, function(isConfirm) {
-        if (isConfirm) {
+      }).then((result) => {
+        if (result.value) {
           this.uploadFile(true);
         } else {
           swal.fire('Cancelled', 'Your upload has been cancelled.', 'error');
         }
-      }.bind(this));
+      });
     }
 
     return;
@@ -287,9 +287,8 @@ class UploadForm extends Component {
           title: 'Upload Successful!',
           text: text,
           type: 'success',
-        }, function() {
-          window.location.assign(loris.BaseURL + '/imaging_uploader/');
         });
+        window.location.assign(loris.BaseURL + '/imaging_uploader/');
       },
       // Upon errors in upload:
       // - Displays pop up window with submission error message


### PR DESCRIPTION
## Brief summary of changes

This PR fixes a bug that would prevent the imaging uploader from starting automatically even if you had the imaging uploader auto-launch set to true and your current upload overwrote an existing file. In a nutshell, the PR replaces the `swal.fire` invocations of this form:

```
swal.fire({
.
.
}, function () {
.
.
}.bind(this));
```

with invocations like these:

```
swal.fire({
.
.
}).then(
.
.
);
```

#### Testing instructions (if applicable)

1. Make sure config setting imaging uploader auto-launch is set to `Yes`.
2. Access the imaging uploader and search for a file that was *not* processed successfully by the MRI pipeline (i.e `Progress=Failure`).
3. Upload a file with exactly the same base name as the file you found in 2. When asked if you want to overwrite the file, click `Yes`.

You should see a message indicating that the MRI pipeline was automatically launched and that your scan archive is being processed. You can also try overwriting a file that has been uploaded but has not yet been processed by the MRI pipeline (`Progress=Not Started`).

#### Link(s) to related issue(s)

* Resolves #6978 