### PR TITLE
Fix undeclared property in htdocs/survey.php

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -45,6 +45,8 @@ class DirectDataEntryMainPage
      */
     var $Subtest;
 
+    public $CommentID;
+
     var $NumPages;
     var $NextPageNum;
     var $PrevPageNum;


### PR DESCRIPTION
#### Testing instructions (if applicable)

1. Enable the setting in phan to detect undeclared properties and ensure it doesn't flag errors in this file.
