### PR TITLE
AnonymousUser getters override to prevent fatals

### DIFF
--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -26,11 +26,71 @@ namespace LORIS;
 class AnonymousUser extends \User
 {
     /**
+     * An anonymous user username
+     *
+     * @return string
+     */
+    function getUsername(): string
+    {
+        return "";
+    }
+
+    /**
      * An anonymous user is not a member of any site.
      *
-     * @return array The empty string
+     * @return array An empty array
      */
     public function getSiteNames() : array
+    {
+        return [];
+    }
+
+    /**
+     * An anonymous user real name
+     *
+     * @return string
+     */
+    function getFullname(): string
+    {
+        return "";
+    }
+
+    /**
+     * An anonymous user is not a member of any site.
+     *
+     * @return array An empty array
+     */
+    function getCenterIDs(): array
+    {
+        return [];
+    }
+
+    /**
+     * An anonymous user is not a member of any project.
+     *
+     * @return array An empty array
+     */
+    function getProjectIDs(): array
+    {
+        return [];
+    }
+
+    /**
+     * An anonymous user's language preference
+     *
+     * @return int
+     */
+    function getLanguagePreference(): int
+    {
+        return -1;
+    }
+
+    /**
+     * Returns all sites where Examiner is active
+     *
+     * @return array
+     */
+    function getExaminerSites(): array
     {
         return [];
     }

--- a/php/libraries/AnonymousUser.class.inc
+++ b/php/libraries/AnonymousUser.class.inc
@@ -52,7 +52,7 @@ class AnonymousUser extends \User
      */
     function getFullname(): string
     {
-        return "";
+        return "AnonymousUser";
     }
 
     /**
@@ -73,16 +73,6 @@ class AnonymousUser extends \User
     function getProjectIDs(): array
     {
         return [];
-    }
-
-    /**
-     * An anonymous user's language preference
-     *
-     * @return int
-     */
-    function getLanguagePreference(): int
-    {
-        return -1;
     }
 
     /**

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -321,9 +321,9 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     /**
      * Get the user's language preference
      *
-     * @return int
+     * @return ?int
      */
-    function getLanguagePreference(): int
+    function getLanguagePreference(): ?int
     {
         return $this->userInfo['language_preference'];
     }


### PR DESCRIPTION
User::factory() allows a nullable username argument. If null, the factory returns an instance of AnonymousUser and let userInfo unset. As most of User's getters rely on userInfo to return a value, such AnonymousUser's getter will return a null value, which contradicts their non-nullable type and throws an error.

This PR overrides the AnonymousUser's getters to return empty values instead of null.

* Resolves #7223