### PR TITLE
[Publication] Display all filterable columns in list

### DIFF
--- a/modules/publication/jsx/publicationIndex.js
+++ b/modules/publication/jsx/publicationIndex.js
@@ -14,10 +14,7 @@ class PublicationIndex extends React.Component {
     super();
     loris.hiddenHeaders = [
       'Description',
-      'Keywords',
-      'Variables Of Interest',
       'Publication ID',
-      'Collaborators',
     ];
     this.state = {
       isLoaded: false,


### PR DESCRIPTION
The publication module allows filtering hidden columns, which is confusing.
This PR makes all the filterable columns visible.

* Resolves #7209
