### PR TITLE
Add ProjectID class to LORIS

### DIFF
--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -41,13 +41,15 @@ class CandidatesRow implements \LORIS\Data\DataInstance
     {
         $this->_candid      = $row['CandID'] ?? null;
         $this->_projectname = $row['ProjectName'] ?? null;
-        $this->_projectid   = $row['ProjectID'] ?? null;
-        $this->_pscid       = $row['PSCID'] ?? null;
-        $this->_sitename    = $row['SiteName'] ?? null;
-        $this->_edc         = $row['EDC'] ?? null;
-        $this->_dob         = $row['DoB'] ?? null;
-        $this->_sex         = $row['Sex'] ?? null;
-        $this->_centerid    = $row['CenterID'] ?? null;
+        if ($row['ProjectID'] !== null) {
+            $this->_projectid = new \ProjectID($row['ProjectID']);
+        }
+        $this->_pscid    = $row['PSCID'] ?? null;
+        $this->_sitename = $row['SiteName'] ?? null;
+        $this->_edc      = $row['EDC'] ?? null;
+        $this->_dob      = $row['DoB'] ?? null;
+        $this->_sex      = $row['Sex'] ?? null;
+        $this->_centerid = $row['CenterID'] ?? null;
     }
 
     /**
@@ -89,13 +91,13 @@ class CandidatesRow implements \LORIS\Data\DataInstance
      * Returns the ProjectID for this row, for filters such as
      * \LORIS\Data\Filters\UserProjectMatch to match against.
      *
-     * @return integer ProjectID
+     * @return \ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
         if ($this->_projectid === null) {
             throw new \Exception('ProjectID is null');
         }
-        return intval($this->_projectid);
+        return $this->_projectid;
     }
 }

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -34,9 +34,10 @@ class CandidateListRow implements \LORIS\Data\DataInstance
     /**
      * Create a new CandidateListRow
      *
-     * @param array   $row    The row (in the same format as
-     *                        \Database::pselectRow returns.)
-     * @param integer $cid    The centerID affiliated with this row.
+     * @param array      $row The row (in the same format as
+     *                        \Database::pselectRow
+     *                        returns.)
+     * @param integer    $cid The centerID affiliated with this row.
      * @param \ProjectID $pid The projectID affiliated with this row.
      */
     public function __construct(array $row, int $cid, \ProjectID $pid)

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -34,10 +34,10 @@ class CandidateListRow implements \LORIS\Data\DataInstance
     /**
      * Create a new CandidateListRow
      *
-     * @param array   $row The row (in the same format as \Database::pselectRow
-     *                     returns
-     * @param integer $cid The centerID affiliated with this row.
-     * @param integer $pid The projectID affiliated with this row.
+     * @param array   $row    The row (in the same format as
+     *                        \Database::pselectRow returns.)
+     * @param integer $cid    The centerID affiliated with this row.
+     * @param \ProjectID $pid The projectID affiliated with this row.
      */
     public function __construct(array $row, int $cid, \ProjectID $pid)
     {

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -39,7 +39,7 @@ class CandidateListRow implements \LORIS\Data\DataInstance
      * @param integer $cid The centerID affiliated with this row.
      * @param integer $pid The projectID affiliated with this row.
      */
-    public function __construct(array $row, int $cid, int $pid)
+    public function __construct(array $row, int $cid, \ProjectID $pid)
     {
         $this->DBRow     = $row;
         $this->CenterID  = $cid;
@@ -71,9 +71,9 @@ class CandidateListRow implements \LORIS\Data\DataInstance
      * Returns the ProjectID for this row, for filters such as
      * \LORIS\Data\Filters\UserProjectMatch to match again.
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
         return $this->ProjectID;
     }

--- a/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
+++ b/modules/candidate_list/php/candidatelistrowprovisioner.class.inc
@@ -96,7 +96,7 @@ class CandidateListRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisio
         // behaviour of requiring the registration site to match
         // one of the user's sites.
         $cid = (int) $row['RegistrationCenterID'];
-        $pid = (int) $row['RegistrationProjectID'];
+        $pid = new \ProjectID($row['RegistrationProjectID']);
         unset($row['RegistrationCenterID']);
         unset($row['RegistrationProjectID']);
         return new CandidateListRow($row, $cid, $pid);

--- a/modules/configuration/php/project.class.inc
+++ b/modules/configuration/php/project.class.inc
@@ -56,7 +56,9 @@ class Project extends \NDB_Form
         foreach (array_keys($projectList) as $ProjectID) {
             $projects[$ProjectID] = $config->getProjectSettings($ProjectID);
             $projects[$ProjectID]['projectSubprojects']
-                = \Utility::getSubprojectsForProject($ProjectID);
+                = \Utility::getSubprojectsForProject(
+                    new \ProjectID(strval($ProjectID))
+                );
         }
         $this->tpl_data['projects']    = $projects;
         $this->tpl_data['subprojects'] = $subprojectList;

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -193,7 +193,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             // if there is only one project, autoselect first project from array of 1
             $project = \Project::getProjectFromID(array_pop($user_list_of_projects));
         } else if (count($user_list_of_projects) > 1) {
-            $project_id = intval($values['project']);
+            $project_id = new ProjectID($values['project']);
             $project    = \Project::getProjectFromID($project_id);
         }
 

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -130,7 +130,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $projectOptions        = [];
         foreach ($user_list_of_projects as $projectID) {
             $project = \Project::getProjectFromID($projectID);
-            $projectOptions[$projectID] = $project->getName();
+            $projectOptions["$projectID"] = $project->getName();
         }
         $values['project'] = $projectOptions;
 

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -193,7 +193,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             // if there is only one project, autoselect first project from array of 1
             $project = \Project::getProjectFromID(array_pop($user_list_of_projects));
         } else if (count($user_list_of_projects) > 1) {
-            $project_id = new ProjectID($values['project']);
+            $project_id = new \ProjectID($values['project']);
             $project    = \Project::getProjectFromID($project_id);
         }
 

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
@@ -35,12 +35,12 @@ class ElectrophysiologyBrowserRow implements \LORIS\Data\DataInstance
     /**
      * Create a new ElectrophysiologyBrowserRow
      *
-     * @param array   $row The row (in the same format as \Database::pselectRow
-     *                     returns
-     * @param integer $cid The centerID affiliated with this row.
-     * @param integer $pid The projectID affiliated with this row.
+     * @param array      $row The row (in the same format as
+     *                        \Database::pselectRow returns
+     * @param integer    $cid The centerID affiliated with this row.
+     * @param \ProjectID $pid The projectID affiliated with this row.
      */
