### PR TITLE
PHPUNIT 9.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     },
     "require-dev" : {
         "squizlabs/php_codesniffer" : "3.5.3",
-        "phpunit/phpunit" : "7.0.0",
+        "phpunit/phpunit" : "9.4.4",
         "phan/phan": "3.0.0",
         "phpmd/phpmd": "~2.8",
-        "phpstan/phpstan": "0.12.17",
+        "phpstan/phpstan": "0.12.58",
         "slevomat/coding-standard": "^6.0",
         "php-webdriver/webdriver" : "dev-main"
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13bb8937123dba1d63dce533bee27cac",
+    "content-hash": "41080c0510101c467723b26cfc4b3af1",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -96,10 +96,6 @@
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
-            "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v3.0.0"
-            },
             "time": "2015-07-22T18:31:08+00:00"
         },
         {
@@ -784,9 +780,6 @@
                 "request",
                 "response"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
-            },
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
@@ -840,10 +833,6 @@
                 "response",
                 "server"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/http-server-handler/issues",
-                "source": "https://github.com/php-fig/http-server-handler/tree/master"
-            },
             "time": "2018-10-30T16:46:14+00:00"
         },
         {
@@ -897,10 +886,6 @@
                 "request",
                 "response"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/http-server-middleware/issues",
-                "source": "https://github.com/php-fig/http-server-middleware/tree/master"
-            },
             "time": "2018-10-30T17:12:04+00:00"
         },
         {
@@ -941,10 +926,6 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
@@ -1668,6 +1649,58 @@
             "time": "2020-04-16T18:48:43+00:00"
         },
         {
+            "name": "nikic/php-parser",
+            "version": "v4.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2020-12-03T17:45:45+00:00"
+        },
+        {
             "name": "pdepend/pdepend",
             "version": "2.8.0",
             "source": {
@@ -1803,28 +1836,29 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1854,28 +1888,24 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
-            },
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1905,11 +1935,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/master"
-            },
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2020-11-30T09:21:21+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -1917,12 +1943,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-webdriver/php-webdriver.git",
-                "reference": "cab6d4acfa659a02d7fbb485ca5991e9a8d679c2"
+                "reference": "31431f02300dc28597c5b50d0742cb49ce6301dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/cab6d4acfa659a02d7fbb485ca5991e9a8d679c2",
-                "reference": "cab6d4acfa659a02d7fbb485ca5991e9a8d679c2",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/31431f02300dc28597c5b50d0742cb49ce6301dd",
+                "reference": "31431f02300dc28597c5b50d0742cb49ce6301dd",
                 "shasum": ""
             },
             "require": {
@@ -1949,7 +1975,6 @@
             "suggest": {
                 "ext-SimpleXML": "For Firefox profile creation"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -1977,11 +2002,7 @@
                 "selenium",
                 "webdriver"
             ],
-            "support": {
-                "issues": "https://github.com/php-webdriver/php-webdriver/issues",
-                "source": "https://github.com/php-webdriver/php-webdriver/tree/main"
-            },
-            "time": "2020-11-28T01:55:19+00:00"
+            "time": "2020-12-04T16:31:47+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2038,28 +2059,27 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.1.0",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e"
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
-                "reference": "cd72d394ca794d3466a3b2fc09d5a6c1dc86b47e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "^7.1",
-                "php": "^7.2",
-                "phpdocumentor/reflection-common": "^2.0",
-                "phpdocumentor/type-resolver": "^1.0",
-                "webmozart/assert": "^1"
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "doctrine/instantiator": "^1",
-                "mockery/mockery": "^1"
+                "mockery/mockery": "~1.3.2"
             },
             "type": "library",
             "extra": {
@@ -2087,11 +2107,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.1.0"
-            },
-            "time": "2020-02-22T12:28:44+00:00"
+            "time": "2020-09-03T19:13:55+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2227,33 +2243,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.10.3",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -2286,11 +2302,7 @@
                 "spy",
                 "stub"
             ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
-            },
-            "time": "2020-03-05T15:02:03+00:00"
+            "time": "2020-09-29T09:10:42+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -2346,20 +2358,23 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.17",
+            "version": "0.12.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b2c37bda79fdb11d801ce208ce391cffc0f572e6"
+                "reference": "2a4847df6047b30af28854ed9dc95304cdb56ae5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b2c37bda79fdb11d801ce208ce391cffc0f572e6",
-                "reference": "b2c37bda79fdb11d801ce208ce391cffc0f572e6",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2a4847df6047b30af28854ed9dc95304cdb56ae5",
+                "reference": "2a4847df6047b30af28854ed9dc95304cdb56ae5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
             },
             "bin": [
                 "phpstan",
@@ -2381,10 +2396,6 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "support": {
-                "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.17"
-            },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
@@ -2399,44 +2410,48 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-03-17T15:39:11+00:00"
+            "time": "2020-11-29T13:32:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.5",
+            "version": "9.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a"
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4cab20a326d14de7575a8e235c70d879b569a57a",
-                "reference": "4cab20a326d14de7575a8e235c70d879b569a57a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -2462,33 +2477,38 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/6.0.5"
-            },
-            "time": "2018-05-28T11:49:20+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:44:49+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2503,7 +2523,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2513,31 +2533,99 @@
                 "filesystem",
                 "iterator"
             ],
-            "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
-            },
-            "time": "2017-11-27T13:52:08+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:57:25+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -2559,36 +2647,38 @@
             "keywords": [
                 "template"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
-            },
-            "time": "2015-06-21T13:50:34+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.3",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2612,123 +2702,65 @@
             "keywords": [
                 "timer"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:20:02+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.0.0",
+            "version": "9.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc"
+                "reference": "6535e637961f0829832621dc1b7308c2d24a799e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc",
-                "reference": "9b3373439fdf2f3e9d1578f5e408a3a0d161c3bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6535e637961f0829832621dc1b7308c2d24a799e",
+                "reference": "6535e637961f0829832621dc1b7308c2d24a799e",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0",
-                "phpunit/php-file-iterator": "^1.4.3",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.0",
-                "phpunit/phpunit-mock-objects": "^6.0",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3",
+                "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "ext-soap": "*",
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -2736,12 +2768,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "9.4-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2762,72 +2797,17 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.0.0"
-            },
-            "time": "2018-02-02T05:04:08+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "6.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
-                "reference": "f9756fd4f43f014cb2dca98deeaaa8ce5500a36e",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/master"
-            },
-            "abandoned": true,
-            "time": "2018-05-29T13:54:20+00:00"
+            "time": "2020-12-01T04:58:47+00:00"
         },
         {
             "name": "psr/container",
@@ -2999,29 +2979,133 @@
             "time": "2020-10-03T11:02:22+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.2",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3041,44 +3125,40 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:15:22+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3092,6 +3172,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -3102,10 +3186,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -3115,37 +3195,92 @@
                 "compare",
                 "equality"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/master"
-            },
-            "time": "2018-02-01T13:46:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.3",
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3175,42 +3310,41 @@
                 "unidiff",
                 "unified diff"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3235,38 +3369,40 @@
                 "environment",
                 "hhvm"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/master"
-            },
-            "time": "2017-07-01T08:51:00+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3306,37 +3442,36 @@
                 "export",
                 "exporter"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2020-09-28T05:24:23+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -3344,7 +3479,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3367,38 +3502,93 @@
             "keywords": [
                 "global state"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
-            },
-            "time": "2017-04-27T15:39:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:55:19+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.4",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3418,42 +3608,38 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:40:27+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3473,42 +3659,38 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:37:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3536,39 +3718,38 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:34:24+00:00"
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3588,33 +3769,87 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
-            },
-            "time": "2015-07-28T20:34:47+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "2.0.1",
+            "name": "sebastian/type",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:18:59+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3635,11 +3870,13 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/master"
-            },
-            "time": "2016-10-03T07:35:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -4811,23 +5048,24 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.8.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
+                "phpstan/phpstan": "<0.12.20",
                 "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
@@ -4855,11 +5093,7 @@
                 "check",
                 "validate"
             ],
-            "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
-            },
-            "time": "2020-04-18T12:12:48+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         }
     ],
     "aliases": [],
@@ -4873,5 +5107,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -186,7 +186,7 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("#swal2-title")
         )->getText();
-        $this->assertContains("Success!", $bodyText);
+        $this->assertStringContainsString("Success!", $bodyText);
     }
 }
 

--- a/modules/acknowledgements/test/AcknowledgementsTest.php
+++ b/modules/acknowledgements/test/AcknowledgementsTest.php
@@ -65,7 +65,7 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(
@@ -80,7 +80,7 @@ class AcknowledgementsIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         $this->DB->delete("acknowledgements", ['ID' => '999']);
         $this->DB->delete("acknowledgements", ['full_name' => 'Test Test']);

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -33,7 +33,7 @@ class LoginTest extends TestCase
      *
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         spl_autoload_register(
             function ($class) {
@@ -59,7 +59,7 @@ class LoginTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_request       = new ServerRequest();
         $this->_authenticator = $this->createMock('\SinglePointLogin');

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -79,7 +79,7 @@ class LoginTest extends TestCase
             ->willReturn(true);
 
         $handler = $this->getMockBuilder('\LORIS\api\Endpoints\Login')
-            ->setMethods(['getLoginAuthenticator', 'getEncodedToken'])
+            ->addMethods(['getLoginAuthenticator', 'getEncodedToken'])
             ->getMock();
 
         $handler->expects($this->once())

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -42,7 +42,10 @@ class BatteryManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**
@@ -58,7 +61,10 @@ class BatteryManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
 

--- a/modules/battery_manager/test/BatteryManagerTest.php
+++ b/modules/battery_manager/test/BatteryManagerTest.php
@@ -42,7 +42,7 @@ class BatteryManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -58,7 +58,7 @@ class BatteryManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
 

--- a/modules/behavioural_qc/test/behavioural_qcTest.php
+++ b/modules/behavioural_qc/test/behavioural_qcTest.php
@@ -32,7 +32,7 @@ class Behavioural_QCTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Behavioural Quality Control", $bodyText);
+        $this->assertStringContainsString("Behavioural Quality Control", $bodyText);
     }
     /**
      * Tests that behavioural_qc does not load with the permission

--- a/modules/brainbrowser/test/brainbrowserTest.php
+++ b/modules/brainbrowser/test/brainbrowserTest.php
@@ -37,7 +37,7 @@ class BrainBrowserTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Brainbrowser", $bodyText);
+        $this->assertStringContainsString("Brainbrowser", $bodyText);
     }
 }
 

--- a/modules/bvl_feedback/test/BvlFeedbackTest.php
+++ b/modules/bvl_feedback/test/BvlFeedbackTest.php
@@ -48,7 +48,7 @@ class BvlFeedbackTest extends LorisIntegrationTest
             "return document.querySelector".
             "('#bvl_feedback_menu > div.breadcrumb-panel > a').textContent"
         );
-        $this->assertContains("Feedback for PSCID: ", $text);
+        $this->assertStringContainsString("Feedback for PSCID: ", $text);
         // Instrument List
         $this->safeGet($this->url . "/instrument_list/?candID=300001&sessionID=1");
         $this->webDriver->executescript(
@@ -59,7 +59,7 @@ class BvlFeedbackTest extends LorisIntegrationTest
             "return document.querySelector".
             "('#bvl_feedback_menu').textContent"
         );
-        $this->assertContains("Feedback for PSCID: ", $text);
+        $this->assertStringContainsString("Feedback for PSCID: ", $text);
         //Todo: Any instrument
 
     }

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -87,7 +87,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -105,14 +105,14 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Access Profile", $bodyText);
+        $this->assertStringContainsString("Access Profile", $bodyText);
         // Ensure that the default is basic mode (which means the button
         // says "Advanced")
         $btn        = self::$advancedFilter;
         $buttonText = $this->safeFindElement(
             WebDriverBy::cssSelector($btn)
         )->getText();
-        $this->assertContains("Advanced", $buttonText);
+        $this->assertStringContainsString("Advanced", $buttonText);
     }
     /**
      * Tests that, after clicking the "Advanced" button, all of the
@@ -126,7 +126,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Access Profile", $bodyText);
+        $this->assertStringContainsString("Access Profile", $bodyText);
         // Switch to Advanced mode
         $btn = self::$advancedFilter;
         $this->safeClick(WebDriverBy::cssSelector($btn));
@@ -339,7 +339,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         //to do check the url
         $this->safeClick(WebDriverBy::cssSelector($btn));
         $URL =  $this->webDriver->executeScript("return window.location.href;");
-        $this->assertContains("300001", $URL);
+        $this->assertStringContainsString("300001", $URL);
         $this->resetPermissions();
     }
     /**
@@ -355,7 +355,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Candidate Profile",
             $bodyText
         );

--- a/modules/candidate_list/test/candidate_listTest.php
+++ b/modules/candidate_list/test/candidate_listTest.php
@@ -58,7 +58,7 @@ class CandidateListTestIntegrationTest extends LorisIntegrationTestWithCandidate
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $this->setupConfigSetting("useEDC", "true");

--- a/modules/candidate_parameters/test/candidate_parametersTest.php
+++ b/modules/candidate_parameters/test/candidate_parametersTest.php
@@ -41,7 +41,7 @@ class CandidateParametersTestIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Candidate Parameters", $bodyText);
+        $this->assertStringContainsString("Candidate Parameters", $bodyText);
     }
 
 }

--- a/modules/candidate_profile/test/candidate_profileTest.php
+++ b/modules/candidate_profile/test/candidate_profileTest.php
@@ -35,7 +35,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Candidate Profile 900000", $bodyText);
+        $this->assertStringContainsString("Candidate Profile 900000", $bodyText);
     }
 
     /**
@@ -53,7 +53,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Permission Denied", $bodyText);
+        $this->assertStringContainsString("Permission Denied", $bodyText);
         $this->resetPermissions();
 
         $this->resetStudySite();
@@ -74,7 +74,7 @@ class CandidateProfileIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Permission Denied", $bodyText);
+        $this->assertStringContainsString("Permission Denied", $bodyText);
         $this->resetPermissions();
 
         $this->resetUserProject();

--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -33,7 +33,7 @@ class ConfigurationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
     }
@@ -43,7 +43,7 @@ class ConfigurationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->delete(
             "subproject",

--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -81,7 +81,7 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertNotContains("You do not have access to this page.", $bodyText);
+         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
          $this->resetPermissions();
     }
     /**
@@ -96,7 +96,7 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertContains("You do not have access to this page.", $bodyText);
+         $this->assertStringContainsString("You do not have access to this page.", $bodyText);
          $this->resetPermissions();
     }
     /**
@@ -110,7 +110,7 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertContains("SubprojectID", $bodyText);
+         $this->assertStringContainsString("SubprojectID", $bodyText);
     }
     /**
      * Tests that subproject navigate back to config page
@@ -127,7 +127,7 @@ class ConfigurationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector("body")
         )->getText();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             "To configure study subprojects click here.",
             $bodyText
         );
@@ -168,7 +168,7 @@ class ConfigurationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector(".active")
         );
         $bodyText   = $webActives[1]->getText();
-        $this->assertContains($text, $bodyText);
+        $this->assertStringContainsString($text, $bodyText);
     }
 
     /**
@@ -200,7 +200,7 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "To configure study projects click here.",
             $bodyText
         );

--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -64,7 +64,7 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertRegexp(
+        $this->assertMatchesRegularExpression(
             "/Please enter the various configuration variables/",
             $bodyText
         );

--- a/modules/configuration/test/ConfigurationTest.php
+++ b/modules/configuration/test/ConfigurationTest.php
@@ -81,7 +81,10 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
          $this->resetPermissions();
     }
     /**
@@ -96,7 +99,10 @@ class ConfigurationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
          $this->resetPermissions();
     }
     /**

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -49,7 +49,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $this->setUpConfigSetting("useProjects", "true");
@@ -60,7 +60,7 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
       *
       * @return void
       */
-    function tearDown()
+    function tearDown(): void
     {
         parent::tearDown();
         $this->restoreConfigSetting("useProjects");

--- a/modules/conflict_resolver/test/conflict_resolverTest.php
+++ b/modules/conflict_resolver/test/conflict_resolverTest.php
@@ -243,6 +243,6 @@ class ConflictResolverTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::cssSelector($row)
         )->getText();
          // 4 means there are 4 records under this site.
-        $this->assertContains("of 575", $bodyText);
+        $this->assertStringContainsString("of 575", $bodyText);
     }
 }

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -32,7 +32,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
     }

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -140,7 +140,10 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
             WebDriverBy::cssSelector("body")
         )->getText();
 
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
 }

