### PR TITLE
[tools] delete_candidate.php delete from candidate_consent_rel 

### DIFF
--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -224,6 +224,15 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
     );
     print_r($result);
 
+    // Print candidate_consent_rel
+    echo "\nCandidate Consent\n";
+    echo "-------------------\n";
+    $result = $DB->pselect(
+        'SELECT * FROM candidate_consent_rel WHERE CandidateID=:cid',
+        ['cid' => $CandID]
+    );
+    print_r($result);
+
     // Print parameter_candidate
     echo "\nParameter Candidate\n";
     echo "---------------------\n";
@@ -299,6 +308,9 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
         //delete from the participant_status_history table
         $DB->delete("participant_status_history", ["CandID" => $CandID]);
 
+        //delete from the candidate_consent_rel table
+        $DB->delete("candidate_consent_rel", ["CandidateID" => $CandID]);
+
         //delete from parameter_candidate
         $DB->delete("parameter_candidate", ["CandID" => $CandID]);
 
@@ -344,6 +356,14 @@ function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
             ["CandID" => $CandID],
             $output,
             $DB
+        );
+
+        //delete from the candidate_consent_rel table
+        _printResultsSQL(
+            "candidate_consent_rel",
+            ["CandidateID" => $CandID],
+            $output,
+            DB
         );
 
         //delete from parameter_candidate


### PR DESCRIPTION
## Brief summary of changes
delete_candidate.php now deletes corresponding rows from the candidate_consent_rel table. 

#### Testing instructions (if applicable)

Delete candidate who has consent

#### Link(s) to related issue(s)

* Resolves #7184 
