### PR TITLE
[smarty] use default to prevent error_log pollution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license" : "GPL-3.0+",
     "description" : "LORIS (Longitudinal Online Research and Imaging System) is a web-accessible database solution for neuroimaging.",
     "require" : {
-        "smarty/smarty" : "~3.1.33",
+        "smarty/smarty" : "~3.1.36",
         "firebase/php-jwt" : "~3.0",
         "google/recaptcha": "~1.1",
         "php-http/guzzle6-adapter": ">=2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "632cce397dbefe6115f7603c941b038c",
+    "content-hash": "13bb8937123dba1d63dce533bee27cac",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -1338,16 +1338,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.4",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba"
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6e076a124f7ee146f2487554a94b6a19a74887ba",
-                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
                 "shasum": ""
             },
             "require": {
@@ -1381,7 +1381,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.4"
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
             },
             "funding": [
                 {
@@ -1397,40 +1397,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:39:10+00:00"
+            "time": "2020-11-13T08:04:11+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -1444,7 +1439,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -1455,7 +1450,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.3.x"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
             },
             "funding": [
                 {
@@ -1471,7 +1466,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1565,16 +1560,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -1611,7 +1606,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
             },
             "funding": [
                 {
@@ -1619,7 +1614,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1922,19 +1917,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-webdriver/php-webdriver.git",
-                "reference": "c106a41a1a75e3e3e163f6a3f58aeec80e434b05"
+                "reference": "cab6d4acfa659a02d7fbb485ca5991e9a8d679c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/c106a41a1a75e3e3e163f6a3f58aeec80e434b05",
-                "reference": "c106a41a1a75e3e3e163f6a3f58aeec80e434b05",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/cab6d4acfa659a02d7fbb485ca5991e9a8d679c2",
+                "reference": "cab6d4acfa659a02d7fbb485ca5991e9a8d679c2",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php": "^5.6 || ~7.0",
+                "php": "^5.6 || ~7.0 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.12",
                 "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0"
             },
@@ -1944,12 +1939,10 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.0",
                 "ondram/ci-detector": "^2.1 || ^3.5",
-                "php-coveralls/php-coveralls": "^2.0",
-                "php-mock/php-mock-phpunit": "^1.1",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-mock/php-mock-phpunit": "^1.1 || ^2.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpunit/phpunit": "^5.7",
-                "sebastian/environment": "^1.3.4 || ^2.0 || ^3.0",
-                "sminnee/phpunit-mock-objects": "^3.4",
+                "phpunit/phpunit": "^5.7 || ^7 || ^8 || ^9",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/var-dumper": "^3.3 || ^4.0 || ^5.0"
             },
@@ -1988,7 +1981,7 @@
                 "issues": "https://github.com/php-webdriver/php-webdriver/issues",
                 "source": "https://github.com/php-webdriver/php-webdriver/tree/main"
             },
-            "time": "2020-10-06T21:13:58+00:00"
+            "time": "2020-11-28T01:55:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2574,23 +2567,23 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -2621,27 +2614,33 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
             },
-            "time": "2019-06-07T04:22:29+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0"
@@ -2674,10 +2673,16 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "abandoned": true,
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2020-11-30T08:38:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -2995,23 +3000,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -3038,9 +3043,15 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/master"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
             },
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -3112,20 +3123,20 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5 || ^8.0",
@@ -3148,12 +3159,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -3166,9 +3177,15 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
             },
-            "time": "2019-02-04T06:01:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3226,20 +3243,20 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.0",
                 "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
@@ -3291,9 +3308,15 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
             },
-            "time": "2019-09-14T09:02:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3352,20 +3375,20 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
+                "php": ">=7.0",
                 "sebastian/object-reflector": "^1.1.1",
                 "sebastian/recursion-context": "^3.0"
             },
@@ -3397,26 +3420,32 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/master"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
             },
-            "time": "2017-08-03T12:35:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0"
@@ -3446,26 +3475,32 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/master"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
             },
-            "time": "2017-03-29T09:07:27+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0"
@@ -3487,12 +3522,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -3503,9 +3538,15 @@
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
             },
