### PR TITLE
[Core] Date field js validation

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1042,10 +1042,18 @@ class DateElement extends Component {
     let disabled = this.props.disabled ? 'disabled' : null;
     let required = this.props.required ? 'required' : null;
     let requiredHTML = null;
+    let errorMessage = null;
+    let elementClass = 'row form-group';
 
     // Add required asterix
     if (required) {
       requiredHTML = <span className="text-danger">*</span>;
+    }
+
+    // Add error message
+    if (this.props.hasError || (this.props.required && this.props.value === '')) {
+      errorMessage = <span>{this.props.errorMessage}</span>;
+      elementClass = elementClass + ' has-error';
     }
 
     // Check if props minYear and maxYear are valid values if supplied
@@ -1070,7 +1078,7 @@ class DateElement extends Component {
     }
 
     return (
-      <div className="row form-group">
+      <div className={elementClass}>
         <label className="col-sm-3 control-label" htmlFor={this.props.label}>
           {this.props.label}
           {requiredHTML}
@@ -1088,6 +1096,7 @@ class DateElement extends Component {
             required={required}
             disabled={disabled}
           />
+          {errorMessage}
         </div>
       </div>
     );
@@ -1104,19 +1113,23 @@ DateElement.propTypes = {
   dateFormat: PropTypes.string,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  hasError: PropTypes.bool,
+  errorMessage: PropTypes.string,
   onUserInput: PropTypes.func,
 };
 
 DateElement.defaultProps = {
   name: '',
   label: '',
-  value: '',
+  value: undefined,
   id: null,
   maxYear: '9999',
   minYear: '1000',
   dateFormat: 'YMd',
   disabled: false,
   required: false,
+  hasError: false,
+  errorMessage: 'The field is required!',
   onUserInput: function() {
     console.warn('onUserInput() callback is not set');
   },


### PR DESCRIPTION
For one of my projects, I need to validate a date field in react and display front-end error message. Select fields have an errorMessage and hasError props for such scenario, but those are not implemented on DateElement. This PR implement the same logic on DateElement. 