### PR TITLE
Remove legacy code to support QuickForm

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2505,8 +2505,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             }
         } else if ($element['type'] === "date") {
             $element['options'] = [
-                'mindate'         => "1990-01-01",
-                'maxdate'         => "2000-12-31",
+                'mindate'         => $this->dateOptions['minYear'] . '-01-01',
+                'maxdate'         => $this->dateOptions['maxYear'] . '-12-31',
                 'RequireResponse' => false,
             ];
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -23,7 +23,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     /**
      * The form object for this instrument.
      *
-     * @var    LorisForm
+     * @var LorisForm
      */
     public $form;
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -24,7 +24,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * The form object for this instrument.
      *
      * @var    LorisForm
-     * @access public
      */
     public $form;
 
@@ -2505,46 +2504,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 }
             }
         } else if ($element['type'] === "date") {
-            if (get_class($this->form) === 'LorisForm') {
-                $element['options'] = [
-                    'mindate'         => "1990-01-01",
-                    'maxdate'         => "2000-12-31",
-                    'RequireResponse' => false,
-                ];
-                //$element['RequireResponse'] = false;
-            } else {
-                $html = new DOMDocument();
-                $html->loadHTML($element['html']);
-                // Parse the HTML to get the min and max date
-                $selects = $html->getElementsByTagName("select");
-                if ($selects->length > 0) {
-                    // Old school QuickForm style. This should be removed
-                    // after QuickForm is retired.
-                    $year = $selects->item(0);
+            $element['options'] = [
+                'mindate'         => "1990-01-01",
+                'maxdate'         => "2000-12-31",
+                'RequireResponse' => false,
+            ];
+        }
 
-                    // If Item 0 is blank, item 1 is the minimum,
-                    $minYear = $year->childNodes->item(0)->textContent;
-
-                    // PHP's trim function doesn't support UTF-8's 0xC2A0 (&nbsp;),
-                    // which seems to be how loadHTML parses spaces. Trim whitespace
-                    // and then specifically trim that character before checking if
-                    // the year is empty, and if it's empty use the next option in
-                    // the dropdown (which should be non-empty)
-                    $minYear = trim($minYear);
-                    $minYear = trim($minYear, chr(0xC2).chr(0xA0));
-                    if (empty($minYear)) {
-                        $minYear = $year->childNodes->item(1)->textContent;
-                    }
-                    // the last item is the maximum year
-                    $maxYear = $year->lastChild->textContent;
-
-                    $element['options'] = [
-                        'mindate' => $minYear . "-01-01",
-                        'maxdate' => $maxYear . "-12-31",
-                    ];
-
-                }
-            }
             if (isset($this->WrapperDateWithStatusElements[$element['name']])) {
                 $element['NoResponse'] = false;
             } else {
@@ -2676,17 +2642,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function toJSON(): string
     {
         $smarty = new Smarty_NeuroDB;
-        //$renderer = new HTML_QuickForm_Renderer_Array($smarty);
 
         $subtests = $this->getSubtestList();
         foreach ($subtests as $subtest) {
-            if (get_class($this->form) === 'LorisForm') {
-                $this->form->addPageBreak(
-                    $subtest['Name'],
-                    $subtest['Description'],
-                    []
-                );
-            }
+            $this->form->addPageBreak(
+                $subtest['Name'],
+                $subtest['Description'],
+                []
+            );
             $this->page = $subtest['Name'];
         }
         $formArray = $this->_toJSONParsePage();

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2504,9 +2504,16 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 }
             }
         } else if ($element['type'] === "date") {
+            $config = \NDB_Factory::singleton()->config();
+
+            $minyear = $this->dateOptions['minYear']
+                ?? $config->getSetting('startYear');
+            $maxyear = $this->dateOptions['endYear']
+                ?? $config->getSetting('endYear');
+
             $element['options'] = [
-                'mindate'         => $this->dateOptions['minYear'] . '-01-01',
-                'maxdate'         => $this->dateOptions['maxYear'] . '-12-31',
+                'mindate'         => $minyear . '-01-01',
+                'maxdate'         => $maxyear . '-12-31',
                 'RequireResponse' => false,
             ];
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2511,13 +2511,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             ];
         }
 
