### PR TITLE
[candidate_list] Move Project column over to array definition

### DIFF
--- a/modules/candidate_list/jsx/candidateListIndex.js
+++ b/modules/candidate_list/jsx/candidateListIndex.js
@@ -322,19 +322,16 @@ class CandidateListIndex extends Component {
           },
         },
       },
-
-    ];
-     fields.push(
-        {
-          'label': 'Project',
-          'show': true,
-          'filter': {
-            name: 'project',
-            type: 'select',
-            options: options.project,
-          },
+      {
+        'label': 'Project',
+        'show': true,
+        'filter': {
+          name: 'project',
+          type: 'select',
+          options: options.project,
         },
-      );
+      },
+    ];
 
     if (options.useedc === 'true') {
       fields.push(


### PR DESCRIPTION
## Brief summary of changes

This PR moves the Project field column over to where the fields array is defined. At the moment, it is being pushed to the fields array, which will create a misalignment of columns in the data table if a new column is added to the end of where the array is initialized. 

#### Testing instructions (if applicable)

1. On the main branch, and this PR branch, test the front-end of the candidate_list module. Make sure that there are no changes to the data table, specifically, the Project column and its neighbours.

#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
