### PR TITLE
[core] fileElement multitype value fix

### DIFF
--- a/jsx/Form.js
+++ b/jsx/Form.js
@@ -1553,7 +1553,23 @@ class FileElement extends Component {
    */
   render() {
     const required = this.props.required ? 'required' : null;
-    const fileName = this.props.value ? this.props.value.name : undefined;
+
+    let fileName = undefined;
+    if (this.props.value) {
+      switch (typeof this.props.value) {
+        case 'string':
+          fileName = this.props.value;
+          break;
+
+        case 'object':
+          fileName = this.props.value.name;
+          break;
+
+        default:
+          break;
+      }
+    }
+
     let requiredHTML = null;
     let errorMessage = '';
     let elementClass = 'row form-group';


### PR DESCRIPTION
The value props of a fileElement can be of type string or Object, but the assignment to filename only covers the object case.
As a result, in media, if we edit a file, the fileElement does not display the file name.
This PR aims to fix this.