### PR TITLE
[dicom_archive] Fix undeclared properties in dicom_archive

### DIFF
--- a/modules/dicom_archive/php/viewdetails.class.inc
+++ b/modules/dicom_archive/php/viewdetails.class.inc
@@ -31,9 +31,16 @@ class ViewDetails extends \NDB_Form
     public $tarchiveID;
 
     /**
+     * A Database connection to a LORIS DB
+     *
+     * @var \Database
+     */
+    protected $DB;
+
+    /**
      * Keeps array of protocols from mri_protocol
      */
-    var $protocols;
+    public $protocols;
 
     /**
      * Determine whether the user has permission to view this page


### PR DESCRIPTION
Fix undeclared properties in the dicom_archive module.

#### Testing instructions (if applicable)

1. Set `"allow_missing_properties" => false` and ensure there's no errors in the `dicom_archive` module from phan