-    public function __construct(array $row, int $cid, int $pid)
+    public function __construct(array $row, int $cid, \ProjectID $pid)
     {
         $this->DBRow     = $row;
         $this->CenterID  = $cid;
@@ -71,9 +71,9 @@ class ElectrophysiologyBrowserRow implements \LORIS\Data\DataInstance
     /**
      * Returns the ProjectID for this row
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
         return $this->ProjectID;
     }

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrowprovisioner.class.inc
@@ -79,7 +79,7 @@ class ElectrophysiologyBrowserRowProvisioner
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
         $cid = (int )$row['CenterID'];
-        $pid = (int )$row['ProjectID'];
+        $pid = new \ProjectID($row['ProjectID']);
         unset($row['CenterID']);
         unset($row['ProjectID']);
         return new ElectrophysiologyBrowserRow($row, $cid, $pid);

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -78,7 +78,7 @@ class New_Profile extends \NDB_Form
             $edc,
             new Sex($values['sex']),
             $values['pscid'] ?? null,
-            intval($values['project'])
+            new \ProjectID($values['project'])
         );
 
         /* Update front-end data. Use passed PSCID when present, otherwise
@@ -257,7 +257,9 @@ class New_Profile extends \NDB_Form
                 $site = \Site::singleton((int) $values['site']);
             }
 
-            $project = \Project::getProjectFromID(intval($values['project']));
+            $project = \Project::getProjectFromID(
+                new \ProjectID($values['project'])
+            );
 
             if (empty($values['pscid'])) {
                 $errors['pscid'] = 'PSCID must be specified';

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -135,7 +135,7 @@ class Stats_Behavioural extends \NDB_Form
                 = htmlspecialchars($_REQUEST['BehaviouralProject']);
         } elseif (!empty($userProjectsIDs)) {
 
-            $currentProject = '';
+            $currentProject = null;
             $paramProjects  = [];
             foreach ($userProjectsIDs as $key => $projectID) {
                 $paramProjects[] = ":paramProjectID$key";
@@ -146,7 +146,7 @@ class Stats_Behavioural extends \NDB_Form
                                        (" . implode(',', $paramProjects) . ")
                                  )";
         } else {
-            $currentProject = '';
+            $currentProject = null;
             $Param_Project  ="AND (s.ProjectID IS NULL)";
         }
 
@@ -155,12 +155,14 @@ class Stats_Behavioural extends \NDB_Form
         $suproject_query = '';
         // Only search for subprojects if $currentProject is a positive int.
         if (is_numeric($currentProject) && intval($currentProject) >= 0) {
-            $subprojects = \Utility::getSubprojectsForProject($currentProject);
+            $cpid = new \ProjectID($currentProject);
+
+            $subprojects = \Utility::getSubprojectsForProject($cpid);
             $subprojList = implode(',', array_keys($subprojects));
             if (!empty($subprojList)) {
                 $suproject_query ="AND s.SubprojectID IN ($subprojList)";
             }
-            $Visits = \Utility::getVisitList($currentProject);
+            $Visits = \Utility::getVisitList($cpid);
         } else {
             $Visits = \Utility::getVisitList();
         }

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -101,9 +101,10 @@ class Stats_Behavioural extends \NDB_Form
         $projects['']   = 'All Projects';
         $Param_Project  = '';
 
-        $userProjectsIDs = $user->getData('ProjectIDs');
+        $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects[$ProjectID] = $allProjectList[$ProjectID];
+            $projects[$ProjectID->__toString()]
+                = $allProjectList[$ProjectID->__toString()];
         }
 
         $this->tpl_data['Projects'] = $projects;

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -255,7 +255,9 @@ class Stats_Demographic extends \NDB_Form
         $subprojects     = \Utility::getSubprojectList();
         // Only search for subprojects if $demographicProject is a positive int.
         if (is_numeric($demographicProject) && intval($demographicProject) >= 0) {
-            $subprojects = \Utility::getSubprojectsForProject($demographicProject);
+            $subprojects = \Utility::getSubprojectsForProject(
+                new \ProjectID($demographicProject)
+            );
             $subprojList = implode(',', array_keys($subprojects));
             if (!empty($subprojList)) {
                 $subprojectQuery ="AND s.SubprojectID IN ($subprojList)";

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -108,7 +108,7 @@ class Stats_Demographic extends \NDB_Form
         $tpl_data['TableHeader']   = $tableHeader;
         $tpl_data['Disclamer']     = $disclamer;
         $tpl_data['Subcategories'] = $subcats;
-        $tpl_var = \Utility::getSubprojectsForProject(($projectID));
+        $tpl_var = \Utility::getSubprojectsForProject($projectID);
         $tpl_data['Subprojects']      = $tpl_var;
         $tpl_data['DropdownName']     = $dropdownName;
         $tpl_data['DropdownOptions']  = $dropdownOpt;

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -97,7 +97,7 @@ class Stats_Demographic extends \NDB_Form
     ): string {
         // This line replaces the empty $projectID string with null
         // `$projectID ?? null` would retain empty strings.
-        $projectID = empty($projectID) ? null : $projectID;
+        $projectID = empty($projectID) ? null : new \ProjectID($projectID);
         $tpl_data  = [];
         $tpl_data['test_name']  = isset($_REQUEST['test_name']) ?
             htmlspecialchars($_REQUEST['test_name']) : '';
@@ -108,7 +108,7 @@ class Stats_Demographic extends \NDB_Form
         $tpl_data['TableHeader']   = $tableHeader;
         $tpl_data['Disclamer']     = $disclamer;
         $tpl_data['Subcategories'] = $subcats;
-        $tpl_var = \Utility::getSubprojectsForProject(intval($projectID));
+        $tpl_var = \Utility::getSubprojectsForProject(($projectID));
         $tpl_data['Subprojects']      = $tpl_var;
         $tpl_data['DropdownName']     = $dropdownName;
         $tpl_data['DropdownOptions']  = $dropdownOpt;
@@ -227,7 +227,7 @@ class Stats_Demographic extends \NDB_Form
 
         $userProjectsIDs = $user->getData('ProjectIDs');
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects[$ProjectID] = $allProjectList[$ProjectID];
+            $projects["$ProjectID"] = $allProjectList["$ProjectID"];
         }
 
         if ($user->hasPermission('access_all_profiles')) {

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -60,20 +60,20 @@ class Stats_MRI extends \NDB_Form
     /**
      * RenderStatsTable function
      *
-     * @param string  $sectionHeader     the value of sectionHeader
-     * @param string  $tableHeader       the value of tableHeader
-     * @param array   $subcats           the value of subcats
-     * @param array   $visits            the value of visits
-     * @param string  $dropdown_name     the value of dropdown_name
-     * @param array   $dropdown_opt      the value of dropdown_opt
-     * @param string  $dropdown_selected the value of dropdown_selected
-     * @param array   $centers           the value of centers
-     * @param array   $data              the value of data
-     * @param string  $Subsection        the value of Subsection=''
-     * @param string  $disclamer         the value of disclamer=''
-     * @param ?string $projectID         the value of projectID is null
-     * @param bool    $renderTable       whether to render the table or display a
-     *                                   default error message
+     * @param string      $sectionHeader     the value of sectionHeader
+     * @param string      $tableHeader       the value of tableHeader
+     * @param array       $subcats           the value of subcats
+     * @param array       $visits            the value of visits
+     * @param string      $dropdown_name     the value of dropdown_name
+     * @param array       $dropdown_opt      the value of dropdown_opt
+     * @param string      $dropdown_selected the value of dropdown_selected
+     * @param array       $centers           the value of centers
+     * @param array       $data              the value of data
+     * @param string      $Subsection        the value of Subsection=''
+     * @param string      $disclamer         the value of disclamer=''
+     * @param ?\ProjectID $projectID         the value of projectID is null
+     * @param bool        $renderTable       whether to render the table or display a
+     *                                       default error message
      *
      * @return string
      */
@@ -241,11 +241,11 @@ class Stats_MRI extends \NDB_Form
 
         $currentProject = null;
         if ($_REQUEST['MRIProject'] ?? '') {
-            $currentProject = htmlspecialchars($_REQUEST['MRIProject']);
+            $currentProject = new \ProjectID($_REQUEST['MRIProject']);
             $this->tpl_data['CurrentProject']
                 = [
                     'ID'   => $currentProject,
-                    'Name' => $projects[$currentProject],
+                    'Name' => $projects[$currentProject->__toString()],
                 ];
             $sqlVar        = 'AND (s.ProjectID IS NULL OR s.ProjectID=:pid) ';
             $Param_Project =$sqlVar;

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -129,7 +129,9 @@ class AddSurvey extends \NDB_Form
                 'v_VL'     => $values['VL']
             ]
         );