-            if (isset($this->WrapperDateWithStatusElements[$element['name']])) {
-                $element['NoResponse'] = false;
-            } else {
-                $element['NoResponse'] = true;
-            }
-
+        if (isset($this->WrapperDateWithStatusElements[$element['name']])) {
+            $element['NoResponse'] = false;
+        } else {
+            $element['NoResponse'] = true;
         }
+
         return $element;
     }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2505,8 +2505,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             }
         } else if ($element['type'] === "date") {
             $element['options'] = [
-                'mindate'         => $this->dateOptions['minYear'] . '-01-01',
-                'maxdate'         => $this->dateOptions['maxYear'] . '-12-31',
+                'mindate'         => "1990-01-01",
+                'maxdate'         => "2000-12-31",
                 'RequireResponse' => false,
             ];
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2504,16 +2504,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 }
             }
         } else if ($element['type'] === "date") {
-            $config = \NDB_Factory::singleton()->config();
-
-            $minyear = $this->dateOptions['minYear']
-                ?? $config->getSetting('startYear');
-            $maxyear = $this->dateOptions['endYear']
-                ?? $config->getSetting('endYear');
-
             $element['options'] = [
-                'mindate'         => $minyear . '-01-01',
-                'maxdate'         => $maxyear . '-12-31',
+                'mindate'         => $this->dateOptions['minYear'] . '-01-01',
+                'maxdate'         => $this->dateOptions['maxYear'] . '-12-31',
                 'RequireResponse' => false,
             ];
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2509,12 +2509,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 'maxdate'         => "2000-12-31",
                 'RequireResponse' => false,
             ];
-        }
 
-        if (isset($this->WrapperDateWithStatusElements[$element['name']])) {
-            $element['NoResponse'] = false;
-        } else {
-            $element['NoResponse'] = true;
+            if (isset($this->WrapperDateWithStatusElements[$element['name']])) {
+                $element['NoResponse'] = false;
+            } else {
+                $element['NoResponse'] = true;
+            }
         }
 
         return $element;

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -1749,37 +1749,6 @@ class NDB_BVL_Instrument_Test extends TestCase
 
     /**
      * Test that _toJSONParseSmarty returns an array with the
-     * correct information for a date type element when the form
-     * is not a LorisForm.
-     *
-     * @covers NDB_BVL_Instrument::_toJSONParseSmarty
-     * @return void
-     */
-    function testToJsonParseSmartyDateTypeNotLorisForm()
-    {
-        $date = ['options' => ['minYear' => '1990',
-            'maxYear' => '2000'
-        ],
-            'type'    => 'select'
-
-        ];
-        $dateHTML = $this->_instrument->form->renderElement($date);
-        $el       = ['type' => 'date',
-            'html' => $dateHTML
-        ];
-        $result   = ['type' => 'date',
-            'html'       => $dateHTML,
-            'options'    => ['mindate' => "1990-01-01",
-                'maxdate' => "2000-12-31"
-            ],
-            'NoResponse' => true
-        ];
-        $this->_instrument->form = new \Candidate();
-        $this->assertEquals($result, $this->_instrument->_toJSONParseSmarty($el));
-    }
-
-    /**
-     * Test that _toJSONParseSmarty returns an array with the
      * correct information
      *
      * @covers NDB_BVL_Instrument::_toJSONParseSmarty


### PR DESCRIPTION
This removes some code that was in place to handle
differences between LorisForm and QuickForm. At this
point there's no excuse for instruments to not have
been migrated (and it's likely that at some point they
would have broken in a PHP upgrade anyways if they
weren't migrated to LorisForm yet.)