### PR TITLE
Remove unused factories

### DIFF
--- a/php/libraries/NDB_Form.class.inc
+++ b/php/libraries/NDB_Form.class.inc
@@ -48,59 +48,6 @@ class NDB_Form extends NDB_Page
     var $_GUIDelimiter = "&nbsp;\n";
 
     /**
-     * Generates a new form instance and runs the appropriate method
-     *
-     * @param string $name       Identifies the form
-     * @param string $page       Identifies the page to show
-     * @param string $identifier Variables passed to form
-     *
-     * @return \NDB_Form
-     */
-    static function &factory($name, $page, $identifier)
-    {
-        // check that the form class exists
-        if (class_exists("NDB_Form_$name")) {
-            $class = "NDB_Form_$name";
-        } else {
-            throw new Exception("The form class ($name) is not defined.");
-        }
-
-        if (isset($_REQUEST['test_name'])) {
-            $module = \Module::factory($_REQUEST['test_name']);
-        } else {
-            $module = \Module::factory($name);
-        }
-
-        // create a form instance
-        $obj = new $class($module, $page, $identifier, '', 'test_form');
-
-        $obj->registerDefaultFilter();
-
-        $access = $obj->_hasAccess();
-
-        // check that user has access
-        if ($access == false) {
-            throw new Exception("You do not have access to this page.", 403);
-        }
-
-        if (method_exists($obj, $page)) {
-            $obj->$page();
-            $obj->template = $page;
-        } elseif (method_exists($obj, $name)) {
-            $obj->$name();
-            $obj->template = $name;
-        } else {
-            throw new Exception("Form does not exist: $name $page", 404);
-        }
-
-        $factory  = NDB_Factory::singleton();
-        $settings = $factory->settings();
-        $obj->setTemplateVar('baseurl', $settings->getBaseURL());
-
-        return $obj;
-    }
-
-    /**
      * By default, trim all fields on the form before any processing/validation
      * is done. Derived classes can override this behaviour if needed.
      *

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -56,50 +56,6 @@ class NDB_Menu extends NDB_Page
         parent::__construct($module, $page, $identifier, $commentID);
         $this->menu = $module->getName();
     }
-    /**
-     * Generates a new menu instance
-     *
-     * @param string $menu The name of the menu to use
-     * @param string $mode The menu's mode
-     *
-     * @return object The new object of $menu type
-     */
-    static function &factory($menu, $mode)
-    {
-        // get the name of the class
-        if (class_exists("NDB_Menu_$menu")) {
-            $class = "NDB_Menu_$menu";
-        } elseif (class_exists("NDB_Menu_Filter_$menu")) {
-            $class = "NDB_Menu_Filter_$menu";
-        } elseif (class_exists("NDB_Menu_Filter_Form_$menu")) {
-            $class = "NDB_Menu_Filter_Form_$menu";
-        } else {
-            throw new Exception("The menu class ($menu) is not defined.");
-        }
-
-        if (isset($_REQUEST['test_name'])) {
-            $module = \Module::factory($_REQUEST['test_name']);
-        } else {
-            $module = \Module::factory($menu);
-        }
-
-        $obj = new $class($module, $menu, '', '', 'menu');
-
-        // set the local variables
-        $obj->mode = $mode;
-        $access    = $obj->_hasAccess();
-
-        // check that user has access
-        if ($access == false) {
-            throw new Exception("You do not have access to this page.", 403);
-        }
-
-        $factory  = NDB_Factory::singleton();
-        $settings = $factory->settings();
-        $obj->setTemplateVar('baseurl', $settings->getBaseURL());
-
-        return $obj;
-    }
 
     /**
      * Displays the menu page


### PR DESCRIPTION
In the days of NDB_Caller there were static factory methods
on different page types which were used to load a page. After
things were turned into modules, these were replaced with directly
constructing the classes which extend NDB_Page.

Remove the unused factories that were replaced by page classes/routers.
(There are no references to them in the code, Phan doesn't raise any
PhanUndeclaredStaticMethod errors after removing them..)