### PR TITLE
[media] jQuery cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,9 +69,9 @@
         "modules/**"
       ],
       "rules": {
-        "no-jquery/no-other-methods": "error",
+        "no-jquery/no-other-methods": "warn",
         "no-jquery/no-other-utils": "error",
-        "no-jquery/no-jquery-constructor": "error",
+        "no-jquery/no-jquery-constructor": "warn",
 
         // methods
         "no-jquery/no-animate": "error",
@@ -147,18 +147,14 @@
     },
     {
       "files": [
-        "modules/media/**",
         "modules/candidate_parameters/**",
         "modules/bvl_feedback/**",
         "modules/dataquery/**",
         "modules/dqt/**",
-        "modules/imaging_browser/**",
         "modules/imaging_uploader/**"
       ],
       "rules": {
-        "no-jquery/no-other-methods": "warn",
         "no-jquery/no-other-utils": "warn",
-        "no-jquery/no-jquery-constructor": "warn",
 
         // methods
         "no-jquery/no-animate": "warn",

--- a/modules/media/jsx/editFormIndex.js
+++ b/modules/media/jsx/editFormIndex.js
@@ -3,7 +3,7 @@
 import MediaEditForm from './editForm';
 const args = QueryString.get(document.currentScript.src);
 
-$(function() {
+document.addEventListener('DOMContentLoaded', () => {
   const mediaEditForm = (
     <div className="page-edit-form">
       <div className="row">


### PR DESCRIPTION
Additionally, this PR modifies the rules for the no-jQuery modules, by turning `no-jquery/no-other-methods` and `no-jquery/no-jquery-constructor` to warn. This is necessary as some modules still depends on jQuery libraries (bootstrap, DynamicTable).