### PR TITLE
[issue_tracker] Fix incorrect url to issues in notification email

### DIFF
--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -572,11 +572,6 @@ function emailUser($issueID, $changed_assignee)
         )
     );
 
-    $msg_data['url']         = $baseurl .
-        "/issue_tracker/issue/?issueID=" . $issueID;
-    $msg_data['issueID']     = $issueID;
-    $msg_data['currentUser'] = $user->getUsername();
-
     foreach ($issue_change_emails as $email) {
         $msg_data['firstname'] = $email['firstname'];
         Email::send($email['Email'], 'issue_change.tpl', $msg_data);


### PR DESCRIPTION
## Brief summary of changes

Currently, the notification email sent by the issue tracker module has the old url . This PR fixes this issue by removing the lines of code completely because the url is correctly set to the new url on lines 534-537

#### Testing instructions (if applicable)

1.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
