### PR TITLE
[Core] Public page missing title fix

### DIFF
--- a/smarty/templates/public_layout.tpl
+++ b/smarty/templates/public_layout.tpl
@@ -8,7 +8,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>{$page_title}</title>
+  <title>{$study_title}</title>
   <link rel="stylesheet" href="{$baseurl}/bootstrap/css/bootstrap.min.css">
   <link rel="stylesheet" href="{$baseurl}/css/public_layout.css">
   <link type="image/x-icon" rel="icon" href="{$baseurl}/images/favicon.ico">


### PR DESCRIPTION
Public pages have an empty title attribute, resulting in a poor Google result preview.

![Screenshot from 2020-11-11 17-35-38](https://user-images.githubusercontent.com/32041423/98876796-05018700-244d-11eb-8dd2-913eb96ccc3c.png)
