### PR TITLE
phan PhanUnusedPublicMethodParameter

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -34,7 +34,6 @@ return [
     "unused_variable_detection" => true,
     "suppress_issue_types" => [
         "PhanUnusedVariable",
-        "PhanUnusedPublicMethodParameter",
         "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",


### PR DESCRIPTION
Do not ignore PhanUnusedPublicMethodParameter in the phan config.

There are no errors of this type detected by phan, so there's no
reason to ignore it.