### PR TITLE
[Publication] File delete not working (#6195 regression)

### DIFF
--- a/modules/publication/jsx/projectFields.js
+++ b/modules/publication/jsx/projectFields.js
@@ -140,7 +140,7 @@ class ProjectFormFields extends React.Component {
       showCancelButton: true,
       confirmButtonText: 'Yes, I am sure!',
       cancelButtonText: 'No, cancel it!',
-    }, function(willDelete) {
+    }).then(function(willDelete) {
         if (willDelete) {
           let url = loris.BaseURL
                     + '/publication/ajax/FileDelete.php?uploadID='


### PR DESCRIPTION
To complement #7091, an additional error introduced by #6195 is fixed by this PR, when a file previously uploaded is deleted.

## To test
- Create a publication with a file and the necessary permission to edit (LORIS Users with Edit Permission).
- Edit and delete the file.
- The file should be deleted without error