### PR TITLE
Session Current_stage - Not Started as default value

### DIFF
--- a/SQL/0000-00-00-schema.sql
+++ b/SQL/0000-00-00-schema.sql
@@ -187,7 +187,7 @@ CREATE TABLE `session` (
   `Visit_label` varchar(255) NOT NULL,
   `SubprojectID` int(10) unsigned DEFAULT NULL,
   `Submitted` enum('Y','N') NOT NULL DEFAULT 'N',
-  `Current_stage` enum('Not Started','Screening','Visit','Approval','Subject','Recycling Bin') DEFAULT NULL,
+  `Current_stage` enum('Not Started','Screening','Visit','Approval','Subject','Recycling Bin') NOT NULL DEFAULT 'Not Started',
   `Date_stage_change` date DEFAULT NULL,
   `Screening` enum('Pass','Failure','Withdrawal','In Progress') DEFAULT NULL,
   `Date_screening` date DEFAULT NULL,

--- a/SQL/New_patches/2020-10-29-session-current-stage-default.sql
+++ b/SQL/New_patches/2020-10-29-session-current-stage-default.sql
@@ -1,0 +1,2 @@
+UPDATE `session` set Current_stage = 'Not Started' WHERE Current_stage IS NULL;
+ALTER TABLE `session` MODIFY Current_stage enum('Not Started','Screening','Visit','Approval','Subject','Recycling Bin') NOT NULL DEFAULT 'Not Started';


### PR DESCRIPTION
Update Current_stage column definition in session:
- Set default value of Current_stage to 'Not Started'
- Set Current_stage not nullable

Resolves #6874