### PR TITLE
[create_timepoint] Use the project for the project, not the site

### DIFF
--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -188,7 +188,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
             // if there is only one project, autoselect first project from array of 1
             $project = \Project::getProjectFromID(array_pop($user_list_of_projects));
         } else if (count($user_list_of_projects) > 1) {
-            $project_id = intval($values['psc']);
+            $project_id = intval($values['project']);
             $project    = \Project::getProjectFromID($project_id);
         }
 


### PR DESCRIPTION
Timepoint creation was incorrectly using the site dropdown as the
projectID instead of the project dropdown when the user had more
than 1 project. This corrects it to use the appropriate dropdown
for creation.