### PR TITLE
[BVL_Feedback] Missing SessionID fixes

### DIFF
--- a/modules/bvl_feedback/ajax/bvl_panel_ajax.php
+++ b/modules/bvl_feedback/ajax/bvl_panel_ajax.php
@@ -20,26 +20,23 @@ use \LORIS\StudyEntities\Candidate\CandID;
 
 $username = \User::singleton()->getUsername();
 
-if (isset($_POST['candID']) && (empty($_POST['sessionID']))) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread = \NDB_BVL_Feedback::Singleton($username, $candID);
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && (empty($_POST['commentID']))
-) {
-    $candID         = new CandID($_POST['candID']);
+if (isset($_POST['candID']) && !empty($_POST['candID'])) {
+    $candID    = new CandID($_POST['candID']);
+    $sessionID = null;
+    $commentID = null;
+
+    if (isset($_POST['sessionID']) && !empty($_POST['sessionID'])) {
+        $sessionID = new \SessionID($_POST['sessionID']);
+    }
+
+    if (isset($_POST['commentID']) && !empty($_POST['commentID'])) {
+        $commentID = $_POST['commentID'];
+    }
+
     $feedbackThread =& \NDB_BVL_Feedback::Singleton(
         $username,
         $candID,
-        $_POST['sessionID']
-    );
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && isset($_POST['commentID'])
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =& \NDB_BVL_Feedback::Singleton(
-        $username,
-        $candID,
-        new \SessionID($_POST['sessionID']),
-        $_POST['commentID']
+        $sessionID,
+        $commentID
     );
 }

--- a/modules/bvl_feedback/ajax/react_get_bvl_threads.php
+++ b/modules/bvl_feedback/ajax/react_get_bvl_threads.php
@@ -24,31 +24,25 @@ require_once __DIR__ . "/../../../vendor/autoload.php";
 
 $username = \User::singleton()->getUsername();
 
+if (isset($_POST['candID']) && !empty($_POST['candID'])) {
+    $candID    = new CandID($_POST['candID']);
+    $sessionID = null;
+    $commentID = null;
 
-if (isset($_POST['candID']) && !(isset($_POST['sessionID']))) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =& \NDB_BVL_Feedback::Singleton($username, $candID);
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && !(isset($_POST['commentID']))
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =&
-        \NDB_BVL_Feedback::Singleton(
-            $username,
-            $candID,
-            new \SessionID($_POST['sessionID'])
-        );
-} elseif (isset($_POST['candID']) && isset($_POST['sessionID'])
-    && isset($_POST['commentID'])
-) {
-    $candID         = new CandID($_POST['candID']);
-    $feedbackThread =&
-        \NDB_BVL_Feedback::Singleton(
-            $username,
-            $candID,
-            new \SessionID($_POST['sessionID']),
-            $_POST['commentID']
-        );
+    if (isset($_POST['sessionID']) && !empty($_POST['sessionID'])) {
+        $sessionID = new \SessionID($_POST['sessionID']);
+    }
+
+    if (isset($_POST['commentID']) && !empty($_POST['commentID'])) {
+        $commentID = $_POST['commentID'];
+    }
+
+    $feedbackThread =& \NDB_BVL_Feedback::Singleton(
+        $username,
+        $candID,
+        $sessionID,
+        $commentID
+    );
 }
 
 $feedbackThreadList = $feedbackThread->getThreadList();

--- a/php/libraries/BVL_Feedback_Panel.class.inc
+++ b/php/libraries/BVL_Feedback_Panel.class.inc
@@ -85,7 +85,10 @@ class BVL_Feedback_Panel
         $candidateObject         = Candidate::singleton($candidateID);
         $this->tpl_data['pscid'] = $candidateObject->getPSCID();
 
-        $this->tpl_data['sessionID'] = $feedbackProfile["SessionID"] ?? null;
+        $this->tpl_data['sessionID'] = null;
+        if (isset($feedbackProfile["SessionID"])) {
+            $this->tpl_data['sessionID'] = strval($feedbackProfile["SessionID"]);
+        }
 
         $feedbackObject = $this->feedbackThread->_feedbackObjectInfo;
         $this->tpl_data['commentID'] = $feedbackObject["CommentID"] ?? null;


### PR DESCRIPTION
This PR completes the work done on #7036 to solve some errors introduced by #5352.

* error 500 if $_POST['sessionID'] is an empty string (react_get_bvl_threads.php)
* console warning: sessionID is of type object (BVL_Feedback_Panel.class.inc)
* one omitted conversion of  $_POST['sessionID'] to new \SessionID($_POST['sessionID']) (bvl_panel_ajax.php)


Resolves #7139 