### PR TITLE
Fix all references to undeclared properties identified by Phan

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -14,7 +14,6 @@ jobs:
             - unit
             - integration
             php:
-            - 7.3
             - 7.4
 
     steps:

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -15,7 +15,7 @@ return [
     "minimum_severity" => 1,
     // FIXME: allow_missing_properties should be false, but there's
     // too many other things to fix first.
-    "allow_missing_properties" => true,
+    "allow_missing_properties" => false,
     "null_casts_as_any_type" => false,
     "scalar_implicit_cast" => false,
     // The line below is required to prevent PhanUndeclaredVariable problems in

--- a/modules/candidate_profile/php/candidatewidget.class.inc
+++ b/modules/candidate_profile/php/candidatewidget.class.inc
@@ -15,6 +15,15 @@ namespace LORIS\candidate_profile;
  */
 class CandidateWidget implements \LORIS\GUI\Widget
 {
+    private string $_title;
+    private string $_url;
+    private string $_componentname;
+    private array $_props;
+
+    private ?int $_width;
+    private ?int $_height;
+    private ?int $_order;
+
     /**
      * Construct a dashboard widget with the specified properties.
      *
@@ -36,13 +45,13 @@ class CandidateWidget implements \LORIS\GUI\Widget
         ?int $height = null,
         ?int $order = null
     ) {
-        $this->title         = $title;
-        $this->url           = $jsurl;
-        $this->width         = $width;
-        $this->height        = $height;
-        $this->componentname = $componentname;
-        $this->props         = $props;
-        $this->order         = $order;
+        $this->_title         = $title;
+        $this->_url           = $jsurl;
+        $this->_width         = $width;
+        $this->_height        = $height;
+        $this->_componentname = $componentname;
+        $this->_props         = $props;
+        $this->_order         = $order;
     }
 
     /**
@@ -53,7 +62,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function __toString()
     {
-        return $this->url;
+        return $this->_url;
     }
 
     /**
@@ -63,7 +72,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getTitle() : string
     {
-        return $this->title;
+        return $this->_title;
     }
 
     /**
@@ -73,7 +82,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getWidth() : ?int
     {
-        return $this->width;
+        return $this->_width;
     }
 
     /**
@@ -83,7 +92,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getHeight() : ?int
     {
-        return $this->height;
+        return $this->_height;
     }
 
     /**
@@ -93,7 +102,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getOrder() : ?int
     {
-        return $this->order;
+        return $this->_order;
     }
 
     /**
@@ -104,7 +113,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getJSURL() : string
     {
-        return $this->url;
+        return $this->_url;
     }
 
     /**
@@ -115,7 +124,7 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getComponentName() : string
     {
-        return $this->componentname;
+        return $this->_componentname;
     }
 
     /**
@@ -126,6 +135,6 @@ class CandidateWidget implements \LORIS\GUI\Widget
      */
     public function getComponentProps() : array
     {
-        return $this->props;
+        return $this->_props;
     }
 }

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -91,9 +91,9 @@ class Configuration extends \NDB_Form
      */
     function _getParentConfigLabels()
     {
-        $this->DB = \Database::singleton();
+        $DB = \Database::singleton();
 
-        $parentConfigItems = $this->DB->pselect(
+        $parentConfigItems = $DB->pselect(
             "SELECT Label, Name 
              FROM ConfigSettings 
              WHERE Parent IS NULL AND Visible=1 ORDER BY OrderNumber",
@@ -113,10 +113,11 @@ class Configuration extends \NDB_Form
      */
     function _getConfigSettingTree()
     {
-        $config =& \NDB_Config::singleton();
+        $config = \NDB_Config::singleton();
+        $DB     = \Database::singleton();
 
         // Get the names and meta-information for the config settings in the database
-        $configs = $this->DB->pselect(
+        $configs = $DB->pselect(
             "SELECT * FROM ConfigSettings WHERE Visible=1 ORDER BY OrderNumber",
             []
         );
@@ -144,7 +145,7 @@ class Configuration extends \NDB_Form
         // overridden in the config.xml
         foreach ($configs as &$setting) {
             if ($setting['Disabled'] == 'No') {
-                $value = $this->DB->pselect(
+                $value = $DB->pselect(
                     "SELECT ID, Value FROM Config WHERE ConfigID=:ID",
                     ['ID' => $setting['ID']]
                 );

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -26,6 +26,8 @@ namespace LORIS\dashboard;
 
 class Dashboard extends \NDB_Form
 {
+    private iterable $_smallwidgets;
+    private iterable $_mainwidgets;
 
     /**
      * Extra CSS URLs that are required for widgets.
@@ -69,11 +71,11 @@ class Dashboard extends \NDB_Form
 
         // FIXME: This should use \LORIS\LorisInstance->getActiveModules(), but there
         // is no access to a LORISInstance object at this point in the code.
-        $this->modules = \Module::getActiveModules($DB);
+        $modules = \Module::getActiveModules($DB);
 
-        $this->smallwidgets = [];
-        $this->mainwidgets  = [];
-        foreach ($this->modules as $module) {
+        $this->_smallwidgets = [];
+        $this->_mainwidgets  = [];
+        foreach ($modules as $module) {
             if ($module->hasAccess($user)) {
                 $widgets = $module->getWidgets('dashboard', $user, []);
                 foreach ($widgets as $widget) {
@@ -82,10 +84,10 @@ class Dashboard extends \NDB_Form
                     }
                     switch ($widget->getSize()) {
                     case "small":
-                        $this->smallwidgets[] = $widget;
+                        $this->_smallwidgets[] = $widget;
                         break;
                     default:
-                        $this->mainwidgets[] = $widget;
+                        $this->_mainwidgets[] = $widget;
                         break;
                     }
                     $this->widgetcss = array_merge(
@@ -102,13 +104,13 @@ class Dashboard extends \NDB_Form
             }
         }
         usort(
-            $this->smallwidgets,
+            $this->_smallwidgets,
             function ($a, $b) {
                 return $a->getOrder() <=> $b->getOrder();
             }
         );
         usort(
-            $this->mainwidgets,
+            $this->_mainwidgets,
             function ($a, $b) {
                 return $a->getOrder() <=> $b->getOrder();
             }
@@ -123,8 +125,8 @@ class Dashboard extends \NDB_Form
     function setup()
     {
 
-        $this->tpl_data['smallwidgets'] = $this->smallwidgets;
-        $this->tpl_data['mainwidgets']  = $this->mainwidgets;
+        $this->tpl_data['smallwidgets'] = $this->_smallwidgets;
+        $this->tpl_data['mainwidgets']  = $this->_mainwidgets;
     }
 
     /**

--- a/modules/dashboard/php/widget.class.inc
+++ b/modules/dashboard/php/widget.class.inc
@@ -30,6 +30,10 @@ namespace LORIS\dashboard;
  */
 class Widget implements \LORIS\GUI\Widget
 {
+    private WidgetContent $_content;
+    private WidgetDisplayProps $_displayprops;
+    private ?WidgetDependencies $_dependencies;
+
     /**
      * Construct a dashboard widget with the specified properties.
      *
@@ -45,9 +49,9 @@ class Widget implements \LORIS\GUI\Widget
         WidgetDisplayProps $props,
         ?WidgetDependencies $deps=null
     ) {
-        $this->content      = $content;
-        $this->displayprops = $props;
-        $this->dependencies = $deps;
+        $this->_content      = $content;
+        $this->_displayprops = $props;
+        $this->_dependencies = $deps;
     }
 
     /**
@@ -57,7 +61,7 @@ class Widget implements \LORIS\GUI\Widget
      */
     public function getSize() : string
     {
-        return $this->displayprops->getSize();
+        return $this->_displayprops->getSize();
     }
 
     /**
@@ -70,7 +74,7 @@ class Widget implements \LORIS\GUI\Widget
      */
     public function getOrder() : int
     {
-        return $this->displayprops->getOrder();
+        return $this->_displayprops->getOrder();
 
     }
 
@@ -81,8 +85,8 @@ class Widget implements \LORIS\GUI\Widget
      */
     public function getCSSDependencies() : array
     {
-        if ($this->dependencies !== null) {
-            return $this->dependencies->getCSSDependencies();
+        if ($this->_dependencies !== null) {
+            return $this->_dependencies->getCSSDependencies();
         }
         return [];
     }
@@ -94,8 +98,8 @@ class Widget implements \LORIS\GUI\Widget
      */
     public function getJSDependencies() : array
     {
-        if ($this->dependencies !== null) {
-            return $this->dependencies->getJSDependencies();
+        if ($this->_dependencies !== null) {
+            return $this->_dependencies->getJSDependencies();
         }
         return [];
     }
@@ -111,10 +115,10 @@ class Widget implements \LORIS\GUI\Widget
         $renderer = new \Smarty_NeuroDB("dashboard");
         $renderer->assign(
             [
-                'title'  => $this->content->getTitle(),
-                'body'   => $this->content->getBody(),
-                'footer' => $this->content->getFooter(),
-                'menus'  => $this->displayprops->getMenus(),
+                'title'  => $this->_content->getTitle(),
+                'body'   => $this->_content->getBody(),
+                'footer' => $this->_content->getFooter(),
+                'menus'  => $this->_displayprops->getMenus(),
             ]
         );
         return $renderer->fetch("panel.tpl");

--- a/modules/dashboard/php/widgetcontent.class.inc
+++ b/modules/dashboard/php/widgetcontent.class.inc
@@ -24,6 +24,10 @@ namespace LORIS\dashboard;
  */
 class WidgetContent
 {
+    private string $_title;
+    private string $_body;
+    private string $_footer;
+
     /**
      * Construct a WidgetContent with the specified properties.
      *
@@ -36,9 +40,9 @@ class WidgetContent
         string $body,
         string $footer=""
     ) {
-        $this->title  = $title;
-        $this->body   = $body;
-        $this->footer = $footer;
+        $this->_title  = $title;
+        $this->_body   = $body;
+        $this->_footer = $footer;
     }
     /**
      * Return the content for the title of the widget.
@@ -47,7 +51,7 @@ class WidgetContent
      */
     public function getTitle() : string
     {
-        return $this->title;
+        return $this->_title;
     }
 
     /**
@@ -57,7 +61,7 @@ class WidgetContent
      */
     public function getBody() : string
     {
-        return $this->body;
+        return $this->_body;
     }
     /**
      * Return the content for the title of the widget.
@@ -66,6 +70,6 @@ class WidgetContent
      */
     public function getFooter() : string
     {
-        return $this->footer;
+        return $this->_footer;
     }
 }

--- a/modules/dashboard/php/widgetdependencies.class.inc
+++ b/modules/dashboard/php/widgetdependencies.class.inc
@@ -26,19 +26,35 @@ namespace LORIS\dashboard;
 class WidgetDependencies
 {
     /**
+     * List of URLs for JS resources that must be loaded for
+     * this widget.
+     *
+     * @var string[]
+     */
+    private iterable $_js;
+
+    /**
+     * List of URLs for CSS resources that must be loaded for
+     * this widget.
+     *
+     * @var string[]
+     */
+    private iterable $_css;
+
+    /**
      * Construct a WidgetDependencies object with the specified properties.
      *
-     * @param array $css An array of CSS requirements that must be loaded for
-     *                   the widget
-     * @param array $js  An array of JS requirements that must be loaded for
-     *                   the widget
+     * @param string[] $css An array of CSS requirements that must be loaded for
+     *                      the widget
+     * @param string[] $js  An array of JS requirements that must be loaded for
+     *                      the widget
      */
     public function __construct(
         array $css,
         array $js
     ) {
-        $this->css = $css;
-        $this->js  = $js;
+        $this->_css = $css;
+        $this->_js  = $js;
     }
 
     /**
@@ -49,7 +65,7 @@ class WidgetDependencies
      */
     public function getJSDependencies() : array
     {
-        return $this->js;
+        return $this->_js;
     }
 
     /**
@@ -60,6 +76,6 @@ class WidgetDependencies
      */
     public function getCSSDependencies() : array
     {
-        return $this->css;
+        return $this->_css;
     }
 }

--- a/modules/dashboard/php/widgetdisplayprops.class.inc
+++ b/modules/dashboard/php/widgetdisplayprops.class.inc
@@ -24,6 +24,10 @@ namespace LORIS\dashboard;
  */
 class WidgetDisplayProps
 {
+    private string $_size;
+    private int $_order;
+    private array $_menus;
+
     /**
      * Construct a WidgetDisplay object with the specified properties.
      *
@@ -45,9 +49,9 @@ class WidgetDisplayProps
             throw new \DomainException("Invalid value for widget size");
         }
 
-        $this->size  = $size;
-        $this->order = $order;
-        $this->menus = $menus;
+        $this->_size  = $size;
+        $this->_order = $order;
+        $this->_menus = $menus;
     }
 
     /**
@@ -60,7 +64,7 @@ class WidgetDisplayProps
      */
     public function getSize() : string
     {
-        return $this->size;
+        return $this->_size;
     }
 
     /**
@@ -73,7 +77,7 @@ class WidgetDisplayProps
      */
     public function getOrder() : int
     {
-        return $this->order;
+        return $this->_order;
     }
 
     /**
@@ -88,6 +92,6 @@ class WidgetDisplayProps
      */
     public function getMenus() : array
     {
-        return $this->menus;
+        return $this->_menus;
     }
 }

--- a/modules/genomic_browser/php/models/cnvdto.class.inc
+++ b/modules/genomic_browser/php/models/cnvdto.class.inc
@@ -239,14 +239,4 @@ class CnvDTO implements \LORIS\Data\DataInstance
             'Platform'          => $this->_Platform,
         ];
     }
-    /**
-     * Returns the CenterID for this row, for filters such as
-     * \LORIS\Data\Filters\UserSiteMatch to match again.
-     *
-     * @return string
-     */
-    public function getPSC(): string
-    {
-        return (string) $this->psc;
-    }
 }

--- a/modules/genomic_browser/php/models/profiledto.class.inc
+++ b/modules/genomic_browser/php/models/profiledto.class.inc
@@ -127,14 +127,4 @@ class ProfileDTO implements \LORIS\Data\DataInstance
             'CPG'        => $this->_CPG,
         ];
     }
-    /**
-     * Returns the CenterID for this row, for filters such as
-     * \LORIS\Data\Filters\UserSiteMatch to match again.
-     *
-     * @return string
-     */
-    public function getPSC(): string
-    {
-        return (string) $this->psc;
-    }
 }

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -27,6 +27,8 @@ namespace LORIS\imaging_browser;
 
 class Imaging_Session_ControlPanel
 {
+    protected array $tpl_data;
+
     /**
      * Var to store the sessionID.
      */

--- a/modules/imaging_browser/php/mrinavigation.class.inc
+++ b/modules/imaging_browser/php/mrinavigation.class.inc
@@ -27,6 +27,11 @@ namespace LORIS\imaging_browser;
 
 class MRINavigation
 {
+    private array $_bits;
+    private int $_currentListIndex;
+    private array $_FilteredSessionList;
+
+    private int $_sessionID;
 
     public $urlParams = [];
 
@@ -39,18 +44,19 @@ class MRINavigation
      */
     function __construct($sessionID = null)
     {
-        $this->sessionID           = $sessionID;
-        $this->FilteredSessionList = $_SESSION['State']
+        $this->_sessionID           = $sessionID;
+        $this->_FilteredSessionList = $_SESSION['State']
             ->getProperty('mriSessionsListed');
 
-        if (!is_array($this->FilteredSessionList)) {
-            $this->FilteredSessionList = [];
+        if (!is_array($this->_FilteredSessionList)) {
+            $this->_FilteredSessionList = [];
         }
-        $this->currentListIndex = array_search(
-            $this->sessionID,
-            $this->FilteredSessionList
+        $this->_currentListIndex = array_search(
+            $this->_sessionID,
+            $this->_FilteredSessionList
         );
-        $this->urlParams        = $this->_splitURL();
+
+        $this->urlParams = $this->_splitURL();
     }
     /**
      * Parses the request into hostname/params, so that it can be
@@ -60,10 +66,10 @@ class MRINavigation
      */
     function _splitURL()
     {
-        $linkBase      = $_SERVER['REQUEST_URI'];
-        $this->bits[0] = substr($linkBase, 0, strpos($linkBase, '?'));
-        $this->bits[1] = substr($linkBase, strpos($linkBase, '?')+1);
-        parse_str($this->bits[1], $urlParams);
+        $linkBase       = $_SERVER['REQUEST_URI'];
+        $this->_bits[0] = substr($linkBase, 0, strpos($linkBase, '?'));
+        $this->_bits[1] = substr($linkBase, strpos($linkBase, '?')+1);
+        parse_str($this->_bits[1], $urlParams);
         return $urlParams;
     }
     /**
@@ -75,15 +81,15 @@ class MRINavigation
      */
     function _otherLink($delta)
     {
-        if (isset($this->FilteredSessionList[$this->currentListIndex+$delta])
+        if (isset($this->_FilteredSessionList[$this->_currentListIndex+$delta])
         ) {
             $urlParams = $this->urlParams;
             $urlParams['sessionID'] = $this
-                ->FilteredSessionList[$this->currentListIndex+$delta];
+                ->_FilteredSessionList[$this->_currentListIndex+$delta];
 
-            $this->bits[1] = http_build_query($urlParams);
+            $this->_bits[1] = http_build_query($urlParams);
 
-            return implode('?', $this->bits);
+            return implode('?', $this->_bits);
         }
     }
     /**

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -28,6 +28,14 @@ namespace LORIS\imaging_browser;
 
 class ViewSession extends \NDB_Form
 {
+    private \Database $_DB;
+
+    /**
+     * The URL to assign to the form on the page rendered by
+     * PageDecorationMiddleware
+     */
+    public string $FormAction;
+
     /**
      * Var to store the scanner information.
      * Will be used from the last file.
@@ -94,7 +102,7 @@ class ViewSession extends \NDB_Form
     function setup()
     {
         parent::setup();
-        $this->DB = \Database::singleton();
+        $this->_DB = \Database::singleton();
 
         $this->sessionID = $_REQUEST['sessionID'];
 
@@ -111,7 +119,7 @@ class ViewSession extends \NDB_Form
 
             $this->tpl_data['showFloatJIV'] = true;
 
-            $file = $this->DB->pselectOne(
+            $file = $this->_DB->pselectOne(
                 "SELECT File FROM files f
                 JOIN session s
                 ON (s.ID=f.SessionID)
@@ -174,7 +182,7 @@ class ViewSession extends \NDB_Form
                 $args["outputType"] = $outputType;
             }
         }
-        $files = $this->DB->pselect(
+        $files = $this->_DB->pselect(
             "SELECT files.FileID, files.ScannerID FROM files
              LEFT JOIN files_qcstatus as sel
              on (files.FileID=sel.FileID)
@@ -194,7 +202,7 @@ class ViewSession extends \NDB_Form
                 if (!empty($scannerID)) {
                     $query         = "SELECT CONCAT_WS(' ', Manufacturer, Model,".
                              " Serial_number) FROM mri_scanner WHERE ID=:ScanID";
-                    $this->scanner = $this->DB->pselectOne(
+                    $this->scanner = $this->_DB->pselectOne(
                         $query,
                         ['ScanID' => $scannerID]
                     );
@@ -371,7 +379,7 @@ class ViewSession extends \NDB_Form
             AND mvl.Header LIKE 'Manual Caveat Set by %';
         ";
 
-        return $this->DB->pselectOneInt($query, ['fileID' => $fileID]);
+        return $this->_DB->pselectOneInt($query, ['fileID' => $fileID]);
     }
 
     /**
@@ -451,7 +459,7 @@ class ViewSession extends \NDB_Form
 
                 // set first change time, if it's null only
                 $params          = ['FID' => $curFileID];
-                $firstChangeTime = $this->DB->pselectOne(
+                $firstChangeTime = $this->_DB->pselectOne(
                     "SELECT QCFirstChangeTime
                     FROM files_qcstatus
                     WHERE FileID=:FID",
@@ -461,7 +469,7 @@ class ViewSession extends \NDB_Form
                     $updateSet['QCFirstChangeTime'] = time();
                 }
 
-                $QCExists    = $this->DB->pselectOne(
+                $QCExists    = $this->_DB->pselectOne(
                     "SELECT 'x'
                     FROM files_qcstatus
                     WHERE FileID=:FID",
@@ -471,7 +479,7 @@ class ViewSession extends \NDB_Form
                 $updateWhere = [];
                 if (!empty($QCExists)) {
                     $updateWhere['FileID'] = $curFileID;
-                    $this->DB->update(
+                    $this->_DB->update(
                         'files_qcstatus',
                         $updateSet,
                         $updateWhere
@@ -483,7 +491,7 @@ class ViewSession extends \NDB_Form
                     );
                     $updateSet['EchoTime']  = $file->getParameter('echo_time');
                     $updateSet['FileID']    = $curFileID;
-                    $this->DB->insert("files_qcstatus", $updateSet);
+                    $this->_DB->insert("files_qcstatus", $updateSet);
                 }
             }
         }
@@ -499,7 +507,7 @@ class ViewSession extends \NDB_Form
                 if ($curCaveat === '') {
                     $curCaveat = null;
                 }
-                $this->DB->update(
+                $this->_DB->update(
                     "files",
                     ['Caveat' => $curCaveat],
                     ['FileID' => $curFileID]
@@ -544,14 +552,14 @@ class ViewSession extends \NDB_Form
                     // We leave MriProtocolChecksGroupID to its default value (null)
                     // since this violation is not tied to any protocol checks group
 
-                    $this->DB->insert("mri_violations_log", $insertSet);
+                    $this->_DB->insert("mri_violations_log", $insertSet);
                     unset($insertSet);
 
                     //--------------------------------------------------------//
                     // Have MySQL compute the md5 hash for the violation that //
                     // was just inserted                                      //
                     //--------------------------------------------------------//
-                    $mriViolationsLogID = $this->DB->getLastInsertID();
+                    $mriViolationsLogID = $this->_DB->getLastInsertID();
                     $query = "
                          SELECT md5(
                              concat_WS(':',MincFile,PatientName,SeriesUID,TimeRun)
@@ -559,7 +567,7 @@ class ViewSession extends \NDB_Form
                          FROM  mri_violations_log
                          WHERE LogID =:logID
                     ";
-                    $hash  = $this->DB->pselectOne(
+                    $hash  = $this->_DB->pselectOne(
                         $query,
                         ['logID' => $mriViolationsLogID]
                     );
@@ -569,7 +577,7 @@ class ViewSession extends \NDB_Form
                     // the last record inserted in mri_violations_log as   //
                     // being resolved, with Resolve set to 'inserted_flag' //
                     //-----------------------------------------------------//
-                    $this->DB->insert(
+                    $this->_DB->insert(
                         'violations_resolved',
                         [
                             'hash'       => $hash,
@@ -580,14 +588,14 @@ class ViewSession extends \NDB_Form
                             'Resolved'   => 'inserted_flag',
                         ]
                     );
-                    $this->DB->update(
+                    $this->_DB->update(
                         'files',
                         ['Caveat' => 1],
                         ['FileID' => $curFileID],
                     );
                 } elseif ($curCaveat === '0' && $caveatViolationsResolvedID) {
                     $quotedViolationsResolvedID
-                        = $this->DB->quote($caveatViolationsResolvedID);
+                        = $this->_DB->quote($caveatViolationsResolvedID);
                     $query = "
                         DELETE FROM mri_violations_log
                         WHERE LogID = (
@@ -597,14 +605,14 @@ class ViewSession extends \NDB_Form
                             AND TypeTable = 'mri_violations_log'
                         )
                     ";
-                    $this->DB->run($query);
+                    $this->_DB->run($query);
 
-                    $this->DB->delete(
+                    $this->_DB->delete(
                         'violations_resolved',
                         ['ID' => $caveatViolationsResolvedID]
                     );
 
-                    $quotedFileID = $this->DB->quote($curFileID);
+                    $quotedFileID = $this->_DB->quote($curFileID);
                     $query        = "
                         UPDATE files f
                         SET f.Caveat = IF(
@@ -623,7 +631,7 @@ class ViewSession extends \NDB_Form
                         )
                         WHERE f.FileID=$quotedFileID
                     ";
-                    $this->DB->run($query);
+                    $this->_DB->run($query);
                 }
             }
         }
@@ -642,17 +650,17 @@ class ViewSession extends \NDB_Form
                 $updateWhere = ['FileID' => $curFileID];
 
                 if ($curSelected == 'Unselected') {
-                    if ($this->DB->pselectOne(
+                    if ($this->_DB->pselectOne(
                         "SELECT COUNT(*)
                         FROM files_qcstatus
                         WHERE FileID=:FID ",
                         $params
                     ) > 0
                     ) {
-                        $this->DB->delete('files_qcstatus', $updateWhere);
+                        $this->_DB->delete('files_qcstatus', $updateWhere);
                     }
                 } else {
-                    if ($this->DB->pselectOne(
+                    if ($this->_DB->pselectOne(
                         "SELECT COUNT(*)
                         FROM files_qcstatus
                         WHERE FileID=:FID ",
@@ -664,7 +672,7 @@ class ViewSession extends \NDB_Form
                             'QCLastChangeTime' => time(),
                         ];
                         $updateSet = \Utility::nullifyEmpty($updateSet, 'Selected');
-                        $this->DB->update(
+                        $this->_DB->update(
                             'files_qcstatus',
                             $updateSet,
                             $updateWhere
@@ -676,7 +684,7 @@ class ViewSession extends \NDB_Form
                             'QCFirstChangeTime' => time(),
                         ];
                         $insertSet = \Utility::nullifyEmpty($insertSet, 'Selected');
-                        $this->DB->insert('files_qcstatus', $insertSet);
+                        $this->_DB->insert('files_qcstatus', $insertSet);
                     }
                 }
             }
@@ -691,19 +699,19 @@ class ViewSession extends \NDB_Form
     {
         if (!empty($_POST['visit_status'])) {
             $params           = ['SID' => $this->sessionID];
-            $old_visit_status = $this->DB->pselectOne(
+            $old_visit_status = $this->_DB->pselectOne(
                 "SELECT MRIQCStatus
                 FROM session
                 WHERE ID=:SID",
                 $params
             );
-            $old_pending_status = $this->DB->pselectOne(
+            $old_pending_status = $this->_DB->pselectOne(
                 "SELECT MRIQCPending
                 FROM session
                 WHERE ID=:SID",
                 $params
             );
-            $old_caveat_status  = $this->DB->pselectOne(
+            $old_caveat_status  = $this->_DB->pselectOne(
                 "SELECT MRICaveat
                 FROM session
                 WHERE ID=:SID",
@@ -716,7 +724,7 @@ class ViewSession extends \NDB_Form
                 'MRICaveat'           => $_POST['visit_caveat'],
                 'MRIQCLastChangeTime' => date("Y-m-d H:i:s"),
             ];
-            $firstChangeTime = $this->DB->pselectOne(
+            $firstChangeTime = $this->_DB->pselectOne(
                 "SELECT MRIQCFirstChangeTime
                 FROM session
                 WHERE ID=:SID",
@@ -727,7 +735,7 @@ class ViewSession extends \NDB_Form
                     = $updateSet['MRIQCLastChangeTime'];
             }
             $updateSet = \Utility::nullifyEmpty($updateSet, 'MRIQCStatus');
-            $this->DB->update(
+            $this->_DB->update(
                 'session',
                 $updateSet,
                 ['ID' => $this->sessionID]
@@ -779,7 +787,7 @@ class ViewSession extends \NDB_Form
     function _getFilesAcrossTimepoints($initialFileID, $initialFileAcquisitionID)
     {
 
-        $selectResults = $this->DB->pselect(
+        $selectResults = $this->_DB->pselect(
             "SELECT FileID FROM files ".
             "WHERE AcquisitionProtocolID =:initialFileAcquisitionID ".
             "AND SessionID in (SELECT s2.ID FROM session s1 RIGHT JOIN session s2 ".
@@ -808,7 +816,7 @@ class ViewSession extends \NDB_Form
     function _getSelected($FileID): ?string
     {
 
-        $selected = $this->DB->pselectOne(
+        $selected = $this->_DB->pselectOne(
             "SELECT Selected FROM files_qcstatus ".
             "WHERE FileID =:FileID",
             ['FileID' => $FileID]
@@ -858,7 +866,7 @@ class ViewSession extends \NDB_Form
         $subjectData['visitLabel']      = $timePoint->getVisitLabel();
         $subjectData['visitNo']         = $timePoint->getVisitNo();
         $subjectData['site']            = $timePoint->getPSC();
-        $qcstatus = $this->DB->pselectRow(
+        $qcstatus = $this->_DB->pselectRow(
             "SELECT MRIQCStatus, MRIQCPending, MRICaveat
             FROM session WHERE ID=:SID",
             ['SID' => $_REQUEST['sessionID']]
@@ -895,7 +903,7 @@ class ViewSession extends \NDB_Form
             $params['PCandID'] = $timePoint->getCandID();
             $params['PVL']     = $timePoint->getVisitLabel();
         }
-        $tarchiveIDs = $this->DB->pselect(
+        $tarchiveIDs = $this->_DB->pselect(
             "SELECT TarchiveID
             FROM tarchive
             WHERE PatientName LIKE $ID",

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -31,6 +31,8 @@ namespace LORIS\instrument_list;
  */
 class Instrument_List_ControlPanel extends \TimePoint
 {
+    protected array $tpl_data;
+
     /**
      * Construct function
      *

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -11,14 +11,14 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Instrument_Manager extends \NDB_Menu_Filter
 {
-    private \NDB_Factory $factory;
+    private \NDB_Factory $_factory;
 
     /**
      * The LORIS base path
      *
      * @var string
      */
-    private string $path;
+    private string $_path;
 
     const PERMISSIONS = [
         'instrument_manager_read',
@@ -58,8 +58,8 @@ class Instrument_Manager extends \NDB_Menu_Filter
     {
         $this->AjaxModule   = true;
         $this->skipTemplate = true;
-        $this->factory      = \NDB_Factory::singleton();
-        $this->path         = $this->factory->config()->getSetting("base");
+        $this->_factory     = \NDB_Factory::singleton();
+        $this->_path        = $this->_factory->config()->getSetting("base");
 
         parent::__construct($module, $page, $id, $commentID);
     }
@@ -121,7 +121,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         $uploaded_file = $request->getUploadedFiles()['install_file'];
         $filename      = $uploaded_file->getClientFilename();
         $instrument    = pathinfo($filename)['filename'];
-        $targetdir     = new \SplFileInfo($this->path . 'project/instruments/');
+        $targetdir     = new \SplFileInfo($this->_path . 'project/instruments/');
         $fullpath      = $targetdir->getPathname() . '/' . $filename;
 
         if ($this->instrumentExists($instrument)) {
@@ -158,7 +158,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
 
         // Scripts in tools/ often make relative imports, so we must change
         // our effective directory in order to use them.
-        chdir($this->path . "/tools");
+        chdir($this->_path . "/tools");
         // Use tools/ script to generate an SQL patch file based on the
         // structure of the uploaded .linst file.
         exec(
@@ -199,7 +199,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
             " -u" . escapeshellarg($db_config['adminUser']).
             " -p" . escapeshellarg($db_config['adminPassword']).
             " " . escapeshellarg($db_config['database']).
-            " < " . $this->path . "project/tables_sql/".
+            " < " . $this->_path . "project/tables_sql/".
             escapeshellarg($table_name . '.sql'),
             $output, // $output and $status are created automatically
             $status  // by `exec` and so need not be declared above.
@@ -305,12 +305,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function checkInstrumentType(string $instrument): string
     {
-        $linst = $this->path . "/project/instruments/$instrument.linst";
+        $linst = $this->_path . "/project/instruments/$instrument.linst";
         if (file_exists($linst)) {
             return 'Instrument Builder';
         }
 
-        $php = $this->path .
+        $php = $this->_path .
             "/project/instruments/NDB_BVL_Instrument_$instrument.class.inc";
 
         if (file_exists($php)) {
@@ -330,7 +330,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function checkPagesValid(string $instrument): string
     {
-        $filename = $this->path . "/project/instruments/$instrument.linst";
+        $filename = $this->_path . "/project/instruments/$instrument.linst";
         if (!file_exists($filename)) {
             return '?';
         } else {
@@ -347,7 +347,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function checkTableValid(string $instrument): string
     {
-        $filename = $this->path . "/project/instruments/$instrument.linst";
+        $filename = $this->_path . "/project/instruments/$instrument.linst";
         if (!file_exists($filename)) {
             return '?';
         } else {
@@ -366,7 +366,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     {
         // This should also check that all the columns exist and
         // have the right type, for new style instruments
-        $exists = $this->factory->database()->pselectOne(
+        $exists = $this->_factory->database()->pselectOne(
             '
            SELECT count(*)
            FROM information_schema.tables
@@ -374,7 +374,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
            TABLE_NAME=:tablename
           ',
             [
-                'dbname'    => $this->factory->settings()->dbName(),
+                'dbname'    => $this->_factory->settings()->dbName(),
                 'tablename' => $instrument,
             ]
         );
@@ -390,7 +390,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function instrumentExists(string $instrument): bool
     {
-        $count = $this->factory->database()->pselectOne(
+        $count = $this->_factory->database()->pselectOne(
             'SELECT count(*) FROM test_names WHERE Test_name=:v_instrument',
             [':v_instrument' => $instrument]
         );
@@ -408,7 +408,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function checkType($tablename, $columnname, $type)
     {
-        $db           = $this->factory->database();
+        $db           = $this->_factory->database();
         $sqlSelectOne = "SELECT count(*)".
                         " FROM information_schema.columns".
                         " WHERE TABLE_SCHEMA=:dbname".
@@ -418,7 +418,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         $exists       = $db->pselectOne(
             $sqlSelectOne,
             [
-                'dbname'     => $this->factory->settings()->dbName(),
+                'dbname'     => $this->_factory->settings()->dbName(),
                 'columnname' => $columnname,
                 'tablename'  => $tablename,
                 'typename'   => $type,
@@ -439,9 +439,9 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function checkTable($instname): string
     {
-        $filename = $this->path . "project/instruments/$instname.linst";
+        $filename = $this->_path . "project/instruments/$instname.linst";
         $fp       = fopen($filename, "r");
-        $db       = $this->factory->database();
+        $db       = $this->_factory->database();
 
         while (($line = fgets($fp, 4096)) !== false) {
             $pieces = explode("{@}", $line);
@@ -488,7 +488,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
                 $db_enum      = $db->pselectOne(
                     $sqlSelectOne,
                     [
-                        'dbname'     => $this->factory->settings()->dbName(),
+                        'dbname'     => $this->_factory->settings()->dbName(),
                         'columnname' => $name,
                         'tablename'  => $instname,
                     ]
@@ -523,9 +523,9 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function checkPages($instname): string
     {
-        $filename = $this->path . "project/instruments/$instname.linst";
+        $filename = $this->_path . "project/instruments/$instname.linst";
         $fp       = fopen($filename, "r");
-        $db       = $this->factory->database();
+        $db       = $this->_factory->database();
 
         while (($line = fgets($fp, 4096)) !== false) {
             $pieces       = explode("{@}", $line);
@@ -564,8 +564,8 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function isAdminUserConfigured() : bool
     {
-        $db        = $this->factory->database();
-        $db_config = $this->factory->config()->getSetting('database');
+        $db        = $this->_factory->database();
+        $db_config = $this->_factory->config()->getSetting('database');
 
         $credentials_set = !empty($db_config['adminUser'])
             && !empty($db_config['adminPassword']);
@@ -596,8 +596,8 @@ class Instrument_Manager extends \NDB_Menu_Filter
      */
     protected function canWriteFiles(): bool
     {
-        $instrument_dir = $this->path . 'project/instruments';
-        $table_dir      = $this->path . 'project/tables_sql';
+        $instrument_dir = $this->_path . 'project/instruments';
+        $table_dir      = $this->_path . 'project/tables_sql';
 
         return is_writable($instrument_dir) && is_writable($table_dir);
     }
@@ -612,7 +612,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
     public function getJSDependencies(): array
     {
         $depends = parent::getJSDependencies();
-        $baseURL = $this->factory->settings()->getBaseURL();
+        $baseURL = $this->_factory->settings()->getBaseURL();
         return array_merge(
             $depends,
             [

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -11,6 +11,15 @@ use \Psr\Http\Message\ResponseInterface;
  */
 class Instrument_Manager extends \NDB_Menu_Filter
 {
+    private \NDB_Factory $factory;
+
+    /**
+     * The LORIS base path
+     *
+     * @var string
+     */
+    private string $path;
+
     const PERMISSIONS = [
         'instrument_manager_read',
         'instrument_manager_write'

--- a/modules/issue_tracker/php/models/attachmentdto.class.inc
+++ b/modules/issue_tracker/php/models/attachmentdto.class.inc
@@ -27,6 +27,17 @@ namespace LORIS\issue_tracker\Models;
  */
 class AttachmentDTO implements \LORIS\Data\DataInstance
 {
+    public string $ID;
+    public string $issueID;
+    public string $file_hash;
+    public string $date_added;
+    public string $file_name;
+    public string $deleted;
+    public string $user;
+    public string $description;
+    public string $file_size;
+    public string $mime_type;
+
     /**
      * Implements \LORIS\Data\DataInstance interface for this row.
      *

--- a/modules/server_processes_manager/php/process.class.inc
+++ b/modules/server_processes_manager/php/process.class.inc
@@ -43,7 +43,7 @@ class Process
      *
      * @var string
      */
-    private $_outfile;
+    private $_outFile;
 
     /**
      * Full path ot the file containing the command std error.
@@ -89,7 +89,7 @@ class Process
 
         $this->_shellCommand = $shellCommand;
         $this->_pid          = null;
-        $this->_outfile      = $stdoutFile;
+        $this->_outFile      = $stdoutFile;
         $this->_errFile      = $stderrFile;
         $this->_exitCodeFile = $exitCodeFile;
     }
@@ -139,7 +139,7 @@ class Process
 
         // This is the main command intended to be run by this process.
         // Stdout and stderr are redirected to $_outfile and $_errfile respectively
-        $mainCmd = "$this->_shellCommand > $this->_outfile 2> $this->_errFile";
+        $mainCmd = "$this->_shellCommand > $this->_outFile 2> $this->_errFile";
 
         // This is the command that is used to fetch the exit code of the main
         // command and store it in $_exitCodeFile
@@ -207,9 +207,9 @@ class Process
     }
 
     /**
-     * Accessor for field $_outfile
+     * Accessor for field $_outFile
      *
-     * @return string value of field $_outfile
+     * @return string value of field $_outFile
      */
     function getOutFile()
     {

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -25,6 +25,8 @@ namespace LORIS\statistics;
  */
 class Stats_MRI extends \NDB_Form
 {
+    protected array $params;
+
     /**
      * Checking user's permission
      *

--- a/modules/user_accounts/php/useraccountrow.class.inc
+++ b/modules/user_accounts/php/useraccountrow.class.inc
@@ -11,6 +11,9 @@ class UserAccountRow implements \LORIS\Data\DataInstance
 {
     protected $DBRow;
 
+    private array $_centerIDs;
+    private array $_projectIDs;
+
      /**
       * Create a new ModuleRow Instance.
       *
@@ -20,9 +23,10 @@ class UserAccountRow implements \LORIS\Data\DataInstance
       */
     public function __construct(array $row, array $cids, array $pids)
     {
-        $this->CenterIDs  = $cids;
-        $this->ProjectIDs = $pids;
-        $this->DBRow      = $row;
+        $this->_centerIDs  = $cids;
+        $this->_projectIDs = $pids;
+
+        $this->DBRow = $row;
     }
 
     /**
@@ -32,7 +36,7 @@ class UserAccountRow implements \LORIS\Data\DataInstance
      */
     public function getCenterIDs() : array
     {
-        return $this->CenterIDs;
+        return $this->_centerIDs;
     }
 
     /**
@@ -42,7 +46,7 @@ class UserAccountRow implements \LORIS\Data\DataInstance
      */
     public function getProjectIDs() : array
     {
-        return $this->ProjectIDs;
+        return $this->_projectIDs;
     }
 
     /**

--- a/php/installer/Database.class.inc
+++ b/php/installer/Database.class.inc
@@ -33,6 +33,11 @@ class Database
     public $PDO;
 
     /**
+     * The last error that occured, to display to the user
+     */
+    public string $lastErr;
+
+    /**
      * Returns one and only one Database object.
      *
      * @return Database

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1507,11 +1507,13 @@ class Database
      */
     private function _createPDOErrorString(): string
     {
+        $error = $this->_PDO->errorInfo();
+
         return sprintf(
             "SQLSTATE: %s. ERROR CODE: %s. ERROR MESSAGE: %s",
-            $this->_PDO->errorInfo[0],
-            $this->_PDO->errorInfo[1],
-            $this->_PDO->errorInfo[2]
+            $error[0],
+            $error[1],
+            $error[2],
         );
     }
 

--- a/php/libraries/ImageCaveats.class.inc
+++ b/php/libraries/ImageCaveats.class.inc
@@ -23,8 +23,14 @@ namespace LORIS;
  */
 class ImageCaveats
 {
+    private ?string $_severity;
+    private ?string $_header;
+    private ?string $_value;
+    private ?string $_validrange;
+    private ?string $_validregex;
+
     /**
-     * Contructor
+     * Constructor
      *
      * @param ?string $severity   Severity
      * @param ?string $header     Header

--- a/php/libraries/InstrumentFlags.class.inc
+++ b/php/libraries/InstrumentFlags.class.inc
@@ -22,6 +22,10 @@
  */
 class InstrumentFlags
 {
+    private ?string $_dataentry;
+    private ?string $_administration;
+    private ?string $_validity;
+
     /**
      * Contructor
      *

--- a/php/libraries/LegacyInstrumentTrait.class.inc
+++ b/php/libraries/LegacyInstrumentTrait.class.inc
@@ -29,6 +29,14 @@
 trait LegacyInstrumentTrait
 {
     /**
+     * The testName being accessed. Not that this is set in
+     * NDB_BVL_Instrument but needs to be redeclared here so
+     * that static analysis tools know that it exists within
+     * the scope of this trait.
+     */
+    public $testName;
+
+    /**
      * Return the full, human readable name for the
      * current instrument.
      *

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1105,22 +1105,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     abstract function getSubtestList(): array;
 
     /**
-     * Marks an element in the lorisform object as being required (for
-     * use with the requiredIf rule)
-     *
-     * @param string $elementName the element to add to the required list
-     *
-     * @return void
-     */
-    function setRequired(string $elementName): void
-    {
-        if (!in_array($elementName, $this->form->_required)) {
-            $this->form->_required[] = $elementName;
-        }
-    }
-
-
-    /**
      * Convert a lorisform date or timestamp into a database acceptable
      * (and storable) date or time
      *

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -30,6 +30,13 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
     public $ValidityEnabled;
     public $ValidityRequired;
     protected $instrument;
+
+    protected CandID $candID;
+    protected SessionID $sessionID;
+
+    protected string $testname;
+    protected ?string $subtest;
+
     /**
      * Construct a controller for the instrument status control panel
      *

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -94,6 +94,15 @@ class NDB_Menu_Filter extends NDB_Menu
     var $formToFilter = [];
 
     /**
+     * A list of filters which should be tested for strict
+     * equality instead of substring equality. Set by subclasses
+     * of NDB_Menu_Filter in their constructor or setup functions.
+     *
+     * @var string[]
+     */
+    protected iterable $EqualityFilters;
+
+    /**
      * An array of all the table headers (optional)
      *
      * The array will automatically be built based on the column array

--- a/php/libraries/NDB_Menu_Filter.class.inc
+++ b/php/libraries/NDB_Menu_Filter.class.inc
@@ -553,23 +553,6 @@ class NDB_Menu_Filter extends NDB_Menu
             }
         }
 
-        if (isset($this->searchKeyword)
-            && is_array($this->searchKeyword)
-            && count($this->searchKeyword) > 0
-            && !empty($this->searchKey['keyword'])
-        ) {
-            $WhereClause .= " AND (";
-            $fields       = [];
-            foreach ($this->searchKeyword as $field) {
-                $fields[] = " $field LIKE CONCAT('%', :v_searchkey, '%')";
-            }
-            $WhereClause .= join(" OR ", $fields);
-
-            $qparams['v_searchkey'] = $this->searchKey['keyword'];
-            $WhereClause           .= ")";
-
-        }
-
         // add GROUP BY if applicable
         if (!empty($this->group_by)) {
             $WhereClause .= " GROUP BY $this->group_by ";
@@ -863,10 +846,6 @@ class NDB_Menu_Filter extends NDB_Menu
                 ." ".$this->filter['order']['fieldOrder'].", ";
         }
         $query .= $this->order_by;
-
-        if (!empty($this->limit)) {
-            $query .= " LIMIT $this->limit";
-        }
 
         // get the list
         $result = $DB->pselect($query, $qparams);

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -92,6 +92,16 @@ class NDB_Page implements RequestHandlerInterface
     protected $tpl_data = [];
 
     /**
+     * The default dateOptions to send to LorisForm to render elements
+     * on this page. This is usually set by subclasses of NDB_Page which
+     * need to modify the options to show on a date (ie. min year, max year,
+     * etc.)
+     *
+     * @var array
+     */
+    public $dateOptions;
+
+    /**
      * Does the setup required for this page. By default, sets up elements
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.

--- a/php/libraries/OutputWrapper.class.inc
+++ b/php/libraries/OutputWrapper.class.inc
@@ -36,6 +36,12 @@ class OutputWrapper
     private $_logDirectory;
 
     /**
+     * The filename which this script is logging to.
+     *
+     * @var string
+     */
+    private $_loggingFileName;
+    /**
      * Create a new command line helper.
      *
      * @param ?SPLFileInfo $logDirectory The full path to the directory that

--- a/php/libraries/Recording.class.inc
+++ b/php/libraries/Recording.class.inc
@@ -37,6 +37,10 @@ class Recording
 
     private $_entitytype;
 
+    private ?string $_channel_file_path;
+    private ?string $_electrode_file_path;
+    private ?string $_event_file_path;
+    private ?string $_archive_file_path;
     /**
      * Constructor
      *

--- a/php/libraries/RecordingChannels.class.inc
+++ b/php/libraries/RecordingChannels.class.inc
@@ -21,6 +21,21 @@ namespace LORIS;
  */
 class RecordingChannels
 {
+    private ?string $_channelname;
+    private ?string $_channeldescription;
+    private ?string $_channeltype;
+    private ?string $_channeltypedescription;
+    private ?string $_channelstatus;
+    private ?string $_statusdescription;
+    private ?string $_samplingfrequency;
+    private ?string $_lowcutoff;
+    private ?string $_highcutoff;
+    private ?string $_manualflag;
+    private ?string $_notch;
+    private ?string $_reference;
+    private ?string $_unit;
+    private ?string $_filepath;
+
     /**
      * Contructor
      *

--- a/php/libraries/RecordingElectrodes.class.inc
+++ b/php/libraries/RecordingElectrodes.class.inc
@@ -21,6 +21,14 @@ namespace LORIS;
  */
 class RecordingElectrodes
 {
+    private ?string $_electrodename;
+    private ?string $_electrodetype;
+    private ?string $_electrodematerial;
+    private ?string $_x;
+    private ?string $_y;
+    private ?string $_z;
+    private ?string $_impedance;
+    private ?string $_filepath;
     /**
      * Contructor
      *

--- a/php/libraries/RecordingEvents.class.inc
+++ b/php/libraries/RecordingEvents.class.inc
@@ -21,8 +21,17 @@ namespace LORIS;
  */
 class RecordingEvents
 {
+    private ?string $_onset;
+    private ?string $_duration;
+    private ?string $_eventcode;
+    private ?string $_eventsample;
+    private ?string $_eventtype;
+    private ?string $_trialtype;
+    private ?string $_responsetime;
+    private ?string $_filepath;
+
     /**
-     * Contructor
+     * Constructor
      *
      * @param ?string $onset        Onset
      * @param ?string $duration     Duration

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -39,6 +39,13 @@ class Settings
     private $_database;
 
     /**
+     * The base of the URL at which LORIS is being served.
+     *
+     * @var string
+     */
+    private $baseURL;
+
+    /**
      * Settings constructor.
      *
      * @param NDB_Config $_config config object

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -43,7 +43,7 @@ class Settings
      *
      * @var string
      */
-    private $baseURL;
+    private $_baseURL;
 
     /**
      * Settings constructor.
@@ -53,8 +53,8 @@ class Settings
      */
     public function __construct(NDB_Config $_config, string $baseURL='')
     {
-        $this->_config = $_config;
-        $this->baseURL = $baseURL;
+        $this->_config  = $_config;
+        $this->_baseURL = $baseURL;
     }
 
     /**
@@ -65,7 +65,7 @@ class Settings
      */
     public function getBaseURL(): string
     {
-        return $this->baseURL;
+        return $this->_baseURL;
     }
 
     /**

--- a/src/Data/Dictionary/DictionaryItem.php
+++ b/src/Data/Dictionary/DictionaryItem.php
@@ -18,6 +18,7 @@ class DictionaryItem implements \LORIS\StudyEntities\AccessibleResource
     protected $description;
     protected $scope;
     protected $type;
+    protected Cardinality $cardinality;
 
     /**
      * Construct a DictionaryItem with the given parameters

--- a/src/Data/Filters/HasAnyPermissionOrUserSiteMatch.php
+++ b/src/Data/Filters/HasAnyPermissionOrUserSiteMatch.php
@@ -29,7 +29,7 @@ use \LORIS\Data\DataInstance;
  */
 class HasAnyPermissionOrUserSiteMatch extends UserSiteMatch
 {
-    protected array $_permissions;
+    protected array $permissions;
 
     /**
      * Constructor
@@ -38,7 +38,7 @@ class HasAnyPermissionOrUserSiteMatch extends UserSiteMatch
      */
     public function __construct(array $permissions)
     {
-        $this->_permissions = $permissions;
+        $this->permissions = $permissions;
     }
 
     /**
@@ -52,7 +52,7 @@ class HasAnyPermissionOrUserSiteMatch extends UserSiteMatch
      */
     public function filter(\User $user, DataInstance $resource) : bool
     {
-        if ($user->hasAnyPermission($this->_permissions)) {
+        if ($user->hasAnyPermission($this->permissions)) {
             return true;
         }
         return parent::filter($user, $resource);

--- a/src/Data/Filters/HasAnyPermissionOrUserSiteMatch.php
+++ b/src/Data/Filters/HasAnyPermissionOrUserSiteMatch.php
@@ -29,6 +29,8 @@ use \LORIS\Data\DataInstance;
  */
 class HasAnyPermissionOrUserSiteMatch extends UserSiteMatch
 {
+    protected array $_permissions;
+
     /**
      * Constructor
      *

--- a/src/Data/Models/DicomSeriesDTO.php
+++ b/src/Data/Models/DicomSeriesDTO.php
@@ -175,8 +175,8 @@ class DicomSeriesDTO
     {
         return array(
                 'id'             => $this->seriesid,
-                'description'    => $this->description,
-                'number'         => $this->number,
+                'description'    => $this->seriesdescription,
+                'number'         => $this->seriesnumber,
                 'echotime'       => $this->echotime,
                 'repetitiontime' => $this->repetitiontime,
                 'inversiontime'  => $this->inversiontime,

--- a/src/Data/Models/ImageDTO.php
+++ b/src/Data/Models/ImageDTO.php
@@ -141,8 +141,8 @@ class ImageDTO implements \LORIS\Data\DataInstance
     public function jsonSerialize() : array
     {
         return [
-                'fileid'              => $this->tarchiveid,
-                'filename'            => $this->tarname,
+                'fileid'              => $this->fileid,
+                'filename'            => $this->filename,
                 'filelocation'        => $this->filelocation,
                 'outputtype'          => $this->outputtype,
                 'acquisitionprotocol' => $this->acquisitionprotocol,

--- a/src/GUI/MenuItem.php
+++ b/src/GUI/MenuItem.php
@@ -7,6 +7,10 @@ namespace LORIS\GUI;
  */
 class MenuItem
 {
+    protected string $category;
+    protected string $label;
+    protected string $link;
+
     /**
      * Constructs a menu item in a given category.
      *

--- a/src/Http/DataIteratorBinaryStream.php
+++ b/src/Http/DataIteratorBinaryStream.php
@@ -14,6 +14,8 @@ class DataIteratorBinaryStream implements StreamInterface
     protected $eof;
     protected $rowgen;
 
+    protected \Traversable $rows;
+
     public function __construct(\Traversable $data)
     {
         $this->position = 0;

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -16,6 +16,8 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
     protected $BaseURL;
     protected $PageName;
 
+    protected \User $user;
+
     public function __construct(
         \User $user,
         string $baseurl,

--- a/src/Router/ModuleAuthenticator.php
+++ b/src/Router/ModuleAuthenticator.php
@@ -31,6 +31,8 @@ use \Psr\Http\Message\ServerRequestInterface;
  */
 class ModuleAuthenticator implements \LORIS\Middleware\Authenticator
 {
+    protected \User $user;
+    protected \Module $Module;
 
     /**
      * The constructor for a ModuleAuthenticator takes the user accessing

--- a/src/Router/ModuleFileRouter.php
+++ b/src/Router/ModuleFileRouter.php
@@ -45,6 +45,8 @@ class ModuleFileRouter implements RequestHandlerInterface
     protected $subdir;
 
     protected $contenttype;
+
+    protected string $moduledir;
     /**
      * The constructor for a ModuleFileRouter takes the Module class,
      * the directory which the module is stored in, and the subdirectory of

--- a/test/integrationtests/BatteryLookup_Test.php
+++ b/test/integrationtests/BatteryLookup_Test.php
@@ -25,6 +25,8 @@ use PHPUnit\Framework\TestCase;
  */
 class NDB_BVL_Battery_Test extends TestCase
 {
+    protected $DB;
+
     /**
      * Set up the data needed for the integration tests.
      *

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -116,6 +116,8 @@ class CandidateTest extends TestCase
      */
     private $_configMap = [];
 
+    private array $_listOfProjects;
+
     /**
      * Sets up fixtures:
      *  - _candidate object

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -76,6 +76,11 @@ class Database_Test extends TestCase
 {
     protected $factory;
     protected $DB;
+
+    private $_PDO;
+
+    protected \NDB_Config $config;
+
     /**
      * This method is called before each test is executed.
      * Sets up fixtures: factory, config, database
@@ -174,21 +179,21 @@ class Database_Test extends TestCase
      */
     function testUpdateEscapesHTML()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['update']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(
             $this->equalTo(['set_field' => '&lt;b&gt;Hello&lt;/b&gt;'])
         );
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->update("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -201,22 +206,22 @@ class Database_Test extends TestCase
      */
     function testUnsafeUpdateDoesntEscapeHTML()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['unsafeupdate']))
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(
             $this->equalTo(['set_field' => '<b>Hello</b>'])
         );
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->unsafeupdate("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -229,21 +234,21 @@ class Database_Test extends TestCase
      */
     function testInsertEscapesHTML()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['insert']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(
             $this->equalTo(['field' => '&lt;b&gt;Hello&lt;/b&gt;'])
         );
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $stub;
         $stub->insert("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -256,22 +261,22 @@ class Database_Test extends TestCase
      */
     function testUnsafeInsertDoesntEscapeHTML()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['unsafeinsert']))
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(
             $this->equalTo(['field' => '<b>Hello</b>'])
         );
 
-        $stub->_PDO->expects($this->once())->method("prepare")
+        $PDO->expects($this->once())->method("prepare")
             ->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->unsafeinsert("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -789,24 +794,24 @@ class Database_Test extends TestCase
      */
     function testInsertOnDuplicateUpdateEscapesHTML()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods(
                 $this->_getAllMethodsExcept(['insertOnDuplicateUpdate'])
             )
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(
             $this->equalTo(['field' => '&lt;b&gt;Hello&lt;/b&gt;'])
         );
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->insertOnDuplicateUpdate(
             "test",
             ['field' => '<b>Hello</b>'],
@@ -822,24 +827,24 @@ class Database_Test extends TestCase
      */
     function testUnsafeInsertOnDuplicateUpdateDoesntEscapeHTML()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods(
                 $this->_getAllMethodsExcept(['unsafeInsertOnDuplicateUpdate'])
             )
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(
             $this->equalTo(['field' => '<b>Hello</b>'])
         );
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->unsafeInsertOnDuplicateUpdate(
             "test",
             ['field' => '<b>Hello</b>'],
@@ -888,17 +893,17 @@ class Database_Test extends TestCase
      */
     function testRun()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['run']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("exec")->with($this->equalTo("SHOW TABLES"));
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->run("SHOW TABLES");
     }
 
@@ -910,19 +915,19 @@ class Database_Test extends TestCase
      */
     function testPrepare()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['prepare']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-        $stmt       = $this->getMockBuilder('PDOStatement')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
-        $stub->_PDO->expects($this->once())
+        $PDO->expects($this->once())
             ->method("prepare")
             ->with($this->equalTo("SHOW TABLES"))
             ->willReturn(new PDOStatement());
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->prepare("SHOW TABLES");
     }
 
@@ -1029,8 +1034,7 @@ class Database_Test extends TestCase
      */
     function testPselectCallsFunctions()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['pselect']))->getMock();
 
         '@phan-var \Database $stub';
@@ -1088,8 +1092,7 @@ class Database_Test extends TestCase
      */
     function testPselectRowCallsPrepare()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['pselectRow']))
             ->getMock();
 
@@ -1336,8 +1339,7 @@ class Database_Test extends TestCase
         $this->markTestIncomplete(
             "This test calls a private method, making it fail for now"
         );
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['insertIgnore']))
             ->getMock();
 
@@ -1603,18 +1605,17 @@ class Database_Test extends TestCase
      */
     function testQuote()
     {
-
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['quote']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
 
         $string = "Co'mpl''ex \"st'\"ring";
-        $stub->_PDO->expects($this->once())->method("quote")
+        $PDO->expects($this->once())->method("quote")
             ->willReturn("Complex string");
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->quote($string);
     }
 
@@ -1638,17 +1639,17 @@ class Database_Test extends TestCase
      */
     function testInTransaction()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['inTransaction']))
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
 
-        $stub->_PDO->expects($this->once())->method("inTransaction")
+        $PDO->expects($this->once())->method("inTransaction")
             ->willReturn(true);
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->inTransaction();
     }
 
@@ -1661,18 +1662,19 @@ class Database_Test extends TestCase
      */
     function testBeginTransaction()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['beginTransaction']))
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(false);
-        $stub->_PDO->expects($this->once())->method("beginTransaction")
+        $PDO->expects($this->once())->method("beginTransaction")
             ->willReturn(true);
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
+
         $stub->beginTransaction();
     }
 
@@ -1684,17 +1686,17 @@ class Database_Test extends TestCase
      */
     function testBeginTransactionThrowsException()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['beginTransaction']))
             ->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(true);
         $this->expectException("DatabaseException");
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->beginTransaction();
     }
 
@@ -1706,16 +1708,16 @@ class Database_Test extends TestCase
      */
     function testRollback()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['rollBack']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(true);
-        $stub->_PDO->expects($this->once())->method("rollBack")->willReturn(true);
+        $PDO->expects($this->once())->method("rollBack")->willReturn(true);
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->rollBack();
     }
 
@@ -1727,16 +1729,16 @@ class Database_Test extends TestCase
      */
     function testRollbackThrowsException()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['rollBack']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(false);
         $this->expectException("DatabaseException");
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->rollBack();
     }
 
@@ -1748,16 +1750,15 @@ class Database_Test extends TestCase
      */
     function testCommit()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['commit']))->getMock();
 
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
-
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stub->expects($this->once())->method("inTransaction")->willReturn(true);
-        $stub->_PDO->expects($this->once())->method("commit")->willReturn(true);
+        $PDO->expects($this->once())->method("commit")->willReturn(true);
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $PDO;
         $stub->commit();
     }
 
@@ -1769,16 +1770,14 @@ class Database_Test extends TestCase
      */
     function testCommitThrowsException()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['commit']))->getMock();
-
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
 
         $stub->expects($this->once())->method("inTransaction")->willReturn(false);
         $this->expectException("DatabaseException");
 
         '@phan-var \Database $stub';
+        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
         $stub->commit();
     }
 
@@ -1790,8 +1789,7 @@ class Database_Test extends TestCase
      */
     function testIsConnectedNoPDO()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
 
@@ -1808,8 +1806,7 @@ class Database_Test extends TestCase
      */
     function testIsConnectedWithPDO()
     {
-        $this->_factory = NDB_Factory::singleton();
-        $stub           = $this->getMockBuilder('FakeDatabase')
+        $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['isConnected']))
             ->getMock();
         '@phan-var \Database $stub';

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -237,7 +237,8 @@ class Database_Test extends TestCase
         $stub = $this->getMockBuilder('FakeDatabase')
             ->onlyMethods($this->_getAllMethodsExcept(['insert']))->getMock();
 
-        $PDO  = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO  = $this->getMockBuilder('FakePDO')
+            ->onlyMethods(['lastInsertId'])->getMock();
         $stmt = $this->getMockBuilder('PDOStatement')->getMock();
 
         $stmt->expects($this->once())->method("execute")->with(

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -193,6 +193,7 @@ class Database_Test extends TestCase
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->update("test", ['field' => '<b>Hello</b>'], []);
 
@@ -221,6 +222,7 @@ class Database_Test extends TestCase
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->unsafeupdate("test", ['field' => '<b>Hello</b>'], []);
 
@@ -249,7 +251,8 @@ class Database_Test extends TestCase
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
-        $stub->_PDO = $stub;
+        '@phan-var \PDO $PDO';
+        $stub->_PDO = $PDO;
         $stub->insert("test", ['field' => '<b>Hello</b>'], []);
 
     }
@@ -277,6 +280,7 @@ class Database_Test extends TestCase
             ->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->unsafeinsert("test", ['field' => '<b>Hello</b>'], []);
 
@@ -812,6 +816,7 @@ class Database_Test extends TestCase
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->insertOnDuplicateUpdate(
             "test",
@@ -845,6 +850,7 @@ class Database_Test extends TestCase
             ->method("prepare")->will($this->returnValue($stmt));
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->unsafeInsertOnDuplicateUpdate(
             "test",
@@ -904,6 +910,7 @@ class Database_Test extends TestCase
             ->method("exec")->with($this->equalTo("SHOW TABLES"));
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->run("SHOW TABLES");
     }
@@ -928,6 +935,7 @@ class Database_Test extends TestCase
             ->willReturn(new PDOStatement());
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->prepare("SHOW TABLES");
     }
@@ -1616,6 +1624,7 @@ class Database_Test extends TestCase
             ->willReturn("Complex string");
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->quote($string);
     }
@@ -1650,6 +1659,7 @@ class Database_Test extends TestCase
             ->willReturn(true);
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->inTransaction();
     }
@@ -1674,6 +1684,7 @@ class Database_Test extends TestCase
             ->willReturn(true);
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
 
         $stub->beginTransaction();
@@ -1697,6 +1708,7 @@ class Database_Test extends TestCase
         $this->expectException("DatabaseException");
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->beginTransaction();
     }
@@ -1718,6 +1730,7 @@ class Database_Test extends TestCase
         $PDO->expects($this->once())->method("rollBack")->willReturn(true);
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->rollBack();
     }
@@ -1739,6 +1752,7 @@ class Database_Test extends TestCase
         $this->expectException("DatabaseException");
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->rollBack();
     }
@@ -1759,6 +1773,7 @@ class Database_Test extends TestCase
         $PDO->expects($this->once())->method("commit")->willReturn(true);
 
         '@phan-var \Database $stub';
+        '@phan-var \PDO $PDO';
         $stub->_PDO = $PDO;
         $stub->commit();
     }
@@ -1778,7 +1793,10 @@ class Database_Test extends TestCase
         $this->expectException("DatabaseException");
 
         '@phan-var \Database $stub';
-        $stub->_PDO = $this->getMockBuilder('FakePDO')->getMock();
+        $PDO = $this->getMockBuilder('FakePDO')->getMock();
+        '@phan-var \PDO $PDO';
+
+        $stub->_PDO = $PDO;
         $stub->commit();
     }
 

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -2246,6 +2246,8 @@ class LorisForms_Test extends TestCase
         $form->expects($this->once())
             ->method('headerHTML');
 
+        '@phan-var \LorisForm $form';
+
         $form->addElement("header", "abc", "Hello");
         $form->renderElement($form->form['abc']);
     }
@@ -2283,6 +2285,7 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $form->expects($this->once())
             ->method('hiddenHTML');
+        '@phan-var \LorisForm $form';
 
         $form->addElement("hidden", "abc", "Hello");
         $form->renderElement($form->form['abc']);
@@ -2328,6 +2331,8 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $f->expects($this->once())
             ->method('linkHTML');
+
+        '@phan-var \LorisForm $f';
 
         $f->addElement("link", "abc", "Hello");
         $f->renderElement($f->form['abc']);

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -26,6 +26,8 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
      */
     protected $i;
 
+    protected \NDB_Client $Client;
+
     /**
      * Set up sets a fake $_SESSION object that we can use for
      * assertions
@@ -39,7 +41,8 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
             define("UNIT_TESTING", true);
         }
         date_default_timezone_set("UTC");
-        $this->Session = $this->getMockBuilder(\stdClass::class)->addMethods(
+
+        $session = $this->getMockBuilder(\stdClass::class)->addMethods(
             [
                 'getProperty',
                 'setProperty',
@@ -47,13 +50,14 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
                 'isLoggedIn'
             ]
         )->getMock();
-        $this->MockSinglePointLogin = $this->getMockBuilder('SinglePointLogin')
+
+        $mockSinglePointLogin = $this->getMockBuilder('SinglePointLogin')
             ->getMock();
-        $this->Session->method("getProperty")
-            ->willReturn($this->MockSinglePointLogin);
+        $session->method("getProperty")
+            ->willReturn($mockSinglePointLogin);
 
         $_SESSION = [
-            'State' => $this->Session
+            'State' => $session,
         ];
 
         $factory = \NDB_Factory::singleton();
@@ -67,8 +71,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
             ->method('pselectOne')
             ->willReturn('999');
 
-        $this->QuickForm = new \LorisForm(); //$this->getMock("HTML_Quickform");
-        $this->Client    = new \NDB_Client;
+        $this->Client = new \NDB_Client;
         $this->Client->makeCommandLine();
         $this->Client->initialize(__DIR__ . "/../../project/config.xml");
 
@@ -82,11 +85,10 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
             ->willReturn(new \SessionID(strval("123456")));
 
         '@phan-var \Loris\Behavioural\NDB_BVL_Instrument_LINST $i';
-        $i->form     = $this->QuickForm;
+        $i->form     = new \LorisForm();
         $i->testName = "Test";
 
         $this->i = $i;
-
     }
 
     /**

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -45,6 +45,23 @@ class NDB_BVL_Instrument_Test extends TestCase
     private $_factoryForDB;
     private $_config;
     private $_DB;
+
+    protected $quickForm;
+
+    /**
+     * The State object for this session
+     *
+     * @var \State
+     */
+    protected $session;
+
+    /**
+     * A Mock SinglePointLogin object
+     *
+     * @var \SinglePointLogin
+     */
+    protected $mockSinglePointLogin;
+
     /**
      * Set up sets a fake $_SESSION object that we can use for
      * assertions
@@ -87,10 +104,10 @@ class NDB_BVL_Instrument_Test extends TestCase
         $instrument->method('getSubtestList')->willReturn([]);
 
         '@phan-var \NDB_BVL_Instrument $instrument';
-        $this->_instrument = $instrument;
+        $instrument->form     = $this->quickForm;
+        $instrument->testName = "Test";
 
-        $this->_instrument->form     = $this->quickForm;
-        $this->_instrument->testName = "Test";
+        $this->_instrument = $instrument;
     }
 
     /**
@@ -859,11 +876,11 @@ class NDB_BVL_Instrument_Test extends TestCase
             ]
         );
 
+        '@phan-var \NDB_BVL_Instrument $i';
         $i->form     = $this->quickForm;
         $i->testName = "Test";
-        '@phan-var \NDB_BVL_Instrument $i';
 
-        $json     = $i->toJSON();
+        $json     = $instrument->toJSON();
         $outArray = json_decode($json, true);
         $page1    = $outArray['Elements'][0];
         $page2    = $outArray['Elements'][1];
@@ -1395,23 +1412,6 @@ class NDB_BVL_Instrument_Test extends TestCase
     }
 
     /**
-     * Test that setRequired sets the required value of the form
-     *
-     * @note This test is being skipped because there is an error in
-     * the setRequired method. Once this is resolved, this test can
-     * be implemented.
-     *
-     * @covers NDB_BVL_Instrument::setRequired
-     * @return void
-     */
-    function testSetRequired()
-    {
-        $this->markTestSkipped("Error in setRequired method");
-        $this->_instrument->setRequired("Required_el");
-        $this->assertEquals("Required_el", $this->_instrument->form->_required[]);
-    }
-
-    /**
      * Test that XINValidate returns true if there are no errors
      * for the given elements array
      *
@@ -1622,10 +1622,12 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_setTableData();
         $this->_instrument->commentID = 'commentID1';
         $this->_instrument->table     = 'medical_history';
-        $otherInstrument            = $this
+        $otherInstrument = $this
             ->getMockBuilder(\NDB_BVL_Instrument::class)
             ->disableOriginalConstructor()
             ->onlyMethods(["getFullName", "getSubtestList"])->getMock();
+        '@phan-var \NDB_BVL_Instrument $otherInstrument';
+
         $otherInstrument->commentID = 'commentID2';
         $otherInstrument->table     = 'medical_history';
         $this->assertEquals(

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -75,13 +75,21 @@ class NDB_BVL_Instrument_Test extends TestCase
             define("UNIT_TESTING", true);
         }
         date_default_timezone_set("UTC");
-        $this->session = $this->getMockBuilder(\stdClass::class)
+
+        $s = $this->getMockBuilder(\State::class)
             ->addMethods(['getUsername','setProperty','getProperty','isLoggedIn'])
             ->getMock();
-        $this->mockSinglePointLogin = $this->getMockBuilder('SinglePointLogin')
+        '@phan-var \State $s';
+        $this->session = $s;
+
+        $spe = $this->getMockBuilder('SinglePointLogin')
             ->getMock();
+
         $this->session->method("getProperty")
-            ->willReturn($this->mockSinglePointLogin);
+            ->willReturn($spe);
+
+        '@phan-var \SinglePointLogin $spe';
+        $this->mockSinglePointLogin = $spe;
 
         $_SESSION = [
             'State' => $this->session
@@ -880,7 +888,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $i->form     = $this->quickForm;
         $i->testName = "Test";
 
-        $json     = $instrument->toJSON();
+        $json     = $i->toJSON();
         $outArray = json_decode($json, true);
         $page1    = $outArray['Elements'][0];
         $page2    = $outArray['Elements'][1];

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -74,6 +74,13 @@ class NDB_ConfigTest extends TestCase
     private $_configMap = [];
 
     /**
+     * A mock NDB_Config object
+     *
+     * @var \NDB_Config
+     */
+    private $_config;
+
+    /**
      * Test double for User object
      *
      * @var User | PHPUnit\Framework\MockObject\MockObject

--- a/test/unittests/NDB_Menu_Filter_Test.php
+++ b/test/unittests/NDB_Menu_Filter_Test.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\TestCase;
  */
 class NDB_Menu_Filter_Test extends TestCase
 {
+    protected $Session;
+
     /**
      * Set up sets a fake $_SESSION object that we can use for
      * assertions

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -33,6 +33,21 @@ class PasswordTest extends TestCase
      */
     private $_configMock;
 
+    /**
+     * Test double for Database object
+     *
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
+     */
+    private $_dbMock;
+
+    /**
+     * NDB_Factory used in tests.
+     * Test doubles are injected to the factory object.
+     *
+     * @var NDB_Factory
+     */
+    private $_factory;
+
     private $_configInfo = [0 => ['65' => 'false']];
 
     /**

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -33,6 +33,14 @@ class SinglePointLoginTest extends TestCase
     private $_login;
 
     /**
+     * Maps config names to values
+     * Used to set behaviour of NDB_Config test double
+     *
+     * @var array config name => value
+     */
+    private $_configMap = [];
+
+    /**
      * Setup
      *
      * @return void

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -204,6 +204,7 @@ class UserTest extends TestCase
      * @var User object
      */
     private $_otherUser;
+
     /**
      * NDB_Factory used in tests.
      * Test doubles are injected to the factory object.
@@ -217,6 +218,7 @@ class UserTest extends TestCase
      * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
+    private $_mockConfig;
     /**
      * Test double for Database object
      *


### PR DESCRIPTION
This toggles sets the `allow_undeclared_properties` flag to false and fixes all references to undeclared properties identified by Phan.