### PR TITLE
Update phan to 3.2 and fix errors which were identified

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev" : {
         "squizlabs/php_codesniffer" : "^3.5",
         "phpunit/phpunit" : "9.4.4",
-        "phan/phan": "3.0.0",
+        "phan/phan": "^3.0",
         "phpmd/phpmd": "~2.8",
         "phpstan/phpstan": "0.12.58",
         "slevomat/coding-standard": "^6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73d365bd384c6a13c6e7608eb1d94d33",
+    "content-hash": "47a203e39a3d5616edff767ab3bde28b",
     "packages": [
         {
             "name": "bjeavons/zxcvbn-php",
@@ -1194,29 +1194,29 @@
     "packages-dev": [
         {
             "name": "composer/semver",
-            "version": "2.0.0",
+            "version": "3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "0ec124f57c7e23925c006cbad0de853e3aec3ba2"
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/0ec124f57c7e23925c006cbad0de853e3aec3ba2",
-                "reference": "0ec124f57c7e23925c006cbad0de853e3aec3ba2",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0"
+                "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.19",
-                "phpunit/phpunit": "^4.5 || ^5.0.5 || ^7"
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1255,7 +1255,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/2.0.0"
+                "source": "https://github.com/composer/semver/tree/3.2.4"
             },
             "funding": [
                 {
@@ -1263,11 +1263,15 @@
                     "type": "custom"
                 },
                 {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/composer/composer",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-04-21T13:19:12+00:00"
+            "time": "2020-11-13T08:59:24+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1518,16 +1522,16 @@
         },
         {
             "name": "microsoft/tolerant-php-parser",
-            "version": "v0.0.20",
+            "version": "v0.0.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/microsoft/tolerant-php-parser.git",
-                "reference": "c5e2bf5d8c9f4f27eef1370bd39ea2d1f374eeb4"
+                "reference": "1d76657e3271754515ace52501d3e427eca42ad0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/c5e2bf5d8c9f4f27eef1370bd39ea2d1f374eeb4",
-                "reference": "c5e2bf5d8c9f4f27eef1370bd39ea2d1f374eeb4",
+                "url": "https://api.github.com/repos/microsoft/tolerant-php-parser/zipball/1d76657e3271754515ace52501d3e427eca42ad0",
+                "reference": "1d76657e3271754515ace52501d3e427eca42ad0",
                 "shasum": ""
             },
             "require": {
@@ -1557,9 +1561,9 @@
             "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
             "support": {
                 "issues": "https://github.com/microsoft/tolerant-php-parser/issues",
-                "source": "https://github.com/microsoft/tolerant-php-parser/tree/master"
+                "source": "https://github.com/microsoft/tolerant-php-parser/tree/v0.0.23"
             },
-            "time": "2020-02-18T02:57:19+00:00"
+            "time": "2020-09-13T17:29:12+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1785,38 +1789,38 @@
         },
         {
             "name": "phan/phan",
-            "version": "3.0.0",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phan/phan.git",
-                "reference": "a2eb629c09952383ae78315d240ce3770670c1a5"
+                "reference": "e14110d4bef8643562b02a4003015c2c0dcc9fe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phan/phan/zipball/a2eb629c09952383ae78315d240ce3770670c1a5",
-                "reference": "a2eb629c09952383ae78315d240ce3770670c1a5",
+                "url": "https://api.github.com/repos/phan/phan/zipball/e14110d4bef8643562b02a4003015c2c0dcc9fe4",
+                "reference": "e14110d4bef8643562b02a4003015c2c0dcc9fe4",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4|^2.0",
+                "composer/semver": "^1.4|^2.0|^3.0",
                 "composer/xdebug-handler": "^1.3.2",
                 "ext-filter": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.4",
-                "microsoft/tolerant-php-parser": "0.0.20",
-                "netresearch/jsonmapper": "^1.6.0|^2.0",
-                "php": "^7.2.0",
-                "sabre/event": "^5.0",
-                "symfony/console": "^2.3|^3.0|^4.0|^5.0",
-                "symfony/polyfill-mbstring": "^1.11.0"
+                "microsoft/tolerant-php-parser": "0.0.23",
+                "netresearch/jsonmapper": "^1.6.0|^2.0|^3.0",
+                "php": "^7.2.0|^8.0.0",
+                "sabre/event": "^5.0.3",
+                "symfony/console": "^3.2|^4.0|^5.0",
+                "symfony/polyfill-mbstring": "^1.11.0",
+                "symfony/polyfill-php80": "^1.20.0"
             },
             "require-dev": {
-                "brianium/paratest": "^4.0.0",
                 "phpunit/phpunit": "^8.5.0"
             },
             "suggest": {
-                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.0.1+ is needed, 1.0.6+ is recommended.",
+                "ext-ast": "Needed for parsing ASTs (unless --use-fallback-parser is used). 1.0.1+ is needed, 1.0.8+ is recommended.",
                 "ext-iconv": "Either iconv or mbstring is needed to ensure issue messages are valid utf-8",
                 "ext-igbinary": "Improves performance of polyfill when ext-ast is unavailable",
                 "ext-mbstring": "Either iconv or mbstring is needed to ensure issue messages are valid utf-8",
@@ -1856,9 +1860,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phan/phan/issues",
-                "source": "https://github.com/phan/phan/tree/v3"
+                "source": "https://github.com/phan/phan/tree/3.2.6"
             },
-            "time": "2020-05-09T13:37:27+00:00"
+            "time": "2020-11-27T19:39:49+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -281,7 +281,7 @@ function editFamilyInfoFields(\Database $db)
     $relationship     = isset($_POST[$relationshipType]) ?
         $_POST[$relationshipType] : null;
 
-    while ($siblingCandID != null ) {
+    if ($siblingCandID != null ) {
 
         $siblingID = $db->pselectOne(
             "SELECT ID from family WHERE CandID=:candid and FamilyID=:familyid",
@@ -298,8 +298,6 @@ function editFamilyInfoFields(\Database $db)
         ];
 
         $db->update('family', $updateValues, ['ID' => $siblingID]);
-
-        $i++;
     }
 }
 

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -122,10 +122,10 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
     /**
      * Testing filter funtion and clear button
      *
-     * @param string $element  The input element loaction
-     * @param string $table    The first row location in the table
+     * @param string  $element The input element loaction
+     * @param string  $table   The first row location in the table
      * @param ?string $records The records number in the table
-     * @param string $value    The test value
+     * @param string  $value   The test value
      *
      * @return void
      */

--- a/modules/dicom_archive/test/dicom_archiveTest.php
+++ b/modules/dicom_archive/test/dicom_archiveTest.php
@@ -122,10 +122,10 @@ class DicomArchiveTestIntegrationTest extends LorisIntegrationTest
     /**
      * Testing filter funtion and clear button
      *
-     * @param string $element The input element loaction
-     * @param string $table   The first row location in the table
-     * @param string $records The records number in the table
-     * @param string $value   The test value
+     * @param string $element  The input element loaction
+     * @param string $table    The first row location in the table
+     * @param ?string $records The records number in the table
+     * @param string $value    The test value
      *
      * @return void
      */

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -371,9 +371,9 @@ function showMediaError($message, $code)
  * Utility function to convert data from database to a
  * (select) dropdown friendly format
  *
- * @param array  $options array of options
- * @param string $item    key
- * @param string $item2   value
+ * @param array   $options array of options
+ * @param string  $item    key
+ * @param ?string $item2   value
  *
  * @return array
  */

--- a/modules/media/test/MediaTest.php
+++ b/modules/media/test/MediaTest.php
@@ -129,10 +129,10 @@ class MediaTest extends LorisIntegrationTest
     /**
      * Testing filter funtion and clear button
      *
-     * @param string $element The input element loaction
-     * @param string $table   The first row location in the table
-     * @param string $records The records number in the table
-     * @param string $value   The test value
+     * @param string $element  The input element loaction
+     * @param string $table    The first row location in the table
+     * @param ?string $records The records number in the table
+     * @param string $value    The test value
      *
      * @return void
      */

--- a/modules/media/test/MediaTest.php
+++ b/modules/media/test/MediaTest.php
@@ -129,10 +129,10 @@ class MediaTest extends LorisIntegrationTest
     /**
      * Testing filter funtion and clear button
      *
-     * @param string $element  The input element loaction
-     * @param string $table    The first row location in the table
+     * @param string  $element The input element loaction
+     * @param string  $table   The first row location in the table
      * @param ?string $records The records number in the table
-     * @param string $value    The test value
+     * @param string  $value   The test value
      *
      * @return void
      */

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -299,9 +299,8 @@ class My_Preferences extends \NDB_Form
         $this->addGroup(
             $nGroup,
             "notification_headers",
-            null,
+            '',
             $this->_GUIDelimiter,
-            false
         );
         unset($nGroup);
 
@@ -342,9 +341,8 @@ class My_Preferences extends \NDB_Form
                 $this->addGroup(
                     $nGroup,
                     "row_".$module."_".$operation,
-                    null,
-                    $this->_GUIDelimiter,
-                    false
+                    '',
+                    $this->_GUIDelimiter
                 );
                 $notification_rows[] ="row_".$module."_".$operation;
                 unset($nGroup);

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -156,8 +156,8 @@ class Next_Stage extends \NDB_Form
             'maxYear'        => $config->getSetting('endYear'),
         ];
 
-        $this->addHidden('candID', $timePoint->getCandID());
-        $this->addHidden('sessionID', $timePoint->getSessionID());
+        $this->addHidden('candID', $timePoint->getCandID()->__toString());
+        $this->addHidden('sessionID', $timePoint->getSessionID()->__toString());
 
         $stage = $timePoint->getNextStage();
         $this->tpl_data['stage'] = $stage;

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -74,16 +74,16 @@ class MriUploadServerProcess extends AbstractServerProcess
     /**
      * Builds a new MriUploadServerProcess
      *
-     * @param ?int     $mriUploadId    MRI upload ID
+     * @param ?int    $mriUploadId    MRI upload ID
      * @param string  $sourceLocation location of the MRI scan.
      * @param ?int    $id             ID of the process in the database.
      * @param ?int    $pid            PID for this process
      * @param ?string $stdoutFile     full path of file used to store the process's
-     *                               stdout
+     *                                stdout
      * @param ?string $stderrFile     full path of file used to store the process's
-     *                               stderr
+     *                                stderr
      * @param ?string $exitCodeFile   full path of file used to store the process's
-     *                               exit code
+     *                                exit code
      * @param ?int    $exitCode       process's exit code
      * @param ?string $userid         ID of the user who launched the process
      * @param ?string $startTime      time at which the process was started

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -74,21 +74,21 @@ class MriUploadServerProcess extends AbstractServerProcess
     /**
      * Builds a new MriUploadServerProcess
      *
-     * @param int    $mriUploadId    MRI upload ID
-     * @param string $sourceLocation location of the MRI scan.
-     * @param int    $id             ID of the process in the database.
-     * @param int    $pid            PID for this process
-     * @param string $stdoutFile     full path of file used to store the process's
+     * @param ?int     $mriUploadId    MRI upload ID
+     * @param string  $sourceLocation location of the MRI scan.
+     * @param ?int    $id             ID of the process in the database.
+     * @param ?int    $pid            PID for this process
+     * @param ?string $stdoutFile     full path of file used to store the process's
      *                               stdout
-     * @param string $stderrFile     full path of file used to store the process's
+     * @param ?string $stderrFile     full path of file used to store the process's
      *                               stderr
-     * @param string $exitCodeFile   full path of file used to store the process's
+     * @param ?string $exitCodeFile   full path of file used to store the process's
      *                               exit code
-     * @param int    $exitCode       process's exit code
-     * @param string $userid         ID of the user who launched the process
-     * @param string $startTime      time at which the process was started
-     * @param string $endTime        time at which the process ended
-     * @param string $exitText       result of the process in text form
+     * @param ?int    $exitCode       process's exit code
+     * @param ?string $userid         ID of the user who launched the process
+     * @param ?string $startTime      time at which the process was started
+     * @param ?string $endTime        time at which the process ended
+     * @param ?string $exitText       result of the process in text form
      */
     public function __construct($mriUploadId, $sourceLocation,
         $id = null, $pid = null, $stdoutFile = null, $stderrFile = null,

--- a/modules/server_processes_manager/php/process.class.inc
+++ b/modules/server_processes_manager/php/process.class.inc
@@ -34,7 +34,7 @@ class Process
     /**
      * Unix PID
      *
-     * @var int
+     * @var ?int
      */
     private $_pid;
 
@@ -197,7 +197,7 @@ class Process
     /**
      * Accessor for field $_pid
      *
-     * @return int value of field $_pid
+     * @return ?int value of field $_pid
      */
     function getPid()
     {

--- a/modules/server_processes_manager/php/serverprocessfactory.class.inc
+++ b/modules/server_processes_manager/php/serverprocessfactory.class.inc
@@ -54,7 +54,7 @@ class ServerProcessFactory
         if ($type == MriUploadServerProcess::PROCESS_TYPE) {
             return new MriUploadServerProcess(
                 null,
-                null,
+                '',
                 $id,
                 $pid,
                 $stdoutFile,

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -68,7 +68,7 @@ class Stats_Demographic extends \NDB_Form
      * @param array   $subcats          the value of subcats
      * @param ?array  $visits           the value of visits
      * @param string  $dropdownName     the value of dropdownName
-     * @param string  $dropdownOpt      the value of dropdownOpt
+     * @param array   $dropdownOpt      the value of dropdownOpt
      * @param string  $dropdownSelected the value of dropdownSelected
      * @param array   $centers          the value of centers
      * @param array   $data             the value of data

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -63,7 +63,7 @@ class Stats_MRI extends \NDB_Form
      * @param array   $subcats           the value of subcats
      * @param array   $visits            the value of visits
      * @param string  $dropdown_name     the value of dropdown_name
-     * @param string  $dropdown_opt      the value of dropdown_opt
+     * @param array   $dropdown_opt      the value of dropdown_opt
      * @param string  $dropdown_selected the value of dropdown_selected
      * @param array   $centers           the value of centers
      * @param array   $data              the value of data

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -844,15 +844,13 @@ class Edit_User extends \NDB_Form
                 $groupA,
                 'examiner_sites',
                 'Examiner At:',
-                $this->_GUIDelimiter,
-                false
+                $this->_GUIDelimiter
             );
             $this->addGroup(
                 $groupB,
                 'examiner_group',
                 'Examiner Status',
-                $this->_GUIDelimiter,
-                false
+                $this->_GUIDelimiter
             );
             unset($groupA);
             unset($groupB);
@@ -923,8 +921,8 @@ class Edit_User extends \NDB_Form
                 $lastRole = $row['type'];
                 $group[]  = $this->form->createElement(
                     'static',
-                    null,
-                    null,
+                    '',
+                    '',
                     '</div>'
                     . "<h3 id=\"header_$lastRole\" "
                     . "class=\"perm_header button\" "
@@ -948,7 +946,7 @@ class Edit_User extends \NDB_Form
                 $attribs
             );
         }
-        $this->addGroup($group, 'PermID_Group', 'Permissions', "", false);
+        $this->addGroup($group, 'PermID_Group', 'Permissions', "");
         unset($group);
 
         //getting users name and emails to create checkboxes
@@ -964,8 +962,8 @@ class Edit_User extends \NDB_Form
         $group   = [];
         $group[] = $this->form->createElement(
             'static',
-            null,
-            null,
+            '',
+            '',
             '</div>'
             . "<h3 id=\"header_supervisors\" class=\"perm_header button\" "
             . "style=\"text-align: center; margin-top: 5px;\"> "
@@ -982,7 +980,7 @@ class Edit_User extends \NDB_Form
             );
         }
 
-        $this->addGroup($group, 'Supervisors_Group', 'Supervisors', "", false);
+        $this->addGroup($group, 'Supervisors_Group', 'Supervisors', "");
         unset($group);
 
         if (!$this->isCreatingNewUser()) {

--- a/modules/user_accounts/test/user_accountsTest.php
+++ b/modules/user_accounts/test/user_accountsTest.php
@@ -141,10 +141,10 @@ class UserAccountsIntegrationTest extends LorisIntegrationTest
     /**
      * Testing filter funtion and clear button
      *
-     * @param string $element The input element location
-     * @param string $table   The first row location in the table
-     * @param string $records The records number in the table
-     * @param string $value   The test value
+     * @param string  $element The input element location
+     * @param string  $table   The first row location in the table
+     * @param ?string $records The records number in the table
+     * @param string  $value   The test value
      *
      * @return void
      */

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -614,9 +614,9 @@ class Database
      */
     function delete(string $table, array $where): void
     {
-        $query  = "DELETE FROM $table WHERE ";
-        $wherestr  = $this->_implodeWithKeys(' AND ', $where, 'where_');
-        $query .= $wherestr;
+        $query    = "DELETE FROM $table WHERE ";
+        $wherestr = $this->_implodeWithKeys(' AND ', $where, 'where_');
+        $query   .= $wherestr;
 
         if (DEBUG) {
             fwrite(STDERR, $query."\n");

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -615,8 +615,8 @@ class Database
     function delete(string $table, array $where): void
     {
         $query  = "DELETE FROM $table WHERE ";
-        $where  = $this->_implodeWithKeys(' AND ', $where, 'where_');
-        $query .= $where;
+        $wherestr  = $this->_implodeWithKeys(' AND ', $where, 'where_');
+        $query .= $wherestr;
 
         if (DEBUG) {
             fwrite(STDERR, $query."\n");
@@ -632,7 +632,7 @@ class Database
 
         // There is no set clause for a delete, so add a fake
         // one.
-        $this->trackChanges($table, [], $where, 'D');
+        $this->trackChanges($table, [], $wherestr, 'D');
 
         $this->_printQuery($query);
         $result = $this->_PDO->exec($query);
@@ -641,7 +641,7 @@ class Database
                 "Database DELETE did not execute successfully."
                 . $this->_createPDOErrorString(),
                 $query,
-                $where
+                $where,
             );
         }
     }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1000,6 +1000,9 @@ class LorisForm
     {
         $attributes = '';
         foreach ($el as $key=>$value) {
+            if ($key=='label' && $value == '') {
+                continue;
+            }
             if ($key=='type') {
                 $value = $type;
             }

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -201,7 +201,7 @@ class LorisForm
     {
         $el         =& $this->addBase(
             $name,
-            null,
+            '',
             array_merge(['value' => $value], $attribs)
         );
         $el['type'] = 'hidden';
@@ -350,8 +350,8 @@ class LorisForm
      *
      * @param string $name  The element name.
      * @param string $label The label to attach to this element.
-     * @param array  $url   The url label to set as href attrib
-     * @param array  $link  The value to display as the link
+     * @param string $url   The url label to set as href attrib
+     * @param string $link  The value to display as the link
      *
      * @return &array
      */
@@ -386,18 +386,18 @@ class LorisForm
      * calls the appropriate $this->addX wrapper based on the "type"
      * passed to the function call.
      *
-     * @param string $type    The type of element to add.
-     * @param string $name    The element name.
-     * @param string $label   The label to attach to this element.
-     * @param array  $options An array of other options that should
-     *                        be added. This generalls maps to the
-     *                        third option of the addX wrapper.
-     * @param array  $attribs Other attributes to be added. This is
-     *                        mostly only used for the "select" type,
-     *                        where "options" has a different meaning
-     *                        and attribs takes the place of what "options"
-     *                        is for other types.
-     * @param array  $customs Only used in a certain mode of advcheckbox
+     * @param string       $type    The type of element to add.
+     * @param string       $name    The element name.
+     * @param string       $label   The label to attach to this element.
+     * @param array|string $options An array of other options that should
+     *                              be added. This generalls maps to the
+     *                              third option of the addX wrapper.
+     * @param array        $attribs Other attributes to be added. This is
+     *                              mostly only used for the "select" type,
+     *                              where "options" has a different meaning
+     *                              and attribs takes the place of what "options"
+     *                              is for other types.
+     * @param array        $customs Only used in a certain mode of advcheckbox
      *
      * @return void (but modifies this->form as a side-effect)
      */
@@ -514,7 +514,7 @@ class LorisForm
     function createSubmit($elname, $value, $attribs = [])
     {
         $attribs['value'] = $value;
-        $el         =& $this->createBase($elname, null, $attribs);
+        $el         =& $this->createBase($elname, '', $attribs);
         $el['type'] = 'submit';
         return $el;
     }
@@ -1737,11 +1737,15 @@ class LorisForm
      * Only 'require', 'compare' and 'numeric' will be implemented
      * since those are the only ones we used.
      *
-     * @param string $element The element name to add the rule to.
-     *                        If this is a 'compare' rule, it will
-     *                        be an array of 2 element names.
-     * @param string $message The message to display if the rule is violated
-     * @param string $type    The rule type. 'compare', 'required' or 'numeric'
+     * @param string|array $element The element name to add the
+     *                              rule to.
+     *                              If this is a 'compare' rule,
+     *                              it will be an array of
+     *                              2 element names.
+     * @param string       $message The message to display if
+     *                              the rule is violated
+     * @param string       $type    The rule type.
+     *                              'compare','required' or 'numeric'
      *
      * @return void
      */
@@ -1820,11 +1824,12 @@ class LorisForm
      *
      * Adds a rule to a group.
      *
-     * @param string $group Form group name
-     * @param array  $arg1  Array for multiple elements or error
-     *                      message string for one element
-     * @param string $type  (optional)Rule type use getRegisteredRules()
-     *                      to get types
+     * @param string        $group Form group name
+     * @param array|string  $arg1  Array for multiple elements
+     *                      or error message string for
+     *                      one element
+     * @param string $type  (optional) Rule type use
+     *                      getRegisteredRules() to get types
      *
      * @return void
      */
@@ -1919,7 +1924,7 @@ class LorisForm
      *
      * @param string $name    The name to use for the new page (in the URL)
      * @param string $label   The label to show to the user for the new page
-     * @param string $attribs Extra attributes for this page.
+     * @param array  $attribs Extra attributes for this page.
      *
      * @return void
      */
@@ -1933,14 +1938,14 @@ class LorisForm
      *
      * Creates an element without adding it to the form.
      *
-     * @param string $type    The type of element to be created.
-     * @param string $elname  The name of the element to be added
-     * @param string $label   The label to attach to the element
-     * @param array  $options Element specific options to pass
+     * @param string       $type    The type of element to be created.
+     * @param string       $elname  The name of the element to be added
+     * @param string       $label   The label to attach to the element
+     * @param array|string $options Element specific options to pass
      *                        to create* wrappers
-     * @param array  $attribs An array of extra HTML attributes to
+     * @param array        $attribs An array of extra HTML attributes to
      *                        add to the element.
-     * @param array  $customs Only used in a certain mode of advcheckbox
+     * @param array        $customs Only used in a certain mode of advcheckbox
      *
      * @return array of the form supported by $this->form
      */

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -1824,12 +1824,13 @@ class LorisForm
      *
      * Adds a rule to a group.
      *
-     * @param string        $group Form group name
-     * @param array|string  $arg1  Array for multiple elements
-     *                      or error message string for
-     *                      one element
-     * @param string $type  (optional) Rule type use
-     *                      getRegisteredRules() to get types
+     * @param string       $group Form group name
+     * @param array|string $arg1  Array for multiple elements
+     *                            or error message string for
+     *                            one element
+     * @param string       $type  (optional) Rule type use
+     *                            getRegisteredRules() to
+     *                            get types
      *
      * @return void
      */
@@ -1942,9 +1943,9 @@ class LorisForm
      * @param string       $elname  The name of the element to be added
      * @param string       $label   The label to attach to the element
      * @param array|string $options Element specific options to pass
-     *                        to create* wrappers
+     *                              to create* wrappers
      * @param array        $attribs An array of extra HTML attributes to
-     *                        add to the element.
+     *                              add to the element.
      * @param array        $customs Only used in a certain mode of advcheckbox
      *
      * @return array of the form supported by $this->form

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -408,7 +408,7 @@ class NDB_BVL_Battery
      *                              battery for. If this is specified the lookup
      *                              will use it as an ADDITIONAL condition to
      *                              $age/$visit_label.
-     * @param boolean $firstVisit   (optional) Whether or not we want the battery
+     * @param ?boolean $firstVisit  (optional) Whether or not we want the battery
      *                              for the first visit of the candidate. If this
      *                              is true, it will get instruments for the first
      *                              visit. If false, it will only get instruments

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -395,27 +395,28 @@ class NDB_BVL_Battery
      * Looks up what the appropriate battery for the current visit should
      * be, based on age AND subproject
      *
-     * @param integer $age          the age of the subject, in months
-     * @param integer $SubprojectID The ID of the subproject that we want
-     *                              to look up the battery for.
-     * @param string  $stage        either 'visit' or 'screening' - determines
-     *                              whether to register only screening
-     *                              instruments or visit instruments
-     * @param string  $visit_label  (optional) The visit label to look up the
-     *                              battery for. If this is specified the battery
-     *                              will use this INSTEAD OF the age of candidate.
-     * @param integer $center_ID    (optional) The center ID to look up the visit
-     *                              battery for. If this is specified the lookup
-     *                              will use it as an ADDITIONAL condition to
-     *                              $age/$visit_label.
-     * @param ?boolean $firstVisit  (optional) Whether or not we want the battery
-     *                              for the first visit of the candidate. If this
-     *                              is true, it will get instruments for the first
-     *                              visit. If false, it will only get instruments
-     *                              where it is NOT the first visit.
-     *                              If null, it will get all instruments matching
-     *                              criteria regardless of if it's the first visit
-     *                              or not.
+     * @param integer  $age          the age of the subject, in months
+     * @param integer  $SubprojectID The ID of the subproject that we want
+     *                               to look up the battery for.
+     * @param string   $stage        either 'visit' or 'screening' - determines
+     *                               whether to register only screening
+     *                               instruments or visit instruments
+     * @param string   $visit_label  (optional) The visit label to look up the
+     *                               battery for. If this is specified the
+     *                               battery will use this INSTEAD OF the age
+     *                               of candidate.
+     * @param integer  $center_ID    (optional) The center ID to look up the visit
+     *                               battery for. If this is specified the lookup
+     *                               will use it as an ADDITIONAL condition to
+     *                               $age/$visit_label.
+     * @param ?boolean $firstVisit   (optional) Whether or not we want the battery
+     *                               for the first visit of the candidate. If this
+     *                               is true, it will get instruments for the
+     *                               first visit. If false, it will only get
+     *                               instruments where it is NOT the first visit.
+     *                               If null, it will get all instruments matching
+     *                               criteria regardless of if it's the first
+     *                               visit or not.
      *
      * @return array  an array of instrument names
      */

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -369,7 +369,7 @@ class NDB_BVL_Feedback
      * This function returns the greatest type of active feedback for the
      * candidate/timepoint/instrument
      *
-     * @param string $select_inactive_threads If non-empty returns inactive
+     * @param boolean $select_inactive_threads If true returns inactive
      *                                        threads, otherwise only returns
      *                                        active threads
      *

--- a/php/libraries/NDB_BVL_Feedback.class.inc
+++ b/php/libraries/NDB_BVL_Feedback.class.inc
@@ -370,8 +370,8 @@ class NDB_BVL_Feedback
      * candidate/timepoint/instrument
      *
      * @param boolean $select_inactive_threads If true returns inactive
-     *                                        threads, otherwise only returns
-     *                                        active threads
+     *                                         threads, otherwise only returns
+     *                                         active threads
      *
      * @return ?string the higest-order status of an active thread
      */

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -468,7 +468,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 ['class' => 'button']
             );
             //$buttons[] = $this->form->createElement('reset', null, 'Reset');
-            $this->addGroup($buttons, null, null, "&nbsp;");
+            $this->addGroup($buttons, '', '', "&nbsp;");
         }
 
         $defaults = $this->getInstanceData();
@@ -1672,7 +1672,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ['class' => 'form-control input-sm not-answered']
         );
 
-        $this->addGroup($group, $field.'_group', $label, null, false);
+        $this->addGroup($group, $field.'_group', $label, '');
         unset($group);
         $rules_array = array_merge([$field.'_status{@}=={@}'], $rules);
         $this->XINRegisterRule($field, $rules_array, $rule_message, $field.'_group');
@@ -1700,7 +1700,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $group[] = $this->form->createElement(
             "textarea",
             $field,
-            null,
+            '',
             [],
             [
                 'cols' => 25,
@@ -1718,7 +1718,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ]
         );
 
-        $this->addGroup($group, $field.'_group', $label, null, false);
+        $this->addGroup($group, $field.'_group', $label, '');
         unset($group);
         $rules_array = array_merge([$field.'_status{@}=={@}'], $rules);
         $this->XINRegisterRule($field, $rules_array, $rule_message, $field.'_group');
@@ -1763,7 +1763,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ],
             ['class' => 'form-control input-sm not-answered']
         );
-        $this->addGroup($group, $field.'_group', $label, null, false);
+        $this->addGroup($group, $field.'_group', $label, '');
         unset($group);
         $rules_array = array_merge([$field.'_status{@}=={@}'], $rules);
         $this->XINRegisterRule(
@@ -1802,9 +1802,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $group[] = $this->form->createElement(
             "time",
             $field,
-            null,
-            null,
-            null
+            '',
         );
 
         $group[] = $this->createSelect(
@@ -1817,7 +1815,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'not_answered' => 'Not Answered',
             ]
         );
-        $this->addGroup($group, $field . "_group", $label, null, false);
+        $this->addGroup($group, $field . "_group", $label, '');
         $this->XINRegisterRule(
             $field,
             array_merge($rules, [$field . '_status{@}=={@}']),
@@ -1865,7 +1863,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
         $group[] = $this->createSelect(
             $name . "_date_status",
-            null,
+            '',
             [
                 null           => "",
                 'not_answered' => "Not Answered",
@@ -1878,7 +1876,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $name . "_date_group",
             $label,
             $this->_GUIDelimiter,
-            false
         );
 
         unset($group);
@@ -1930,12 +1927,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         array $dateArray
     ): void {
         $group   = [];
-        $group[] = $this->createDate($name . "_date", null, $dateArray);
+        $group[] = $this->createDate($name . "_date", '', $dateArray);
         //add to array of dates and times.
         $this->dateTimeFields[] = $name . "_date";
         $group[] = $this->createSelect(
             $name . "_date_status",
-            null,
+            '',
             [
                 null             => "",
                 '88_refused'     => "88 Refused",
@@ -1948,7 +1945,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $name . "_date_group",
             $label,
             $this->_GUIDelimiter,
-            false
         );
         unset($group);
         $this->XINRegisterRule(
@@ -1987,14 +1983,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $this->WrapperNumericElements[$field] = $group[0];
         $group[] = $this->createSelect(
             $field . "_status",
-            null,
+            '',
             [
                 null           => "",
                 'not_answered' => "Not Answered",
             ],
             ['class' => 'form-control input-sm not-answered']
         );
-        $this->addGroup($group, $field . "_group", $label, null, false);
+        $this->addGroup($group, $field . "_group", $label, '');
         unset($group);
         $this->addGroupRule(
             $field . "_group",
@@ -2023,7 +2019,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $group[] = $this->createText($field, $label);
         $group[] = $this->createSelect(
             $field . "_status",
-            null,
+            '',
             [
                 null             => "",
                 "88_refused"     => "88 Refused",
@@ -2032,7 +2028,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ],
             ['class' => 'form-control input-sm not-answered']
         );
-        $this->addGroup($group, $field . "_group", $label, null, false);
+        $this->addGroup($group, $field . "_group", $label, '');
         unset($group);
         $this->addGroupRule(
             $field . "_group",

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -491,10 +491,9 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         $groupLabel = $pieces[2];
                         $this->addGroup(
                             $Group['Elements'],
-                            $Group['Name'],
+                            $Group['Name'] ?? '',
                             $groupLabel,
                             $Group['Delimiter'],
-                            false
                         );
 
                         $Group['Name']     = null;
@@ -506,7 +505,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     if ($addElements) {
                         $this->form->addElement(
                             'static',
-                            null,
+                            '',
                             "</td></tr></table><table><tr><td>&nbsp;",
                             ""
                         );
@@ -516,7 +515,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     if ($addElements) {
                         $this->form->addElement(
                             'static',
-                            null,
+                            '',
                             "</td></tr></table><table><tr><td>&nbsp;",
                             ""
                         );
@@ -663,7 +662,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                         $pieces[1],
                                         $pieces[2],
                                         $opt,
-                                        "multiple"
+                                        [ "multiple" => "multiple" ]
                                     );
                             } else {
                                 $Group['Elements'][]
@@ -702,7 +701,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     break;
                 case 'header':
                     if ($addElements) {
-                        $this->form->addElement('header', null, "$pieces[2]");
+                        $this->form->addElement('header', '', "$pieces[2]");
                     }
                     break;
                 case 'static':
@@ -714,7 +713,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                 = $this->form->createElement(
                                     'static',
                                     $pieces[1],
-                                    null,
+                                    '',
                                     $pieces[2]
                                 );
                         } else {

--- a/php/libraries/NDB_Config.class.inc
+++ b/php/libraries/NDB_Config.class.inc
@@ -171,14 +171,14 @@ class NDB_Config
                 $name      = $child->getName();
                 $tagExists = isset($retVal[$name]) && is_array($retVal[$name]);
                 if ($tagExists) {
-                    if (!self::isNumericArray($retVal[$name])) {
+                    if (!self::isNumericArray($retVal[$name] ?? [])) {
                         // The tag is duplicated in the XML, so it should
                         // be stored in an array. Create a new array and replace
                         // the tag with what was already parsed before appending
                         // the child
                         $newArray = [];
 
-                        $Extant        = $retVal[$name];
+                        $Extant        = $retVal[$name] ?? [];
                         $newArray[]    = $Extant;
                         $retVal[$name] = $newArray;
                     }

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -399,9 +399,9 @@ class NDB_Factory
      */
     public function settings(string $configfile = "../project/config.xml"): \Settings
     {
-        // self::$_settings needs to be put into a simple var because of phan/phan#4169,
-        // otherwise we get a false positive warning about how it may be null inside of
-        // the if.
+        // self::$_settings needs to be put into a simple var because of
+        // phan/phan#4169, otherwise we get a false positive warning about
+        // how it may return null inside of the if.
         $settings = self::$_settings;
         if ($settings !== null) {
             return $settings;

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -51,7 +51,7 @@ class NDB_Factory
      * Settings object
      * A proxy to NDB_Config
      *
-     * @var Settings object
+     * @var ?\Settings
      */
     private static $_settings = null;
 
@@ -399,8 +399,12 @@ class NDB_Factory
      */
     public function settings(string $configfile = "../project/config.xml"): \Settings
     {
-        if (self::$_settings !== null) {
-            return self::$_settings;
+        // self::$_settings needs to be put into a simple var because of phan/phan#4169,
+        // otherwise we get a false positive warning about how it may be null inside of
+        // the if.
+        $settings = self::$_settings;
+        if ($settings !== null) {
+            return $settings;
         }
         self::$_settings = new Settings($this->config($configfile), $this->_baseURL);
         return self::$_settings;

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -207,9 +207,9 @@ abstract class NDB_Notifier_Abstract
             return [];
         }
         $info_array          = [];
-        $info_array['ID']       = $result['ID'];
-        $info_array['name']     = $result['Real_name'];
-        $info_array['email']    = $result['Email'];
+        $info_array['ID']    = $result['ID'];
+        $info_array['name']  = $result['Real_name'];
+        $info_array['email'] = $result['Email'];
         $info_array['username'] = $result['UserID'];
         return $info_array;
     }

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -66,7 +66,7 @@ abstract class NDB_Notifier_Abstract
     /**
      * Admin user issuing the notification (if applicable).
      *
-     * @var string
+     * @var array
      */
     private $_adminNotifier;
 
@@ -163,7 +163,9 @@ abstract class NDB_Notifier_Abstract
             $this->_asAdmin = ($nmInfo['as_admin'] === 'N') ? false : true;
         }
         if ($this->_asAdmin) {
-            $this->notifier =$this->_adminNotifier;
+            $this->notifier = \User::singleton(
+                $this->_adminNotifier['username']
+            );
         }
 
         //TEMPLATE File
@@ -198,16 +200,17 @@ abstract class NDB_Notifier_Abstract
     private function _getAdminUser(): array
     {
         $result = \Database::singleton()->pselectRow(
-            "SELECT ID, Real_name, Email FROM users WHERE UserID='admin'",
+            "SELECT ID, Real_name, Email, UserID FROM users WHERE UserID='admin'",
             []
         );
         if (is_null($result)) {
             return [];
         }
         $info_array          = [];
-        $info_array['ID']    = $result['ID'];
-        $info_array['name']  = $result['Real_name'];
-        $info_array['email'] = $result['Email'];
+        $info_array['ID']       = $result['ID'];
+        $info_array['name']     = $result['Real_name'];
+        $info_array['email']    = $result['Email'];
+        $info_array['username'] = $result['UserID'];
         return $info_array;
     }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -172,7 +172,7 @@ class NDB_Page implements RequestHandlerInterface
      */
     function addHeader($header)
     {
-        $this->form->addElement('header', null, $header);
+        $this->form->addElement('header', '', $header);
     }
 
     /**
@@ -209,7 +209,7 @@ class NDB_Page implements RequestHandlerInterface
      */
     function addLabel($label)
     {
-        $this->form->addElement('static', null, $label);
+        $this->form->addElement('static', '', $label);
     }
 
     /**
@@ -343,16 +343,16 @@ class NDB_Page implements RequestHandlerInterface
                 ]
             );
         }
-        $this->addGroup($radGroup, $name . '_group', $groupLabel, null, false);
+        $this->addGroup($radGroup, $name . '_group', $groupLabel, '');
     }
 
     /**
      * Adds a hidden element to the current page. Note if the hidden element
      * needs a value it should be added to the defaults.
      *
-     * @param string $name    The name of the hidden element to add
-     * @param array  $value   The value of the hidden element to add
-     * @param array  $attribs Additional html attributes for element
+     * @param string  $name    The name of the hidden element to add
+     * @param ?string $value   The value of the hidden element to add
+     * @param array  $attribs  Additional html attributes for element
      *
      * @return void
      */
@@ -389,7 +389,7 @@ class NDB_Page implements RequestHandlerInterface
             ['class' => 'form-control input-sm not-answered']
         );
 
-        $this->addGroup($group, $field . '_group', $label, null, false);
+        $this->addGroup($group, $field . '_group', $label, '');
 
     }
 
@@ -414,7 +414,7 @@ class NDB_Page implements RequestHandlerInterface
     /**
      * Adds a QuickForm rule to an element on the page.
      *
-     * @param string $element The name of the element to have the rule
+     * @param string|array $element The name of the element to have the rule
      * @param string $message The message to show on failure
      * @param string $type    The type of rule to add
      * @param string $format  See QuickForm documentation.
@@ -456,7 +456,7 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $name      The name to give this group
      * @param string $label     A label to attach to the group
      * @param string $delimiter The separator to use between group elements
-     * @param string $options   An optional array to include prefix_wrapper and
+     * @param ?array $options   An optional array to include prefix_wrapper and
      *                          postfix_wrapper strings - html that will be
      *                          placed before and after the group html
      *
@@ -507,7 +507,7 @@ class NDB_Page implements RequestHandlerInterface
     {
         return $this->form->createElement(
             "static",
-            null,
+            '',
             $labelString
         );
     }
@@ -585,7 +585,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @param string $field   The fieldname for this checkbox
      * @param string $label   The label to attach to this checkbox
-     * @param string $attribs Attributes to pass to HTML_QuickForm
+     * @param array  $attribs Attributes to pass to HTML_QuickForm
      *
      * @return array representing checkbox
      */

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -352,7 +352,7 @@ class NDB_Page implements RequestHandlerInterface
      *
      * @param string  $name    The name of the hidden element to add
      * @param ?string $value   The value of the hidden element to add
-     * @param array  $attribs  Additional html attributes for element
+     * @param array   $attribs Additional html attributes for element
      *
      * @return void
      */
@@ -415,9 +415,9 @@ class NDB_Page implements RequestHandlerInterface
      * Adds a QuickForm rule to an element on the page.
      *
      * @param string|array $element The name of the element to have the rule
-     * @param string $message The message to show on failure
-     * @param string $type    The type of rule to add
-     * @param string $format  See QuickForm documentation.
+     * @param string       $message The message to show on failure
+     * @param string       $type    The type of rule to add
+     * @param string       $format  See QuickForm documentation.
      *
      * @return void
      *

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -54,7 +54,7 @@ class UserPermissions
         $query  = "SELECT ID FROM users WHERE UserID =:UName";
         $params = ['UName' => $username];
 
-        $this->userID = \Database::singleton()->pselectOne($query, $params);
+        $this->userID = \Database::singleton()->pselectOneInt($query, $params);
         if (empty($this->userID)) {
             return false;
         }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -25,7 +25,7 @@ class UserPermissions
     /**
      * User's ID
      *
-     * @var    int
+     * @var    string
      * @access private
      */
     var $userID;
@@ -54,7 +54,7 @@ class UserPermissions
         $query  = "SELECT ID FROM users WHERE UserID =:UName";
         $params = ['UName' => $username];
 
-        $this->userID = \Database::singleton()->pselectOneInt($query, $params);
+        $this->userID = \Database::singleton()->pselectOne($query, $params);
         if (empty($this->userID)) {
             return false;
         }

--- a/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
+++ b/test/test_instrument/NDB_BVL_Instrument_testtest.class.inc
@@ -98,8 +98,7 @@ class NDB_BVL_Instrument_Testtest extends NDB_BVL_Instrument
             $group,
             "consent_group",
             "Test selecting 'Yes' from the dropdown menu.",
-            null,
-            false
+            '',
         );
         unset($group);
     }

--- a/test/unittests/BreadcrumbTrailTest.php
+++ b/test/unittests/BreadcrumbTrailTest.php
@@ -27,7 +27,7 @@ class BreadcrumbTrailTest extends TestCase
     /**
      * Breadcrumb list used for testing
      *
-     * @var Breadcrumb[]
+     * @var BreadcrumbTrail
      */
     protected $breadcrumbTrail;
 

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -66,8 +66,7 @@ class LorisForms_Test extends TestCase
      * is correct
      *
      * @param string $el    The element name
-     * @param string $label The expected type of this element
-     *                      (ie select, checkbox, etc)
+     * @param ?string $label The expected label for this element
      *
      * @return void but makes assertions
      */
@@ -88,10 +87,10 @@ class LorisForms_Test extends TestCase
      * Custom assertion to assert that some attribute of an element
      * is correct
      *
-     * @param string $el          The element name
-     * @param string $attribute   The attribute name to assert
+     * @param string       $el          The element name
+     * @param string       $attribute   The attribute name to assert
      *                            (ie class, id, value, etc)
-     * @param string $attribValue The expected content of the attribute
+     * @param string|array $attribValue The expected content of the attribute
      *
      * @return void but makes assertions
      */
@@ -1403,7 +1402,6 @@ class LorisForms_Test extends TestCase
         $this->form->addElement(
             'advcheckbox',
             "abc",
-            "Hello",
             "text",
             $testAttributes,
             $testCheckStates

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -65,7 +65,7 @@ class LorisForms_Test extends TestCase
      * Custom assertion to assert that the label of an element
      * is correct
      *
-     * @param string $el    The element name
+     * @param string  $el    The element name
      * @param ?string $label The expected label for this element
      *
      * @return void but makes assertions
@@ -89,7 +89,7 @@ class LorisForms_Test extends TestCase
      *
      * @param string       $el          The element name
      * @param string       $attribute   The attribute name to assert
-     *                            (ie class, id, value, etc)
+     *                                  (ie class, id, value, etc)
      * @param string|array $attribValue The expected content of the attribute
      *
      * @return void but makes assertions

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -1403,6 +1403,7 @@ class LorisForms_Test extends TestCase
             'advcheckbox',
             "abc",
             "text",
+            "Hello",
             $testAttributes,
             $testCheckStates
         );

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -1402,8 +1402,8 @@ class LorisForms_Test extends TestCase
         $this->form->addElement(
             'advcheckbox',
             "abc",
-            "text",
             "Hello",
+            "text",
             $testAttributes,
             $testCheckStates
         );

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -88,7 +88,9 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
      */
     function _getAllMethodsExcept($methods)
     {
-        $AllMethods = get_class_methods('NDB_BVL_Instrument_LINST');
+        $AllMethods = get_class_methods(
+            '\Loris\Behavioural\NDB_BVL_Instrument_LINST'
+        );
 
         return array_diff($AllMethods, $methods);
     }

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -762,12 +762,12 @@ class NDB_BVL_Instrument_Test extends TestCase
         // that the serialization won't die on a 0 element "section"
         $this->_instrument->form->addElement(
             "header",
-            null,
+            '',
             "I am your test header"
         );
         $this->_instrument->form->addElement(
             "header",
-            null,
+            '',
             "I am another test header"
         );
         $this->_instrument->addScoreColumn(

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -1117,7 +1117,7 @@ class UserTest extends TestCase
     {
         $this->_user = \User::factory(self::USERNAME);
         $this->_setPermissions();
-        $this->assertTrue($this->_user->hasCenterPermission("test", 1));
+        $this->assertTrue($this->_user->hasCenterPermission("test_permission", 1));
     }
 
     /**


### PR DESCRIPTION
With this, we can finally run "composer install" with php8.

Note that phpmd still doesn't work with php8 (see phpmd/phpmd#853),
so our CI still can't be updated to test under php8 yet and `make
checkstatic` will fail, but `make` and `make dev` now work.