### PR TITLE
[Core] Datastream iterator fix

### DIFF
--- a/jslib/fetchDataStream.js
+++ b/jslib/fetchDataStream.js
@@ -35,7 +35,6 @@ async function processLines(data, rowcb, endstreamcb) {
                 row = [];
                 continue;
             case 0x04: // end of stream
-                rowcb(row);
                 endstreamcb(row);
                 return {remainder: [], eos: true};
         }

--- a/src/Http/DataIteratorBinaryStream.php
+++ b/src/Http/DataIteratorBinaryStream.php
@@ -183,15 +183,17 @@ class DataIteratorBinaryStream implements StreamInterface
         if ($this->eof) {
             return "";
         }
-        $this->rowgen->next();
-        $row = $this->rowgen->current();
         if (!$this->rowgen->valid()) {
             $this->eof = true;
             return chr(0x04);
         }
+        $row = $this->rowgen->current();
+        $this->rowgen->next();
+
         $rowArray        = array_values(json_decode(json_encode($row), true));
         $rowVal          = join(chr(0x1e), $rowArray) . chr(0x1f);
         $this->position += strlen($rowVal);
+
         return $rowVal;
     }
 


### PR DESCRIPTION
Fix problems found on the datastream iterator
* the first element of the stream is always skipped
* an empty element is added at the end

To see this issue, go to /datadict/
* on the last page, notice the empty element
* compare the number of results with https://localhost/datadict/?format=json

### Origins of the problem
* The iterator call next before current, causing the first element to be skipped
* the row callback is called when the last line is detected, causing the last empty line issue.
