### PR TITLE
[middleware/UserPageDecorationMiddleware.php] fix visit candidate profile error

### DIFF
--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -245,7 +245,9 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // but is currently required for backwards compatibility.
         // This should also come after the above call to handle() in order for updated data
         // on the controlPanel to be properly displayed.
-        if (method_exists($page, 'getControlPanel')) {
+        if (isset($page)
+            && method_exists($page, 'getControlPanel')
+        ) {
             $tpl_data['control_panel'] = $page->getControlPanel();
         }
 

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -136,8 +136,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
-        $page = $request->getAttribute("pageclass") ?? '';
-        if (!empty($page)
+        $page = $request->getAttribute("pageclass");
+        if ($page !== null
             && method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null
@@ -245,7 +245,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // but is currently required for backwards compatibility.
         // This should also come after the above call to handle() in order for updated data
         // on the controlPanel to be properly displayed.
-        if (!empty($page)
+        if ($page !== null
             && method_exists($page, 'getControlPanel')
         ) {
             $tpl_data['control_panel'] = $page->getControlPanel();

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -137,7 +137,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
         $page = $request->getAttribute("pageclass") ?? '';
-        if (method_exists($page, 'getFeedbackPanel')
+        if (isset($page)
+            && method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null
         ) {

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -137,7 +137,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
         $page = $request->getAttribute("pageclass") ?? '';
-        if (isset($page)
+        if (!empty($page)
             && method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null
@@ -245,7 +245,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         // but is currently required for backwards compatibility.
         // This should also come after the above call to handle() in order for updated data
         // on the controlPanel to be properly displayed.
-        if (isset($page)
+        if (!empty($page)
             && method_exists($page, 'getControlPanel')
         ) {
             $tpl_data['control_panel'] = $page->getControlPanel();

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -136,7 +136,7 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
 
         $tpl_data['subtest'] = $request->getAttribute("pageclass")->page ?? null;
 
-        $page = $request->getAttribute("pageclass");
+        $page = $request->getAttribute("pageclass") ?? '';
         if (method_exists($page, 'getFeedbackPanel')
             && $user->hasPermission('bvl_feedback')
             && $candID !== null


### PR DESCRIPTION
## Brief summary of changes
The PR solves the following:
Fatal error: Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in Loris/src/Middleware/UserPageDecorationMiddleware.php on line 139

The not empty checks solve the PhanEmptyFQSENInClasslike warnings.
src/Middleware/UserPageDecorationMiddleware.php:139 PhanEmptyFQSENInClasslike Possible use of a classlike '' with an empty FQSEN.
src/Middleware/UserPageDecorationMiddleware.php:251 PhanEmptyFQSENInClasslike Possible use of a classlike '' with an empty FQSEN.

#### Testing instructions (if applicable)

1. MainMenu->Canditate-> Access Profile.
2. Visit candidate of choice
3. Check error_log
