### PR TITLE
Removed typo preventing end-point to reply

### DIFF
--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -929,7 +929,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource
              FROM participant_status ps
                 JOIN participant_status_options pso ON (ps.participant_status=pso.ID)
              WHERE CandID=:candid",
-            ['candid' => $this->getCandID()],
+            ['candid' => $this->getCandID()]
         );
         return $res['Description'] ?? '';
     }


### PR DESCRIPTION
The end-point "v0.0.3/candidates/{candID}/{visitLabel}/images" was not working due to this typo.

## Brief summary of changes
Typo preventing end-point to reply
- [ ] Have you updated related documentation?

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
