### PR TITLE
Install php-ast via setup-php

### DIFF
--- a/.github/workflows/loristest.yml
+++ b/.github/workflows/loristest.yml
@@ -24,6 +24,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        extensions: php-ast
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -39,9 +40,6 @@ jobs:
 
     - name: Change PHP Version in Dockerfile
       run: sed -i "s/7.4/${{ matrix.php }}/g" Dockerfile.test.php7
-
-    - name: Install OS package dependencies
-      run: sudo apt-get install php-ast
 
     - name: Install composer dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
GitHub Actions appears to have started failing on `apt-get install php-ast` for an unknown reason.

This replaces the setup of php-ast with setting it up as an extension in the `setup-php` part of the GitHub Workflow to avoid needing to connect to whatever remote server is now failing/misconfigured/changed that caused `apt-get` to fail.