### PR TITLE
This fixes the undeclared properties identifier by phan in one file

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
@@ -35,6 +35,13 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
     private $_instrument;
 
     /**
+     * The current flag status
+     *
+     * @var \NDB_BVL_InstrumentStatus
+     */
+    private $_instrumentStatus;
+
+    /**
      * The visit from which the instrument is filled
      *
      * @var \Timepoint


### PR DESCRIPTION
There are many more that need to be fixed before the phan rule can
be enforced, but you eat an elephant one bite at a time.

#### Testing instructions (if applicable)

1. Set `"allow_missing_properties" => false,` (is currently true) in .phan/config.php
2. Run phan and check for errors in the modified file. (There are still many from other files, but there shouldn't be any in this one.) 
