### PR TITLE
[Create timepoint] Language dropdown index fix

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -205,7 +205,7 @@ class Create_Timepoint extends \NDB_Form
 
                 $languages = \Utility::getLanguageList();
                 if (count($languages) > 1) {
-                    array_unshift($languages, null);
+                    $languages = [null] + $languages;
                     $this->addSelect(
                         'languageID',
                         'Language',


### PR DESCRIPTION
Small change to fix a reindexing of the languages, causing a database insert error (key constraint failure on languageID).

## To test
Add languages to the database (language) at sparse indexes (ex: 2, 4).
You should be able to submit without a 500 error.

* Related to #7145 (main)