### PR TITLE
Fetch response status fix

### DIFF
--- a/modules/datadict/jsx/dataDictIndex.js
+++ b/modules/datadict/jsx/dataDictIndex.js
@@ -94,7 +94,7 @@ class DataDictIndex extends Component {
             method: 'POST',
             body: formData,
           }).then((response) => {
-            if (response.status !== 200) {
+            if (!response.ok) {
               console.error(response.status);
               return;
             }

--- a/modules/publication/jsx/projectFields.js
+++ b/modules/publication/jsx/projectFields.js
@@ -148,7 +148,7 @@ class ProjectFormFields extends React.Component {
           fetch(url, {
             method: 'DELETE',
           }).then((response) => {
-            if (response.status !== 200) {
+            if (!response.ok) {
               console.error(response.status);
               return;
             }

--- a/modules/publication/jsx/publicationIndex.js
+++ b/modules/publication/jsx/publicationIndex.js
@@ -42,7 +42,7 @@ class PublicationIndex extends React.Component {
       method: 'GET',
     }).then(
       (response) => {
-        if (response.status !== 200) {
+        if (!response.ok) {
           console.error(response.status);
           return;
         }

--- a/modules/publication/jsx/uploadForm.js
+++ b/modules/publication/jsx/uploadForm.js
@@ -40,7 +40,7 @@ class PublicationUploadForm extends React.Component {
     fetch(this.props.DataURL, {
       method: 'GET',
     }).then((response) => {
-      if (response.status !== 200) {
+      if (!response.ok) {
         console.error(response.status);
         return;
       }
@@ -163,7 +163,7 @@ class PublicationUploadForm extends React.Component {
       method: 'POST',
       body: formObj,
     }).then((response) => {
-      if (response.status !== 200) {
+      if (!response.ok) {
         console.error(response.status);
         return;
       }

--- a/modules/publication/jsx/viewProject.js
+++ b/modules/publication/jsx/viewProject.js
@@ -63,7 +63,7 @@ class ViewProject extends React.Component {
       method: 'POST',
       body: formObj,
     }).then((response) => {
-      if (response.status !== 200) {
+      if (!response.ok) {
         console.error(response.status);
         return;
       }
@@ -81,7 +81,7 @@ class ViewProject extends React.Component {
     fetch(this.props.DataURL, {
       method: 'GET',
     }).then((response) => {
-      if (response.status !== 200) {
+      if (!response.ok) {
         console.error(response.status);
         return;
       }


### PR DESCRIPTION
Previous fetch implementations (PR #7293, #7283) were assuming a response status of 200, which will produce problems if the status is in the range [200..299]. Such status still confirms that the request ran successfully.