### PR TITLE
Add interface to replace method_exists('getCenterID') checks

### DIFF
--- a/modules/api/php/models/candidatesrow.class.inc
+++ b/modules/api/php/models/candidatesrow.class.inc
@@ -20,7 +20,8 @@ namespace LORIS\api\Models;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class CandidatesRow implements \LORIS\Data\DataInstance
+class CandidatesRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     private $_candid;
     private $_projectname;

--- a/modules/api/php/models/projectimagesrow.class.inc
+++ b/modules/api/php/models/projectimagesrow.class.inc
@@ -20,7 +20,8 @@ namespace LORIS\api\Models;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class ProjectImagesRow implements \LORIS\Data\DataInstance
+class ProjectImagesRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     private $_candid;
     private $_pscid;

--- a/modules/battery_manager/php/test.class.inc
+++ b/modules/battery_manager/php/test.class.inc
@@ -25,7 +25,9 @@ namespace LORIS\battery_manager;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class Test implements \LORIS\Data\DataInstance
+class Test implements
+    \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\MultiSiteHaver
 {
     public $row;
 

--- a/modules/candidate_list/php/candidatelistrow.class.inc
+++ b/modules/candidate_list/php/candidatelistrow.class.inc
@@ -25,7 +25,8 @@ namespace LORIS\candidate_list;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class CandidateListRow implements \LORIS\Data\DataInstance
+class CandidateListRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     protected $DBRow;
     protected $CenterID;

--- a/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
+++ b/modules/dicom_archive/php/dicomarchiveanonymizer.class.inc
@@ -44,25 +44,23 @@ class DICOMArchiveAnonymizer implements Mapper
         \User $user,
         DataInstance $resource
     ) : DataInstance {
-        $res = $resource;
-        '@phan-var object $res';
 
         static $config = null;
         if ($config === null) {
             $config = \NDB_Config::singleton()->getSetting("imaging_modules");
         }
 
-        if (!method_exists($res, 'getCenterID')) {
+        if (!$resource instanceof \LORIS\StudyEntities\SiteHaver) {
             throw new \LorisException(
                 "Mapper requires a resource type with getCenterID"
             );
         }
-        $newrow = json_decode(json_encode($res), true);
+        $newrow = json_decode(json_encode($resource), true);
         if (!is_array($newrow)) {
             throw new \Exception("Error converting DataInstance to array");
         }
 
-        $cid = $res->getCenterID();
+        $cid = $resource->getCenterID();
 
         // escape any forward slashes
         $pNameRegex      = preg_replace(

--- a/modules/dicom_archive/php/dicomarchiverow.class.inc
+++ b/modules/dicom_archive/php/dicomarchiverow.class.inc
@@ -25,7 +25,8 @@ namespace LORIS\dicom_archive;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class DICOMArchiveRow implements \LORIS\Data\DataInstance
+class DICOMArchiveRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     protected $DBRow;
     protected $CenterID;
@@ -59,7 +60,7 @@ class DICOMArchiveRow implements \LORIS\Data\DataInstance
      *
      * @return integer The CenterID
      */
-    public function getCenterID()
+    public function getCenterID() : int
     {
         return $this->CenterID;
     }

--- a/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
+++ b/modules/electrophysiology_browser/php/electrophysiologybrowserrow.class.inc
@@ -26,7 +26,8 @@ namespace LORIS\electrophysiology_browser;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class ElectrophysiologyBrowserRow implements \LORIS\Data\DataInstance
+class ElectrophysiologyBrowserRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     protected $DBRow;
     protected $CenterID;

--- a/modules/imaging_browser/php/imagingbrowserrow.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrow.class.inc
@@ -25,7 +25,8 @@ namespace LORIS\imaging_browser;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class ImagingBrowserRow implements \LORIS\Data\DataInstance
+class ImagingBrowserRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     protected $DBRow;
     protected $CenterID;

--- a/modules/issue_tracker/php/issuerow.class.inc
+++ b/modules/issue_tracker/php/issuerow.class.inc
@@ -11,7 +11,9 @@ namespace LORIS\issue_tracker;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class IssueRow implements \LORIS\Data\DataInstance
+class IssueRow implements
+    \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\MultiSiteHaver
 {
     protected $DBRow;
     protected $CenterIDs;
@@ -48,9 +50,9 @@ class IssueRow implements \LORIS\Data\DataInstance
      * Returns the CenterID for this row, for filters such as
      * \LORIS\Data\Filters\UserSiteMatch to match again.
      *
-     * @return array The CenterIDs
+     * @return int[] The CenterIDs
      */
-    public function getCenterIDs()
+    public function getCenterIDs() : iterable
     {
         return $this->CenterIDs;
     }

--- a/modules/media/php/mediafile.class.inc
+++ b/modules/media/php/mediafile.class.inc
@@ -25,7 +25,8 @@ namespace LORIS\media;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class MediaFile implements \LORIS\Data\DataInstance
+class MediaFile implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     protected $DBRow;
     protected $CenterID;

--- a/modules/survey_accounts/php/surveyaccountsrow.class.inc
+++ b/modules/survey_accounts/php/surveyaccountsrow.class.inc
@@ -26,7 +26,8 @@ namespace LORIS\survey_accounts;
  * @license    http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link       https://www.github.com/aces/Loris/
  */
-class SurveyAccountsRow implements \LORIS\Data\DataInstance
+class SurveyAccountsRow implements \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
     protected $DBRow;
     protected $CenterID;

--- a/modules/user_accounts/php/useraccountrow.class.inc
+++ b/modules/user_accounts/php/useraccountrow.class.inc
@@ -7,7 +7,9 @@ namespace LORIS\user_accounts;
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
-class UserAccountRow implements \LORIS\Data\DataInstance
+class UserAccountRow implements
+    \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\MultiSiteHaver
 {
     protected $DBRow;
     protected $ProjectIDs;

--- a/php/libraries/Candidate.class.inc
+++ b/php/libraries/Candidate.class.inc
@@ -31,7 +31,8 @@ define('DOB_NOT_SPECIFIED', 6);
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-class Candidate implements \LORIS\StudyEntities\AccessibleResource
+class Candidate implements \LORIS\StudyEntities\AccessibleResource,
+    \LORIS\StudyEntities\SiteHaver
 {
     var $candidateInfo;
     var $listOfTimePoints;

--- a/php/libraries/Site.class.inc
+++ b/php/libraries/Site.class.inc
@@ -21,7 +21,7 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class Site
+class Site implements \LORIS\StudyEntities\SiteHaver
 {
     var $_siteInfo;
 

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -23,7 +23,8 @@ use \LORIS\Data\Filters\HasAnyPermissionOrUserSiteMatch;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-class TimePoint implements \LORIS\StudyEntities\AccessibleResource
+class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
+    \LORIS\StudyEntities\SiteHaver
 {
     /* NOTE If these are private variables then they should probably be
      * declared and scoped as such. var is equivalent to public.

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -284,20 +284,6 @@ class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleRes
         return explode(';', $this->userInfo['Sites']);
     }
 
-     /**
-      * Get the user's site's ID number
-      *
-      * @return array
-      */
-    function getCenterID()
-    {
-        throw new \LorisException(
-            "The function getCenterID
-                                   is deprecated and is replaced
-                                   with getCenterIDs"
-        );
-    }
-
     /**
      * Get the user's sites' ID numbers
      *

--- a/php/libraries/User.class.inc
+++ b/php/libraries/User.class.inc
@@ -21,7 +21,9 @@
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris-Trunk/
  */
-class User extends UserPermissions implements \LORIS\StudyEntities\AccessibleResource
+class User extends UserPermissions implements
+    \LORIS\StudyEntities\AccessibleResource,
+    \LORIS\StudyEntities\MultiSiteHaver
 {
     /**
      * Stores user information

--- a/src/Data/Filters/PhantomsFilter.php
+++ b/src/Data/Filters/PhantomsFilter.php
@@ -53,10 +53,10 @@ class PhantomsFilter implements Filter
             return true;
         }
 
-        if (method_exists($res, 'getCenterID')
+        if ($resource instanceof \LORIS\StudyEntities\SiteHaver
             && $user->hasPermission('imaging_browser_phantom_ownsite')
         ) {
-            return $user->hasCenter($res->getCenterID());
+            return $user->hasCenter($resource->getCenterID());
         }
 
         return false;

--- a/src/Data/Filters/ScansFilter.php
+++ b/src/Data/Filters/ScansFilter.php
@@ -53,10 +53,10 @@ class ScansFilter implements Filter
             return true;
         }
 
-        if (method_exists($res, 'getCenterID')
+        if ($resource instanceof \LORIS\StudyEntities\SiteHaver
             && $user->hasPermission('imaging_browser_view_site')
         ) {
-            return $user->hasCenter($res->getCenterID());
+            return $user->hasCenter($resource->getCenterID());
         }
 
         return false;

--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -41,18 +41,10 @@ class UserSiteMatch implements \LORIS\Data\Filter
      */
     public function filter(\User $user, \Loris\Data\DataInstance $resource) : bool
     {
-        // phan only understands method_exists on simple variables, not
-        // Assigning to a variable is the a workaround
-        // for false positive 'getCenterIDs doesn't exist errors suggested
-        // in https://github.com/phan/phan/issues/2628
-        $res = $resource;
-        '@phan-var object $res';
-
-        if (method_exists($res, 'getCenterIDs')) {
+        if ($resource instanceof \LORIS\StudyEntities\MultiSiteHaver) {
             // If the Resource belongs to multiple CenterIDs, the user can
             // access the data if the user is part of any of those centers.
-            $resourceSites = $res->getCenterIDs();
-            foreach ($resourceSites as $site) {
+            foreach ($resource->getCenterIDs() as $site) {
                 if ($user->hasCenter($site)) {
                        return true;
                 }

--- a/src/Data/Filters/UserSiteMatch.php
+++ b/src/Data/Filters/UserSiteMatch.php
@@ -58,15 +58,8 @@ class UserSiteMatch implements \LORIS\Data\Filter
                 }
             }
             return false;
-        } elseif (method_exists($res, 'getCenterID')) {
-            $resourceSite = $res->getCenterID();
-            if (!is_null($resourceSite)) {
-                return $user->hasCenter($resourceSite);
-            }
-            // We don't know if the resource thought a null CenterID
-            // should mean "no one can access it" or "anyone can access
-            // it", so throw an exception.
-            throw new \LorisException("getCenterID on resource returned null");
+        } elseif ($resource instanceof \LORIS\StudyEntities\SiteHaver) {
+            return $user->hasCenter($resource->getCenterID());
         }
         throw new \LorisException(
             "Can not implement UserSiteMatch on a resource type that has no sites."

--- a/src/Data/Models/ImageDTO.php
+++ b/src/Data/Models/ImageDTO.php
@@ -22,7 +22,9 @@ namespace LORIS\Data\Models;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class ImageDTO implements \LORIS\Data\DataInstance
+class ImageDTO implements
+    \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
 
     private $fileid;

--- a/src/Data/Models/RecordingDTO.php
+++ b/src/Data/Models/RecordingDTO.php
@@ -22,7 +22,9 @@ namespace LORIS\Data\Models;
  * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  * @link     https://www.github.com/aces/Loris/
  */
-class RecordingDTO implements \LORIS\Data\DataInstance
+class RecordingDTO implements
+    \LORIS\Data\DataInstance,
+    \LORIS\StudyEntities\SiteHaver
 {
 
     private $fileid;

--- a/src/StudyEntities/MultiSiteHaver.php
+++ b/src/StudyEntities/MultiSiteHaver.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace LORIS\StudyEntities;
+
+/**
+ * The Accessible interface is used to determine whether
+ * a LORIS user should be allowed access to a resource.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+interface MultiSiteHaver
+{
+    /**
+     * Return true if the entity is accessible by the
+     * user.
+     *
+     * @return int[]
+     */
+    public function getCenterIDs() : iterable;
+}

--- a/src/StudyEntities/SiteHaver.php
+++ b/src/StudyEntities/SiteHaver.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+namespace LORIS\StudyEntities;
+
+/**
+ * The Accessible interface is used to determine whether
+ * a LORIS user should be allowed access to a resource.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+interface SiteHaver
+{
+    /**
+     * Return true if the entity is accessible by the
+     * user.
+     *
+     * @return int
+     */
+    public function getCenterID() : int;
+}


### PR DESCRIPTION
This adds 2 interfaces, SiteHaver and MultiSiteHaver to implement on classes that implement `getCenterID` and `getCenterIDs` functions respectively. This replaces the lossy method_exists checks for the 2 methods, which only verifies that a method with that name exists, and doesn't validate any type information such as arguments or return types. (In fact, it turns out there's a class in the examiners module which has an unrelated getCenterID($sitename) function, it's just luckily never passed to a pass which does a method_exists check).

This has a few benefits:
1. Static analysis tools are better able to analyze types
2. Some code can be simplified, since the types/nullability are explicit in the interface they don't need to be verified inside the method_exists checks
3. Some hacks that were necessary because of the method_exists checks (such as assigning arguments to a temporary variable and coercing the types for phan to recognize the methods exist inside of the method_exists blocks) aren't necessary inside of instanceof checks. 
3. If we change the signature (or decide other methods should be added) it can be updated in the interface to ensure we don't miss any classes that were implicitly implementing the getCenterID contract.

I'm not crazy about the interface names, but I couldn't think of anything better. The downside is that classes now need to explicitly implement the interface in their signature in order to have the data filters work on them, but I've updated all the ones that currently exist in LORIS.