### PR TITLE
[instrument_list] Add project permissions

### DIFF
--- a/modules/instrument_list/README.md
+++ b/modules/instrument_list/README.md
@@ -21,11 +21,10 @@ entered.
 
 ## Permissions
 
-One of three conditions must be met to have access to the module:
+One of the following conditions must be met to have access to the module:
 
 1. The user has the permission `access_all_profiles`
-2. The user is at the same site as the visit.
-3. The user is at the same site as one of the candidate's other visits.
+2. The user shares a project and site with the visit
 
 The `send_to_dcc` permission is required in order to send the
 timepoint to DCC (finalize the visit).

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -92,9 +92,8 @@ class Instrument_List extends \NDB_Menu_Filter
         }
 
         //These variable are only for checking the permissions.
-        return ($user->hasPermission('access_all_profiles')
+        return $user->hasPermission('access_all_profiles')
             || $this->timePoint->isAccessibleBy($user);
-        );
     }
 
     /**

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -93,14 +93,7 @@ class Instrument_List extends \NDB_Menu_Filter
 
         //These variable are only for checking the permissions.
         return ($user->hasPermission('access_all_profiles')
-            || (in_array(
-                $candidate->getData('CenterID'),
-                $user->getData('CenterIDs')
-            )) || (in_array(
-                $timePoint->getData('CenterID'),
-                $user->getData('CenterIDs')
-            )
-            )
+            || $this->timePoint->isAccessibleBy($user);
         );
     }
 

--- a/modules/instrument_list/test/TestPlan.md
+++ b/modules/instrument_list/test/TestPlan.md
@@ -1,6 +1,6 @@
 # Instrument List Test Plan
 
-1. Verify that in order to access the module, the user must either have the `Across all sites access candidate profiles` permission, or be at the same site as the visit.
+1. Verify that in order to access the module, the user must either have the `Across all sites access candidate profiles` permission, or be at the same site and project as the visit.
 2. Verify that in order to update the current `Stage` status, the user requires `Data entry` permissions, and must be at the proper site. Exception: if the current `Stage` status is `Approval`, then only the `Behavioural QC` permission is necessary to update the `Stage` status.
 3. Verify that each instrument in the list directs to the corresponding instrument page.
 4. Verify that the flags' values (Data Entry, Administration, Feedback, Double Data Entry Form, Double Data Entry Status) for each instrument in the list are showing up appropriately.


### PR DESCRIPTION
This updates the instrument_list page to use the TimePoint's
isAccessibleBy function for access checking rather than manually
doing a site comparison for more consistency across LORIS. A result
of this is that project permissions for the timepoint are now enforced
on the instrument_list page.

The "or the same site of the candidate" is removed from the README
because:
1. That doesn't make sense if they have access to a different timepoint
   than the one being accessed.
2. The test plan doesn't agree and says you must have the timepoint's
   visit.