-        if (!\NDB_Factory::singleton()->user()->hasProject($projectID)) {
+
+        $user = \NDB_Factory::singleton()->user();
+        if (!$user->hasProject(new \ProjectID($projectID))) {
             return [
                 'Project' => "You are not affiliated with this session's project"
             ];

--- a/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsprovisioner.class.inc
@@ -69,7 +69,7 @@ class SurveyAccountsProvisioner
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
         $cid = (int )$row['CenterID'];
-        $pid = (int )$row['ProjectID'];
+        $pid = new \ProjectID($row['ProjectID']);
         return new SurveyAccountsRow($row, $cid, $pid);
     }
 }

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -35,10 +35,10 @@ class SurveyAccountsRow implements \LORIS\Data\DataInstance
     /**
      * Create a new SurveyAccountsRow
      *
-     * @param array   $row The row (in the same format as \Database::pselectRow
-     *                     returns
-     * @param integer $cid The centerID affiliated with this row.
-     * @param integer $pid The projectID affiliated with this row.
+     * @param array   $row    The row (in the same format as
+     *                        \Database::pselectRow returns.)
+     * @param integer $cid    The centerID affiliated with this row.
+     * @param \ProjectID $pid The projectID affiliated with this row.
      */
     public function __construct(array $row, int $cid, \ProjectID $pid)
     {

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -35,9 +35,10 @@ class SurveyAccountsRow implements \LORIS\Data\DataInstance
     /**
      * Create a new SurveyAccountsRow
      *
-     * @param array   $row    The row (in the same format as
-     *                        \Database::pselectRow returns.)
-     * @param integer $cid    The centerID affiliated with this row.
+     * @param array      $row The row (in the same format as
+     *                        \Database::pselectRow
+     *                        returns.)
+     * @param integer    $cid The centerID affiliated with this row.
      * @param \ProjectID $pid The projectID affiliated with this row.
      */
     public function __construct(array $row, int $cid, \ProjectID $pid)

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -40,7 +40,7 @@ class SurveyAccountsRow implements \LORIS\Data\DataInstance
      * @param integer $cid The centerID affiliated with this row.
      * @param integer $pid The projectID affiliated with this row.
      */
-    public function __construct(array $row, int $cid, int $pid)
+    public function __construct(array $row, int $cid, \ProjectID $pid)
     {
         $this->DBRow     = $row;
         $this->CenterID  = $cid;
@@ -70,9 +70,9 @@ class SurveyAccountsRow implements \LORIS\Data\DataInstance
     /**
      * Returns the ProjectID for this row
      *
-     * @return integer The ProjectID
+     * @return \ProjectID The ProjectID
      */
-    public function getProjectID(): int
+    public function getProjectID(): \ProjectID
     {
         return $this->ProjectID;
     }

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -785,7 +785,8 @@ class Edit_User extends \NDB_Form
         $projects       = \Utility::getProjectList();
         $projectOptions = [];
         foreach ($editorProjects as $key => $projectID) {
-            $projectOptions[$projectID] = $projects[$projectID];
+            $projectOptions[$projectID->__toString()]
+                = $projects[$projectID->__toString()];
         }
 
         $this->addSelect(

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -781,7 +781,7 @@ class Edit_User extends \NDB_Form
         );
 
         // START PROJECT SECTION
-        $editorProjects = $editor->getData('ProjectIDs');
+        $editorProjects = $editor->getProjectIDs();
         $projects       = \Utility::getProjectList();
         $projectOptions = [];
         foreach ($editorProjects as $key => $projectID) {

--- a/modules/user_accounts/php/useraccountrow.class.inc
+++ b/modules/user_accounts/php/useraccountrow.class.inc
@@ -10,6 +10,7 @@ namespace LORIS\user_accounts;
 class UserAccountRow implements \LORIS\Data\DataInstance
 {
     protected $DBRow;
+    protected $ProjectIDs;
 
     private array $_centerIDs;
     private array $_projectIDs;
@@ -42,7 +43,7 @@ class UserAccountRow implements \LORIS\Data\DataInstance
     /**
      * Returns the ProjectID for this row.
      *
-     * @return array The ProjectIds
+     * @return \ProjectID[] The ProjectIds
      */
     public function getProjectIDs() : array
     {

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -46,7 +46,12 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
     {
         $cids = explode(',', $row['centerIds'] ?? '');
         $row['centerIds'] = $cids;
-        $pids = explode(',', $row['projectIds'] ?? '');
+        $pids = array_map(
+            function(string $pid) : \ProjectID {
+                return new \ProjectID($pid);
+            },
+            explode(',', $row['projectIds']),
+        );
         $row['projectIds'] = $pids;
         return new UserAccountRow($row, $cids, $pids);
     }

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -47,7 +47,7 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
         $cids = explode(',', $row['centerIds'] ?? '');
         $row['centerIds'] = $cids;
         $pids = array_map(
-            function(string $pid) : \ProjectID {
+            function (string $pid) : \ProjectID {
                 return new \ProjectID($pid);
             },
             explode(',', $row['projectIds']),

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -53,7 +53,7 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
             explode(',', $row['projectIds']),
         );
 
-        $row['centerIds'] = $cids;
+        $row['centerIds']  = $cids;
         $row['projectIds'] = $pids;
         return new UserAccountRow($row, $cids, $pids);
     }

--- a/modules/user_accounts/php/useraccountrowprovisioner.class.inc
+++ b/modules/user_accounts/php/useraccountrowprovisioner.class.inc
@@ -45,13 +45,15 @@ class UserAccountRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisione
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
         $cids = explode(',', $row['centerIds'] ?? '');
-        $row['centerIds'] = $cids;
+
         $pids = array_map(
             function (string $pid) : \ProjectID {
                 return new \ProjectID($pid);
             },
             explode(',', $row['projectIds']),
         );
+
+        $row['centerIds'] = $cids;
         $row['projectIds'] = $pids;
         return new UserAccountRow($row, $cids, $pids);
     }

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -889,7 +889,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
     {
         $centers = $user->getCenterIDs();
 
-        $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs(), true);
+        $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs());
         $centerMatch = in_array($this->getCenterID(), $centers, true);
 
         // The candidate is accessible based on its registration

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -107,6 +107,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             case 'EntityType':
                 $this->candidateInfo[$key] = new EntityType($value);
                 break;
+            case 'ProjectID':
+                $this->candidateInfo[$key] = new \ProjectID($value);
+                break;
             default:
                 $this->candidateInfo[$key] = $value;
             }
@@ -443,9 +446,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
      *
      * @return integer CandID of candidate
      */
-    function getProjectID(): int
+    function getProjectID(): \ProjectID
     {
-        return intval($this->candidateInfo["RegistrationProjectID"] ?? null);
+        return $this->candidateInfo["RegistrationProjectID"];
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -193,13 +193,14 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
      *                                           candidate will belong
      * @param string|null $dateOfBirth           date of birth written as YYYY-MM-DD
      * @param string|null $edc                   estimated date of confinement
-     *                                           written as YYYY-MM-DD. Value should
-     *                                           be null unless the useEDC setting
-     *                                           is configured to be true.
+     *                                           written as YYYY-MM-DD. Value
+     *                                           should be null unless the
+     *                                           useEDC setting is configured
+     *                                           to be true.
      * @param Sex         $sex                   An instance of the Sex class.
      * @param string|null $PSCID                 PSCID specified by the user,
      *                                           if available
-     * @param int|null    $registrationProjectID The project ID, if available
+     * @param ?ProjectID  $registrationProjectID The project ID, if available
      *
      * @return CandID   $candID      candidate id of the new candidate
      * @throws Exception
@@ -211,7 +212,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
         ?string $edc,
         Sex $sex,
         ?string $PSCID = null,
-        int $registrationProjectID = null
+        ProjectID $registrationProjectID = null
     ): CandID {
         $factory = NDB_Factory::singleton();
 

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -115,6 +115,9 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             }
         }
 
+        var_dump($row);
+        var_dump($this->candidateInfo);
+
         $this->candidateInfo['ProjectTitle'] = $this->getProjectTitle();
 
         $headerSetting = $config->getSetting('HeaderTable');

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -444,7 +444,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
     /**
      * Returns the ProjectID for the current candidate
      *
-     * @return integer CandID of candidate
+     * @return \ProjectID RegistrationProjectID of candidate
      */
     function getProjectID(): \ProjectID
     {
@@ -460,7 +460,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
     function getProjectTitle(): string
     {
         $ProjectList = Utility::getProjectList();
-        return $ProjectList[$this->getProjectID()] ?? '';
+        return $ProjectList[$this->getProjectID()->__toString()] ?? '';
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -115,9 +115,6 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             }
         }
 
-        var_dump($row);
-        var_dump($this->candidateInfo);
-
         $this->candidateInfo['ProjectTitle'] = $this->getProjectTitle();
 
         $headerSetting = $config->getSetting('HeaderTable');

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -107,7 +107,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
             case 'EntityType':
                 $this->candidateInfo[$key] = new EntityType($value);
                 break;
-            case 'ProjectID':
+            case 'RegistrationProjectID':
                 $this->candidateInfo[$key] = new \ProjectID($value);
                 break;
             default:

--- a/php/libraries/Project.class.inc
+++ b/php/libraries/Project.class.inc
@@ -28,9 +28,10 @@ class Project implements \JsonSerializable
     /**
      * The id of the project in database.
      *
-     * @var int
+     * @var \ProjectID
      */
     private $_projectId;
+
     private $_projectName;
     private $_projectAlias;
     private $_recruitmentTarget;
@@ -80,7 +81,7 @@ class Project implements \JsonSerializable
 
             $project = new Project();
 
-            $project->_projectId         = (int) $projectData['projectId'];
+            $project->_projectId         = new ProjectID($projectData['projectId']);
             $project->_projectName       = $projectData['name'];
             $project->_projectAlias      = $projectData['Alias'];
             $project->_recruitmentTarget = (integer) $projectData['recTarget'];
@@ -95,13 +96,13 @@ class Project implements \JsonSerializable
      * Get a project object from the ID by mapping the ID to a name and using the
      * singleton function
      *
-     * @param int $projectID The ID of the project queried
+     * @param ProjectID $projectID The ID of the project queried
      *
      * @return Project
      *
      * @throws NotFound
      */
-    static function getProjectFromID(int $projectID) : \Project
+    static function getProjectFromID(ProjectID $projectID) : \Project
     {
         $factory = \NDB_Factory::singleton();
 
@@ -183,9 +184,9 @@ class Project implements \JsonSerializable
     /**
      * Get this project's id
      *
-     * @return integer This project's id
+     * @return ProjectID This project's id
      */
-    public function getId(): int
+    public function getId(): ProjectID
     {
         return $this->_projectId;
     }
@@ -193,11 +194,11 @@ class Project implements \JsonSerializable
     /**
      * Set this project's id
      *
-     * @param integer $projectId This project's id
+     * @param ProjectID $projectId This project's id
      *
      * @return void
      */
-    public function setId(int $projectId): void
+    public function setId(ProjectID $projectId): void
     {
         $this->_projectId = $projectId;
     }

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -17,7 +17,7 @@ class ProjectID extends ValidatableIdentifier implements \JsonSerializable
     }
 
     /**
-     * Validate that the value of the ProjectID is a positive integer that does
+     * Validate that the value of the ProjectID is a positive integer.
      *
      * This does not check for uniqueness in the database or any other
      * state-related facts.

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -4,7 +4,7 @@
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
-class ProjectID extends ValidatableIdentifier
+class ProjectID extends ValidatableIdentifier implements \JsonSerializable
 {
     /**
      * Returns this identifier type
@@ -32,13 +32,27 @@ class ProjectID extends ValidatableIdentifier
     }
 
     /**
-     * Generates a string representation of this SessionID.
+     * Generates a string representation of this ProjectID.
      *
-     * @return string The SessionID value.
+     * @return string The ProjectID value.
      */
     public function __toString(): string
     {
         return $this->value;
     }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     * Returns data which can be serialized by json_encode(), which is a value of
+     * any type other than a resource.
+     *
+     * @see https://www.php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed
+     */
+    public function jsonSerialize()
+    {
+        return (int) $this->value;
+    }
+
 }
 

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * A representation of a ProjectID object. A ProjectID is always an integer
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class ProjectID extends ValidatableIdentifier
+{
+    /**
+     * Returns this identifier type
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return 'ProjectID';
+    }
+
+    /**
+     * Validate that the value of the ProjectID is a positive integer that does
+     *
+     * This does not check for uniqueness in the database or any other
+     * state-related facts.
+     *
+     * @param string $value The value to be validated
+     *
+     * @return bool True if the value format is valid
+     */
+    protected function validate(string $value): bool
+    {
+        return \Utility::valueIsPositiveInteger($value);
+    }
+
+    /**
+     * Generates a string representation of this SessionID.
+     *
+     * @return string The SessionID value.
+     */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}
+

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -42,11 +42,8 @@ class ProjectID extends ValidatableIdentifier implements \JsonSerializable
     }
 
     /**
-     * Specify data which should be serialized to JSON.
-     * Returns data which can be serialized by json_encode(), which is a value of
-     * any type other than a resource.
+     * Specify how the data should be serialized to JSON.
      *
-     * @see https://www.php.net/manual/en/jsonserializable.jsonserialize.php
      * @return mixed
      */
     public function jsonSerialize()

