### PR TITLE
Remove most references to Candidate->getData

### DIFF
--- a/modules/create_timepoint/php/create_timepoint.class.inc
+++ b/modules/create_timepoint/php/create_timepoint.class.inc
@@ -48,11 +48,7 @@ class Create_Timepoint extends \NDB_Form
         // check user permissions
         return (
             $user->hasPermission('data_entry') &&
-            (in_array(
-                $this->candidate->getData('RegistrationCenterID'),
-                $user->getCenterIDs()
-            )
-            )
+            $user->hasCenter($this->candidate->getCenterID())
         );
     }
 

--- a/modules/create_timepoint/php/timepoint.class.inc
+++ b/modules/create_timepoint/php/timepoint.class.inc
@@ -229,11 +229,7 @@ class Timepoint extends \NDB_Page implements ETagCalculator
         $candidate = \Candidate::singleton(new CandID($identifier));
         return (
             $user->hasPermission('data_entry') &&
-            (in_array(
-                $candidate->getData('RegistrationCenterID'),
-                $user->getData('CenterIDs')
-            )
-            )
+            $user->hasCenter($candidate->getCenterID())
         );
     }
 

--- a/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
+++ b/modules/imaging_browser/php/imaging_session_controlpanel.class.inc
@@ -113,7 +113,7 @@ class Imaging_Session_ControlPanel
          */
         $params     = [];
         $ID         = 'NULL';
-        $EntityType = $candidate->getData('Entity_type');
+        $EntityType = $candidate->getEntityType();
         if ($EntityType == 'Scanner') {
             $ID            = ":PVL";
             $params['PVL'] = $timePoint->getVisitLabel();

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -80,7 +80,6 @@ class ViewSession extends \NDB_Form
                 ))
                 && $user->hasProject($session->getProject()->getId());
         }
-
         return false;
     }
 

--- a/modules/imaging_browser/php/viewsession.class.inc
+++ b/modules/imaging_browser/php/viewsession.class.inc
@@ -65,14 +65,14 @@ class ViewSession extends \NDB_Form
         $candid    = $session->getCandID();
         $candidate = \Candidate::singleton($candid);
 
-        if ($candidate->getData('Entity_type') == 'Scanner') {
+        if ($candidate->getEntityType() == 'Scanner') {
             return ($user->hasPermission('imaging_browser_phantom_allsites')
                 || $user->hasCenterPermission(
                     'imaging_browser_phantom_ownsite',
                     $session->getCenterID()
                 ))
                 && ($user->hasProject($session->getProject()->getId()));
-        } elseif ($candidate->getData('Entity_type') == 'Human') {
+        } elseif ($candidate->getEntityType() == 'Human') {
             return ($user->hasPermission('imaging_browser_view_allsites')
                 || $user->hasCenterPermission(
                     'imaging_browser_view_site',
@@ -893,7 +893,7 @@ class ViewSession extends \NDB_Form
         //Need to find the proper way to get the TarchiveID.
         //It should be per file, not per candidate. --Dave
         $params     = [];
-        $EntityType = $candidate->getData('Entity_type');
+        $EntityType = $candidate->getEntityType();
         if ($EntityType == 'Scanner') {
             $ID = ":PPSCID";
             $params['PPSCID'] = $timePoint->getData('PSCID');

--- a/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
+++ b/modules/timepoint_list/php/timepoint_list_controlpanel.class.inc
@@ -59,9 +59,9 @@ Class TimePoint_List_ControlPanel extends \Candidate
     {
         $user =& \User::singleton();
 
-        $cand_CenterID = $this->getData('RegistrationCenterID');
+        $cand_CenterID = $this->getCenterID();
 
-        $this->tpl_data['candID'] = $this->getData('CandID');
+        $this->tpl_data['candID'] = $this->getCandID();
 
         $this->tpl_data['isDataEntryPerson']
             = $user->hasCenterPermission("data_entry", $cand_CenterID);

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -105,7 +105,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             case 'Sex':
                 $this->candidateInfo[$key] = new Sex($value);
                 break;
-            case 'EntityType':
+            case 'Entity_type':
                 $this->candidateInfo[$key] = new EntityType($value);
                 break;
             case 'RegistrationProjectID':
@@ -544,7 +544,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getEntityType(): ?EntityType
     {
-        return $this->candidateInfo["EntityType"];
+        return $this->candidateInfo["Entity_type"];
     }
 
     /**

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -435,7 +435,7 @@ class Candidate implements \LORIS\StudyEntities\AccessibleResource,
             'candidate',
             $newData,
             [
-                'CandID' => $this->getData('CandID'),
+                'CandID' => $this->getCandID(),
             ]
         );
         return true;

--- a/src/Middleware/AuthMiddleware.php
+++ b/src/Middleware/AuthMiddleware.php
@@ -62,7 +62,6 @@ class AuthMiddleware implements MiddlewareInterface, MiddlewareChainer
         if ($this->authenticator->authenticate($request) === true) {
             return $this->next->process($request, $handler);
         }
-
         return (new \LORIS\Middleware\PageDecorationMiddleware(
             $request->getAttribute("user") ?? new \LORIS\AnonymousUser()
         ))->process(

--- a/src/StudyEntities/Candidate/EntityType.php
+++ b/src/StudyEntities/Candidate/EntityType.php
@@ -42,9 +42,9 @@ class EntityType
      */
     public function __construct(string $value)
     {
-        if (self::validate($value)) {
+        if (!self::validate($value)) {
             throw new \DomainException(
-                'The value is not valid. Must be one of: '
+                "The value '$value' is not valid. Must be one of: "
                 . implode(', ', self::VALID_VALUES)
             );
         }


### PR DESCRIPTION
This is analagous to #7334 but for `Candidate->getData`. It removes calls to `getData` in the candidate class and replaces them with appropriate getters. There are a few places where the array for getData is passed to a smarty template and some unit tests which rely on it, and these are untouched as they need more thorough testing 

This should improve the ability of phan to track our type information while it analyses the code.