### PR TITLE
[document repository] prevent to add same category name under same parent directory

### DIFF
--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -131,7 +131,7 @@ class DocCategoryForm extends React.Component {
         this.setState({
           formData: {}, // reset form data after successful file upload
         });
-        swal.fire('Add Successful!', '', 'success');
+        swal.fire('Category Successfully Added!', '', 'success');
       } else {
         resp.json().then((data) => {
           swal.fire('Could not add category!', data.error, 'error');

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -122,7 +122,7 @@ class DocCategoryForm extends React.Component {
       credentials: 'same-origin',
       body: formObj,
     })
-    .then((resp)=>{
+    .then((resp) => {
       if (resp.ok) {
         this.props.refreshPage();
         this.fetchData();

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -139,7 +139,7 @@ class DocCategoryForm extends React.Component {
           console.error(error);
           swal.fire(
             'Unknown Error!',
-            'Please report the issue or contact your administrator',
+            'Please report the issue or contact your administrator.',
             'error'
           );
         });

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -143,7 +143,7 @@ class DocCategoryForm extends React.Component {
             'error'
           );
         });
-      } 
+      }
     });
   }
   /**

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -134,7 +134,7 @@ class DocCategoryForm extends React.Component {
         swal.fire('Add Successful!', '', 'success');
       } else {
         resp.json().then((data) => {
-          swal.fire('Could not add category', data.error, 'error');
+          swal.fire('Could not add category!', data.error, 'error');
         }).catch((error) => {
           console.error(error);
           swal.fire(

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -138,7 +138,7 @@ class DocCategoryForm extends React.Component {
         }).catch((error) => {
           console.error(error);
           swal.fire(
-            'Unknown Error',
+            'Unknown Error!',
             'Please report the issue or contact your administrator',
             'error'
           );

--- a/modules/document_repository/jsx/categoryForm.js
+++ b/modules/document_repository/jsx/categoryForm.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import Loader from 'Loader';
+import swal from 'sweetalert2';
+
 /**
  * Document Upload Form
  *
@@ -120,8 +122,8 @@ class DocCategoryForm extends React.Component {
       credentials: 'same-origin',
       body: formObj,
     })
-    .then((resp) => resp.json())
-    .then(()=>{
+    .then((resp)=>{
+      if (resp.ok) {
         this.props.refreshPage();
         this.fetchData();
         // refresh the upload page
@@ -129,7 +131,19 @@ class DocCategoryForm extends React.Component {
         this.setState({
           formData: {}, // reset form data after successful file upload
         });
-        swal('Add Successful!', '', 'success');
+        swal.fire('Add Successful!', '', 'success');
+      } else {
+        resp.json().then((data) => {
+          swal.fire('Could not add category', data.error, 'error');
+        }).catch((error) => {
+          console.error(error);
+          swal.fire(
+            'Unknown Error',
+            'Please report the issue or contact your administrator',
+            'error'
+          );
+        });
+      } 
     });
   }
   /**

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -50,7 +50,7 @@ class UploadCategory extends \NDB_Page
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         if ($request->getMethod() == "POST") {
-            $this->uploadDocCategory($request);
+            if ($this->uploadDocCategory($request)) {
             return (new \LORIS\Http\Response())
                 ->withHeader("Content-Type", "text/plain")
                 ->withStatus(200)
@@ -59,6 +59,10 @@ class UploadCategory extends \NDB_Page
                         json_encode("uploaded successfully")
                     )
                 );
+             } 
+            return new \LORIS\Http\Response\JSON\Conflict(
+                "duplicate category name under same parent folder"
+            );
         } else {
             return (new \LORIS\Http\Response())
                 ->withHeader("Content-Type", "text/plain")
@@ -71,16 +75,19 @@ class UploadCategory extends \NDB_Page
      *
      * @param ServerRequestInterface $request The incoming PSR7 request
      *
-     * @return void
+     * @return bool
      */
