### PR TITLE
Add setup php step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 


### PR DESCRIPTION
`make dev` and composer were being run with the default
php version, not the PHP version from the build matrix.
This was causing build failures as the default version is
PHP8 and some dependencies do not support it.

Add a Setup PHP step to fix.