### PR TITLE
[LINST] Implement getFullName() and getSubtestList() and fix numeric type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 - *Add item here*
 ### Notes For Existing Projects
 - New function Candidate::getSubjectForMostRecentVisit replaces Utility::getSubprojectIDUsingCandID, adding ability to determine which subproject a candidate belongs to given their most recent visit.
+- LINST instrument class was modified to implement the getFullName() and getSubtestList() functions thus making entries in the test_names and instrument_subtests tables respectively unnecessary for LINST instruments (PR #7169)
 ### Notes For Developers
 - *Add item here*
 

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -23,18 +23,15 @@ namespace Loris\Behavioural;
  */
 class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 {
-    /**
-     * FIXME: LINST instruments should parse the full name
-     * and the subtest names from the linst file, not select
-     * them from the database.
-     */
-    use \LegacyInstrumentTrait;
-
     public $InstrumentType = 'LINST';
 
     public $LinstQuestions = [];
 
     public $LinstLines = [];
+
+    protected $subtests = [];
+
+    protected $fullName;
 
     /**
      * Sets up the variables required for a LINST instrument to load
@@ -160,7 +157,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             // dealing with _status==not_answered easier, because the rules for
             // enforcing range are independent of the rules for enforcing
             // required.
-            if ($this->LinstQuestions[$elname]['type'] === 'numeric') {
+            if (isset($this->LinstQuestions[$elname])
+                && $this->LinstQuestions[$elname]['type'] === 'numeric'
+            ) {
                 // Cast everything to a double so that < and > work as
                 // expected
                 $value = doubleval($elements[$elname]);
@@ -391,7 +390,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
     {
         if (file_exists($filename) || $base64 === true) {
             $this->InstrumentType = 'LINST';
-            $db = \Database::singleton();
 
             if (!isset($this->form)) {
                 $this->form = new \LorisForm();
@@ -413,8 +411,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 $currentPage = 'top';
                 $addElements = true;
             }
+            $subtestCount = 1;
 
-            $parsingPage      = 'top';
             $firstFieldOfPage = true;
 
             $Group = [
@@ -445,28 +443,27 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 }
                 switch($type) {
                 case 'page':
-                    $parsingPage = trim($pieces[2]);
-                    $pageName    = $db->pselectOne(
-                        "SELECT Subtest_name
-                        FROM instrument_subtests
-                        WHERE Test_name=:testinst AND Description=:parsing",
-                        [
-                            'testinst' => $this->testName,
-                            'parsing'  => $parsingPage,
-                        ]
-                    );
+                    $pageDescription  = trim($pieces[2]);
+                    $pageName         = "page_$subtestCount";
+                    $this->subtests[] = [
+                        'Name'        => $pageName,
+                        'Description' => $pageDescription
+                    ];
+
                     if ($currentPage == $pageName) {
                         $addElements = true;
                     } else {
                         $addElements = false;
                     }
                     $firstFieldOfPage = true;
+                    $subtestCount++;
                     break;
                 case 'table':
                     $this->testName = trim($pieces[1]);
                     $this->table    = trim($pieces[1]);
                     break;
                 case 'title':
+                    $this->fullName = $pieces[1];
                     if ($addElements) {
                         $this->form->addElement(
                             'header',
@@ -622,8 +619,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         $this->_requiredElements[] = $fieldname;
                         $firstFieldOfPage          = false;
                     }
-                    // FIXME: This variable is never populated.
-                    $options = [];
+                    $options = [
+                        'min' =>$pieces[3] ?? null,
+                        'max' =>$pieces[4] ?? null
+                    ];
                     $this->LinstQuestions[$pieces[1]]
                         = [
                             'type'    => 'numeric',
@@ -942,7 +941,27 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         return json_encode($jsonObject);
     }
 
+    /**
+     * Return the full, human readable name for the
+     * current instrument.
+     *
+     * @return ?string the full name of the instrument
+     */
+    public function getFullName(): ?string
+    {
+        return $this->fullName;
+    }
 
+    /**
+     * Returns a list of subtests of the current instrument.
+     * The returned array should be a list of rows where each
+     * row has a key for "Name" (the subpage name) and "Description"
+     * (the human readable name)
+     *
+     * @return array
+     */
+    function getSubtestList(): array
+    {
+        return $this->subtests;
+    }
 }
-
-

--- a/raisinbread/instruments/bmi.linst
+++ b/raisinbread/instruments/bmi.linst
@@ -6,17 +6,20 @@ static{@}Window_Difference{@}Window Difference (+/- Days)
 select{@}Examiner{@}Examiner{@}NULL=>''
 static{@}{@}Note: Please enter measurements in Standard OR Metric units
 select{@}unit_classification{@}Choose unit of measurement{@}NULL=>''{-}'metric'=>'Metric'{-}'standard'=>'Standard'
+page{@}{@}Standard units
 static{@}{@}Standard units
 numeric{@}height_feet{@}Your height (feet) :
 select{@}height_feet_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'
 numeric{@}height_inches{@}Your height (inches) :
 select{@}height_inches_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'
-numeric{@}weight_lbs{@}Your weight (lbs) :
+numeric{@}weight_lbs{@}Your weight (lbs) :{@}50{@}500
 select{@}weight_lbs_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'
+page{@}{@}Metric Units
 static{@}{@}Metric units
 numeric{@}height_cms{@}Your height (cms) :
 select{@}height_cms_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'
 numeric{@}weight_kgs{@}Your weight (kgs) :
 select{@}weight_kgs_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'
+page{@}{@}Results
 static{@}bmi{@}Your BMI
 static{@}bmi_category{@}Your BMI Classification


### PR DESCRIPTION
## Brief summary of changes

LINST instrument class was using the legacy trait to bypass defining it's own instrument's full name and subtests, both values were already somewhere in the file and should now be implemented without using the database values

additional fix for numeric elements for which the min and max values were not passed on to the instrument

#### Testing instructions (if applicable)

1. LINST instruments should work... more specifically LINST instruments with pages, pages should load properly
