### PR TITLE
[LINST] Support for different test_name and table name

### DIFF
--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -72,6 +72,7 @@ var Instrument = {
             return;
         }
 
+        // TODO: remove "table" from this file and add to .meta file instead
         content += "table{@}" + name + "\n";
         if (title) {
             content += "title{@}" + title + "\n";

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -273,6 +273,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if (!empty($commentID)) {
             $obj->setupCandidateInfoTables();
         }
+        if (file_exists($base."project/instruments/$instrument.meta")) {
+            $obj->loadInstrumentMetadata(
+                $base . "project/instruments/$instrument.meta"
+            );
+        }
         // Adds all of the form element and form rules to the page after
         // having instantiated the form above
         $obj->loadInstrumentFile(
@@ -2313,6 +2318,22 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             array('CID' => $this->commentID),
             array('nofetch' => true)
         );
+    }
+
+    /**
+     * Parses the metadata of a LINST instrument and sets the proper variables
+     * in the instrument class accordingly
+     *
+     * This is intended to be overridden by a subclass of NDB_BVL_Instrument
+     * to add support for other file formats.
+     *
+     * @param string $filename The filename to be loaded, or a base64 encoded
+     *                         string.
+     *
+     * @return void
+     */
+    function loadInstrumentMetadata(string $filename): void
+    {
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2321,14 +2321,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
-     * Parses the metadata of a LINST instrument and sets the proper variables
+     * Loads the metadata of an instrument and sets the proper variables
      * in the instrument class accordingly
      *
      * This is intended to be overridden by a subclass of NDB_BVL_Instrument
      * to add support for other file formats.
      *
-     * @param string $filename The filename to be loaded, or a base64 encoded
-     *                         string.
+     * @param string $filename The filename to be loaded
      *
      * @return void
      */

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -461,14 +461,13 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     }
                     $firstFieldOfPage = true;
                     break;
-                case 'test':
-                    $this->testName = trim($pieces[1]);
-                    break;
                 case 'table':
-                    // The line below offers backwards compatibility to LINST
-                    // files that don't define a test name
+                    // The 'test' and 'table' variables of the .meta file
+                    // take precedence over this variable in the .linst file.
+                    // The lines below offer backwards compatibility until
+                    // the feature is completely deprecated.
                     $this->testName = $this->testName ?? trim($pieces[1]);
-                    $this->table    = trim($pieces[1]);
+                    $this->table    = $this->table ?? trim($pieces[1]);
                     break;
                 case 'title':
                     if ($addElements) {
@@ -737,6 +736,44 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             }
             fclose($fp);
         }
