### PR TITLE
[API] Fix v0.0.3 of API

### DIFF
--- a/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/dicoms.class.inc
@@ -140,6 +140,7 @@ class Dicoms extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 $this->_visit,
                 ...$dicomtars
             ))->toArray();
+            break;
         default:
             $view = (new \LORIS\api\Views\Visit\Dicoms_0_0_4_Dev(
                 $this->_visit,

--- a/modules/api/php/endpoints/candidate/visit/images.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/images.class.inc
@@ -140,7 +140,7 @@ class Images extends Endpoint implements \LORIS\Middleware\ETagCalculator
                 $this->_visit,
                 ...$images
             ))->toArray();
-
+            break;
         default:
             $view = (new \LORIS\api\Views\Visit\Images_0_0_4_Dev(
                 $this->_visit,


### PR DESCRIPTION
The switches doing a version check for the API
were missing break statements, causing all versions
to fall through to the default and have the `$view`
variable immediately overwritten by the dev version,
for all versions of the API.

This adds a break so that the correct code is used.