### PR TITLE
[DQT] Longitudinal bug when multiple spaces exist in visit label

### DIFF
--- a/modules/dqt/jsx/react.app.js
+++ b/modules/dqt/jsx/react.app.js
@@ -886,13 +886,21 @@ class DataQueryApp extends Component {
             if (RowHeaders.hasOwnProperty(colHeader)) {
               temp = Identifiers[identifier]
                 + ','
-                + RowHeaders[colHeader].split(' ')[0];
+                + RowHeaders[colHeader].substr(
+                  0,
+                  RowHeaders[colHeader].lastIndexOf(' ')
+                );
               index = sessiondata[temp];
               if (!index) {
                 currow.push('.');
               } else {
-                temp = index[RowHeaders[colHeader].split(',')[0].split(' ')[1]];
-                fieldSplit = RowHeaders[colHeader].split(' ')[1].split(',');
+                const instrument = RowHeaders[colHeader].substr(
+                  RowHeaders[colHeader].lastIndexOf(' ') + 1
+                ).split(',')[0];
+                temp = index[instrument];
+                fieldSplit = RowHeaders[colHeader].substr(
+                  RowHeaders[colHeader].lastIndexOf(' ')
+                ).split(',');
                 if (temp) {
                   if (temp.data[RowHeaders[colHeader].split(',')[1]]
                     && downloadableFields[fieldSplit[0]

--- a/modules/dqt/jsx/react.sidebar.js
+++ b/modules/dqt/jsx/react.sidebar.js
@@ -92,7 +92,9 @@ class FieldsSidebar extends Component {
       for (let i = this.props.Fields.length - 1; i >= 0; i--) {
         let fieldInfo = this.props.Fields[i].split(',');
         fieldList.push(
-          <div className='list-group-item row' key={this.props.Fields[i]}>
+          <div className='list-group-item row'
+               style={{overflowX: 'scroll'}}
+               key={this.props.Fields[i]}>
             <h4 className='list-group-item-heading col-xs-12'>
               {fieldInfo[0]}
             </h4>


### PR DESCRIPTION
## Brief summary of changes

Solves Longitudinal bug when multiple spaces exist in visit label.

Also solves text overflow from fields. Thanks @zaliqarosli for that fix.

#### Testing instructions (if applicable)

1. Visit DQT
2. Make a query that has spaces in visit label for query.
3. Visit the Longitudinal after query is run.
4. Rows should be populated with the data.
