### PR TITLE
[phan] Fix errors of type PhanTypeArraySuspiciousNullable

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -38,7 +38,6 @@ return [
         "PhanTypePossiblyInvalidDimOffset",
         "PhanUndeclaredMethod",
         "PhanTypeMismatchArgument",
-        "PhanTypeArraySuspiciousNullable",
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
@@ -157,6 +157,12 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         $data = json_decode((string) $request->getBody(), true);
 
+        if (!is_array($data)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'Invalid request'
+            );
+        }
+
         try {
 
             $requiredfields = [
@@ -217,6 +223,11 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'Invalid request'
+            );
+        }
 
         if (!$this->_instrument->validate($data)) {
             return new \LORIS\Http\Response\JSON\Forbidden(

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -164,6 +164,11 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'Invalid request'
+            );
+        }
 
         if (!$this->_instrument->validate($data)) {
             return new \LORIS\Http\Response\JSON\Forbidden(
@@ -200,6 +205,13 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
         }
 
         $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'Invalid request'
+            );
+        }
+
+
 
         if (!$this->_instrument->validate($data)) {
             return new \LORIS\Http\Response\JSON\Forbidden(

--- a/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/instrument.class.inc
@@ -211,8 +211,6 @@ class Instrument extends Endpoint implements \LORIS\Middleware\ETagCalculator
             );
         }
 
