### PR TITLE
23.0-release build fix

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -956,8 +956,9 @@ class TimePoint
         if (!is_null($this->getSubprojectID())) {
             $settings = \NDB_Config::singleton()
                 ->getSubprojectSettings($this->getSubprojectID());
-            if (isset($settings['options']['useEDC']) 
-                && $settings['options']['useEDC'] == "true") {
+            if (isset($settings['options']['useEDC'])
+                && $settings['options']['useEDC'] == "true"
+            ) {
                 return $candidate->getCandidateEDC();
             }
         }


### PR DESCRIPTION
The last commit broke the build. This PR fixes the PHPCS error.

FILE: /var/www/Loris/php/libraries/TimePoint.class.inc
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
 959 | ERROR | [x] Whitespace found at end of line
 960 | ERROR | [x] Closing parenthesis of a multi-line IF statement must be on
     |       |     a new line
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------

Time: 6.09 secs; Memory: 24MB
