### PR TITLE
[Tools] delete_candidate fix

### DIFF
--- a/tools/delete_candidate.php
+++ b/tools/delete_candidate.php
@@ -25,6 +25,7 @@ set_include_path(
 );
 require_once __DIR__ . "/../vendor/autoload.php";
 require_once "generic_includes.php";
+use \LORIS\StudyEntities\Candidate\CandID;
 
 /**
  * This script deletes the specified candidate information.
@@ -162,9 +163,10 @@ USAGE;
 function deleteCandidate($CandID, $PSCID, $confirm, $printToSQL, $DB, &$output)
 {
 
-    //Find candidate...
+    // Find candidate...
     $candidate = new Candidate();
-    $candidate->select($CandID); //find the candidate with the given CandID
+    // find the candidate with the given CandID
+    $candidate->select(new CandID($CandID));
 
     // Passing argument to delete session script
     $outputType ="";


### PR DESCRIPTION
Fixes a fatal error in tools/delete_candidate.

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Candidate::select() must be an instance of LORIS\StudyEntities\Candidate\CandID, string given, called in /var/www/Loris/tools/delete_candidate.php on line 167 and defined in /var/www/Loris/php/libraries/Candidate.class.inc:67
```