### PR TITLE
Fix PhanUndeclaredMethod in tests directory

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -37,6 +37,7 @@ return [
         "PhanUnusedPublicMethodParameter",
         "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
+        "PhanUndeclaredMethod",
         "PhanTypeMismatchArgument",
         "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -37,7 +37,6 @@ return [
         "PhanUnusedPublicMethodParameter",
         "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
-        "PhanUndeclaredMethod",
         "PhanTypeMismatchArgument",
         "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -185,6 +185,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
+
+        '@phan-var \Database $stub';
         $stub->update("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -211,6 +213,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
+
+        '@phan-var \Database $stub';
         $stub->unsafeupdate("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -236,6 +240,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
+
+        '@phan-var \Database $stub';
         $stub->insert("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -262,6 +268,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())->method("prepare")
             ->will($this->returnValue($stmt));
+
+        '@phan-var \Database $stub';
         $stub->unsafeinsert("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -795,6 +803,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
+
+        '@phan-var \Database $stub';
         $stub->insertOnDuplicateUpdate(
             "test",
             ['field' => '<b>Hello</b>'],
@@ -826,6 +836,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
+
+        '@phan-var \Database $stub';
         $stub->unsafeInsertOnDuplicateUpdate(
             "test",
             ['field' => '<b>Hello</b>'],
@@ -883,6 +895,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())
             ->method("exec")->with($this->equalTo("SHOW TABLES"));
+
+        '@phan-var \Database $stub';
         $stub->run("SHOW TABLES");
     }
 
@@ -905,6 +919,8 @@ class Database_Test extends TestCase
             ->method("prepare")
             ->with($this->equalTo("SHOW TABLES"))
             ->willReturn(new PDOStatement());
+
+        '@phan-var \Database $stub';
         $stub->prepare("SHOW TABLES");
     }
 
@@ -1015,13 +1031,17 @@ class Database_Test extends TestCase
         $stub           = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['pselect']))->getMock();
 
+        '@phan-var \Database $stub';
         $stmt   = $stub->prepare("SHOW TABLES");
         $params = ['test' => 'test'];
 
+        '@phan-var \PHPUnit\Framework\MockObject\MockObject $stub';
         $stub->expects($this->once())
             ->method("prepare")->with($this->equalTo("SHOW TABLES"));
         $stub->expects($this->once())->method("execute")
             ->with($this->equalTo($stmt), $this->equalTo($params), []);
+
+        '@phan-var \Database $stub';
         $stub->pselect("SHOW TABLES", $params);
     }
 
@@ -1078,6 +1098,8 @@ class Database_Test extends TestCase
                 $this->equalTo($query . " LIMIT 2"),
                 $params
             );
+
+        '@phan-var \Database $stub';
         $stub->pselectRow(
             $query,
             $params
@@ -1322,6 +1344,8 @@ class Database_Test extends TestCase
 
         $stub->expects($this->once())
             ->method("_realinsert")->with($this->equalTo($table), $set, true, true);
+
+        '@phan-var \Database $stub';
         $stub->insertIgnore($table, $set);
     }
 
@@ -1587,6 +1611,8 @@ class Database_Test extends TestCase
         $string = "Co'mpl''ex \"st'\"ring";
         $stub->_PDO->expects($this->once())->method("quote")
             ->willReturn("Complex string");
+
+        '@phan-var \Database $stub';
         $stub->quote($string);
     }
 
@@ -1619,6 +1645,8 @@ class Database_Test extends TestCase
 
         $stub->_PDO->expects($this->once())->method("inTransaction")
             ->willReturn(true);
+
+        '@phan-var \Database $stub';
         $stub->inTransaction();
     }
 
@@ -1641,6 +1669,8 @@ class Database_Test extends TestCase
         $stub->expects($this->once())->method("inTransaction")->willReturn(false);
         $stub->_PDO->expects($this->once())->method("beginTransaction")
             ->willReturn(true);
+
+        '@phan-var \Database $stub';
         $stub->beginTransaction();
     }
 
