### PR TITLE
[instrument_builder] Loading existing instrument corrupts Date element

### DIFF
--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -117,24 +117,25 @@ var Instrument = {
                         content += "select{@}" + element.Name + "_status" +
                             "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
                         break;
-                    case "date":
+                    case "date" : case 'basicdate' : case 'monthyear':
                         var elName = element.Name.replace(/\s/g, "").toLowerCase();
-                        var dropdown = "";
-
                         // Add dropdown and special naming when no date format is set
                         // (i.e when addDateElement() is used)
-                        if (element.Options.dateFormat === "") {
-                            elName = elName + "_date";
-                            dropdown = "select{@}" + elName + "_status" +
-                            "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
+                      if (!element.Options.dateFormat) {
+                          // Makes the date be the default 'Date' if undefined.
+                          let dateFormat = 'Date';
+                          if (element.Type === 'basicdate') {
+                              dateFormat = 'BasicDate';
+                          } else if (element.Type === 'monthyear') {
+                              dateFormat = 'MonthYear';
+                          }
+                          element.Options.dateFormat = dateFormat;
                         }
-
                         content += 'date{@}';
                         content += elName + "{@}" + element.Description;
                         content += "{@}" + element.Options.MinDate.split('-')[0];
                         content += "{@}" + element.Options.MaxDate.split('-')[0];
                         content += "{@}" + element.Options.dateFormat + "\n";
-                        content += dropdown;
                         break;
                     case "numeric":
                         content += 'numeric{@}';
@@ -249,12 +250,13 @@ var Instrument = {
                             };
                             break;
                         case "date":
-                            tempElement.Type = 'date';
+                            tempElement.Type = pieces[5].toLowerCase();
                             tempElement.Name = pieces[1];
                             tempElement.Description = pieces[2];
                             tempElement.Options = {
                                 MinDate : pieces[3] + "-01-01",
-                                MaxDate : pieces[4] + "-12-31"
+                                MaxDate : pieces[4] + "-12-31",
+                                dateFormat: pieces[5],
                             };
                             tempElement.selected = {
                                 id: "date",

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -70,7 +70,7 @@ class LorisElement extends Component {
                                        options={element.Options.Values}/>;
         }
         break;
-      case 'date':
+      case 'date': case 'basicdate': case 'monthyear':
         elementHtml = <DateElement
           label={element.Description}
           minYear={element.Options.MinDate}
@@ -395,13 +395,6 @@ class DateOptions extends Component {
   }
 
   /**
-   * Called by React when the component has been rendered on the page.
-   */
-  componentDidMount() {
-    this.props.element.Options.dateFormat = '';
-  }
-
-  /**
    * On change
    * Keep track of the inputed years
    * @param {object} e - Event object
@@ -426,6 +419,13 @@ class DateOptions extends Component {
   render() {
     let minYear = this.props.element.Options.MinDate;
     let maxYear = this.props.element.Options.MaxDate;
+    let dateFormat = this.props.element.Options.dateFormat;
+    if (minYear && minYear.length > 4) {
+      minYear = minYear.substr(0, 4);
+    }
+    if (maxYear && maxYear.length > 4) {
+      maxYear = maxYear.substr(0, 4);
+    }
 
     let dateOptionsClass = 'options form-group';
     let errorMessage = '';
@@ -481,7 +481,9 @@ class DateOptions extends Component {
             <select
               id="dateFormat"
               className="form-control"
-              onChange={this.onChange}>
+              onChange={this.onChange}
+              defaultValue={dateFormat}
+            >
               {Object.keys(dateFormatOptions).map(function(option, key) {
                 return (
                   <option key={key} value={option}>
@@ -826,11 +828,11 @@ class AddElement extends Component {
     super(props);
     if (this.props !== undefined && this.props.element) {
       // Editing an element, set to elements state
+      let element = JSON.parse(JSON.stringify(this.props.element));
       this.state = {
-        Options: Instrument.clone(this.props.element.Options === undefined ?
+        Options: element.Options === undefined ?
           {} :
-          this.props.element.Options
-        ),
+          element.Options,
         Description: Instrument.clone(
           this.props.element.Description === undefined ?
           {} :
@@ -1037,7 +1039,6 @@ class AddElement extends Component {
       default:
         break;
     }
-
     // Remove all error flags
     delete this.state.error;
     let element = {

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -828,11 +828,10 @@ class AddElement extends Component {
     super(props);
     if (this.props !== undefined && this.props.element) {
       // Editing an element, set to elements state
-      // let element = JSON.parse(JSON.stringify(this.props.element));
       this.state = {
         Options: Instrument.clone(this.props.element.Options === undefined ?
-           {} :
-           this.props.element.Options
+          {} :
+          this.props.element.Options
         ),
         Description: Instrument.clone(
           this.props.element.Description === undefined ?
@@ -1040,6 +1039,7 @@ class AddElement extends Component {
       default:
         break;
     }
+
     // Remove all error flags
     delete this.state.error;
     let element = {

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -828,11 +828,12 @@ class AddElement extends Component {
     super(props);
     if (this.props !== undefined && this.props.element) {
       // Editing an element, set to elements state
-      let element = JSON.parse(JSON.stringify(this.props.element));
+      // let element = JSON.parse(JSON.stringify(this.props.element));
       this.state = {
-        Options: element.Options === undefined ?
-          {} :
-          element.Options,
+        Options: Instrument.clone(this.props.element.Options === undefined ?
+           {} :
+           this.props.element.Options
+        ),
         Description: Instrument.clone(
           this.props.element.Description === undefined ?
           {} :


### PR DESCRIPTION
## Brief summary of changes

This PR is on main since it's more convenient for me in the meantime.
See https://github.com/aces/Loris/pull/6863 for previous discussion.

1) This PR fixes the loading of instrument linst files and specifically when having Date fields used.
2) Also fixes the edit mode for Date that previously didn't have the correct values set in options.
3) Solves the three types being Date, BasicDate, MonthYear

**Notice:** I believe _date is unnecessary/irrelevant in the string at all of a linst file. Until, I'm convinced otherwise I just removed that while fixing things in this PR and is why this is a seperate PR than #6863 until we know for sure.

@driusan, @ridz1208, @zaliqarosli please comment on the notice. My understanding is the beginning of the linst line signals it as a date by being `Date` and then to follow in the string is for details including type at the very end for if Date or BasicDate or MonthYear. I believe @zaliqarosli is correct that regular Date type can be at the end as Date or missing (if I understood her correctly).

Example 1 of Date (see last line)
```
table{@}test1standard
title{@}test1standard
date{@}Date_taken{@}Date of Administration{@}2006{@}2012
static{@}Candidate_Age{@}Candidate Age (Months)
static{@}Window_Difference{@}Window Difference (+/- Days)
select{@}Examiner{@}Examiner{@}NULL=>''
header{@}{@}test1
date{@}test1datestandard{@}test1dateStandard{@}2020{@}2021{@}Date

```

Example 2 of BasicDate (see last line)
```
table{@}test2basic
title{@}test2basic
date{@}Date_taken{@}Date of Administration{@}2006{@}2012
static{@}Candidate_Age{@}Candidate Age (Months)
static{@}Window_Difference{@}Window Difference (+/- Days)
select{@}Examiner{@}Examiner{@}NULL=>''
header{@}{@}test2date
date{@}test2datebasic{@}test2datebasic{@}2020{@}2021{@}BasicDate

```

Example 3 of MonthYear (see last line)
```
table{@}test3monthyear
title{@}test3monthyear
date{@}Date_taken{@}Date of Administration{@}2006{@}2012
static{@}Candidate_Age{@}Candidate Age (Months)
static{@}Window_Difference{@}Window Difference (+/- Days)
select{@}Examiner{@}Examiner{@}NULL=>''
header{@}{@}test3date
date{@}test3monthyear{@}test3monthyear{@}2020{@}2021{@}MonthYear

```

#### Testing instructions (if applicable)

1. Checkout the PR
2. Visit Instrument_builder module
3. Make three instrument files with different types of date
4. Load them and then save again.
5. Compare the original files to the new.
6. Also try editing the date field once loaded.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
