### PR TITLE
[instrument_builder] Fix Date element corruption in LINST files when load/saving 

### DIFF
--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -120,7 +120,7 @@ var Instrument = {
 
                         // Add dropdown and special naming when no date format is set
                         // (i.e when addDateElement() is used)
-                        if (element.Options.dateFormat === "") {
+                        if (element.Options.dateFormat === "Date") {
                             elName = elName + "_date";
                             dropdown = "select{@}" + elName + "_status" +
                             "{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
@@ -128,8 +128,8 @@ var Instrument = {
 
                         content += 'date{@}';
                         content += elName + "{@}" + element.Description;
-                        content += "{@}" + element.Options.MinDate.split('-')[0];
-                        content += "{@}" + element.Options.MaxDate.split('-')[0];
+                        content += "{@}" + element.Options.MinYear;
+                        content += "{@}" + element.Options.MaxYear;
                         content += "{@}" + element.Options.dateFormat + "\n";
                         content += dropdown;
                         break;
@@ -245,14 +245,18 @@ var Instrument = {
                                 value: (specialCase) ? "Textarea" : "Textbox"
                             };
                             break;
-                        case "date":
+                      case "date":
                             tempElement.Type = 'date';
                             tempElement.Name = pieces[1];
                             tempElement.Description = pieces[2];
+                            // If dateformat is null or empty default to "Date" to support instruments developed
+                            // before addition of new date formats
                             tempElement.Options = {
-                                MinDate : pieces[3] + "-01-01",
-                                MaxDate : pieces[4] + "-12-31"
+                                MinYear : pieces[3],
+                                MaxYear : pieces[4],
+                                dateFormat: pieces[5] || 'Date'
                             };
+
                             tempElement.selected = {
                                 id: "date",
                                 value: "Date"

--- a/modules/instrument_builder/js/instrument_builder.instrument.js
+++ b/modules/instrument_builder/js/instrument_builder.instrument.js
@@ -256,7 +256,13 @@ var Instrument = {
                                 MaxYear : pieces[4],
                                 dateFormat: pieces[5] || 'Date'
                             };
-
+                            // To mimic the NDB_BVL_Instrument_LINST class behaviour we strip the _date
+                            // from the standard dates name before loading it to the front end
+                            // the _date will be re-appended on saving
+                            if (tempElement.Options.dateFormat === 'Date'
+                                && tempElement.Name.substring(tempElement.Name.length-5) === '_date') {
+                              tempElement.Name = tempElement.Name.substring(0,tempElement.Name.length-5);
+                            }
                             tempElement.selected = {
                                 id: "date",
                                 value: "Date"

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -317,11 +317,7 @@ class DateOptions extends Component {
     };
     this.onChange = this.onChange.bind(this);
   }
-
-  componentDidMount() {
-    this.props.element.Options.dateFormat = 'Date';
-  }
-    // Keep track of the inputed years
+  // Keep track of the inputed years
   onChange(e) {
     let options = Instrument.clone(this.props.element.Options);
     if (e.target.id === 'yearmin') {
@@ -337,6 +333,7 @@ class DateOptions extends Component {
   render() {
     let minYear = this.props.element.Options.MinYear;
     let maxYear = this.props.element.Options.MaxYear;
+    let dateFormat = this.props.element.Options.dateFormat;
 
     let dateOptionsClass = 'options form-group';
     let errorMessage = '';
@@ -390,7 +387,8 @@ class DateOptions extends Component {
             <select
               id="dateFormat"
               className="form-control"
-              onChange={this.onChange}>
+              onChange={this.onChange}
+              defaultValue={dateFormat}>
               {Object.keys(dateFormatOptions).map(function(option, key) {
                 return (
                   <option key={key} value={option}>

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -317,6 +317,14 @@ class DateOptions extends Component {
     };
     this.onChange = this.onChange.bind(this);
   }
+  componentDidMount() {
+    // Check if the date format is already set (editing elements)
+    // if not, set it to default value (new elements)
+    if (!this.props.element.Options.dateFormat) {
+      this.props.element.Options.dateFormat = 'Date';
+    }
+  }
+
   // Keep track of the inputed years
   onChange(e) {
     let options = Instrument.clone(this.props.element.Options);

--- a/modules/instrument_builder/jsx/react.questions.js
+++ b/modules/instrument_builder/jsx/react.questions.js
@@ -63,8 +63,8 @@ class LorisElement extends Component {
       case 'date':
         elementHtml = <DateElement
           label={element.Description}
-          minYear={element.Options.MinDate}
-          maxYear={element.Options.MaxDate}
+          minYear={element.Options.MinYear}
+          maxYear={element.Options.MaxYear}
         />;
         break;
       case 'numeric':
@@ -319,15 +319,15 @@ class DateOptions extends Component {
   }
 
   componentDidMount() {
-    this.props.element.Options.dateFormat = '';
+    this.props.element.Options.dateFormat = 'Date';
   }
     // Keep track of the inputed years
   onChange(e) {
     let options = Instrument.clone(this.props.element.Options);
-    if (e.target.id === 'datemin') {
-      options.MinDate = e.target.value;
-    } else if (e.target.id === 'datemax') {
-      options.MaxDate = e.target.value;
+    if (e.target.id === 'yearmin') {
+      options.MinYear = e.target.value;
+    } else if (e.target.id === 'yearmax') {
+      options.MaxYear = e.target.value;
     } else if (e.target.id === 'dateFormat') {
       options.dateFormat = e.target.value;
     }
@@ -335,8 +335,8 @@ class DateOptions extends Component {
   }
   // Render the HTML
   render() {
-    let minYear = this.props.element.Options.MinDate;
-    let maxYear = this.props.element.Options.MaxDate;
+    let minYear = this.props.element.Options.MinYear;
+    let maxYear = this.props.element.Options.MaxYear;
 
     let dateOptionsClass = 'options form-group';
     let errorMessage = '';
@@ -363,7 +363,7 @@ class DateOptions extends Component {
             <input
               className="form-control"
               type="number"
-              id="datemin"
+              id="yearmin"
               min="1900"
               max="2100"
               value={minYear}
@@ -376,7 +376,7 @@ class DateOptions extends Component {
             <input
               className="form-control"
               type="number"
-              id="datemax"
+              id="yearmax"
               min="1900"
               max="2100"
               onChange={this.onChange}
@@ -520,8 +520,8 @@ class ListElements extends Component {
         break;
       case 'date':
         newState.Options = {
-          MinDate: '',
-          MaxDate: '',
+          MinYear: '',
+          MaxYear: '',
         };
         break;
       case 'numeric':
@@ -654,8 +654,8 @@ class AddElement extends Component {
     }
 
     if (selected === 'date') {
-      let min = this.state.Options.MinDate;
-      let max = this.state.Options.MaxDate;
+      let min = this.state.Options.MinYear;
+      let max = this.state.Options.MaxYear;
       let minYear = parseInt(min, 10);
       let maxYear = parseInt(max, 10);
       let minDate = Date.parse(min);

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -590,7 +590,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                     $pieces[2],
                                     $dateOptions
                                 );
-                            } else {
+                            }
+                            if ($dateFormat === 'BasicDate') {
                                 // Shows date without not answered dropdown
                                 $this->addBasicDate(
                                     $pieces[1],
@@ -598,8 +599,28 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                     $dateOptions
                                 );
                             }
+                            if ($dateFormat === 'Date') {
+                                // Shows standard date
+                                $this->addDateElement(
+                                    $pieces[1],
+                                    $pieces[2],
+                                    $dateOptions
+                                );
+                            }
                         } else {
-                            // Shows standard date
+                            // it will only enter here if the date format is not
+                            // explicitly set. This functionality is confusing and
+                            // should be deprecated
+                            error_log(
+                                "DEPRECATION MESSAGE: $filename defines the field ".
+                                "$pieces[1] as a date without specifying the ".
+                                "format explicitly. Defaulting to standard dates ".
+                                "when the format is undefined will no longer be ".
+                                "supported in future versions of loris. Make sure ".
+                                "to specify the format as `Date` in all your ".
+                                ".linst files as the 6th parameter of you date ".
+                                "entries where applicable."
+                            );
                             $this->addDateElement(
                                 $pieces[1],
                                 $pieces[2],

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -609,18 +609,10 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             }
                         } else {
                             // it will only enter here if the date format is not
-                            // explicitly set. This functionality is confusing and
-                            // should be deprecated
-                            error_log(
-                                "DEPRECATION MESSAGE: $filename defines the field ".
-                                "$pieces[1] as a date without specifying the ".
-                                "format explicitly. Defaulting to standard dates ".
-                                "when the format is undefined will no longer be ".
-                                "supported in future versions of loris. Make sure ".
-                                "to specify the format as `Date` in all your ".
-                                ".linst files as the 6th parameter of you date ".
-                                "entries where applicable."
-                            );
+                            // explicitly set. This offers backwards compatibility
+                            // for date elements created before the date formats were
+                            // explicitly specified. An empty date format will be
+                            // handled as a `Date` element
                             $this->addDateElement(
                                 $pieces[1],
                                 $pieces[2],


### PR DESCRIPTION
## Brief summary of changes

This PR fixes multiple issues with Date elements in LINST files that have existed for several previous releases. Due to the age of these issues, some backwards compatibility logic was necessary for proper functioning of existing projects.

1. when adding a date field in the instrument builder, If the date format was not manually changed on the frontend, the default format was simply an empty string `''`. If however a user selected a date format and then re-selected the default standard date, the date format was saved as `Date`. Standard dates in existing instruments are saved as either `Date` or `''` currently due to this bug and thus both versions are currently!! Prospectively only `Date` will be saved in .linst files and a deprecation message was added to slowly modify all empty empty or null date formats to `Date`
2. When loading a linst in the builder, the dateformat was never being loaded and thus when saving an instrument with a date after loading it, the date would save as `undefined` (see linked issue for more details )
3. There was a confusion regarding `MinDate` and `MaxDate` in some instances they were handled as regular date formats `YYYY-MM-DD` in other places they were handled as minimum year and maximum year. There was NO evidence of full dates being ever required in the code... so I converted all `MinDate` occurrences to `MinYear` and all `MaxDate` occurrences to `MaxYear` to avoid further confusion and removed all code handling splitting the dates to extract the year element from both loading and saving.

#### Testing instructions (if applicable)

1. Follow instructions and examples in linked issue

#### Link(s) to related issue(s)

* Resolves #6669
* This PR replaces #7147 