-            "time": "2017-03-03T06:23:57+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3703,16 +3744,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "11baeefa4c179d6908655a7b6be728f62367c193"
+                "reference": "fa1219ecbf96bb5db59f2599cba0960a0d9c3aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/11baeefa4c179d6908655a7b6be728f62367c193",
-                "reference": "11baeefa4c179d6908655a7b6be728f62367c193",
+                "url": "https://api.github.com/repos/symfony/config/zipball/fa1219ecbf96bb5db59f2599cba0960a0d9c3aea",
+                "reference": "fa1219ecbf96bb5db59f2599cba0960a0d9c3aea",
                 "shasum": ""
             },
             "require": {
@@ -3761,7 +3802,7 @@
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.1.8"
+                "source": "https://github.com/symfony/config/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -3777,20 +3818,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-11-16T18:02:40+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e"
+                "reference": "3e0564fb08d44a98bd5f1960204c958e57bd586b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
-                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e0564fb08d44a98bd5f1960204c958e57bd586b",
+                "reference": "3e0564fb08d44a98bd5f1960204c958e57bd586b",
                 "shasum": ""
             },
             "require": {
@@ -3851,8 +3892,14 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.1.8"
+                "source": "https://github.com/symfony/console/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -3868,20 +3915,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-11-28T11:24:18+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "829ca6bceaf68036a123a13a979f3c89289eae78"
+                "reference": "98cec9b9f410a4832e239949a41d47182862c3a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/829ca6bceaf68036a123a13a979f3c89289eae78",
-                "reference": "829ca6bceaf68036a123a13a979f3c89289eae78",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/98cec9b9f410a4832e239949a41d47182862c3a4",
+                "reference": "98cec9b9f410a4832e239949a41d47182862c3a4",
                 "shasum": ""
             },
             "require": {
@@ -3939,7 +3986,7 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.1.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -3955,7 +4002,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-27T10:11:13+00:00"
+            "time": "2020-11-28T11:24:18+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4026,16 +4073,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "df08650ea7aee2d925380069c131a66124d79177"
+                "reference": "bb92ba7f38b037e531908590a858a04d85c0e238"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/df08650ea7aee2d925380069c131a66124d79177",
-                "reference": "df08650ea7aee2d925380069c131a66124d79177",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/bb92ba7f38b037e531908590a858a04d85c0e238",
+                "reference": "bb92ba7f38b037e531908590a858a04d85c0e238",
                 "shasum": ""
             },
             "require": {
@@ -4068,7 +4115,7 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.1.8"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -4084,7 +4131,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-11-12T09:58:18+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4490,16 +4537,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f00872c3f6804150d6a0f73b4151daab96248101"
+                "reference": "240e74140d4d956265048f3025c0aecbbc302d54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f00872c3f6804150d6a0f73b4151daab96248101",
-                "reference": "f00872c3f6804150d6a0f73b4151daab96248101",
+                "url": "https://api.github.com/repos/symfony/process/zipball/240e74140d4d956265048f3025c0aecbbc302d54",
+                "reference": "240e74140d4d956265048f3025c0aecbbc302d54",
                 "shasum": ""
             },
             "require": {
@@ -4532,7 +4579,7 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.1.8"
+                "source": "https://github.com/symfony/process/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -4548,7 +4595,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-11-02T15:47:15+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4631,16 +4678,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea"
+                "reference": "40e975edadd4e32cd16f3753b3bad65d9ac48242"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a97573e960303db71be0dd8fda9be3bca5e0feea",
-                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea",
+                "url": "https://api.github.com/repos/symfony/string/zipball/40e975edadd4e32cd16f3753b3bad65d9ac48242",
+                "reference": "40e975edadd4e32cd16f3753b3bad65d9ac48242",
                 "shasum": ""
             },
             "require": {
@@ -4694,7 +4741,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.1.8"
+                "source": "https://github.com/symfony/string/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -4710,7 +4757,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-10-24T12:08:07+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/htdocs/feedback_mri_popup.php
+++ b/htdocs/feedback_mri_popup.php
@@ -46,7 +46,9 @@ if (isset($_POST['fire_away']) && $_POST['fire_away']) {
     $comments->clearAllComments();
 
     // set selected predefined comments
-    $comments->setPredefinedComments($_POST['savecomments']['predefined']);
+    if (isset($_POST['savecomments']['predefined'])) {
+        $comments->setPredefinedComments($_POST['savecomments']['predefined']);
+    }
 
     // save all textual comments but only if there is an entry [sebas]
     foreach (\Utility::asArray($_POST['savecomments']['text'])
@@ -58,7 +60,9 @@ if (isset($_POST['fire_away']) && $_POST['fire_away']) {
     }
 
     // save all comment status fields
-    if (is_array($_POST['saveCommentStatusField'])) {
+    if (isset($_POST['saveCommentStatusField'])
+        && is_array($_POST['saveCommentStatusField'])
+    ) {
         foreach ($_POST['saveCommentStatusField'] as $status_field => $value) {
             $comments->setMRIValue($status_field, $value);
         }

--- a/modules/configuration/templates/form_configuration.tpl
+++ b/modules/configuration/templates/form_configuration.tpl
@@ -80,7 +80,7 @@
 
 {function name=printForm}
     <div class="config-form-group" id="{$node['ID']}">
-    {foreach from=$node['Value'] key=k item=v}
+    {foreach from=$node['Value']|default key=k item=v}
         {if $node['AllowMultiple'] == 1}<div class="input-group entry">{/if}
         {if $node['DataType'] eq 'boolean'}
             {call createRadio k=$k v=$v d=$node['Disabled']}
@@ -140,8 +140,8 @@
 {/function}
 
 <p>Please enter the various configuration variables into the fields below. For information on how to configure LORIS, please refer to the Help section and/or the Developer's guide.</p>
-<p>To configure study subprojects <a href="{$baseurl}/configuration/subproject/">click here</a>.
-    To configure study projects <a href="{$baseurl}/configuration/project/">click here</a>.
+<p>To configure study subprojects <a href="{$baseurl|default}/configuration/subproject/">click here</a>.
+    To configure study projects <a href="{$baseurl|default}/configuration/project/">click here</a>.
 </p>
 <br>
 

--- a/modules/configuration/templates/form_project.tpl
+++ b/modules/configuration/templates/form_project.tpl
@@ -1,11 +1,11 @@
-<script language="javascript" src="{$baseurl}/configuration/js/project.js">
+<script language="javascript" src="{$baseurl|default}/configuration/js/project.js">
 </script>
 <p>Use this page to manage the configuration of existing projects, or to add a new one.</p>
-<p>To configure study subprojects <a href="{$baseurl}/configuration/subproject/">click here</a>.</p>
+<p>To configure study subprojects <a href="{$baseurl|default}/configuration/subproject/">click here</a>.</p>
 
 <div class="col-md-3">
 <ul class="nav nav-pills nav-stacked" role="tablist" data-tabs="tabs">
-    <li class="active"><a id="#projectnew{$ProjectID}" href="#projectnew" data-toggle="tab" class="active">New ProjectID</a></li>
+    <li class="active"><a id="#projectnew{$ProjectID|default}" href="#projectnew" data-toggle="tab" class="active">New ProjectID</a></li>
     {foreach from=$projects key=ProjectID item=project name=configContent}
     <li><a id="#project{$ProjectID}" href="#project{$ProjectID}" data-toggle="tab">{$project.Name}</a></li>
     {/foreach}

--- a/modules/dashboard/templates/welcomefooter.tpl
+++ b/modules/dashboard/templates/welcomefooter.tpl
@@ -1,4 +1,4 @@
 {foreach from=$dashboard_links item=link name=links}
-    <a href="{$link.url}" target="{$link.windowName}">{$link.label}</a>
+    <a href="{$link.url}" target="{$link.windowName|default}">{$link.label}</a>
     {if !$smarty.foreach.links.last}|{/if}
 {/foreach}

--- a/modules/examiner/templates/form_editExaminer.tpl
+++ b/modules/examiner/templates/form_editExaminer.tpl
@@ -35,13 +35,13 @@
                     </div>
                     {/foreach}
                     <div class="row">
-                        {if not $success}
+                        {if not $success|default}
                         <div class="col-xs-12">
                             <div class="col-sm-6 col-md-2 col-xs-12 col-md-offset-8">
                                 <input class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit">
                             </div>
                             <div class="col-sm-6 col-md-2 col-xs-12">
-                                <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" onclick="location.href='{$baseurl}/examiner/editExaminer/?reset=true&identifier={$identifier}'">
+                                <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" onclick="location.href='{$baseurl|default}/examiner/editExaminer/?reset=true&identifier={$identifier}'">
                             </div>
                         </div>
                         {/if}

--- a/modules/imaging_browser/templates/form_viewSession.tpl
+++ b/modules/imaging_browser/templates/form_viewSession.tpl
@@ -1,5 +1,5 @@
 <!-- Main table -->
-{if $show3DViewer}
+{if $show3DViewer|default}
 {*<td nowrap="nowrap">the first opening td already opened in main.tpl *}<input type="button" name="button" value="3D Viewer" class="button" id = "dccid" name = "dccid" style = "background-color: #816e91" onclick="window.open('BrainBrowser/display.html?sessionID={$subject.sessionID}')" /></td>
 
 </br>

--- a/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
+++ b/modules/imaging_browser/templates/imaging_session_controlpanel.tpl
@@ -1,14 +1,14 @@
     <h3>Navigation</h3>
     <ul>
-        {if $subject.backURL}
-            <li><a href="{$subject.backURL}">
+        {if $subject.backURL|default}
+            <li><a href="{$subject.backURL|default}">
                     <span class="text-default">
                         <span class="glyphicon glyphicon-backward"></span>&nbsp;Back to list
                     </span>
                 </a>
              </li>
         {/if}
-        {if $subject.prevTimepoint.URL != ''}
+        {if $subject.prevTimepoint.URL|default != ''}
             <li>
                 <a href="{$subject.prevTimepoint.URL}">
                    <span class="text-default">
@@ -25,25 +25,25 @@
            </li>
         {/if}
     </ul>
-    {if $prevTimepoint.URL!="" && $nextTimepoint.URL!=""}<br><br>{/if}
+    {if $prevTimepoint.URL|default !="" && $nextTimepoint.URL!=""}<br><br>{/if}
     <h3>Volume Viewer</h3>
        <input id="bbonly" type="button" class="btn btn-volume-viewer" accesskey="d" value="3D Only">
        <input id="bboverlay" type="button" class="btn btn-volume-viewer" accesskey="c" value="3D + Overlay">
 
-{if $subject.links|@count || $subject.tarchiveIDLoc|@count || $mantis}
+{if $subject.links|@count || $subject.tarchiveIDLoc|@count || $mantis|default}
     <h3>Links</h3>
     <ul>
         {foreach from=$subject.links item=link}
-            <li><a href="{$baseurl}/instruments/{$link.BEName}/?commentID={$link.CommentID}&sessionID={$subject.sessionID}&candID={$subject.candid}">{$link.FEName}</a></li>
+            <li><a href="{$baseurl|default}/instruments/{$link.BEName}/?commentID={$link.CommentID}&sessionID={$subject.sessionID}&candID={$subject.candid}">{$link.FEName}</a></li>
         {/foreach}
         {foreach from=$subject.tarchiveIDLoc key=tarchive item=tarchiveLoc}
-            <li><a href="{$baseurl}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|escape:"url"}">DICOM Archive {$tarchive}</a></li>
+            <li><a href="{$baseurl|default}/dicom_archive/viewDetails/?tarchiveID={$tarchive}&backURL={$backURL|default|escape:"url"}">DICOM Archive {$tarchive}</a></li>
             <li><a href="/mri/jiv/get_file.php?file={$tarchiveLoc['ArchiveLocation']}&patientName={$tarchiveLoc['PatientName']}" class="btn btn-primary btn-small">
                     <span class="glyphicon glyphicon-cloud-download"></span><span class="hidden-xs"> Download DICOM {$tarchive}</span>
                 </a>
             </li>
         {/foreach}
-        {if $mantis}
+        {if $mantis|default}
             <li><a target="mantis" href="{$issue_tracker_url}">Report a Bug (Mantis)</a></li>
         {/if}
     </ul>
@@ -52,7 +52,7 @@
     <h3>Visit Level QC</h3>
     <div class="visit-level-feedback">
           <a class="btn btn-default" href="#"
-               onClick="javascript:open_popup('{$baseurl}/feedback_mri_popup.php?sessionID={$subject.sessionID}')">
+               onClick="javascript:open_popup('{$baseurl|default}/feedback_mri_popup.php?sessionID={$subject.sessionID}')">
                  <span class="text-default">
                      <span class="glyphicon glyphicon-pencil feedback-text"></span>
                      <span class="hidden-xs feedback-text"> Visit Level Feedback</span>

--- a/modules/imaging_browser/templates/table_session_header.tpl
+++ b/modules/imaging_browser/templates/table_session_header.tpl
@@ -13,7 +13,7 @@
             <th>Output Type</th>
             <th>Scanner</th>
             <th>Subproject</th>
-            {if $useEDC}
+            {if $useEDC|default}
             <th>EDC</th>
             {/if}
         </tr>
@@ -29,10 +29,10 @@
             <td>{if $subject.mriqcpending=="Y"}<img src="{$baseurl}/images/check_blue.gif" width="12" height="12">{else}&nbsp;{/if}</td>
             <td>{$subject.dob}</td>
             <td>{$subject.sex}</td>
-            <td>{$outputType}</td>
+            <td>{$outputType|default}</td>
             <td>{$subject.scanner}</td>
             <td>{$subject.SubprojectTitle}</td>
-            {if $useEDC}
+            {if $useEDC|default}
             <td>{$subject.edc}</td>
             {/if}
         </tr>

--- a/modules/instrument_list/templates/instrument_list_controlpanel.tpl
+++ b/modules/instrument_list/templates/instrument_list_controlpanel.tpl
@@ -15,7 +15,7 @@
 	<ul class="controlPanel fa-ul">
 		{section name=item loop=$status}
 		<li>
-			{if $access.status and $status[item].showlink}
+			{if $access.status and $status[item].showlink|default}
                         	<span class="fa-li"><i class="{$status[item].icon|default:'far fa-square'}"></i></span><a href="?candID={$candID}&sessionID={$sessionID}&setStageUpdate={$status[item].label}">{$status[item].label}</a>
 			{else}
                         	<span class="fa-li"><i class="{$status[item].icon|default:'far fa-square'}"></i></span>{$status[item].label}
@@ -37,7 +37,7 @@
 			{else}
                         <span title='{$access.send_to_dcc_status_message}'><span class="fa-li"><i class="{$send_to_dcc.icon|default:'fas fa-times'}"></i></span>Send To DCC</span>
 			{/if}
-		</li>		
+		</li>
 	</ul>
 
 
@@ -45,16 +45,16 @@
 	<ul class="controlPanel fa-ul">
 		<li>
 			<span class="fa-li"><i class="{$bvl_qc_type_none.icon|default:'far fa-square'}"></i></span>
-			{if $bvl_qc_type_none.showlink}
+			{if $bvl_qc_type_none.showlink|default}
                         	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=">Not Done</a>
 			{else}
                                                 Not Done
 			{/if}
 		</li>
-		
+
 		<li>
 		          <span class="fa-li"><i class="{$bvl_qc_type_visual.icon|default:'far fa-square'}"></i></span>
-			{if $bvl_qc_type_visual.showlink}
+			{if $bvl_qc_type_visual.showlink|default}
                         	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=Visual">Visual</a>
 			{else}
                                                 Visual
@@ -62,7 +62,7 @@
 		</li>
 		<li>
                 	<span class="fa-li"><i class="{$bvl_qc_type_hardcopy.icon|default:'far fa-square'}"></i></span>
-			{if $bvl_qc_type_hardcopy.showlink}
+			{if $bvl_qc_type_hardcopy.showlink|default}
                         	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCType=Hardcopy">Hardcopy</a>
 			{else}
                                                 Hardcopy
@@ -74,16 +74,16 @@
 	<ul class="controlPanel fa-ul">
 		<li>
 			<span class="fa-li"><i class="{$bvl_qc_status_none.icon|default:'far fa-square'}"></i></span>
-			{if $bvl_qc_status_none.showlink}
+			{if $bvl_qc_status_none.showlink|default}
                         	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=">Not Done</a>
 			{else}
                                                 Not Done
 			{/if}
 		</li>
-		
+
 		<li>
                 	<span class="fa-li"><i class="{$bvl_qc_status_complete.icon|default:'far fa-square'}"></i></span>
-			{if $bvl_qc_status_complete.showlink}
+			{if $bvl_qc_status_complete.showlink|default}
                         	<a href="?candID={$candID}&sessionID={$sessionID}&setBVLQCStatus=Complete">Complete</a>
 			{else}
                                                 Complete

--- a/modules/instrument_list/templates/menu_instrument_list.tpl
+++ b/modules/instrument_list/templates/menu_instrument_list.tpl
@@ -43,7 +43,7 @@
       <th>
         Within Permitted
       </th>
-      {if $SupplementalSessionStatuses }
+      {if $SupplementalSessionStatuses|default}
         {foreach from=$timePoint.status item=status key=name}
           <th>
             {$name}
@@ -90,23 +90,23 @@
         {$display.SubprojectTitle}
       </td>
       <td>
-        {$display.Scan_done|default:"<img alt=\"Data Missing\" src=\"$baseurl/images/help2.gif\" width=\"12\" height=\"12\" />"}
+        {$display.Scan_done|default:"<img alt=\"Data Missing\" src=\"{$baseurl|default}/images/help2.gif\" width=\"12\" height=\"12\" />"}
       </td>
       <td>
-        {if $display.WindowInfo.Optimum}
+        {if $display.WindowInfo.Optimum|default}
           Yes
         {else}
           No
         {/if}
       </td>
-      <td {if not $display.WindowInfo.Optimum}class="error"{/if}>
-        {if $display.WindowInfo.Permitted}
+      <td {if not $display.WindowInfo.Optimum|default}class="error"{/if}>
+        {if $display.WindowInfo.Permitted|default}
           Yes
         {else}
           No
         {/if}
       </td>
-      {if $SupplementalSessionStatuses }
+      {if $SupplementalSessionStatuses|default}
         {foreach from=$display.status item=status}
           <td>
             {$status}
@@ -192,21 +192,21 @@
 	    <th>Double Data Entry Form</th>
 	    <th>Double Data Entry Status</th>
     </tr>
-    </thead>	
+    </thead>
 	{section name=instrument loop=$instruments[group]}
 	<tbody>
 	   	<tr{if $instruments[group][instrument].isDirectEntry} class="directentry"{/if}>
 	    	<td>
-                <a href="{$baseurl}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].commentID}&sessionID={$sessionID}&candID={$candID}">
+                <a href="{$baseurl|default}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].commentID}&sessionID={$sessionID}&candID={$candID}">
 	            {$instruments[group][instrument].fullName}</a></td>
 	    	<td>{$instruments[group][instrument].dataEntryStatus}</td>
 	    	<td>{$instruments[group][instrument].administrationStatus}</td>
-	    	<td bgcolor="{$instruments[group][instrument].feedbackColor}">
+	    	<td bgcolor="{$instruments[group][instrument].feedbackColor|default}">
 		    	{$instruments[group][instrument].feedbackStatus}
 	        </td>
 			<td>
 				{if $instruments[group][instrument].isDdeEnabled }
-				    	<a href="{$baseurl}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].ddeCommentID}&sessionID={$sessionID}&candID={$candID}">Double Data Entry</a>
+				    	<a href="{$baseurl|default}/instruments/{$instruments[group][instrument].testName}/?commentID={$instruments[group][instrument].ddeCommentID}&sessionID={$sessionID}&candID={$candID}">Double Data Entry</a>
 			   {/if}&nbsp;
 			</td>
 			<td>{if $instruments[group][instrument].isDdeEnabled }{$instruments[group][instrument].ddeDataEntryStatus}{/if}&nbsp;</td>
@@ -220,6 +220,6 @@
   <div class="col-xs-12 row">
   </div>
   <div class="col-xs-12 row">
-    <button class="btn btn-primary" onclick="location.href='{$baseurl}/imaging_browser/viewSession/?sessionID={$sessionID}'">View Imaging data</button>
+    <button class="btn btn-primary" onclick="location.href='{$baseurl|default}/imaging_browser/viewSession/?sessionID={$sessionID}'">View Imaging data</button>
   </div>
 </div>

--- a/modules/login/templates/form_login.tpl
+++ b/modules/login/templates/form_login.tpl
@@ -8,16 +8,16 @@
         <div class="panel-body">
           {if $study_logo}
             <section class="study-logo">
-              <img src="{$baseurl}/{$study_logo}" alt="{$study_title}"/>
+              <img src="{$baseurl|default}/{$study_logo}" alt="{$study_title}"/>
             </section>
           {/if}
-          <form method="POST" action="{$action}">
+          <form method="POST">
             <div class="form-group">
-              <input type="text" name="username" class="form-control" placeholder="Username" value="{$username}"/>
+              <input type="text" name="username" class="form-control" placeholder="Username"}"/>
             </div>
             <div class="form-group">
               <input type="password" name="password" class="form-control" placeholder="Password" aria-describedby="helpBlock" />
-              {if $error_message}
+              {if $error_message|default}
                 <span id="helpBlock" class="help-block">
                     <b class="text-danger">{$error_message}</b>
                 </span>
@@ -28,8 +28,8 @@
             </div>
           </form>
           <div class="help-links">
-            <a href="{$baseurl}/login/password-reset/">Forgot your password?</a><br/>
-            <a href="{$baseurl}/login/request-account/">Request Account</a>
+            <a href="{$baseurl|default}/login/password-reset/">Forgot your password?</a><br/>
+            <a href="{$baseurl|default}/login/request-account/">Request Account</a>
           </div>
           <div class="help-text">
             A WebGL-compatible browser is required for full functionality (Mozilla Firefox, Google Chrome)

--- a/modules/login/templates/form_passwordreset.tpl
+++ b/modules/login/templates/form_passwordreset.tpl
@@ -4,7 +4,7 @@
       <h3 class="panel-title">{$page_title}</h3>
     </div>
     <div class="panel-body">
-      {if $success}
+      {if $success|default}
         <div class="success-message">
           <h1>Thank you!</h1>
           <p>{$success}</p>
@@ -18,8 +18,8 @@
             Please enter your username below, and a new password will be sent to you.
           </p>
           <div class="form-group">
-		{$form.username.html} 
-                {if $form.username.error}
+		{$form.username.html}
+                {if $form.username.error|default}
                 <span id="helpBlock" class="help-block">
                    <b class="text-danger">{$form.username.error}</b>
                  </span>

--- a/modules/login/templates/form_requestaccount.tpl
+++ b/modules/login/templates/form_requestaccount.tpl
@@ -8,7 +8,7 @@
     </h3>
   </div>
   <div class="panel-body">
-      {if $success}
+      {if $success|default}
     <div class="success-message">
       <h1>Thank you!</h1>
       <p>Your request for an account has been received successfully.</p>
@@ -24,7 +24,7 @@
     <form method="POST" name="form1" id="form1">
       <div class="form-group">
           {$form.firstname.html}
-          {if $form.firstname.error}
+          {if $form.firstname.error|default}
             <span id="helpBlock" class="help-block">
               <b class="text-danger">{$form.firstname.error}</b>
             </span>
@@ -32,7 +32,7 @@
       </div>
       <div class="form-group">
           {$form.lastname.html}
-          {if $form.lastname.error}
+          {if $form.lastname.error|default}
             <span id="helpBlock" class="help-block">
               <b class="text-danger">{$form.lastname.error}</b>
             </span>
@@ -40,7 +40,7 @@
       </div>
       <div class="form-group">
           {$form.from.html}
-          {if $form.from.error}
+          {if $form.from.error|default}
             <span id="helpBlock" class="help-block">
               <b class="text-danger">{$form.from.error}</b>
             </span>
@@ -48,7 +48,7 @@
       </div>
       <div class="form-group">
           {$form.site.html}
-          {if $form.site.error}
+          {if $form.site.error|default}
             <span id="helpBlock" class="help-block">
               <b class="text-danger">{$form.site.error}</b>
             </span>
@@ -56,7 +56,7 @@
       </div>
       <div class="form-group">
           {$form.project.html}
-          {if $form.project.error}
+          {if $form.project.error|default}
             <span id="helpBlock" class="help-block">
               <b class="text-danger">{$form.project.error}</b>
             </span>
@@ -75,7 +75,7 @@
 {$form.captcha.html}
             <div class="g-recaptcha" data-sitekey="{$captcha_key}"></div>
             <script src="https://www.google.com/recaptcha/api.js?render={$captcha_key}&onload=onloadCallback nonce={$nonce}"></script>
-            {if $form.captcha.error}
+            {if $form.captcha.error|default}
                 <span id="helpBlock" class="help-block">
                   <b class="text-danger">{$form.captcha.error}</b>
                 </span>

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -252,8 +252,8 @@ function getUploadFields()
         $qparam
     );
 
-    $instrumentsList = toSelect($sessionRecords, "Test_name", null);
-    $candidatesList  = toSelect($sessionRecords, "PSCID", null);
+    $instrumentsList = toSelect($sessionRecords, "Test_name", '');
+    $candidatesList  = toSelect($sessionRecords, "PSCID", '');
     $visitList       = Utility::getVisitList();
     $languageList    = Utility::getLanguageList();
     $startYear       = $config->getSetting('startYear');

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -252,8 +252,8 @@ function getUploadFields()
         $qparam
     );
 
-    $instrumentsList = toSelect($sessionRecords, "Test_name", '');
-    $candidatesList  = toSelect($sessionRecords, "PSCID", '');
+    $instrumentsList = toSelect($sessionRecords, "Test_name", null);
+    $candidatesList  = toSelect($sessionRecords, "PSCID", null);
     $visitList       = Utility::getVisitList();
     $languageList    = Utility::getLanguageList();
     $startYear       = $config->getSetting('startYear');

--- a/modules/mri_violations/templates/menu_mri_violations.tpl
+++ b/modules/mri_violations/templates/menu_mri_violations.tpl
@@ -1,11 +1,11 @@
-<script src="{$baseurl}/js/filterControl.js" type="text/javascript"></script>
-<link rel="stylesheet" href="{$baseurl}/css/c3.css">
-<script src="{$baseurl}/js/d3.min.js" charset="utf-8"></script>
-<script src="{$baseurl}/js/c3.min.js"></script>
+<script src="{$baseurl|default}/js/filterControl.js" type="text/javascript"></script>
+<link rel="stylesheet" href="{$baseurl|default}/css/c3.css">
+<script src="{$baseurl|default}/js/d3.min.js" charset="utf-8"></script>
+<script src="{$baseurl|default}/js/c3.min.js"></script>
 <div class="row">
     <div class="col-sm-12">
         <div class="col-md-8 col-sm-8">
-            <form method="post" action="{$baseurl}/mri_violations/" name="mri_violations" id="mri_violations">
+            <form method="post" action="{$baseurl|default}/mri_violations/" name="mri_violations" id="mri_violations">
                 <div class="panel panel-primary">
                     <div class="panel-heading" onclick="hideFilter();">
                         Selection Filter
@@ -63,7 +63,7 @@
                                 <div class="visible-xs col-xs-12"> </div>
                                 <div class="visible-xs col-xs-12"> </div>
                                 <div class="col-sm-6 col-xs-12">
-                                    <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/mri_violations/?reset=true'">
+                                    <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl|default}/mri_violations/?reset=true'">
                                 </div>
                             </div>
                         </div>
@@ -73,7 +73,7 @@
                                 <input type="submit" name="filter" value="Show Data" class="btn btn-sm btn-primary col-xs-12"/>
                             </div>
                             <div class="col-sm-6 col-xs-12">
-                                <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/mri_violations/?reset=true'">
+                                <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl|default}/mri_violations/?reset=true'">
                             </div>
                         </div>
                         <input type="hidden" name="test_name" value="mri_violations" />
