### PR TITLE
[Instrument] Date field required rule

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1914,6 +1914,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             "A Date, or Not Answered is required.",
             $name . "_date_group"
         );
+
+        $this->addRule(
+            $name . "_date_group",
+            $label . 'is required.',
+            'required'
+        );
     }
 
     /**


### PR DESCRIPTION
By design a DateElement is required but is not displaying a red asterisk. 
This PR adds a rule to solve this.

![Screenshot from 2020-12-18 16-21-37](https://user-images.githubusercontent.com/32041423/102662627-31e04280-414d-11eb-8c3f-cf3511826777.png)
