### PR TITLE
Genomic browser post-reactification

### DIFF
--- a/modules/genomic_browser/jsx/tabs_content/cnv.js
+++ b/modules/genomic_browser/jsx/tabs_content/cnv.js
@@ -54,7 +54,6 @@ class CNV extends Component {
           const data = {
             fieldOptions: json.fieldOptions,
             Data: json.data.map((e) => Object.values(e)),
-            subprojects: json.subprojects,
           };
           this.setState({
             data,
@@ -87,9 +86,6 @@ class CNV extends Component {
       case 'PSCID':
         const url = `${this.props.baseURL}/${rowData.DCCID}/`;
         reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
-        break;
-      case 'Subproject':
-        reactElement = <td>{this.state.data.subprojects[parseInt(cell)]}</td>;
         break;
       default:
         reactElement = <td>{cell}</td>;
@@ -155,7 +151,7 @@ class CNV extends Component {
         filter: {
           name: 'Subproject',
           type: 'select',
-          options: options.Subproject,
+          options: options.Subprojects,
         },
       },
       {

--- a/modules/genomic_browser/jsx/tabs_content/methylation.js
+++ b/modules/genomic_browser/jsx/tabs_content/methylation.js
@@ -55,7 +55,6 @@ class Methylation extends Component {
           const data = {
             fieldOptions: json.fieldOptions,
             Data: json.data.map((e) => Object.values(e)),
-            subprojects: json.subprojects,
           };
           this.setState({
             data,
@@ -88,9 +87,6 @@ class Methylation extends Component {
       case 'PSCID':
         const url = `${this.props.baseURL}/${rowData.DCCID}/`;
         reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
-        break;
-      case 'Subproject':
-        reactElement = <td>{this.state.data.subprojects[parseInt(cell)]}</td>;
         break;
       default:
         reactElement = <td>{cell}</td>;
@@ -156,7 +152,7 @@ class Methylation extends Component {
         filter: {
           name: 'Subproject',
           type: 'select',
-          options: options.Subproject,
+          options: options.Subprojects,
         },
       },
       {

--- a/modules/genomic_browser/jsx/tabs_content/profiles.js
+++ b/modules/genomic_browser/jsx/tabs_content/profiles.js
@@ -55,7 +55,6 @@ class Profiles extends Component {
           const data = {
             fieldOptions: json.fieldOptions,
             Data: json.data.map((e) => Object.values(e)),
-            subprojects: json.subprojects,
           };
           this.setState({
             data,
@@ -183,7 +182,7 @@ class Profiles extends Component {
         filter: {
           name: 'Subproject',
           type: 'select',
-          options: options.Subproject,
+          options: options.Subprojects,
         },
       },
       {

--- a/modules/genomic_browser/jsx/tabs_content/snp.js
+++ b/modules/genomic_browser/jsx/tabs_content/snp.js
@@ -55,7 +55,6 @@ class SNP extends Component {
           const data = {
             fieldOptions: json.fieldOptions,
             Data: json.data.map((e) => Object.values(e)),
-            subprojects: json.subprojects,
           };
           this.setState({
             data,
@@ -88,9 +87,6 @@ class SNP extends Component {
       case 'PSCID':
         const url = `${this.props.baseURL}/${rowData.DCCID}/`;
         reactElement = <td><a href={url}>{rowData.PSCID}</a></td>;
-        break;
-      case 'Subproject':
-        reactElement = <td>{this.state.data.subprojects[parseInt(cell)]}</td>;
         break;
       default:
         reactElement = <td>{cell}</td>;
@@ -156,7 +152,7 @@ class SNP extends Component {
         filter: {
           name: 'Subproject',
           type: 'select',
-          options: options.Subproject,
+          options: options.Subprojects,
         },
       },
       {

--- a/modules/genomic_browser/php/cnvbrowser.class.inc
+++ b/modules/genomic_browser/php/cnvbrowser.class.inc
@@ -22,7 +22,7 @@ use \LORIS\Middleware\ETagCalculator;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class CnvBrowser extends \NDB_Page implements ETagCalculator
+class CnvBrowser extends \DataFrameworkMenu implements ETagCalculator
 {
 
     /**
@@ -68,7 +68,7 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
             ->toArray($user);
         $body = [
             'data'         => $data,
-            'fieldOptions' => $this->_getFieldOptions($request),
+            'fieldOptions' => $this->getFieldOptions(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -76,13 +76,11 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
     /**
      * Provide the select inputs options
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request.
-     *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(ServerRequestInterface $request) : array
+    function getFieldOptions() : array
     {
-        $user = $request->getAttribute('user');
+        $user = \NDB_Factory::singleton()->user();
 
         // Platform
         $DB = \Database::singleton();
@@ -153,6 +151,27 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
     protected function allowedMethods(): array
     {
         return ['GET'];
+    }
+
+    /**
+     * Gets the data source for this menu filter.
+     *
+     * @return \LORIS\Data\Provisioner
+     */
+    function getBaseDataProvisioner() : \LORIS\Data\Provisioner
+    {
+        return new CnvProvisioner();
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always true
+     */
+    public function useProjectFilter(): bool
+    {
+        return true;
     }
 
 }

--- a/modules/genomic_browser/php/cnvbrowser.class.inc
+++ b/modules/genomic_browser/php/cnvbrowser.class.inc
@@ -3,6 +3,7 @@
 namespace LORIS\genomic_browser;
 
 use LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
+use LORIS\Data\Filters\UserProjectMatch;
 use LORIS\genomic_browser\Provisioners\CnvProvisioner;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -53,11 +54,14 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
      */
     private function _handleGET(ServerRequestInterface $request) : ResponseInterface
     {
-        $filter      = new HasAnyPermissionOrUserSiteMatch(
+        $sitesFilter = new HasAnyPermissionOrUserSiteMatch(
             ['genomic_browser_view_allsites']
         );
-        $provisioner = (new CnvProvisioner())->filter($filter);
-        $user        = $request->getAttribute('user');
+        $provisioner = (new CnvProvisioner())
+            ->filter($sitesFilter)
+            ->filter(new UserProjectMatch());
+
+        $user = $request->getAttribute('user');
 
         $data = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)
@@ -65,7 +69,6 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
         $body = [
             'data'         => $data,
             'fieldOptions' => $this->_getFieldOptions($request),
-            'subprojects'  => \Utility::getSubprojectList(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -77,15 +80,10 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
      *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(
-        ServerRequestInterface $request
-    ) : array {
+    private function _getFieldOptions(ServerRequestInterface $request) : array
+    {
         $user = $request->getAttribute('user');
-        // centerID
-        $list_of_sites = $user->hasPermission('genomic_browser_view_allsites')
-            ? \Utility::getSiteList()
-            : $user->getStudySites();
-        $list_of_sites = array_combine($list_of_sites, $list_of_sites);
+
         // Platform
         $DB = \Database::singleton();
         $platform_results = $DB->pselect(
@@ -100,8 +98,8 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
 
         return (new \LORIS\genomic_browser\Views\CNV(
             $platform_options,
-            \Utility::getSubprojectList(),
-            $list_of_sites
+            $this->getSiteOptions($user, false),
+            $this->getSubprojectOptions($user),
         ))->toArray();
     }
 
@@ -134,6 +132,17 @@ class CnvBrowser extends \NDB_Page implements ETagCalculator
                 'genomic_browser_view_site'
             ]
         );
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function allSitePermissionNames() : ?array
+    {
+        return ['genomic_browser_view_allsites'];
     }
 
     /**

--- a/modules/genomic_browser/php/filemanager.class.inc
+++ b/modules/genomic_browser/php/filemanager.class.inc
@@ -2,7 +2,6 @@
 
 namespace LORIS\genomic_browser;
 
-use LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
 use LORIS\genomic_browser\Provisioners\FilesProvisioner;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -55,10 +54,7 @@ class FileManager extends \NDB_Page implements ETagCalculator
      */
     private function _handleGET(ServerRequestInterface $request) : ResponseInterface
     {
-        $filter      = new HasAnyPermissionOrUserSiteMatch(
-            ['genomic_browser_view_allsites']
-        );
-        $provisioner = (new FilesProvisioner())->filter($filter);
+        $provisioner = new FilesProvisioner();
         $user        = $request->getAttribute('user');
 
         $data = (new \LORIS\Data\Table())

--- a/modules/genomic_browser/php/gwasbrowser.class.inc
+++ b/modules/genomic_browser/php/gwasbrowser.class.inc
@@ -2,7 +2,6 @@
 
 namespace LORIS\genomic_browser;
 
-use LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
 use LORIS\genomic_browser\Provisioners\GwasProvisioner;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -53,10 +52,7 @@ class GwasBrowser extends \NDB_Page implements ETagCalculator
      */
     private function _handleGET(ServerRequestInterface $request) : ResponseInterface
     {
-        $filter      = new HasAnyPermissionOrUserSiteMatch(
-            ['genomic_browser_view_allsites']
-        );
-        $provisioner = (new GwasProvisioner())->filter($filter);
+        $provisioner = new GwasProvisioner();
         $user        = $request->getAttribute('user');
 
         $data = (new \LORIS\Data\Table())

--- a/modules/genomic_browser/php/methylation.class.inc
+++ b/modules/genomic_browser/php/methylation.class.inc
@@ -3,6 +3,7 @@
 namespace LORIS\genomic_browser;
 
 use LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
+use LORIS\Data\Filters\UserProjectMatch;
 use LORIS\genomic_browser\Provisioners\MethylationProvisioner;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -54,19 +55,21 @@ class Methylation extends \NDB_Page implements ETagCalculator
      */
     private function _handleGET(ServerRequestInterface $request) : ResponseInterface
     {
-        $filter      = new HasAnyPermissionOrUserSiteMatch(
+        $sitesFilter = new HasAnyPermissionOrUserSiteMatch(
             ['genomic_browser_view_allsites']
         );
-        $provisioner = (new MethylationProvisioner())->filter($filter);
-        $user        = $request->getAttribute('user');
+        $provisioner = (new MethylationProvisioner())
+            ->filter($sitesFilter)
+            ->filter(new UserProjectMatch());
+
+        $user = $request->getAttribute('user');
 
         $data = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)
             ->toArray($user);
         $body = [
             'data'         => $data,
-            'fieldOptions' => $this->_getFieldOptions($request),
-            'subprojects'  => \Utility::getSubprojectList(),
+            'fieldOptions' => $this->_getFieldOptions(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -81,18 +84,11 @@ class Methylation extends \NDB_Page implements ETagCalculator
     private function _getFieldOptions(
         ServerRequestInterface $request
     ) : array {
-
         $user = $request->getAttribute('user');
 
-        // centerID
-        $list_of_sites = $user->hasPermission('genomic_browser_view_allsites')
-            ? \Utility::getSiteList()
-            : $user->getStudySites();
-        $list_of_sites = array_combine($list_of_sites, $list_of_sites);
-
         return (new \LORIS\genomic_browser\Views\Methylation(
-            $list_of_sites,
-            \Utility::getSubprojectList()
+            $this->getSiteOptions($user, false),
+            $this->getSubprojectOptions($user),
         ))->toArray();
     }
 
@@ -125,6 +121,17 @@ class Methylation extends \NDB_Page implements ETagCalculator
                 'genomic_browser_view_site'
             ]
         );
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function allSitePermissionNames() : ?array
+    {
+        return ['genomic_browser_view_allsites'];
     }
 
     /**

--- a/modules/genomic_browser/php/methylation.class.inc
+++ b/modules/genomic_browser/php/methylation.class.inc
@@ -23,7 +23,7 @@ use \LORIS\Middleware\ETagCalculator;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Methylation extends \NDB_Page implements ETagCalculator
+class Methylation extends \DataFrameworkMenu implements ETagCalculator
 {
 
     /**
@@ -69,7 +69,7 @@ class Methylation extends \NDB_Page implements ETagCalculator
             ->toArray($user);
         $body = [
             'data'         => $data,
-            'fieldOptions' => $this->_getFieldOptions(),
+            'fieldOptions' => $this->getFieldOptions(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -77,14 +77,11 @@ class Methylation extends \NDB_Page implements ETagCalculator
     /**
      * Provide the select inputs options
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request.
-     *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(
-        ServerRequestInterface $request
-    ) : array {
-        $user = $request->getAttribute('user');
+    function getFieldOptions() : array
+    {
+        $user = \NDB_Factory::singleton()->user();
 
         return (new \LORIS\genomic_browser\Views\Methylation(
             $this->getSiteOptions($user, false),
@@ -144,4 +141,24 @@ class Methylation extends \NDB_Page implements ETagCalculator
         return ['GET'];
     }
 
+    /**
+     * Gets the data source for this menu filter.
+     *
+     * @return \LORIS\Data\Provisioner
+     */
+    function getBaseDataProvisioner() : \LORIS\Data\Provisioner
+    {
+        return new MethylationProvisioner();
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always true
+     */
+    public function useProjectFilter(): bool
+    {
+        return true;
+    }
 }

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomic_Browser
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\Models;
 
@@ -29,6 +20,20 @@ namespace LORIS\genomic_browser\Models;
  */
 class CnvDTO implements \LORIS\Data\DataInstance
 {
+    /**
+     * The centerID
+     *
+     * @var string
+     */
+    private $_centerID = "";
+
+    /**
+     * The projectID
+     *
+     * @var string
+     */
+    private $_projectID = "";
+
     /**
      * The PSC
      *
@@ -238,5 +243,25 @@ class CnvDTO implements \LORIS\Data\DataInstance
             'Validation_Method' => $this->_Validation_Method,
             'Platform'          => $this->_Platform,
         ];
+    }
+
+    /**
+     * Returns the CenterID for this row
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID(): int
+    {
+        return (int) $this->_centerID;
+    }
+
+    /**
+     * Returns the ProjectID for this row
+     *
+     * @return integer The ProjectID
+     */
+    public function getProjectID(): int
+    {
+        return (int) $this->_projectID;
     }
 }

--- a/modules/genomic_browser/php/models/filesdto.class.inc
+++ b/modules/genomic_browser/php/models/filesdto.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomic_Browser
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\Models;
 

--- a/modules/genomic_browser/php/models/methylationdto.class.inc
+++ b/modules/genomic_browser/php/models/methylationdto.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomic_Browser
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\Models;
 
@@ -29,6 +20,20 @@ namespace LORIS\genomic_browser\Models;
  */
 class MethylationDTO implements \LORIS\Data\DataInstance
 {
+    /**
+     * The centerID
+     *
+     * @var string
+     */
+    private $_centerID = "";
+
+    /**
+     * The projectID
+     *
+     * @var string
+     */
+    private $_projectID = "";
+
     /**
      * The PSC
      *
@@ -302,5 +307,25 @@ class MethylationDTO implements \LORIS\Data\DataInstance
             'DHS'              => $this->_DHS,
             'Platform'         => $this->_Platform,
         ];
+    }
+
+    /**
+     * Returns the CenterID for this row
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID(): int
+    {
+        return (int) $this->_centerID;
+    }
+
+    /**
+     * Returns the ProjectID for this row
+     *
+     * @return integer The ProjectID
+     */
+    public function getProjectID(): int
+    {
+        return (int) $this->_projectID;
     }
 }

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -29,12 +29,27 @@ namespace LORIS\genomic_browser\Models;
  */
 class ProfileDTO implements \LORIS\Data\DataInstance
 {
+
     /**
      * The centerID
      *
      * @var string
      */
     private $_centerID = "";
+
+    /**
+     * The projectID
+     *
+     * @var string
+     */
+    private $_projectID = "";
+
+    /**
+     * The PSC name
+     *
+     * @var string
+     */
+    private $_PSC = "";
 
     /**
      * The DCCID
@@ -114,7 +129,7 @@ class ProfileDTO implements \LORIS\Data\DataInstance
     public function jsonSerialize(): array
     {
         return [
-            'centerID'   => $this->_centerID,
+            'centerID'   => $this->_PSC,
             'DCCID'      => $this->_DCCID,
             'PSCID'      => $this->_PSCID,
             'Sex'        => $this->_Sex,
@@ -126,5 +141,25 @@ class ProfileDTO implements \LORIS\Data\DataInstance
             'CNV'        => $this->_CNV,
             'CPG'        => $this->_CPG,
         ];
+    }
+
+    /**
+     * Returns the CenterID for this row
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID(): int
+    {
+        return (int) $this->_centerID;
+    }
+
+    /**
+     * Returns the ProjectID for this row
+     *
+     * @return integer The ProjectID
+     */
+    public function getProjectID(): int
+    {
+        return (int) $this->_projectID;
     }
 }

--- a/modules/genomic_browser/php/models/snpdto.class.inc
+++ b/modules/genomic_browser/php/models/snpdto.class.inc
@@ -30,6 +30,20 @@ namespace LORIS\genomic_browser\Models;
 class SnpDTO implements \LORIS\Data\DataInstance
 {
     /**
+     * The centerID
+     *
+     * @var string
+     */
+    private $_centerID = "";
+
+    /**
+     * The projectID
+     *
+     * @var string
+     */
+    private $_projectID = "";
+
+    /**
      * The PSC
      *
      * @var string
@@ -278,5 +292,25 @@ class SnpDTO implements \LORIS\Data\DataInstance
             'Genotype_Quality'    => $this->_Genotype_Quality,
             'Exonic_Function'     => $this->_Exonic_Function,
         ];
+    }
+
+    /**
+     * Returns the CenterID for this row
+     *
+     * @return integer The CenterID
+     */
+    public function getCenterID(): int
+    {
+        return (int) $this->_centerID;
+    }
+
+    /**
+     * Returns the ProjectID for this row
+     *
+     * @return integer The ProjectID
+     */
+    public function getProjectID(): int
+    {
+        return (int) $this->_projectID;
     }
 }

--- a/modules/genomic_browser/php/profiles.class.inc
+++ b/modules/genomic_browser/php/profiles.class.inc
@@ -3,6 +3,7 @@
 namespace LORIS\genomic_browser;
 
 use LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
+use LORIS\Data\Filters\UserProjectMatch;
 use LORIS\genomic_browser\Provisioners\ProfileProvisioner;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -53,11 +54,14 @@ class Profiles extends \NDB_Page implements ETagCalculator
      */
     private function _handleGET(ServerRequestInterface $request) : ResponseInterface
     {
-        $filter      = new HasAnyPermissionOrUserSiteMatch(
+        $sitesFilter = new HasAnyPermissionOrUserSiteMatch(
             ['genomic_browser_view_allsites']
         );
-        $provisioner = (new ProfileProvisioner())->filter($filter);
-        $user        = $request->getAttribute('user');
+        $provisioner = (new ProfileProvisioner())
+            ->filter($sitesFilter)
+            ->filter(new UserProjectMatch());
+
+        $user = $request->getAttribute('user');
 
         $data = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)
@@ -65,7 +69,6 @@ class Profiles extends \NDB_Page implements ETagCalculator
         $body = [
             'data'         => $data,
             'fieldOptions' => $this->_getFieldOptions($request),
-            'subprojects'  => \Utility::getSubprojectList(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -77,19 +80,13 @@ class Profiles extends \NDB_Page implements ETagCalculator
      *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(
-        ServerRequestInterface $request
-    ) : array {
+    private function _getFieldOptions(ServerRequestInterface $request) : array
+    {
         $user = $request->getAttribute('user');
-        // centerID
-        $list_of_sites = $user->hasPermission('genomic_browser_view_allsites')
-            ? \Utility::getSiteList()
-            : $user->getStudySites();
-        $list_of_sites = array_combine($list_of_sites, $list_of_sites);
 
         return (new \LORIS\genomic_browser\Views\Profiles(
-            $list_of_sites,
-            \Utility::getSubprojectList()
+            $this->getSiteOptions($user, false),
+            $this->getSubprojectOptions($user, false),
         ))->toArray();
     }
 
@@ -122,6 +119,17 @@ class Profiles extends \NDB_Page implements ETagCalculator
                 'genomic_browser_view_site'
             ]
         );
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function allSitePermissionNames() : ?array
+    {
+        return ['genomic_browser_view_allsites'];
     }
 
     /**

--- a/modules/genomic_browser/php/profiles.class.inc
+++ b/modules/genomic_browser/php/profiles.class.inc
@@ -22,7 +22,7 @@ use \LORIS\Middleware\ETagCalculator;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Profiles extends \NDB_Page implements ETagCalculator
+class Profiles extends \DataFrameworkMenu implements ETagCalculator
 {
 
     /**
@@ -68,7 +68,7 @@ class Profiles extends \NDB_Page implements ETagCalculator
             ->toArray($user);
         $body = [
             'data'         => $data,
-            'fieldOptions' => $this->_getFieldOptions($request),
+            'fieldOptions' => $this->getFieldOptions(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -76,13 +76,11 @@ class Profiles extends \NDB_Page implements ETagCalculator
     /**
      * Provide the select inputs options
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request.
-     *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(ServerRequestInterface $request) : array
+    function getFieldOptions() : array
     {
-        $user = $request->getAttribute('user');
+        $user = \NDB_Factory::singleton()->user();
 
         return (new \LORIS\genomic_browser\Views\Profiles(
             $this->getSiteOptions($user, false),
@@ -142,4 +140,24 @@ class Profiles extends \NDB_Page implements ETagCalculator
         return ['GET'];
     }
 
+    /**
+     * Gets the data source for this menu filter.
+     *
+     * @return \LORIS\Data\Provisioner
+     */
+    function getBaseDataProvisioner() : \LORIS\Data\Provisioner
+    {
+        return new ProfileProvisioner();
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always true
+     */
+    public function useProjectFilter(): bool
+    {
+        return true;
+    }
 }

--- a/modules/genomic_browser/php/provisioners/cnvprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/cnvprovisioner.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomic_Browser
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\provisioners;
 
@@ -22,23 +13,15 @@ namespace LORIS\genomic_browser\provisioners;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 class CnvProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
 {
-    private $_and = '';
-
     /**
      * Create a RowProvisioner
      */
     function __construct()
     {
-        $user = \User::singleton();
-        if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $site_arr   = implode(",", $user->getCenterIDs());
-            $this->_and = " AND candidate.RegistrationCenterID IN ("
-                . $site_arr . ")";
-        }
         parent::__construct(
             "
             SELECT
@@ -49,6 +32,8 @@ class CnvProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
                 cohort.SubprojectID AS _Subproject,
                 DATE_FORMAT(candidate.DoB, '%Y-%m-%d') AS _DoB,
                 candidate.ExternalID AS _ExternalID,
+                candidate.RegistrationCenterID as _centerID,
+                candidate.RegistrationProjectID as _projectID,
                 CNV.Chromosome AS _Chromosome,
                 CNV.Strand AS _Strand,
                 CNV.StartLoc AS _StartLoc,
@@ -85,7 +70,6 @@ class CnvProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             WHERE
                 candidate.Entity_type = 'Human'
                 AND candidate.Active = 'Y'
-                $this->_and
             ",
             [],
             '\LORIS\genomic_browser\Models\CnvDTO'

--- a/modules/genomic_browser/php/provisioners/filesprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/filesprovisioner.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomics
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\provisioners;
 
@@ -22,7 +13,7 @@ namespace LORIS\genomic_browser\provisioners;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 class FilesProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
 {

--- a/modules/genomic_browser/php/provisioners/gwasprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/gwasprovisioner.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomics
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\provisioners;
 
@@ -22,7 +13,7 @@ namespace LORIS\genomic_browser\provisioners;
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 class GwasProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
 {

--- a/modules/genomic_browser/php/provisioners/methylationprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/methylationprovisioner.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomics
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\provisioners;
 
@@ -17,27 +8,20 @@ namespace LORIS\genomic_browser\provisioners;
  *
  * PHP version 7
  *
- * @category Datadict
+ * @category Genomics
  * @package  Main
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 class MethylationProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
 {
-    private $_and = '';
-
     /**
      * Create a RowProvisioner
      */
     function __construct()
     {
-        $user = \User::singleton();
-        if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            $site_arr   = implode(",", $user->getCenterIDs());
-            $this->_and = " AND candidate.RegistrationCenterID IN ($site_arr)";
-        }
         parent::__construct(
             "
            SELECT
@@ -45,6 +29,8 @@ class MethylationProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisione
                 LPAD(candidate.CandID, 6, '0') AS _DCCID,
                 candidate.PSCID AS _PSCID,
                 candidate.Sex AS _Sex,
+                candidate.RegistrationCenterID as _centerID,
+                candidate.RegistrationProjectID as _projectID,
                 cohort.SubprojectID AS _Subproject,
                 DATE_FORMAT(candidate.DoB, '%Y-%m-%d') AS _DoB,
                 gscr.sample_label AS _Sample,
@@ -95,7 +81,6 @@ class MethylationProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisione
                 cpg.beta_value IS NOT NULL
                 AND candidate.Entity_type = 'Human'
                 AND candidate.Active = 'Y'
-                $this->_and
             ",
             [],
             '\LORIS\genomic_browser\Models\MethylationDTO'

--- a/modules/genomic_browser/php/provisioners/profileprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/profileprovisioner.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomics
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\provisioners;
 
@@ -17,38 +8,32 @@ namespace LORIS\genomic_browser\provisioners;
  *
  * PHP version 7
  *
- * @category Datadict
+ * @category Genomics
  * @package  Main
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 class ProfileProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
 {
-    private $_and = '';
-
     /**
      * Create a RowProvisioner
      */
     function __construct()
     {
-        $user = \User::singleton();
-        if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            // allow only to view own site data
-            $site_arr   = implode(",", $user->getCenterIDs());
-            $this->_and = " AND candidate.RegistrationCenterID IN ($site_arr)";
-        }
         parent::__construct(
             "
             SELECT
-                psc.Name AS _centerID,
+                psc.Name AS _PSC,
                 LPAD(candidate.CandID, 6, '0') AS _DCCID,
                 candidate.PSCID AS _PSCID,
                 candidate.Sex AS _Sex,
                 subproj.title AS _Subproject,
                 DATE_FORMAT(candidate.DoB, '%Y-%m-%d') AS _DoB,
                 candidate.ExternalID AS _externalID,
+                candidate.RegistrationCenterID as _centerID,
+                candidate.RegistrationProjectID as _projectID,
                 CASE WHEN EXISTS (
                     SELECT
                         genomicfileid
@@ -107,7 +92,6 @@ class ProfileProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             WHERE
                 candidate.Entity_type = 'Human'
                 AND candidate.Active = 'Y'
-                $this->_and
             ",
             [],
             '\LORIS\genomic_browser\Models\ProfileDTO'

--- a/modules/genomic_browser/php/provisioners/snpprovisioner.class.inc
+++ b/modules/genomic_browser/php/provisioners/snpprovisioner.class.inc
@@ -1,14 +1,5 @@
-<?php declare(strict_types=1);
-/**
- * PHP version 7
- *
- * @category Genomics
- * @package  Main
- * @author   Xavier Lecours <xavier.lecours@mcin.ca>
- *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
- * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
- */
+<?php
+declare(strict_types=1);
 
 namespace LORIS\genomic_browser\provisioners;
 
@@ -17,29 +8,20 @@ namespace LORIS\genomic_browser\provisioners;
  *
  * PHP version 7
  *
- * @category Datadict
+ * @category Genomics
  * @package  Main
  * @author   Xavier Lecours <xavier.lecours@mcin.ca>
  *           Alizée Wickenheiser <alizee.wickenheiser@mcin.ca>
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
- * @link     https://github.com/aces/Loris-Trunk
+ * @link     https://github.com/aces/Loris
  */
 class SnpProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
 {
-    private $_and = '';
-
     /**
      * Create a RowProvisioner
      */
     function __construct()
     {
-        $user = \User::singleton();
-        if (!$user->hasPermission('genomic_browser_view_allsites')) {
-            // restrict data to own site
-            $site_arr   = implode(",", $user->getCenterIDs());
-            $this->_and = " AND candidate.RegistrationCenterID IN ("
-                . $site_arr . ")";
-        }
         parent::__construct(
             "
             SELECT
@@ -50,6 +32,8 @@ class SnpProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
                 subproj.title AS _Subproject,
                 DATE_FORMAT(candidate.DoB, '%Y-%m-%d') AS _DoB,
                 candidate.ExternalID AS _externalID,
+                candidate.RegistrationCenterID as _centerID,
+                candidate.RegistrationProjectID as _projectID,
                 SNP.Chromosome AS _Chromosome,
                 SNP.Strand AS _Strand,
                 SNP.StartLoc AS _StartLoc,
@@ -95,8 +79,6 @@ class SnpProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
             WHERE
                 candidate.Entity_type = 'Human'
                 AND candidate.Active = 'Y'
-                $this->_and
-            LIMIT 10000
             ",
             [],
             '\LORIS\genomic_browser\Models\SnpDTO'

--- a/modules/genomic_browser/php/snpbrowser.class.inc
+++ b/modules/genomic_browser/php/snpbrowser.class.inc
@@ -22,7 +22,7 @@ use \LORIS\Middleware\ETagCalculator;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class SnpBrowser extends \NDB_Page implements ETagCalculator
+class SnpBrowser extends \DataFrameworkMenu implements ETagCalculator
 {
     /**
      * This function will return a json response.
@@ -67,7 +67,7 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
             ->toArray($user);
         $body = [
             'data'         => $data,
-            'fieldOptions' => $this->_getFieldOptions(),
+            'fieldOptions' => $this->getFieldOptions(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -75,13 +75,11 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
     /**
      * Provide the select inputs options
      *
-     * @param ServerRequestInterface $request The incoming PSR7 request.
-     *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(ServerRequestInterface $request) : array
+    function getFieldOptions() : array
     {
-        $user = $request->getAttribute('user');
+        $user = \NDB_Factory::singleton()->user();
         $DB   = \Database::singleton();
         $platform_results
             = $DB->pselect(
@@ -152,4 +150,24 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
         return ['GET'];
     }
 
+    /**
+     * Gets the data source for this menu filter.
+     *
+     * @return \LORIS\Data\Provisioner
+     */
+    function getBaseDataProvisioner() : \LORIS\Data\Provisioner
+    {
+        return new SnpProvisioner();
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support
+     * the UserProjectMatch filter.
+     *
+     * @return bool always true
+     */
+    public function useProjectFilter(): bool
+    {
+        return true;
+    }
 }

--- a/modules/genomic_browser/php/snpbrowser.class.inc
+++ b/modules/genomic_browser/php/snpbrowser.class.inc
@@ -3,6 +3,7 @@
 namespace LORIS\genomic_browser;
 
 use LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
+use LORIS\Data\Filters\UserProjectMatch;
 use LORIS\genomic_browser\Provisioners\SnpProvisioner;
 use \Psr\Http\Message\ServerRequestInterface;
 use \Psr\Http\Message\ResponseInterface;
@@ -52,19 +53,21 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
      */
     private function _handleGET(ServerRequestInterface $request) : ResponseInterface
     {
-        $filter      = new HasAnyPermissionOrUserSiteMatch(
+        $sitesFilter = new HasAnyPermissionOrUserSiteMatch(
             ['genomic_browser_view_allsites']
         );
-        $provisioner = (new SnpProvisioner())->filter($filter);
-        $user        = $request->getAttribute('user');
+        $provisioner = (new SnpProvisioner())
+            ->filter($sitesFilter)
+            ->filter(new UserProjectMatch());
+
+        $user = $request->getAttribute('user');
 
         $data = (new \LORIS\Data\Table())
             ->withDataFrom($provisioner)
             ->toArray($user);
         $body = [
             'data'         => $data,
-            'fieldOptions' => $this->_getFieldOptions($request),
-            'subprojects'  => \Utility::getSubprojectList(),
+            'fieldOptions' => $this->_getFieldOptions(),
         ];
         return new \LORIS\Http\Response\JsonResponse($body);
     }
@@ -76,18 +79,10 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
      *
      * @return array Dynamic field options
      */
-    private function _getFieldOptions(
-        ServerRequestInterface $request
-    ) : array {
+    private function _getFieldOptions(ServerRequestInterface $request) : array
+    {
         $user = $request->getAttribute('user');
-
-        // centerID
-        $list_of_sites = $user->hasPermission('genomic_browser_view_allsites')
-            ? \Utility::getSiteList()
-            : $user->getStudySites();
-        $list_of_sites = array_combine($list_of_sites, $list_of_sites);
-
-        $DB = \Database::singleton();
+        $DB   = \Database::singleton();
         $platform_results
             = $DB->pselect(
                 "SELECT distinct Name FROM genotyping_platform ",
@@ -99,9 +94,9 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
             $platform_options[$name] = $name;
         }
         return (new \LORIS\genomic_browser\Views\SNP(
-            $list_of_sites,
-            \Utility::getSubprojectList(),
-            $platform_options
+            $this->getSiteOptions($user, false),
+            $this->getSubprojectOptions($user, false),
+            $platform_options,
         ))->toArray();
     }
 
@@ -134,6 +129,17 @@ class SnpBrowser extends \NDB_Page implements ETagCalculator
                 'genomic_browser_view_site'
             ]
         );
+    }
+
+    /**
+     * Tells the base class that this page's provisioner can support the
+     * HasAnyPermissionOrUserSiteMatch filter.
+     *
+     * @return ?array of site permissions or null
+     */
+    public function allSitePermissionNames() : ?array
+    {
+        return ['genomic_browser_view_allsites'];
     }
 
     /**

--- a/modules/genomic_browser/php/views/cnv.class.inc
+++ b/modules/genomic_browser/php/views/cnv.class.inc
@@ -34,15 +34,15 @@ class CNV
      * Constructor
      *
      * @param array $platform_options The platform_options for form element
-     * @param array $subprojects      The subprojects for form element
      * @param array $sites            The sites for form element
+     * @param array $subprojects      The subprojects for form element
      */
-    public function __construct($platform_options, $subprojects, $sites)
+    public function __construct($platform_options, $sites, $subprojects)
     {
         $this->_formElement = [
-            'Sites'        => $sites,
-            'SubprojectID' => $subprojects,
-            'Platform'     => $platform_options,
+            'Sites'       => $sites,
+            'Subprojects' => $subprojects,
+            'Platform'    => $platform_options,
         ];
     }
 

--- a/modules/genomic_browser/php/views/methylation.class.inc
+++ b/modules/genomic_browser/php/views/methylation.class.inc
@@ -33,14 +33,14 @@ class Methylation
     /**
      * Constructor
      *
-     * @param array $list_of_sites The list_of_sites for form element
-     * @param array $subprojects   The subprojects for form element
+     * @param array $sites       The list_of_sites for form element
+     * @param array $subprojects The subprojects for form element
      */
-    public function __construct($list_of_sites, $subprojects)
+    public function __construct($sites, $subprojects)
     {
         $this->_formElement = [
-            'Sites'           => $list_of_sites,
-            'SubprojectID'    => $subprojects,
+            'Sites'           => $sites,
+            'Subprojects'     => $subprojects,
             'Context'         => $this->_getDistinctValues(
                 'genomic_cpg_annotation',
                 'island_relation'

--- a/modules/genomic_browser/php/views/profiles.class.inc
+++ b/modules/genomic_browser/php/views/profiles.class.inc
@@ -33,14 +33,14 @@ class Profiles
     /**
      * Constructor
      *
-     * @param array $list_of_sites The list_of_sites for form element
-     * @param array $subprojects   The subprojects for form element
+     * @param array $sites       The sites for form element
+     * @param array $subprojects The subprojects for form element
      */
-    public function __construct($list_of_sites, $subprojects)
+    public function __construct($sites, $subprojects)
     {
         $this->_formElement = [
-            'Sites'        => $list_of_sites,
-            'SubprojectID' => $subprojects,
+            'Sites'       => $sites,
+            'Subprojects' => $subprojects,
         ];
     }
 

--- a/modules/genomic_browser/php/views/snp.class.inc
+++ b/modules/genomic_browser/php/views/snp.class.inc
@@ -33,16 +33,16 @@ class SNP
     /**
      * Constructor
      *
-     * @param array $list_of_sites    The list_of_sites for form element
+     * @param array $sites            The list_of_sites for form element
      * @param array $subprojects      The subprojects for form element
      * @param array $platform_options The platform_options for form element
      */
-    public function __construct($list_of_sites, $subprojects, $platform_options)
+    public function __construct($sites, $subprojects, $platform_options)
     {
         $this->_formElement = [
-            'Sites'        => $list_of_sites,
-            'SubprojectID' => $subprojects,
-            'Platform'     => $platform_options,
+            'Sites'       => $sites,
+            'Subprojects' => $subprojects,
+            'Platform'    => $platform_options,
         ];
     }
 


### PR DESCRIPTION
Fixes following the reactification of the module:
- subproject filter not functional
- required getCenterID() for HasAnyPermissionOrUserSiteMatch missing
- user can see entries from projects he does not have permission for 
- move the logic of site, project and subproject options in methods in NDB_Page (see #6836)

Resolves partially #6829