### PR TITLE
Fix all calls to undeclared methods

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -36,7 +36,6 @@ return [
         "PhanUnusedVariable",
         "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
-        "PhanUndeclaredMethod",
         "PhanTypeMismatchArgument",
     ],
     "analyzed_file_extensions" => ["php", "inc"],

--- a/modules/api/test/login_Test.php
+++ b/modules/api/test/login_Test.php
@@ -91,7 +91,10 @@ class LoginTest extends TestCase
      */
     public function testLoginSuccess(): void
     {
-        $this->_authenticator->expects($this->once())
+        $authenticator = $this->_authenticator;
+        '@phan-var \PHPUnit\Framework\MockObject\MockObject $authenticator';
+
+        $authenticator->expects($this->once())
             ->method('passwordAuthenticate')
             ->with('test_username', 'test_password')
             ->willReturn(true);
@@ -102,11 +105,12 @@ class LoginTest extends TestCase
 
         $handler->expects($this->once())
             ->method('getLoginAuthenticator')
-            ->willReturn($this->_authenticator);
+            ->willReturn($authenticator);
 
         $handler->expects($this->once())
             ->method('getEncodedToken')
             ->willReturn('jwt_token');
+        '@phan-var \LORIS\api\Endpoints\Login $handler';
 
         $request = $this->_request
             ->withAttribute('pathparts', ['login'])

--- a/modules/candidate_list/php/validateids.class.inc
+++ b/modules/candidate_list/php/validateids.class.inc
@@ -73,8 +73,8 @@ class ValidateIDs extends \NDB_Page
         // Ensure it's a GET request.
         if ($request->getMethod() != "GET") {
             return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
                 ->withStatus(405)
+                ->withHeader("Content-Type", "text/plain")
                 ->withHeader("Allow", "GET")
                 ->withBody(
                     new \LORIS\Http\StringStream(
@@ -87,8 +87,8 @@ class ValidateIDs extends \NDB_Page
         $gets = $request->getQueryParams();
         if (!isset($gets['CandID'], $gets['PSCID'])) {
             return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
                 ->withStatus(400)
+                ->withHeader("Content-Type", "text/plain")
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         "Must provide PSCID and CandID to validate"
@@ -106,8 +106,8 @@ class ValidateIDs extends \NDB_Page
         ) ? "1" : "0";
 
         return (new \LORIS\Http\Response())
-            ->withHeader("Content-Type", "text/plain")
             ->withStatus(200)
+            ->withHeader("Content-Type", "text/plain")
             ->withBody(new \LORIS\Http\StringStream($exists));
     }
 }

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -53,7 +53,9 @@ class DICOMArchiveAnonymizer implements Mapper
         }
 
         if (!method_exists($res, 'getCenterID')) {
-            throw new \LorisException("Mapper requires a resource type with getCenterID");
+            throw new \LorisException(
+                "Mapper requires a resource type with getCenterID"
+            );
         }
 
         $newrow = json_decode(json_encode($res), true);

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -44,17 +44,24 @@ class DICOMArchiveAnonymizer implements Mapper
         \User $user,
         DataInstance $resource
     ) : DataInstance {
+        $res = $resource;
+        '@phan-var object $res';
 
         static $config = null;
         if ($config === null) {
             $config = \NDB_Config::singleton()->getSetting("imaging_modules");
         }
 
-        $newrow = json_decode(json_encode($resource), true);
+        if (!method_exists($res, 'getCenterID')) {
+            throw new \LorisException("Mapper requires a resource type with getCenterID");
+        }
+
+        $newrow = json_decode(json_encode($res), true);
         if (!is_array($newrow)) {
             throw new \Exception("Error converting DataInstance to array");
         }
-        $cid = $resource->getCenterID();
+
+        $cid = $res->getCenterID();
 
         // escape any forward slashes
         $pNameRegex      = preg_replace(

--- a/modules/document_repository/php/doctree.class.inc
+++ b/modules/document_repository/php/doctree.class.inc
@@ -63,8 +63,8 @@ class DocTree extends \NDB_Page
         if ($request->getMethod()=='GET') {
             $id = basename($request->getUri()->getPath());
             return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
                 ->withStatus(200)
+                ->withHeader("Content-Type", "text/plain")
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode($this->fileTree($id))

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -52,8 +52,8 @@ class UploadCategory extends \NDB_Page
         if ($request->getMethod() == "POST") {
             $this->uploadDocCategory($request);
             return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
                 ->withStatus(200)
+                ->withHeader("Content-Type", "text/plain")
                 ->withBody(
                     new \LORIS\Http\StringStream(
                         json_encode("uploaded successfully")
@@ -61,8 +61,8 @@ class UploadCategory extends \NDB_Page
                 );
         } else {
             return (new \LORIS\Http\Response())
-                ->withHeader("Content-Type", "text/plain")
                 ->withStatus(405)
+                ->withHeader("Content-Type", "text/plain")
                 ->withHeader("Allow", "POST");
         }
     }

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -62,6 +62,7 @@ class Module extends \Module
         // and SessionID are valid, and if so attach the models to
         // the request.
         $page = $this->loadPage("instrument_list");
+        '@phan-var Instrument_List $page';
 
         $gets = $request->getQueryParams();
 

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -71,8 +71,8 @@ class Module extends \Module
         $commentID = $params['commentID'] ?? null;
         if (empty($commentID)) {
             return (new \Laminas\Diactoros\Response())
-                ->withBody(new \LORIS\Http\StringStream("Missing CommentID"))
-                ->withStatus(400);
+                ->withStatus(400)
+                ->withBody(new \LORIS\Http\StringStream("Missing CommentID"));
         }
         $instrument = \NDB_BVL_Instrument::factory(
             $instrumentName,

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -92,12 +92,12 @@ class Attachment extends \NDB_Page implements ETagCalculator
         $name = rawurldecode($result['file_name']);
 
         return (new \LORIS\Http\Response())
+            ->withStatus(200)
             ->withHeader('Content-Type', $result['mime_type'])
             ->withHeader(
                 'Content-Disposition',
                 'attachment; filename=' . basename($name)
             )
-            ->withStatus(200)
             ->withBody(new \LORIS\Http\FileStream($fileToDownload));
     }
 

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -68,8 +68,8 @@ class Attachment extends \NDB_Page implements ETagCalculator
         $result  = $DB->pselectRow($query, ['ID' => $ID]);
         if ($result === null) {
             return (new \LORIS\Http\Response())
-                ->withHeader('Content-Type', 'text/plain')
                 ->withStatus(404)
+                ->withHeader('Content-Type', 'text/plain')
                 ->withBody(new \LORIS\Http\StringStream("Not found"));
 
         }

--- a/modules/issue_tracker/php/issuewatchermapper.class.inc
+++ b/modules/issue_tracker/php/issuewatchermapper.class.inc
@@ -43,6 +43,8 @@ class IssueWatcherMapper implements Mapper
         \User $user,
         DataInstance $resource
     ) : DataInstance {
+        $res = $resource;
+        assert($res instanceof IssueRow);
 
         static $config = null;
         if ($config === null) {
@@ -61,8 +63,8 @@ class IssueWatcherMapper implements Mapper
 
         return new IssueRow(
             $newrow,
-            $resource->getCenterIDs(),
-            $resource->getModule()
+            $res->getCenterIDs(),
+            $res->getModule()
         );
     }
 }

--- a/modules/media/php/hidefilefilter.class.inc
+++ b/modules/media/php/hidefilefilter.class.inc
@@ -39,6 +39,14 @@ class HideFileFilter implements \LORIS\Data\Filter
      */
     public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
-        return $resource->getHideFile() !== self::HIDE;
+        // phan only understands method_exists on simple variables, not
+        // Assigning to a variable is the a workaround
+        // for false positive 'getCenterIDs doesn't exist errors suggested
+        // in https://github.com/phan/phan/issues/2628
+        $res = $resource;
+        '@phan-var object $res';
+
+        return method_exists($res, 'getHideFile')
+            && $res->getHideFile() !== self::HIDE;
     }
 }

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -171,11 +171,11 @@ class File_Upload
                 return false;
             }
 
