### PR TITLE
Fix phan mismatched property errors

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -39,7 +39,6 @@ return [
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",
         "PhanTypeMismatchArgument",
-        "PhanTypeMismatchProperty",
         "PhanTypeArraySuspiciousNullable",
     ],
     "analyzed_file_extensions" => ["php", "inc"],

--- a/modules/api/php/endpoints/candidate/visit/visit.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/visit.class.inc
@@ -38,7 +38,7 @@ class Visit extends Endpoint implements \LORIS\Middleware\ETagCalculator
     /**
      * The requested Visit
      *
-     * @var \Timepoint
+     * @var ?\Timepoint
      */
     private $_visit;
 

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -76,8 +76,11 @@ class LoginTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->_request       = new ServerRequest();
-        $this->_authenticator = $this->createMock('\SinglePointLogin');
+        $this->_request = new ServerRequest();
+
+        $authenticator = $this->createMock('\SinglePointLogin');
+        '@phan-var \SinglePointLogin $authenticator';
+        $this->_authenticator = $authenticator;
     }
 
     /**

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -30,9 +30,10 @@ class HelpFile
     /**
      * Identifies the help file
      *
-     * @var    int
+     * @var    ?int
+     * @access private
      */
-    private $helpID;
+    var $helpID;
 
     /**
      * The help file's data

--- a/modules/help_editor/php/helpfile.class.inc
+++ b/modules/help_editor/php/helpfile.class.inc
@@ -30,10 +30,9 @@ class HelpFile
     /**
      * Identifies the help file
      *
-     * @var    array
-     * @access private
+     * @var    int
      */
-    var $helpID;
+    private $helpID;
 
     /**
      * The help file's data
@@ -67,7 +66,7 @@ class HelpFile
             ['HID' => $helpID]
         );
         // set the help file
-        $obj->data = $result;
+        $obj->data = $result ?? [];
 
         return $obj;
     }

--- a/modules/server_processes_manager/php/abstractserverprocess.class.inc
+++ b/modules/server_processes_manager/php/abstractserverprocess.class.inc
@@ -55,7 +55,7 @@ abstract class AbstractServerProcess
     /**
      * Unix process ID for that process
      *
-     * @var int
+     * @var ?int
      */
     private $_pid;
 
@@ -112,7 +112,7 @@ abstract class AbstractServerProcess
     /**
      * Time at which the process finished (in format PROCESS_TIME_FORMAT)
      *
-     * @var string
+     * @var ?string
      */
     private $_endTime;
 
