### PR TITLE
[Create timepoint] Language dropdown index fix

### DIFF
--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -120,7 +120,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         // List languages
         $languages = \Utility::getLanguageList();
         if (count($languages) > 1) {
-            array_unshift($languages, null);
+            $languages = [null] + $languages;
         }
         $values['languages'] = $languages;
 


### PR DESCRIPTION
Small change to fix a reindexing of the languages, causing a database insert error (key constraint failure on languageID).

## To test
Add languages to the database (language) at sparse indexes (ex: 2, 4).
You should be able to submit without a 500 error.

* Related to #7146 (v23.0 release)