### PR TITLE
Add configuration to run CI with GitHub actions

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -1,0 +1,49 @@
+name: LORIS Test Suite
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            testsuite:
+            - static
+            - unit
+            - integration
+            php:
+            - 7.3
+            - 7.4
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Change PHP Version in Dockerfile
+      run: sed -i "s/7.3/${{ matrix.php }}/g" Dockerfile.test.php7
+
+    - name: Install OS package dependencies
+      run: sudo apt-get install php-ast
+
+    - name: Install composer dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Build LORIS
+      run: make dev
+
+    - name: Run Test Suite
+      run: npm run tests:${{ matrix.testsuite }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 php: 
   - 7.3
-  - 7.4
     
 # Testing Ubuntu 18.04
 os: linux


### PR DESCRIPTION
Given the changes to Travis pricing which are changing
at the end of the year and the long VM startup times
we've been experiencing lately, this adds a configuration
for GitHub actions to run our continuous integration
directly on GitHub.

The .travis.yml is kept around for now, but will likely
eventually be removed. PHP 7.4 is also removed from the
Travis configuration, because I discovered while setting
this up that there's a bug where both "PHP 7.3" and "PHP 7.4"
are running PHP 7.3 under docker with our current configuration.
(The bug is fixed in the GitHub actions configurations, but
given that we'll be moving away from Travis, isn't worth fixing
there.)