### PR TITLE
Downgrade composer to latest 1.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
 - sudo apt-get install -y libapparmor1
 - pecl install -f ast-1.0.3
 - sudo apt-get install nodejs-dev node-gyp libssl1.0-dev npm
+- composer self-update 1.10.17
 - make dev
 
 script: "npm run tests:$TEST_SUITE"


### PR DESCRIPTION
Go back to using latest 1.x branch of composer on Travis for compatiblity with our dependencies.