### PR TITLE
[instruments] Save value into UserID field

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -767,6 +767,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $this->_saveCandidateAge($values);
         }
 
+        // Save UserID, the data entry personnel, into flag Data and
+        // instrument table
+        $user = \NDB_Factory::singleton()->user();
+        if (! $user instanceof \LORIS\AnonymousUser) {
+            // Add UserID to $values
+            $values['UserID'] = $user->getUsername();
+        }
+
         //Convert select multiple elements into database storable values
         if (!empty($this->selectMultipleElements)) {
             foreach ($this->selectMultipleElements AS $elname) {

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -47,7 +47,7 @@ $history = $DB->pselect(
               AND type='U'
             GROUP BY primaryVals
         ) h2 USING (primaryVals, changeDate)
-            GROUP BY CommentID",
+            GROUP BY CommentID, h1.userID",
     array()
 );
 // Loop and index results from history by testname
@@ -70,7 +70,10 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
     $table = null;
     if ($JSONData === false) {
         $table = $instrument->table;
-        if (!$DB->tableExists($table)) {
+        if (!$table) {
+            echo "The table name for instrument $testname cannot be found.\n";
+            continue;
+        } else if (!$DB->tableExists($table)) {
             echo "Table $table for instrument $testname does not exist in the Database.\n";
             continue;
         }

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This script is intended for a one-time use only to restore the value of the
+ * `UserID` column of instrument tables and the `UserID` key of the instrument
+ * JSON `Data` in the flag table.
+ * 
+ * This tool queries data from the `history` table and meaningfully imports
+ * data from its `userID` column back into the instrument and `flag` tables.
+ *
+ * Example use:
+ * $ php SaveUserIDToInstrumentData.php [confirm]
+
+ * PHP Version 7
+ *
+ * @category Tools
+ * @package  Loris
+ * @author   Zaliqa Rosli <zaliqa.rosli@mcin.ca>
+ * @licence  LORIS License
+ * @link     https://www.github.com/aces/Loris
+ */
+require_once __DIR__ . '/../generic_includes.php';
+
+$confirm = false;
+if (isset($argv[1]) && $argv[1] === 'confirm') {
+    $confirm = true;
+}
+
+echo "\n\nQuerying data...\n";
+$db      = \NDB_Factory::singleton()->database();
+// Query CommentIDs with DECS 'Complete', and
+// userID for latest changes made to the instrument data
+$history = $db->pselect(
+        "SELECT h1.tbl, h1.primaryVals AS CommentID, h1.userID
+            FROM history h1
+            INNER JOIN
+            (
+                SELECT primaryVals, MAX(changeDate) AS max_date
+                    FROM history
+                    WHERE primaryVals IN (
+                        SELECT primaryVals
+                        FROM history
+                        WHERE col = 'Data_entry_completion_status'
+                            AND primaryCols = 'CommentID'
+                            AND new = 'Complete'
+                    )
+                    GROUP BY primaryVals
+            ) h2
+                ON h1.primaryVals = h2.primaryVals
+                    AND h1.changeDate = h2.max_date
+                WHERE userID <> 'unknown'
+                    AND tbl <> 'flag'
+                    AND col <> 'CommentID'
+                GROUP BY h1.primaryVals, h1.changeDate, h1.userID",
+        array()
+);
+if (empty($history)) {
+    echo "\n\nThere is no data to import.\n";
+    die();
+}
+echo "\n\nThe following data can be imported into the instrument tables:\n";
+foreach ($history as $index => $row) {
+    $result = $index + 1;
+    echo "\n\nResult $result:\n";
+    print_r($row);
+
+    $table     = $row['tbl'];
+    $commentID = $row['CommentID'];
+    $userID    = $row['userID'];
+
+    // Extract old data from flag so we can update it with merge so that we
+    // don't overwrite it
+    $oldData = $db->pselectOne(
+        "SELECT Data FROM flag WHERE CommentID=:cid",
+        array('cid' => $commentID)
+    );
+    echo "\n\nOld Data: \n";
+    print_r($oldData);
+
+    // (The PDO driver seems to return null as "null" for JSON column types)
+    if (!empty($oldData) && $oldData !== "null") {
+        $oldData = json_decode($oldData, true);
+    } else {
+        $oldData = array();
+    }
+    $newData = array_merge(
+        $oldData ?? array(),
+        array('UserID' => $userID)
+    ); 
+    echo "\n\nNew Data: \n";
+    print_r(json_encode($newData));
+
+    if ($confirm) {
+        echo "\n\nImporting data into respective instrument tables and commentID flag entries...\n";
+        // Update instrument table
+        $db->update(
+            $table,
+            array('UserID' => $userID),
+            array('CommentID' => $commentID)
+        );
+
+        // Save the JSON to the flag.Data column.
+        //
+        // json_encode ensures that this is safe. If we use the safe wrapper,
+        // HTML encoding the quotation marks will make it invalid JSON.
+        $db->unsafeUpdate(
+            "flag",
+            array("Data" => json_encode($newData)),
+            array('CommentID' => $commentID)
+        );
+        echo "\n\nDone. $userID saved as UserID in $table and flag tables for CommentID $commentID.\n";
+    }
+}
+
+if (!$confirm) {
+    echo "\n\nRun this tool again with the argument 'confirm' to ".
+         "perform the changes.\n";
+}

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -40,11 +40,11 @@ $result_count = 1;
 $history = $DB->pselect(
     "SELECT f.Test_name, f.CommentID, h1.userID
       FROM flag f
-      JOIN $hDB.history h1 on (f.CommentID=h1.primaryVals)
+      JOIN " . $DB->escape($hDB) . ".history h1 on (f.CommentID=h1.primaryVals)
       JOIN
         (
           SELECT primaryVals, MAX(changeDate) as changeDate
-            FROM $hDB.history
+            FROM " . $DB->escape($hDB) . ".history
             WHERE userID <> 'unknown'
               AND type='U'
               AND NOT (

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -45,6 +45,9 @@ $history = $DB->pselect(
             FROM $hDB.history
             WHERE userID <> 'unknown'
               AND type='U'
+              AND NOT (
+                col='Data_entry' AND old IS NULL
+              )
             GROUP BY primaryVals
         ) h2 USING (primaryVals, changeDate)
             GROUP BY CommentID, h1.userID",

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -100,7 +100,7 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
         echo "\nImporting data into $testname...\n\n";
 
         // Instantiate instrument at the session level in order to
-        // use _saveValues() function
+        // use _save() function
         foreach ($idxHist[$testname] as $row) {
             $commentID = $row['CommentID'];
             $userID = $row['userID'];
@@ -127,7 +127,7 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
 
             // Save userID
             echo "\tSaving userID $userID for CommentID: $commentID\n\n";
-            $sessionInst->_saveValues(
+            $sessionInst->_save(
                 array(
                     'UserID' => $userID
                 )

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -71,7 +71,7 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
     if ($JSONData === false) {
         $table = $instrument->table;
         if (!$table) {
-            echo "The table name for instrument $testname cannot be found.\n";
+            echo "\n\nERROR: The table name for instrument $testname cannot be found.\n";
             continue;
         } else if (!$DB->tableExists($table)) {
             echo "Table $table for instrument $testname does not exist in the Database.\n";
@@ -83,18 +83,18 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
         echo "\n\nThere is no data to import into $testname.\n";
         continue;
     } else {
-        echo "\n\nThe following data can be imported into $testname:\n";
+        echo "\n\nThe following data can be imported into $testname:\n\n";
         foreach ($idxHist[$testname] as $row) {
             $commentID = $row['CommentID'];
             $userID = $row['userID'];
-            echo "\n\nResult $result_count: $commentID user: $userID\n";
+            echo "\nResult $result_count: $commentID userID: $userID\n";
             $result_count++;
         }
     }
 
     // Update the instrument table
     if ($confirm) {
-        echo "\n\nImporting data into $testname...\n";
+        echo "\nImporting data into $testname...\n\n";
 
         // Instantiate instrument at the session level in order to
         // use _saveValues() function
@@ -123,7 +123,7 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
             }
 
             // Save userID
-            echo "\tSaving userID for CommentID: $commentID\n\n";
+            echo "\tSaving userID $userID for CommentID: $commentID\n\n";
             $sessionInst->_saveValues(
                 array(
                     'UserID' => $userID

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -115,7 +115,7 @@ foreach(\Utility::getAllInstruments() as $table => $name) {
         try {
             $db->beginTransaction();
             $stmt_table->execute();
-            $stmt_table->execute();
+            $stmt_flag->execute();
             $db->commit();
             echo "\n\nData import done for $table.\n";
         } catch (Exception $e) {

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * This script is intended for a one-time use only to restore the value of the
+  * RUN-TIME WARNING FOR PROJECTS: It can take up to a whole day to run this script. It took 14 hours to run the script on the CCNA DB during testing.
+  *
+  * This script is intended for a one-time use only to restore the value of the
  * `UserID` column of instrument tables and the `UserID` key of the instrument
  * JSON `Data` in the flag table.
  *

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -29,6 +29,7 @@ echo "\n\nQuerying data...\n";
 
 $db = \NDB_Factory::singleton()->database();
 
+$result_count = 1;
 foreach(\Utility::getAllInstruments() as $table => $name) {
     // Query entries in the history table for the latest change
     // made to the Data column of the flag table, for every CommentID.
@@ -60,10 +61,10 @@ foreach(\Utility::getAllInstruments() as $table => $name) {
         continue;
     } else {
         echo "\n\nThe following data can be imported into $table:\n";
-        foreach ($history as $index => $row) {
-            $result = $index + 1;
-            echo "\n\nResult $result:\n";
+        foreach ($history as $row) {
+            echo "\n\nResult $result_count:\n";
             print_r($row);
+            $result_count++;
         }
     }
 

--- a/tools/single_use/SaveUserIDToInstrumentData.php
+++ b/tools/single_use/SaveUserIDToInstrumentData.php
@@ -79,6 +79,9 @@ foreach(\Utility::getAllInstruments() as $testname => $fullName) {
         } else if (!$DB->tableExists($table)) {
             echo "Table $table for instrument $testname does not exist in the Database.\n";
             continue;
+        } else if (!$DB->columnExists($table, 'UserID')) {
+            echo "Column 'UserID' does not exist in the $table table.\n";
+            continue;
         }
     }
 


### PR DESCRIPTION
## Brief summary of changes

Currently, nothing is ever saved into the UserID field of instruments. This PR fixes that by inserting into the field the user's Real_name.

Context: Project require to render the Name of the Data Entry personnel on the instrument page on 21.0-release.

#### Testing instructions (if applicable)

1. On main branch, go to any instrument page. Complete an instrument and save. Check the Data column of flag table and the UserID column of the instrument table. You will see that the UserID data is empty / doesn't exist. There is a UserID column of flag that has data in it, however that is specific to the session, not the instrument data entry.

2. On this PR branch, repeat the above step and notice the UserID in the instrument table will now be populated with your user account username, as well as the UserID key in the JSON data of flag table Data column.

3. On this PR branch, run `php tools/single_use/SaveUserIDToInstrumentData.php` to back populate all the UserID fields with data queried from the history table. Run without the confirm flag to check that the correct data has been queried and printed. Run `php tools/single_use/SaveUserIDToInstrumentData.php confirm` to apply the changes.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
