### PR TITLE
[battery_manager] Fix phan undeclared property errors

### DIFF
--- a/modules/battery_manager/php/testendpoint.class.inc
+++ b/modules/battery_manager/php/testendpoint.class.inc
@@ -33,6 +33,20 @@ class TestEndpoint implements RequestHandlerInterface
 {
 
     /**
+     * The database connection
+     *
+     * @var \Database
+     */
+    protected $db;
+
+    /**
+     * The user accessing the endpoint
+     *
+     * @var \User
+     */
+    protected $user;
+
+    /**
      * Returns true if user has access to this endpoint.
      *
      * @param \User $user The user whose access is being checked


### PR DESCRIPTION
This declares the properties that are undeclared in the battery_manager module.

#### Testing instructions (if applicable)

1. Set `"allow_missing_properties" => false,` (is currently true) in .phan/config.php
2. Run phan and check for errors in the modified file. (There are still many from other files, but there shouldn't be any in this one.) 