--- a/modules/create_timepoint/test/create_timepointTest.php
+++ b/modules/create_timepoint/test/create_timepointTest.php
@@ -62,7 +62,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Create Time Point", $bodyText);
+        $this->assertStringContainsString("Create Time Point", $bodyText);
     }
 
     /**
@@ -119,7 +119,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
         );
         $this->webDriver->findElement(WebDriverBy::Name("fire_away"))->click();
         $bodyText = $this->webDriver->getPageSource();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "New time point successfully registered.",
             $bodyText
         );
@@ -140,7 +140,7 @@ class CreateTimepointTestIntegrationTest extends LorisIntegrationTestWithCandida
             WebDriverBy::cssSelector("body")
         )->getText();
 
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
 }

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -332,7 +332,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $welcomeText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector(".welcome"))->getText();
-        $this->assertContains("Welcome", $welcomeText);
+        $this->assertStringContainsString("Welcome", $welcomeText);
     }
 
     /**
@@ -369,8 +369,8 @@ class DashboardTest extends LorisIntegrationTest
                     "/div[2]/div[1]/div/div/ul/li[2]/a"
                 )
             )->getText();
-        $this->assertContains("View overall recruitment", $assertText1);
-        $this->assertContains("View site breakdown", $assertText2);
+        $this->assertStringContainsString("View overall recruitment", $assertText1);
+        $this->assertStringContainsString("View site breakdown", $assertText2);
     }
 
     /**
@@ -473,7 +473,7 @@ class DashboardTest extends LorisIntegrationTest
         );
         $this->safeGet($this->url . '/dashboard/');
         $bodyText = $this->webDriver->getPageSource();
-        $this->assertContains("Incomplete forms", $bodyText);
+        $this->assertStringContainsString("Incomplete forms", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -527,7 +527,7 @@ class DashboardTest extends LorisIntegrationTest
         );
         $this->safeGet($this->url . '/dashboard/');
         $bodyText = $this->webDriver->getPageSource();
-        $this->assertContains("test.jpg", $bodyText);
+        $this->assertStringContainsString("test.jpg", $bodyText);
         $this->resetPermissions();
     }
 
@@ -566,7 +566,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->login("UnitTester", $this->validPassword);
         $welcomeText = $this->webDriver
             ->findElement(WebDriverBy::cssSelector(".welcome"))->getText();
-        $this->assertContains("Unit Tester", $welcomeText);
+        $this->assertStringContainsString("Unit Tester", $welcomeText);
     }
     /**
      * Make sure there is no recruitment target set in the configuration
@@ -580,7 +580,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $testText = $this->webDriver
             ->findElement(WebDriverBy::Id("overall-recruitment"))->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Please add a recruitment target for Overall Recruitment.",
             $testText
         );
@@ -618,7 +618,7 @@ class DashboardTest extends LorisIntegrationTest
         $this->safeGet($this->url . '/dashboard/');
         $testText = $this->webDriver
             ->findElement(WebDriverBy::Id("overall-recruitment"))->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "888",
             $testText
         );
@@ -640,7 +640,7 @@ class DashboardTest extends LorisIntegrationTest
                     "//*[@id='lorisworkspace']/div/div[1]/div[2]"
                 )
             )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "There have been no candidates registered yet.",
             $testText
         );
@@ -662,12 +662,12 @@ class DashboardTest extends LorisIntegrationTest
                     "//*[@id='lorisworkspace']/div/div[1]/div[3]"
                 )
             )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Scan sessions per site",
             $testText
         );
 
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "There have been no candidates registered yet.",
             $testText
         );

--- a/modules/dashboard/test/DashboardTest.php
+++ b/modules/dashboard/test/DashboardTest.php
@@ -34,7 +34,7 @@ class DashboardTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         //Insert a pending user
@@ -229,7 +229,7 @@ class DashboardTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->run('SET foreign_key_checks =0');
         $this->DB->delete(

--- a/modules/data_release/test/data_releaseTest.php
+++ b/modules/data_release/test/data_releaseTest.php
@@ -16,7 +16,7 @@ class DataReleaseIntegrationTest extends LorisIntegrationTest
      */
     function testPageLoadsWithViewPermission(): void
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Data Release",
             $this->_loadWithPermission('data_release_view')
         );
@@ -30,7 +30,7 @@ class DataReleaseIntegrationTest extends LorisIntegrationTest
      */
     function testPageLoadsWithEditPermission(): void
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Data Release",
             $this->_loadWithPermission('data_release_edit_file_access')
         );
@@ -44,7 +44,7 @@ class DataReleaseIntegrationTest extends LorisIntegrationTest
      */
     function testPageLoadsWithUploadPermission(): void
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Data Release",
             $this->_loadWithPermission('data_release_upload')
         );
@@ -59,7 +59,7 @@ class DataReleaseIntegrationTest extends LorisIntegrationTest
      */
     function testPageDoesNotLoadWithoutPermission(): void
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You do not have access',
             $this->_loadWithPermission('')
         );

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -96,7 +96,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
                 $bodyText = $this->webDriver->findElement(
                     WebDriverBy::cssSelector("body")
                 )->getText();
