### PR TITLE
[Instrument] fix undefined array key in PHP 8

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -1539,7 +1539,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             $statusField = $field . '_status';
             // field shouldn't be just empty() b/c 0 is a valid
             // value for some required fields
-            if ((is_null($allData[$field]) || $allData[$field] === "")
+            if ((is_null($allData[$field] ?? null) || $allData[$field] === "")
                 && empty($allData[$statusField])
             ) {
                 return 'Incomplete';


### PR DESCRIPTION
## Brief summary of changes
Fixing undefined array key in PHP 8.
#### Testing instructions (if applicable)
Clicking the save button in an instrument on PHP 8.
There is no error message.
