### PR TITLE
[NDB_BVL_Instrument] Only update instrument table if $values not empty

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -788,7 +788,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $values = Utility::nullifyEmpty($values, $key);
         }
 
-        if ($this->jsonData !== true) {
+        if ($this->jsonData !== true && !empty($values)) {
             // If the instrument is saving as JSON into the Data column, the
             // table may not exist, so don't try and update it.
             $db->update(


### PR DESCRIPTION
## Brief summary of changes

This PR fixes the _save() method to call db update only if $values is not empty. This case pops up when you have a subtest with only static score elements. No error should be thrown so that $this->score() can eventually be called within the save() method. 

#### Testing instructions (if applicable)

1. Mock an instrument subtest with only static score fields or test with one that you already have
2. on aces/main, click 'Save Data' on the front-end on that subtest. You will get a SQL error page.
2. on this PR branch, repeat the above, and no errors. you can add a .score file to test that the scoring still works even if no values are saved