@@ -87,16 +87,16 @@
 <div class="row">
     <div id="tabs" style="background: white">
         <ul class="nav nav-tabs">
-            <li class="statsTab active"><a class="statsTabLink" id="onLoad" href="{$baseurl}/mri_violations/">Not Resolved</a></li>
-            <li class="statsTab"><a class="statsTabLink" href="{$baseurl}/mri_violations/resolved_violations/">Resolved</a></li>
+            <li class="statsTab active"><a class="statsTabLink" id="onLoad" href="{$baseurl|default}/mri_violations/">Not Resolved</a></li>
+            <li class="statsTab"><a class="statsTabLink" href="{$baseurl|default}/mri_violations/resolved_violations/">Resolved</a></li>
         </ul>
         <div class="tab-content">
             <div class="tab-pane active">
                 <div>
                     <!--  title table with pagination -->
-                    <form method="post" action="{$baseurl}/mri_violations/"  name="mri_violations" id="mri_violations">
+                    <form method="post" action="{$baseurl|default}/mri_violations/"  name="mri_violations" id="mri_violations">
                         <!--  title table with pagination -->
-                        <div class="dynamictable" id="datatable"></div>                        
+                        <div class="dynamictable" id="datatable"></div>
                         <div class="pull-right">
                             <input class="btn btn-sm btn-primary" name="fire_away" value="Save" type="submit" />
                             <input class="btn btn-sm btn-primary" value="Reset" type="reset" />
@@ -115,7 +115,7 @@ var table = RDynamicDataTable({
      "DataURL" : loris.BaseURL + "/mri_violations/?format=json",
      "getFormattedCell" : formatColumn,
      "freezeColumn" : "PatientName"
-     
+
   });
 ReactDOM.render(table, document.getElementById("datatable"));
 

--- a/modules/mri_violations/templates/menu_resolved_violations.tpl
+++ b/modules/mri_violations/templates/menu_resolved_violations.tpl
@@ -1,8 +1,8 @@
-<script src="{$baseurl}/js/filterControl.js" type="text/javascript"></script>
+<script src="{$baseurl|default}/js/filterControl.js" type="text/javascript"></script>
 <div class="row">
 <div class="col-sm-12">
     <div class="col-md-8 col-sm-8">
-        <form method="post" action="{$baseurl}/mri_violations/resolved_violations/">
+        <form method="post" action="{$baseurl|default}/mri_violations/resolved_violations/">
             <div class="panel panel-primary">
                 <div class="panel-heading" onclick="hideFilter();">
                     Selection Filter
@@ -52,7 +52,7 @@
                             <div class="visible-xs col-xs-12"> </div>
                             <div class="visible-xs col-xs-12"> </div>
                             <div class="col-sm-6 col-xs-12">
-                                <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/mri_violations/resolved_violations/?reset=true'">
+                                <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl|default}/mri_violations/resolved_violations/?reset=true'">
                             </div>
                         </div>
                     </div>
@@ -61,7 +61,7 @@
                             <input type="submit" name="filter" value="Show Data" class="btn btn-sm btn-primary col-xs-12"/>
                         </div>
                         <div class="col-sm-6 col-xs-12">
