### PR TITLE
[instrument_list] Fix side effect in conditional

### DIFF
--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -133,7 +133,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             }
             $this->startStage($nextStage);
 
-            if ($nextStage = 'Recycling Bin') {
+            if ($nextStage == 'Recycling Bin') {
 
                 $battery = new \NDB_BVL_Battery();
 


### PR DESCRIPTION
The check for `$nextStage == 'Recycling Bin'` in the
instrument_list_controlpanel was doing an assignment,
not an equality check.