### PR TITLE
[Core] Download CSV issues

### DIFF
--- a/jsx/StaticDataTable.js
+++ b/jsx/StaticDataTable.js
@@ -432,7 +432,6 @@ class StaticDataTable extends Component {
 
         if (this.hasFilterKeyword(this.props.Headers[j], data)) {
           filterMatchCount++;
-          filteredData.push(this.props.Data[index[i].RowIdx]);
         }
 
         if (useKeyword === true) {
@@ -464,7 +463,8 @@ class StaticDataTable extends Component {
         }
       }
 
-      // Only display a row if all filter values have been matched
+      // Only display a row in the table or csv
+      // if all filter values have been matched
       if ((filterLength === filterMatchCount) &&
         ((useKeyword === true && keywordMatch > 0) ||
           (useKeyword === false && keywordMatch === 0))) {
@@ -478,6 +478,8 @@ class StaticDataTable extends Component {
             </tr>
           );
         }
+
+        filteredData.push(this.props.Data[index[i].RowIdx]);
       }
     }
 


### PR DESCRIPTION
This PR solves 2 issues:
- when a row matches 2 filtering criteria, this row is included twice in the csv
- the rows matching the filtering criteria partially are included in the csv 

The bug was found on the publication module and probably affects all modules using the StaticDataTable.

## To test
Filter a data table with 2 criteria:
- check that the rows matching all criteria are not included twice in the csv
- check that the rows that match some but not all criteria are not included in the csv

* Resolves #7229 