-                            <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/mri_violations/resolved_violations/?reset=true'">
+                            <input type="button" name="reset" value="Clear Form" class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl|default}/mri_violations/resolved_violations/?reset=true'">
                         </div>
                     </div>
                     <input type="hidden" name="test_name" value="mri_violations" />
@@ -73,8 +73,8 @@
 
 <div id="tabs" style="background: white">
     <ul class="nav nav-tabs">
-        <li class="statsTab"><a class="statsTabLink" id="onLoad" href="{$baseurl}/mri_violations/">Not Resolved</a></li>
-        <li class="statsTab active"><a class="statsTabLink" href="{$baseurl}/mri_violations/resolved_violations/">Resolved</a></li>
+        <li class="statsTab"><a class="statsTabLink" id="onLoad" href="{$baseurl|default}/mri_violations/">Not Resolved</a></li>
+        <li class="statsTab active"><a class="statsTabLink" href="{$baseurl|default}/mri_violations/resolved_violations/">Resolved</a></li>
     </ul>
     <div class="tab-content">
         <div class="tab-pane active">
@@ -87,7 +87,7 @@
 <script>
 loris.hiddenHeaders = {(empty($hiddenHeaders))? [] : $hiddenHeaders };
 var table = RDynamicDataTable({
-     "DataURL" : "{$baseurl}/mri_violations/resolved_violations/?format=json",
+     "DataURL" : "{$baseurl|default}/mri_violations/resolved_violations/?format=json",
      "getFormattedCell" : formatColumn,
      "freezeColumn" : "PatientName"
   });

--- a/modules/my_preferences/templates/form_my_preferences.tpl
+++ b/modules/my_preferences/templates/form_my_preferences.tpl
@@ -99,5 +99,5 @@
     </div>
 
 
-{$form.hidden}
+{$form.hidden|default}
 </form>

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -245,13 +245,10 @@ class Stats_Behavioural extends \NDB_Form
             $center = $row['CenterID'];
             $vl     = $row['VLabel'];
             $value  = intval($row['val']);
-            if (!isset($this->tpl_data['behaviour']['C' . $center])) {
-                $this->tpl_data['behaviour']['C' . $center] = [$vl => []];
-            }
+
+            $this->tpl_data['behaviour']['C' . $center][$vl]
+                = $this->tpl_data['behaviour']['C' . $center][$vl] ?? [];
             $c =& $this->tpl_data['behaviour']['C' . $center];
-            if (!isset($c[$vl])) {
-                $c[$vl] = [];
-            }
 
             if (array_key_exists('total', $c[$vl])) {
                 $c[$vl]['total'] += $value;
@@ -322,13 +319,10 @@ class Stats_Behavioural extends \NDB_Form
             $center = $row['CenterID'];
             $vl     = $row['VLabel'];
             $value  = intval($row['val']);
-            if (!isset($this->tpl_data['dde']['C' . $center])) {
-                $this->tpl_data['dde']['C' . $center] = [$vl => []];
-            }
+
+            $this->tpl_data['dde']['C' . $center][$vl]
+                = $this->tpl_data['dde']['C' . $center][$vl] ?? [];
             $c =& $this->tpl_data['dde']['C' . $center];
-            if (!isset($c[$vl])) {
-                $c[$vl] = [];
-            }
 
             if (array_key_exists('total', $c[$vl])) {
                 $c[$vl]['total'] += $value;

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -248,7 +248,7 @@ class Stats_Behavioural extends \NDB_Form
             if (!isset($this->tpl_data['behaviour']['C' . $center])) {
                 $this->tpl_data['behaviour']['C' . $center] = [$vl => []];
             }
-            $c      =& $this->tpl_data['behaviour']['C' . $center];
+            $c =& $this->tpl_data['behaviour']['C' . $center];
             if (!isset($c[$vl])) {
                 $c[$vl] = [];
             }
@@ -325,7 +325,7 @@ class Stats_Behavioural extends \NDB_Form
             if (!isset($this->tpl_data['dde']['C' . $center])) {
                 $this->tpl_data['dde']['C' . $center] = [$vl => []];
             }
-            $c      =& $this->tpl_data['dde']['C' . $center];
+            $c =& $this->tpl_data['dde']['C' . $center];
             if (!isset($c[$vl])) {
                 $c[$vl] = [];
             }

--- a/modules/statistics/php/stats_behavioural.class.inc
+++ b/modules/statistics/php/stats_behavioural.class.inc
@@ -245,7 +245,13 @@ class Stats_Behavioural extends \NDB_Form
             $center = $row['CenterID'];
             $vl     = $row['VLabel'];
             $value  = intval($row['val']);
+            if (!isset($this->tpl_data['behaviour']['C' . $center])) {
+                $this->tpl_data['behaviour']['C' . $center] = [$vl => []];
+            }
             $c      =& $this->tpl_data['behaviour']['C' . $center];
+            if (!isset($c[$vl])) {
+                $c[$vl] = [];
+            }
 
             if (array_key_exists('total', $c[$vl])) {
                 $c[$vl]['total'] += $value;
@@ -316,7 +322,13 @@ class Stats_Behavioural extends \NDB_Form
             $center = $row['CenterID'];
             $vl     = $row['VLabel'];
             $value  = intval($row['val']);
+            if (!isset($this->tpl_data['dde']['C' . $center])) {
+                $this->tpl_data['dde']['C' . $center] = [$vl => []];
+            }
             $c      =& $this->tpl_data['dde']['C' . $center];
+            if (!isset($c[$vl])) {
+                $c[$vl] = [];
+            }
 
             if (array_key_exists('total', $c[$vl])) {
                 $c[$vl]['total'] += $value;

--- a/modules/statistics/templates/form_statistics.tpl
+++ b/modules/statistics/templates/form_statistics.tpl
@@ -3,7 +3,7 @@
         <ul class="nav nav-tabs">
             {foreach from=$StatsTabs item=tab name=tabs}
             <li class="statsTab{if $smarty.foreach.tabs.first} active onLoad{/if}">
-                <a class="statsTabLink" value="{$baseurl}/{$tab.ModuleName}/{$tab.SubModuleName}/?dynamictabs=dynamictabs">{$tab.Description}</a>
+                <a class="statsTabLink" value="{$baseurl|default}/{$tab.ModuleName}/{$tab.SubModuleName}/?dynamictabs=dynamictabs">{$tab.Description}</a>
             </li>
             {/foreach}
         </ul>
@@ -17,7 +17,7 @@
         <ul class="list-group" style="display:none" id="tabsContent">
             {foreach from=$StatsTabs item=tab}
             <li class="statsTab list-group-item">
-                <a class="statsTabLink" value="{$baseurl}/{$tab.ModuleName}/{$tab.SubModuleName}/?dynamictabs=dynamictabs">{$tab.Description}</a>
+                <a class="statsTabLink" value="{$baseurl|default}/{$tab.ModuleName}/{$tab.SubModuleName}/?dynamictabs=dynamictabs">{$tab.Description}</a>
             </li>
             {/foreach}
         </ul>

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -2,10 +2,10 @@
     <script type="text/javascript" src="{$baseurl}/statistics/js/form_stats_MRI.js"></script>
     <h2 class="statsH2">General Statistics with QC Status</h2>
     <div class="col-sm-2">
-        {html_options id="MRIsite" options=$Sites name="MRIsite" selected=$CurrentSite.ID class="form-control"}
+        {html_options id="MRIsite" options=$Sites name="MRIsite" selected=$CurrentSite.ID|default class="form-control"}
     </div>
         <div class="col-sm-2">
-            {html_options id="MRIProject" options=$Projects name="MRIProject" selected=$CurrentProject.ID class="form-control"}
+            {html_options id="MRIProject" options=$Projects name="MRIProject" selected=$CurrentProject.ID|default class="form-control"}
         </div>
     <br><br>
     <div id="scancheckbox">

--- a/modules/statistics/templates/form_stats_MRI.tpl
+++ b/modules/statistics/templates/form_stats_MRI.tpl
@@ -1,5 +1,5 @@
 <div id="mri">
-    <script type="text/javascript" src="{$baseurl}/statistics/js/form_stats_MRI.js"></script>
+    <script type="text/javascript" src="{$baseurl|default}/statistics/js/form_stats_MRI.js"></script>
     <h2 class="statsH2">General Statistics with QC Status</h2>
     <div class="col-sm-2">
         {html_options id="MRIsite" options=$Sites name="MRIsite" selected=$CurrentSite.ID|default class="form-control"}

--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -1,8 +1,8 @@
 <div id="data_entry">
-    <h2 class="statsH2">Data Entry Statistics  {if $CurrentProject} for {$CurrentProject.Name} {/if}</h2>
+    <h2 class="statsH2">Data Entry Statistics  {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</h2>
     <script type="text/javascript" src="{$baseurl}/statistics/js/form_stats_behavioural.js"></script>
         <div class="col-sm-2">
-            {html_options id="BehaviouralProject" options=$Projects name="BehaviouralProject" selected=$CurrentProject.ID class="form-control"}
+            {html_options id="BehaviouralProject" options=$Projects name="BehaviouralProject" selected=$CurrentProject.ID|default class="form-control"}
         </div>
         <button class="btn btn-primary btn-sm" onClick="updateBehaviouralTab()">Submit Query</button>
         <br><br>
@@ -46,7 +46,7 @@
             <td class="   pis">Per Instrument Stats</td>
             {foreach from=$Centers item=center key=centername}
                 <td id='{$center.ID}PIS' class="pis" colspan="2">
-                    <a href='{$baseurl}/statistics/statistics_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID}' target="_blank">View Details</a>
+                    <a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID|default}' target="_blank">View Details</a>
                 </td>
             {/foreach}
         </tr>
@@ -55,7 +55,7 @@
 
 
 
-    <b><a href='{$baseurl}/statistics/statistics_site/?CenterID={$CurrentSite.ID}&ProjectID={$CurrentProject.ID}' target="_blank">Click here for breakdown per participant {if $CurrentSite} for {$CurrentSite.Name} {/if} {if $CurrentProject} for {$CurrentProject.Name} {/if}</a></b>
+    <b><a href='{$baseurl|default}/statistics/statistics_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">Click here for breakdown per participant {if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
     <br><br>
     <h2 class="statsH2">Double Data Entry Statistics:</h2>
 
@@ -100,14 +100,14 @@
             <td class=" pis">Per Instrument Stats</td>
             {foreach from=$Centers item=center key=centername}
                 <td id='{$center.ID}DDPIS' class="pis" colspan="2">
-                    <a href='{$baseurl}/statistics/statistics_dd_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID}' target="_blank">View Details</a>
+                    <a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$center.NumericID}&ProjectID={$CurrentProject.ID|default}' target="_blank">View Details</a>
                 </td>
             {/foreach}
         </tr>
         </tbody>
     </table>
     <div>
-        <b><a href='{$baseurl}/statistics/statistics_dd_site/?CenterID={$CurrentSite.ID}&ProjectID={$CurrentProject.ID}' target="_blank">Click here for breakdown per participant{if $CurrentSite} for {$CurrentSite.Name} {/if} {if $CurrentProject} for {$CurrentProject.Name} {/if}</a></b>
+        <b><a href='{$baseurl|default}/statistics/statistics_dd_site/?CenterID={$CurrentSite.ID|default}&ProjectID={$CurrentProject.ID|default}' target="_blank">Click here for breakdown per participant{if $CurrentSite|default} for {$CurrentSite.Name|default} {/if} {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</a></b>
     </div>
 </div>
 

--- a/modules/statistics/templates/form_stats_behavioural.tpl
+++ b/modules/statistics/templates/form_stats_behavioural.tpl
@@ -1,6 +1,6 @@
 <div id="data_entry">
     <h2 class="statsH2">Data Entry Statistics  {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</h2>
-    <script type="text/javascript" src="{$baseurl}/statistics/js/form_stats_behavioural.js"></script>
+    <script type="text/javascript" src="{$baseurl|default}/statistics/js/form_stats_behavioural.js"></script>
         <div class="col-sm-2">
             {html_options id="BehaviouralProject" options=$Projects name="BehaviouralProject" selected=$CurrentProject.ID|default class="form-control"}
         </div>

--- a/modules/statistics/templates/form_stats_demographic.tpl
+++ b/modules/statistics/templates/form_stats_demographic.tpl
@@ -8,7 +8,7 @@
     <div class="col-sm-3">
         {html_options id="DemographicProject" options=$Projects name="DemographicProject" selected=$CurrentProject.ID|default class="form-control"}
     </div>
-    <script type="text/javascript" src="{$baseurl}/statistics/js/form_stats_demographic.js"></script>
+    <script type="text/javascript" src="{$baseurl|default}/statistics/js/form_stats_demographic.js"></script>
     <button  onClick="updateDemographicTab()" class="btn btn-primary btn-small">Submit Query</button>
     <br><br>
     <table id="generalDemographics" class="data generalStats table table-primary table-bordered dynamictable">

--- a/modules/statistics/templates/form_stats_demographic.tpl
+++ b/modules/statistics/templates/form_stats_demographic.tpl
@@ -1,12 +1,12 @@
 <div id="demographics">
-    <h2 class="statsH2">General Demographic Statistics{if $CurrentSite} for {$CurrentSite.Name}{/if}
-        {if $CurrentProject} for {$CurrentProject.Name} {/if}</h2>
+    <h2 class="statsH2">General Demographic Statistics{if $CurrentSite|default} for {$CurrentSite.Name|default}{/if}
+        {if $CurrentProject|default} for {$CurrentProject.Name|default} {/if}</h2>
 
     <div class="col-sm-2">
-        {html_options id="DemographicSite" options=$Sites name="DemographicSite" selected=$CurrentSite.ID class="form-control"}
+        {html_options id="DemographicSite" options=$Sites name="DemographicSite" selected=$CurrentSite.ID|default class="form-control"}
     </div>
     <div class="col-sm-3">
-        {html_options id="DemographicProject" options=$Projects name="DemographicProject" selected=$CurrentProject.ID class="form-control"}
+        {html_options id="DemographicProject" options=$Projects name="DemographicProject" selected=$CurrentProject.ID|default class="form-control"}
     </div>
     <script type="text/javascript" src="{$baseurl}/statistics/js/form_stats_demographic.js"></script>
     <button  onClick="updateDemographicTab()" class="btn btn-primary btn-small">Submit Query</button>
@@ -15,10 +15,10 @@
         <thead>
         <tr>
             <th colspan="2" id="demog">Demographics</th>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 <th>Undefined</th>
             {/if}
-            {foreach from=$Subprojects item=name key=proj}
+            {foreach from=$Subprojects|default item=name key=proj}
                 <th>{$name}</th>
             {/foreach}
             <th class="data">Total</th>
@@ -27,14 +27,14 @@
         <tbody align="right">
         <tr>
             <td colspan="2" align="left">Registered candidates</td>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 {if {$registered[$keyid]}>0}
                     <td><b>{$registered[NULL]}</b></td>
                 {else}
                     <td><b>0</b></td>
                 {/if}
             {/if}
-            {foreach from=$Subprojects item=proj key=keyid}
+            {foreach from=$Subprojects|default item=proj key=keyid}
                 {if {$registered[$keyid]}>0}
                     <td><b>{$registered[$keyid]}</b></td>
                 {else}
@@ -46,7 +46,7 @@
         <tr >
             <td rowspan="2" align="left" style="vertical-align:middle;background-color: #FFFFFF;">Participant Status</td>
             <td align="left" class="status_active">Active</td>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 {if {$registered[$NULL]}>0}
                     {if {$ps_active[$NULL]}>0}
                         <td class="status_active">{$ps_active[$NULL]}<font size="1"><b>/{$registered[$NULL]}</b></font></td>
@@ -57,7 +57,7 @@
                     <td class="status_active">0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/if}
-            {foreach from=$Subprojects item=proj key=keyid}
+            {foreach from=$Subprojects|default item=proj key=keyid}
                 {if {$registered[$keyid]}>0}
                     {if {$ps_active[$keyid]}>0}
                         <td class="status_active">{$ps_active[$keyid]}<font size="1"><b>/{$registered[$keyid]}</b></font></td>
@@ -80,7 +80,7 @@
         </tr>
         <tr class="status_inactive">
             <td align="left" class="status_inactive">Inactive</td>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 {if {$registered[$NULL]}>0}
                     {if {$ps_inactive[$NULL]}>0}
                         <td class="status_inactive">{$ps_inactive[$NULL]}<font size="1"><b>/{$registered[$NULL]}</b></font></td>
@@ -91,7 +91,7 @@
                     <td class="status_inactive">0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/if}
-            {foreach from=$Subprojects item=proj key=keyid}
+            {foreach from=$Subprojects|default item=proj key=keyid}
                 {if {$registered[$keyid]}>0}
                     {if {$ps_inactive[$keyid]}>0}
                         <td class="status_inactive">{$ps_inactive[$keyid]}<font size="1"><b>/{$registered[$keyid]}</b></font></td>
@@ -117,7 +117,7 @@
         <tr>
             <td rowspan="2" align="left" style="vertical-align:middle">Sex</td>
             <td align="left" >Male</td>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 {if {$ps_active[$NULL]}>0}
                     {if {$sex_male[$NULL]}>0}
                         <td>{$sex_male[$NULL]}<font size="1"><b>/{$ps_active[$NULL]}</b></font></td>
@@ -128,7 +128,7 @@
                     <td>0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/if}
-            {foreach from=$Subprojects item=proj key=keyid}
+            {foreach from=$Subprojects|default item=proj key=keyid}
                 {if {$ps_active[$keyid]}>0}
                     {if {$sex_male[$keyid]}>0}
                         <td>{$sex_male[$keyid]}<font size="1"><b>/{$ps_active[$keyid]}</b></font></td>
@@ -152,7 +152,7 @@
         </tr>
         <tr>
             <td align="left">Female</td>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 {if {$ps_active[$NULL]}>0}
                     {if {$sex_female[$NULL]}>0}
                         <td >{$sex_female[$NULL]}<font size="1"><b>/{$ps_active[$NULL]}</b></font></td>
@@ -163,7 +163,7 @@
                     <td >0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/if}
-            {foreach from=$Subprojects item=proj key=keyid}
+            {foreach from=$Subprojects|default item=proj key=keyid}
                 {if {$ps_active[$keyid]}>0}
                     {if {$sex_female[$keyid]}>0}
                         <td >{$sex_female[$keyid]}<font size="1"><b>/{$ps_active[$keyid]}</b></font></td>
@@ -188,14 +188,14 @@
         </tr>
         <tr>
             <td colspan="2" align="left" style="vertical-align:middle">Age Average (months)</td>
-            {if {$CurrentProject.ID > 0}}
+            {if {$CurrentProject.ID|default > 0}}
                 {if {$age_avg[$NULL]}>0}
                     <td>{$age_avg[$NULL]}</td>
                 {else}
                     <td>0</td>
                 {/if}
             {/if}
-            {foreach from=$Subprojects item=proj key=keyid}
+            {foreach from=$Subprojects|default item=proj key=keyid}
                 {if {$age_avg[$keyid]}>0}
                     <td>{$age_avg[$keyid]}</td>
                 {else}

--- a/modules/statistics/templates/form_stats_demographic.tpl
+++ b/modules/statistics/templates/form_stats_demographic.tpl
@@ -28,14 +28,14 @@
         <tr>
             <td colspan="2" align="left">Registered candidates</td>
             {if {$CurrentProject.ID|default > 0}}
-                {if {$registered[$keyid]}>0}
+                {if {$registered[$keyid]|default}>0}
                     <td><b>{$registered[NULL]}</b></td>
                 {else}
                     <td><b>0</b></td>
                 {/if}
             {/if}
             {foreach from=$Subprojects|default item=proj key=keyid}
-                {if {$registered[$keyid]}>0}
+                {if {$registered[$keyid]|default}>0}
                     <td><b>{$registered[$keyid]}</b></td>
                 {else}
                     <td><b>0</b></td>
@@ -47,30 +47,30 @@
             <td rowspan="2" align="left" style="vertical-align:middle;background-color: #FFFFFF;">Participant Status</td>
             <td align="left" class="status_active">Active</td>
             {if {$CurrentProject.ID|default > 0}}
-                {if {$registered[$NULL]}>0}
-                    {if {$ps_active[$NULL]}>0}
-                        <td class="status_active">{$ps_active[$NULL]}<font size="1"><b>/{$registered[$NULL]}</b></font></td>
+                {if {$registered[$NULL]|default}>0}
+                    {if {$ps_active[$NULL]|default}>0}
+                        <td class="status_active">{$ps_active[$NULL]|default}<font size="1"><b>/{$registered[$NULL]}</b></font></td>
                     {else}
-                        <td class="status_active">0<font size="1"><b>/{$registered[$NULL]}</b></font></td>
+                        <td class="status_active">0<font size="1"><b>/{$registered[$NULL]|default}</b></font></td>
                     {/if}
                 {else}
                     <td class="status_active">0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/if}
             {foreach from=$Subprojects|default item=proj key=keyid}