-                $this->assertContains("Data Dictionary", $bodyText);
+                $this->assertStringContainsString("Data Dictionary", $bodyText);
     }
     /**
      * Testing UI elements when page loads
@@ -110,7 +110,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
             $text = $this->safeFindElement(
                 WebDriverBy::cssSelector($value)
             )->getText();
-            $this->assertContains($key, $text);
+            $this->assertStringContainsString($key, $text);
         }
     }
 }

--- a/modules/datadict/test/datadictTest.php
+++ b/modules/datadict/test/datadictTest.php
@@ -47,7 +47,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(
@@ -69,7 +69,7 @@ class DatadictTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         parent::tearDown();
         $this->DB->delete(

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -70,7 +70,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/dicom_archive/viewDetails/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("View Details", $bodyText);
+        $this->assertStringContainsString("View Details", $bodyText);
     }
     /**
      * Tests that help editor loads with the permission
@@ -84,11 +84,11 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "An error occured while loading the page.",
             $bodyText
         );
@@ -145,7 +145,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
             $bodyText = $this->webDriver->executescript(
                 "return document.querySelector('$table').textContent"
             );
-            $this->assertContains($value, $bodyText);
+            $this->assertStringContainsString($value, $bodyText);
         } else {
             $this->webDriver->executescript(
                 "input = document.querySelector('$element');
@@ -159,7 +159,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
                 "return document.querySelector('$row').textContent"
             );
             // 4 means there are 4 records under this site.
-            $this->assertContains($records, $bodyText);
+            $this->assertStringContainsString($records, $bodyText);
         }
         //test clear filter
         $btn = self::$clearFilter;
@@ -193,7 +193,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
             "document.querySelector('$location').click()"
         );
         $text = $this->webDriver->getPageSource();
-        $this->assertContains('View Details', $text);
+        $this->assertStringContainsString('View Details', $text);
     }
     /**
      * Tests that the (view-Images) link works

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -46,7 +46,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
     }
@@ -55,7 +55,7 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         parent::tearDown();
     }

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -62,7 +62,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -83,7 +83,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("#bc2 > a:nth-child(2) > div")
         )->getText();
-        $this->assertContains("Document Repository", $bodyText);
+        $this->assertStringContainsString("Document Repository", $bodyText);
     }
     /**
      * Tests Upload page.
@@ -101,7 +101,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
             "return document.querySelector('#upload > div > div > form > div >".
             "div:nth-child(1) > h3').textContent"
         );
-        $this->assertContains("Upload a file", $text);
+        $this->assertStringContainsString("Upload a file", $text);
 
     }
     /**
@@ -121,7 +121,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
         $test = $this->safeFindElement(
             WebDriverBy::linkText("README.md")
         )->getText();
-        $this->assertContains("README.md", $test);
+        $this->assertStringContainsString("README.md", $test);
 
     }
     /**
@@ -163,7 +163,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
             3000
         )
             ->getText();
-         $this->assertContains("This is a test comment!", $text);
+         $this->assertStringContainsString("This is a test comment!", $text);
 
          // delete upload file
 

--- a/modules/document_repository/test/document_repositoryTest.php
+++ b/modules/document_repository/test/document_repositoryTest.php
@@ -37,7 +37,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -46,7 +46,7 @@ class DocumentRepositoryTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }

--- a/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
+++ b/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
@@ -51,7 +51,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(

--- a/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
+++ b/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
@@ -215,7 +215,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Electrophysiology Browser", $bodyText);
+        $this->assertStringContainsString("Electrophysiology Browser", $bodyText);
     }
 
     /**
@@ -250,7 +250,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
         $this->resetStudySite();
     }
@@ -346,20 +346,20 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $firstEntry = $this->safeFindElement(
             WebDriverBy::cssSelector("#dynamictable > tbody > tr:nth-child(1)")
         )->getText();
-        $this->assertContains("OTT166", $firstEntry);
+        $this->assertStringContainsString("OTT166", $firstEntry);
         $this->safeClick(
             WebDriverBy::cssSelector(self::$PSCIDHeader)
         );
         $firstEntry = $this->safeFindElement(
             WebDriverBy::cssSelector(self::$firstElement)
         )->getText();
-        $this->assertContains("TST0001", $firstEntry);
+        $this->assertStringContainsString("TST0001", $firstEntry);
 
         //Test DCCID Header
         $firstEntry = $this->safeFindElement(
             WebDriverBy::cssSelector(self::$firstElement)
         )->getText();
-        $this->assertContains("900000", $firstEntry);
+        $this->assertStringContainsString("900000", $firstEntry);
 
         $this->safeClick(
             WebDriverBy::cssSelector(self::$DCCIDHeader)
@@ -368,7 +368,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $firstEntry = $this->safeFindElement(
             WebDriverBy::cssSelector(self::$firstElement)
         )->getText();
-        $this->assertContains("900000", $firstEntry);
+        $this->assertStringContainsString("900000", $firstEntry);
     }
 
     /**
@@ -384,7 +384,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "View Session",
             $bodyText
         );
@@ -403,7 +403,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "View Session",
             $bodyText
         );
@@ -420,7 +420,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Electrophysiology Browser", $bodyText);
+        $this->assertStringContainsString("Electrophysiology Browser", $bodyText);
     }
 
     /**
@@ -456,7 +456,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
 
         $this->setupPermissions(['electrophysiology_browser_view_allsites']);
@@ -464,7 +464,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
 
         $this->resetStudySite();
@@ -486,7 +486,7 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
 
         $this->resetUserProject();
@@ -507,14 +507,14 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "View Session",
             $bodyText
         );
-        $this->assertContains("167", $this->webDriver->getCurrentURL());
+        $this->assertStringContainsString("167", $this->webDriver->getCurrentURL());
 
         $this->safeClick(WebDriverBy::cssSelector(self::$prevLink));
-        $this->assertContains("166", $this->webDriver->getCurrentURL());
+        $this->assertStringContainsString("166", $this->webDriver->getCurrentURL());
     }
 
     /**
@@ -531,11 +531,11 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("View Session", $bodyText);
-        $this->assertContains(
+        $this->assertStringNotContainsString("View Session", $bodyText);
+        $this->assertStringContainsString(
             "/electrophysiology_browser",
             $this->webDriver->getCurrentURL()
         );
-        $this->assertNotContains("sessions", $this->webDriver->getCurrentURL());
+        $this->assertStringNotContainsString("sessions", $this->webDriver->getCurrentURL());
     }
 }

--- a/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
+++ b/modules/electrophysiology_browser/test/electrophysiologyBrowserTest.php
@@ -215,7 +215,10 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringContainsString("Electrophysiology Browser", $bodyText);
+        $this->assertStringContainsString(
+            "Electrophysiology Browser",
+            $bodyText
+        );
     }
 
     /**
@@ -250,7 +253,10 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
         $this->resetStudySite();
     }
@@ -346,7 +352,10 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $firstEntry = $this->safeFindElement(
             WebDriverBy::cssSelector("#dynamictable > tbody > tr:nth-child(1)")
         )->getText();
-        $this->assertStringContainsString("OTT166", $firstEntry);
+        $this->assertStringContainsString(
+            "OTT166",
+            $firstEntry
+        );
         $this->safeClick(
             WebDriverBy::cssSelector(self::$PSCIDHeader)
         );
@@ -456,7 +465,10 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
 
         $this->setupPermissions(['electrophysiology_browser_view_allsites']);
@@ -464,7 +476,10 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
 
         $this->resetStudySite();
@@ -486,7 +501,10 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText
             = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
 
         $this->resetUserProject();
@@ -536,6 +554,9 @@ class EEGBrowserIntegrationTest extends LorisIntegrationTestWithCandidate
             "/electrophysiology_browser",
             $this->webDriver->getCurrentURL()
         );
-        $this->assertStringNotContainsString("sessions", $this->webDriver->getCurrentURL());
+        $this->assertStringNotContainsString(
+            "sessions",
+            $this->webDriver->getCurrentURL()
+        );
     }
 }

--- a/modules/examiner/test/ExaminerTest.php
+++ b/modules/examiner/test/ExaminerTest.php
@@ -89,9 +89,9 @@ class ExaminerTest extends LorisIntegrationTest
         $tableText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Examiner", $tableText);
-        $this->assertContains("Site", $tableText);
-        $this->assertContains("Radiologist", $tableText);
+        $this->assertStringContainsString("Examiner", $tableText);
+        $this->assertStringContainsString("Site", $tableText);
+        $this->assertStringContainsString("Radiologist", $tableText);
 
         $this->resetPermissions();
     }
@@ -108,7 +108,7 @@ class ExaminerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -124,7 +124,7 @@ class ExaminerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -188,7 +188,7 @@ class ExaminerTest extends LorisIntegrationTest
                 "('#dynamictable > tbody > tr:nth-child(1) > td:nth-child(2) > a')".
                 ".textContent"
         );
-        $this->assertContains("Test_Examiner", $text);
+        $this->assertStringContainsString("Test_Examiner", $text);
     }
     /**
      * Testing UI elements when page loads
@@ -205,7 +205,7 @@ class ExaminerTest extends LorisIntegrationTest
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );
-            $this->assertContains($key, $text);
+            $this->assertStringContainsString($key, $text);
         }
     }
 

--- a/modules/examiner/test/ExaminerTest.php
+++ b/modules/examiner/test/ExaminerTest.php
@@ -108,7 +108,10 @@ class ExaminerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**
@@ -124,7 +127,10 @@ class ExaminerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**

--- a/modules/examiner/test/ExaminerTest.php
+++ b/modules/examiner/test/ExaminerTest.php
@@ -52,7 +52,7 @@ class ExaminerTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }
@@ -61,7 +61,7 @@ class ExaminerTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->delete(
             "examiners",

--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -61,7 +61,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertContains("You do not have access to this page.", $bodyText);
+         $this->assertStringContainsString("You do not have access to this page.", $bodyText);
          $this->resetPermissions();
     }
     /**
@@ -83,7 +83,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertNotContains("You do not have access to this page.", $bodyText);
+         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
          $this->resetPermissions();
     }
     /**
@@ -187,7 +187,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );
-            $this->assertContains($key, $text);
+            $this->assertStringContainsString($key, $text);
         }
 
     }
@@ -214,7 +214,7 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
                 $text = $this->webDriver->executescript(
                     "return document.querySelector('#datatable').textContent"
                 );
-                  $this->assertContains($expectDataRows, $text);
+                  $this->assertStringContainsString($expectDataRows, $text);
     }
     /**
      * Tests that, when clicking the upload button,the upload window should show up
@@ -238,6 +238,6 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );
-            $this->assertContains("Upload File", $text);
+            $this->assertStringContainsString("Upload File", $text);
     }
 }

--- a/modules/genomic_browser/test/genomic_browserTest.php
+++ b/modules/genomic_browser/test/genomic_browserTest.php
@@ -61,7 +61,10 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
          $this->resetPermissions();
     }
     /**
@@ -83,7 +86,10 @@ class GenomicBrowserTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
          $this->resetPermissions();
     }
     /**

--- a/modules/help_editor/test/help_editorTest.php
+++ b/modules/help_editor/test/help_editorTest.php
@@ -74,7 +74,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/help_editor/");
         $bodyText = $this->safeFindElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Help Editor", $bodyText);
+        $this->assertStringContainsString("Help Editor", $bodyText);
     }//end test_help_pageload()
     /**
      * Tests that, when loading the help_editor module > edit help submodule, some
@@ -90,7 +90,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         )
             ->getText();
 
-        $this->assertContains("Edit Help Content", $assertText);
+        $this->assertStringContainsString("Edit Help Content", $assertText);
 
     }//end test_page_load()
 
@@ -106,7 +106,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertNotContains("You do not have access to this page.", $bodyText);
+         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
          $this->resetPermissions();
     }
     /**
@@ -121,7 +121,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertContains("You do not have access to this page.", $bodyText);
+         $this->assertStringContainsString("You do not have access to this page.", $bodyText);
          $this->resetPermissions();
     }
     /**
@@ -144,7 +144,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         )->click();
          $this->safeGet($this->url . "/help_editor/?format=json");
          $bodyText = $this->webDriver->getPageSource();
-         $this->assertContains("Test Topic", $bodyText);
+         $this->assertStringContainsString("Test Topic", $bodyText);
     }
     /**
      * Tests that help editor does not load with the permission
@@ -166,7 +166,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         )->click();
          $this->safeGet($this->url . "/help_editor/?format=json");
          $bodyText = $this->webDriver->getPageSource();
-         $this->assertContains("test content", $bodyText);
+         $this->assertStringContainsString("test content", $bodyText);
     }
 
 }

--- a/modules/help_editor/test/help_editorTest.php
+++ b/modules/help_editor/test/help_editorTest.php
@@ -31,7 +31,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $md5String = md5("TestTestTest");
@@ -51,7 +51,7 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         parent::tearDown();
         $this->DB->delete("help", ['helpID' => '999999']);

--- a/modules/help_editor/test/help_editorTest.php
+++ b/modules/help_editor/test/help_editorTest.php
@@ -106,7 +106,10 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
          $this->resetPermissions();
     }
     /**
@@ -121,7 +124,10 @@ class HelpEditorTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-         $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
          $this->resetPermissions();
     }
     /**

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -357,7 +357,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $breadcrumbText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Imaging Browser", $breadcrumbText);
+        $this->assertStringContainsString("Imaging Browser", $breadcrumbText);
     }
 
     /******** A ********/
@@ -380,7 +380,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $errorText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $errorText
         );
@@ -397,7 +397,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $breadcrumbText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Imaging Browser", $breadcrumbText);
+        $this->assertStringContainsString("Imaging Browser", $breadcrumbText);
     }
 
     function testImagingBrowserDoespageLoadWithPermissionsAllSites()
