### PR TITLE
[LINST] modify LINST class to only strip '_date' from standard dates

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -604,7 +604,12 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                     0,
                                     -5
                                 );
-                            }
+                            } else {
+                                throw new \LorisException(
+                                    "Standard Date format field $pieces[1] must end"
+                                        . " with '_date'."
+                                );
+                            }                            
                             // Shows standard date
                             $this->addDateElement(
                                 $pieces[1],
@@ -954,5 +959,4 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
 
 }
-
 

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -609,7 +609,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                     "Standard Date format field $pieces[1] must end"
                                         . " with '_date'."
                                 );
-                            }                            
+                            }
                             // Shows standard date
                             $this->addDateElement(
                                 $pieces[1],

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -607,7 +607,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             } else {
                                 throw new \LorisException(
                                     "Standard Date format field `$pieces[1]` ".
-                                    "in LINST file `$filename` must end with '_date'."
+                                    "in LINST file `$filename` must end with ".
+                                    "'_date'."
                                 );
                             }
                             // Shows standard date

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -558,13 +558,6 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                     $this->LinstQuestions[$pieces[1]] = array('type' => 'textarea');
                     break;
                 case 'date':
-                    if (strpos($pieces[1], "_date") !== false) {
-                        $pieces[1] = substr(
-                            $pieces[1],
-                            0,
-                            strpos($pieces[1], "_date")
-                        );
-                    }
                     if ($addElements) {
                         if ($pieces[3] == 1900 && $pieces[4] == 2100) {
                             $dateOptions = null;
@@ -582,41 +575,46 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                         // Set date format
                         $dateFormat = isset($pieces[5]) ? trim($pieces[5]) : "";
 
-                        if (isset($dateFormat) && $dateFormat != "") {
-                            if ($dateFormat === 'MonthYear') {
-                                // Shows date without day of month
-                                $this->addMonthYear(
+                        if ($dateFormat === 'MonthYear') {
+                            // Shows date without day of month
+                            $this->addMonthYear(
+                                $pieces[1],
+                                $pieces[2],
+                                $dateOptions
+                            );
+                        } elseif ($dateFormat === 'BasicDate') {
+                            // Shows date without not answered dropdown
+                            $this->addBasicDate(
+                                $pieces[1],
+                                $pieces[2],
+                                $dateOptions
+                            );
+                        } elseif ($dateFormat === 'Date' || $dateFormat === "") {
+                            // The dateformat for a standard date should be
+                            // explicitly set to `Date` but for backwards
+                            // compatibility we support a null/empty dateformat and
+                            // default to standard date
+
+                            // Check that the field name ENDS with `_date` as it
+                            // should for standard dates. Then strip the `_date` so
+                            // it is not duplicated by the addDateElement function
+                            if (substr($pieces[1], -5) === "_date") {
+                                $pieces[1] = substr(
                                     $pieces[1],
-                                    $pieces[2],
-                                    $dateOptions
+                                    0,
+                                    -5
                                 );
                             }
-                            if ($dateFormat === 'BasicDate') {
-                                // Shows date without not answered dropdown
-                                $this->addBasicDate(
-                                    $pieces[1],
-                                    $pieces[2],
-                                    $dateOptions
-                                );
-                            }
-                            if ($dateFormat === 'Date') {
-                                // Shows standard date
-                                $this->addDateElement(
-                                    $pieces[1],
-                                    $pieces[2],
-                                    $dateOptions
-                                );
-                            }
-                        } else {
-                            // it will only enter here if the date format is not
-                            // explicitly set. This offers backwards compatibility
-                            // for date elements created before the date formats were
-                            // explicitly specified. An empty date format will be
-                            // handled as a `Date` element
+                            // Shows standard date
                             $this->addDateElement(
                                 $pieces[1],
                                 $pieces[2],
                                 $dateOptions
+                            );
+                        } else {
+                            throw new \LorisException(
+                                "Unsupported dateformat `$dateFormat` in LINST".
+                                " file `$filename` for date element `$pieces[1]`."
                             );
                         }
                     }

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -606,8 +606,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                 );
                             } else {
                                 throw new \LorisException(
-                                    "Standard Date format field `$pieces[1]` in LINST file `$filename` must end"
-                                        . " with '_date'."
+                                    "Standard Date format field `$pieces[1]` ".
+                                    "in LINST file `$filename` must end with '_date'."
                                 );
                             }
                             // Shows standard date
@@ -618,8 +618,8 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                             );
                         } else {
                             throw new \LorisException(
-                                "Unsupported dateformat `$dateFormat` in LINST".
-                                " file `$filename` for date element `$pieces[1]`."
+                                "Unsupported dateformat `$dateFormat` in LINST ".
+                                "file `$filename` for date element `$pieces[1]`."
                             );
                         }
                     }

--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -606,7 +606,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
                                 );
                             } else {
                                 throw new \LorisException(
-                                    "Standard Date format field $pieces[1] must end"
+                                    "Standard Date format field `$pieces[1]` in LINST file `$filename` must end"
                                         . " with '_date'."
                                 );
                             }
@@ -959,4 +959,3 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
 
 
 }
-

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -88,7 +88,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
         $instrument .= "select{@}textarea_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
         $instrument .= "select{@}FieldName{@}Field Description{@}NULL=>''{-}'option_1'=>'Option 1'{-}'option_2'=>'Option 2'{-}'option_3'=>'Option 3'{-}'not_answered'=>'Not Answered'\n";
         $instrument .= "selectmultiple{@}FieldName{@}Field Description{@}NULL=>''{-}'option_1'=>'Option 1'{-}'option_2'=>'Option 2'{-}'option_3'=>'Option 3'{-}'option_4'=>'Option 4'{-}'not_answered'=>'Not Answered'\n";
-        $instrument .= "date{@}FieldName{@}Field Description{@}2003{@}2014\n";
+        $instrument .= "date{@}FieldName_date{@}Field Description{@}2003{@}2014\n";
         $instrument .= "select{@}date_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'\n";
         $instrument .= "numeric{@}FieldName{@}Field Description{@}0{@}20\n";
         $instrument .= "select{@}numeric_status{@}{@}NULL=>''{-}'not_answered'=>'Not Answered'";
@@ -182,7 +182,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
                 ],
                 [
                     'Type'        => "date",
-                    "Name"        => "FieldName",
+                    "Name"        => "FieldName_date",
                     "Description" => "Field Description",
                     "Options"     => [
                         "MinDate" => "2003-01-01",


### PR DESCRIPTION
## Brief summary of changes
These changes were made to reflect the https://github.com/aces/Loris/pull/6923 which was issued to the `main` branch

Additional changes not in #6923:
 - modified the "stripping" function to only remove `_date` if it is positioned at the end of the field name. For example if the user names their date field `my_date_of_release_date`, previously the function would strip the field name to `my`; now it would only strip the last `_date` to become `my_date_of_release`
- removed the check for `isset($dateformat)` since the code is already converting a null $dateformat to an empty string 2 lines above !
- reorganized the if statements to reduce over all complexity
- added an exception if the date format does not match any known formats