-            if(!$f->isUploadedFile()) {
+            if (!$f->isUploadedFile()) {
                 return false;
             }
 
-            $this->file = $f;
+            $this->file     = $f;
             $this->fileInfo = $this->file->getValue();
             return true;
         } else {

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -165,16 +165,19 @@ class File_Upload
     function preProcessFile()
     {
         if (!$this->isCLImport) {
-            $this->file = $this->form->getElement($this->fieldName);
-            if (!method_exists($this->file, "isUploadedFile")) {
+            $f = $this->form->getElement($this->fieldName);
+
+            if (!($f instanceof LorisFormFileElement)) {
                 return false;
             }
-            if ($this->file->isUploadedFile()) {
-                $this->fileInfo = $this->file->getValue();
-                return true;
-            } else {
+
+            if(!$f->isUploadedFile()) {
                 return false;
             }
+
+            $this->file = $f;
+            $this->fileInfo = $this->file->getValue();
+            return true;
         } else {
             $this->file     =$this->CLFiles[$this->fieldName];
             $this->fileInfo =$this->file['info'];

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2479,7 +2479,8 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             // getAttribute only exists on the DOMElement type
             // (which extends DOMNode)
             if ($selectEl instanceof \DOMElement
-                && $selectEl->getAttribute("multiple") == 'multiple') {
+                && $selectEl->getAttribute("multiple") == 'multiple'
+            ) {
                 $element['Multiselect'] = true;
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2475,7 +2475,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
             $selectEl = $html->getElementsByTagName("select")->item(0);
 
-            if ($selectEl->getAttribute("multiple") == 'multiple') {
+            // getElementsByTagName returns DOMNodeList, but
+            // getAttribute only exists on the DOMElement type
+            // (which extends DOMNode)
+            if ($selectEl instanceof \DOMElement
+                && $selectEl->getAttribute("multiple") == 'multiple') {
                 $element['Multiselect'] = true;
             }
 

--- a/src/Data/Filters/PhantomsFilter.php
+++ b/src/Data/Filters/PhantomsFilter.php
@@ -37,7 +37,15 @@ class PhantomsFilter implements Filter
      */
     public function filter(\User $user, DataInstance $resource) : bool
     {
-        if (!$resource->isPhantom()) {
+        // phan only understands method_exists on simple variables, not
+        // Assigning to a variable is the a workaround
+        // for false positive 'getCenterIDs doesn't exist errors suggested
+        // in https://github.com/phan/phan/issues/2628
+        $res = $resource;
+
+        '@phan-var object $res';
+        if (method_exists($res, 'isPhantom')
+            && !$res->isPhantom()) {
             // This filter only have jurisdiction over phantom images.
             return true;
         }
@@ -45,8 +53,10 @@ class PhantomsFilter implements Filter
             return true;
         }
 
-        if ($user->hasPermission('imaging_browser_phantom_ownsite')) {
-            return $user->hasCenter($resource->getCenterID());
+        if (method_exists($res, 'getCenterID')
+            && $user->hasPermission('imaging_browser_phantom_ownsite')
+        ) {
+            return $user->hasCenter($res->getCenterID());
         }
 
         return false;

--- a/src/Data/Filters/ScansFilter.php
+++ b/src/Data/Filters/ScansFilter.php
@@ -37,7 +37,14 @@ class ScansFilter implements Filter
      */
     public function filter(\User $user, DataInstance $resource) : bool
     {
-        if ($resource->isPhantom()) {
+        // phan only understands method_exists on simple variables, not
+        // Assigning to a variable is the a workaround
+        // for false positive 'getCenterIDs doesn't exist errors suggested
+        // in https://github.com/phan/phan/issues/2628
+        $res = $resource;
+        '@phan-var object $res';
+
+        if (method_exists($res, 'isPhantom') && $res->isPhantom()) {
             // This filter only have jurisdiction over non-phantom images.
             return true;
         }
@@ -46,8 +53,10 @@ class ScansFilter implements Filter
             return true;
         }
 
-        if ($user->hasPermission('imaging_browser_view_site')) {
-            return $user->hasCenter($resource->getCenterID());
+        if (method_exists($res, 'getCenterID')
+            && $user->hasPermission('imaging_browser_view_site')
+        ) {
+            return $user->hasCenter($res->getCenterID());
         }
 
         return false;

--- a/src/Data/Filters/UserProjectMatch.php
+++ b/src/Data/Filters/UserProjectMatch.php
@@ -41,18 +41,25 @@ class UserProjectMatch implements \LORIS\Data\Filter
      */
     public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
-        if (method_exists($resource, 'getProjectIDs')) {
+        // phan only understands method_exists on simple variables, not
+        // Assigning to a variable is the a workaround
+        // for false positive 'getCenterIDs doesn't exist errors suggested
+        // in https://github.com/phan/phan/issues/2628
+        $res = $resource;
+        '@phan-var object $res';
+
+        if (method_exists($res, 'getProjectIDs')) {
             // If the Resource belongs to multiple ProjectIDs, the user can
             // access the data if the user is part of any of those projects.
-            $resourceProjects = $resource->getProjectIDs();
+            $resourceProjects = $res->getProjectIDs();
             foreach ($resourceProjects as $project) {
                 if ($user->hasProject($project)) {
                     return true;
                 }
             }
             return false;
-        } elseif (method_exists($resource, 'getProjectID')) {
-            $resourceProject = $resource->getProjectID();
+        } elseif (method_exists($res, 'getProjectID')) {
+            $resourceProject = $res->getProjectID();
             if (!is_null($resourceProject)) {
                 return $user->hasProject($resourceProject);
             }

--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -41,18 +41,25 @@ class UserSiteMatch implements \LORIS\Data\Filter
      */
     public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
-        if (method_exists($resource, 'getCenterIDs')) {
+        // phan only understands method_exists on simple variables, not 
+        // Assigning to a variable is the a workaround
+        // for false positive 'getCenterIDs doesn't exist errors suggested
+        // in https://github.com/phan/phan/issues/2628
+        $res = $resource;
+        '@phan-var object $res';
+
+        if (method_exists($res, 'getCenterIDs')) {
             // If the Resource belongs to multiple CenterIDs, the user can
             // access the data if the user is part of any of those centers.
-            $resourceSites = $resource->getCenterIDs();
+            $resourceSites = $res->getCenterIDs();
             foreach ($resourceSites as $site) {
                 if ($user->hasCenter($site)) {
                        return true;
                 }
             }
             return false;
-        } elseif (method_exists($resource, 'getCenterID')) {
-            $resourceSite = $resource->getCenterID();
+        } elseif (method_exists($res, 'getCenterID')) {
+            $resourceSite = $res->getCenterID();
             if (!is_null($resourceSite)) {
                 return $user->hasCenter($resourceSite);
             }

--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -41,7 +41,7 @@ class UserSiteMatch implements \LORIS\Data\Filter
      */
     public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
-        // phan only understands method_exists on simple variables, not 
+        // phan only understands method_exists on simple variables, not
         // Assigning to a variable is the a workaround
         // for false positive 'getCenterIDs doesn't exist errors suggested
         // in https://github.com/phan/phan/issues/2628

--- a/src/Middleware/ETag.php
+++ b/src/Middleware/ETag.php
@@ -68,6 +68,10 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
             }
         }
 
+        // This assertion is always true because of the function signature
+        // but is required because of
+        // https://github.com/phan/phan/issues/2129
+        assert($handler instanceof RequestHandlerInterface);
         // It either doesn't match or the client didn't send an ETag. In either
         // case, we calculate one and add it to the response header after calling
         // the handler.
@@ -79,6 +83,10 @@ class ETag implements MiddlewareInterface, MiddlewareChainer
         }
 
         if (empty($response->getHeaderLine('Etag'))) {
+            // Re-assert precondition of function to work around
+            // https://github.com/phan/phan/issues/2129
+            assert($handler instanceof ETagCalculator);
+
             // If a sub-endpoint already added a Etag, do not calculate ETag
             $response = $response->withHeader(
                 "ETag",

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -2250,6 +2250,7 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $form->expects($this->once())
             ->method('submitHTML');
+        '@phan-var \LorisForm $form';
 
         $testSubmit = $form->createSubmit("abc", "Hello", []);
         $form->renderElement($testSubmit);
@@ -2289,6 +2290,7 @@ class LorisForms_Test extends TestCase
             ->getMock();
         $f->expects($this->once())
             ->method('timeHTML');
+        '@phan-var \LorisForm $f';
 
         $testTime = $f->createElement(
             "time",

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -79,14 +79,15 @@ class NDB_BVL_Instrument_Test extends TestCase
         $s = $this->getMockBuilder(\State::class)
             ->addMethods(['getUsername','setProperty','getProperty','isLoggedIn'])
             ->getMock();
-        '@phan-var \State $s';
-        $this->session = $s;
 
         $spe = $this->getMockBuilder('SinglePointLogin')
             ->getMock();
 
-        $this->session->method("getProperty")
+        $s->method("getProperty")
             ->willReturn($spe);
+
+        '@phan-var \State $s';
+        $this->session = $s;
 
         '@phan-var \SinglePointLogin $spe';
         $this->mockSinglePointLogin = $spe;


### PR DESCRIPTION
This fixes all calls to undeclared methods caught by phan and removes the PhanUndeclaredMethod from the suppressed issue types.

The fixes are broadly classified into:
1. False positives caused by phan/phan#2628
2. False positives caused by phan/phan#2129
3. Mostly harmless positives caused by chaining withStatus on a PSR interface *after* a different call which lower the specificity from ResponseInterface to MessageInterface (because of which level of inheritance the method is defined on..)
4. Real positives

The first class of problems is fixed by putting the variable into a simple variable so that `@phan-var` annotations can be used on them to assert the type. These should eventually be removed when the above issue is solved.
The second class of problems by asserting the correct type before the calls
The third class is solved by re-ordering the method chaining
The fourth class is fixed, mostly by adding method_exists or instanceof checks where required.