-                {if {$registered[$keyid]}>0}
-                    {if {$ps_active[$keyid]}>0}
-                        <td class="status_active">{$ps_active[$keyid]}<font size="1"><b>/{$registered[$keyid]}</b></font></td>
+                {if {$registered[$keyid]|default}>0}
+                    {if {$ps_active[$keyid]|default}>0}
+                        <td class="status_active">{$ps_active[$keyid]|default}<font size="1"><b>/{$registered[$keyid]|default}</b></font></td>
                     {else}
-                        <td class="status_active">0<font size="1"><b>/{$registered[$keyid]}</b></font></td>
+                        <td class="status_active">0<font size="1"><b>/{$registered[$keyid]|default}</b></font></td>
                     {/if}
                 {else}
                     <td class="status_active">0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/foreach}
-            {if {$registered.total}>0}
+            {if {$registered.total|default}>0}
                 {if {$ps_active.total}>0}
-                    <td class="total">{$ps_active.total}<font size="1"><b>/{$registered.total}</b></font></td>
+                    <td class="total">{$ps_active.total|default}<font size="1"><b>/{$registered.total}</b></font></td>
                 {else}
                     <td class="total">0<font size="1"><b>/{$registered.total}</b></font></td>
                 {/if}
@@ -81,8 +81,8 @@
         <tr class="status_inactive">
             <td align="left" class="status_inactive">Inactive</td>
             {if {$CurrentProject.ID|default > 0}}
-                {if {$registered[$NULL]}>0}
-                    {if {$ps_inactive[$NULL]}>0}
+                {if {$registered[$NULL]|default}>0}
+                    {if {$ps_inactive[$NULL]|default}>0}
                         <td class="status_inactive">{$ps_inactive[$NULL]}<font size="1"><b>/{$registered[$NULL]}</b></font></td>
                     {else}
                         <td class="status_inactive">0<font size="1"><b>/{$registered[$NULL]}</b></font></td>
@@ -92,8 +92,8 @@
                 {/if}
             {/if}
             {foreach from=$Subprojects|default item=proj key=keyid}
-                {if {$registered[$keyid]}>0}
-                    {if {$ps_inactive[$keyid]}>0}
+                {if {$registered[$keyid]|default}>0}
+                    {if {$ps_inactive[$keyid]|default}>0}
                         <td class="status_inactive">{$ps_inactive[$keyid]}<font size="1"><b>/{$registered[$keyid]}</b></font></td>
                     {else}
                         <td class="status_inactive">0<font size="1"><b>/{$registered[$keyid]}</b></font></td>
