### PR TITLE
[error_log] cleanup error pollution when 404 on php8

### DIFF
--- a/smarty/templates/404.tpl
+++ b/smarty/templates/404.tpl
@@ -1,9 +1,9 @@
 <div class="container">
     <h2>404: Not Found</h2>
     <h3>{$message}</h3>
-    <div><a href="{$baseurl}">Go to main page</a>{if $canReport}or <a href="{$issueTrackerURL}">report an issue</a>{/if}.
+    <div><a href="{$baseurl|default}">Go to main page</a>{if $canReport|default}or <a href="{$issueTrackerURL}">report an issue</a>{/if}.
 
-    {if $contact}
-    If you have any questions, please <a href="mailto:{$contact}">contact your project administrator.</a></div>
+    {if $contact|default}
+    If you have any questions, please <a href="mailto:{$contact|default}">contact your project administrator.</a></div>
 {/if}
 </div>


### PR DESCRIPTION
## Brief summary of changes

Cleanup of error pollution of error_log when 404 on php8.

Solves the following:
```
PHP Warning:  Undefined array key "canReport"
PHP Warning:  Attempt to read property "value" on null
PHP Warning:  Undefined array key "contact"
```

#### Testing instructions (if applicable)

1. Visit an incorrect path of Loris Ex. https://<your_sandbox>/test
2. Check error_log

