### PR TITLE
Instrument class and LINST class cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ requesting a new account and will be displayed in the User Accounts module (PR #
 ### Notes For Existing Projects
 - New function Candidate::getSubjectForMostRecentVisit replaces Utility::getSubprojectIDUsingCandID, adding ability to determine which subproject a candidate belongs to given their most recent visit.
 - LINST instrument class was modified to implement the getFullName() and getSubtestList() functions thus making entries in the test_names and instrument_subtests tables respectively unnecessary for LINST instruments (PR #7169)
+- Deprecation of `begintable` and `endtable` elements in LINST instruments
+- Deletion of `dateTimeFields` variable in instrument class. all references to this variable should be removed from project instruments.
+- Deletion of `monthYearFields` variable in instrument class. all references to this variable should be removed from project instruments.
 ### Notes For Developers
 - *Add item here*
 

--- a/docs/instruments/NDB_BVL_Instrument_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_TEMPLATE.class.inc
@@ -7,7 +7,7 @@
  *
  * @category Instrument
  * @package  TEMPLATE
- * @author   Stella Lee <slee.mcin@gmail.com>
+ * @author   Author Name
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/loris/
  */
@@ -17,7 +17,7 @@
  *
  * @category Instrument
  * @package  TEMPLATE
- * @author   Stella Lee <slee.mcin@gmail.com>
+ * @author   Author Name
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/loris/
  */
@@ -25,7 +25,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
 {
 
     /**
-     * Sets up basic data such as the HTML_Quickform object, database references
+     * Sets up basic data.
      *
      * @param string $commentID the CommentID identifying the data to load
      * @param string $page      if a multipage form, the page to show
@@ -49,12 +49,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
         // data keyed by commentID
         $this->commentID = $commentID;
 
-        //The array of dates/timestamps to convert to database dates/timestamps
-        //Any HTML_Quickform date elements must be listed here
-        $this->dateTimeFields =array("Date_taken");
-
         //The array of selects with multiple answers allowed
-        //Any HTML_Quickform multiple selects must be listed here
         $this->selectMultipleElements = array();
 
         // required fields for data entry completion status
@@ -69,7 +64,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
     }
 
     /**
-     * Builds the HTML_Quickform object into a paged form
+     * Builds the object into a paginated form
      *
      * @return void
      * @access private
@@ -81,7 +76,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
         } else {
             $this->_main();
         }
-        // Defines the call back function for HTML Quickform to use in validation
+        // Defines the call back function to use in validation
         $this->form->addFormRule(array(&$this, 'XINValidate'));
     }
 
@@ -126,5 +121,27 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
         //continue onto further pages, if needed.
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getFullName(): ?string
+    {
+        return "TEMPLATE TEST NAME";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    function getSubtestList(): array
+    {
+        $subtest = [
+            ['Name'=>'<TEST_NAME>_page1','Description'=>'Subtest One'],
+            ['Name'=>'<TEST_NAME>_page2','Description'=>'Subtest Two'],
+        ];
+        return $subtest;
+    }
 }
-?>

--- a/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
+++ b/docs/instruments/NDB_BVL_Instrument_UPLOADER_TEMPLATE.class.inc
@@ -1,8 +1,30 @@
 <?php
+/**
+ * This file contains the NDB_BVL_Instrument_TEMPLATE
+ * class
+ *
+ * PHP Version 5
+ *
+ * @category Instrument
+ * @package  TEMPLATE
+ * @author   Author Name
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/loris/
+ */
+
+/**
+ * Creates the form elements for the Boston_Diagnostic_Aphasia_Exam instrument
+ *
+ * @category Instrument
+ * @package  TEMPLATE
+ * @author   Author Name
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/loris/
+ */
 class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
 {
     /**
-    * sets up basic data, such as the HTML_Quickform object, and so on.
+    * sets up basic data.
     *
     * @param string $commentID  the CommentID identifying the data to load
     * @param string $page       if a multipage form, the page to show
@@ -23,12 +45,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
         // data keyed by commentID
         $this->commentID = $commentID;
 
-        //The array of dates/timestamps to convert to database dates/timestamps
-        //Any HTML_Quickform date elements must be listed here
-        $this->dateTimeFields=array("Date_taken");
-
         //The array of selects with multiple answers allowed
-        //Any HTML_Quickform multiple selects must be listed here
         $this->selectMultipleElements = array();
 
         // required fields for data entry completion status
@@ -42,7 +59,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
     //If the instrument is not paged, remove the switch from the _setupForm method and add all the form Elements in this function.
 
     /**
-    * method to build the HTML_Quickform object into a paged form
+    * method to build the object into a paginated form
     *
     * @return void
     * @access private
@@ -57,7 +74,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
             $this->_main();
             break;
         }
-        //Defines the call back function for HTML Quickform to use when validating the form.
+        //Defines the call back function to use when validating the form.
         $this->form->addFormRule(array(&$this,'XINValidate'));
     }
 
@@ -86,7 +103,7 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
 
     }
 
-    function _saveValues($values)
+    function _saveValues($values) :void
     {
          $timepoint = TimePoint::singleton($this->getSessionID());
          $candidate = Candidate::singleton($timepoint->getCandID());
@@ -187,5 +204,26 @@ class NDB_BVL_Instrument_TEST_NAME extends NDB_BVL_Instrument
        return true;
    }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return string|null
+     */
+    public function getFullName(): ?string
+    {
+        return "UPLOADER TEMPLATE TEST NAME";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    function getSubtestList(): array
+    {
+        $subtest = [
+            ['Name'=>'<TEST_NAME>_page1','Description'=>'Subtest One'],
+        ];
+        return $subtest;
+    }
 }
-?>

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1129,21 +1129,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     abstract function getSubtestList(): array;
 
     /**
-     * Marks an element in the lorisform object as being required (for
-     * use with the requiredIf rule)
-     *
-     * @param string $elementName the element to add to the required list
-     *
-     * @return void
-     */
-    function setRequired(string $elementName): void
-    {
-        if (!in_array($elementName, $this->form->_required)) {
-            $this->form->_required[] = $elementName;
-        }
-    }
-
-    /**
      * This runs the XIN rules on all the elements on the current page to ensure
      * that no rules were violated.
      *

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -29,11 +29,41 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     public $form;
 
+    /**
+     * Variable defining the type of form in use
+     *
+     * Note: this seems to always be defined as 'XIN'
+     *
+     * @var string
+     */
     public $formType;
 
+    /**
+     * Array holding the date format
+     *
+     * @var array
+     */
     public $dateOptions;
+
+    /**
+     * Type of instrument. Can be 'normal' or 'DirectEntry'
+     *
+     * @var string
+     */
     public $DataEntryType;
+
+    /**
+     * Array holding XIN rules
+     *
+     * @var array
+     */
     public $XINRules;
+
+    /**
+     * Boolean enabling/disabling debugging statements for XIN rules
+     *
+     * @var boolean
+     */
     public $XINDebug;
 
     /**
@@ -102,21 +132,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     var $_requiredElements = [];
 
-    /**
-     * Array of date fields to be processed into QuickForm dates
-     * NOTE: When abstracting the _saveValues() method in the child <instrument>
-     * class, add only the dates from the current page to the array using the
-     * instruments switch($page) otherwise you'll end up overwriting (NULLing)
-     * all other dates in the table that appear on other pages (if they are
-     * listed in the array of date fields) - note by @dariovins
-     */
-    public $dateTimeFields = [];
-
-    /**
-     * Array of date fields that contain only month year fields in frontend with
-     * a static value for the date
-     */
-    public $monthYearFields = [];
     /**
      * Array of column names to be ignored by the double data entry conflict
      * detector.
@@ -288,11 +303,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $base . "project/instruments/$instrument.linst"
         );
         // Add rules only if they exist.
-        if (file_exists($base."project/instruments/$instrument.rules")) {
-            $obj->loadInstrumentRules(
-                $base . "project/instruments/$instrument.rules"
-            );
-        }
+        $obj->loadInstrumentRules(
+            $base . "project/instruments/$instrument.rules"
+        );
 
         $user   = \User::singleton();
         $access = $obj->_hasAccess($user);
@@ -373,7 +386,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
-     * Sets up basic data, such as the HTML_Quickform object, and so on.
+     * Sets up basic data.
      *
      * @param string|null $commentID The CommentID identifying the data to load
      * @param string|null $page      If a multipage form, the page to show
@@ -532,22 +545,16 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     }
 
     /**
-     * Accepts an array usable as input to HTML_Quickform::setDefaults()
-     * and does any necessary preprocessing on that array.
+     * Accepts an array of existing values and sets them as defaults on the
+     * instrument
      *
-     * @param array $defaults the array to be passed on to
-     *                        HTML_Quickform::setDefaults()
+     * @param array $defaults the array of default values
      *
      * @return array the processed array ready for setDefaults()
      * @access private
      */
     function _setDefaultsArray(array $defaults): array
     {
-        //Convert date/time fields into lorisform date/timestamps
-        if (empty($this->dateTimeFields)) {
-            $this->dateTimeFields = ["Date_taken"];
-        }
-
         if (isset($defaults['Window_Difference'])
             && $defaults['Window_Difference'] != 0
         ) {
@@ -618,7 +625,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * This handles the saving of the Candidate_Age and Window_Difference columns
      * to the database when the save function is called with a Date_taken.
      *
-     * @param array $values A reference to the values saved from QuickForm that
+     * @param array $values A reference to the values saved from the form that
      *                      will be passed to update. This will be modified to
      *                      have Candidate_Age and Window_Difference if the
      *                      Date_taken field is included.
@@ -754,11 +761,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _saveValues(array $values): void
     {
-        //Convet date/timestamps into database format
-        if (empty($this->dateTimeFields)) {
-            $this->dateTimeFields = ["Date_taken"];
-        }
-
         if (strrpos($this->testName, "_proband") === false) {
             $this->_saveCandidateAge($values);
         }
@@ -1110,12 +1112,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function getDateOfAdministration()
     {
-        $db  = \Database::singleton();
-        $doa = $db->pselectOne(
-            "SELECT Date_taken FROM $this->table WHERE CommentID=:CID",
-            ['CID' => $this->getCommentID()]
-        );
-        $this->dateOfAdministration = $doa;
+        $this->dateOfAdministration = $this->getFieldValue('Date_taken');
 
         return $this->dateOfAdministration;
     }
@@ -1132,80 +1129,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     abstract function getSubtestList(): array;
 
     /**
-     * Convert a lorisform date or timestamp into a database acceptable
-     * (and storable) date or time
+     * Marks an element in the lorisform object as being required (for
+     * use with the requiredIf rule)
      *
-     * @param array $formDateValue the lorisform date/timestamp array
+     * @param string $elementName the element to add to the required list
      *
-     * @return string the date or timestamp from the database
-     * @access private
+     * @return void
      */
-    function _getDatabaseDate(array $formDateValue): string
+    function setRequired(string $elementName): void
     {
-        $databaseValue = "";
-        if (!empty($formDateValue)) {
-            if (array_key_exists("Y", $formDateValue)
-                || array_key_exists("M", $formDateValue)
-                || array_key_exists("d", $formDateValue)
-            ) {
-
-                if (array_key_exists("Y", $formDateValue)) {
-                    $yearString = $formDateValue['Y'];
-                } else {
-                    $yearString = "0001";
-                }
-
-                if (array_key_exists("M", $formDateValue)) {
-                    $monthString = $formDateValue['M'];
-                } else {
-                    $monthString = "01";
-                }
-
-                if (array_key_exists("d", $formDateValue)) {
-                    $dayString = $formDateValue['d'];
-                } else {
-                    $dayString = "01";
-                }
-
-                $databaseValue = $yearString . "-" . $monthString . "-" . $dayString;
-
-            } elseif (array_key_exists("H", $formDateValue)
-                || array_key_exists("i", $formDateValue)
-            ) {
-                if (array_key_exists("H", $formDateValue)) {
-                    $hourString = $formDateValue['H'];
-                } else {
-                    $hourString = "01";
-                }
-                if (array_key_exists("i", $formDateValue)) {
-                    $minuteString = $formDateValue['i'];
-                } else {
-                    $minuteString = "01";
-                }
-
-                $databaseValue = $hourString . ":" . $minuteString;
-
-            }
+        if (!in_array($elementName, $this->form->_required)) {
+            $this->form->_required[] = $elementName;
         }
-        return $databaseValue;
     }
-
-
-    /**
-     * Convert a database date or timestamp into a QuickForm acceptable date or time
-     *
-     * @param string $databaseValue the date or timestamp from the database
-     *
-     * @return array the lorisform date/timestamp array
-     */
-    function _getQuickformDate(string $databaseValue)
-    {
-        throw new Exception(
-            "The function _getQuickformDate has been deprecated.
-            Please contact LORIS developer mail list for support."
-        );
-    }
-
 
     /**
      * This runs the XIN rules on all the elements on the current page to ensure
@@ -1787,7 +1723,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     /**
      * Wrapper to create an Hour/Minute field, with an accompanying status field.
      *
-     * @param string      $field        Name given to the HTML QuickForm Element
+     * @param string      $field        Name given to the HTML form Element
      *                                  being created
      * @param string      $label        The question text to display
      * @param array       $rules        Additional rules to apply to the element
@@ -1840,7 +1776,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * Note: $this->dateOptions must be defined by the subclass calling this
      * wrapper function
      *
-     * @param string $name    Name prepended to the HTMLQuickform element
+     * @param string $name    Name prepended to the form element
      * @param string $label   Element label
      * @param array  $options optional override of class's dateOptions
      *
@@ -1867,9 +1803,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ]
         );
         $this->WrapperDateWithStatusElements[$name . "_date"] = $group[0];
-        if (!in_array($name . "_date", $this->dateTimeFields)) {
-            $this->dateTimeFields[] = $name . "_date";
-        }
 
         $group[] = $this->createSelect(
             $name . "_date_status",
@@ -1916,7 +1849,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $options['format'] = 'YM';
         }
         $this->form->addElement('date', $field, $label, $options);
-        $this->monthYearFields[] = $field;
     }
 
 
@@ -1925,7 +1857,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      *
      * @param string $name      The database name to add to the form
      * @param string $label     The question text
-     * @param array  $dateArray QuickForm date options to use
+     * @param array  $dateArray Date options to use
      *
      * @return void
      * @note   This was only ever used by the EARLI instrument and should be
@@ -1939,7 +1871,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $group   = [];
         $group[] = $this->createDate($name . "_date", '', $dateArray);
         //add to array of dates and times.
-        $this->dateTimeFields[] = $name . "_date";
         $group[] = $this->createSelect(
             $name . "_date_status",
             '',
@@ -2589,7 +2520,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function _toJSONParseSmarty(array &$element): array
     {
         /* Hacks to get data that QuickForm_Renderer_Array doesn't provide
-         * an easy way to get */
+         * an easy way to get
+         *
+         * TODO: are these hacks still valid ?
+         * */
         if ($element['type'] === 'select') {
             // Parse the HTML to get the options from the select
             $html = new DOMDocument();
@@ -2692,12 +2626,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                         if (isset($el['elements'][0]['label'])) {
                             $el['label'] = $el['elements'][0]['label'];
                         }
-                        //unset($el['elements']);
-                        //unset($el['delimiter']);
-                        //$label = $el['label'];
-                        //$el = $this->_toJSONParseSmarty($el['elements'][0]);
-                        //$el['label'] = $label;
-                        //$el = $this->_toJSONParseSmarty($el);
                     }
                 };
                 array_map($mapFunc, $formArray['elements']);

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -579,11 +579,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                 case 'begintable':
                 case 'endtable':
                     error_log(
-                        "DEPRECATION MESSAGE: The use of `begintable` and ".
-                        "`endtable` elements of LINST instruments has is no longer ".
-                        "necessary. The $this->testName LINST instrument should ".
-                        "be modified to remove these elements as they will be ".
-                        "completely deprecated in a future version of LORIS"
+                        "DEPRECATION MESSAGE: `begintable` and `endtable` elements ".
+                        "are deprecated. $this->testName instrument should be ".
+                        "modified to remove these elements as they will be ".
+                        "completely removed in a future version of LORIS."
                     );
                     break;
                 case 'text':

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -471,8 +471,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
             if (!isset($this->form)) {
                 $this->form = new \LorisForm();
             }
-            $this->dateTimeFields = ["Date_taken"];
-            $this->formType       = 'XIN';
+            $this->formType = 'XIN';
 
             $this->form->addFormRule([&$this, 'XINValidate']);
             $fp = fopen($filename, "r");
@@ -577,26 +576,15 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         $Group['Elements'] = [];
                     }
                     break;
-
                 case 'begintable':
-                    if ($addElements) {
-                        $this->form->addElement(
-                            'static',
-                            '',
-                            "</td></tr></table><table><tr><td>&nbsp;",
-                            ""
-                        );
-                    }
-                    break;
                 case 'endtable':
-                    if ($addElements) {
-                        $this->form->addElement(
-                            'static',
-                            '',
-                            "</td></tr></table><table><tr><td>&nbsp;",
-                            ""
-                        );
-                    }
+                    error_log(
+                        "DEPRECATION MESSAGE: The use of `begintable` and ".
+                        "`endtable` elements of LINST instruments has is no longer ".
+                        "necessary. The $this->testName LINST instrument should ".
+                        "be modified to remove these elements as they will be ".
+                        "completely deprecated in a future version of LORIS"
+                    );
                     break;
                 case 'text':
                     if ($addElements) {

--- a/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_aosi.class.inc
@@ -46,10 +46,6 @@ class NDB_BVL_Instrument_aosi extends NDB_BVL_Instrument
         // data keyed by commentID
         $this->commentID = $commentID;
 
-        //The array of dates/timestamps to convert to database dates/timestamps
-        //Any LorisForm date elements must be listed here
-        $this->dateTimeFields =array("Date_taken");
-
         //The array of selects with multiple answers allowed
         //Any LorisForm multiple selects must be listed here
         $this->selectMultipleElements = array();

--- a/raisinbread/instruments/NDB_BVL_Instrument_medical_history.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_medical_history.class.inc
@@ -49,10 +49,6 @@ class NDB_BVL_Instrument_medical_history extends NDB_BVL_Instrument
         $this->table     = 'medical_history'; // database table
         $this->commentID = $commentID; // data keyed by commentID
 
-        //The array of dates/timestamps to convert to database dates/timestamps
-        //Any HTML_Quickform date elements must be listed here
-        $this->dateTimeFields = array("Date_taken");
-
         //The array of selects with multiple answers allowed
         //Any HTML_Quickform multiple selects must be listed here
         $this->selectMultipleElements = array('current_concussion_symptoms');

--- a/raisinbread/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_mri_parameter_form.class.inc
@@ -56,13 +56,6 @@ class NDB_BVL_Instrument_mri_parameter_form extends NDB_BVL_Instrument
         $this->table     = 'mri_parameter_form';
         $this->commentID = $commentID; // data keyed by commentID
 
-        //The array of dates/timestamps to convert to database dates/timestamps
-        //Any LorisForm date elements must be listed here
-        $this->dateTimeFields = array(
-            "Date_taken",
-            "scan_date",
-        );
-
         //The array of selects with multiple answers allowed
         //Any LorisForm multiple selects must be listed here
         $this->selectMultipleElements = array();

--- a/raisinbread/instruments/NDB_BVL_Instrument_radiology_review.class.inc
+++ b/raisinbread/instruments/NDB_BVL_Instrument_radiology_review.class.inc
@@ -34,12 +34,6 @@ class NDB_BVL_Instrument_radiology_review extends NDB_BVL_Instrument
             'Examiner'
         );
 
-        $this->dateTimeFields = array(
-            'Date_taken',
-            'MRI',
-            'Review'
-        );
-
         // setup the form
         $this->_setupForm();
     }

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -476,7 +476,6 @@ class NDB_BVL_Instrument_Test extends TestCase
                 ]
             ]
         );
-        $this->assertEquals($this->_instrument->monthYearFields[0], "Field1");
     }
 
     /**
@@ -1223,8 +1222,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     }
 
     /**
-     * Test that _setDefaultsArray changes the candidate age and sets
-     * the instrument's dateTimeFields value
+     * Test that _setDefaultsArray changes the candidate age
      *
      * @covers NDB_BVL_Instrument::_setDefaultsArray
      * @return void
@@ -1238,7 +1236,6 @@ class NDB_BVL_Instrument_Test extends TestCase
         $result   = $this->_instrument->_setDefaultsArray($defaults);
         $defaults['Candidate_Age'] = '2020-01-01 (Age out of range)';
         $this->assertEquals($defaults, $result);
-        $this->assertEquals(["Date_taken"], $this->_instrument->dateTimeFields);
     }
 
     /**


### PR DESCRIPTION
## Brief summary of changes
1. Deprecation of `begintable` and `endtable` in LINST instruments. these elements do not appear to be used anywhere and when tested they only seemed to corrupt the HTML without bringing any advantages. The instrument template automatically converts groups to tables (behaviour that should be changed in the future) so removing these elements will just bring LINST to par with PHP instruments for now

2. Added a bunch of PHP docs on variables not having them

3. Deletion of the `dateTimeFields` and `monthYearFields` class arrays. Projects still maintain off and on these arrays which are unused anywhere. These arrays are being populated but their usage died with the LorisForm replacing quickform. [Here is an example of where they were used](https://github.com/aces/Loris/blob/53dd32dcb657e6f7199a63be6acfc8307b6e8efe/php/libraries/NDB_BVL_Instrument.class.inc#L537)

4. Deletion of the unused `_getDatabaseDate()` function