### PR TITLE
[data_dict] Convert list of instruments back to multiselect

### DIFF
--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -102,7 +102,7 @@ class DataDictIndex extends Component {
             show: true,
             filter: {
                 name: 'Source From',
-                type: 'select',
+                type: 'multiselect',
                 options: options.sourceFrom,
             },
         },

--- a/modules/datadict/test/TestPlan.md
+++ b/modules/datadict/test/TestPlan.md
@@ -21,12 +21,12 @@ these permissions:
 the Description field. Edit a description, access the Candidate Profile page and 
 access the Data Dictionary page again. Make sure the edit was saved.
   [Automation Testing]
-9. Check that you can navigate through the search result pages (both by clicking on 
+8. Check that you can navigate through the search result pages (both by clicking on
 the numbers and arrows in the bottom right corner of the table).
   [Automation Testing]
-10. Check that the maximum rows displayed dropdown works, also check that the 
+9. Check that the maximum rows displayed dropdown works, also check that the
 download table as CSV works as well.
   [Automation Testing]
-11. Check that the `tools/exporters/data_dictionary_builder.php` works. Try changing 
+10. Check that the `tools/exporters/data_dictionary_builder.php` works. Try changing
 field names in an instrument before running the script and make sure that the 
 corresponding entries in Data Dictionary are updated correctly.

--- a/modules/datadict/test/TestPlan.md
+++ b/modules/datadict/test/TestPlan.md
@@ -9,25 +9,18 @@ these permissions:
   [Automation Testing]
 3. Perform various searches and validate the results. 
  - Use any combination of the available search criteria. 
- - Make sure that when performing a keyword search the algorithm takes column Name, 
- SourceField and Description into account. 
  - Make sure that when you choose "Empty" in the Description combo box, all the rows 
  returned have an empty description.
   [Automation Testing]
 4. Check that selecting multiple instruments returns all relevant results.
 5. Check that the table can be sorted according to any column (ascending and descending).
   [Automation Testing]
-6. Check that pushing the Clear button sets the Description search field to 'All', 
-the Instruments search field to 'All instruments', clears the search keyword text 
-field and performs a search with these criteria. Validate the results.
+6. Check that pushing the "Clear Filter" button sets resets all filters to empty
   [Automation Testing]
 7. Check that if (and only if) you have the 'data_dict_edit' permission you can edit 
 the Description field. Edit a description, access the Candidate Profile page and 
 access the Data Dictionary page again. Make sure the edit was saved.
   [Automation Testing]
-8. Make sure that search keywords are not case-sensitive and that when you specify 
-more than one keyword, the search returns entries that match the whole string.
-  [Automation Testing] 
 9. Check that you can navigate through the search result pages (both by clicking on 
 the numbers and arrows in the bottom right corner of the table).
   [Automation Testing]


### PR DESCRIPTION
Remove references to "search keyword" in test plan. The
search keyword was lost in reactification in favour of filters
consistent with the data table columns, like in other modules.
(Searching across multiple columns with the same filter is not
supported by our FilterableDataTable)

Update the "Source From" column to be a multiselect. This was
also lost in reactification, but is a simple fix.

Resolves #7205