@@ -1661,6 +1691,8 @@ class Database_Test extends TestCase
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(true);
         $this->expectException("DatabaseException");
+
+        '@phan-var \Database $stub';
         $stub->beginTransaction();
     }
 
@@ -1680,6 +1712,8 @@ class Database_Test extends TestCase
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(true);
         $stub->_PDO->expects($this->once())->method("rollBack")->willReturn(true);
+
+        '@phan-var \Database $stub';
         $stub->rollBack();
     }
 
@@ -1699,6 +1733,8 @@ class Database_Test extends TestCase
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(false);
         $this->expectException("DatabaseException");
+
+        '@phan-var \Database $stub';
         $stub->rollBack();
     }
 
@@ -1718,6 +1754,8 @@ class Database_Test extends TestCase
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(true);
         $stub->_PDO->expects($this->once())->method("commit")->willReturn(true);
+
+        '@phan-var \Database $stub';
         $stub->commit();
     }
 
@@ -1737,6 +1775,8 @@ class Database_Test extends TestCase
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(false);
         $this->expectException("DatabaseException");
+
+        '@phan-var \Database $stub';
         $stub->commit();
     }
 
@@ -1753,6 +1793,7 @@ class Database_Test extends TestCase
             ->onlyMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
 
+        '@phan-var \Database $stub';
         $val = $stub->isConnected();
         $this->assertEquals($val, false);
     }
@@ -1770,6 +1811,7 @@ class Database_Test extends TestCase
             ->onlyMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
 
+        '@phan-var \Database $stub';
         $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $val        = $stub->isConnected();
         $this->assertEquals($val, true);

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -157,7 +157,11 @@ class LorisForms_Test extends TestCase
         // first child of that is the rendered element
         $element = $html->documentElement->firstChild->firstChild;
 
+        // The DOMNode $element needs to be a DOMElement for
+        // hasAttribute to exist.
+        assert($element instanceof \DOMElement);
         $this->assertEquals($element->nodeName, "select");
+
         $this->assertTrue($element->hasAttribute("multiple"));
     }
 
