### PR TITLE
[instrument_manager] Fix write permission

### DIFF
--- a/modules/instrument_manager/jsx/instrumentManagerIndex.js
+++ b/modules/instrument_manager/jsx/instrumentManagerIndex.js
@@ -110,7 +110,7 @@ class InstrumentManagerIndex extends Component {
     }
 
     const feedback = () => {
-      if (!this.state.data.caninstall) {
+      if (!this.state.data.caninstall && this.props.hasPermission('instrument_manager_write')) {
         return (
           <div className='alert alert-warning'>
             Instrument installation is not possible given the current server

--- a/modules/instrument_manager/jsx/instrumentManagerIndex.js
+++ b/modules/instrument_manager/jsx/instrumentManagerIndex.js
@@ -103,8 +103,11 @@ class InstrumentManagerIndex extends Component {
 
     const tabs = [
       {id: 'browse', label: 'Browse'},
-      {id: 'upload', label: 'Upload'},
     ];
+
+    if (this.props.hasPermission('instrument_manager_write')) {
+      tabs.push({id: 'upload', label: 'Upload'});
+    }
 
     const feedback = () => {
       if (!this.state.data.caninstall) {
@@ -121,7 +124,13 @@ class InstrumentManagerIndex extends Component {
 
     const uploadTab = () => {
       let content = null;
-      if (this.state.data.writable) {
+      if (!this.props.hasPermission('instrument_manager_write')) {
+        content = (
+          <div className='alert alert-warning'>
+            You do not have access to this page.
+          </div>
+        );
+      } else if (this.state.data.writable) {
         let url = loris.BaseURL.concat('/instrument_manager/?format=json');
         content = (
           <InstrumentUploadForm action={url}/>

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -116,7 +116,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     protected function handlePOST(ServerRequestInterface $request): ResponseInterface
     {
         // Ensure the user is allowed to upload.
-        if (! \User::singleton()->hasPermission('superuser')) {
+        if (! \User::singleton()->hasPermission('instrument_manager_write')) {
             return (new \LORIS\Http\Response())
                 ->withStatus(403, 'Forbidden')
                 ->withBody(

--- a/modules/instrument_manager/test/TestPlan.md
+++ b/modules/instrument_manager/test/TestPlan.md
@@ -6,7 +6,7 @@
    [Automation Testing]
 3. Check that the warning text is accurate if the `project/instruments` or `project/tables_sql` directories are not writable by Apache. The select file/upload panel should only be there if it's writable.
    [Manual Testing]
-4. Take the sample .linst instrument file `test_all_fields.linst` in `docs/instruments` and upload it in Instrument Manager. This must be done be a user with the `superuser` permission.
+4. Take the sample .linst instrument file `test_all_fields.linst` in `docs/instruments` and upload it in Instrument Manager. This must be done be a user with the `instrument_manager_write` permission.
 Check that instrument gets installed properly. (New files should exist in `project/instruments/` & `project/tables_sql/`.) 
 Also check the paths in the code - eg uploaded instruments in the instruments directory with right permissions.
    [Manual Testing]


### PR DESCRIPTION
## Brief summary of changes
This PR makes it so that users with the instrument_manager_write permission are able to upload on instrument manager, and people without this permission do not have access to the upload tab. 

- [x] Have you updated related documentation?

#### Testing instructions (if applicable)

1. Access the instrument manager page with only the view permission. Make sure that you only see the "Browse" tab, and not the "Upload" tab. 
2. Attempt to go directly to the upload tab by adding /instrument_manager/?#upload to your base link. Make sure that the page loads with "You do not have access to this page"
3. Give yourself the instrument_manager_write permission.
4. Make sure that you now have access to the upload tab, either by reloading the page and clicking on the tab, or by navigating directly to the link.
5. Attempt to upload a file. Ensure that you are not given the "forbidden" error (you may get other errors though).

#### Link(s) to related issue(s)

* Resolves #7129