### PR TITLE
[behavioural_qc] Resolving redirect to conflict resolver issue

### DIFF
--- a/modules/behavioural_qc/jsx/behavioural_qc_module.js
+++ b/modules/behavioural_qc/jsx/behavioural_qc_module.js
@@ -200,7 +200,9 @@ class InstrumentConflictsRow extends Component {
           </td>
         <td>
           <a href={baseURL + '/conflict_resolver/?pSCID=' + row.PSCID +
-           '&instrument=' + row.TableName}>{row.test_name_display}</a>
+           '&instrument=' + row.TableName + '&question=' + row.FieldName}>
+             {row.test_name_display}
+          </a>
         </td>
         <td>{row.FieldName}</td>
       </tr>

--- a/modules/behavioural_qc/jsx/behavioural_qc_module.js
+++ b/modules/behavioural_qc/jsx/behavioural_qc_module.js
@@ -199,12 +199,8 @@ class InstrumentConflictsRow extends Component {
               <a href={baseURL + '/' + row.CandID + '/'}>{row.PSCID}</a>
           </td>
         <td>
-          <a href="#" onClick={loris.loadFilteredMenuClickHandler(
-                 'conflict_resolver/',
-                  {CandID: row.CandID,
-                  Instrument: row.TableName,
-                  Question: row.FieldName}
-          )}>{row.test_name_display}</a>
+          <a href={baseURL + '/conflict_resolver/?pSCID=' + row.PSCID +
+           '&instrument=' + row.TableName}>{row.test_name_display}</a>
         </td>
         <td>{row.FieldName}</td>
       </tr>


### PR DESCRIPTION
## Brief summary of changes
This PR fixes a bug in the Behavioural QC module. The issue was that clicking on link in the `Instrument` column of the `Data Conflicts` tab would redirect to the Conflict Resolver module, but would not include the appropriate filters.

#### Testing instructions
1. Go to Behaviour QC Module
2. Click on Data Conflicts Tab
3. Click on link in the Instruments column
4. Ensure that you are redirected to the Conflict Resolver module with the appropriate filters applied

#### Link to related issue
* Resolves #7159
