### PR TITLE
Remove mandatory underscore from private properties

### DIFF
--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -25,18 +25,16 @@ class UserPermissions
     /**
      * User's ID
      *
-     * @var    string
-     * @access private
+     * @var ?string
      */
-    var $userID;
+    private $userID;
 
     /**
      * Stores the permissions
      *
-     * @var    array<string,bool>
-     * @access private
+     * @var array<string,bool>
      */
-    var $permissions = [];
+    private $permissions = [];
 
 
     /**

--- a/test/LorisCS.xml
+++ b/test/LorisCS.xml
@@ -10,6 +10,7 @@
         <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag"/>
         <exclude name="PEAR.Commenting.ClassComment.MissingVersion"/>
         <exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag"/>
+        <exclude name="PEAR.NamingConventions.ValidVariableName"/>
     </rule>
 
     <!-- Pieces of other standards to include... -->


### PR DESCRIPTION
This removes the rule from PHPCS enforcing a mandatory `_` on private class properties in the php/libraries directory. Having this rule enforced prevents us from converting some of our code from PHP4 phpdoc style `@access` comments to proper php private/protected/public keywords (without updating all the code referencing the variables, which is risky since `allow_missing_properties` is true in our phan config.) It's also one of the incompatibilities between our old PEAR based php/libraries and PSR2 based src coding standards which prevents us from using the same standard throughout LORIS.