### PR TITLE
[23.0][document_repository] Fix for contents displayed at root

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -86,7 +86,7 @@ class DocIndex extends React.Component {
         });
         this.setState({
           global: false,
-          tableData: id == 0 ? filterData : fillData,
+          tableData: fillData,
           childrenNode: myJson['subcategories'],
           parentNode: myJson['parentcategory'],
         });


### PR DESCRIPTION
## Brief summary of changes
Related to aces/CCNA#4302

Root directory of the doc repo should only contain files that are located at root. All other files will be in subfolders.
Can see all files by filtering globally. 

This was a design decision made by Zal and Derek a while ago but was reverted in #6408.

Please see @zaliqarosli 's comment [here](https://github.com/aces/Loris/pull/6408#issuecomment-745620992)