@@ -102,8 +102,8 @@
                     <td class="status_inactive">0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/foreach}
-            {if {$registered.total}>0}
-                {if {$ps_inactive.total}>0}
+            {if {$registered.total|default}>0}
+                {if {$ps_inactive.total|default}>0}
                     <td class="total">{$ps_inactive.total}<font size="1"><b>/{$registered.total}</b></font></td>
                 {else}
                     <td class="total">0<font size="1"><b>/{$registered.total}</b></font></td>
@@ -118,9 +118,9 @@
             <td rowspan="2" align="left" style="vertical-align:middle">Sex</td>
             <td align="left" >Male</td>
             {if {$CurrentProject.ID|default > 0}}
-                {if {$ps_active[$NULL]}>0}
-                    {if {$sex_male[$NULL]}>0}
-                        <td>{$sex_male[$NULL]}<font size="1"><b>/{$ps_active[$NULL]}</b></font></td>
+                {if {$ps_active[$NULL]|default}>0}
+                    {if {$sex_male[$NULL]|default}>0}
+                        <td>{$sex_male[$NULL]}<font size="1"><b>/{$ps_active[$NULL]|default}</b></font></td>
                     {else}
                         <td>0<font size="1"><b>/{$ps_active[$NULL]}</b></font></td>
                     {/if}
@@ -129,21 +129,21 @@
                 {/if}
             {/if}
             {foreach from=$Subprojects|default item=proj key=keyid}
-                {if {$ps_active[$keyid]}>0}
-                    {if {$sex_male[$keyid]}>0}
-                        <td>{$sex_male[$keyid]}<font size="1"><b>/{$ps_active[$keyid]}</b></font></td>
+                {if {$ps_active[$keyid]|default}>0}
+                    {if {$sex_male[$keyid]|default}>0}
+                        <td>{$sex_male[$keyid]}<font size="1"><b>/{$ps_active[$keyid]|default}</b></font></td>
                     {else}
-                        <td>0<font size="1"><b>/{$ps_active[$keyid]}</b></font></td>
+                        <td>0<font size="1"><b>/{$ps_active[$keyid]|default}</b></font></td>
                     {/if}
                 {else}
                     <td>0<font size="1"><b>/0</b></font></td>
                 {/if}
             {/foreach}
-            {if {$ps_active.total}>0}
-                {if {$sex_male.total}>0}
-                    <td class="total">{$sex_male.total}<font size="1"><b>/{$ps_active.total}</b></font></td>
+            {if {$ps_active.total|default}>0}
+                {if {$sex_male.total|default}>0}
+                    <td class="total">{$sex_male.total}<font size="1"><b>/{$ps_active.total|default}</b></font></td>
                 {else}
-                    <td class="total">0<font size="1"><b>/{$ps_active.total}</b></font></td>
+                    <td class="total">0<font size="1"><b>/{$ps_active.total|default}</b></font></td>
                 {/if}
             {else}
                 <td class="total">0<font size="1"><b>/0</b></font></td>
@@ -153,8 +153,8 @@
         <tr>
             <td align="left">Female</td>
             {if {$CurrentProject.ID|default > 0}}
-                {if {$ps_active[$NULL]}>0}
-                    {if {$sex_female[$NULL]}>0}
+                {if {$ps_active[$NULL]|default}>0}
+                    {if {$sex_female[$NULL]|default}>0}
                         <td >{$sex_female[$NULL]}<font size="1"><b>/{$ps_active[$NULL]}</b></font></td>
                     {else}
                         <td >0<font size="1"><b>/{$ps_active[$NULL]}</b></font></td>
@@ -164,8 +164,8 @@
                 {/if}
             {/if}
             {foreach from=$Subprojects|default item=proj key=keyid}
-                {if {$ps_active[$keyid]}>0}
-                    {if {$sex_female[$keyid]}>0}
+                {if {$ps_active[$keyid]|default}>0}
+                    {if {$sex_female[$keyid]|default}>0}
                         <td >{$sex_female[$keyid]}<font size="1"><b>/{$ps_active[$keyid]}</b></font></td>
                     {else}
                         <td>0<font size="1"><b>/{$ps_active[$keyid]}</b></font></td>
@@ -175,8 +175,8 @@
                 {/if}
 
             {/foreach}
-            {if {$ps_active.total}>0}
-                {if {$sex_female.total}>0}
+            {if {$ps_active.total|default}>0}
+                {if {$sex_female.total|default}>0}
                     <td class="total">{$sex_female.total}<font size="1"><b>/{$ps_active.total}</b></font></td>
                 {else}
                     <td class="total">0<font size="1"><b>/{$ps_active.total}</b></font></td>
@@ -189,14 +189,14 @@
         <tr>
             <td colspan="2" align="left" style="vertical-align:middle">Age Average (months)</td>
             {if {$CurrentProject.ID|default > 0}}
-                {if {$age_avg[$NULL]}>0}
+                {if {$age_avg[$NULL]|default}>0}
                     <td>{$age_avg[$NULL]}</td>
                 {else}
                     <td>0</td>
                 {/if}
             {/if}
             {foreach from=$Subprojects|default item=proj key=keyid}
-                {if {$age_avg[$keyid]}>0}
+                {if {$age_avg[$keyid]|default}>0}
                     <td>{$age_avg[$keyid]}</td>
                 {else}
                     <td>0</td>

--- a/modules/statistics/templates/progress_bar.tpl
+++ b/modules/statistics/templates/progress_bar.tpl
@@ -1,6 +1,6 @@
-  {if $project['recruitment_target'] neq ""}
+  {if $project['recruitment_target']|default neq ""}
     <h5>{$project['title']}</h5>
-    {if $project['surpassed_recruitment'] eq "true"}
+    {if $project['surpassed_recruitment']|default eq "true"}
         <p>The recruitment target ({$project['recruitment_target']}) has been passed.</p>
         <div class="progress">
             <div class="progress-bar progress-bar-female" role="progressbar" style="width: {$project['female_full_percent']}%" data-toggle="tooltip" data-placement="bottom" title="{$project['female_full_percent']}%">

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -12,7 +12,7 @@
      - Visits (the visits to display)
      - Data (the data that populates the table)
  *}
-<script type="text/javascript" src="{$baseurl}/statistics/js/table_statistics.js"></script>
+<script type="text/javascript" src="{$baseurl|default}/statistics/js/table_statistics.js"></script>
 <h2 class="statsH3">{$SectionHeader}</h2>
 <h3 class="statsH3">{$TableHeader}</h3>
 <p>{$Disclamer}</p>

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -92,7 +92,7 @@
           {assign var="subtotal" value="0" }
           {foreach key=sub item=subcat from=$Subcategories}
             {if $subcat@index eq 0}
-              {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]}
+              {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]|default}
               {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total}}
               {if $subtotal > 0 and $Numerator > 0}
                 {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
@@ -108,8 +108,8 @@
         {* Totals for row *}
         {foreach key=sub item=subcat from=$Subcategories}
           {if $subcat@index eq 0}
-            {assign var="Numerator" value=$data[$center.ID][$visit][$Subcategories.0]}
-            {assign var="rowtotal" value=$data[$center.ID][$visit].total}
+            {assign var="Numerator" value=$data[$center.ID][$visit][$Subcategories.0]|default}
+            {assign var="rowtotal" value=$data[$center.ID][$visit].total|default}
             {if $rowtotal > 0 and $Numerator > 0}
               {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$rowtotal format="%.0f"}}
             {else}
@@ -129,7 +129,7 @@
         {assign var="sitetotal" value="0"}
         {foreach key=sub item=subcat from=$Subcategories}
           {if $subcat@index eq 0}
-            {assign var="Numerator" value=$data[$proj][$center.ID][$Subcategories.0]}
+            {assign var="Numerator" value=$data[$proj][$center.ID][$Subcategories.0]|default}
             {assign var="sitetotal" value=$data[$proj][$center.ID].total}
             {if $sitetotal > 0 and $Numerator > 0}
               {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$sitetotal format="%.0f"}}
@@ -144,7 +144,7 @@
       {/foreach}
       {foreach key=sub item=subcat from=$Subcategories}
         {if $subcat@index eq 0}
-          {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]}
+          {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]|default}
           {assign var="totalsitetotal" value=$data[$center.ID].total}
           {if $totalsitetotal > 0 and $Numerator > 0}
             {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totalsitetotal format="%.0f"}}
@@ -174,7 +174,7 @@
           {assign var="subtotal" value="0" }
           {foreach key=sub item=subcat from=$Subcategories}
             {if $subcat@index eq 0}
-              {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]}
+              {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]|default}
               {assign var="subtotal" value={$data[$proj][$visit].total}}
               {if $subtotal > 0 and $Numerator > 0}
                 {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
@@ -190,7 +190,7 @@
         {assign var="finaltotal" value="0" }
         {foreach key=sub item=subcat from=$Subcategories}
           {if $subcat@index eq 0}
-            {assign var="Numerator" value=$data[$visit][$Subcategories.0]}
+            {assign var="Numerator" value=$data[$visit][$Subcategories.0]|default}
             {assign var="finaltotal" value=$data[$visit].total}
             {if $finaltotal > 0 and $Numerator > 0}
               {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$finaltotal format="%.0f"}}
@@ -214,7 +214,7 @@
         {assign var="total" value="0"}
         {foreach key=sub item=subcat from=$Subcategories}
           {if $subcat@index eq 0}
-            {assign var="Numerator" value=$data[$proj][$Subcategories.0]}
+            {assign var="Numerator" value=$data[$proj][$Subcategories.0]|default}
             {assign var="total" value=$data[$proj].total}
             {if $total > 0 and $Numerator > 0}
               {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$total format="%.0f"}}
@@ -230,7 +230,7 @@
       {* Totals for grand total *}
       {foreach key=sub item=subcat from=$Subcategories}
         {if $subcat@index eq 0}
-          {assign var="Numerator" value=$data[$Subcategories.0]}
+          {assign var="Numerator" value=$data[$Subcategories.0]|default}
           {assign var="totaltotal" value=$data.total}
           {if $totaltotal > 0 and $Numerator > 0}
             {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totaltotal format="%.0f"}}

--- a/modules/statistics/templates/table_statistics.tpl
+++ b/modules/statistics/templates/table_statistics.tpl
@@ -93,7 +93,7 @@
           {foreach key=sub item=subcat from=$Subcategories}
             {if $subcat@index eq 0}
               {assign var="Numerator" value=$data[$proj][$center.ID][$visit][$Subcategories.0]|default}
-              {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total}}
+              {assign var="subtotal" value={$data[$proj][$center.ID][$visit].total|default}}
               {if $subtotal > 0 and $Numerator > 0}
                 {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
               {else}
@@ -145,7 +145,7 @@
       {foreach key=sub item=subcat from=$Subcategories}
         {if $subcat@index eq 0}
           {assign var="Numerator" value=$data[$center.ID][$Subcategories.0]|default}
-          {assign var="totalsitetotal" value=$data[$center.ID].total}
+          {assign var="totalsitetotal" value=$data[$center.ID].total|default}
           {if $totalsitetotal > 0 and $Numerator > 0}
             {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totalsitetotal format="%.0f"}}
           {else}
@@ -175,7 +175,7 @@
           {foreach key=sub item=subcat from=$Subcategories}
             {if $subcat@index eq 0}
               {assign var="Numerator" value=$data[$proj][$visit][$Subcategories.0]|default}
-              {assign var="subtotal" value={$data[$proj][$visit].total}}
+              {assign var="subtotal" value={$data[$proj][$visit].total|default}}
               {if $subtotal > 0 and $Numerator > 0}
                 {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$subtotal format="%.0f"}}
               {else}
@@ -191,7 +191,7 @@
         {foreach key=sub item=subcat from=$Subcategories}
           {if $subcat@index eq 0}
             {assign var="Numerator" value=$data[$visit][$Subcategories.0]|default}
