### PR TITLE
PhanTypeMismatchArgument tests

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -36,7 +36,6 @@ return [
         "PhanUnusedVariable",
         "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
-        "PhanTypeMismatchArgument",
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -36,6 +36,7 @@ return [
         "PhanUnusedVariable",
         "PhanUnusedPublicNoOverrideMethodParameter",
         "PhanTypePossiblyInvalidDimOffset",
+        "PhanTypeMismatchArgument",
     ],
     "analyzed_file_extensions" => ["php", "inc"],
     "directory_list" => [

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -243,7 +243,7 @@ class Database
      * escaped to avoid injection.
      *
      * @param string               $table the table into which to insert the row
-     * @param array<string,string> $set   the values with which to fill the new row
+     * @param array<string,string|int> $set   the values with which to fill the new row
      *
      * @return void
      */
@@ -294,7 +294,7 @@ class Database
      * updated.
      *
      * @param string               $table the table into which to insert the row
-     * @param array<string,string> $set   the values with which to fill the row
+     * @param array<string,string|int> $set   the values with which to fill the row
      *
      * @return bool
      */
@@ -488,8 +488,8 @@ class Database
      * any HTML in the data being inserted for security.
      *
      * @param string               $table   the table into which to insert the row
-     * @param array<string,string> $set     the values with which to fill the new row
-     * @param array<string,string> $i_where the selection filter, joined as a
+     * @param array<string,string|int> $set     the values with which to fill the new row
+     * @param array<string,string|int> $i_where the selection filter, joined as a
      *                                      boolean and
      *
      * @return void
@@ -606,7 +606,7 @@ class Database
      * Deletes a single row in the specified table
      *
      * @param string               $table the table into which to insert the row
-     * @param array<string,string> $where the selection filter, joined as
+     * @param array<string,string|int> $where the selection filter, joined as
      *                                    a boolean and
      *
      * @return void
@@ -697,7 +697,7 @@ class Database
      *                                       or update prepared
      *                                       statements.
      *
-     * @return array<int,array<string,string>> An array of rows in the format
+     * @return array<int,array<string,string|int>> An array of rows in the format
      *                                  ColName => Value after
      *                                      executing the statement.
      */
@@ -1275,9 +1275,9 @@ class Database
      * without mocking every single query that needs to be used in
      * that test.
      *
-     * @param string                $tableName The table name to fake
-     * @param array<string, string> $rowData   An array of data to be inserted into
-     *                                         the fake table.
+     * @param string  $tableName The table name to fake
+     * @param array[] $rowData   An array of data to be inserted into
+     *                           the fake table.
      *
      * @return void
      */

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -242,8 +242,8 @@ class Database
      * This will insert a row. HTML from any field in the row will be automatically
      * escaped to avoid injection.
      *
-     * @param string               $table the table into which to insert the row
-     * @param array<string,string|int> $set   the values with which to fill the new row
+     * @param string              $table the table into which to insert the row
+     * @param array<string,mixed> $set   the values with which to fill the new row
      *
      * @return void
      */
@@ -259,8 +259,8 @@ class Database
      * automatically escaped. This should only be called when we know the source of
      * the input is trustworthy and must contain HTML.
      *
-     * @param string               $table the table into which to insert the row
-     * @param array<string,string> $set   the values with which to fill the new row
+     * @param string              $table the table into which to insert the row
+     * @param array<string,mixed> $set   the values with which to fill the new row
      *
      * @return void
      */
@@ -275,8 +275,8 @@ class Database
      * This will insert a row. HTML from any field in the row will be automatically
      * escaped to avoid injection.
      *
-     * @param string               $table the table into which to insert the row
-     * @param array<string,string> $set   the values with which to fill the new row
+     * @param string              $table the table into which to insert the row
+     * @param array<string,mixed> $set   the values with which to fill the new row
      *
      * @return void
      */
@@ -293,8 +293,8 @@ class Database
      * value for any unique key, the row where the duplicate is present will be
      * updated.
      *
-     * @param string               $table the table into which to insert the row
-     * @param array<string,string|int> $set   the values with which to fill the row
+     * @param string              $table the table into which to insert the row
+     * @param array<string,mixed> $set   the values with which to fill the row
      *
      * @return bool
      */
@@ -312,7 +312,7 @@ class Database
      * updated. HTML from any field in the row will *not* be automatically escaped.
      *
      * @param string               $table the table into which to insert the row
-     * @param array<string,string> $set   the values with which to fill the row
+     * @param array<string,mixed> $set   the values with which to fill the row
      *
      * @return bool
      */
@@ -333,9 +333,9 @@ class Database
      *
      * This function alone does not guarantee safety.
      *
-     * @param array<string,string> $set The array to be inserted as a new row
+     * @param array<string,mixed> $set The array to be inserted as a new row
      *
-     * @return array<string,string> A copy of $set with the HTML characters escaped
+     * @return array<string,mixed> A copy of $set with the HTML characters escaped
      */
     private function _HTMLEscapeArray(array $set): array
     {
@@ -360,9 +360,9 @@ class Database
      *
      * Inserts a single row into the specified table, containing the values specified
      *
-     * @param string               $table             the table into which to
+     * @param string              $table             the table into which to
      *                                                insert the row
-     * @param array<string,string> $set               the values with which to
+     * @param array<string,mixed> $set               the values with which to
      *                                                fill the new row
      * @param bool                 $autoescape        determines whether the
      *                                                values to be set
@@ -455,8 +455,8 @@ class Database
      * Replaces into the table such if there already exists a row with
      * the same primary key it will be replaced by the new row
      *
-     * @param string               $table the table into which to insert the row
-     * @param array<string,string> $set   the values with which to fill the new row
+     * @param string $table the table into which to insert the row
+     * @param array  $set   the values with which to fill the new row
      *
      * @return void
      * @access public
@@ -487,9 +487,9 @@ class Database
      * Updates a single row in the specified table. This will automatically escape
      * any HTML in the data being inserted for security.
      *
-     * @param string               $table   the table into which to insert the row
-     * @param array<string,string|int> $set     the values with which to fill the new row
-     * @param array<string,string|int> $i_where the selection filter, joined as a
+     * @param string              $table   the table into which to insert the row
+     * @param array<string,mixed> $set     the values with which to fill the new row
+     * @param array<string,mixed> $i_where the selection filter, joined as a
      *                                      boolean and
      *
      * @return void
@@ -507,9 +507,9 @@ class Database
      * insert HTML and know that you can trust it.
      *
      * @param string               $table   the table into which to insert the row
-     * @param array<string,string> $set     the values with which to fill the
+     * @param array<string,mixed> $set     the values with which to fill the
      *                                      new row
-     * @param array<string,string> $i_where the selection filter, joined as
+     * @param array<string,mixed> $i_where the selection filter, joined as
      *                                      a boolean and
      *
      * @return void
@@ -528,15 +528,15 @@ class Database
      *
      * Updates a single row in the specified table
      *
-     * @param string               $table      the table into which to insert
-     *                                         the row
-     * @param array<string,string> $set        the values with which to fill
-     *                                         the new row
-     * @param array<string,string> $i_where    the selection filter, joined as
-     *                                         a boolean and
-     * @param bool                 $autoescape determines whether the values to
-     *                                         be set should
-     *                                         automatically have the html escaped
+     * @param string              $table      the table into which to insert
+     *                                        the row
+     * @param array<string,mixed> $set        the values with which to fill
+     *                                        the new row
+     * @param array<string,mixed> $i_where    the selection filter, joined as
+     *                                        a boolean and
+     * @param bool                $autoescape determines whether the values to
+     *                                        be set should
+     *                                        automatically have the html escaped
      *
      * @return bool Always true. An exception should be thrown if something goes
      *              wrong. FIXME This should probably be void.
@@ -605,8 +605,8 @@ class Database
      *
      * Deletes a single row in the specified table
      *
-     * @param string               $table the table into which to insert the row
-     * @param array<string,string|int> $where the selection filter, joined as
+     * @param string              $table the table into which to insert the row
+     * @param array<string,mixed> $where the selection filter, joined as
      *                                    a boolean and
      *
      * @return void
@@ -687,17 +687,17 @@ class Database
      * Executes a previously prepared statements using the variable
      * bindings given.
      *
-     * @param PDOStatement         $prepared The prepared statement
-     * @param array<string,string> $params   The values to bind to the statement
-     *                                       while executing it
-     * @param array<string,string> $options  A list of key=>value pairs.
+     * @param PDOStatement $prepared The prepared statement
+     * @param array        $params   The values to bind to the statement
+     *                               while executing it
+     * @param array        $options  A list of key=>value pairs.
      *                                       - nofetch : to prevent the
      *                                       fetchAll function to be
      *                                       excuted. Useful for insert
      *                                       or update prepared
      *                                       statements.
      *
-     * @return array<int,array<string,string|int>> An array of rows in the format
+     * @return array<int,array<string,mixed>> An array of rows in the format
      *                                  ColName => Value after
      *                                      executing the statement.
      */
@@ -713,7 +713,7 @@ class Database
             throw new DatabaseException($err[2], $prepared->queryString, $params);
         }
 
-        if (!empty($options['nofetch']) && $options['nofetch'] == true) {
+        if (!empty($options['nofetch'])) {
             return [];
         }
 
@@ -730,9 +730,9 @@ class Database
     /**
      * Runs an SQL select statement as a prepared query
      *
-     * @param string               $query  The SQL SELECT query to be run
-     * @param array<string,string> $params Values to use for binding to the
-     *                                     prepared statement
+     * @param string              $query  The SQL SELECT query to be run
+     * @param array<string,mixed> $params Values to use for binding to the
+     *                                    prepared statement
      *
      * @return array<int,array<string,string>> An array of arrays containing
      *                                          the data.
@@ -751,12 +751,12 @@ class Database
      * Runs an SQL select statement as a prepared query and re-indexes
      * the results using the given unique non-nullable key.
      *
-     * @param string               $query     The SQL SELECT query to be run
-     * @param array<string,string> $params    Values to use for binding to the
-     *                                        prepared statement
-     * @param string               $uniqueKey Key to use when re-indexing, this
-     *                                        key must be a single column and
-     *                                        must be unique
+     * @param string              $query     The SQL SELECT query to be run
+     * @param array<string,mixed> $params    Values to use for binding to the
+     *                                       prepared statement
+     * @param string              $uniqueKey Key to use when re-indexing, this
+     *                                       key must be a single column and
+     *                                       must be unique
      *
      * @throws LorisException     If the supplied key is empty or null
      * @throws DatabaseException  If the key is not part of the query itself
@@ -828,11 +828,11 @@ class Database
      * associative array. Automatically adds a limit clause to the query being
      * run for efficiency.
      *
-     * @param string               $query  The SQL SELECT query to be run
-     * @param array<string,string> $params Values to use for binding to prepared
-     *                                     statement
+     * @param string              $query  The SQL SELECT query to be run
+     * @param array<string,mixed> $params Values to use for binding to prepared
+     *                                    statement
      *
-     * @return array<string,string>|null Associative array of form
+     * @return ?array<string,mixed> Associative array of form
      *                              ColumnName => Value for each column in the
      *                              first row of the query, or null.
      *

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1274,8 +1274,8 @@ class Database
      * without mocking every single query that needs to be used in
      * that test.
      *
-     * @param string                 $tableName The table name to fake
-     * @param array<string,string>[] $rowData   An array of data to be inserted
+     * @param string                $tableName The table name to fake
+     * @param array<string,mixed>[] $rowData   An array of data to be inserted
      *                                          into the fake table.
      *
      * @return void

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -311,7 +311,7 @@ class Database
      * value for any unique key, the row where the duplicate is present will be
      * updated. HTML from any field in the row will *not* be automatically escaped.
      *
-     * @param string               $table the table into which to insert the row
+     * @param string              $table the table into which to insert the row
      * @param array<string,mixed> $set   the values with which to fill the row
      *
      * @return bool
@@ -361,20 +361,20 @@ class Database
      * Inserts a single row into the specified table, containing the values specified
      *
      * @param string              $table             the table into which to
-     *                                                insert the row
+     *                                               insert the row
      * @param array<string,mixed> $set               the values with which to
-     *                                                fill the new row
-     * @param bool                 $autoescape        determines whether the
-     *                                                values to be set
-     *                                                should automatically
-     *                                                have the html escaped
-     * @param bool                 $ignore            determines whether the insert
-     *                                                throws an
-     *                                                error or is discarded
-     *                                                when value exists in DB
-     * @param bool                 $onDuplicateUpdate determines whether the row
-     *                                                should be updated
-     *                                                upon unique key duplication
+     *                                               fill the new row
+     * @param bool                $autoescape        determines whether the
+     *                                               values to be set
+     *                                               should automatically
+     *                                               have the html escaped
+     * @param bool                $ignore            determines whether the insert
+     *                                               throws an error or is
+     *                                               discarded when value exists
+     *                                               in DB
+     * @param bool                $onDuplicateUpdate determines whether the row
+     *                                               should be updated upon
+     *                                               unique key duplication
      *
      * @return bool
      */
@@ -455,8 +455,8 @@ class Database
      * Replaces into the table such if there already exists a row with
      * the same primary key it will be replaced by the new row
      *
-     * @param string $table the table into which to insert the row
-     * @param array  $set   the values with which to fill the new row
+     * @param string              $table the table into which to insert the row
+     * @param array<string,mixed> $set   the values with which to fill the new row
      *
      * @return void
      * @access public
@@ -490,7 +490,7 @@ class Database
      * @param string              $table   the table into which to insert the row
      * @param array<string,mixed> $set     the values with which to fill the new row
      * @param array<string,mixed> $i_where the selection filter, joined as a
-     *                                      boolean and
+     *                                     boolean and
      *
      * @return void
      */
@@ -506,11 +506,11 @@ class Database
      * escape and should be used with caution, only when you know you need to
      * insert HTML and know that you can trust it.
      *
-     * @param string               $table   the table into which to insert the row
+     * @param string              $table   the table into which to insert the row
      * @param array<string,mixed> $set     the values with which to fill the
-     *                                      new row
+     *                                     new row
      * @param array<string,mixed> $i_where the selection filter, joined as
-     *                                      a boolean and
+     *                                     a boolean and
      *
      * @return void
      */
@@ -607,7 +607,7 @@ class Database
      *
      * @param string              $table the table into which to insert the row
      * @param array<string,mixed> $where the selection filter, joined as
-     *                                    a boolean and
+     *                                   a boolean and
      *
      * @return void
      * @access public
@@ -687,15 +687,14 @@ class Database
      * Executes a previously prepared statements using the variable
      * bindings given.
      *
-     * @param PDOStatement $prepared The prepared statement
-     * @param array        $params   The values to bind to the statement
-     *                               while executing it
-     * @param array        $options  A list of key=>value pairs.
+     * @param PDOStatement         $prepared The prepared statement
+     * @param array<string,mixed>  $params   The values to bind to the statement
+     *                                       while executing it
+     * @param array<string,string> $options  A list of key=>value pairs.
      *                                       - nofetch : to prevent the
      *                                       fetchAll function to be
-     *                                       excuted. Useful for insert
-     *                                       or update prepared
-     *                                       statements.
+     *                                       executed. Useful for insert
+     *                                       or update prepared statements.
      *
      * @return array<int,array<string,mixed>> An array of rows in the format
      *                                  ColName => Value after
@@ -854,9 +853,9 @@ class Database
      * column given in the select statement. If multiple columns are given,
      * an error is thrown.
      *
-     * @param string               $query  The SQL SELECT query to be run
+     * @param string              $query  The SQL SELECT query to be run
      * @param array<string,mixed> $params Values to use for binding to prepared
-     *                                     statement
+     *                                    statement
      *
      * @throws DatabaseException if the query selected more than one column
      *
@@ -889,12 +888,12 @@ class Database
      * the results using the given unique non-nullable key in the same
      * format as the pselectCol() function.
      *
-     * @param string               $query     The SQL SELECT query to be run
+     * @param string              $query     The SQL SELECT query to be run
      * @param array<string,mixed> $params    Values to use for binding to the
-     *                                        prepared statement
-     * @param string               $uniqueKey Key to use when re-indexing, this
-     *                                        key must be a single column and
-     *                                        must be unique
+     *                                       prepared statement
+     * @param string              $uniqueKey Key to use when re-indexing, this
+     *                                       key must be a single column and
+     *                                       must be unique
      *
      * @throws LorisException     If the supplied key is empty or null
      * @throws DatabaseException  If the key is not part of the query itself or
@@ -972,9 +971,9 @@ class Database
      * value as a string. The calling code is responsible for doing the relevant
      * validation with respect to the type of the data returned.
      *
-     * @param string               $query  The SQL statement to run
+     * @param string              $query  The SQL statement to run
      * @param array<string,mixed> $params Values to use for binding in the
-     *                                     prepared statement
+     *                                    prepared statement
      *
      * @return ?string A single cell from the database.
      */
@@ -1275,9 +1274,9 @@ class Database
      * without mocking every single query that needs to be used in
      * that test.
      *
-     * @param string  $tableName The table name to fake
-     * @param array[] $rowData   An array of data to be inserted into
-     *                           the fake table.
+     * @param string                 $tableName The table name to fake
+     * @param array<string,string>[] $rowData   An array of data to be inserted
+     *                                          into the fake table.
      *
      * @return void
      */

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -855,7 +855,7 @@ class Database
      * an error is thrown.
      *
      * @param string               $query  The SQL SELECT query to be run
-     * @param array<string,string> $params Values to use for binding to prepared
+     * @param array<string,mixed> $params Values to use for binding to prepared
      *                                     statement
      *
      * @throws DatabaseException if the query selected more than one column
@@ -890,7 +890,7 @@ class Database
      * format as the pselectCol() function.
      *
      * @param string               $query     The SQL SELECT query to be run
-     * @param array<string,string> $params    Values to use for binding to the
+     * @param array<string,mixed> $params    Values to use for binding to the
      *                                        prepared statement
      * @param string               $uniqueKey Key to use when re-indexing, this
      *                                        key must be a single column and
@@ -973,7 +973,7 @@ class Database
      * validation with respect to the type of the data returned.
      *
      * @param string               $query  The SQL statement to run
-     * @param array<string,string> $params Values to use for binding in the
+     * @param array<string,mixed> $params Values to use for binding in the
      *                                     prepared statement
      *
      * @return ?string A single cell from the database.

--- a/php/libraries/Database.class.inc
+++ b/php/libraries/Database.class.inc
@@ -1276,7 +1276,7 @@ class Database
      *
      * @param string                $tableName The table name to fake
      * @param array<string,mixed>[] $rowData   An array of data to be inserted
-     *                                          into the fake table.
+     *                                         into the fake table.
      *
      * @return void
      */

--- a/php/libraries/Visit.class.inc
+++ b/php/libraries/Visit.class.inc
@@ -25,13 +25,6 @@ namespace LORIS;
 class Visit
 {
     /**
-     * The visit ID
-     *
-     * @var ?string
-     */
-    protected $id;
-
-    /**
      * The visit name (formely known as visit_label)
      *
      * @var ?string
@@ -46,10 +39,8 @@ class Visit
      */
     public function __construct(
         ?string $name = null,
-        ?string $id   = null
     ) {
         $this->name = $name;
-        $this->id   = $id;
     }
 
     /**

--- a/php/libraries/Visit.class.inc
+++ b/php/libraries/Visit.class.inc
@@ -37,7 +37,7 @@ class Visit
      * @param ?string $name The visit name
      */
     public function __construct(
-        ?string $name = null,
+        ?string $name = null
     ) {
         $this->name = $name;
     }

--- a/php/libraries/Visit.class.inc
+++ b/php/libraries/Visit.class.inc
@@ -35,7 +35,6 @@ class Visit
      * The contructor
      *
      * @param ?string $name The visit name
-     * @param ?string $id   The ID of the visit
      */
     public function __construct(
         ?string $name = null,

--- a/test/integrationtests/BatteryLookup_Test.php
+++ b/test/integrationtests/BatteryLookup_Test.php
@@ -212,7 +212,7 @@ class NDB_BVL_Battery_Test extends TestCase
             1,
             'Visit',
             'V01',
-            '1',
+            1,
             null
         );
 
@@ -236,7 +236,7 @@ class NDB_BVL_Battery_Test extends TestCase
     {
         $battery = new NDB_BVL_Battery();
 
-        $instruments = $battery->lookupBattery(50, 2, 'Visit', 'V01', '1', true);
+        $instruments = $battery->lookupBattery(50, 2, 'Visit', 'V01', 1, true);
 
         $this->assertEquals(
             $instruments,
@@ -262,7 +262,7 @@ class NDB_BVL_Battery_Test extends TestCase
             1,
             'Visit',
             'V01',
-            '2',
+            2,
             true
         );
         $instrumentsByVisit = $battery->lookupBattery(
@@ -270,7 +270,7 @@ class NDB_BVL_Battery_Test extends TestCase
             2,
             'Visit',
             'V01',
-            '2',
+            2,
             true
         );
 
@@ -305,7 +305,7 @@ class NDB_BVL_Battery_Test extends TestCase
             1,
             'Visit',
             'V01',
-            '1',
+            1,
             true
         );
 
@@ -323,7 +323,7 @@ class NDB_BVL_Battery_Test extends TestCase
             1,
             'Visit',
             'V01',
-            '1',
+            1,
             false
         );
 

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -74,7 +74,7 @@ abstract class LorisIntegrationTest extends TestCase
             $database['username'],
             $database['password'],
             $database['host'],
-            1
+            true,
         );
 
         $this->factory->setDatabase($this->DB);

--- a/test/integrationtests/LorisIntegrationTest.class.inc
+++ b/test/integrationtests/LorisIntegrationTest.class.inc
@@ -301,7 +301,7 @@ abstract class LorisIntegrationTest extends TestCase
             $this->DB->execute(
                 $prepare,
                 ["perm" => $value],
-                ['nofetch' => true]
+                ['nofetch' => "true"]
             );
         }
     }

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -141,8 +141,7 @@ class CandidateTest extends TestCase
         $this->_configMock = $configMock;
         $this->_dbMock     = $dbMock;
 
