### PR TITLE
[eslint] Fix babel loader and eslint webpack plugin conflict

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules/*
+vendor/*
 
 # compiled js ignored since it is run on the jsx directory
 modules/*/js/*
@@ -16,3 +17,7 @@ htdocs/js/shims/*
 htdocs/js/c3.min.js
 htdocs/js/d3.min.js
 htdocs/js/FileSaver.min.js
+htdocs/vendor/
+htdocs/fontawesome/
+htdocs/bootstrap/
+

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,7 +69,7 @@
         "modules/**"
       ],
       "rules": {
-	    "no-jquery/no-other-methods": "error",
+        "no-jquery/no-other-methods": "error",
         "no-jquery/no-other-utils": "error",
         "no-jquery/no-jquery-constructor": "error",
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-google": "0.9.1",
     "eslint-plugin-no-jquery": "^2.5.0",
     "eslint-plugin-react": "^7.16.0",
-    "eslint-webpack-plugin": "^2.4.1",
+    "eslint-webpack-plugin": "2.1.0",
     "style-loader": "^1.1.3",
     "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.41.2",


### PR DESCRIPTION
Since eslint loader has been replaced by  eslint webpack plugin (#7137) a conflict babel-loader prevent eslint to run.