+    }
+
+    /**
+     * Parses the metadata of a LINST instrument and sets the proper variables
+     * in the instrument class accordingly
+     *
+     * This is intended to be overridden by a subclass of NDB_BVL_Instrument
+     * to add support for other file formats.
+     *
+     * @param string $filename The filename to be loaded, or a base64 encoded
+     *                         string.
+     *
+     * @return void
+     */
+    function loadInstrumentMetadata(string $filename): void
+    {
+        $fp = fopen($filename, "r");
+        while (($line = fgets($fp, 4096)) !== false) {
+            $pieces = preg_split("/{@}/", $line);
+            $this->LinstLines[] = $pieces;
+
+            $type = $pieces[0];
+
+            switch ($type) {
+            case 'test':
+                $this->testName = trim($pieces[1]);
+                break;
+            case 'table':
+                $this->table = trim($pieces[1]);
+                break;
+            case 'jsondata':
+                $this->jsonData = trim($pieces[1]) === 'true';
+                break;
+            default:
+                break;
+            }
+        }
+        fclose($fp);
     }
 
     /**

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -461,8 +461,13 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     }
                     $firstFieldOfPage = true;
                     break;
-                case 'table':
+                case 'test':
                     $this->testName = trim($pieces[1]);
+                    break;
+                case 'table':
+                    // The line below offers backwards compatibility to LINST
+                    // files that don't define a test name
+                    $this->testName = $this->testName ?? trim($pieces[1]);
                     $this->table    = trim($pieces[1]);
                     break;
                 case 'title':

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -760,7 +760,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             $type = $pieces[0];
 
             switch ($type) {
-            case 'test':
+            case 'testname':
                 $this->testName = trim($pieces[1]);
                 break;
             case 'table':

--- a/raisinbread/instruments/bmi.linst
+++ b/raisinbread/instruments/bmi.linst
@@ -1,5 +1,3 @@
-test{@}bmi
-table{@}bmi
 title{@}BMI Calculator
 date{@}Date_taken{@}Date of Administration{@}2006{@}2012
 static{@}Candidate_Age{@}Candidate Age (Months)

--- a/raisinbread/instruments/bmi.linst
+++ b/raisinbread/instruments/bmi.linst
@@ -1,3 +1,4 @@
+test{@}bmi
 table{@}bmi
 title{@}BMI Calculator
 date{@}Date_taken{@}Date of Administration{@}2006{@}2012

--- a/raisinbread/instruments/bmi.meta
+++ b/raisinbread/instruments/bmi.meta
@@ -1,3 +1,3 @@
-test{@}bmi
+testname{@}bmi
 table{@}bmi
 jsondata{@}false

--- a/raisinbread/instruments/bmi.meta
+++ b/raisinbread/instruments/bmi.meta
@@ -1,0 +1,3 @@
+test{@}bmi
+table{@}bmi
+jsondata{@}false

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -72,7 +72,7 @@ foreach ($files AS $file) {
     }
 
     if (is_array($obj->getFullName())) {
-        echo "Could not find row for $matches[1] in table test_names, 
+        echo "Could not find row for $matches[1] in table test_names,
         please populate test_names, instrument_subtests\n";
         continue;
     }
@@ -85,6 +85,7 @@ foreach ($files AS $file) {
 
     echo "Parsing instrument object...\n";
 
+    $output .="test{@}".$obj->testName."\n";
     $output .="table{@}".$obj->table."\n";
 
     $output .="title{@}".$obj->getFullName()."\n";

--- a/tools/lorisform_parser.php
+++ b/tools/lorisform_parser.php
@@ -85,7 +85,7 @@ foreach ($files AS $file) {
 
     echo "Parsing instrument object...\n";
 
-    $output .="test{@}".$obj->testName."\n";
+    $output .="testname{@}".$obj->testName."\n";
     $output .="table{@}".$obj->table."\n";
 
     $output .="title{@}".$obj->getFullName()."\n";


### PR DESCRIPTION
## Brief summary of changes
The `NDB_BVL_Instrument` class has supported instruments having test names different from the table names. The testname is generally used to load instruments in the front en while the table name is used to save/load data as well as the data dictionary.

These LINST tinstrument class extends the `NDB_BVL_Instrument` class but does not incorporate such functionality making it more restrictive than it's parent. This fix adds that capability while keeping the class 100% backwards compatible

This branch also adds the capacity to define if your LINST instrument should use the jsonData saving methid or the regular SQL saving.

All changes in this PR are 100% backwards compatible and futre deprecations will be done in the next major release.

### testing
- load this branch and test any existing LINST instrument. everything should work fine. (you can use the old version of the bmi for that before the changes)
- On this branch again, create (or modify) and instrument to use a table name different than the testname and add a line in the LINST file for the `test` variable (see code changes for BMI example). The testname should now be loaded from `test` and the table name separately loaded from `table`. toggle the jsondata value from false to true and make sure the instrument then saves as JSON data in the flag table


PS: I did not modify the behaviour of the instrument builder since I think we should instead make the instrument builder define (by default) `jsonData=true` instead of using and SQL table, in which case the table variable would be deprecated and the LINST class would need to be updated. This work should be done in the next major release