@@ -410,7 +410,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $breadcrumbText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Imaging Browser", $breadcrumbText);
+        $this->assertStringContainsString("Imaging Browser", $breadcrumbText);
     }
     function testImagingBrowserDoespageLoadWithPermissionsPhontomAllSites()
     {
@@ -422,7 +422,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $breadcrumbText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Imaging Browser", $breadcrumbText);
+        $this->assertStringContainsString("Imaging Browser", $breadcrumbText);
     }
 
     /**
@@ -447,7 +447,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $ControlPanelText = $this->webDriver->findElement(
             WebDriverBy::cssSelector(".controlPanelSection")
         )->getText();
-        $this->assertContains("0 subject timepoint(s) selected", $ControlPanelText);
+        $this->assertStringContainsString("0 subject timepoint(s) selected", $ControlPanelText);
 
         // With permission imaging_browser_view_allsites:
         // 2 subjects with imaging data found
@@ -460,7 +460,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $ControlPanelText = $this->webDriver->findElement(
             WebDriverBy::cssSelector(".controlPanelSection")
         )->getText();
-        $this->assertContains("2 subject timepoint(s) selected", $ControlPanelText);
+        $this->assertStringContainsString("2 subject timepoint(s) selected", $ControlPanelText);
     }
 
     /**
@@ -497,7 +497,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $ControlPanelText = $this->webDriver->findElement(
             WebDriverBy::cssSelector(".controlPanelSection")
         )->getText();
-        $this->assertContains("1 subject timepoint(s) selected", $ControlPanelText);
+        $this->assertStringContainsString("1 subject timepoint(s) selected", $ControlPanelText);
 
         // Now reset using clear button and confirm site
         // set back to all and 2 subjects found
@@ -526,7 +526,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $ControlPanelText = $this->webDriver->findElement(
             WebDriverBy::cssSelector(".controlPanelSection")
         )->getText();
-        $this->assertContains("2 subject timepoint(s) selected", $ControlPanelText);
+        $this->assertStringContainsString("2 subject timepoint(s) selected", $ControlPanelText);
     }
 
     /**
@@ -552,7 +552,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SiteFilterText = $this->webDriver->findElement(
             WebDriverBy::Name("site")
         )->getText();
-        $this->assertContains("All User Sites", $SiteFilterText);
+        $this->assertStringContainsString("All User Sites", $SiteFilterText);
 
         // With permission imaging_browser_view_allsites
         $this->setupPermissions(array('imaging_browser_view_allsites'));
@@ -563,7 +563,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SiteFilterText     = $this->webDriver->findElement(
             WebDriverBy::Name("site")
         )->getText();
-        $this->assertContains("All", $SiteFilterText);
+        $this->assertStringContainsString("All", $SiteFilterText);
     }
 
     /**
@@ -595,7 +595,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 ".table > tbody:nth-child(2) > tr:nth-child(1) > td:nth-child(3)"
             )
         )->getText();
-        $this->assertContains("AOL0002", $FirstEntry);
+        $this->assertStringContainsString("AOL0002", $FirstEntry);
 
         // click again and make sure the order is now reversed
         $PSCIDHeader = $this->webDriver->findElement(
@@ -610,7 +610,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 ".table > tbody:nth-child(2) > tr:nth-child(1) > td:nth-child(3)"
             )
         )->getText();
-        $this->assertContains("BOL0003", $FirstEntry);
+        $this->assertStringContainsString("BOL0003", $FirstEntry);
     }
 
     /**
@@ -641,7 +641,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("View Session", $bodyText);
+        $this->assertStringContainsString("View Session", $bodyText);
 
         // Selected link tested in the next test
     }
@@ -687,7 +687,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SelectionFilter = $this->safeFindElement(
             WebDriverBy::xPath('//*[@id="lorisworkspace"]/div[1]/div/div/div[1]')
         )->getText();
-        $this->assertContains("Selection Filter", $SelectionFilter);
+        $this->assertStringContainsString("Selection Filter", $SelectionFilter);
 
         //Next Button
         $this->safeGet(
@@ -707,7 +707,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SiteText2 = $this->safeFindElement(
             WebDriverBy::xPath('//*[@id="table-header-left"]/tbody/tr/td[5]')
         )->getText();
-        $this->assertContains("Test Site BOL", $SiteText2);
+        $this->assertStringContainsString("Test Site BOL", $SiteText2);
 
         //Previous Button
         $this->safeClick(
@@ -719,7 +719,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SiteText1 = $this->safeFindElement(
             WebDriverBy::xPath('//*[@id="table-header-left"]/tbody/tr/td[5]')
         )->getText();
-        $this->assertContains("Test Site AOL", $SiteText1);
+        $this->assertStringContainsString("Test Site AOL", $SiteText1);
     }
 
     /**
@@ -756,8 +756,8 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
             WebDriverBy::xPath('//*[@id="sidebar-content"]/ul[2]/li[1]/a')
         )->getText();
         // IF NO FORM PRESENT, ALLOW SECOND ASSERTION
-        //$this->assertContains("MRI Parameter Form", $MRIFormHeader);
-        $this->assertContains(
+        //$this->assertStringContainsString("MRI Parameter Form", $MRIFormHeader);
+        $this->assertStringContainsString(
             "This page (mri_parameter_form) is under construction",
             $MRIFormHeader
         );
@@ -782,8 +782,8 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $RadFormHeader = $this->webDriver->findElement(
             WebDriverBy::xPath('//*[@id="test_form"]/div/div[1]/div/h3')
         )->getText();
-        //$this->assertContains("Radiology Review Form", $RadFormHeader);
-        $this->assertContains(
+        //$this->assertStringContainsString("Radiology Review Form", $RadFormHeader);
+        $this->assertStringContainsString(
             "This page (radiology_review) is under construction",
             $RadFormHeader
         );
@@ -825,7 +825,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $BreadCrumbText = $this->webDriver->findElement(
             WebDriverBy::xPath('//*[@id="page"]/div/div[1]/a/label')
         )->getText();
-        $this->assertContains("Brainbrowser", $BreadCrumbText);
+        $this->assertStringContainsString("Brainbrowser", $BreadCrumbText);
     }
 
     /**
@@ -870,7 +870,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $NewWindowPopUpPSCID = $this->webDriver->findElement(
             WebDriverBy::xPath('/html/body/div/table/tbody/tr[2]/td')
         )->getText();
-        $this->assertContains("AOL0002", $NewWindowPopUpPSCID);
+        $this->assertStringContainsString("AOL0002", $NewWindowPopUpPSCID);
         $this->webDriver->switchTo()->window($diff[1])->close();
         $this->webDriver->switchTo()->window($handleList[0]);
 
@@ -879,12 +879,12 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $QCStatusVisit = $this->webDriver->findElement(
             WebDriverBy::xPath('//*[@id="sidebar-content"]/div[2]/div/label')
         )->getText();
-        $this->assertContains("QC Status", $QCStatusVisit);
+        $this->assertStringContainsString("QC Status", $QCStatusVisit);
 
         $QCPending = $this->webDriver->findElement(
             WebDriverBy::xPath('//*[@id="sidebar-content"]/div[2]/label')
         )->getText();
-        $this->assertContains("QC Pending", $QCPending);
+        $this->assertStringContainsString("QC Pending", $QCPending);
 
         // Check that the QC -VISIT LEVEL- options are viewable
         // with correct permission
@@ -899,12 +899,12 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $QCStatusVisitPass = $this->webDriver->findElement(
             WebDriverBy::Name("visit_status")
         )->getText();
-        $this->assertContains("Pass", $QCStatusVisitPass);
+        $this->assertStringContainsString("Pass", $QCStatusVisitPass);
 
         $QCPendingNo = $this->webDriver->findElement(
             WebDriverBy::Name("visit_pending")
         )->getText();
-        $this->assertContains("No", $QCPendingNo);
+        $this->assertStringContainsString("No", $QCPendingNo);
 
         // Test that we can edit the QC status -VISIT LEVEL-
         // with the correct permission
@@ -924,7 +924,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $QCStatusVisit = $this->webDriver->findElement(
             WebDriverBy::Name("visit_status")
         )->getText();
-        $this->assertContains("Fail", $QCStatusVisit);
+        $this->assertStringContainsString("Fail", $QCStatusVisit);
     }
 
     /**
@@ -967,7 +967,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $SelectionFilter = $this->webDriver->findElement(
             WebDriverBy::xPath('//*[@id="lorisworkspace"]/div[1]/div/div/div[1]')
         )->getText();
-        $this->assertContains("Selection Filter", $SelectionFilter);
+        $this->assertStringContainsString("Selection Filter", $SelectionFilter);
     }
 
     /******** C ********/
@@ -1011,7 +1011,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "div:nth-child(1) > label:nth-child(1)"
             )
         )->getText();
-        $this->assertContains("QC Status", $ImagePanelText1);
+        $this->assertStringContainsString("QC Status", $ImagePanelText1);
 
         $ImagePanelText2 = $this->webDriver->findElement(
             WebDriverBy::cssSelector(
@@ -1019,7 +1019,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "div:nth-child(2) > label:nth-child(1)"
             )
         )->getText();
-        $this->assertContains("Selected", $ImagePanelText2);
+        $this->assertStringContainsString("Selected", $ImagePanelText2);
 
         $ImagePanelText3 = $this->webDriver->findElement(
             WebDriverBy::cssSelector(
@@ -1027,7 +1027,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "div:nth-child(3) > label:nth-child(1)"
             )
         )->getText();
-        $this->assertContains("Caveat", $ImagePanelText3);
+        $this->assertStringContainsString("Caveat", $ImagePanelText3);
 
         // Setting permissions to view all sites and have qc permissions
         $this->setupPermissions(
@@ -1055,7 +1055,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "div:nth-child(1) > select:nth-child(2)"
             )
         )->getText();
-        $this->assertContains("Pass", $QCStatusPass);
+        $this->assertStringContainsString("Pass", $QCStatusPass);
 
         $QCSelectedFlair = $this->webDriver->findElement(
             WebDriverBy::cssSelector(
@@ -1063,7 +1063,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "div:nth-child(2) > select:nth-child(2)"
             )
         )->getText();
-        $this->assertContains("flair", $QCSelectedFlair);
+        $this->assertStringContainsString("flair", $QCSelectedFlair);
 
         $QCStatusCaveatTrue = $this->webDriver->findElement(
             WebDriverBy::cssSelector(
@@ -1071,7 +1071,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "option:nth-child(2)"
             )
         )->getText();
-        $this->assertContains("True", $QCStatusCaveatTrue);
+        $this->assertStringContainsString("True", $QCStatusCaveatTrue);
 
         // Test that we can edit the QC status -IMAGE LEVEL-
         // by changing it from Blank to Pass
@@ -1104,7 +1104,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
                 "#image-1 > div > div > div.panel-heading > span.label.label-success"
             )
         )->getText();
