### PR TITLE
[23.0][bvl_feedback] Bugfix for re-opening a closed thread throwing 400 error

### DIFF
--- a/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
+++ b/modules/bvl_feedback/ajax/open_bvl_feedback_thread.php
@@ -13,7 +13,7 @@
 ini_set('default_charset', 'utf-8');
 require_once "bvl_panel_ajax.php";
 
-$feedbackid = $_POST['feedbackID'] ?? '';
+$feedbackID = $_POST['feedbackID'] ?? '';
 
 if (! \Utility::valueIsPositiveInteger($feedbackID)) {
     header("HTTP/1.1 400 Bad Request");


### PR DESCRIPTION
## Brief summary of changes
This PR fixes a typo that was leading to a 400 error when trying to re-open a closed bvl thread. 


#### Testing instructions (if applicable)

1. Try to open a closed thread in `bvl_feedback` module

#### Link(s) to related issue(s)

* Resolves #7189 