--- a/php/libraries/ProjectID.php
+++ b/php/libraries/ProjectID.php
@@ -48,7 +48,7 @@ class ProjectID extends ValidatableIdentifier implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        return (int) $this->value;
+        return $this->value;
     }
 
 }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -150,7 +150,9 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource
             $this->_timePointInfo['SubprojectTitle'] = $title;
 
             if ($this->_timePointInfo['ProjectID'] !== null) {
-                $this->_timePointInfo['ProjectID'] = new \ProjectID($row['ProjectID']);
+                $this->_timePointInfo['ProjectID'] = new \ProjectID(
+                    $row['ProjectID']
+                );
             }
         } else {
             // return error when 0 rows to prevent creation of an empty object

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -149,7 +149,9 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource
             $title = $subprojectSettings['title'] ?? '';
             $this->_timePointInfo['SubprojectTitle'] = $title;
 
-            $this->_timePointInfo['ProjectID'] = new \ProjectID($row['ProjectID']);
+            if ($this->_timePointInfo['ProjectID'] !== null) {
+                $this->_timePointInfo['ProjectID'] = new \ProjectID($row['ProjectID']);
+            }
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new LorisException(

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -148,6 +148,8 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource
             );
             $title = $subprojectSettings['title'] ?? '';
             $this->_timePointInfo['SubprojectTitle'] = $title;
+
+            $this->_timePointInfo['ProjectID'] = new \ProjectID($row['ProjectID']);
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new LorisException(
@@ -1193,11 +1195,11 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource
     /**
      * Returns the ProjectID for this TimePoint
      *
-     * @return integer
+     * @return \ProjectID
      */
-    public function getProjectID() : int
+    public function getProjectID() : \ProjectID
     {
-        return intval($this->getData('ProjectID'));
+        return $this->getData('ProjectID');
     }
 
     /**
@@ -1212,7 +1214,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource
     {
         $centers = $user->getCenterIDs();
 
-        $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs(), true);
+        $projMatch   = in_array($this->getProjectID(), $user->getProjectIDs());
         $centerMatch = in_array($this->getCenterID(), $centers, true);
         return $projMatch && $centerMatch;
     }

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -151,7 +151,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource
 
             if ($this->_timePointInfo['ProjectID'] !== null) {
                 $this->_timePointInfo['ProjectID'] = new \ProjectID(
-                    $row['ProjectID']
+                    $this->_timePointInfo['ProjectID']
                 );
             }
         } else {

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -100,7 +100,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
             ['uid' => $row['ID']]
         );
         foreach ($user_pid as $k=>$pid) {
-            $user_pid[$k] = intval($pid);
+            $user_pid[$k] = new ProjectID($pid);
         }
 
         // Get examiner information
@@ -311,7 +311,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     /**
      * Get the user's sites' ID numbers
      *
-     * @return array
+     * @return ProjectID[]
      */
     function getProjectIDs(): array
     {
@@ -423,11 +423,11 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     /**
      * Determines if the user has a project
      *
-     * @param int $projectID The project ID
+     * @param ProjectID $projectID The project ID
      *
      * @return bool
      */
-    public function hasProject(int $projectID) : bool
+    public function hasProject(ProjectID $projectID) : bool
     {
         return in_array(
             $projectID,

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -431,8 +431,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     {
         return in_array(
             $projectID,
-            $this->getProjectIDs(),
-            true
+            $this->getProjectIDs()
         );
     }
 

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -230,13 +230,13 @@ class Utility
     /**
      * Returns a list of study Visit Labels that are being used by this study.
      *
-     * @param integer|null $projectID Limit visit labels to labels used by this
-     *                                project.
+     * @param ?ProjectID $projectID Limit visit labels to labels used by this
+     *                              project.
      *
      * @return array of study visits in the format array('VL' => 'VL')
      *         where VL is the visit label
      */
-    static function getVisitList(?int $projectID = null) : array
+    static function getVisitList(?ProjectID $projectID = null) : array
     {
         $factory = \NDB_Factory::singleton();
         $db      = $factory->database();
@@ -287,12 +287,12 @@ class Utility
     /**
      * Returns a list of study Subprojects
      *
-     * @param integer|null $projectID The project for which you would like
-     *                                to get the subprojects
+     * @param ?ProjectID $projectID The project for which you would like
+     *                              to get the subprojects
      *
      * @return array       an associative array("SubprojectID" => "Subproject title")
      */
-    static function getSubprojectList(?int $projectID = null): array
+    static function getSubprojectList(?ProjectID $projectID = null): array
     {
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
@@ -318,12 +318,12 @@ class Utility
     /**
      * Returns a list of study Subprojects associated with a project
      *
-     * @param integer|null $projectID The project for which you would like
-     *                                to get the subprojects
+     * @param ?ProjectID $projectID The project for which you would like
+     *                              to get the subprojects
      *
      * @return array an associative array("SubprojectID" => "Subproject title")
      */
-    static function getSubprojectsForProject(?int $projectID = null): array
+    static function getSubprojectsForProject(?ProjectID $projectID = null): array
     {
         if (is_null($projectID)) {
             return [];

--- a/src/Data/Filters/UserProjectMatch.php
+++ b/src/Data/Filters/UserProjectMatch.php
@@ -61,7 +61,9 @@ class UserProjectMatch implements \LORIS\Data\Filter
         } elseif (method_exists($res, 'getProjectID')) {
             $resourceProject = $res->getProjectID();
             if (!is_null($resourceProject)) {
-                return $user->hasProject($resourceProject);
+                return $user->hasProject(
+                    new \ProjectID(strval($resourceProject))
+                );
             }
             // We don't know if the resource thought a null ProjectID
             // should mean "no one can access it" or "anyone can access

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -9,11 +9,11 @@
         </testsuite>
 
         <testsuite name='LorisCoreIntegrationTests'>
-            <directory>./integrationtests/</directory>
+            <!--directory>./integrationtests/</directory-->
         </testsuite>
 
         <testsuite name='LorisModuleIntegrationTests'>
-            <directory>../raisinbread/test/api/</directory>
+            <!--directory>../raisinbread/test/api/</directory>
             <directory>../modules/api/test/</directory>
             <directory>../modules/acknowledgements/test/</directory>
             <directory>../modules/brainbrowser/test/</directory>
@@ -52,9 +52,9 @@
             <directory>../modules/survey_accounts/test/</directory>
             <directory>../modules/timepoint_flag/test/</directory>
             <directory>../modules/timepoint_list/test/</directory>
-            <directory>../modules/training/test/</directory>
+            <directory>../modules/training/test/</directory-->
             <directory>../modules/user_accounts/test/</directory>
-            <directory>../test/test_instrument/</directory>
+            <!--directory>../test/test_instrument/</directory-->
         </testsuite>
 
     </testsuites>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -9,11 +9,11 @@
         </testsuite>
 
         <testsuite name='LorisCoreIntegrationTests'>
-            <!--directory>./integrationtests/</directory-->
+            <directory>./integrationtests/</directory>
         </testsuite>
 
         <testsuite name='LorisModuleIntegrationTests'>
-            <!--directory>../raisinbread/test/api/</directory>
+            <directory>../raisinbread/test/api/</directory>
             <directory>../modules/api/test/</directory>
             <directory>../modules/acknowledgements/test/</directory>
             <directory>../modules/brainbrowser/test/</directory>
@@ -52,9 +52,9 @@
             <directory>../modules/survey_accounts/test/</directory>
             <directory>../modules/timepoint_flag/test/</directory>
             <directory>../modules/timepoint_list/test/</directory>
-            <directory>../modules/training/test/</directory-->
+            <directory>../modules/training/test/</directory>
             <directory>../modules/user_accounts/test/</directory>
-            <!--directory>../test/test_instrument/</directory-->
+            <directory>../test/test_instrument/</directory>
         </testsuite>
 
     </testsuites>

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -1149,7 +1149,7 @@ class CandidateTest extends TestCase
         $user->expects($this->once())->method("getCenterIDs")
             ->willReturn([1, 2]);
         $user->expects($this->once())->method("getProjectIDs")
-            ->willReturn([1, 3]);
+            ->willReturn([new \ProjectID("1"), new \ProjectID("3")]);
 
         $result = $this->_candidate->isAccessibleBy($user);
         $this->assertTrue($result);
@@ -1172,7 +1172,7 @@ class CandidateTest extends TestCase
         $user->expects($this->atLeastOnce())->method("getCenterIDs")
             ->willReturn([1, 2]);
         $user->expects($this->atLeastOnce())->method("getProjectIDs")
-            ->willReturn([2, 3]);
+            ->willReturn([new \ProjectID("2"), new \ProjectID("3")]);
 
         $result = $this->_candidate->isAccessibleBy($user);
         $this->assertFalse($result);

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -151,7 +151,7 @@ class CandidateTest extends TestCase
             'Active'                => 'Y',
             'RegisteredBy'          => 'Admin Admin',
             'UserID'                => 'admin',
-            'RegistrationProjectID' => new ProjectID('1'),
+            'RegistrationProjectID' => '1',
             'ProjectTitle'          => '',
         ];
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -28,22 +28,7 @@ class CandidateTest extends TestCase
      *
      * @var array contains _candidate info retrieved by the select method
      */
-    private $_candidateInfo
-        = [
-            'RegistrationCenterID'  => '2',
-            'CandID'                => '969664',
-            'PSCID'                 => 'AAA0011',
-            'DoB'                   => '2007-03-02',
-            'EDC'                   => null,
-            'Sex'                   => 'Male',
-            'PSC'                   => 'AAA',
-            'Ethnicity'             => 'White',
-            'Active'                => 'Y',
-            'RegisteredBy'          => 'Admin Admin',
-            'UserID'                => 'admin',
-            'RegistrationProjectID' => '1',
-            'ProjectTitle'          => '',
-        ];
+    private $_candidateInfo;
 
     /**
      * List of timepoints (visits) that a Candidate has registered
@@ -154,9 +139,21 @@ class CandidateTest extends TestCase
         $this->_factory->setConfig($this->_configMock);
         $this->_factory->setDatabase($this->_dbMock);
 
-        $this->_candidateInfo['CandID'] = new CandID(
-            $this->_candidateInfo['CandID']
-        );
+        $this->_candidateInfo = [
+            'RegistrationCenterID'  => '2',
+            'CandID'                => new CandID('969664'),
+            'PSCID'                 => 'AAA0011',
+            'DoB'                   => '2007-03-02',
+            'EDC'                   => null,
+            'Sex'                   => 'Male',
+            'PSC'                   => 'AAA',
+            'Ethnicity'             => 'White',
+            'Active'                => 'Y',
+            'RegisteredBy'          => 'Admin Admin',
+            'UserID'                => 'admin',
+            'RegistrationProjectID' => new ProjectID('1'),
+            'ProjectTitle'          => '',
+        ];
 
         $this->_candidate = new Candidate();
     }
@@ -1195,7 +1192,7 @@ class CandidateTest extends TestCase
         $user->expects($this->atLeastOnce())->method("getCenterIDs")
             ->willReturn([1, 3]);
         $user->expects($this->atLeastOnce())->method("getProjectIDs")
-            ->willReturn([1, 3]);
+            ->willReturn([new \ProjectID("1"), new \ProjectID("3")]);
 
         $result = $this->_candidate->isAccessibleBy($user);
         $this->assertFalse($result);

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -262,7 +262,7 @@ class NDB_Factory_Test extends TestCase
         $this->_factory->setDatabase($mockdb);
         $mockdb->expects($this->any())
             ->method('pselectRow')
-            ->willReturn(['1']);
+            ->willReturn(['SessionID' => '1', 'ProjectID' => '1']);
 
         $sessionID = new \SessionID("1");
         $this->assertEquals(

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -238,7 +238,7 @@ class NDB_Factory_Test extends TestCase
         $this->_factory->setDatabase($mockdb);
         $mockdb->expects($this->any())
             ->method('pselectRow')
-            ->willReturn(['DCCID'=>'300001']);
+            ->willReturn(['DCCID'=>'300001', 'RegistrationProjectID' => '1']);
 
         $candID = new CandID("300001");
         $this->assertEquals(

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -570,7 +570,7 @@ class UserTest extends TestCase
     public function testHasProjectWhenTrue()
     {
         $this->_user = \User::factory(self::USERNAME);
-        $this->assertTrue($this->_user->hasProject(3));
+        $this->assertTrue($this->_user->hasProject(new \ProjectID("3")));
     }
 
     /**
@@ -582,7 +582,7 @@ class UserTest extends TestCase
     public function testHasProjectWhenFalse()
     {
         $this->_user = \User::factory(self::USERNAME);
-        $this->assertFalse($this->_user->hasProject(5));
+        $this->assertFalse($this->_user->hasProject(new \ProjectID("5")));
     }
 
     /**

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -328,7 +328,7 @@ class UtilityTest extends TestCase
 
         $this->assertEquals(
             ['123' => 'DemoProject'],
-            Utility::getSubprojectList(123)
+            Utility::getSubprojectList(new ProjectID("123"))
         );
     }
 
@@ -358,7 +358,7 @@ class UtilityTest extends TestCase
 
         $this->assertEquals(
             ['123' => 'DemoProject'],
-            Utility::getSubprojectsForProject(123)
+            Utility::getSubprojectsForProject(new \ProjectID("123"))
         );
     }
 
@@ -566,7 +566,7 @@ class UtilityTest extends TestCase
 
         $this->assertEquals(
             ['VL1' => 'VL1'],
-            Utility::getVisitList(1)
+            Utility::getVisitList(new \ProjectID("1"))
         );
     }
 


### PR DESCRIPTION
This adds a ProjectID class to LORIS so that the typing
system can catch errors where the wrong type of integer
is passed.

I updated Project->getId and then updated the callsites
which were required to get `make checkstatic` to pass.
It ended up being a more significant change than expected,
but that's probably for the best.