-        $this->assertContains("Fail", $QCStatusImageCheck);
+        $this->assertStringContainsString("Fail", $QCStatusImageCheck);
 
         // Caveat Link only if view all_sites violated scans permissions
         $this->setupPermissions(
@@ -1136,7 +1136,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $breadcrumbText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Mri Violations", $breadcrumbText);
+        $this->assertStringContainsString("Mri Violations", $breadcrumbText);
     }
 
     /**
@@ -1200,7 +1200,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
         $newWindowText = $this->webDriver->findElement(
             WebDriverBy::xPath('//body')
         )->getText();
-        $this->assertContains("Click here to close this window", $newWindowText);
+        $this->assertStringContainsString("Click here to close this window", $newWindowText);
         $this->webDriver->switchTo()->window($diff[1])->close();
     }
 

--- a/modules/imaging_browser/test/imaging_browserTest.php
+++ b/modules/imaging_browser/test/imaging_browserTest.php
@@ -36,7 +36,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
 
         parent::setUp();
@@ -311,7 +311,7 @@ class ImagingBrowserTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         // tear down test-specific dataset

--- a/modules/imaging_uploader/test/imaging_uploaderTest.php
+++ b/modules/imaging_uploader/test/imaging_uploaderTest.php
@@ -134,7 +134,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Imaging Upload", $bodyText);
+        $this->assertStringContainsString("Imaging Upload", $bodyText);
     }
     /**
      * Tests that, when loading the Imaging_uploader module without permission,
@@ -149,7 +149,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
     }
     /**
      * Tests that, when loading the Imaging_uploader module with permission,
@@ -164,7 +164,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -236,7 +236,7 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
             $text     = $this->webDriver->executescript(
                 "return document.querySelector('$location').textContent"
             );
-            $this->assertContains($ui['label'], $text);
+            $this->assertStringContainsString($ui['label'], $text);
         }
     }
 }

--- a/modules/imaging_uploader/test/imaging_uploaderTest.php
+++ b/modules/imaging_uploader/test/imaging_uploaderTest.php
@@ -134,7 +134,10 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("Imaging Upload", $bodyText);
+        $this->assertStringContainsString(
+            "Imaging Upload",
+            $bodyText
+        );
     }
     /**
      * Tests that, when loading the Imaging_uploader module without permission,
@@ -149,7 +152,10 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
     }
     /**
      * Tests that, when loading the Imaging_uploader module with permission,
@@ -164,7 +170,10 @@ class ImagingUploaderTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**

--- a/modules/instrument_builder/test/instrument_builderTest.php
+++ b/modules/instrument_builder/test/instrument_builderTest.php
@@ -39,7 +39,7 @@ class InstrumentBuilderTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/instrument_builder/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Instrument Builder", $bodyText);
+        $this->assertStringContainsString("Instrument Builder", $bodyText);
     }
     /**
      * Tests that, when loading the Instrument builder module with permission, some
@@ -53,7 +53,7 @@ class InstrumentBuilderTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/instrument_builder/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Instrument Builder", $bodyText);
+        $this->assertStringContainsString("Instrument Builder", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -68,7 +68,7 @@ class InstrumentBuilderTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/instrument_builder/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
 

--- a/modules/instrument_builder/test/instrument_builderTest.php
+++ b/modules/instrument_builder/test/instrument_builderTest.php
@@ -68,7 +68,10 @@ class InstrumentBuilderTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/instrument_builder/");
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
 

--- a/modules/instrument_list/test/instrument_listTest.php
+++ b/modules/instrument_list/test/instrument_listTest.php
@@ -55,7 +55,10 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("Behavioural Battery of Instruments", $bodyText);
+        $this->assertStringContainsString(
+            "Behavioural Battery of Instruments",
+            $bodyText
+        );
     }
 
     /**
@@ -73,7 +76,10 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("Behavioural Battery of Instruments", $bodyText);
+        $this->assertStringContainsString(
+            "Behavioural Battery of Instruments",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**
@@ -91,7 +97,10 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringNotContainsString("Behavioural Battery of Instruments", $bodyText);
+        $this->assertStringNotContainsString(
+            "Behavioural Battery of Instruments",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**

--- a/modules/instrument_list/test/instrument_listTest.php
+++ b/modules/instrument_list/test/instrument_listTest.php
@@ -55,7 +55,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Behavioural Battery of Instruments", $bodyText);
+        $this->assertStringContainsString("Behavioural Battery of Instruments", $bodyText);
     }
 
     /**
@@ -73,7 +73,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Behavioural Battery of Instruments", $bodyText);
+        $this->assertStringContainsString("Behavioural Battery of Instruments", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -91,7 +91,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("Behavioural Battery of Instruments", $bodyText);
+        $this->assertStringNotContainsString("Behavioural Battery of Instruments", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -111,7 +111,7 @@ class InstrumentListTestIntegrationTest extends LorisIntegrationTest
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );
-            $this->assertContains($key, $text);
+            $this->assertStringContainsString($key, $text);
         }
     }
 }

--- a/modules/instrument_manager/test/instrument_managerTest.php
+++ b/modules/instrument_manager/test/instrument_managerTest.php
@@ -40,7 +40,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Instrument Manager", $bodyText);
+        $this->assertStringContainsString("Instrument Manager", $bodyText);
     }
     /**
      * Tests that, when loading the instrument_manager module with permission,
@@ -56,7 +56,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Instrument Manager", $bodyText);
+        $this->assertStringContainsString("Instrument Manager", $bodyText);
         $this->resetPermissions();
 
         // Check write permission, 'instrument_manager_write'
@@ -65,7 +65,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Instrument Manager", $bodyText);
+        $this->assertStringContainsString("Instrument Manager", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -81,7 +81,7 @@ class InstrumentManagerTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -91,7 +91,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("#bc2 > a:nth-child(2) > div")
         )->getText();
-        $this->assertContains("Issue Tracker", $bodyText);
+        $this->assertStringContainsString("Issue Tracker", $bodyText);
     }
 
     /**
@@ -106,7 +106,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("#bc2 > a:nth-child(2) > div")
         )->getText();
-        $this->assertContains("Issue Tracker", $bodyText);
+        $this->assertStringContainsString("Issue Tracker", $bodyText);
         $this->resetPermissions();
     }
 
@@ -136,7 +136,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
     {
         $this->webDriver->get($this->url . "/issue_tracker/?format=json");
         $bodyText = $this->webDriver->getPageSource();
-        $this->assertContains($value, $bodyText);
+        $this->assertStringContainsString($value, $bodyText);
 
     }
     /**
@@ -156,7 +156,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
          //$bodyText =$this->webDriver->findElement(
          //    WebDriverBy::Name("keyword")
          //)->getText();
-         //$this->assertNotContains("TestTestTest", $bodyText);
+         //$this->assertStringNotContainsString("TestTestTest", $bodyText);
     }
 }
 

--- a/modules/issue_tracker/test/Issue_TrackerTest.php
+++ b/modules/issue_tracker/test/Issue_TrackerTest.php
@@ -34,7 +34,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(
@@ -71,7 +71,7 @@ class Issue_TrackerTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         parent::tearDown();
         $this->DB->delete("issues", ['issueID' => '999999']);

--- a/modules/media/test/MediaTest.php
+++ b/modules/media/test/MediaTest.php
@@ -52,7 +52,10 @@ class MediaTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**
@@ -68,7 +71,10 @@ class MediaTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**

--- a/modules/media/test/MediaTest.php
+++ b/modules/media/test/MediaTest.php
@@ -52,7 +52,7 @@ class MediaTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -68,7 +68,7 @@ class MediaTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -106,7 +106,7 @@ class MediaTest extends LorisIntegrationTest
         $text = $this->webDriver->executescript(
             "return document.querySelector('body').textContent"
         );
-        $this->assertContains("TimePoint", $text);
+        $this->assertStringContainsString("TimePoint", $text);
 
         $this->safeGet($this->url . "/media/");
         // click the Edit link
@@ -117,7 +117,7 @@ class MediaTest extends LorisIntegrationTest
         $text = $this->webDriver->executescript(
             "return document.querySelector('body').textContent"
         );
-        $this->assertContains("Edit Media File", $text);
+        $this->assertStringContainsString("Edit Media File", $text);
 
     }
     /**
@@ -147,7 +147,7 @@ class MediaTest extends LorisIntegrationTest
             $bodyText = $this->webDriver->executescript(
                 "return document.querySelector('$table').textContent"
             );
-            $this->assertContains($value, $bodyText);
+            $this->assertStringContainsString($value, $bodyText);
         } else {
             $this->safeFindElement(WebDriverBy::cssSelector($element));
             $this->webDriver->executescript(
@@ -162,7 +162,7 @@ class MediaTest extends LorisIntegrationTest
                 WebDriverBy::cssSelector($row)
             )->getText();
             // 4 means there are 4 records under this site.
-            $this->assertContains($records, $bodyText);
+            $this->assertStringContainsString($records, $bodyText);
         }
         //test clear filter
             $btn = self::$clearFilter;

--- a/modules/module_manager/test/module_managerTest.php
+++ b/modules/module_manager/test/module_managerTest.php
@@ -40,7 +40,7 @@ class ModuleManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -61,7 +61,7 @@ class ModuleManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -73,7 +73,7 @@ class ModuleManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -85,7 +85,7 @@ class ModuleManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -39,7 +39,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(
@@ -224,7 +224,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->delete(
             "MRICandidateErrors",

--- a/modules/mri_violations/test/mri_violationsTest.php
+++ b/modules/mri_violations/test/mri_violationsTest.php
@@ -364,7 +364,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -384,7 +384,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -403,7 +403,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -425,7 +425,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("#tabs > ul > li.statsTab.active > a")
         )->getText();
-        $this->assertContains("Resolved", $bodyText);
+        $this->assertStringContainsString("Resolved", $bodyText);
     }
     /**
      * Tests clear button in the filter section, input some data,
@@ -555,7 +555,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
         $this->safeGet($this->url . "/mri_violations/resolved_violations/");
         sleep(1);
         $body = $this->webDriver->getPageSource();
-        $this->assertContains("[name]test", $body);
+        $this->assertStringContainsString("[name]test", $body);
     }
     /**
      * Tests that, input some data and click search button, check the results.
@@ -676,7 +676,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
                     '#datatable > div > div.table-header.panel-heading > div')
                  .textContent"
         );
-        $this->assertContains("1 rows displayed of 1", $bodyText);
+        $this->assertStringContainsString("1 rows displayed of 1", $bodyText);
         $this->webDriver->findElement(
             WebDriverBy::Name("reset")
         )->click();
@@ -693,7 +693,7 @@ class MriViolationsTestIntegrationTest extends LorisIntegrationTest
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );
-            $this->assertContains($key, $text);
+            $this->assertStringContainsString($key, $text);
         }
     }
 }

--- a/modules/my_preferences/test/my_preferencesTest.php
+++ b/modules/my_preferences/test/my_preferencesTest.php
@@ -34,7 +34,7 @@ class MyPreferencesIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $password = new \Password($this->validPassword);
@@ -335,7 +335,7 @@ class MyPreferencesIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         $this->DB->delete("users", ["UserID" => 'userid']);
         $this->DB->delete("user_psc_rel", ["UserID" => 999995]);

--- a/modules/my_preferences/test/my_preferencesTest.php
+++ b/modules/my_preferences/test/my_preferencesTest.php
@@ -226,7 +226,7 @@ class MyPreferencesIntegrationTest extends LorisIntegrationTest
         // Try changing the password to the same value.
         $this->_sendPasswordValues($page, $userId, self::UNITTESTER_EMAIL_NEW);
         // This text comes from the class constants in Edit User/My Preferences
-        $this->assertContains('cannot be your email', $this->getBody());
+        $this->assertStringContainsString('cannot be your email', $this->getBody());
     }
 
     /**
@@ -249,7 +249,7 @@ class MyPreferencesIntegrationTest extends LorisIntegrationTest
             \Utility::randomString()
         );
         // This text comes from the class constants in Edit User/My Preferences
-        $this->assertContains('do not match', $this->getBody());
+        $this->assertStringContainsString('do not match', $this->getBody());
     }
 
     /**
@@ -278,7 +278,7 @@ class MyPreferencesIntegrationTest extends LorisIntegrationTest
             $newPassword
         );
         // This text comes from the class constants in Edit User/My Preferences
-        $this->assertContains(
+        $this->assertStringContainsString(
             'New and old passwords are identical',
             $this->getBody()
         );

--- a/modules/new_profile/test/new_profileTest.php
+++ b/modules/new_profile/test/new_profileTest.php
@@ -53,21 +53,21 @@ class NewProfileTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("New Profile", $bodyText);
+        $this->assertStringContainsString("New Profile", $bodyText);
         // check EDC shows on the page
         $value = "#lorisworkspace > fieldset > div > form > div > div:nth-child(3)>".
                  " div > div:nth-child(1) > label";
         $EDC   = $this->safeFindElement(
             WebDriverBy::cssSelector($value)
         )->getText();
-        $this->assertContains("Expected Date of Confinement", $EDC);
+        $this->assertStringContainsString("Expected Date of Confinement", $EDC);
         // check Project shows on the page
         $value   = "#lorisworkspace > fieldset > div > form>div>div:nth-child(7)>".
                    " div > label";
         $project = $this->safeFindElement(
             WebDriverBy::cssSelector($value)
         )->getText();
-        $this->assertContains("Project", $project);
+        $this->assertStringContainsString("Project", $project);
 
         $this->restoreConfigSetting("useEDC");
     }
@@ -107,7 +107,7 @@ class NewProfileTestIntegrationTest extends LorisIntegrationTest
             "return document.querySelector('#default-panel').textContent"
         );
 
-        $this->assertContains("New candidate created.", $bodyText);
+        $this->assertStringContainsString("New candidate created.", $bodyText);
         $this->restoreConfigSetting("useEDC");
     }
 

--- a/modules/next_stage/test/next_stageTest.php
+++ b/modules/next_stage/test/next_stageTest.php
@@ -43,7 +43,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Next Stage", $bodyText);
+        $this->assertStringContainsString("Next Stage", $bodyText);
     }
     /**
      * Tests that, page loads with data_entry permission
@@ -60,7 +60,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Next Stage", $bodyText);
+        $this->assertStringContainsString("Next Stage", $bodyText);
         $this->resetPermissions();
     }
 
@@ -79,7 +79,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -107,7 +107,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -122,7 +122,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -168,7 +168,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Both Date fields must match.", $bodyText);
+        $this->assertStringContainsString("Both Date fields must match.", $bodyText);
     }
 
     /**
@@ -206,7 +206,7 @@ class NextStageTestIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Next stage started.", $bodyText);
+        $this->assertStringContainsString("Next stage started.", $bodyText);
     }
 }
 

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -88,7 +88,10 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**
@@ -104,7 +107,10 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
 

--- a/modules/server_processes_manager/test/server_processes_managerTest.php
+++ b/modules/server_processes_manager/test/server_processes_managerTest.php
@@ -69,7 +69,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains('Cannot continue', $bodyText);
+        $this->assertStringContainsString('Cannot continue', $bodyText);
         $this->resetPermissions();
     }
 
@@ -88,7 +88,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -104,7 +104,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains("You do not have access to this page.", $bodyText);
+        $this->assertStringNotContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
 
@@ -122,7 +122,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             $text = $this->webDriver->executescript(
                 "return document.querySelector('$value').textContent"
             );
-            $this->assertContains($key, $text);
+            $this->assertStringContainsString($key, $text);
         }
     }
     /**
@@ -168,7 +168,7 @@ class Server_Processes_ManagerTest extends LorisIntegrationTest
             " > div > div:nth-child(2) > input').click()"
         );
 
-        $this->assertContains($expectDataRows, $text);
+        $this->assertStringContainsString($expectDataRows, $text);
     }
 }
 

--- a/modules/statistics/test/Statistics_Test.php
+++ b/modules/statistics/test/Statistics_Test.php
@@ -39,7 +39,7 @@ class StatisticsTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("General Description", $bodyText);
+        $this->assertStringContainsString("General Description", $bodyText);
 
     }
     /**
@@ -57,7 +57,7 @@ class StatisticsTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -77,7 +77,7 @@ class StatisticsTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "You do not have access to this page.",
             $bodyText
         );
@@ -99,7 +99,7 @@ class StatisticsTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector(".statsH2")
         )->getText();
-        $this->assertContains("Data Entry Statistics", $bodyText);
+        $this->assertStringContainsString("Data Entry Statistics", $bodyText);
     }
     /**
      * Tests that, when loading the Demographic Statistics Tab
@@ -120,6 +120,6 @@ class StatisticsTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector(".statsH2")
         )->getText();
-        $this->assertContains("General Demographic Statistics", $bodyText);
+        $this->assertStringContainsString("General Demographic Statistics", $bodyText);
     }
 }

--- a/modules/statistics/test/Statistics_Test.php
+++ b/modules/statistics/test/Statistics_Test.php
@@ -120,6 +120,9 @@ class StatisticsTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector(".statsH2")
         )->getText();
-        $this->assertStringContainsString("General Demographic Statistics", $bodyText);
+        $this->assertStringContainsString(
+            "General Demographic Statistics",
+            $bodyText
+        );
     }
 }

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -42,7 +42,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(
@@ -131,7 +131,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->delete(
             "participant_accounts",

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -183,7 +183,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $bodyText
             = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains("Survey Accounts", $bodyText);
+        $this->assertStringContainsString("Survey Accounts", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -199,7 +199,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
         $this->resetPermissions();
     }
     /**
@@ -236,7 +236,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $bodyText =  $this->safeFindElement(
             WebDriverBy::cssSelector(".error")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Please choose an instrument.",
             $bodyText
         );
@@ -267,7 +267,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $bodyText =  $this->safeFindElement(
             WebDriverBy::cssSelector(".error")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Visit $visitLabel does not exist for given candidate",
             $bodyText
         );
@@ -288,7 +288,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $bodyText =  $this->safeFindElement(
             WebDriverBy::cssSelector(".error")
         )->getText();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "PSCID and CandID do not match or candidate does not exist",
             $bodyText
         );
@@ -340,7 +340,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             $bodyText = $this->webDriver->executescript(
                 "return document.querySelector('$table').textContent"
             );
-            $this->assertContains($records, $bodyText);
+            $this->assertStringContainsString($records, $bodyText);
         } else {
             $this->safeFindElement(WebDriverBy::cssSelector($element));
             $this->webDriver->executescript(
@@ -353,7 +353,7 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
             $bodyText = $this->webDriver->executescript(
                 "return document.querySelector('$table').textContent"
             );
-            $this->assertContains($records, $bodyText);
+            $this->assertStringContainsString($records, $bodyText);
         }
         //test clear filter
         $btn = self::$clearFilter;

--- a/modules/survey_accounts/test/survey_accountsTest.php
+++ b/modules/survey_accounts/test/survey_accountsTest.php
@@ -199,7 +199,10 @@ class Survey_AccountsTestIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("You do not have access to this page.", $bodyText);
+        $this->assertStringContainsString(
+            "You do not have access to this page.",
+            $bodyText
+        );
         $this->resetPermissions();
     }
     /**

--- a/modules/timepoint_list/test/timepoint_listTest.php
+++ b/modules/timepoint_list/test/timepoint_listTest.php
@@ -59,7 +59,7 @@ class TimepointListIntegrationTest extends LorisIntegrationTestWithCandidate
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Candidate Profile", $bodyText);
+        $this->assertStringContainsString("Candidate Profile", $bodyText);
     }
     /**
      * Checks the contents of the session table and compares it against an expected

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -56,7 +56,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $password = new \Password($this->validPassword);
@@ -493,7 +493,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    function tearDown()
+    function tearDown(): void
     {
         $this->DB->delete("users", ["UserID" => 'userid']);
         $this->DB->delete("user_psc_rel", ["UserID" => 999995]);

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -107,7 +107,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
         $bodyText = $this->safeFindElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Edit User", $bodyText);
+        $this->assertStringContainsString("Edit User", $bodyText);
         $this->assertEquals(
             "password",
             $this->safeFindElement(
@@ -165,7 +165,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $bodyText = $this->webDriver->executescript(
                 "return document.querySelector('$table').textContent"
             );
-            $this->assertContains($value, $bodyText);
+            $this->assertStringContainsString($value, $bodyText);
         } else {
             $this->safeFindElement(WebDriverBy::cssSelector($element));
             $this->webDriver->executescript(
@@ -182,7 +182,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
                 WebDriverBy::cssSelector($row)
             )->getText();
                     // 4 means there are 4 records under this site.
-                    $this->assertContains($records, $bodyText);
+                    $this->assertStringContainsString($records, $bodyText);
         }
         //test clear filter
         $btn = $this->_clearFilter;
@@ -385,7 +385,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             self::UNITTESTER_EMAIL_NEW
         );
         // This text comes from the class constants in Edit User
-        $this->assertContains('cannot be your email', $this->getBody());
+        $this->assertStringContainsString('cannot be your email', $this->getBody());
     }
 
     /**
@@ -404,7 +404,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             \Utility::randomString()
         );
         // This text comes from the class constants in Edit User
-        $this->assertContains('do not match', $this->getBody());
+        $this->assertStringContainsString('do not match', $this->getBody());
     }
 
     /**
@@ -428,7 +428,7 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
             $newPassword
         );
         // This text comes from the class constants in Edit User
-        $this->assertContains(
+        $this->assertStringContainsString(
             'New and old passwords are identical',
             $this->getBody()
         );

--- a/php/libraries/SiteIDGenerator.php
+++ b/php/libraries/SiteIDGenerator.php
@@ -150,7 +150,7 @@ class SiteIDGenerator extends IdentifierGenerator
      * @param string $setting One of: 'generation', 'length', 'alphabet',
      *                        'min', 'max'.
      *
-     * @return array<int,int|float>|string|null
+     * @return array<int,int|string>|string|null
      */
     private function _getIDSetting(
         string $setting

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -464,7 +464,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         $factory = \NDB_Factory::singleton();
         $DB      = $factory->database();
 
-        $count = $DB->pselectOne(
+        $count = $DB->pselectOneInt(
             "SELECT
                COUNT(1)
              FROM user_login_history

--- a/raisinbread/test/api/LorisApiAuthenticatedTest.php
+++ b/raisinbread/test/api/LorisApiAuthenticatedTest.php
@@ -34,7 +34,7 @@ class LorisApiAuthenticatedTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -182,7 +182,7 @@ class LorisApiAuthenticatedTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->delete("session", ['CandID' => '900000']);
         $this->DB->delete("candidate", ['CandID' => '900000']);

--- a/test/integrationtests/Login_Test.php
+++ b/test/integrationtests/Login_Test.php
@@ -36,7 +36,10 @@ class LorisLoginTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertStringContainsString("Incorrect username or password", $bodyText);
+        $this->assertStringContainsString(
+            "Incorrect username or password",
+            $bodyText
+        );
     }
 
     /**

--- a/test/integrationtests/Login_Test.php
+++ b/test/integrationtests/Login_Test.php
@@ -36,7 +36,7 @@ class LorisLoginTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Incorrect username or password", $bodyText);
+        $this->assertStringContainsString("Incorrect username or password", $bodyText);
     }
 
     /**
@@ -65,7 +65,7 @@ class LorisLoginTest extends LorisIntegrationTest
         $bodyText = $this->webDriver->findElement(
             WebDriverBy::cssSelector("body")
         )->getText();
-        $this->assertContains("Welcome", $bodyText);
+        $this->assertStringContainsString("Welcome", $bodyText);
     }
 }
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -661,7 +661,7 @@ abstract class LorisIntegrationTest extends TestCase
         string $jsError= "An error occured while loading the page."
     ): void {
         $this->assertStringContainsString($needle, $haystack);
-        $this->assertNotContains($jsError, $haystack);
+        $this->assertStringNotContainsString($jsError, $haystack);
         $this->resetPermissions();
     }
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -59,7 +59,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         // Set up database wrapper and config
         $this->factory = NDB_Factory::singleton();
@@ -196,7 +196,7 @@ abstract class LorisIntegrationTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (extension_loaded('xdebug')) {
             $data = xdebug_get_code_coverage();

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -660,7 +660,7 @@ abstract class LorisIntegrationTest extends TestCase
         string $haystack,
         string $jsError= "An error occured while loading the page."
     ): void {
-        $this->assertContains($needle, $haystack);
+        $this->assertStringContainsString($needle, $haystack);
         $this->assertNotContains($jsError, $haystack);
         $this->resetPermissions();
     }
@@ -713,7 +713,7 @@ abstract class LorisIntegrationTest extends TestCase
                 WebDriverBy::cssSelector("$row")
             )->getText();
             // 4 means there are 4 records under this site.
-            $this->assertContains($expect_records, $bodyText);
+            $this->assertStringContainsString($expect_records, $bodyText);
             //test clear filter
             $this->safeFindElement(WebDriverBy::cssSelector("$btn"))->click();
     }
@@ -733,7 +733,7 @@ abstract class LorisIntegrationTest extends TestCase
         $this->safeGet($this->url . '/dashboard/');
         $link     =$this->safeFindElement(WebDriverBy::cssSelector($className));
         $bodyText = $link->findElement(WebDriverBy::cssSelector(".huge"))->getText();
-        $this->assertContains($value, $bodyText);
+        $this->assertStringContainsString($value, $bodyText);
         $this->safeClick(WebDriverBy::cssSelector($className));
         $this->webDriver->wait(3, 500)->until(
             WebDriverExpectedCondition::presenceOfElementLocated(
@@ -741,6 +741,6 @@ abstract class LorisIntegrationTest extends TestCase
             )
         );
         $pageSource = $this->webDriver->getPageSource();
-        $this->assertContains($label, $pageSource);
+        $this->assertStringContainsString($label, $pageSource);
     }
 }

--- a/test/integrationtests/LorisIntegrationTestWithCandidate.class.inc
+++ b/test/integrationtests/LorisIntegrationTestWithCandidate.class.inc
@@ -24,7 +24,7 @@ abstract class LorisIntegrationTestWithCandidate extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/test/test_instrument/test_instrumentTest.php
+++ b/test/test_instrument/test_instrumentTest.php
@@ -95,7 +95,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
         $this->_landing();
         $bodyText = $this->webDriver->findElement(WebDriverBy::cssSelector("body"))
             ->getText();
-        $this->assertContains($content, $bodyText);
+        $this->assertStringContainsString($content, $bodyText);
     }
     /**
      * Testing instrument element appears in the body.
@@ -153,7 +153,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
             'SELECT Data FROM flag where SessionID = 999999',
             []
         );
-        $this->assertContains('Test Text successful', $data);
+        $this->assertStringContainsString('Test Text successful', $data);
     }
 
     /**
@@ -174,7 +174,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
             'SELECT Data FROM flag where SessionID = 999999',
             []
         );
-        $this->assertContains('"testCheckbox":"1"', $data);
+        $this->assertStringContainsString('"testCheckbox":"1"', $data);
     }
 
     /**
@@ -198,7 +198,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
             'SELECT Data FROM flag where SessionID = 999999',
             []
         );
-        $this->assertContains('"consent":"yes"', $data);
+        $this->assertStringContainsString('"consent":"yes"', $data);
 
         // select 'No' option and check it.
         $this->_landing();
@@ -214,7 +214,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
             'SELECT Data FROM flag where SessionID = 999999',
             []
         );
-        $this->assertContains('"consent":"no"', $data);
+        $this->assertStringContainsString('"consent":"no"', $data);
 
     }
 

--- a/test/test_instrument/test_instrumentTest.php
+++ b/test/test_instrument/test_instrumentTest.php
@@ -21,7 +21,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->DB->insert(
@@ -74,7 +74,7 @@ class TestInstrumentTestIntegrationTest extends LorisIntegrationTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->DB->delete("session", ['CandID' => '900000']);
         $this->DB->delete("candidate", ['CandID' => '900000']);

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -97,14 +97,14 @@ class CandidateTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
+     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
 
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnitFrameworkMockObjectMockObject
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -97,14 +97,14 @@ class CandidateTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
      */
     private $_configMock;
 
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnit_Framework_MockObject_MockObject
+     * @var \Database | PHPUnitFrameworkMockObjectMockObject
      */
     private $_dbMock;
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -586,7 +586,7 @@ class CandidateTest extends TestCase
         $subprojects = [];
         $this->_setUpTestDoublesForSelectCandidate();
 
-        $this->_dbMock->expects($this->exactly(3))
+        $this->_dbMock->expects($this->exactly(2))
             ->method('pselect')
             ->willReturn(
                 $subprojects
@@ -648,7 +648,7 @@ class CandidateTest extends TestCase
         $this->_dbMock->expects($this->any())
             ->method('pselectOne')
             ->with($this->stringContains("SELECT MAX(s.VisitNo)+1"))
-            ->willReturn(2);
+            ->willReturn('2');
 
         $this->_candidate->select($this->_candidateInfo['CandID']);
         $this->assertEquals(2, $this->_candidate->getNextVisitNo());

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -126,7 +126,7 @@ class CandidateTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -164,7 +164,7 @@ class CandidateTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->_factory->reset();

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -749,7 +749,13 @@ class CandidateTest extends TestCase
             ->willReturn($this->_candidateInfo);
         $this->_dbMock
             ->method('pselect')
-            ->will($this->onConsecutiveCalls($this->_listOfTimePoints, [["ID" => 97],["ID"=>98]], $this->_listOfTimePoints));
+            ->will(
+                $this->onConsecutiveCalls(
+                    $this->_listOfTimePoints,
+                    [["ID" => 97],["ID"=>98]],
+                    $this->_listOfTimePoints
+                )
+            );
 
         $this->_candidate->select($this->_candidateInfo['CandID']);
         $this->assertEquals(97, $this->_candidate->getSessionID(1));
@@ -1207,7 +1213,12 @@ class CandidateTest extends TestCase
     {
         $this->_dbMock
             ->method('pselect')
-            ->will($this->onConsecutiveCalls( [["ID" => 97],["ID"=>98]], $this->_listOfTimePoints));
+            ->will(
+                $this->onConsecutiveCalls(
+                    [["ID" => 97],["ID"=>98]],
+                    $this->_listOfTimePoints
+                )
+            );
 
         $this->_dbMock->expects($this->once())
             ->method('pselectRow')

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -82,7 +82,7 @@ class Database_Test extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = NDB_Factory::singleton();
         $this->factory->reset();
@@ -104,7 +104,7 @@ class Database_Test extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->factory->reset();

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -174,7 +174,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['update']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['update']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
@@ -199,7 +199,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['unsafeupdate']))
+            ->addMethods($this->_getAllMethodsExcept(['unsafeupdate']))
             ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
@@ -225,7 +225,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['insert']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['insert']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
@@ -250,7 +250,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['unsafeinsert']))
+            ->addMethods($this->_getAllMethodsExcept(['unsafeinsert']))
             ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