@@ -404,12 +408,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementSelect()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addSelect', 'addDate'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addSelect');
-        $this->form->addElement("select", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("select", "abc", "Hello");
     }
 
     /**
@@ -421,12 +427,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementDate()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addDate'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addDate');
-        $this->form->addElement("date", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("date", "abc", "Hello");
     }
 
     /**
@@ -438,12 +446,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementText()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addText'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addText');
-        $this->form->addElement("text", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("text", "abc", "Hello");
     }
 
     /**
@@ -455,12 +465,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementFile()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addFile'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addFile');
-        $this->form->addElement("file", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("file", "abc", "Hello");
     }
 
     /**
@@ -472,12 +484,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementPassword()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addPassword'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addPassword');
-        $this->form->addElement("password", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("password", "abc", "Hello");
     }
 
     /**
@@ -489,12 +503,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementStatic()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addStatic'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addStatic');
-        $this->form->addElement("static", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("static", "abc", "Hello");
     }
 
     /**
@@ -506,12 +522,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementTextArea()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addTextArea'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addTextArea');
-        $this->form->addElement("textarea", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("textarea", "abc", "Hello");
     }
 
     /**
@@ -523,12 +541,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementHeader()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addHeader'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addHeader');
-        $this->form->addElement("header", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("header", "abc", "Hello");
     }
 
     /**
@@ -540,12 +560,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementRadio()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addRadio'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addRadio');
-        $this->form->addElement("radio", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("radio", "abc", "Hello");
     }
 
     /**
@@ -557,12 +579,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementHidden()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addHidden'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addHidden');
-        $this->form->addElement("hidden", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("hidden", "abc", "Hello");
     }
 
     /**
@@ -574,12 +598,14 @@ class LorisForms_Test extends TestCase
      */
     function testAddElementLink()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['addLink'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('addLink');
-        $this->form->addElement("link", "abc", "Hello");
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("link", "abc", "Hello");
     }
 
     /**
@@ -636,12 +662,14 @@ class LorisForms_Test extends TestCase
      */
     function testCreateElementText()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['createText'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('createText');
-        $this->form->createElement("text", "abc", "Hello", [], []);
+
+        '@phan-var \LorisForm $form';
+        $form->createElement("text", "abc", "Hello", [], []);
     }
 
     /**
@@ -653,12 +681,14 @@ class LorisForms_Test extends TestCase
      */
     function testCreateElementSelect()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['createSelect'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('createSelect');
-        $this->form->createElement("select", "abc", "Hello", [], []);
+
+        '@phan-var \LorisForm $form';
+        $form->createElement("select", "abc", "Hello", [], []);
     }
 
     /**
@@ -670,12 +700,14 @@ class LorisForms_Test extends TestCase
      */
     function testCreateElementSubmit()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['createSubmit'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('createSubmit');
-        $this->form->createElement("submit", "abc", "Hello", [], []);
+
+        '@phan-var \LorisForm $form';
+        $form->createElement("submit", "abc", "Hello", [], []);
     }
 
     /**
@@ -1001,16 +1033,18 @@ class LorisForms_Test extends TestCase
             'maxYear' => '2019',
             'format'  => 'y'
         ];
-        $this->form     = $this->getMockBuilder('LorisForm')
+        $form     = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['yearHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('yearHTML')
             ->willReturn('called yearHTML function');
-        $this->form->addDate("abc", "Hello", $testOptions, $testAttributes);
+
+        '@phan-var \LorisForm $form';
+        $form->addDate("abc", "Hello", $testOptions, $testAttributes);
         $this->assertEquals(
             "called yearHTML function",
-            $this->form->dateHTML($this->form->form["abc"])
+            $form->dateHTML($form->form["abc"])
         );
     }
 
@@ -1317,12 +1351,14 @@ class LorisForms_Test extends TestCase
             'off' => 'default_on'
         ];
 
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['advCheckboxHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('advCheckboxHTML');
-        $this->form->addElement(
+
+        '@phan-var \LorisForm $form';
+        $form->addElement(
             'advcheckbox',
             "abc",
             "Hello",
@@ -1330,10 +1366,10 @@ class LorisForms_Test extends TestCase
             $testAttributes,
             $testCheckStates
         );
-        $this->form->setDefaults(['abc' => 'default_on']);
+        $form->setDefaults(['abc' => 'default_on']);
         $this->assertEquals(
             null,
-            $this->form->checkboxHTML($this->form->form['abc'])
+            $form->checkboxHTML($form->form['abc'])
         );
     }
 
@@ -1979,13 +2015,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementDate()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['dateHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('dateHTML');
-        $this->form->addElement("date", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("date", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -1997,13 +2035,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementSelect()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['selectHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('selectHTML');
-        $this->form->addElement("select", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("select", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2015,13 +2055,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementStatic()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['staticHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('staticHTML');
-        $this->form->addElement("static", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("static", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2033,13 +2075,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementTextArea()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['textareaHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('textareaHTML');
-        $this->form->addElement("textarea", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("textarea", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2051,13 +2095,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementFile()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['fileHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('fileHTML');
-        $this->form->addElement("file", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("file", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2069,13 +2115,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementPassword()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['textHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('textHTML');
-        $this->form->addElement("password", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("password", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2087,13 +2135,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementText()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['textHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('textHTML');
-        $this->form->addElement("text", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("text", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2105,13 +2155,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementCheckbox()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['checkboxHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('checkboxHTML');
-        $this->form->addElement("advcheckbox", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("advcheckbox", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2123,13 +2175,15 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementRadio()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['radioHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('radioHTML');
-        $this->form->addElement("radio", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $form->addElement("radio", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2141,14 +2195,16 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementGroup()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['groupHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('groupHTML');
-        $testText = $this->form->createText("text1", "textlabel", []);
-        $this->form->addGroup([$testText], "abc", "Hello", ", ", []);
-        $this->form->renderElement($this->form->form['abc']);
+
+        '@phan-var \LorisForm $form';
+        $testText = $form->createText("text1", "textlabel", []);
+        $form->addGroup([$testText], "abc", "Hello", ", ", []);
+        $form->renderElement($form->form['abc']);
     }
 
     /**

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -26,7 +26,13 @@ use PHPUnit\Framework\TestCase;
  */
 class LorisForms_Test extends TestCase
 {
-    /** @var \LorisForm */
+    /**
+     * A LorisForm to test. This is a non-mocked form
+     * set up by the setup function. Tests using a mock
+     * use their own local variables.
+     *
+     * @var \LorisForm
+     */
     protected $form;
 
     /**
@@ -1033,7 +1039,8 @@ class LorisForms_Test extends TestCase
             'maxYear' => '2019',
             'format'  => 'y'
         ];
-        $form     = $this->getMockBuilder('LorisForm')
+
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['yearHTML'])
             ->getMock();
         $form->expects($this->once())

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -2165,8 +2165,11 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $this->form->expects($this->once())
             ->method('headerHTML');
-        $this->form->addElement("header", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+
+        $form = $this->form;
+        '@phan-var \LorisForm $form';
+        $form->addElement("header", "abc", "Hello");
+        $form->renderElement($form->form['abc']);
     }
 
     /**
@@ -2183,8 +2186,11 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $this->form->expects($this->once())
             ->method('submitHTML');
-        $testSubmit = $this->form->createSubmit("abc", "Hello", []);
-        $this->form->renderElement($testSubmit);
+
+        $form = $this->form;
+        '@phan-var \LorisForm $form';
+        $testSubmit = $form->createSubmit("abc", "Hello", []);
+        $form->renderElement($testSubmit);
     }
 
     /**
@@ -2202,9 +2208,10 @@ class LorisForms_Test extends TestCase
         $this->form->expects($this->once())
             ->method('hiddenHTML');
 
-        '@phan-var \LorisForm $this->form';
-        $this->form->addElement("hidden", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+        $form = $this->form;
+        '@phan-var \LorisForm $form';
+        $form->addElement("hidden", "abc", "Hello");
+        $form->renderElement($this->form->form['abc']);
     }
 
     /**
@@ -2221,14 +2228,18 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $this->form->expects($this->once())
             ->method('timeHTML');
-        $testTime = $this->form->createElement(
+
+        $f = $this->form;
+        '@phan-var \LorisForm $f';
+        $testTime = $f->createElement(
             "time",
             "abc",
             "Hello",
             [],
             []
         );
-        $this->form->renderElement($testTime);
+
+        $f->renderElement($testTime);
     }
 
     /**
@@ -2246,9 +2257,11 @@ class LorisForms_Test extends TestCase
         $this->form->expects($this->once())
             ->method('linkHTML');
 
-        '@phan-var \LorisForm $this->form';
-        $this->form->addElement("link", "abc", "Hello");
-        $this->form->renderElement($this->form->form['abc']);
+        $f = $this->form;
+        '@phan-var \LorisForm $f';
+
+        $f->addElement("link", "abc", "Hello");
+        $f->renderElement($this->form->form['abc']);
     }
 
     /**

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
  */
 class LorisForms_Test extends TestCase
 {
+    /** @var \LorisForm */
     protected $form;
 
     /**
@@ -2200,6 +2201,8 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $this->form->expects($this->once())
             ->method('hiddenHTML');
+
+        '@phan-var \LorisForm $this->form';
         $this->form->addElement("hidden", "abc", "Hello");
         $this->form->renderElement($this->form->form['abc']);
     }
@@ -2242,6 +2245,8 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $this->form->expects($this->once())
             ->method('linkHTML');
+
+        '@phan-var \LorisForm $this->form';
         $this->form->addElement("link", "abc", "Hello");
         $this->form->renderElement($this->form->form['abc']);
     }

--- a/test/unittests/NDB_BVL_FeedbackTest.php
+++ b/test/unittests/NDB_BVL_FeedbackTest.php
@@ -12,7 +12,6 @@
  * @link     https://www.github.com/aces/Loris/
  */
 
-
 /**
  * Class NDB_BVL_FeedbackTest
  *
@@ -61,7 +60,7 @@ class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
      */
     public function testCreateFeedbackTypeWithInvalidName()
     {
-        $this->setExpectedException('LorisException');
+        $this->expectException('LorisException');
         $this->_feedbackObj->createFeedbackType("");
     }
 

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -19,8 +19,13 @@ use PHPUnit\Framework\TestCase;
  */
 class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
 {
-    /** @var \NDB_BVL_Instrument */
+    /**
+     * An instrument class for testing
+     *
+     * @var \NDB_BVL_Instrument
+     */
     protected $i;
+
     /**
      * Set up sets a fake $_SESSION object that we can use for
      * assertions

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\TestCase;
  */
 class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
 {
+    /** @var \NDB_BVL_Instrument */
+    protected $i;
     /**
      * Set up sets a fake $_SESSION object that we can use for
      * assertions

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -31,7 +31,11 @@ require_once 'SessionID.php';
  */
 class NDB_BVL_Instrument_Test extends TestCase
 {
-    /** @var \NDB_BVL_Instrument */
+    /**
+     * The instrument (or instrument mock) being tested.
+     *
+     * @var \NDB_BVL_Instrument
+     */
     private $_instrument;
 
     private $_factory;

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -726,7 +726,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $this->_instrument->addScoreColumn(
             "FieldName2",
-            "Field 2",
+            "",
         );
         $json          = $this->_instrument->toJSON();
         $outArray      = json_decode($json, true);

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -31,8 +31,9 @@ require_once 'SessionID.php';
  */
 class NDB_BVL_Instrument_Test extends TestCase
 {
-    /** @var \NDB_BVL_Instrument&\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \NDB_BVL_Instrument */
     private $_instrument;
+
     private $_factory;
     private $_mockConfig;
     private $_mockDB;
@@ -721,7 +722,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $this->_instrument->addScoreColumn(
             "FieldName2",
-            null
+            "Field 2",
         );
         $json          = $this->_instrument->toJSON();
         $outArray      = json_decode($json, true);
@@ -855,7 +856,14 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->form     = $this->quickForm;
         $this->_instrument->testName = "Test";
 
-        $json     = $this->_instrument->toJSON();
+        // Phan isn't interpreting the phpdoc correctly and thinks
+        // this is a \PHPUnit\Framework\MockObject\MockObject, not
+        // an instrument, so put it into a variable and assert its
+        // type.
+        $i = $this->_instrument;
+        '@phan-var \NDB_BVL_Instrument $i';
+
+        $json     = $i->toJSON();
         $outArray = json_decode($json, true);
         $page1    = $outArray['Elements'][0];
         $page2    = $outArray['Elements'][1];
@@ -1809,10 +1817,13 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setTableData();
         $this->_instrument->commentID = 'commentID2';
         $this->_instrument->table     = 'medical_history';
-        $this->_instrument->form      = $this->getMockBuilder("\LorisForm")
-            ->getMock();
-        $this->_instrument->form
-            ->method('getSubmitValues')->willReturn(['1', '2']);
+
+        $mockform = $this->getMockBuilder("\LorisForm")->getMock();
+
+        $mockform->method('getSubmitValues')->willReturn(['1', '2']);
+
+        $this->_instrument->form = $mockform;
+
         $this->assertFalse($this->_instrument->save());
     }
 

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -31,6 +31,7 @@ require_once 'SessionID.php';
  */
 class NDB_BVL_Instrument_Test extends TestCase
 {
+    /** @var \NDB_BVL_Instrument */
     private $_instrument;
     private $_factory;
     private $_mockConfig;

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -31,7 +31,7 @@ require_once 'SessionID.php';
  */
 class NDB_BVL_Instrument_Test extends TestCase
 {
-    /** @var \NDB_BVL_Instrument */
+    /** @var \NDB_BVL_Instrument&\PHPUnit\Framework\MockObject\MockObject */
     private $_instrument;
     private $_factory;
     private $_mockConfig;

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -44,7 +44,6 @@ class NDB_Factory_Test extends TestCase
             $database['password'],
             $database['host'],
             true
-
         );
 
         $this->_factory->setDatabase($this->_DB);

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -44,7 +44,11 @@ class NDB_Factory_Test extends TestCase
             $database['password'],
             $database['host'],
             true
+
         );
+
+        $this->_factory->setDatabase($this->_DB);
+        $this->_factory->setConfig($this->_config);
     }
 
     /**

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -239,6 +239,12 @@ class NDB_Factory_Test extends TestCase
      */
     function testCandidate()
     {
+        $mockdb = $this->getMockBuilder("\Database")->getMock();
+        $this->_factory->setDatabase($mockdb);
+        $mockdb->expects($this->any())
+            ->method('pselectRow')
+            ->willReturn(['DCCID'=>'300001']);
+
         $candID = new CandID("300001");
         $this->assertEquals(
             Candidate::singleton($candID),
@@ -255,6 +261,14 @@ class NDB_Factory_Test extends TestCase
      */
     function testTimepoint()
     {
+        $mockdb     = $this->getMockBuilder("\Database")->getMock();
+        $mockconfig = $this->getMockBuilder("\NDB_Config")->getMock();
+        $this->_factory->setConfig($mockconfig);
+        $this->_factory->setDatabase($mockdb);
+        $mockdb->expects($this->any())
+            ->method('pselectRow')
+            ->willReturn(['1']);
+
         $sessionID = new \SessionID("1");
         $this->assertEquals(
             \TimePoint::singleton($sessionID),

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -63,6 +63,7 @@ class NDB_Menu_Filter_Test extends TestCase
             ->onlyMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
+        '@phan-var \NDB_Menu_Filter $stub';
 
         // Reset calls
         $this->Session->expects($this->exactly(2))
@@ -91,6 +92,7 @@ class NDB_Menu_Filter_Test extends TestCase
             ->onlyMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
+        '@phan-var \NDB_Menu_Filter $stub';
 
         $stub->_setSearchKeyword('abc');
 
@@ -119,6 +121,7 @@ class NDB_Menu_Filter_Test extends TestCase
             ->onlyMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
+        '@phan-var \NDB_Menu_Filter $stub';
 
         $stub->form = new LorisForm();
         $stub->form->applyFilter('__ALL__', 'trim');
@@ -177,6 +180,7 @@ class NDB_Menu_Filter_Test extends TestCase
             ->onlyMethods($allOtherMethods)
             ->disableOriginalConstructor()
             ->getMock();
+        '@phan-var \NDB_Menu_Filter $stub';
 
         $stub->headers      = ['FakeField', "FakeField2"];
         $stub->formToFilter = [

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -25,7 +25,11 @@ use PHPUnit\Framework\TestCase;
  */
 class SinglePointLoginTest extends TestCase
 {
-    /** @var \SinglePointLogin */
+    /**
+     * The SinglePointLogin mock for testing
+     *
+     * @var \SinglePointLogin
+     */
     private $_login;
 
     /**

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SinglePointLoginTest extends TestCase
 {
+    /** @var \SinglePointLogin */
     private $_login;
 
     /**


### PR DESCRIPTION
This fixes all of the "PhanUndeclaredMethod" class errors in the test directory. These are mostly caused by phan not knowing that mock objects have the methods of the class being mocked, and it needs to be specifically told so with a phan type assertion.

Calling methods that don't exist is a bad idea. We should unignore this error type, but first the errors need to be fixed. This PR starts with a large number of false positives caused by mock objects..

#### Testing instructions
1. Remove "PhanUndeclaredMethod" from `.phan/config.php`.
2. Verify that there are no errors from the test directory (there are other errors from our code)
3. Check that the tests still pass. (The behaviour of them shouldn't have changed.)