### PR TITLE
[API] New api candidates endpoint post tests

### DIFF
--- a/raisinbread/test/api/LorisApiCandidatesTest.php
+++ b/raisinbread/test/api/LorisApiCandidatesTest.php
@@ -233,6 +233,34 @@ class LorisApiCandidatesTest extends LorisApiAuthenticatedTest
         $body = $response_new->getBody();
         $this->assertNotEmpty($body);
 
+        // Second, try to create a valid new candidate in a site that the
+        // user is not affiliated with. The test user is only afficilated to
+        // Data Coordinating Center
+        $json_new     = [
+            'Candidate' =>
+                [
+                    'Project' => "Rye",
+                    'Site'    => "Montreal",
+                    'EDC'     => "2020-01-03",
+                    'DoB'     => "2020-01-03",
+                    'Sex'     => "Male"
+                ]
+        ];
+        $response_new = $this->client->request(
+            'POST',
+            "candidates",
+            [
+                'headers'     => $this->headers,
+                'http_errors' => false,
+                'json'        => $json_new
+            ]
+        );
+        // Verify the status code
+        $this->assertEquals(403, $response_new->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response_new->getBody();
+        $this->assertNotEmpty($body);
+
         // Finally, try to create a new candidate with an invalid input
         $json_invalid = [
             'Candidate' =>

--- a/raisinbread/test/api/LorisApiCandidatesTest.php
+++ b/raisinbread/test/api/LorisApiCandidatesTest.php
@@ -261,6 +261,31 @@ class LorisApiCandidatesTest extends LorisApiAuthenticatedTest
         $body = $response_new->getBody();
         $this->assertNotEmpty($body);
 
+        $json_new     = [
+            'Candidate' =>
+                [
+                    'Project' => "",
+                    'Site'    => "Data Coordinating Center",
+                    'EDC'     => "2020-01-03",
+                    'DoB'     => "2020-01-03",
+                    'Sex'     => "Male"
+                ]
+        ];
+        $response_new = $this->client->request(
+            'POST',
+            "candidates",
+            [
+                'headers'     => $this->headers,
+                'http_errors' => false,
+                'json'        => $json_new
+            ]
+        );
+        // Verify the status code
+        $this->assertEquals(400, $response_new->getStatusCode());
+        // Verify the endpoint has a body
+        $body = $response_new->getBody();
+        $this->assertNotEmpty($body);
+
         // Finally, try to create a new candidate with an invalid input
         $json_invalid = [
             'Candidate' =>


### PR DESCRIPTION
## Brief summary of changes

Adds two new tests for POST requests to the \Candidates endpoint. 

1- A valid POST request to create a new candidate at a site where the user is not affiliated with. It expects a Forbidden HTTP error (403). 
2- An invalid POST request where the project is an empty string. It has to be an existing project, so it fails with NotFound error (400). 

#### Link(s) to related issue(s)

* Resolves #