-        $this->_factory    = NDB_Factory::singleton();
-
+        $this->_factory = NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);
         $this->_factory->setDatabase($this->_dbMock);
 

--- a/test/unittests/CandidateTest.php
+++ b/test/unittests/CandidateTest.php
@@ -132,8 +132,15 @@ class CandidateTest extends TestCase
             ]
         ];
 
-        $this->_configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        $dbMock     = $this->getMockBuilder('Database')->getMock();
+
+        '@phan-var \NDB_Config $configMock';
+        '@phan-var \Database $dbMock';
+
+        $this->_configMock = $configMock;
+        $this->_dbMock     = $dbMock;
+
         $this->_factory    = NDB_Factory::singleton();
 
         $this->_factory->setConfig($this->_configMock);
@@ -885,7 +892,7 @@ class CandidateTest extends TestCase
 
         $this->assertFalse(
             Candidate::candidateExists(
-                new CandID(123123),
+                new CandID("123123"),
                 'Test'
             )
         );
@@ -1147,6 +1154,7 @@ class CandidateTest extends TestCase
             ->willReturn([1, 2]);
         $user->expects($this->once())->method("getProjectIDs")
             ->willReturn([new \ProjectID("1"), new \ProjectID("3")]);
+        '@phan-var \User $user';
 
         $result = $this->_candidate->isAccessibleBy($user);
         $this->assertTrue($result);