-            {assign var="finaltotal" value=$data[$visit].total}
+            {assign var="finaltotal" value=$data[$visit].total|default}
             {if $finaltotal > 0 and $Numerator > 0}
               {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$finaltotal format="%.0f"}}
             {else}
@@ -215,7 +215,7 @@
         {foreach key=sub item=subcat from=$Subcategories}
           {if $subcat@index eq 0}
             {assign var="Numerator" value=$data[$proj][$Subcategories.0]|default}
-            {assign var="total" value=$data[$proj].total}
+            {assign var="total" value=$data[$proj].total|default}
             {if $total > 0 and $Numerator > 0}
               {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$total format="%.0f"}}
             {else}
@@ -231,7 +231,7 @@
       {foreach key=sub item=subcat from=$Subcategories}
         {if $subcat@index eq 0}
           {assign var="Numerator" value=$data[$Subcategories.0]|default}
-          {assign var="totaltotal" value=$data.total}
+          {assign var="totaltotal" value=$data.total|default}
           {if $totaltotal > 0 and $Numerator > 0}
             {assign var="percent" value={math equation="x*y/z" x=$Numerator y=100 z=$totaltotal format="%.0f"}}
           {else}

--- a/modules/timepoint_list/templates/menu_timepoint_list.tpl
+++ b/modules/timepoint_list/templates/menu_timepoint_list.tpl
@@ -85,14 +85,14 @@
     <tbody>
     {section name=timepoint loop=$timePoints}
         <tr>
-            <td><a href="{$baseurl}/instrument_list/?candID={$candID}&sessionID={$timePoints[timepoint].SessionID}">{$timePoints[timepoint].Visit_label}</a></td>
+            <td><a href="{$baseurl|default}/instrument_list/?candID={$candID}&sessionID={$timePoints[timepoint].SessionID}">{$timePoints[timepoint].Visit_label}</a></td>
 
             <td>{$timePoints[timepoint].SubprojectTitle}</td>
 
             <td>{$timePoints[timepoint].SiteAlias}</td>
             <td>{$timePoints[timepoint].ProjectName}</td>
 
-            {if $timePoints[timepoint].staticStage != "" || $timePoints[timepoint].Current_stage == "Not Started"}
+            {if $timePoints[timepoint].staticStage|default != "" || $timePoints[timepoint].Current_stage == "Not Started"}
             <td colspan="3">{$timePoints[timepoint].Current_stage}</td>
             {else}
             <td>{$timePoints[timepoint].Current_stage}</td>
@@ -102,7 +102,7 @@
 
             <td>
             {if $timePoints[timepoint].Submitted == "Y"}
-        	    <img src="{$baseurl}/images/check_blue.gif" border="0" />
+        	    <img src="{$baseurl|default}/images/check_blue.gif" border="0" />
             {else}
         	    -
             {/if}
@@ -111,14 +111,14 @@
             {if $timePoints[timepoint].Scan_done != ""}
                     {if $timePoints[timepoint].Scan_done == 'Y'}
                         {assign var="scan_done" value="Yes"}
-                        <a href="{$baseurl}/imaging_browser/viewSession/?sessionID={$timePoints[timepoint].SessionID}" class="timepoint_list">
+                        <a href="{$baseurl|default}/imaging_browser/viewSession/?sessionID={$timePoints[timepoint].SessionID}" class="timepoint_list">
                         {$scan_done}</a>
                     {else}
                         {assign var="scan_done" value="No"}
                         {$scan_done}
                     {/if}
             {else}
-                <img alt="Data Missing" src="{$baseurl}/images/help2.gif" border=0>
+                <img alt="Data Missing" src="{$baseurl|default}/images/help2.gif" border=0>
             {/if}
             </td>
 
@@ -134,7 +134,7 @@
             {if $timePoints[timepoint].BVLQCStatus}
                 {$timePoints[timepoint].BVLQCType}
             {else}
-                <img src="{$baseurl}/images/delete.gif" border="0" />
+                <img src="{$baseurl|default}/images/delete.gif" border="0" />
             {/if}
             </td>
 
@@ -146,7 +146,7 @@
                 Fail
                 {/if}
             {else}
-                <img src="{$baseurl}/images/delete.gif" border="0" />
+                <img src="{$baseurl|default}/images/delete.gif" border="0" />
             {/if}
             </td>
 

--- a/modules/user_accounts/templates/form_edit_user.tpl
+++ b/modules/user_accounts/templates/form_edit_user.tpl
@@ -30,15 +30,15 @@
 	    </ul>
         {/foreach} -->
         <!-- <div class="row"> -->
-        {if $form.errors.UserID_Group}
+        {if $form.errors.UserID_Group|default}
         <div class="row form-group form-inline form-inline has-error">
             {else}
             <div class="row form-group form-inline form-inline">
                 {/if}
-                {if $form.UserID_Group != null}
+                {if $form.UserID_Group|default != null}
                 <label class="col-sm-12 col-sm-2 form-label">
                     {$form.UserID_Group.label}
-                    {if $form.UserID_Group.options.required}
+                    {if $form.UserID_Group.options.required|default}
                         <span class="userid-star" style="color: red">*</span>
                     {/if}
              </label>
@@ -53,7 +53,7 @@
             {else}
             <label class="col-sm-12 col-sm-2 form-label">
                 {$form.UserID.label}
-                {if $form.UserID.options.required}
+                {if $form.UserID.options.required|default}
                     <span style="color: red">*</span>
                 {/if}
             </label>
@@ -65,20 +65,20 @@
      </div>
      <!-- </div> -->
      <br>
-     {if $form.errors.Password}
+     {if $form.errors.Password|default}
         <div class="row form-group form-inline has-error">
      {else}
         <div class="row form-group form-inline">
      {/if}
           <label class="col-sm-2">
-            {$form.Password_hash.label}
+            {$form.Password_hash.label|default}
             <span class="pwd-star password {if isset($form.Password_hash.required) && $form.Password_hash.required} required{/if}" style="color: red">*</span>
           </label>
           <div class="col-sm-2">
               <input type="password" name="{$form.Password_hash.name}" />
           </div>
           <div class="col-sm-4">{$form.NA_Password.html}</div>
-          {if $form.errors.Password}
+          {if $form.errors.Password|default}
           <div class="col-sm-offset-2 col-xs-12">
             <font class="form-error">{$form.errors.Password}</font>
         </div>
@@ -101,41 +101,41 @@
             {$form.Real_name.html}
         </div>
     </div> -->
-    {if $form.errors.First_name}
+    {if $form.errors.First_name|default}
     <div class="row form-group form-inline form-inline has-error">
         {else}
         <div class="row form-group form-inline form-inline">
             {/if}
             <label class="col-sm-2 form-label">
-                {$form.First_name.label}
-                {if $form.First_name.required}
+                {$form.First_name.label|default}
+                {if $form.First_name.required|default}
                     <span style="color: red">*</span>
                 {/if}
           </label>
           <div class="col-sm-10">
               {$form.First_name.html}
           </div>
-          {if $form.errors.First_name}
+          {if $form.errors.First_name|default}
           <div class="col-sm-offset-2 col-xs-12">
-            <font class="form-error">{$form.errors.First_name}</font>
+            <font class="form-error">{$form.errors.First_name|default}</font>
         </div>
         {/if}
     </div>
-    {if $form.errors.Last_name}
+    {if $form.errors.Last_name|default}
     <div class="row form-group form-inline form-inline has-error">
         {else}
         <div class="row form-group form-inline form-inline">
             {/if}
             <label class="col-sm-2 form-label">
                 {$form.Last_name.label}
-                {if $form.Last_name.required}
+                {if $form.Last_name.required|default}
                     <span style="color: red">*</span>
                 {/if}
           </label>
           <div class="col-sm-10">
               {$form.Last_name.html}
           </div>
-          {if $form.errors.Last_name}
+          {if $form.errors.Last_name|default}
           <div class="col-sm-offset-2 col-xs-12">
             <font class="form-error">{$form.errors.Last_name}</font>
         </div>