@@ -781,7 +781,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods(
+            ->addMethods(
                 $this->_getAllMethodsExcept(['insertOnDuplicateUpdate'])
             )
             ->getMock();
@@ -812,7 +812,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods(
+            ->addMethods(
                 $this->_getAllMethodsExcept(['unsafeInsertOnDuplicateUpdate'])
             )
             ->getMock();
@@ -876,7 +876,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['run']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['run']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
@@ -896,7 +896,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['prepare']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['prepare']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
@@ -1013,7 +1013,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['pselect']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['pselect']))->getMock();
 
         $stmt   = $stub->prepare("SHOW TABLES");
         $params = ['test' => 'test'];
@@ -1068,7 +1068,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['pselectRow']))
+            ->addMethods($this->_getAllMethodsExcept(['pselectRow']))
             ->getMock();
 
         $query  = "SELECT ID, Name, Description, Visible FROM ConfigSettings";
@@ -1314,7 +1314,7 @@ class Database_Test extends TestCase
         );
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['insertIgnore']))
+            ->addMethods($this->_getAllMethodsExcept(['insertIgnore']))
             ->getMock();
 
         $table = "ConfigSettings";
@@ -1580,7 +1580,7 @@ class Database_Test extends TestCase
 
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['quote']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['quote']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
 
