### PR TITLE
Remove references to User->getData()

### DIFF
--- a/modules/candidate_parameters/ajax/formHandler.php
+++ b/modules/candidate_parameters/ajax/formHandler.php
@@ -355,7 +355,7 @@ function editParticipantStatusFields(\Database $db)
     $id = null;
     if (!(is_null($_SESSION['State']))) {
         $currentUser =& User::singleton($_SESSION['State']->getUsername());
-        $id          = $currentUser->getData("UserID");
+        $id          = $currentUser->getUsername();
     }
 
     $updateValues = [

--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -50,7 +50,7 @@ class Create_Timepoint extends \NDB_Form
             $user->hasPermission('data_entry') &&
             (in_array(
                 $this->candidate->getData('RegistrationCenterID'),
-                $user->getData('CenterIDs')
+                $user->getCenterIDs()
             )
             )
         );

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -260,7 +260,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
 
         // validate site entered
         $site = (int) $values['psc'];
-        $user_list_of_sites = $user->getData('CenterIDs');
+        $user_list_of_sites = $user->getCenterIDs();
         $num_sites          = count($user_list_of_sites);
         $conflict           = [];
         if ($num_sites == 0) {

--- a/modules/examiner/php/editexaminer.class.inc
+++ b/modules/examiner/php/editexaminer.class.inc
@@ -62,7 +62,7 @@ class EditExaminer extends \NDB_Form
             // Access is only granted if user sites are a superset of examiner sites
             // considering that certification changes affect all sites
             $permitted         = $user->hasPermission('examiner_view')
-                && empty(array_diff($centerIDs, $user->getData('CenterIDs')));
+                && empty(array_diff($centerIDs, $user->getCenterIDs()));
             $permittedAllSites
                 = $user->hasPermission('examiner_multisite');
             return $permitted || $permittedAllSites;

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -181,7 +181,7 @@ class Instrument_List extends \NDB_Menu_Filter
         // display list of instruments
         if (!empty($listOfInstruments)) {
             $user     =& \User::singleton();
-            $username = $user->getData('UserID');
+            $username = $user->getUsername();
 
             $feedback_select_inactive = false;
             if ($user->hasPermission('bvl_feedback')) {

--- a/modules/issue_tracker/ajax/EditIssue.php
+++ b/modules/issue_tracker/ajax/EditIssue.php
@@ -91,7 +91,8 @@ function editIssue()
     }
 
     $issueID = intval($_POST['issueID']);
-    $issueValues['lastUpdatedBy'] = $user->getData('UserID');
+
+    $issueValues['lastUpdatedBy'] = $user->getUsername();
 
     $validatedInput = validateInput($validateValues);
     if (array_key_exists('sessionID', $validatedInput)) {
@@ -108,7 +109,7 @@ function editIssue()
     if (!empty($issueID)) {
         $db->update('issues', $issueValues, ['issueID' => $issueID]);
     } else {
-        $issueValues['reporter']    = $user->getData('UserID');
+        $issueValues['reporter']    = $user->getUsername();
         $issueValues['dateCreated'] = date('Y-m-d H:i:s');
         $db->insert('issues', $issueValues);
         $issueID = intval($db->getLastInsertId());
@@ -172,7 +173,7 @@ function editIssue()
     // Add editor to the watching table unless they don't want to be added.
     if (isset($_POST['watching']) &&  $_POST['watching'] == 'Yes') {
         $nowWatching = [
-            'userID'  => $user->getData('UserID'),
+            'userID'  => $user->getUsername(),
             'issueID' => $issueID,
         ];
         $db->replace('issues_watching', $nowWatching);
@@ -181,7 +182,7 @@ function editIssue()
             'issues_watching',
             [
                 'issueID' => $issueID,
-                'userID'  => $user->getData('UserID'),
+                'userID'  => $user->getUsername(),
             ]
         );
     }
@@ -359,7 +360,7 @@ function updateHistory($values, $issueID)
                 'newValue'     => $value ?? '',
                 'fieldChanged' => $key,
                 'issueID'      => $issueID,
-                'addedBy'      => $user->getData('UserID'),
+                'addedBy'      => $user->getUsername(),
             ];
             $db->insert('issues_history', $changedValues);
         }
@@ -385,7 +386,7 @@ function updateComments($comment, $issueID)
     if (isset($comment) && $comment != "null") {
         $commentValues = [
             'issueComment' => $comment,
-            'addedBy'      => $user->getData('UserID'),
+            'addedBy'      => $user->getUsername(),
             'issueID'      => $issueID,
         ];
         $db->insert('issues_comments', $commentValues);
@@ -411,7 +412,7 @@ function updateCommentHistory($issueCommentID, $newCommentValue)
     $changedValue = [
         'issueCommentID' => $issueCommentID,
         'newValue'       => $newCommentValue,
-        'editedBy'       => $user->getData('UserID'),
+        'editedBy'       => $user->getUsername(),
     ];
 
     $db->insert('issues_comments_history', $changedValue);
@@ -644,7 +645,7 @@ function getIssueFields()
         []
     );
     foreach ($potential_watchers_expanded as $w_row) {
-        if ($w_row['UserID'] != $user->getData('UserID')) {
+        if ($w_row['UserID'] != $user->getUsername()) {
             $otherWatchers[$w_row['UserID']] = $w_row['Real_name'];
         }
     }
@@ -721,7 +722,7 @@ function getIssueFields()
             WHERE issueID=:issueID AND userID=:userID",
             [
                 'issueID' => $issueID,
-                'userID'  => $user->getData('UserID'),
+                'userID'  => $user->getUsername(),
             ]
         );
         if ($isWatching === null) {
@@ -746,7 +747,7 @@ function getIssueFields()
     }
     $issueData['comment'] = null;
 
-    if ($issueData['reporter'] == $user->getData('UserID')) {
+    if ($issueData['reporter'] == $user->getUsername()) {
         $isOwnIssue = true;
     } else {
         $isOwnIssue = false;
@@ -795,9 +796,9 @@ function getIssueData($issueID=null)
     }
 
     return [
-        'reporter'      => $user->getData('UserID'),
+        'reporter'      => $user->getUsername(),
         'dateCreated'   => date('Y-m-d H:i:s'),
-        'centerID'      => $user->getData('CenterIDs'),
+        'centerID'      => $user->getCenterIDs(),
         'status'        => "new",
         'priority'      => "normal",
         'issueID'       => 0, //TODO: this is dumb

--- a/modules/issue_tracker/php/issue.class.inc
+++ b/modules/issue_tracker/php/issue.class.inc
@@ -107,7 +107,7 @@ class Issue extends \NDB_Form
             ['issueID' => $issueID]
         );
         return (is_null($issueData)
-            || in_array($issueData['centerID'], $user->getData('CenterIDs'))
+            || in_array($issueData['centerID'], $user->getCenterIDs())
             || ($user->hasPermission('access_all_profiles'))
             || (empty($issueData['centerID']))
         );

--- a/modules/issue_tracker/php/module.class.inc
+++ b/modules/issue_tracker/php/module.class.inc
@@ -93,7 +93,7 @@ class Module extends \Module
                     $DB,
                     "SELECT COUNT(*) FROM issues
                      WHERE status != 'closed' AND assignee="
-                     . $DB->quote($user->getData('UserID')),
+                     . $DB->quote($user->getUsername()),
                     '',
                     '',
                     $baseURL . "/issue_tracker/?$url",

--- a/modules/issue_tracker/php/uploadhelper.class.inc
+++ b/modules/issue_tracker/php/uploadhelper.class.inc
@@ -83,7 +83,7 @@ class UploadHelper
                 'mime_type'   => $this->getFileMimeType($files['file']['name']),
                 'tmp_name'    => $files['file']['tmp_name'],
                 'size'        => $this->_bytes,
-                'inserted_by' => $this->_user->getData('UserID'),
+                'inserted_by' => $this->_user->getUsername(),
                 'description' => $this->_values['fileDescription'] ?? '',
             ];
 

--- a/modules/login/php/passwordexpiry.class.inc
+++ b/modules/login/php/passwordexpiry.class.inc
@@ -87,7 +87,6 @@ class PasswordExpiry extends \NDB_Form
     function _validate($values)
     {
         $this->_user = \User::factory($this->_username);
-        $data        = $this->_user->getData();
         $plaintext   = htmlspecialchars_decode($values['password']);
         $confirm     = htmlspecialchars_decode($values['confirm']);
 
@@ -107,7 +106,7 @@ class PasswordExpiry extends \NDB_Form
         // Ensure that the password is not the user's email
         // Otherwise an exception is thrown in User.class::updatePassword
         // TODO This validation should be done on the front-end too.
-        if ($plaintext === $data['Email']) {
+        if ($plaintext === $this->_user->getEmail()) {
             $error_msg = "You cannot use your email as your password.";
             $this->tpl_data['error_message'] = $error_msg;
             return ['password' => $error_msg];

--- a/modules/login/php/passwordreset.class.inc
+++ b/modules/login/php/passwordreset.class.inc
@@ -57,7 +57,7 @@ class PasswordReset extends \NDB_Form
         $username = $values['username'];
         $user     = \User::factory($username);
 
-        $email = $user->getData('Email');
+        $email = $user->getEmail();
         // check that it is a valid user
         if (empty($email) || empty($user)) {
             return;
@@ -81,7 +81,7 @@ class PasswordReset extends \NDB_Form
                 $msg_data          = [];
                 $msg_data['study'] = $config->getSetting('title');
                 $msg_data['url']   = $factory->settings()->getBaseURL();
-                $msg_data['realname'] = $user->getData('Real_name');
+                $msg_data['realname'] = $user->getFullname();
                 $msg_data['password'] = $password;
                 \Email::send($email, 'lost_password.tpl', $msg_data);
             } else {

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -133,7 +133,7 @@ function uploadFile()
         return;
     }
 
-    $userID = $user->getData('UserID');
+    $userID = $user->getUsername();
 
     $sessionID = $db->pselectOne(
         "SELECT s.ID as session_id FROM candidate c " .

--- a/modules/my_preferences/php/my_preferences.class.inc
+++ b/modules/my_preferences/php/my_preferences.class.inc
@@ -75,7 +75,7 @@ class My_Preferences extends \NDB_Form
         // Notification defaults
         // "notif_".$module."_".$operation."_".$service
         $curr_sub = \NDB_Notifier::getUserNotificationModuleServices(
-            intval($user->getData("ID"))
+            $user->getId()
         );
         foreach ($curr_sub as $module=>$operations) {
             foreach ($operations as $operation => $services) {
@@ -113,7 +113,7 @@ class My_Preferences extends \NDB_Form
         // START NOTIFICATIONS UPDATE
         // get current notifications for user
         $curr_sub = \NDB_Notifier::getUserNotificationModuleServices(
-            intval($user->getData("ID"))
+            $user->getId()
         );
 
         // get notification details
@@ -138,7 +138,7 @@ class My_Preferences extends \NDB_Form
                                 [
                                     "module_id"  => $module_id,
                                     "service_id" => $service_id,
-                                    "user_id"    => $user->getData("ID"),
+                                    "user_id"    => $user->getId(),
                                 ]
                             );
                         }
@@ -149,7 +149,7 @@ class My_Preferences extends \NDB_Form
                                 [
                                     "module_id"  => $module_id,
                                     "service_id" => $service_id,
-                                    "user_id"    => $user->getData("ID"),
+                                    "user_id"    => $user->getId(),
                                 ]
                             );
                         }

--- a/modules/new_profile/php/new_profile.class.inc
+++ b/modules/new_profile/php/new_profile.class.inc
@@ -54,7 +54,7 @@ class New_Profile extends \NDB_Form
         /* When a user has only one site and centerID has not been
          * passed, choose the first one in the User's centerID list.
          */
-        $centerIDs = \User::singleton()->getData('CenterIDs');
+        $centerIDs = \User::singleton()->getCenterIDs();
         if (count($centerIDs) <= 1 && !isset($values['site'])) {
             $values['site'] = $centerIDs[0];
         }
@@ -149,7 +149,7 @@ class New_Profile extends \NDB_Form
         $maxYear   = (isset($endYear, $ageMin)) ? $endYear - $ageMin : null;
 
         // Get sites for the select dropdown
-        $user_list_of_sites = $user->getData('CenterIDs');
+        $user_list_of_sites = $user->getCenterIDs();
         $site = \Utility::getSiteNameListByIDs($user_list_of_sites);
 
         // Get projects for the select dropdown
@@ -281,7 +281,7 @@ class New_Profile extends \NDB_Form
 
         // Validate site entered
         $psc = isset($values['site']) ? (int)$values['site'] : '';
-        $user_list_of_sites = $user->getData('CenterIDs');
+        $user_list_of_sites = $user->getCenterIDs();
         $num_sites          = count($user_list_of_sites);
         if ($num_sites > 1 && (empty($psc) || !$user->hasCenter($psc))) {
             $errors['site'] = "Site must be selected from the available dropdown.";

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -139,7 +139,7 @@ class Statistics_Site extends \NDB_Menu
             $this->query_criteria   .= " AND s.ProjectID =:pid ";
             $this->query_vars['pid'] = $projectID;
         } else {
-            $userProjectsIDs = $user->getData('ProjectIDs');
+            $userProjectsIDs = $user->getProjectIDs();
             if (!empty($userProjectsIDs)) {
                 $paramProjects = [];
                 $projectsIDs   = [];

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -225,7 +225,7 @@ class Stats_Demographic extends \NDB_Form
         $projects     = [];
         $projects[''] = 'All Projects';
 
-        $userProjectsIDs = $user->getData('ProjectIDs');
+        $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
             $projects["$ProjectID"] = $allProjectList["$ProjectID"];
         }

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -234,7 +234,7 @@ class Stats_MRI extends \NDB_Form
         $projects     = [];
         $projects[''] = 'All Projects';
 
-        $userProjectsIDs = $user->getData('ProjectIDs');
+        $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
             $projects[$ProjectID] = $allProjectList[$ProjectID];
         }

--- a/modules/statistics/php/stats_mri.class.inc
+++ b/modules/statistics/php/stats_mri.class.inc
@@ -236,7 +236,7 @@ class Stats_MRI extends \NDB_Form
 
         $userProjectsIDs = $user->getProjectIDs();
         foreach ($userProjectsIDs as $ProjectID) {
-            $projects[$ProjectID] = $allProjectList[$ProjectID];
+            $projects["$ProjectID"] = $allProjectList["$ProjectID"];
         }
 
         $currentProject = null;

--- a/modules/timepoint_list/php/timepoint_list.class.inc
+++ b/modules/timepoint_list/php/timepoint_list.class.inc
@@ -84,7 +84,7 @@ class Timepoint_List extends \NDB_Menu
         $listOfSessionIDs = $candidate->getListOfTimePoints();
 
         $user     = \User::singleton();
-        $username = $user->getData('UserID');
+        $username = $user->getUsername();
 
         $feedback_select_inactive = false;
         if ($user->hasPermission('bvl_feedback')) {

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -142,7 +142,7 @@ class Edit_User extends \NDB_Form
 
             // Notification defaults
             // "notif_".$module."_".$operation."_".$service
-            $user_id  = $user->getData("ID") ?? -1;
+            $user_id  = $user->getId() ?? -1;
             $curr_sub = \NDB_Notifier::getUserNotificationModuleServices(
                 $user_id
             );
@@ -270,7 +270,7 @@ class Edit_User extends \NDB_Form
             unset($values['Password_hash']);
         }
         // multi-site UPDATE
-        $uid           = $user->getData('ID');
+        $uid           = $user->getId();
         $us_curr_sites = $values['CenterIDs'];
         if (!$this->isCreatingNewUser()) {
             $DB->delete('user_psc_rel', ["UserID" => $uid]);
@@ -467,7 +467,7 @@ class Edit_User extends \NDB_Form
             // insert a new user
             \User::insert($set);
             $user = \User::factory($set['UserID']);
-            $uid  = $user->getData('ID');
+            $uid  = $user->getId();
             foreach ($us_curr_sites as $site) {
                 $DB->insert(
                     'user_psc_rel',
@@ -1015,7 +1015,7 @@ class Edit_User extends \NDB_Form
      */
     static function canRejectAccount(\User $user)
     {
-        return $user->getData('Pending_approval') == 'Y'
+        return $user->isPendingApproval()
             && !$user->hasLoggedIn();
     }
 

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -405,7 +405,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
         if (!$user->hasPermission('data_entry')
             || !in_array(
                 $timePoint->getData('CenterID'),
-                $user->getData('CenterIDs')
+                $user->getCenterIDs()
             )
         ) {
             return false;
@@ -413,7 +413,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
 
         // make a feedback object
         $feedback = \NDB_BVL_Feedback::singleton(
-            $user->getData('UserID'),
+            $user->getUsername(),
             null,
             null,
             $this->_commentID

--- a/php/libraries/NDB_Notifier.class.inc
+++ b/php/libraries/NDB_Notifier.class.inc
@@ -85,8 +85,8 @@ class NDB_Notifier extends NDB_Notifier_Abstract
     private function _sendEmails(): void
     {
         foreach ($this->notified['email_text'] as $name=>$uid) {
-            $notifierID  = $this->notifier->getData('ID');
-            $senderEmail = $this->notifier->getData('Email');
+            $notifierID  = $this->notifier->getId();
+            $senderEmail = $this->notifier->getEmail();
             $this->tpl_data['notified_user'] = $name;
             $this->tpl_data['notifier_user'] = "$notifierID <$senderEmail>";
             $recipientEmail = $this->getEmail((int)$uid);

--- a/php/libraries/NDB_Notifier_Abstract.class.inc
+++ b/php/libraries/NDB_Notifier_Abstract.class.inc
@@ -50,10 +50,8 @@ abstract class NDB_Notifier_Abstract
 {
     /**
      * Current logged in user issuing the notification.
-     *
-     * @var \User
      */
-    protected $notifier;
+    protected \User $notifier;
 
     /**
      * Boolean for notification being issue as administrator. Comes from DB

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -195,6 +195,38 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     }
 
     /**
+     * Returns data from the userInfo array according to the key provided
+     * as argument.
+     *
+     * @param string $var Name of variable to get
+     *
+     * @note   Call without any arguments to get the entire user data array
+     * @return array<array|string>|string
+     * @access public
+     * @throws LorisException
+     */
+    public function getData(string $var = '')
+    {
+        if ($var === '') {
+            return $this->userInfo;
+        } elseif ($var === 'CenterID') {
+            throw new \LorisException(
+                "The function getData('CenterID')
+                                        is deprecated and is replaced
+                                        with getData('CenterIDs')"
+            );
+        } elseif ($var === 'Site') {
+            throw new \LorisException(
+                "The function getData('Site')
+                                        is deprecated and is replaced
+                                        with getData('Sites')"
+            );
+        } else {
+            return $this->userInfo[$var];
+        }
+    }
+
+    /**
      * Get users real name
      *
      * @return string

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -27,9 +27,9 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
      * Stores user information
      *
      * @var    array
-     * @access private
      */
     protected $userInfo = [];
+
     /**
      * The date format used by MySQL.
      *
@@ -350,8 +350,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     /**
      * Checks that the user's email is valid
      *
-     * @return boolean
-     * @access public
+     * @return bool
      */
     public function isEmailValid(): bool
     {
@@ -359,6 +358,15 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
             return false;
         };
         return true;
+    }
+
+    /**
+     * Returns the user's email address
+     *
+     * @return string
+     */
+    public function getEmail() : string {
+        return $this->userInfo['Email'];
     }
 
     /**
@@ -542,5 +550,10 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         );
 
         return $projMatch && $centerMatch;
+    }
+
+    public function isPendingApproval() : bool
+    {
+        return $this->userInfo['Pending_approval'] == 'Y';
     }
 }

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -26,7 +26,7 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     /**
      * Stores user information
      *
-     * @var    array
+     * @var array
      */
     protected $userInfo = [];
 
@@ -397,7 +397,8 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
      *
      * @return string
      */
-    public function getEmail() : string {
+    public function getEmail() : string
+    {
         return $this->userInfo['Email'];
     }
 
@@ -584,6 +585,12 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         return $projMatch && $centerMatch;
     }
 
+    /**
+     * Returns whether the user's account is pending approval by
+     * an admin.
+     *
+     * @return bool
+     */
     public function isPendingApproval() : bool
     {
         return $this->userInfo['Pending_approval'] == 'Y';

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -195,38 +195,6 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
     }
 
     /**
-     * Returns data from the userInfo array according to the key provided
-     * as argument.
-     *
-     * @param string $var Name of variable to get
-     *
-     * @note   Call without any arguments to get the entire user data array
-     * @return array<array|string>|string
-     * @access public
-     * @throws LorisException
-     */
-    public function getData(string $var = '')
-    {
-        if ($var === '') {
-            return $this->userInfo;
-        } elseif ($var === 'CenterID') {
-            throw new \LorisException(
-                "The function getData('CenterID')
-                                        is deprecated and is replaced
-                                        with getData('CenterIDs')"
-            );
-        } elseif ($var === 'Site') {
-            throw new \LorisException(
-                "The function getData('Site')
-                                        is deprecated and is replaced
-                                        with getData('Sites')"
-            );
-        } else {
-            return $this->userInfo[$var];
-        }
-    }
-
-    /**
      * Get users real name
      *
      * @return string

--- a/src/Middleware/UserPageDecorationMiddleware.php
+++ b/src/Middleware/UserPageDecorationMiddleware.php
@@ -197,14 +197,14 @@ class UserPageDecorationMiddleware implements MiddlewareInterface
         }
 
         $oneIsStudySite   = in_array("1", $isStudySite);
-        $tpl_data['user'] = $this->user->getData();
+        $tpl_data['user'] = [];
         $tpl_data['user']['permissions']          = $this->user->getPermissions();
         $tpl_data['user']['user_from_study_site'] = $oneIsStudySite;
         $tpl_data['userNumSites']         = count($site_arr);
         $tpl_data['user']['SitesTooltip'] = str_replace(
             ";",
             "<br/>",
-            $this->user->getData('Sites')
+            $this->user->getSiteNames()
         );
 
         $tpl_data['hasHelpEditPermission'] = $this->user->hasPermission(

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -693,6 +693,7 @@ class UserTest extends TestCase
         $this->_user->updatePassword(
             new \Password(\Utility::randomString(16))
         );
+
         //Re-populate the user object now that the password has been changed
         $this->_user = \User::factory(self::USERNAME);
 


### PR DESCRIPTION
The `getData` function is a code smell which we still have scattered throughout our code. It loses type information and generally makes it harder for static analysis tools (or humans) to figure out what our code is doing.

This updates most of the references to use the User class's getters for the appropriate field, which does not lose type information.

There are a couple exceptions which were not updated: 1. 2 places in the code use `getData()` to send the all the user's data to a template (`my_preferences` and `edit_user`). 2. Unit tests for the user class use it to get test the internal state. These situations need to be fixed/tested separately before the function could be completely removed.