### PR TITLE
[imaging_qc] Update Test Plan

### DIFF
--- a/modules/imaging_qc/test/TestPlan.md
+++ b/modules/imaging_qc/test/TestPlan.md
@@ -5,7 +5,7 @@
 4. Navigate through pages by selecting the page numbers at the top right of the result section and the bottom right of the result section.
 5. Navigate from first to last page & vice versa using the double arrows at the top right of the result section and the bottom right of the result section.
 6. Download the table as CSV. Make sure that the file downloads and that the contents of the file correspond exactly to the contents of the results table, including column and row order.
-7. Select some filters to reduce the size of the data set. Click to download the table as CSV. Make sure that the file downloads and that the contents of the file correspond exactly to the filtered results displayed in the table, including column and row order.
+7. Select some filters to reduce the size of the data set. Click to download the table as CSV. Make sure that the file downloads and that the contents of the file correspond exactly to the filtered results displayed in the table.
 8. Select filters in each category, make sure that the results change corresponding to what is selected.
 9. Select combinations of various filters, make sure that the results change corresponding to what is selected.
 10. Select several filters to reduce the size of the imaging data set, and then select clear filters. Make sure that it returns to the full data set and that each filter is cleared.


### PR DESCRIPTION
## Brief summary of changes
Remove part of test planning stating that downloaded csv should maintain the same row order as displayed in the datatable.

#### Link to related issue
* Resolves #7191
