### PR TITLE
[Instrument.class.inc] Fix _nullScores() so that only score fields are saved

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2086,7 +2086,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _nullScores(array $scoreCols): void
     {
-        $record = $this->loadInstanceData($this);
+        $record    = $this->loadInstanceData($this);
         $scoreCols = array_combine($scoreCols, $scoreCols);
         // order is important here because it keeps values of first array
         // unsetting all columns which are not scores

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2086,7 +2086,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _nullScores(array $scoreCols): void
     {
-        $data = $this->loadInstanceData($this);
+        $record = $this->loadInstanceData($this);
+        $scoreCols = array_combine($scoreCols, $scoreCols);
+        // order is important here because it keeps values of first array
+        // unsetting all columns which are not scores
+        $data = array_intersect_key($record, $scoreCols);
 
         // set the scoring cols to NULL
         foreach ($scoreCols as $key => $val) {


### PR DESCRIPTION
## Brief summary of changes
Currently the `_nullScores()` function saves all fields in the table, leading to an issue with double escaping of special characters. In other to amend, this PR ensures that only score fields are being saved by the `_nullScores()` function. 


#### Testing instructions (if applicable)

1. Input a special character in an instrument text field (ex: `<`, `>`, `"`, `&`)
2. Run score instrument script to ensure no double escaping occurs.

#### Link(s) to related issue(s)

* Resolves #7140 
