### PR TITLE
Add setup php step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 


### PR DESCRIPTION
This is the same as #7227 but fixes the build on the main branch instead of the release branch.