### PR TITLE
[Instrument] Select required option displays a multiselect fix (group …

### DIFF
--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2037,7 +2037,7 @@ class LorisForm
         $el            =& $this->createBase($name, $label, $attribs);
         $el['type']    = 'select';
         $el['options'] = $options;
-        if (isset($attribs['multiple']) || in_array('multiple', $attribs)) {
+        if (isset($attribs['multiple']) || in_array('multiple', $attribs, true)) {
             $el['multiple'] = 'multiple';
         }
         return $el;


### PR DESCRIPTION
in_array by default performs a loose comparison. As an effect in a group field, setting a select required will enable the multiple option. This PR fixes this by forcing the strict comparison.