### PR TITLE
Add ability to get database connection info from environment

### DIFF
--- a/php/libraries/NDB_Client.class.inc
+++ b/php/libraries/NDB_Client.class.inc
@@ -53,23 +53,9 @@ class NDB_Client
 
         $config = $factory->config($configFile);
 
-        // Load the database object with settings from config
-        // so that after this we can just call Database::singleton()
-        // with no parameters
-        $DBSettings = $config->getSetting("database");
-        if (!defined("UNIT_TESTING")) {
-            $DB = Database::singleton(
-                $DBSettings['database'],
-                $DBSettings['username'],
-                $DBSettings['password'],
-                $DBSettings['host'],
-                true
-            );
-            // Now make sure the factory reference is the same as the
-            // singleton reference
-            $factory->setDatabase($DB);
-        }
-
+        // The factory uses the Settings object to call Database::singleton().
+        // This is required so that further calls to Database::singleton()
+        // will work.
         $DB = $factory->database();
 
         // add extra include paths. This must be done

--- a/php/libraries/NDB_Factory.class.inc
+++ b/php/libraries/NDB_Factory.class.inc
@@ -163,22 +163,13 @@ class NDB_Factory
             return $db_ref;
         }
 
-        $config = $this->config();
-        $dbc    = $config->getSetting('database');
-        // This check was added to satisfy phan, our static analysis tool.
-        // $db_ref should be set to either a new MockDatabase or a Database
-        // singleton above.
-        if ($db_ref === null) {
-            throw new \ConfigurationException(
-                'Could not configure database for LORIS'
-            );
-        }
+        $settings = $this->settings();
 
         $db_ref = \Database::singleton(
-            $dbc['database'],
-            $dbc['username'],
-            $dbc['password'],
-            $dbc['host'],
+            $settings->dbName(),
+            $settings->dbUserName(),
+            $settings->dbPassword(),
+            $settings->dbHost(),
             true
         );
 

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -135,6 +135,11 @@ class Settings
      */
     private function _getDatabaseSetting(string $settingName): string
     {
+        $envvar = getenv("LORIS_DB_" . strtoupper($settingName));
+        if($envvar !== false && $envvar !== "") {
+            return $envvar;
+        }
+
         if (empty($this->_database)) {
             $this->_database = $this->_config->getSetting('database');
         }

--- a/php/libraries/Settings.class.inc
+++ b/php/libraries/Settings.class.inc
@@ -136,7 +136,7 @@ class Settings
     private function _getDatabaseSetting(string $settingName): string
     {
         $envvar = getenv("LORIS_DB_" . strtoupper($settingName));
-        if($envvar !== false && $envvar !== "") {
+        if ($envvar !== false && $envvar !== "") {
             return $envvar;
         }
 


### PR DESCRIPTION
This adds the ability for LORIS to get the database connection
information from environment variables prefixed by "LORIS_DB_".

This is primarily intended to make it easier to make it easier
to write a re-useable Docker image. The config.xml is normally
set up by the install.sh script with the connection info. However,
the values need to be known at the time that install.sh is run for
this to work. In the case of a Dockerfile, that needs to be known
when the image is being built. Allowing them to be overridden at runtime
allows the same docker image to be used to run multiple servers.

Note that this is only a first step. There is still a requirement to
mount a config.xml in the usual location when running a container in
order to get visit label and identifier format settings, but this
allows a container to be run using the default values, rather than
breaking entirely, if database environment variable settings are set.

There should be further work done to move the remaining settings into the
database so that a container can just point at a database and work.