### PR TITLE
[dashboard] Fix step 6 of TestPlan

### DIFF
--- a/modules/dashboard/test/TestPlan.md
+++ b/modules/dashboard/test/TestPlan.md
@@ -24,7 +24,7 @@
    Check that you are taken to that page (with the Selection Filter correctly set) when you
    click on the task.
    [Automate Test]
-6. Verify that the number of new issues in the My Tasks panel is accessible if and only if a user has the 'issue_tracker_reporter'
+6. Verify that the number of assigned issues in the My Tasks panel is accessible if and only if a user has the 'issue_tracker_reporter'
    or the 'issue_tracker_developer' permission.
    [Automate Test on Travis_CI]
 7. Verify that if a user has 'User Management / Survey Participant Management' permission, the number of pending

--- a/modules/dashboard/test/TestPlan.md
+++ b/modules/dashboard/test/TestPlan.md
@@ -24,8 +24,8 @@
    Check that you are taken to that page (with the Selection Filter correctly set) when you
    click on the task.
    [Automate Test]
-6. Verify that the number of assigned issues in the My Tasks panel is accessible if and only if a user has the 'issue_tracker_reporter'
-   or the 'issue_tracker_developer' permission.
+6. Verify that the number of assigned issues in the My Tasks panel is displayed if and only if a user has the 'issue_tracker_reporter'
+   or the 'issue_tracker_developer' permission. Check that you are taken to the issue tracker page when you click on the task.
    [Automate Test on Travis_CI]
 7. Verify that if a user has 'User Management / Survey Participant Management' permission, the number of pending
    account approvals is displayed in the My Task panel. This should be the number of entries in the User Account

--- a/modules/dashboard/test/TestPlan.md
+++ b/modules/dashboard/test/TestPlan.md
@@ -24,7 +24,7 @@
    Check that you are taken to that page (with the Selection Filter correctly set) when you
    click on the task.
    [Automate Test]
-6. Verify that the issue tracker panel is accessible if and only if a user has the 'issue_tracker_reporter'
+6. Verify that the number of new issues in the My Tasks panel is accessible if and only if a user has the 'issue_tracker_reporter'
    or the 'issue_tracker_developer' permission.
    [Automate Test on Travis_CI]
 7. Verify that if a user has 'User Management / Survey Participant Management' permission, the number of pending


### PR DESCRIPTION
## Brief summary of changes
The dashboard TestPlan previously implied that there should be a separate issue tracker panel. This PR changes the wording of step 6 to refer to a row in the My Tasks panel rather than a separate panel. 

- [x] Have you updated related documentation?

* Resolves https://github.com/aces/CCNA/issues/4275