@@ -1612,7 +1612,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['inTransaction']))
+            ->addMethods($this->_getAllMethodsExcept(['inTransaction']))
             ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
@@ -1633,7 +1633,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['beginTransaction']))
+            ->addMethods($this->_getAllMethodsExcept(['beginTransaction']))
             ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
@@ -1654,7 +1654,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['beginTransaction']))
+            ->addMethods($this->_getAllMethodsExcept(['beginTransaction']))
             ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
@@ -1674,7 +1674,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['rollBack']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['rollBack']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
 
@@ -1693,7 +1693,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['rollBack']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['rollBack']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
 
@@ -1712,7 +1712,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['commit']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['commit']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
 
@@ -1731,7 +1731,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['commit']))->getMock();
+            ->addMethods($this->_getAllMethodsExcept(['commit']))->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
 
@@ -1750,7 +1750,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['isConnected']))
+            ->addMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
 
         $val = $stub->isConnected();
@@ -1767,7 +1767,7 @@ class Database_Test extends TestCase
     {
         $this->_factory = NDB_Factory::singleton();
         $stub           = $this->getMockBuilder('FakeDatabase')
-            ->setMethods($this->_getAllMethodsExcept(['isConnected']))
+            ->addMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
 
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -33,7 +33,7 @@ class LorisForms_Test extends TestCase
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         $this->form = new LorisForm();
     }

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -405,7 +405,7 @@ class LorisForms_Test extends TestCase
     function testAddElementSelect()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addSelect', 'addDate'])
