### PR TITLE
[issue_tracker] Only show inactive user if already selected in form

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -532,6 +532,7 @@ class SelectElement extends Component {
     let disabled = this.props.disabled ? 'disabled' : null;
     let sortByValue = this.props.sortByValue;
     let options = this.props.options;
+    let disabledOptions = this.props.disabledOptions;
     let errorMessage = null;
     let emptyOptionHTML = null;
     let requiredHTML = null;
@@ -564,16 +565,28 @@ class SelectElement extends Component {
         }
       }
       optionList = Object.keys(newOptions).sort().map(function(option) {
+        let isDisabled = (newOptions[option] in disabledOptions);
         return (
-          <option value={newOptions[option]} key={newOptions[option]}>
+          <option
+            value={newOptions[option]}
+            key={newOptions[option]}
+            disabled={isDisabled}
+          >
             {option}
           </option>
         );
       });
     } else {
       optionList = Object.keys(options).map(function(option) {
+        let isDisabled = (option in disabledOptions);
         return (
-          <option value={option} key={option}>{options[option]}</option>
+          <option
+            value={option}
+            key={option}
+            disabled={isDisabled}
+          >
+            {options[option]}
+          </option>
         );
       });
     }
@@ -624,6 +637,7 @@ class SelectElement extends Component {
 SelectElement.propTypes = {
   name: PropTypes.string.isRequired,
   options: PropTypes.object.isRequired,
+  disabledOptions: PropTypes.object,
   label: PropTypes.string,
   value: PropTypes.oneOfType([
     PropTypes.string,
@@ -644,6 +658,7 @@ SelectElement.propTypes = {
 SelectElement.defaultProps = {
   name: '',
   options: {},
+  disabledOptions: {},
   value: undefined,
   id: null,
   multiple: false,

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -611,7 +611,7 @@ function getIssueFields()
     $sites = Issue_Tracker::getSites(false, true);
 
     //not yet ideal permissions
-    $assignees = [];
+    $assignees      = [];
     $inactive_users = [];
     if ($user->hasPermission('access_all_profiles')) {
         $assignee_expanded = $db->pselect(

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -617,6 +617,12 @@ function getIssueFields()
             "SELECT Real_name, UserID FROM users",
             []
         );
+
+        $inactive_users_expanded = $db->pselect(
+            "SELECT Real_name, UserID FROM users
+              WHERE Active='N'",
+            array()
+        );
     } else {
         $CenterID = implode(',', $user->getCenterIDs());
         $DCCID    = $db->pselectOne(
@@ -632,10 +638,22 @@ function getIssueFields()
                 'DCC'      => $DCCID,
             ]
         );
+
+        $inactive_users_expanded = $db->pselect(
+            "SELECT DISTINCT u.Real_name, u.UserID FROM users u
+             LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
+             WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)
+             AND Active='N'",
+            array()
+        );
     }
 
     foreach ($assignee_expanded as $a_row) {
         $assignees[$a_row['UserID']] = $a_row['Real_name'];
+    }
+
+    foreach ($inactive_users_expanded as $u_row) {
+        $inactive_users[$u_row['UserID']] = $u_row['Real_name'];
     }
 
     $otherWatchers = [];
@@ -754,6 +772,7 @@ function getIssueFields()
 
     $result = [
         'assignees'         => $assignees,
+        'inactiveUsers'     => $inactive_users,
         'sites'             => $sites,
         'statuses'          => $statuses,
         'priorities'        => $priorities,

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -621,7 +621,7 @@ function getIssueFields()
         $inactive_users_expanded = $db->pselect(
             "SELECT Real_name, UserID FROM users
               WHERE Active='N'",
-            array()
+            []
         );
     } else {
         $CenterID = implode(',', $user->getCenterIDs());
@@ -644,7 +644,7 @@ function getIssueFields()
              LEFT JOIN user_psc_rel upr ON (upr.UserID=u.ID)
              WHERE FIND_IN_SET(upr.CenterID,:CenterID) OR (upr.CenterID=:DCC)
              AND Active='N'",
-            array()
+            []
         );
     }
 

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -612,6 +612,7 @@ function getIssueFields()
 
     //not yet ideal permissions
     $assignees = [];
+    $inactive_users = [];
     if ($user->hasPermission('access_all_profiles')) {
         $assignee_expanded = $db->pselect(
             "SELECT Real_name, UserID FROM users",

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -242,6 +242,7 @@ class IssueForm extends Component {
             label='Assignee'
             emptyOption={true}
             options={this.state.Data.assignees}
+            disabledOptions={this.state.Data.inactiveUsers}
             onUserInput={this.setFormData}
             disabled={!hasEditPermission}
             value={this.state.formData.assignee}

--- a/modules/issue_tracker/jsx/IssueForm.js
+++ b/modules/issue_tracker/jsx/IssueForm.js
@@ -371,6 +371,10 @@ class IssueForm extends Component {
           // the user's sites.
           if (newIssue) {
             formData.centerID = null;
+            Object.keys(data.inactiveUsers).map((user) => {
+              delete data.assignees[user];
+            });
+            data.inactiveUsers = {};
           } else {
             // if we edit an issue
             // a NULL centerID (= All Sites) is converted to the ALL Sites option


### PR DESCRIPTION
## Brief summary of changes

Currently, the issue tracker shows inactive users. You are able to create a new issue and assign it to them.

This PR filters out inactive users so that they don't show up in the list of assignees in the 'New Issue' form. In the 'Edit Issue' form, the inactive user appears in the list of assignees but the option is disabled. this is so that inactive users that are already assigned show up but cannot be reselected.

I thought of this fix super quickly, so am open to suggestions of perhaps better ways of doing this! I know that there are multiple modules across loris that show inactive users in a select element only because they may have been previously selected and the value cannot be orphaned.

#### Testing instructions (if applicable)

1. Set one of your users as Inactive using the user accounts module.
2. On 23.0-release branch, notice that the inactive user shows up as an option in the 'Create New Issue' and 'Edit Issue' forms.
3. On this PR branch, `make dev` and check both forms again. You will see that in the 'Create New Issue' form, the inactive user is not there.
4. Select an existing issue assigned to an inactive user. In the 'Edit Issue' form, you will see that inactive assignee is selected but the option is greyed out. You can update the issue i.e. Save the form, without changing assignees with no problems. If you change the assignee, you will see that you cannot reassign the issue back to the inactive user.
5. Select an existing issue assigned to an active user. You will see the inactive user in the options for assignee but you won't be able to select it.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
