### PR TITLE
[Media] Distinguish between file and other fields missing.

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -114,15 +114,14 @@ function uploadFile()
     $language   = isset($_POST['language']) ? $_POST['language'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES)) {
+    if (empty($_FILES)) {
         showMediaError(
-            "The uploaded file is missing. Pelase contact the administrator",
+            "The uploaded file is missing. Please contact the administrator",
             400
         );
-        return;
     }
 
-    if (!isset($pscid, $visit)) {
+    if (empty($pscid) || empty($visit)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -114,7 +114,15 @@ function uploadFile()
     $language   = isset($_POST['language']) ? $_POST['language'] : null;
 
     // If required fields are not set, show an error
-    if (!isset($_FILES, $pscid, $visit)) {
+    if (!isset($_FILES)) {
+        showMediaError(
+            "The uploaded file is missing. Pelase contact the administrator",
+            400
+        );
+        return;
+    }
+
+    if (!isset($pscid, $visit)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -121,7 +121,7 @@ function uploadFile()
         );
     }
 
-    if (empty($pscid) || empty($visit)) {
+    if (!isset($pscid, $visit)) {
         showMediaError("Please fill in all required fields!", 400);
         return;
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -116,7 +116,8 @@ function uploadFile()
     // If required fields are not set, show an error
     if (empty($_FILES)) {
         showMediaError(
-            "File could not be uploaded successfully. Please contact the administrator.",
+            "File could not be uploaded successfully. 
+            Please contact the administrator.",
             400
         );
     }

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -116,7 +116,7 @@ function uploadFile()
     // If required fields are not set, show an error
     if (empty($_FILES)) {
         showMediaError(
-            "The uploaded file is missing. Please contact the administrator",
+            "File could not be uploaded successfully. Please contact the administrator.",
             400
         );
     }


### PR DESCRIPTION
This is a proposed solution for https://github.com/aces/Loris/issues/7207

> uploading a big (>1024M) file and got an error message saying that there was an upload error. The message said that some of the required fields were missing even though I filled out the PSCID and VLabel.

This adds a specific error message for when the file can't be or is not uploaded.