### PR TITLE
[webpack.config.js] update copy-webpack-plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/runtime": "^7.10.5",
     "@fortawesome/fontawesome-free": "^5.11.2",
-    "copy-webpack-plugin": "^5.1.1",
+    "copy-webpack-plugin": "^6.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-addons-create-fragment": "^15.6.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,30 +148,41 @@ const config = [
     },
     devtool: 'source-map',
     plugins: [
-      new CopyPlugin([
-        {
-          from: path.resolve(__dirname, 'node_modules/react/umd/*'),
-          to: path.resolve(__dirname, 'htdocs/vendor/js/react'),
-          force: true,
-          flatten: true,
-          ignore: ['react.profiling.min.js'],
-        },
-        {
-          from: path.resolve(__dirname, 'node_modules/react-dom/umd/*'),
-          to: path.resolve(__dirname, 'htdocs/vendor/js/react'),
-          force: true,
-          flatten: true,
-          ignore: [
-            'react-dom.profiling.min.js',
-            'react-dom-server.*',
-            'react-dom-test-utils.*',
-            'react-dom-unstable-fizz.*',
-            'react-dom-unstable-flight-client.*',
-            'react-dom-unstable-flight-server.*',
-            'react-dom-unstable-native-dependencies.*',
-          ],
-        },
-      ]),
+      new CopyPlugin({
+        patterns: [
+          {
+            from: path.resolve(__dirname, 'node_modules/react/umd'),
+            to: path.resolve(__dirname, 'htdocs/vendor/js/react'),
+            flatten: true,
+            force: true,
+            globOptions: {
+              ignore: ['react.profiling.min.js'],
+            },
+            filter: async (path) => {
+              const file = path.split('\\').pop().split('/').pop();
+              const keep = [
+                'react.development.js',
+                'react.production.min.js',
+              ];
+              return keep.includes(file);
+            },
+          },
+          {
+            from: path.resolve(__dirname, 'node_modules/react-dom/umd'),
+            to: path.resolve(__dirname, 'htdocs/vendor/js/react'),
+            flatten: true,
+            force: true,
+            filter: async (path) => {
+              const file = path.split('\\').pop().split('/').pop();
+              const keep = [
+                'react-dom.development.js',
+                'react-dom.production.min.js',
+              ];
+              return keep.includes(file);
+            },
+          },
+        ],
+      }),
     ],
     optimization: optimization,
     resolve: resolve,


### PR DESCRIPTION
## Brief summary of changes

Updates the dependancy copy-webpack-plugin in package.json.
Also updates the webpack.config.js to use the new copy-webpack-plugin format.

#### Testing instructions (if applicable)

1. npm install
2. npm run compile

https://github.com/aces/Loris/issues/7109