@@ -145,7 +145,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Degree.label}
-            {if $form.Degree.required}
+            {if $form.Degree.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -158,7 +158,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Position_title.label}
-            {if $form.Position_title.required}
+            {if $form.Position_title.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -171,7 +171,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Institution.label}
-            {if $form.Institution.required}
+            {if $form.Institution.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -184,7 +184,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Department.label}
-            {if $form.Department.required}
+            {if $form.Department.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -197,7 +197,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Address.label}
-            {if $form.Address.required}
+            {if $form.Address.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -210,7 +210,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.City.label}
-            {if $form.City.required}
+            {if $form.City.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -223,7 +223,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.State.label}
-            {if $form.State.required}
+            {if $form.State.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -232,11 +232,11 @@
     	</div>
     </div>
     {/if}
-    {if $form.ZipCode}
+    {if $form.ZipCode|default}
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Zip_code.label}
-            {if $form.Zip_code.required}
+            {if $form.Zip_code.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -249,7 +249,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Country.label}
-            {if $form.Country.required}
+            {if $form.Country.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -262,7 +262,7 @@
     <div class="row form-group form-inline">
     	<label class="col-sm-2">
             {$form.Fax.label}
-            {if $form.Fax.required}
+            {if $form.Fax.required|default}
                 <span style="color: red">*</span>
             {/if}
     	</label>
@@ -271,27 +271,27 @@
     	</div>
     </div>
     {/if}
-    {if $form.errors.Email_Group}
+    {if $form.errors.Email_Group|default}
     <div class="row form-group form-inline form-inline has-error">
         {else}
         <div class="row form-group form-inline form-inline">
             {/if}
             <label class="col-sm-2 form-label">
                 {$form.Email_Group.label}
-                {if $form.Email_Group.options.required}
+                {if $form.Email_Group.options.required|default}
                     <span style="color: red">*</span>
                 {/if}
           </label>
           <div class="col-sm-10">
               {$form.Email_Group.html}
           </div>
-          {if $form.errors.Email_Group}
+          {if $form.errors.Email_Group|default}
           <div class="col-sm-offset-2 col-xs-12">
             <font class="form-error">{$form.errors.Email_Group}</font>
         </div>
         {/if}
     </div>
-    {if $form.__ConfirmEmail}
+    {if $form.__ConfirmEmail|default}
     {if $form.errors.__ConfirmEmail}
     <div class="row form-group form-inline form-inline has-error">
         {else}
@@ -313,7 +313,7 @@
         {/if}
     </div>
     {/if}
-    {if $form.errors.sites_group}
+    {if $form.errors.sites_group|default}
     <div class="row form-group form-inline has-error">
     {else}
     <div class="row form-group form-inline">
@@ -327,13 +327,13 @@
         <div class="col-sm-10">
             {$form.CenterIDs.html}
         </div>
-        {if $form.errors.sites_group}
+        {if $form.errors.sites_group|default}
         <div class="col-sm-offset-2 col-xs-12">
             <font class="form-error">{$form.errors.sites_group}</font>
         </div>
         {/if}
     </div>
-        {if $form.errors.projects_group}
+        {if $form.errors.projects_group|default}
         <div class="row form-group form-inline has-error">
             {else}
             <div class="row form-group form-inline">
@@ -347,50 +347,50 @@
                 <div class="col-sm-10">
                     {$form.ProjectIDs.html}
                 </div>
-                {if $form.errors.projects_group}
+                {if $form.errors.projects_group|default}
                     <div class="col-sm-offset-2 col-xs-12">
                         <font class="form-error">{$form.errors.projects_group}</font>
                     </div>
                 {/if}
             </div>
-    {if $form.examiner_sites}
-    {if $form.errors.examiner_sites}
+    {if $form.examiner_sites|default}
+    {if $form.errors.examiner_sites|default}
     <div class="row form-group form-inline form-inline has-error">
         {else}
         <div class="row form-group form-inline form-inline">
             {/if}
             <label class="col-sm-2">
                 {$form.examiner_sites.label}
-                {if $form.examiner_sites.required}
+                {if $form.examiner_sites.required|default}
                     <span style="color: red">*</span>
                 {/if}
             </label>
             <div class="col-sm-10">
                 {$form.examiner_sites.html}
             </div>
-            {if $form.errors.examiner_sites}
+            {if $form.errors.examiner_sites|default}
             <div class="col-sm-offset-2 col-xs-12">
                 <font class="form-error">{$form.errors.examiner_sites}</font>
             </div>
             {/if}
         </div>
     {/if}
-      {if $form.examiner_group}
-    {if $form.errors.examiner_group}
+      {if $form.examiner_group|default}
+    {if $form.errors.examiner_group|default}
     <div class="row form-group form-inline form-inline has-error">
         {else}
         <div class="row form-group form-inline form-inline">
             {/if}
             <label class="col-sm-2">
                 {$form.examiner_group.label}
-                {if $form.examiner_group.required}
+                {if $form.examiner_group.required|default}
                     <span style="color: red">*</span>
                 {/if}
             </label>
             <div class="col-sm-10">
                 <b>{$form.examiner_group.html}</b>
                 </div>
-                {if $form.errors.examiner_group}
+                {if $form.errors.examiner_group|default}
                 <div class="col-sm-offset-2 col-xs-12">
                     <font class="form-error">{$form.errors.examiner_group}</font>
                 </div>
@@ -399,50 +399,50 @@
       {/if}
       <div class="row form-group form-inline">
            <label class="col-sm-2">
-               {$form.Active.label}
-               {if $form.Active.required}
+               {$form.Active.label|default}
+               {if $form.Active.required|default}
                    <span style="color: red">*</span>
                {/if}
           </label>
           <div class="col-sm-10">
-              {$form.Active.html}
+              {$form.Active.html|default}
           </div>
       </div>
 
-	{if $form.errors.active_timeWindows}
+	{if $form.errors.active_timeWindows|default}
 	    <div class="alert alert-danger" role="alert">
-	        {$form.errors.active_timeWindows}
+	        {$form.errors.active_timeWindows|default}
 	    </div>
 	{/if}
 
-	{if $form.errors.active_timeWindows}
+	{if $form.errors.active_timeWindows|default}
 		<div class="row form-group form-inline form-inline has-error">
 	{else}
 		<div class="row form-group form-inline">
 	{/if}
 		<label class="col-sm-2">
-			{$form.active_from.label}
-            {if $form.active_from.required}
+			{$form.active_from.label|default}
+            {if $form.active_from.required|default}
                 <span style="color: red">*</span>
             {/if}
 		 </label>
 		 <div class="col-sm-10">
-			{$form.active_from.html}
+			{$form.active_from.html|default}
 		 </div>
 	</div>
-	{if $form.errors.active_timeWindows}
+	{if $form.errors.active_timeWindows|default}
 		<div class="row form-group form-inline form-inline has-error">
 	{else}
 		<div class="row form-group form-inline">
 	{/if}
 		<label class="col-sm-2">
-			{$form.active_to.label}
-            {if $form.active_to.required}
+			{$form.active_to.label|default}
+            {if $form.active_to.required|default}
                 <span style="color: red">*</span>
             {/if}
 		 </label>
 		 <div class="col-sm-10">
-			{$form.active_to.html}
+			{$form.active_to.html|default}
 		 </div>
 	</div>
 
@@ -457,19 +457,19 @@
 
       <div class="row form-group form-inline">
        <label class="col-sm-2">
-           {$form.Pending_approval.label}
-           {if $form.Pending_approval.required}
+           {$form.Pending_approval.label|default}
+           {if $form.Pending_approval.required|default}
                <span style="color: red">*</span>
            {/if}
       </label>
       <div class="col-sm-10">
-          {$form.Pending_approval.html}
+          {$form.Pending_approval.html|default}
       </div>
   </div>
   <div class="row form-group form-inline">
    <label class="col-sm-2">
        {$form.PermID_Group.label}
-       {if $form.PermID_Group.required}
+       {if $form.PermID_Group.required|default}
            <span style="color: red">*</span>
        {/if}
   </label>
@@ -482,7 +482,7 @@
 <div class="row form-group form-inline">
     <label class="col-sm-2">
         {$form.Supervisors_Group.label}
-        {if $form.Supervisors_Group.required}
+        {if $form.Supervisors_Group.required|default}
             <span style="color: red">*</span>
         {/if}
   </label>
@@ -500,7 +500,7 @@
     <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset"/>
 </div>
 <div class="col-sm-2">
-  <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/user_accounts/'" value="Back" type="button" />
+  <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl|default}/user_accounts/'" value="Back" type="button" />
 </div>
 {if $can_reject}
 

--- a/smarty/templates/bvl_feedback_panel.tpl
+++ b/smarty/templates/bvl_feedback_panel.tpl
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{$baseurl}/css/panel.css" type="text/css"/>
+<link rel="stylesheet" href="{$baseurl|default}/css/panel.css" type="text/css"/>
 <meta itemprop="candID" context="{$candID}">
 <meta itemprop="sessionID" context="{$sessionID}">
 <meta itemprop="commentID" context="{$commentID}">
@@ -9,8 +9,8 @@
   </div><!-- /panel -->
 </body>
 
-<script type="text/javascript" src ="{$baseurl}/bvl_feedback/js/bvl_feedback_panel_jquery.js"></script>
-<script type="text/javascript" src="{$baseurl}/bvl_feedback/js/react.behavioural_feedback_panel.js"></script>
+<script type="text/javascript" src ="{$baseurl|default}/bvl_feedback/js/bvl_feedback_panel_jquery.js"></script>
+<script type="text/javascript" src="{$baseurl|default}/bvl_feedback/js/react.behavioural_feedback_panel.js"></script>
 <script type="text/javascript">
   var feedback_level = {$feedback_level|@json_encode};
   var candID = {$candID|@json_encode};

--- a/smarty/templates/feedback_mri_popup.tpl
+++ b/smarty/templates/feedback_mri_popup.tpl
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <link rel="stylesheet" href="{$css}" type="text/css" />
 <!-- shortcut icon that displays on the browser window -->
-<link rel="shortcut icon" href="{$baseurl}/images/mni_icon.ico" type="image/ico" />
+<link rel="shortcut icon" href="{$baseurl|default}/images/mni_icon.ico" type="image/ico" />
 
 <title>DCC MRI Quality Control</title>
 </head>
@@ -17,7 +17,7 @@
 
 <div>
 
-{if $saved}
+{if $saved|default}
 <p>Comments saved.</p>
 {/if}
 
@@ -36,12 +36,12 @@
 
 {foreach from=$comment item=curr_comment}
 <h3>
-{if $curr_comment.select_value_array and $curr_comment.select_name}
+{if $curr_comment.select_value_array|default and $curr_comment.select_name|default}
 {* the assign is simply because i [jharlap] don't have time to figure out how to make this work otherwise *}
 {assign var="save_comment_status_field_name" value="saveCommentStatusField["|cat:$curr_comment.select_name|cat:"]"}
-{html_options name=$save_comment_status_field_name values=$curr_comment.select_value_array selected=$curr_comment.selected output=$curr_comment.select_value_array}
+{html_options name=$save_comment_status_field_name values=$curr_comment.select_value_array selected=$curr_comment.selected|default output=$curr_comment.select_value_array}
 {else}
-{$curr_comment.selected}
+{$curr_comment.selected|default}
 {/if}
 {$curr_comment.name}
 </h3>

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -27,7 +27,7 @@
         </title>
         <script type="text/javascript">
           $(document).ready(function() {
-            {if $breadcrumbs != "" && empty($error_message)}
+            {if $breadcrumbs|default != "" && empty($error_message)}
               const breadcrumbs = [{$breadcrumbs}];
 
               ReactDOM.render(
@@ -212,7 +212,7 @@
                     </div>
 
                 {/if}
-                {if $breadcrumbs != "" && empty($error_message)}
+                {if $breadcrumbs|default != "" && empty($error_message)}
                     <div id="breadcrumbs"></div>
                 {/if}
                         <div>

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -176,7 +176,7 @@
 			{/if}
 		    <div id="bvl_panel_wrapper">
                 <!-- Sidebar -->
-                            {$feedback_panel}
+                            {$feedback_panel|default}
 			    {if $control_panel|default}
                     <div id="sidebar-wrapper" class="sidebar-div">
                        <div id="sidebar-content">

--- a/smarty/templates/main.tpl
+++ b/smarty/templates/main.tpl
@@ -90,7 +90,7 @@
                             <span class="sr-only">Toggle navigation</span>
                             <img width=17 src="{$baseurl}/images/help.gif">
                         </button>
-                       {if $bvl_feedback}
+                       {if $bvl_feedback|default}
                        <button type="button" class="navbar-toggle">
                             <span class="sr-only">Toggle navigation</span>
                             <span class="glyphicon glyphicon-edit" style="color:white"></span>
@@ -99,7 +99,7 @@
 
 
                        <!-- toggle sidebar in mobile view -->
-                        {if $control_panel}
+                        {if $control_panel|default}
                             <a id="menu-toggle" href="#" class="navbar-brand">
                                 <span class="glyphicon glyphicon-th-list"></span>
                             </a>
@@ -124,7 +124,7 @@
                             {/foreach}
                         </ul>
                         <ul class="nav navbar-nav navbar-right" id="nav-right">
-                            {if $bvl_feedback}
+                            {if $bvl_feedback|default}
                             <li class="hidden-xs hidden-sm">
                                 <a href="#" class="navbar-toggle" data-toggle="offcanvas" data-target=".navmenu" data-canvas="body">
                                     <span class="glyphicon glyphicon-edit"></span>
@@ -170,14 +170,14 @@
             </nav>
         {/if}
         <div id="page" class="container-fluid">
-		{if $control_panel or $feedback_panel}
-			{if $control_panel}
+		{if $control_panel|default or $feedback_panel|default}
+			{if $control_panel|default}
 				<div id = "page_wrapper_sidebar" class ="wrapper">
 			{/if}
 		    <div id="bvl_panel_wrapper">
                 <!-- Sidebar -->
                             {$feedback_panel}
-			    {if $control_panel}
+			    {if $control_panel|default}
                     <div id="sidebar-wrapper" class="sidebar-div">
                        <div id="sidebar-content">
                             {$control_panel}
@@ -216,7 +216,7 @@
                     <div id="breadcrumbs"></div>
                 {/if}
                         <div>
-                            {if $error_message != ""}
+                            {if $error_message|default != ""}
                                 <p>
                                     The following errors occurred while attempting to display this page:
                                     <ul>
@@ -258,12 +258,12 @@
 
 	</div>
 
-        {if $control_panel or $feedback_panel}
+        {if $control_panel|default or $feedback_panel|default}
         </div></div>
         {/if}
 
         {if $dynamictabs neq "dynamictabs"}
-            {if $control_panel}
+            {if $control_panel|default}
             <div id="footer" class="footer navbar-bottom wrapper">
             {else}
             <div id="footer" class="footer navbar-bottom">

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -135,7 +135,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
-        $page = $request->getAttribute("pageclass");
+        $page = $request->getAttribute("pageclass") ?? '';
         if (method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -135,7 +135,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
-        $page = $request->getAttribute("pageclass") ?? '';
+        $page = $request->getAttribute("pageclass");
         if (method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null


### PR DESCRIPTION
## Brief summary of changes

Updating to use php 8 and updating composer.json dependencies results in smarty polluting error_log about undefined variables. $some_variable|default will mimic the existing behaviour and have the variable be set to an empty string if undefined. 

#### Testing instructions (if applicable)

1. Checkout PR.
2. Visit Loris everywhere

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
