### PR TITLE
[eslint] Missing key prop for element in iterator  react/jsx-key

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -879,6 +879,7 @@ class TagsElement extends Component {
             type="button"
             onClick={this.handleRemove}
             data-item={item}
+            key={item}
           >
             {itmTxt}
             &nbsp;


### PR DESCRIPTION
## Brief summary of changes

Solves eslint errors for react/jsx-key and useful for removing the off found in this PR: https://github.com/aces/Loris/pull/7137