@@ -173,7 +173,7 @@ abstract class AbstractServerProcess
     /**
      * Accessor for field $_pid.
      *
-     * @return int value of $_pid
+     * @return ?int
      */
     public function getPid()
     {

--- a/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
+++ b/modules/server_processes_manager/php/mriuploadserverprocess.class.inc
@@ -39,7 +39,7 @@ class MriUploadServerProcess extends AbstractServerProcess
     /**
      * ID of the MRI upload request in the mri_upload table.
      *
-     * @var int
+     * @var ?int
      */
     private $_mriUploadId;
 

--- a/modules/server_processes_manager/php/process.class.inc
+++ b/modules/server_processes_manager/php/process.class.inc
@@ -150,12 +150,14 @@ class Process
         // Since both command are run in succession, when the main command is
         // finished, the $getExitCodeCmd will be run, storing the $mainCmd
         // exit code in $_exitCodeFile
-        $this->_pid = intval(exec(
-            "(bash -c '$mainCmd ; $getExitCodeCmd') > /dev/null 2> /dev/null & "
-            . " echo $!",
-            $execOutput,
-            $returnStatus
-        ));
+        $this->_pid = intval(
+            exec(
+                "(bash -c '$mainCmd ; $getExitCodeCmd') > /dev/null 2> /dev/null & "
+                . " echo $!",
+                $execOutput,
+                $returnStatus
+            )
+        );
 
         if ($returnStatus != 0) {
             throw new \RuntimeException(

--- a/modules/server_processes_manager/php/process.class.inc
+++ b/modules/server_processes_manager/php/process.class.inc
@@ -62,7 +62,7 @@ class Process
     /**
      * Will provide access to the database
      *
-     * @var IDatabaseProvider
+     * @var IProcessMonitor
      */
     private $_processMonitor;
 
@@ -110,7 +110,7 @@ class Process
     /**
      * Accessor for field $_processMonitor
      *
-     * @return IDatabaseProvider value of field $_processMonitor
+     * @return IProcessMonitor
      */
     public function getProcessMonitor()
     {
@@ -150,12 +150,12 @@ class Process
         // Since both command are run in succession, when the main command is
         // finished, the $getExitCodeCmd will be run, storing the $mainCmd
         // exit code in $_exitCodeFile
-        $this->_pid = exec(
+        $this->_pid = intval(exec(
             "(bash -c '$mainCmd ; $getExitCodeCmd') > /dev/null 2> /dev/null & "
             . " echo $!",
             $execOutput,
             $returnStatus
-        );
+        ));
 
         if ($returnStatus != 0) {
             throw new \RuntimeException(

--- a/php/libraries/ImageQcStatus.class.inc
+++ b/php/libraries/ImageQcStatus.class.inc
@@ -27,7 +27,7 @@ class ImageQcStatus
     /**
      * The label to display to the frontend user
      *
-     * @var string
+     * @var ?string
      */
     private $_qcstatus;
 

--- a/php/libraries/TimePointImagingQC.class.inc
+++ b/php/libraries/TimePointImagingQC.class.inc
@@ -28,21 +28,21 @@ class TimePointImagingQC
     /**
      * The QC value
      *
-     * @var string
+     * @var ?string
      */
     private $_qc;
 
     /**
      * A flag to tell if the QC is still pending
      *
-     * @var string
+     * @var ?string
      */
     private $_qcpending;
 
     /**
      * A flag to indicate if there is a caveat
      *
-     * @var string
+     * @var ?string
      */
     private $_hascaveat;
 

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -27,7 +27,7 @@ class UserPermissions
      *
      * @var ?string
      */
-    private $userID;
+    var $userID;
 
     /**
      * Stores the permissions

--- a/php/libraries/Visit.class.inc
+++ b/php/libraries/Visit.class.inc
@@ -27,22 +27,22 @@ class Visit
     /**
      * The visit ID
      *
-     * @var int
+     * @var ?string
      */
     protected $id;
 
     /**
      * The visit name (formely known as visit_label)
      *
-     * @var string
+     * @var ?string
      */
     protected $name;
 
     /**
      * The contructor
      *
-     * @param string|null $name The visit name
-     * @param string|null $id   The ID of the visit
+     * @param ?string $name The visit name
+     * @param ?string $id   The ID of the visit
      */
     public function __construct(
         ?string $name = null,
@@ -59,6 +59,9 @@ class Visit
      */
     public function getName(): string
     {
+        if ($this->name === null) {
+            throw new \LorisException("No name defined for Visit");
+        }
         return $this->name;
     }
 }

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -1812,9 +1812,12 @@ class Database_Test extends TestCase
         $stub           = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
-
         '@phan-var \Database $stub';
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
+        '@phan-var \FakePDO $PDO';
+
+        $stub->_PDO = $PDO;
         $val        = $stub->isConnected();
         $this->assertEquals($val, true);
     }

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -2285,7 +2285,7 @@ class LorisForms_Test extends TestCase
             ->method('hiddenHTML');
 
         $form->addElement("hidden", "abc", "Hello");
-        $form->renderElement($this->form->form['abc']);
+        $form->renderElement($form->form['abc']);
     }
 
     /**

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -2240,14 +2240,12 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementHeader()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['headerHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('headerHTML');
 
-        $form = $this->form;
-        '@phan-var \LorisForm $form';
         $form->addElement("header", "abc", "Hello");
         $form->renderElement($form->form['abc']);
     }
@@ -2261,14 +2259,12 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementSubmit()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['submitHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('submitHTML');
 
-        $form = $this->form;
-        '@phan-var \LorisForm $form';
         $testSubmit = $form->createSubmit("abc", "Hello", []);
         $form->renderElement($testSubmit);
     }
@@ -2282,14 +2278,12 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementHidden()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $form = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['hiddenHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $form->expects($this->once())
             ->method('hiddenHTML');
 
-        $form = $this->form;
-        '@phan-var \LorisForm $form';
         $form->addElement("hidden", "abc", "Hello");
         $form->renderElement($this->form->form['abc']);
     }
@@ -2303,14 +2297,12 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementTime()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $f = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['timeHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $f->expects($this->once())
             ->method('timeHTML');
 
-        $f = $this->form;
-        '@phan-var \LorisForm $f';
         $testTime = $f->createElement(
             "time",
             "abc",
@@ -2331,17 +2323,14 @@ class LorisForms_Test extends TestCase
      */
     function testRenderElementLink()
     {
-        $this->form = $this->getMockBuilder('LorisForm')
+        $f = $this->getMockBuilder('LorisForm')
             ->onlyMethods(['linkHTML'])
             ->getMock();
-        $this->form->expects($this->once())
+        $f->expects($this->once())
             ->method('linkHTML');
 
-        $f = $this->form;
-        '@phan-var \LorisForm $f';
-
         $f->addElement("link", "abc", "Hello");
-        $f->renderElement($this->form->form['abc']);
+        $f->renderElement($f->form['abc']);
     }
 
     /**

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -84,6 +84,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
         '@phan-var \Loris\Behavioural\NDB_BVL_Instrument_LINST $i';
         $i->form     = $this->QuickForm;
         $i->testName = "Test";
+
         $this->i = $i;
 
     }

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -72,16 +72,20 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
         $this->Client->makeCommandLine();
         $this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
-        $this->i = $this
+        $i = $this
             ->getMockBuilder('\Loris\Behavioural\NDB_BVL_Instrument_LINST')
             ->disableOriginalConstructor()
             ->onlyMethods(['getFullName', 'getSessionID'])
             ->getMock();
-        $this->i->method('getFullName')->willReturn("Test Instrument");
-        $this->i->method('getSessionID')
+        $i->method('getFullName')->willReturn("Test Instrument");
+        $i->method('getSessionID')
             ->willReturn(new \SessionID(strval("123456")));
-        $this->i->form     = $this->QuickForm;
-        $this->i->testName = "Test";
+
+        '@phan-var \Loris\Behavioural\NDB_BVL_Instrument_LINST $i';
+        $i->form     = $this->QuickForm;
+        $i->testName = "Test";
+        $this->i = $i;
+
     }
 
     /**

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -80,11 +80,15 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $this->quickForm = new \LorisForm();
 
-        $this->_instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
+        $instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
             ->onlyMethods(["getFullName", "getSubtestList"])->getMock();
-        $this->_instrument->method('getFullName')->willReturn("Test Instrument");
-        $this->_instrument->method('getSubtestList')->willReturn([]);
+        $instrument->method('getFullName')->willReturn("Test Instrument");
+        $instrument->method('getSubtestList')->willReturn([]);
+
+        '@phan-var \NDB_BVL_Instrument $instrument';
+        $this->_instrument = $instrument;
+
         $this->_instrument->form     = $this->quickForm;
         $this->_instrument->testName = "Test";
     }
@@ -842,27 +846,21 @@ class NDB_BVL_Instrument_Test extends TestCase
      */
     function testPageGroup()
     {
-        $this->_instrument = $this->getMockBuilder(\NDB_BVL_Instrument::class)
+        $i= $this->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
             ->onlyMethods(
                 ["getFullName", "getSubtestList"]
             )->addMethods(['_setupForm'])->getMock();
-        $this->_instrument->method('getFullName')->willReturn("Test Instrument");
-        $this->_instrument->method('getSubtestList')->willReturn(
+        $i->method('getFullName')->willReturn("Test Instrument");
+        $i->method('getSubtestList')->willReturn(
             [
                 ['Name' => 'Page 1', 'Description' => 'The first page'],
                 ['Name' => 'Page 2', 'Description' => 'The second page'],
             ]
         );
 
-        $this->_instrument->form     = $this->quickForm;
-        $this->_instrument->testName = "Test";
-
-        // Phan isn't interpreting the phpdoc correctly and thinks
-        // this is a \PHPUnit\Framework\MockObject\MockObject, not
-        // an instrument, so put it into a variable and assert its
-        // type.
-        $i = $this->_instrument;
+        $i->form     = $this->quickForm;
+        $i->testName = "Test";
         '@phan-var \NDB_BVL_Instrument $i';
 
         $json     = $i->toJSON();
@@ -1823,6 +1821,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $mockform = $this->getMockBuilder("\LorisForm")->getMock();
 
         $mockform->method('getSubmitValues')->willReturn(['1', '2']);
+        '@phan-var \LorisForm $mockform';
 
         $this->_instrument->form = $mockform;
 

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -846,7 +846,7 @@ class NDB_BVL_Instrument_Test extends TestCase
      */
     function testPageGroup()
     {
-        $i= $this->getMockBuilder(\NDB_BVL_Instrument::class)
+        $i = $this->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
             ->onlyMethods(
                 ["getFullName", "getSubtestList"]

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -62,7 +62,7 @@ class SinglePointLoginTest extends TestCase
             ->onlyMethods($exceptMethod)->getMock();
 
         '@phan-var \SinglePointLogin $login';
-        $this->login = $login;
+        $this->_login = $login;
 
     }
 

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -58,8 +58,10 @@ class SinglePointLoginTest extends TestCase
         $method       = ['JWTAuthenticate', 'PasswordAuthenticate', 'authenticate'];
         $AllMethods   = get_class_methods('SinglePointLogin');
         $exceptMethod = array_diff($AllMethods, $method);
-        $this->_login = $this->getMockBuilder('SinglePointLogin')
+        $login = $this->getMockBuilder('SinglePointLogin')
             ->onlyMethods($exceptMethod)->getMock();
+        '@phan-var \SinglePointLogin $login';
+        $this->login = $login;
 
     }
 

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -58,8 +58,9 @@ class SinglePointLoginTest extends TestCase
         $method       = ['JWTAuthenticate', 'PasswordAuthenticate', 'authenticate'];
         $AllMethods   = get_class_methods('SinglePointLogin');
         $exceptMethod = array_diff($AllMethods, $method);
-        $login = $this->getMockBuilder('SinglePointLogin')
+        $login        = $this->getMockBuilder('SinglePointLogin')
             ->onlyMethods($exceptMethod)->getMock();
+
         '@phan-var \SinglePointLogin $login';
         $this->login = $login;
 


### PR DESCRIPTION
This fixes all the errors identified by phan where a property
was being assigned to an incompatible type. Most of these were
caused by assigning null to a non-nullable property, which was
fixed by declaring the property nullable.