@@ -1170,6 +1178,7 @@ class CandidateTest extends TestCase
             ->willReturn([1, 2]);
         $user->expects($this->atLeastOnce())->method("getProjectIDs")
             ->willReturn([new \ProjectID("2"), new \ProjectID("3")]);
+        '@phan-var \User $user';
 
         $result = $this->_candidate->isAccessibleBy($user);
         $this->assertFalse($result);
@@ -1193,6 +1202,8 @@ class CandidateTest extends TestCase
             ->willReturn([1, 3]);
         $user->expects($this->atLeastOnce())->method("getProjectIDs")
             ->willReturn([new \ProjectID("1"), new \ProjectID("3")]);
+
+        '@phan-var \User $user';
 
         $result = $this->_candidate->isAccessibleBy($user);
         $this->assertFalse($result);
@@ -1318,7 +1329,7 @@ class CandidateTest extends TestCase
             $database['username'],
             $database['password'],
             $database['host'],
-            1
+            true
         );
 
         $this->_factoryForDB->setDatabase($this->_DB);

--- a/test/unittests/Database_Test.php
+++ b/test/unittests/Database_Test.php
@@ -98,7 +98,7 @@ class Database_Test extends TestCase
             $database['username'],
             $database['password'],
             $database['host'],
-            1
+            true,
         );
 
         $this->factory->setDatabase($this->DB);
