### PR TITLE
[filterable_datatable] Fix Query Param Filtering Bug

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -122,7 +122,7 @@ class DataTable extends Component {
 
   getFilteredRowIndexes() {
     let useKeyword = false;
-    let filterValuesCount = Object.keys(this.props.filter).length;
+    let filterValuesCount = Object.keys(this.props.filters).length;
     let tableData = this.props.data;
     let fieldData = this.props.fields;
 
@@ -137,7 +137,7 @@ class DataTable extends Component {
       return filteredIndexes;
     }
 
-    if (this.props.filter.keyword) {
+    if (this.props.filters.keyword) {
       useKeyword = true;
     }
 
@@ -260,10 +260,10 @@ class DataTable extends Component {
     let searchKey = null;
     let searchString = null;
 
-    if (this.props.filter[name]) {
-      filterData = this.props.filter[name].value;
-      exactMatch = this.props.filter[name].exactMatch;
-      opposite = this.props.filter[name].opposite;
+    if (this.props.filters[name]) {
+      filterData = this.props.filters[name].value;
+      exactMatch = this.props.filters[name].exactMatch;
+      opposite = this.props.filters[name].opposite;
     }
 
     // Handle null inputs
@@ -403,7 +403,7 @@ class DataTable extends Component {
     let index = this.sortRows(filteredRowIndexes);
     let currentPageRow = (rowsPerPage * (this.state.page.number - 1));
 
-    if (this.props.filter.keyword) {
+    if (this.props.filters.keyword) {
       useKeyword = true;
     }
 
@@ -580,7 +580,7 @@ DataTable.defaultProps = {
   headers: [],
   data: {},
   rowNumLabel: 'No.',
-  filter: {},
+  filters: {},
   hide: {
     rowsPerPage: false,
     downloadCSV: false,

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -317,7 +317,7 @@ class DataTable extends Component {
         searchKey = filterData[i].toLowerCase();
         searchString = data ? data.toString().toLowerCase() : '';
 
-        match = (searchString.indexOf(searchKey) > -1);
+        match = (searchString === searchKey);
         if (match) {
           result = true;
         }

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -40,7 +40,8 @@ class Filter extends Component {
   onFieldUpdate(name, value) {
     const {filter, fields} = JSON.parse(JSON.stringify(this.props));
     const searchParams = new URLSearchParams(location.search);
-    const type = fields.find((field) => (field.filter||{}).name == name).type;
+    const type = fields
+      .find((field) => (field.filter||{}).name == name).filter.type;
     const exactMatch = (!(type === 'text' || type === 'date'));
     if (value === null || value === '' ||
         (value.constructor === Array && value.length === 0)) {

--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -418,7 +418,7 @@ class SelectElement extends Component {
       }
     }
 
-    this.props.onUserInput(this.props.name, value, e.target.id, 'select');
+    this.props.onUserInput(this.props.name, value);
   }
 
   render() {


### PR DESCRIPTION
## Brief summary of changes
This PR updates the functionality of the Filterable datatable by changing the way that it loads filters via the URL query params. 

Instead of simply loading the query params into the filter object, upon component mount the query params will each trigger the update of the respective field they are associated with, if they exist. 

The resolves the issue #7216 which was causing filters that were meant to be exact match filters to be treated as substring, or "partial", filters.

#### Testing instructions (if applicable)
1. Go to any module with a reactified filterable datatable.
2. Enter some filter values.
3. Refresh the page and ensure that the exact same filters are applied.
4. Do steps 2-3 with a select dropdown where the index for the value selected is a substring of other index values. (E.g. Select a subproject whose index is `1` when there are other subprojects in the list whose indexes are anywhere from 10-19).

#### Link to related issue
* Resolves #7216
