### PR TITLE
[23.0][dashboard] Study Progression panel graphs only show data when zoomed out

### DIFF
--- a/modules/dashboard/css/dashboard.css
+++ b/modules/dashboard/css/dashboard.css
@@ -58,3 +58,18 @@
     margin-top: 10px;
     float: left;
 }
+
+/*Custom legend scrollable*/
+.legend-container span {
+  display: inline-block;
+  margin-left: 7px;
+  margin-right: 7px;
+  padding: 5px;
+}
+.legend-container div {
+  width: 100%;
+}
+.legend-container {
+  height: 300px;
+  overflow: scroll;
+}

--- a/modules/dashboard/css/dashboard.css
+++ b/modules/dashboard/css/dashboard.css
@@ -70,6 +70,6 @@
   width: 100%;
 }
 .legend-container {
-  height: 300px;
+  max-height: 300px;
   overflow: scroll;
 }

--- a/modules/statistics/js/studyprogression.js
+++ b/modules/statistics/js/studyprogression.js
@@ -85,6 +85,10 @@ $(document).ready(function() {
         url: loris.BaseURL + '/statistics/charts/siterecruitment_line',
         type: 'get',
         success: function(data) {
+            let lengendNames = [];
+            for (let j=0; j<data.datasets.length; j++) {
+                lengendNames.push(data.datasets[j].name);
+            }
             var recruitmentLineData = formatLineData(data);
             recruitmentLineChart = c3.generate({
                 bindto: '#recruitmentChart',
@@ -93,6 +97,13 @@ $(document).ready(function() {
                     xFormat: '%m-%Y',
                     columns: recruitmentLineData,
                     type: 'area-spline'
+                },
+                size: {
+                    // height: 240,
+                    width: '100%'
+                },
+                legend: {
+                    show: false,
                 },
                 axis: {
                     x: {
@@ -112,11 +123,37 @@ $(document).ready(function() {
                     pattern: siteColours
                 }
             });
+            console.log(d3);
+            d3.select('.legend-container')
+              .insert('div', '.recruitmentChart')
+              .attr('class', 'legend')
+              .selectAll('div').data(lengendNames).enter()
+              .append('div')
+              .attr('data-id', function(id) {
+                return id;
+              })
+              .html(function(id) {
+                return '<span></span>' + id;
+              })
+              .each(function(id) {
+                d3.select(this).select('span').style('background-color', recruitmentLineChart.color(id));
+              })
+              .on('mouseover', function(id) {
+                recruitmentLineChart.focus(id);
+              })
+              .on('mouseout', function(id) {
+                recruitmentLineChart.revert();
+              })
+              .on('click', function(id) {
+                $(this).toggleClass("c3-legend-item-hidden")
+                recruitmentLineChart.toggle(id);
+              });
         },
         error: function(xhr, desc, err) {
             console.log(xhr);
             console.log("Details: " + desc + "\nError:" + err);
         }
     });
+
 });
 

--- a/modules/statistics/js/studyprogression.js
+++ b/modules/statistics/js/studyprogression.js
@@ -98,10 +98,6 @@ $(document).ready(function() {
                     columns: recruitmentLineData,
                     type: 'area-spline'
                 },
-                size: {
-                    // height: 240,
-                    width: '100%'
-                },
                 legend: {
                     show: false,
                 },

--- a/modules/statistics/js/studyprogression.js
+++ b/modules/statistics/js/studyprogression.js
@@ -63,6 +63,9 @@ $(document).ready(function() {
                     columns: scanLineData,
                     type: 'area-spline'
                 },
+                legend: {
+                    show: false,
+                },
                 axis: {
                     x: {
                         type: 'timeseries',

--- a/modules/statistics/js/studyprogression.js
+++ b/modules/statistics/js/studyprogression.js
@@ -47,8 +47,15 @@ $(document).ready(function() {
         url: loris.BaseURL + '/statistics/charts/scans_bymonth',
         type: 'get',
         success: function(data) {
-            var scanLineData = formatLineData(data);
+            let lengendNames = [];
+            for (let j=0; j<data.datasets.length; j++) {
+                lengendNames.push(data.datasets[j].name);
+            }
+            let scanLineData = formatLineData(data);
             scanLineChart = c3.generate({
+                size: {
+                    height: '100%',
+                },
                 bindto: '#scanChart',
                 data: {
                     x: 'x',
@@ -74,6 +81,30 @@ $(document).ready(function() {
                     pattern: siteColours
                 }
             });
+            d3.select('.scanChartLegend')
+              .insert('div', '.scanChart')
+              .attr('class', 'legend')
+              .selectAll('div').data(lengendNames).enter()
+              .append('div')
+              .attr('data-id', function(id) {
+                return id;
+              })
+              .html(function(id) {
+                return '<span></span>' + id;
+              })
+              .each(function(id) {
+                d3.select(this).select('span').style('background-color', scanLineChart.color(id));
+              })
+              .on('mouseover', function(id) {
+                scanLineChart.focus(id);
+              })
+              .on('mouseout', function(id) {
+                scanLineChart.revert();
+              })
+              .on('click', function(id) {
+                $(this).toggleClass("c3-legend-item-hidden")
+                scanLineChart.toggle(id);
+              });
         },
         error: function(xhr, desc, err) {
             console.log(xhr);
@@ -89,8 +120,11 @@ $(document).ready(function() {
             for (let j=0; j<data.datasets.length; j++) {
                 lengendNames.push(data.datasets[j].name);
             }
-            var recruitmentLineData = formatLineData(data);
+            let recruitmentLineData = formatLineData(data);
             recruitmentLineChart = c3.generate({
+                size: {
+                    height: '100%',
+                },
                 bindto: '#recruitmentChart',
                 data: {
                     x: 'x',
@@ -119,8 +153,7 @@ $(document).ready(function() {
                     pattern: siteColours
                 }
             });
-            console.log(d3);
-            d3.select('.legend-container')
+            d3.select('.recruitmentChartLegend')
               .insert('div', '.recruitmentChart')
               .attr('class', 'legend')
               .selectAll('div').data(lengendNames).enter()
@@ -152,4 +185,3 @@ $(document).ready(function() {
     });
 
 });
-

--- a/modules/statistics/templates/studyprogression.tpl
+++ b/modules/statistics/templates/studyprogression.tpl
@@ -1,7 +1,10 @@
 <div id="scan-line-chart-panel">
     <h5 class="chart-title">Scan sessions per site</h5>
     {if $total_scans neq 0}
-        <div id="scanChart"></div>
+        <div class="row">
+            <div id="scanChart" class="col-xs-10"></div>
+            <div class='scanChartLegend legend-container col-xs-2'></div>
+        </div>
     {else}
         <p>There have been no scans yet.</p>
     {/if}
@@ -11,7 +14,7 @@
     {if $recruitment['overall']['total_recruitment'] neq 0}
         <div class="row">
             <div id="recruitmentChart" class="col-xs-10"></div>
-            <div class='legend-container col-xs-2'></div>
+            <div class='recruitmentChartLegend legend-container col-xs-2'></div>
         </div>
     {else}
         <p>There have been no candidates registered yet.</p>

--- a/modules/statistics/templates/studyprogression.tpl
+++ b/modules/statistics/templates/studyprogression.tpl
@@ -9,7 +9,10 @@
 <div id="recruitment-line-chart-panel" class="hidden">
     <h5 class="chart-title">Recruitment per site</h5>
     {if $recruitment['overall']['total_recruitment'] neq 0}
-        <div id="recruitmentChart"></div>
+        <div class="row">
+            <div id="recruitmentChart" class="col-xs-10"></div>
+            <div class='legend-container col-xs-2'></div>
+        </div>
     {else}
         <p>There have been no candidates registered yet.</p>
     {/if}


### PR DESCRIPTION
## Brief summary of changes

The PR will make the study progression legend a scrollable list and position it to the right of the graph. Also the new change allows user to click on the legend items to hide or show them on the graph. That's pretty cool imo.

Preview:
![ex](https://user-images.githubusercontent.com/16293415/102657588-eecda180-4143-11eb-8fe8-1bc5ac51d745.jpg)


#### Testing instructions (if applicable)

1. Use the CCNA data with lots of labels for the legend.
2. View the dashboard and visit the graph.

#### Link(s) to related issue(s)

* Resolves #7196
