### PR TITLE
Fix PhanUndeclaredProperty Errors for API

### DIFF
--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -38,6 +38,7 @@ class LoginTest extends TestCase
 
     /**
      * A SinglePointLogin instances used for authentication
+     *
      * @var \SinglePointLogin
      */
     private $_authenticator;

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -29,6 +29,20 @@ use \Laminas\Diactoros\ServerRequest;
 class LoginTest extends TestCase
 {
     /**
+     * A PSR Request object representing the incoming request
+     * to test.
+     *
+     * @var \Psr\Http\Message\ServerRequestInterface
+     */
+    private $_request;
+
+    /**
+     * A SinglePointLogin instances used for authentication
+     * @var \SinglePointLogin
+     */
+    private $_authenticator;
+
+    /**
      * Provide an autoloader for the api module namespace.
      *
      * @return void


### PR DESCRIPTION
Fixes the PhanUndeclaredProperty errors in the API
module.

This probably should have been done in #7265, but this
fixes the rest of the module.