+            ->addMethods(['addSelect', 'addDate'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addSelect');
@@ -422,7 +422,7 @@ class LorisForms_Test extends TestCase
     function testAddElementDate()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addDate'])
+            ->addMethods(['addDate'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addDate');
@@ -439,7 +439,7 @@ class LorisForms_Test extends TestCase
     function testAddElementText()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addText'])
+            ->addMethods(['addText'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addText');
@@ -456,7 +456,7 @@ class LorisForms_Test extends TestCase
     function testAddElementFile()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addFile'])
+            ->addMethods(['addFile'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addFile');
@@ -473,7 +473,7 @@ class LorisForms_Test extends TestCase
     function testAddElementPassword()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addPassword'])
+            ->addMethods(['addPassword'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addPassword');
@@ -490,7 +490,7 @@ class LorisForms_Test extends TestCase
     function testAddElementStatic()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addStatic'])
+            ->addMethods(['addStatic'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addStatic');
@@ -507,7 +507,7 @@ class LorisForms_Test extends TestCase
     function testAddElementTextArea()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addTextArea'])
+            ->addMethods(['addTextArea'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addTextArea');
@@ -524,7 +524,7 @@ class LorisForms_Test extends TestCase
     function testAddElementHeader()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addHeader'])
+            ->addMethods(['addHeader'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addHeader');
@@ -541,7 +541,7 @@ class LorisForms_Test extends TestCase
     function testAddElementRadio()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addRadio'])
+            ->addMethods(['addRadio'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addRadio');
@@ -558,7 +558,7 @@ class LorisForms_Test extends TestCase
     function testAddElementHidden()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addHidden'])
+            ->addMethods(['addHidden'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addHidden');
@@ -575,7 +575,7 @@ class LorisForms_Test extends TestCase
     function testAddElementLink()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['addLink'])
+            ->addMethods(['addLink'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('addLink');
@@ -637,7 +637,7 @@ class LorisForms_Test extends TestCase
     function testCreateElementText()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['createText'])
+            ->addMethods(['createText'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('createText');
@@ -654,7 +654,7 @@ class LorisForms_Test extends TestCase
     function testCreateElementSelect()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['createSelect'])
+            ->addMethods(['createSelect'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('createSelect');
@@ -671,7 +671,7 @@ class LorisForms_Test extends TestCase
     function testCreateElementSubmit()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['createSubmit'])
+            ->addMethods(['createSubmit'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('createSubmit');
@@ -1002,7 +1002,7 @@ class LorisForms_Test extends TestCase
             'format'  => 'y'
         ];
         $this->form     = $this->getMockBuilder('LorisForm')
-            ->setMethods(['yearHTML'])
+            ->addMethods(['yearHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('yearHTML')
@@ -1318,7 +1318,7 @@ class LorisForms_Test extends TestCase
         ];
 
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['advCheckboxHTML'])
+            ->addMethods(['advCheckboxHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('advCheckboxHTML');
@@ -1980,7 +1980,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementDate()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['dateHTML'])
+            ->addMethods(['dateHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('dateHTML');
@@ -1998,7 +1998,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementSelect()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['selectHTML'])
+            ->addMethods(['selectHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('selectHTML');
@@ -2016,7 +2016,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementStatic()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['staticHTML'])
+            ->addMethods(['staticHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('staticHTML');
@@ -2034,7 +2034,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementTextArea()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['textareaHTML'])
+            ->addMethods(['textareaHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('textareaHTML');
@@ -2052,7 +2052,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementFile()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['fileHTML'])
+            ->addMethods(['fileHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('fileHTML');
@@ -2070,7 +2070,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementPassword()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['textHTML'])
+            ->addMethods(['textHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('textHTML');
@@ -2088,7 +2088,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementText()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['textHTML'])
+            ->addMethods(['textHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('textHTML');
@@ -2106,7 +2106,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementCheckbox()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['checkboxHTML'])
+            ->addMethods(['checkboxHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('checkboxHTML');
@@ -2124,7 +2124,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementRadio()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['radioHTML'])
+            ->addMethods(['radioHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('radioHTML');
@@ -2142,7 +2142,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementGroup()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['groupHTML'])
+            ->addMethods(['groupHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('groupHTML');
@@ -2161,7 +2161,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementHeader()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['headerHTML'])
+            ->addMethods(['headerHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('headerHTML');
@@ -2179,7 +2179,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementSubmit()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['submitHTML'])
+            ->addMethods(['submitHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('submitHTML');
@@ -2197,7 +2197,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementHidden()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['hiddenHTML'])
+            ->addMethods(['hiddenHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('hiddenHTML');
@@ -2215,7 +2215,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementTime()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['timeHTML'])
+            ->addMethods(['timeHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('timeHTML');
@@ -2239,7 +2239,7 @@ class LorisForms_Test extends TestCase
     function testRenderElementLink()
     {
         $this->form = $this->getMockBuilder('LorisForm')
-            ->setMethods(['linkHTML'])
+            ->addMethods(['linkHTML'])
             ->getMock();
         $this->form->expects($this->once())
             ->method('linkHTML');

--- a/test/unittests/Loris_PHPUnit_Database_TestCase.php
+++ b/test/unittests/Loris_PHPUnit_Database_TestCase.php
@@ -60,7 +60,7 @@ abstract class Loris_PHPUnit_Database_TestCase extends TestCase
      * @throws Exception
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = NDB_Factory::singleton();
 

--- a/test/unittests/NDB_BVL_FeedbackTest.php
+++ b/test/unittests/NDB_BVL_FeedbackTest.php
@@ -41,7 +41,7 @@ class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
      * @throws Exception
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->createLorisDBConnection();

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -25,7 +25,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         global $_SESSION;
         if (!defined("UNIT_TESTING")) {

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -32,7 +32,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
             define("UNIT_TESTING", true);
         }
         date_default_timezone_set("UTC");
-        $this->Session = $this->getMockBuilder(\stdClass::class)->setMethods(
+        $this->Session = $this->getMockBuilder(\stdClass::class)->addMethods(
             [
                 'getProperty',
                 'setProperty',
@@ -69,7 +69,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
         $this->i = $this
             ->getMockBuilder('\Loris\Behavioural\NDB_BVL_Instrument_LINST')
             ->disableOriginalConstructor()
-            ->setMethods(['getFullName', 'getSessionID'])
+            ->addMethods(['getFullName', 'getSessionID'])
             ->getMock();
         $this->i->method('getFullName')->willReturn("Test Instrument");
         $this->i->method('getSessionID')

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -45,7 +45,7 @@ class NDB_BVL_Instrument_Test extends TestCase
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         global $_SESSION;
         if (!defined("UNIT_TESTING")) {

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1822,7 +1822,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setTableData();
         $this->_instrument->setup("commentID1", "page");
         $this->_instrument->table = 'medical_history';
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<input  name=\"candID\" value=\"\" type=\"hidden\">\n",
             $this->_instrument->display()
         );

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -53,7 +53,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         }
         date_default_timezone_set("UTC");
         $this->session = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(
+            ->addMethods(
                 ['getProperty', 'setProperty', 'getUsername', 'isLoggedIn']
             )
             ->getMock();
@@ -80,7 +80,7 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $this->_instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
-            ->setMethods(["getFullName", "getSubtestList"])->getMock();
+            ->addMethods(["getFullName", "getSubtestList"])->getMock();
         $this->_instrument->method('getFullName')->willReturn("Test Instrument");
         $this->_instrument->method('getSubtestList')->willReturn([]);
         $this->_instrument->form     = $this->quickForm;
@@ -842,7 +842,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $this->_instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->addMethods(
                 ["getFullName", "getSubtestList", '_setupForm']
             )->getMock();
         $this->_instrument->method('getFullName')->willReturn("Test Instrument");
@@ -1618,7 +1618,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $otherInstrument            = $this
             ->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
-            ->setMethods(["getFullName", "getSubtestList"])->getMock();
+            ->addMethods(["getFullName", "getSubtestList"])->getMock();
         $otherInstrument->commentID = 'commentID2';
         $otherInstrument->table     = 'medical_history';
         $this->assertEquals(

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -54,14 +54,14 @@ class NDB_ConfigTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var NDB_Config | PHPUnitFrameworkMockObjectMockObject
      */
     private $_configMock;
 
     /**
      * Test double for Database object
      *
-     * @var Database | PHPUnit_Framework_MockObject_MockObject
+     * @var Database | PHPUnitFrameworkMockObjectMockObject
      */
     private $_dbMock;
 
@@ -76,7 +76,7 @@ class NDB_ConfigTest extends TestCase
     /**
      * Test double for User object
      *
-     * @var User | PHPUnit_Framework_MockObject_MockObject
+     * @var User | PHPUnitFrameworkMockObjectMockObject
      */
     private $_user;
 

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -171,7 +171,7 @@ class NDB_ConfigTest extends TestCase
         $this->assertNull($this->_config->getSettingFromDB("showDatabaseQueries"));
         $this->_dbMock->expects($this->any())
             ->method('isConnected')
-            ->willReturn('true');
+            ->willReturn(true);
         $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->willReturn([['AllowMultiple' => '0', 'ParentID' => 'test']]);

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -54,14 +54,14 @@ class NDB_ConfigTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var NDB_Config | PHPUnitFrameworkMockObjectMockObject
+     * @var NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
 
     /**
      * Test double for Database object
      *
-     * @var Database | PHPUnitFrameworkMockObjectMockObject
+     * @var Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
 

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -76,7 +76,7 @@ class NDB_ConfigTest extends TestCase
     /**
      * Test double for User object
      *
-     * @var User | PHPUnitFrameworkMockObjectMockObject
+     * @var User | PHPUnit\Framework\MockObject\MockObject
      */
     private $_user;
 

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -85,7 +85,7 @@ class NDB_ConfigTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->_config     = FakeConfig::singleton();
@@ -104,7 +104,7 @@ class NDB_ConfigTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->_factory->reset();

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -120,7 +120,7 @@ class NDB_ConfigTest extends TestCase
     public function testConfigFilePath()
     {
         $text = $this->_config->configFilePath("config.xml");
-        $this->assertContains("config.xml", $text);
+        $this->assertStringContainsString("config.xml", $text);
 
     }
 

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -20,7 +20,7 @@ class NDB_Menu_Filter_Test extends TestCase
      *
      * @return void
      */
-    function setUp()
+    function setUp(): void
     {
         global $_SESSION;
         $this->Session = $this->getMockBuilder(stdClass::class)->setMethods(

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -23,7 +23,7 @@ class NDB_Menu_Filter_Test extends TestCase
     function setUp(): void
     {
         global $_SESSION;
-        $this->Session = $this->getMockBuilder(stdClass::class)->setMethods(
+        $this->Session = $this->getMockBuilder(stdClass::class)->addMethods(
             [
                 'getProperty',
                 'setProperty',
@@ -64,7 +64,7 @@ class NDB_Menu_Filter_Test extends TestCase
         $method          = ['_resetFilters'];
         $allOtherMethods = $this->_getAllMethodsExcept($method);
         $stub            = $this->getMockBuilder('NDB_Menu_Filter')
-            ->setMethods($allOtherMethods)
+            ->addMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -92,7 +92,7 @@ class NDB_Menu_Filter_Test extends TestCase
         $method          = ['_setSearchKeyword'];
         $allOtherMethods = $this->_getAllMethodsExcept($method);
         $stub            = $this->getMockBuilder('NDB_Menu_Filter')
-            ->setMethods($allOtherMethods)
+            ->addMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -120,7 +120,7 @@ class NDB_Menu_Filter_Test extends TestCase
         $method          = ['_setFilters'];
         $allOtherMethods = $this->_getAllMethodsExcept($method);
         $stub            = $this->getMockBuilder('NDB_Menu_Filter')
-            ->setMethods($allOtherMethods)
+            ->addMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -178,7 +178,7 @@ class NDB_Menu_Filter_Test extends TestCase
         $method          = ['_setFilterSortOrder'];
         $allOtherMethods = $this->_getAllMethodsExcept($method);
         $stub            = $this->getMockBuilder('NDB_Menu_Filter')
-            ->setMethods($allOtherMethods)
+            ->addMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -42,7 +42,7 @@ class NDB_PageTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class NDB_PageTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -58,7 +58,7 @@ class PasswordTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->_factory->reset();

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -29,7 +29,7 @@ class PasswordTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
      */
     private $_configMock;
 

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -106,6 +106,7 @@ class PasswordTest extends TestCase
      */
     public function testContructorInvalidValues($invalidValue): void
     {
+        $this->expectException("InvalidArgumentException");
         $this->_configMock->expects($this->any())
             ->method('getSetting')
             ->willReturn('false');

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -29,7 +29,7 @@ class PasswordTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
+     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
 

--- a/test/unittests/SettingsTest.php
+++ b/test/unittests/SettingsTest.php
@@ -27,7 +27,7 @@ class SettingsTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var NDB_Config | PHPUnitFrameworkMockObjectMockObject
+     * @var NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
 

--- a/test/unittests/SettingsTest.php
+++ b/test/unittests/SettingsTest.php
@@ -54,7 +54,7 @@ class SettingsTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/unittests/SettingsTest.php
+++ b/test/unittests/SettingsTest.php
@@ -27,7 +27,7 @@ class SettingsTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var NDB_Config | PHPUnitFrameworkMockObjectMockObject
      */
     private $_configMock;
 

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -32,7 +32,7 @@ class SinglePointLoginTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $Factory = NDB_Factory::singleton();
         $Factory->setTesting(true);

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -55,7 +55,7 @@ class SinglePointLoginTest extends TestCase
         $AllMethods   = get_class_methods('SinglePointLogin');
         $exceptMethod = array_diff($AllMethods, $method);
         $this->_login = $this->getMockBuilder('SinglePointLogin')
-            ->setMethods($exceptMethod)->getMock();
+            ->addMethods($exceptMethod)->getMock();
 
     }
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -309,7 +309,7 @@ class UserTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->_factory->reset();

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -702,7 +702,7 @@ class UserTest extends TestCase
         $this->_user = \User::factory(self::USERNAME);
         $count       = 1;
         $this->_mockDB->expects($this->any())
-            ->method('pselectOne')
+            ->method('pselectOneInt')
             ->with(
                 $this->stringContains("FROM user_login_history")
             )
@@ -723,7 +723,7 @@ class UserTest extends TestCase
         $this->_user = \User::factory(self::USERNAME);
         $count       = 0;
         $this->_mockDB->expects($this->any())
-            ->method('pselectOne')
+            ->method('pselectOneInt')
             ->with(
                 $this->stringContains("FROM user_login_history")
             )

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -214,13 +214,13 @@ class UserTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnit_Framework_MockObject_MockObject
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
     /**
@@ -231,7 +231,7 @@ class UserTest extends TestCase
      *       This can be changed when the rest of the User class updates how it
      *       declares its database. - Alexandra Livadas
      *
-     * @var \Database | PHPUnit_Framework_MockObject_MockObject
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_mockDB;
     /**

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -182,7 +182,7 @@ class UtilityTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->_factory->reset();

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -124,13 +124,13 @@ class UtilityTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
+     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnitFrameworkMockObjectMockObject
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
 
@@ -139,7 +139,7 @@ class UtilityTest extends TestCase
      *
      * @note Used in the _setMockDB function
      *
-     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
+     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_mockConfig;
     /**
@@ -147,7 +147,7 @@ class UtilityTest extends TestCase
      *
      * @note Used in the _setMockDB function
      *
-     * @var \Database | PHPUnitFrameworkMockObjectMockObject
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_mockDB;
     /**

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -124,13 +124,13 @@ class UtilityTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
      */
     private $_configMock;
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnit_Framework_MockObject_MockObject
+     * @var \Database | PHPUnitFrameworkMockObjectMockObject
      */
     private $_dbMock;
 
@@ -139,7 +139,7 @@ class UtilityTest extends TestCase
      *
      * @note Used in the _setMockDB function
      *
-     * @var \NDB_Config | PHPUnit_Framework_MockObject_MockObject
+     * @var \NDB_Config | PHPUnitFrameworkMockObjectMockObject
      */
     private $_mockConfig;
     /**
@@ -147,7 +147,7 @@ class UtilityTest extends TestCase
      *
      * @note Used in the _setMockDB function
      *
-     * @var \Database | PHPUnit_Framework_MockObject_MockObject
+     * @var \Database | PHPUnitFrameworkMockObjectMockObject
      */
     private $_mockDB;
     /**

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -243,7 +243,7 @@ class UtilityTest extends TestCase
      */
     public function testGetConsentList()
     {
-        $this->_dbMock->expects($this->at(0))
+        $this->_dbMock->expects($this->any())
             ->method('pselectWithIndexKey')
             ->willReturn($this->_consentInfo);
         $this->assertEquals($this->_consentInfo, Utility::getConsentList());
@@ -257,7 +257,7 @@ class UtilityTest extends TestCase
      */
     public function testGetProjectList()
     {
-        $this->_dbMock->expects($this->at(0))
+        $this->_dbMock->expects($this->any())
             ->method('pselectColWithIndexKey')
             ->willReturn($this->_projectInfo);
         $this->assertEquals(
@@ -825,7 +825,7 @@ class UtilityTest extends TestCase
      */
     public function testGetSourcefieldsWithInstrumentSpecified()
     {
-        $this->_dbMock->expects($this->at(0))
+        $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->with($this->stringContains("AND sourcefrom = :sf"))
             ->willReturn(
@@ -882,7 +882,7 @@ class UtilityTest extends TestCase
      */
     public function testGetSourcefieldsWithNameSpecified()
     {
-        $this->_dbMock->expects($this->at(0))
+        $this->_dbMock->expects($this->any())
             ->method('pselectRow')
             ->willReturn(
                 [
@@ -910,7 +910,7 @@ class UtilityTest extends TestCase
      */
     public function testGetSourcefieldsWithAllThreeParameters()
     {
-        $this->_dbMock->expects($this->at(0))
+        $this->_dbMock->expects($this->any())
             ->method('pselect')
             ->with($this->stringContains("AND sourcefrom = :sf"))
             ->willReturn(

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -46,7 +46,7 @@ class VisitTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = NDB_Factory::singleton();
         $this->factory->reset();
@@ -185,7 +185,7 @@ class VisitTest extends TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->factory->reset();

--- a/test/unittests/studyentities/CandID_Test.php
+++ b/test/unittests/studyentities/CandID_Test.php
@@ -56,12 +56,13 @@ class CandID_Test extends TestCase
      *
      * @dataProvider invalidValues
      *
-     * @expectedException \DomainException
+     * @expectedException DomainException
      * @return            void
      */
     public function testContructorInvalidValues($invalidValue): void
     {
-        $candid = new CandID($invalidValue);
+       $this->expectException("DomainException");
+       $candid = new CandID($invalidValue);
     }
 
     /**

--- a/test/unittests/studyentities/CandID_Test.php
+++ b/test/unittests/studyentities/CandID_Test.php
@@ -61,8 +61,8 @@ class CandID_Test extends TestCase
      */
     public function testContructorInvalidValues($invalidValue): void
     {
-       $this->expectException("DomainException");
-       $candid = new CandID($invalidValue);
+        $this->expectException("DomainException");
+        $candid = new CandID($invalidValue);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes
Update the PHPunit version to 9.4, it will be easy to update Loris to php 8.0.
Fix deprecated methods in this PR. (at , setMethods, assertContains ... )

Test:
passing git actions