-    function uploadDocCategory($request): void
+    function uploadDocCategory($request): bool
     {
         $DB            = \Database::singleton();
         $req           = $request->getParsedBody();
         $category_name = $req['categoryName']; // required
         $parent_id     = isset($req['parentId']) ? $req['parentId'] : '0';
         $comments      = isset($req['comments']) ? $req['comments'] : null;
-        // todo check duplicate name category
+        //check duplicate name category
+        if ($this->existCategoryName($category_name, $parent_id)) {
+        return false;
+        } 
         $DB->insert(
             "document_repository_categories",
             array(
@@ -89,5 +96,27 @@ class UploadCategory extends \NDB_Page
                 "comments"      => $comments,
             )
         );
+        return true;
+    }
+    /**
+     * Check the category name under the same parent folder in the database,
+     * if exists return true
+     *
+     * @param string $categoryName file name
+     *
+     * @return bool
+     */
+    function existCategoryName(string $categoryName, int $parent_id): bool
+    {
+        $DB        = \Database::singleton();
+        $categoryCount =  $DB->pselectOne(
+            "SELECT COUNT(*) FROM document_repository_categories
+             WHERE category_name=:name and parent_id=:id ",
+            array('name' => $categoryName, 'id' => $parent_id)
+        );
+        if ((int)$categoryCount > 0) {
+            return true;
+        }
+        return false;
     }
 }

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -51,15 +51,15 @@ class UploadCategory extends \NDB_Page
     {
         if ($request->getMethod() == "POST") {
             if ($this->uploadDocCategory($request)) {
-            return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
-                ->withStatus(200)
-                ->withBody(
-                    new \LORIS\Http\StringStream(
-                        json_encode("uploaded successfully")
-                    )
-                );
-             } 
+                return (new \LORIS\Http\Response())
+                    ->withHeader("Content-Type", "text/plain")
+                    ->withStatus(200)
+                    ->withBody(
+                        new \LORIS\Http\StringStream(
+                            json_encode("uploaded successfully")
+                        )
+                    );
+            }
             return new \LORIS\Http\Response\JSON\Conflict(
                 "duplicate category name under same parent folder"
             );
@@ -86,8 +86,8 @@ class UploadCategory extends \NDB_Page
         $comments      = isset($req['comments']) ? $req['comments'] : null;
         //check duplicate name category
         if ($this->existCategoryName($category_name, $parent_id)) {
-        return false;
-        } 
+            return false;
+        }
         $DB->insert(
             "document_repository_categories",
             array(
@@ -103,12 +103,13 @@ class UploadCategory extends \NDB_Page
      * if exists return true
      *
      * @param string $categoryName file name
+     * @param int    $parent_id    parent folder id
      *
      * @return bool
      */
     function existCategoryName(string $categoryName, int $parent_id): bool
     {
-        $DB        = \Database::singleton();
+        $DB            = \Database::singleton();
         $categoryCount =  $DB->pselectOne(
             "SELECT COUNT(*) FROM document_repository_categories
              WHERE category_name=:name and parent_id=:id ",

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -61,7 +61,7 @@ class UploadCategory extends \NDB_Page
                     );
             }
             return new \LORIS\Http\Response\JSON\Conflict(
-                "duplicate category name under same parent folder"
+                "Duplicate category name under same parent folder."
             );
         } else {
             return (new \LORIS\Http\Response())

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -109,7 +109,7 @@ class UploadCategory extends \NDB_Page
      */
     function existCategoryName(string $categoryName, int $parent_id): bool
     {
-        $DB            = \Database::singleton();
+        $DB            = \NDB_Factory::singleton()->database();
         $categoryCount =  $DB->pselectOne(
             "SELECT COUNT(*) FROM document_repository_categories
              WHERE category_name=:name and parent_id=:id ",


### PR DESCRIPTION
## Brief summary of changes

Preventing to add same category name under same parent directory.

#### Testing instructions (if applicable)
If add same category name under same parent directory,
it will show a warning.
![屏幕快照 2020-12-18 下午10 06 26](https://user-images.githubusercontent.com/9876007/102679539-7fc16e80-417e-11eb-8faf-e4755619b3bb.png)

#### Link(s) to related issue(s)
https://github.com/aces/Loris/issues/7232


