### PR TITLE
[candidate_profile] Update API version used by candidate_profile to be v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 - Readability of comments and history was improved. (PR #6138)
 #### API
 - Creation of a new version of the API under development (v0.0.4-dev) (PR #6944)
-- Deletion of support for the oldest version of the API (v0.0.2) (PR #6844)
+- Deletion of support for the oldest version of the API (v0.0.2) (PR #6944)
 #### Candidate Parameters
 - Consents may now be grouped in UI of consent tab (PR #6042, PR #6044)
 ### Clean Up

--- a/modules/candidate_profile/templates/form_candidate_profile.tpl
+++ b/modules/candidate_profile/templates/form_candidate_profile.tpl
@@ -11,7 +11,7 @@
 window.addEventListener('load', () => {
     let candidate = null;
     async function loadCandidate() {
-        let response = await fetch(loris.BaseURL + '/api/v0.0.2/candidates/{$candidate->getCandID()}');
+        let response = await fetch(loris.BaseURL + '/api/v0.0.3/candidates/{$candidate->getCandID()}');
         let data = await response.json();
         candidate = data;
         return data;


### PR DESCRIPTION
v0.0.2 support was removed in #6944.

The CHANGELOG was also referencing the wrong pull request.