### PR TITLE
[DQT|dataquery] Define Fields showing incorrect field description

### DIFF
--- a/modules/dataquery/jsx/react.fieldselector.js
+++ b/modules/dataquery/jsx/react.fieldselector.js
@@ -199,6 +199,7 @@ class FieldList extends Component {
     // Display the fields using the FieldItem component
     for (let i = start; i < filteredItems.length; i += 1) {
       fieldName = filteredItems[i].key[1];
+      desc = filteredItems[i].value.Description;
       type = filteredItems[i].value.Type || 'varchar(255)';
 
       // Check if field is a file, if so set flag to true

--- a/modules/dqt/jsx/react.fieldselector.js
+++ b/modules/dqt/jsx/react.fieldselector.js
@@ -268,6 +268,7 @@ class FieldList extends Component {
     // Display the fields using the FieldItem component
     for (let i = start; i < filteredItems.length; i += 1) {
       fieldName = filteredItems[i].key[1];
+      desc = filteredItems[i].value.Description;
       type = filteredItems[i].value.Type || 'varchar(255)';
 
       // Check if field is a file, if so set flag to true


### PR DESCRIPTION
## Brief summary of changes

Define Fields of the DQT module has incorrect field description. This PR fixes the bug.

#### Testing instructions (if applicable)

1. Visit DQT
2. Add demographics to fields.
3. Look at the field descriptions