@@ -627,18 +627,18 @@ class Database_Test extends TestCase
         $this->DB->replace(
             "ConfigSettings",
             [
-                'ID'          => 99991,
+                'ID'          => '99991',
                 'Name'        => 'test 1',
-                'Visible'     => 1,
+                'Visible'     => '1',
                 'Description' => null
             ]
         );
         $this->DB->replace(
             "ConfigSettings",
             [
-                'ID'          => 99992,
+                'ID'          => '99992',
                 'Name'        => 'test 2',
-                'Visible'     =>  1,
+                'Visible'     =>  '1',
                 'Description' => null
             ]
         );
@@ -1013,7 +1013,7 @@ class Database_Test extends TestCase
         $allSetting = $this->DB->execute(
             $statement,
             [':id' => 99991, ':name' => 'new name'],
-            ['nofetch' => true]
+            ['nofetch' => "true"]
         );
         $check      = $this->DB->pselect(
             "SELECT ID, Name, Description, Visible FROM ConfigSettings",

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -1867,9 +1867,10 @@ class LorisForms_Test extends TestCase
      */
     function testAddFormRule()
     {
-        $this->form->addFormRule([$this->form, 'validate']);
+        $callback = [$this->form, 'validate'];
+        $this->form->addFormRule($callback);
         $this->assertEquals(
-            $this->form->validate(),
+            $callback,
             $this->form->formRules[0]
         );
     }

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -94,9 +94,9 @@ class LorisForms_Test extends TestCase
      * Custom assertion to assert that some attribute of an element
      * is correct
      *
-     * @param string       $el          The element name
-     * @param string       $attribute   The attribute name to assert
-     *                                  (ie class, id, value, etc)
+     * @param string               $el          The element name
+     * @param string               $attribute   The attribute name to assert
+     *                                          (ie class, id, value, etc)
      * @param string|array|boolean $attribValue The expected content of the
      *                                          attribute
      *

--- a/test/unittests/LorisForms_Test.php
+++ b/test/unittests/LorisForms_Test.php
@@ -97,7 +97,8 @@ class LorisForms_Test extends TestCase
      * @param string       $el          The element name
      * @param string       $attribute   The attribute name to assert
      *                                  (ie class, id, value, etc)
-     * @param string|array $attribValue The expected content of the attribute
+     * @param string|array|boolean $attribValue The expected content of the
+     *                                          attribute
      *
      * @return void but makes assertions
      */
@@ -1762,18 +1763,6 @@ class LorisForms_Test extends TestCase
     }
 
     /**
-     * Test that addRule throws a LorisException if the element name is not a string
-     *
-     * @covers LorisForm::addRule
-     * @return void
-     */
-    function testAddRuleIfElementNameNotString()
-    {
-        $this->expectException('\LorisException');
-        $this->form->addRule(0, "Message", "required");
-    }
-
-    /**
      * Test that addRule throws a LorisException if the element
      * is not set in the form
      *
@@ -1878,7 +1867,7 @@ class LorisForms_Test extends TestCase
      */
     function testAddFormRule()
     {
-        $this->form->addFormRule($this->form->validate());
+        $this->form->addFormRule([$this->form, 'validate']);
         $this->assertEquals(
             $this->form->validate(),
             $this->form->formRules[0]

--- a/test/unittests/NDB_BVL_FeedbackTest.php
+++ b/test/unittests/NDB_BVL_FeedbackTest.php
@@ -31,7 +31,7 @@ class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
      */
     private $_feedbackObj;
 
-    private $_sessionID = 11;
+    private $_sessionID;
 
 
     /**
@@ -43,6 +43,9 @@ class NDB_BVL_FeedbackTest extends Loris_PHPUnit_Database_TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->_sessionID = new \SessionID("11");
+
         $this->createLorisDBConnection();
         $this->_feedbackObj = NDB_BVL_Feedback::singleton(
             "karo_test",

--- a/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_LINST_ToJSON_Test.php
@@ -65,11 +65,15 @@ class NDB_BVL_Instrument_LINST_ToJSON_Test extends TestCase
         $mockdb     = $this->getMockBuilder("\Database")->getMock();
         $mockconfig = $this->getMockBuilder("\NDB_Config")->getMock();
 
-        $factory->setDatabase($mockdb);
-        $factory->setConfig($mockconfig);
         $mockdb->expects($this->any())
             ->method('pselectOne')
             ->willReturn('999');
+
+        '@phan-var \Database $mockdb';
+        '@phan-var \NDB_Config $mockconfig';
+
+        $factory->setDatabase($mockdb);
+        $factory->setConfig($mockconfig);
 
         $this->Client = new \NDB_Client;
         $this->Client->makeCommandLine();

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -40,6 +40,12 @@ class NDB_BVL_Instrument_Test extends TestCase
 
     private $_factory;
     private $_mockConfig;
+
+    /**
+     * Mock for testing database calls
+     *
+     * @var \Database | \PHPUnit\Framework\MockObject\MockObject
+     */
     private $_mockDB;
 
     private $_factoryForDB;
@@ -98,8 +104,14 @@ class NDB_BVL_Instrument_Test extends TestCase
 
         $this->_factory = \NDB_Factory::singleton();
 
-        $this->_mockDB     = $this->getMockBuilder("\Database")->getMock();
-        $this->_mockConfig = $this->getMockBuilder("\NDB_Config")->getMock();
+        $mockDB     = $this->getMockBuilder("\Database")->getMock();
+        $mockConfig = $this->getMockBuilder("\NDB_Config")->getMock();
+
+        '@phan-var \Database $mockDB';
+        '@phan-var \NDB_Config $mockConfig';
+
+        $this->_mockDB     = $mockDB;
+        $this->_mockConfig = $mockConfig;
 
         $this->_factory->setDatabase($this->_mockDB);
         $this->_factory->setConfig($this->_mockConfig);
@@ -1060,6 +1072,7 @@ class NDB_BVL_Instrument_Test extends TestCase
     function testGetSessionID()
     {
         $this->_instrument->commentID = 'commentID1';
+
         $this->_mockDB->expects($this->once())->method('pselectOne')
             ->with(
                 "SELECT SessionID FROM flag WHERE CommentID = :CID",
@@ -2002,7 +2015,7 @@ class NDB_BVL_Instrument_Test extends TestCase
             $database['username'],
             $database['password'],
             $database['host'],
-            1
+            true,
         );
 
         $this->_factoryForDB->setDatabase($this->_DB);

--- a/test/unittests/NDB_BVL_Instrument_Test.php
+++ b/test/unittests/NDB_BVL_Instrument_Test.php
@@ -83,7 +83,7 @@ class NDB_BVL_Instrument_Test extends TestCase
         date_default_timezone_set("UTC");
 
         $s = $this->getMockBuilder(\State::class)
-            ->addMethods(['getUsername','setProperty','getProperty','isLoggedIn'])
+            ->onlyMethods(['getUsername','setProperty','getProperty','isLoggedIn'])
             ->getMock();
 
         $spe = $this->getMockBuilder('SinglePointLogin')

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -95,7 +95,7 @@ class NDB_ConfigTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->_config     = FakeConfig::singleton();
+        $this->_config = FakeConfig::singleton();
 
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
         $dbMock     = $this->getMockBuilder('Database')->getMock();

--- a/test/unittests/NDB_ConfigTest.php
+++ b/test/unittests/NDB_ConfigTest.php
@@ -11,7 +11,7 @@
  * @link     https://www.github.com/aces/Loris/
  */
 use PHPUnit\Framework\TestCase;
-use \LORIS\Installer\Database as Database;
+
 /**
  * Fake NDB_Config class
  *
@@ -61,7 +61,7 @@ class NDB_ConfigTest extends TestCase
     /**
      * Test double for Database object
      *
-     * @var Database | PHPUnit\Framework\MockObject\MockObject
+     * @var \Database | PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
 
@@ -96,10 +96,20 @@ class NDB_ConfigTest extends TestCase
     {
         parent::setUp();
         $this->_config     = FakeConfig::singleton();
-        $this->_configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
-        $this->_user       = $this->getMockBuilder('User')->getMock();
-        $this->_factory    = \NDB_Factory::singleton();
+
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        $dbMock     = $this->getMockBuilder('Database')->getMock();
+        $user       = $this->getMockBuilder('User')->getMock();
+
+        '@phan-var \NDB_Config $configMock';
+        '@phan-var \Database $dbMock';
+        '@phan-var \User $user';
+
+        $this->_configMock = $configMock;
+        $this->_dbMock     = $dbMock;
+        $this->_user       = $user;
+
+        $this->_factory = \NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);
         $this->_factory->setDatabase($this->_dbMock);
         $this->_factory->setUser($this->_user);

--- a/test/unittests/NDB_Factory_Test.php
+++ b/test/unittests/NDB_Factory_Test.php
@@ -235,10 +235,13 @@ class NDB_Factory_Test extends TestCase
     function testCandidate()
     {
         $mockdb = $this->getMockBuilder("\Database")->getMock();
-        $this->_factory->setDatabase($mockdb);
         $mockdb->expects($this->any())
             ->method('pselectRow')
             ->willReturn(['DCCID'=>'300001', 'RegistrationProjectID' => '1']);
+
+        '@phan-var \Database $mockdb';
+
+        $this->_factory->setDatabase($mockdb);
 
         $candID = new CandID("300001");
         $this->assertEquals(
@@ -258,11 +261,16 @@ class NDB_Factory_Test extends TestCase
     {
         $mockdb     = $this->getMockBuilder("\Database")->getMock();
         $mockconfig = $this->getMockBuilder("\NDB_Config")->getMock();
-        $this->_factory->setConfig($mockconfig);
-        $this->_factory->setDatabase($mockdb);
+
         $mockdb->expects($this->any())
             ->method('pselectRow')
             ->willReturn(['SessionID' => '1', 'ProjectID' => '1']);
+
+        '@phan-var \NDB_Config $mockconfig';
+        '@phan-var \Database $mockdb';
+
+        $this->_factory->setConfig($mockconfig);
+        $this->_factory->setDatabase($mockdb);
 
         $sessionID = new \SessionID("1");
         $this->assertEquals(

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -678,7 +678,8 @@ class NDB_PageTest extends TestCase
     {
         $this->markTestIncomplete("This test is incomplete!");
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $factory    = NDB_Factory::singleton();
+        '@phan-var \NDB_Config $configMock';
+        $factory = NDB_Factory::singleton();
         $factory->setConfig($configMock);
         $smarty = $this->getMockBuilder(Smarty_NeuroDB::class)
             ->disableOriginalConstructor()
@@ -724,6 +725,7 @@ class NDB_PageTest extends TestCase
     public function testHasAccess()
     {
         $user = $this->getMockBuilder('\User')->getMock();
+        '@phan-var \User $user';
         $this->assertTrue($this->_page->_hasAccess($user));
     }
 
@@ -779,7 +781,9 @@ class NDB_PageTest extends TestCase
     public function testGetJSDependencies()
     {
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $factory    = NDB_Factory::singleton();
+        '@phan-var \NDB_Config $configMock';
+
+        $factory = NDB_Factory::singleton();
         $factory->setConfig($configMock);
         $this->assertEquals(
             [
@@ -812,7 +816,9 @@ class NDB_PageTest extends TestCase
     public function testGetCSSDependencies()
     {
         $configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $factory    = NDB_Factory::singleton();
+        '@phan-var \NDB_Config $configMock';
+
+        $factory = NDB_Factory::singleton();
         $factory->setConfig($configMock);
         $this->assertEquals(
             [

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -59,8 +59,13 @@ class PasswordTest extends TestCase
     {
         parent::setUp();
 
-        $this->_configMock = $this->getMockBuilder('NDB_Config')->getMock();
-        $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        $dbMock     = $this->getMockBuilder('Database')->getMock();
+        '@phan-var \NDB_Config $configMock';
+        '@phan-var \Database $dbMock';
+
+        $this->_configMock = $configMock;
+        $this->_dbMock = $dbMock;
 
         $this->_factory = NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);

--- a/test/unittests/PasswordTest.php
+++ b/test/unittests/PasswordTest.php
@@ -65,7 +65,7 @@ class PasswordTest extends TestCase
         '@phan-var \Database $dbMock';
 
         $this->_configMock = $configMock;
-        $this->_dbMock = $dbMock;
+        $this->_dbMock     = $dbMock;
 
         $this->_factory = NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);

--- a/test/unittests/SettingsTest.php
+++ b/test/unittests/SettingsTest.php
@@ -58,7 +58,9 @@ class SettingsTest extends TestCase
     {
         parent::setUp();
 
-        $this->_configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        '@phan-var \NDB_Config $configMock';
+        $this->_configMock = $configMock;
 
         $this->_settings = new Settings($this->_configMock);
 

--- a/test/unittests/SinglePointLoginTest.php
+++ b/test/unittests/SinglePointLoginTest.php
@@ -60,6 +60,9 @@ class SinglePointLoginTest extends TestCase
 
          $mockconfig->method('getSetting')
              ->will($this->returnValueMap($this->_configMap));
+
+        '@phan-var \Database $mockdb';
+        '@phan-var \NDB_Config $mockconfig';
         $Factory->setConfig($mockconfig);
         $Factory->setDatabase($mockdb);
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -274,8 +274,9 @@ class UserTest extends TestCase
             true
         );
 
-        $mockconfig  = $this->getMockBuilder('NDB_Config')->getMock();
-        $mockdb      = $this->getMockBuilder('Database')->getMock();
+        $mockconfig = $this->getMockBuilder('NDB_Config')->getMock();
+        $mockdb     = $this->getMockBuilder('Database')->getMock();
+
         '@phan-var \Database $mockdb';
         '@phan-var \NDB_Config $mockconfig';
 

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -215,14 +215,14 @@ class UserTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
+     * @var \NDB_Config&PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
     private $_mockConfig;
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnit\Framework\MockObject\MockObject
+     * @var \Database&PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
     /**
@@ -274,10 +274,16 @@ class UserTest extends TestCase
             true
         );
 
-        $this->_mockConfig  = $this->getMockBuilder('NDB_Config')->getMock();
-        $this->_mockDB      = $this->getMockBuilder('Database')->getMock();
+        $mockconfig  = $this->getMockBuilder('NDB_Config')->getMock();
+        $mockdb      = $this->getMockBuilder('Database')->getMock();
+        '@phan-var \Database $mockdb';
+        '@phan-var \NDB_Config $mockconfig';
+
+        $this->_mockDB      = $mockdb;
+        $this->_mockConfig  = $mockconfig;
         $this->_mockFactory = \NDB_Factory::singleton();
-        $this->_mockFactory->setDatabase($this->_mockDB);
+        $this->_mockFactory->setDatabase($mockdb);
+
         $this->_factory->setConfig($this->_mockConfig);
 
         $this->_userInfoComplete       = $this->_userInfo;
@@ -646,7 +652,9 @@ class UserTest extends TestCase
         $passwordExpired = true;
 
         // Cause usePwnedPasswordsAPI config option to return false.
-        $this->_mockConfig->expects($this->any())
+        $mockConfig = &$this->_mockConfig;
+        '@phan-var \PHPUnit\Framework\MockObject\MockObject $mockConfig';
+        $mockConfig->expects($this->any())
             ->method('settingEnabled')
             ->willReturn(false);
 
@@ -836,6 +844,7 @@ class UserTest extends TestCase
             ->willReturn([1, 2]);
         $mockUser->expects($this->once())->method("getProjectIDs")
             ->willReturn([1, 3]);
+        '@phan-var \User $mockUser';
         $this->assertTrue($this->_user->isAccessibleBy($mockUser));
     }
 
@@ -854,6 +863,8 @@ class UserTest extends TestCase
             ->willReturn([2, 2]);
         $mockUser->expects($this->once())->method("getProjectIDs")
             ->willReturn([4, 4]);
+        '@phan-var \User $mockUser';
+
         $this->assertFalse($this->_user->isAccessibleBy($mockUser));
     }
 

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -124,7 +124,7 @@ class UtilityTest extends TestCase
     /**
      * Test double for NDB_Config object
      *
-     * @var \NDB_Config | PHPUnit\Framework\MockObject\MockObject
+     * @var \NDB_Config&PHPUnit\Framework\MockObject\MockObject
      */
     private $_configMock;
     /**
@@ -168,7 +168,9 @@ class UtilityTest extends TestCase
     {
         parent::setUp();
 
-        $this->_configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        $configMock = $this->getMockBuilder('NDB_Config')->getMock();
+        '@phan-var \NDB_Config $configMock';
+        $this->_configMock = $configMock;
         $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
 
         $mock = $this->_dbMock;

--- a/test/unittests/UtilityTest.php
+++ b/test/unittests/UtilityTest.php
@@ -130,7 +130,7 @@ class UtilityTest extends TestCase
     /**
      * Test double for Database object
      *
-     * @var \Database | PHPUnit\Framework\MockObject\MockObject
+     * @var \Database&PHPUnit\Framework\MockObject\MockObject
      */
     private $_dbMock;
 
@@ -171,9 +171,12 @@ class UtilityTest extends TestCase
         $this->_configMock = $this->getMockBuilder('NDB_Config')->getMock();
         $this->_dbMock     = $this->getMockBuilder('Database')->getMock();
 
+        $mock = $this->_dbMock;
+        '@phan-var \Database $mock';
+
         $this->_factory = NDB_Factory::singleton();
         $this->_factory->setConfig($this->_configMock);
-        $this->_factory->setDatabase($this->_dbMock);
+        $this->_factory->setDatabase($mock);
     }
 
     /**
@@ -1141,6 +1144,8 @@ class UtilityTest extends TestCase
         $config->expects($this->any())
             ->method('getSetting')
             ->willReturn('Y-m-d H:i:s');
+        '@phan-var \NDB_Config $config';
+
         $this->_mockFactory->setConfig($config);
 
         $date = "2000-01-01";

--- a/test/unittests/VisitTest.php
+++ b/test/unittests/VisitTest.php
@@ -62,19 +62,19 @@ class VisitTest extends TestCase
             $database['username'],
             $database['password'],
             $database['host'],
-            1
+            true,
         );
         $this->visitController = new \Loris\VisitController($this->DB);
 
-        $v1 = new \Loris\Visit('V1', 1);
-        $v2 = new \Loris\Visit('V2', 2);
-        $v3 = new \Loris\Visit('V3', 3);
-        $v4 = new \Loris\Visit('V4', 4);
-        $v5 = new \Loris\Visit('V5', 5);
-        $v6 = new \Loris\Visit('V6', 6);
-        $v7 = new \Loris\Visit('Living_Phantom_DCC_SD_3t2', 7);
-        $v8 = new \Loris\Visit('Living_Phantom_DCC_SD_3dwi', 8);
-        $v9 = new \Loris\Visit('Living_Phantom_DCC_SD_3mprage', 9);
+        $v1 = new \Loris\Visit('V1');
+        $v2 = new \Loris\Visit('V2');
+        $v3 = new \Loris\Visit('V3');
+        $v4 = new \Loris\Visit('V4');
+        $v5 = new \Loris\Visit('V5');
+        $v6 = new \Loris\Visit('V6');
+        $v7 = new \Loris\Visit('Living_Phantom_DCC_SD_3t2');
+        $v8 = new \Loris\Visit('Living_Phantom_DCC_SD_3dwi');
+        $v9 = new \Loris\Visit('Living_Phantom_DCC_SD_3mprage');
 
         $this->listOfVisit = [
             $v1,
@@ -174,7 +174,7 @@ class VisitTest extends TestCase
      */
     function testGetVisitsByName()
     {
-        $visit_result = new \Loris\Visit('V1', 1);
+        $visit_result = new \Loris\Visit('V1');
         $visits       = $this->visitController->getVisitsByName("V1");
         $this->assertEquals(
             [$visit_result],

--- a/test/unittests/studyentities/CandID_Test.php
+++ b/test/unittests/studyentities/CandID_Test.php
@@ -72,7 +72,7 @@ class CandID_Test extends TestCase
      */
     public function testGetType(): void
     {
-        $candid = new CandID(123456);
+        $candid = new CandID("123456");
         $this->assertEquals('CandID', $candid->getType());
     }
 
@@ -83,7 +83,7 @@ class CandID_Test extends TestCase
      */
     public function testToString(): void
     {
-        $candid = new CandID(123456);
+        $candid = new CandID("123456");
         $this->assertEquals('123456', (string) $candid);
     }
 }


### PR DESCRIPTION
This fixes all the PhanTypeMismatchArguments in the tests directory. These are primarily caused by either phan not understanding that PHPUnit mocks should be compatible with the underlying type or incorrect phpdoc comment.

Mismatches outside of the test directory are not yet fixed.

#### Testing instructions (if applicable)

1. Unignore PhanTypeMismatchArgument in `.phan/config.php` and ensure that there are no errors in the tests directory.