### PR TITLE
[Battery] Potential improvement for battery assignment

### DIFF
--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -161,16 +161,18 @@ class NDB_BVL_Battery
      * Computes the difference between the existing battery and the
      * theoretical battery and returns only the missing tests as an array
      *
-     * @param array $currentBattery
-     * @param array $lookupBattery
+     * @param array $currentBattery Existing battery at the specified timepoint
+     * @param array $lookupBattery  Theoretical battery from the test_battery table
      *
      * @return array
      */
-    function getBatteryDifference(array $currentBattery=[], array $lookupBattery=[]) : array
-    {
+    function getBatteryDifference(
+        array $currentBattery=[],
+        array $lookupBattery=[]
+    ) : array {
         return array_unique(array_diff($lookupBattery, $currentBattery));
     }
-    
+
     /**
      * Adds the specified instrument to the current battery, so long
      * as it is not already there (singleton model)

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -147,7 +147,7 @@ class NDB_BVL_Battery
 
         // assert that the current battery is empty
         if (count($currentTests) > 0) {
-            $neededTests = $this->getBatteryDifference($neededTests);
+            $neededTests = $this->getBatteryDifference($currentTests, $neededTests);
         }
 
         // loop over the list of instruments

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -135,13 +135,6 @@ class NDB_BVL_Battery
             );
         }
 
-        // assert that the current battery is empty
-        if (count($currentTests) > 0) {
-            throw new Exception(
-                "Battery is not empty - will not clobber an existing battery."
-            );
-        }
-
         // determine the list of instruments to register
         $neededTests = $this->lookupBattery(
             $this->age,
@@ -152,6 +145,11 @@ class NDB_BVL_Battery
             $firstVisit
         );
 
+        // assert that the current battery is empty
+        if (count($currentTests) > 0) {
+            $neededTests = $this->getBatteryDifference($neededTests);
+        }
+
         // loop over the list of instruments
         foreach ($neededTests AS $testName) {
             // add the instrument
@@ -159,6 +157,20 @@ class NDB_BVL_Battery
         } // end looping over the list of instruments
     } // end createBattery()
 
+    /**
+     * Computes the difference between the existing battery and the
+     * theoretical battery and returns only the missing tests as an array
+     *
+     * @param array $currentBattery
+     * @param array $lookupBattery
+     *
+     * @return array
+     */
+    function getBatteryDifference(array $currentBattery=[], array $lookupBattery=[]) : array
+    {
+        return array_unique(array_diff($lookupBattery, $currentBattery));
+    }
+    
     /**
      * Adds the specified instrument to the current battery, so long
      * as it is not already there (singleton model)


### PR DESCRIPTION
## Brief summary of changes
The behaviour change in the battery was copied over from the `assign_missing _instruments` php script. This is not the ideal implementation but is sufficient to serve as a proposal up for discussion. Alternate solutions can include

- completely separate function to populate vs create a battery
- only allow to "fill in" battery if already existing instruments are surveys (not a prepopulated battery of instruments)
- behaviour could be added uniquely to next stage (although this limits the potential to allow users to have a button au run "assign missing instruments from the front end")
- ... other combinations...


fixes #7162