-
-
         if (!$this->_instrument->validate($data)) {
             return new \LORIS\Http\Response\JSON\Forbidden(
                 'Could not update.'

--- a/modules/api/php/endpoints/candidate/visit/qc.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/qc.class.inc
@@ -140,6 +140,11 @@ class Qc extends Endpoint implements \LORIS\Middleware\ETagCalculator
     private function _handlePUT(ServerRequestInterface $request): ResponseInterface
     {
         $data = json_decode((string) $request->getBody(), true);
+        if (!is_array($data)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'Invalid request'
+            );
+        }
 
         $requiredfields = [
             'Meta',

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -544,7 +544,7 @@ function getDODFields(): array
     if ($candidateData === null) {
         throw new \LorisException("Invalid candidate");
     }
-    $result        = [
+    $result = [
         'pscid'  => $candidateData['PSCID'],
         'candID' => $candID->__toString(),
         'dod'    => $candidateData['DoD'],

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -541,6 +541,9 @@ function getDODFields(): array
         'SELECT PSCID,DoD, DoB FROM candidate where CandID =:candid',
         ['candid' => $candID]
     );
+    if ($candidateData === null) {
+        throw new \LorisException("Invalid candidate");
+    }
     $result        = [
         'pscid'  => $candidateData['PSCID'],
         'candID' => $candID->__toString(),

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -159,6 +159,11 @@ class Timepoint extends \NDB_Page implements ETagCalculator
     {
         // Parse POST request body.
         $values = json_decode((string) $request->getBody(), true);
+        if (!is_array($values)) {
+            return new \LORIS\Http\Response\JSON\BadRequest(
+                'Invalid request'
+            );
+        }
 
         if (!$this->_verifyCreatePermissions($request, $values['identifier'])) {
             return new \LORIS\Http\Response\JSON\Forbidden(

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -51,6 +51,9 @@ class DICOMArchiveAnonymizer implements Mapper
         }
 
         $newrow = json_decode(json_encode($resource), true);
+        if(!is_array($newrow)) {
+            throw new \Exception("Error converting DataInstance to array");
+        }
         $cid    = $resource->getCenterID();
 
         // escape any forward slashes

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -51,10 +51,10 @@ class DICOMArchiveAnonymizer implements Mapper
         }
 
         $newrow = json_decode(json_encode($resource), true);
-        if(!is_array($newrow)) {
+        if (!is_array($newrow)) {
             throw new \Exception("Error converting DataInstance to array");
         }
-        $cid    = $resource->getCenterID();
+        $cid = $resource->getCenterID();
 
         // escape any forward slashes
         $pNameRegex      = preg_replace(

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -297,7 +297,11 @@ class Files extends \NDB_Page
         }
 
         // Do some validation and fail early on bad inputs.
-        $body         = $request->getParsedBody();
+        $body = $request->getParsedBody();
+        if (!is_array($body)) {
+            throw new \LorisException("Expected parsed body to be an array");
+        }
+
         $uploadedFile = $request->getUploadedFiles()['file'] ?? null;
         if (is_null($uploadedFile)) {
             return new \LORIS\Http\Response\JSON\BadRequest(

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -77,6 +77,9 @@ class UploadCategory extends \NDB_Page
     {
         $DB            = \Database::singleton();
         $req           = $request->getParsedBody();
+        if(!is_array($req)) {
+            throw new \LorisException("Invalid JSON");
+        }
         $category_name = $req['categoryName']; // required
         $parent_id     = isset($req['parentId']) ? $req['parentId'] : '0';
         $comments      = isset($req['comments']) ? $req['comments'] : null;

--- a/modules/document_repository/php/uploadcategory.class.inc
+++ b/modules/document_repository/php/uploadcategory.class.inc
@@ -75,9 +75,9 @@ class UploadCategory extends \NDB_Page
      */
     function uploadDocCategory($request): void
     {
-        $DB            = \Database::singleton();
-        $req           = $request->getParsedBody();
-        if(!is_array($req)) {
+        $DB  = \Database::singleton();
+        $req = $request->getParsedBody();
+        if (!is_array($req)) {
             throw new \LorisException("Invalid JSON");
         }
         $category_name = $req['categoryName']; // required

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -42,6 +42,7 @@ class Instrument_List_ControlPanel extends \TimePoint
      */
     function __construct($sessionID)
     {
+        $this->tpl_data = [];
         $this->select($sessionID);
     }
 
@@ -466,6 +467,10 @@ class Instrument_List_ControlPanel extends \TimePoint
                 $this->tpl_data['bvl_qc_type_'.$type]['icon']
                     = 'far fa-check-square';
             }
+
+            // ensure the variable checked is set the same way as in display()
+            $user =& \User::singleton();
+            $this->tpl_data['access']['bvl_qc'] = $user->hasPermission('bvl_feedback');
             //If a BVLQC status is not selected,
             // and this type is not already chosen, show the link.
             if (!$isSelected
@@ -501,6 +506,8 @@ class Instrument_List_ControlPanel extends \TimePoint
             }
             //If a BVLQC type is selected,
             // and this status is not already chosen, show the link.
+            $user =& \User::singleton();
+            $this->tpl_data['access']['bvl_qc'] = $user->hasPermission('bvl_feedback');
             if (!empty($qcType)
                 && !$isSelected
                 && $this->tpl_data['access']['bvl_qc']

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -470,7 +470,9 @@ class Instrument_List_ControlPanel extends \TimePoint
 
             // ensure the variable checked is set the same way as in display()
             $user =& \User::singleton();
-            $this->tpl_data['access']['bvl_qc'] = $user->hasPermission('bvl_feedback');
+            $this->tpl_data['access']['bvl_qc']
+                = $user->hasPermission('bvl_feedback');
+
             //If a BVLQC status is not selected,
             // and this type is not already chosen, show the link.
             if (!$isSelected
@@ -507,7 +509,8 @@ class Instrument_List_ControlPanel extends \TimePoint
             //If a BVLQC type is selected,
             // and this status is not already chosen, show the link.
             $user =& \User::singleton();
-            $this->tpl_data['access']['bvl_qc'] = $user->hasPermission('bvl_feedback');
+            $this->tpl_data['access']['bvl_qc']
+                = $user->hasPermission('bvl_feedback');
             if (!empty($qcType)
                 && !$isSelected
                 && $this->tpl_data['access']['bvl_qc']

--- a/modules/issue_tracker/php/attachment.class.inc
+++ b/modules/issue_tracker/php/attachment.class.inc
@@ -66,6 +66,13 @@ class Attachment extends \NDB_Page implements ETagCalculator
                     WHERE
                         ID = :ID';
         $result  = $DB->pselectRow($query, ['ID' => $ID]);
+        if ($result === null) {
+            return (new \LORIS\Http\Response())
+                ->withHeader('Content-Type', 'text/plain')
+                ->withStatus(404)
+                ->withBody(new \LORIS\Http\StringStream("Not found"));
+
+        }
 
         $factory = \NDB_Factory::singleton();
         $config  = $factory->config();

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -43,6 +43,9 @@ function editFile()
     // Read JSON from STDIN
     $stdin       = file_get_contents('php://input');
     $req         = json_decode($stdin, true);
+    if (!is_array($req)) {
+        throw new Exception("Invalid JSON");
+    }
     $idMediaFile = $req['idMediaFile'] ?? '';
 
     if (!$idMediaFile) {
@@ -289,9 +292,10 @@ function getUploadFields()
             $sessionData[$pscid]['instruments']['all'] = [];
         }
 
-        if ($record["Test_name"] !== null && !in_array(
+        if ($record["Test_name"] !== null
+            && !in_array(
             $record["Test_name"],
-            $sessionData[$pscid]['instruments'][$visit],
+            $sessionData[$pscid]['instruments'][$visit] ?? [],
             true
         )
         ) {

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -41,8 +41,8 @@ function editFile()
     }
 
     // Read JSON from STDIN
-    $stdin       = file_get_contents('php://input');
-    $req         = json_decode($stdin, true);
+    $stdin = file_get_contents('php://input');
+    $req   = json_decode($stdin, true);
     if (!is_array($req)) {
         throw new Exception("Invalid JSON");
     }
@@ -294,10 +294,10 @@ function getUploadFields()
 
         if ($record["Test_name"] !== null
             && !in_array(
-            $record["Test_name"],
-            $sessionData[$pscid]['instruments'][$visit] ?? [],
-            true
-        )
+                $record["Test_name"],
+                $sessionData[$pscid]['instruments'][$visit] ?? [],
+                true
+            )
         ) {
             $sessionData[$pscid]['instruments'][$visit][$record["Test_name"]]
                 = $record["Test_name"];

--- a/modules/statistics/php/statistics_mri_site.class.inc
+++ b/modules/statistics/php/statistics_mri_site.class.inc
@@ -223,7 +223,7 @@ class Statistics_Mri_Site extends Statistics_Site
 
             $test_url = $issue;
             foreach ($results as $row) {
-                if (!in_array($row['Visit_label'], $visits)) {
+                if (!in_array($row['Visit_label'] ?? [], $visits)) {
                     $visits[] = $row['Visit_label'];
                 }
                 $results[$row['Visit_label']][] = [

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -292,7 +292,7 @@ class Statistics_Site extends \NDB_Menu
                 $test_url = $instrument;
 
                 foreach ($results as $row) {
-                    if (!in_array($row['Visit_label'], $visits)) {
+                    if (!in_array($row['Visit_label'] ?? [], $visits)) {
                         $visits[] = $row['Visit_label'];
                     }
                     $arrayVar = [

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -115,6 +115,8 @@ class Stats_Demographic extends \NDB_Form
         $tpl_data['DropdownSelected'] = $dropdownSelected;
         $tpl_data['Centers']          = $centers ?? [];
 
+        $tpl_data['data'] = [];
+
         foreach ($data as $row) {
             $subproj = $row['SubprojectID'];
             $vl      = $row['VLabel'];

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -177,6 +177,7 @@ class Stats_MRI extends \NDB_Form
 
                 // Update the $subcat and total values for each element.
                 // Data
+                assert(is_array($tpl_data['data']));
                 $tpl_data['data'][$subcat] += $row['val'];
                 $tpl_data['data']['total'] += $row['val'];
                 // Data => Visit_Label

--- a/php/libraries/CouchDB.class.inc
+++ b/php/libraries/CouchDB.class.inc
@@ -562,9 +562,15 @@ class CouchDB
     {
         $getjson = $this->_getRelativeURL($id);
         $getdata = json_decode($getjson, true);
+        if (!is_array($getdata)) {
+            return false;
+        }
 
         $json = $this->_getRelativeURL($id . "?rev=" . $getdata['_rev'], "DELETE");
         $data = json_decode($json, true);
+        if (!is_array($data)) {
+            return false;
+        }
 
         if (!isset($data['ok'])) {
             return false;

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -38,7 +38,12 @@ class File_Upload
     public $isCLImport        = false;
     public $handlerArgs;
     public $file;
+
+    /**
+     * @var array
+     */
     public $fileInfo;
+
     public $fileHandlers;
     public $destinationDirectory;
     public $destinationFilename;

--- a/php/libraries/File_Upload.class.inc
+++ b/php/libraries/File_Upload.class.inc
@@ -40,6 +40,8 @@ class File_Upload
     public $file;
 
     /**
+     * The fileInfo in the format stored by $_FILES
+     *
      * @var array
      */
     public $fileInfo;

--- a/php/libraries/LorisForm.class.inc
+++ b/php/libraries/LorisForm.class.inc
@@ -2123,7 +2123,7 @@ class LorisForm
             }
 
             if ($el['type'] === 'time') {
-                $value = $this->getValue($name);
+                $value = $this->getValue($name) ?? [];
                 if (($value['H'] || $value['H'] === '0')
                     && ($value['i'] || $value['i'] === '0')
                 ) {

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2515,7 +2515,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * @return void (but side-effect modified $formArray to populate the element
      *         with the appropriate format needed for JSON serialization.)
      */
-    function _toJSONParsePageElement(array &$element, array &$formArray): void
+    function _toJSONParsePageElement(array $element, array &$formArray): void
     {
         $name = isset($element['name']) ? $element['name'] : '';
         if ($element['type'] === 'group') {
@@ -2605,8 +2605,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                     foreach ($section['elements'] as &$element) {
                         $this->_toJSONParsePageElement($element, $section);
                     }
-                } else {
-                    $this->_toJSONParsePageElement($element, $section);
                 }
             }
         }

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -52,10 +52,11 @@ class UserPermissions
         $query  = "SELECT ID FROM users WHERE UserID =:UName";
         $params = ['UName' => $username];
 
-        $this->userID = \Database::singleton()->pselectOne($query, $params);
-        if (empty($this->userID)) {
+        $userID = \Database::singleton()->pselectOne($query, $params);
+        if ($userID === null) {
             return false;
         }
+        $this->userID = $userID;
 
         // load the user's permissions
         $this->setPermissions();

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -125,6 +125,7 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
         }
         $json         = $this->i->toJSON();
         $outArray     = json_decode($json, true);
+        assert(is_array($outArray));
         $ExpectedMeta = [
             'InstrumentVersion'       => "1l",
             'InstrumentFormatVersion' => "v0.0.1a-dev",

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -123,8 +123,8 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
             // This can occur when no SessionID exists. It's not important
             // for this test.
         }
-        $json         = $this->i->toJSON();
-        $outArray     = json_decode($json, true);
+        $json     = $this->i->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $ExpectedMeta = [
             'InstrumentVersion'       => "1l",

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -143,6 +143,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     {
         $json         = $this->_instrument->toJSON();
         $outArray     = json_decode($json, true);
+        assert(is_array($outArray));
         $ExpectedMeta = [
             'InstrumentVersion'       => "1l",
             'InstrumentFormatVersion' => "v0.0.1a-dev",
@@ -186,6 +187,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json           = $this->_instrument->toJSON();
         $outArray       = json_decode($json, true);
+        assert(is_array($outArray));
         $selectElement  = $outArray['Elements'][0];
         $selectElement2 = $outArray['Elements'][1];
 
@@ -279,6 +281,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json            = $this->_instrument->toJSON();
         $outArray        = json_decode($json, true);
+        assert(is_array($outArray));
         $textElement     = $outArray['Elements'][0];
         $textareaElement = $outArray['Elements'][1];
 
@@ -343,6 +346,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json     = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
+        assert(is_array($outArray));
         $this->assertEquals(
             $outArray['Elements'][0],
             ['Type' => "Group", 'Error' => "Unimplemented"]
@@ -407,6 +411,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json     = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
+        assert(is_array($outArray));
         $this->assertEquals(
             $outArray['Elements'][0],
             ['Type' => "Group", 'Error' => "Unimplemented"]
@@ -508,6 +513,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json         = $this->_instrument->toJSON();
         $outArray     = json_decode($json, true);
+        assert(is_array($outArray));
         $dateElement  = $outArray['Elements'][0];
         $dateElement2 = $outArray['Elements'][1];
         $dateElement3 = $outArray['Elements'][2];
@@ -582,6 +588,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json     = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
+        assert(is_array($outArray));
         $this->assertEquals(
             $outArray['Elements'][0],
             ['Type' => "Group", 'Error' => "Unimplemented"]
@@ -654,6 +661,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->addNumericElement("TestElement", "Test Description");
         $json           = $this->_instrument->toJSON();
         $outArray       = json_decode($json, true);
+        assert(is_array($outArray));
         $numericElement = $outArray['Elements'][0];
 
         $this->assertEquals(
@@ -681,6 +689,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->addNumericElementRD("TestElement", "Test Description");
         $json           = $this->_instrument->toJSON();
         $outArray       = json_decode($json, true);
+        assert(is_array($outArray));
         $numericElement = $outArray['Elements'][0];
         $this->assertEquals(
             $numericElement,
@@ -757,6 +766,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json          = $this->_instrument->toJSON();
         $outArray      = json_decode($json, true);
+        assert(is_array($outArray));
         $scoreElement  = $outArray['Elements'][0];
         $scoreElement2 = $outArray['Elements'][1];
 
@@ -810,6 +820,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json           = $this->_instrument->toJSON();
         $outArray       = json_decode($json, true);
+        assert(is_array($outArray));
         $headerElement  = $outArray['Elements'][0];
         $headerElement2 = $outArray['Elements'][1];
 
@@ -850,6 +861,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->addLabel("I am a label");
         $json         = $this->_instrument->toJSON();
         $outArray     = json_decode($json, true);
+        assert(is_array($outArray));
         $labelElement = $outArray['Elements'][0];
 
         $this->assertEquals(
@@ -890,6 +902,7 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $json     = $i->toJSON();
         $outArray = json_decode($json, true);
+        assert(is_array($outArray));
         $page1    = $outArray['Elements'][0];
         $page2    = $outArray['Elements'][1];
         $this->assertEquals(
@@ -968,6 +981,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         $this->_instrument->addYesNoElement("field1", "label1");
         $json     = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
+        assert(is_array($outArray));
         $this->assertEquals(
             $outArray['Elements'][0],
             ['Type' => 'select',
@@ -1000,6 +1014,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         );
         $json     = $this->_instrument->toJSON();
         $outArray = json_decode($json, true);
+        assert(is_array($outArray));
         $this->assertEquals(
             $outArray['Elements'][0],
             ['Type' => 'select',

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -141,8 +141,8 @@ class NDB_BVL_Instrument_Test extends TestCase
      */
     function testMetaData()
     {
-        $json         = $this->_instrument->toJSON();
-        $outArray     = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $ExpectedMeta = [
             'InstrumentVersion'       => "1l",
@@ -185,8 +185,8 @@ class NDB_BVL_Instrument_Test extends TestCase
             $not_answered,
             ['multiple' => "multiple"]
         );
-        $json           = $this->_instrument->toJSON();
-        $outArray       = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $selectElement  = $outArray['Elements'][0];
         $selectElement2 = $outArray['Elements'][1];
@@ -279,8 +279,8 @@ class NDB_BVL_Instrument_Test extends TestCase
             "Field Description2 for Text",
             ["value" => "Option"]
         );
-        $json            = $this->_instrument->toJSON();
-        $outArray        = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $textElement     = $outArray['Elements'][0];
         $textareaElement = $outArray['Elements'][1];
@@ -511,8 +511,8 @@ class NDB_BVL_Instrument_Test extends TestCase
                 "addEmptyOption" => true,
             ]
         );
-        $json         = $this->_instrument->toJSON();
-        $outArray     = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $dateElement  = $outArray['Elements'][0];
         $dateElement2 = $outArray['Elements'][1];
@@ -659,8 +659,8 @@ class NDB_BVL_Instrument_Test extends TestCase
     function testNumericElement()
     {
         $this->_instrument->addNumericElement("TestElement", "Test Description");
-        $json           = $this->_instrument->toJSON();
-        $outArray       = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $numericElement = $outArray['Elements'][0];
 
@@ -687,8 +687,8 @@ class NDB_BVL_Instrument_Test extends TestCase
     function testNumericElementRD()
     {
         $this->_instrument->addNumericElementRD("TestElement", "Test Description");
-        $json           = $this->_instrument->toJSON();
-        $outArray       = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $numericElement = $outArray['Elements'][0];
         $this->assertEquals(
@@ -764,8 +764,8 @@ class NDB_BVL_Instrument_Test extends TestCase
             "FieldName2",
             "",
         );
-        $json          = $this->_instrument->toJSON();
-        $outArray      = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $scoreElement  = $outArray['Elements'][0];
         $scoreElement2 = $outArray['Elements'][1];
@@ -818,8 +818,8 @@ class NDB_BVL_Instrument_Test extends TestCase
             "Field Description",
             "45"
         );
-        $json           = $this->_instrument->toJSON();
-        $outArray       = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $headerElement  = $outArray['Elements'][0];
         $headerElement2 = $outArray['Elements'][1];
@@ -859,8 +859,8 @@ class NDB_BVL_Instrument_Test extends TestCase
     function testLabelElement()
     {
         $this->_instrument->addLabel("I am a label");
-        $json         = $this->_instrument->toJSON();
-        $outArray     = json_decode($json, true);
+        $json     = $this->_instrument->toJSON();
+        $outArray = json_decode($json, true);
         assert(is_array($outArray));
         $labelElement = $outArray['Elements'][0];
 
@@ -903,8 +903,8 @@ class NDB_BVL_Instrument_Test extends TestCase
         $json     = $i->toJSON();
         $outArray = json_decode($json, true);
         assert(is_array($outArray));
-        $page1    = $outArray['Elements'][0];
-        $page2    = $outArray['Elements'][1];
+        $page1 = $outArray['Elements'][0];
+        $page2 = $outArray['Elements'][1];
         $this->assertEquals(
             $page1,
             [


### PR DESCRIPTION
This fixes all errors from phan of type PhanTypeArraySuspiciousNullable. This catches situations where a variable or property may be null in some code paths, but the array is unconditionallly indexed as an array.