### PR TITLE
[document_repository] Solves special characters issue

### DIFF
--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -35,6 +35,18 @@ class DocIndex extends React.Component {
       .then(() => this.setState({isLoaded: true}));
   }
 
+  htmlSpecialCharsDecode(text) {
+    if (text != null) {
+      return text
+        .replace(/&amp;/g, '&')
+        .replace(/&quot;/g, '"')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>');
+    } else {
+      return text;
+    }
+  }
+
   handleGlobal(formElement, value) {
     const parentNode = this.state.parentNode;
     parentNode.shift(['0', 'Root']);
@@ -123,11 +135,13 @@ class DocIndex extends React.Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
+    cell = this.htmlSpecialCharsDecode(cell);
     let result = <td>{cell}</td>;
     switch (column) {
       case 'File Name':
-        let downloadURL = loris.BaseURL + '/document_repository/Files/' + encodeURIComponent(row['File Name']);
-        result = <td><a href={downloadURL} target="_blank" download={row['File Name']}>{cell}</a></td>;
+        let fileName = this.htmlSpecialCharsDecode(row['File Name']);
+        let downloadURL = loris.BaseURL + '/document_repository/Files/' + encodeURIComponent(fileName);
+        result = <td><a href={downloadURL} target="_blank" download={fileName}>{cell}</a></td>;
         break;
       case 'Edit':
         let editURL = loris.BaseURL + '/document_repository/edit/' + row['Edit'];

--- a/modules/document_repository/jsx/docIndex.js
+++ b/modules/document_repository/jsx/docIndex.js
@@ -35,18 +35,6 @@ class DocIndex extends React.Component {
       .then(() => this.setState({isLoaded: true}));
   }
 
-  htmlSpecialCharsDecode(text) {
-    if (text != null) {
-      return text
-        .replace(/&amp;/g, '&')
-        .replace(/&quot;/g, '"')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>');
-    } else {
-      return text;
-    }
-  }
-
   handleGlobal(formElement, value) {
     const parentNode = this.state.parentNode;
     parentNode.shift(['0', 'Root']);
@@ -135,13 +123,11 @@ class DocIndex extends React.Component {
    * @return {*} a formated table cell for a given column
    */
   formatColumn(column, cell, row) {
-    cell = this.htmlSpecialCharsDecode(cell);
     let result = <td>{cell}</td>;
     switch (column) {
       case 'File Name':
-        let fileName = this.htmlSpecialCharsDecode(row['File Name']);
-        let downloadURL = loris.BaseURL + '/document_repository/Files/' + encodeURIComponent(fileName);
-        result = <td><a href={downloadURL} target="_blank" download={fileName}>{cell}</a></td>;
+        let downloadURL = loris.BaseURL + '/document_repository/Files/' + encodeURIComponent(row['File Name']);
+        result = <td><a href={downloadURL} target="_blank" download={row['File Name']}>{cell}</a></td>;
         break;
       case 'Edit':
         let editURL = loris.BaseURL + '/document_repository/edit/' + row['Edit'];

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -116,7 +116,7 @@ class Files extends \NDB_Page
                 $uploadedBy = $DB->pselectOne(
                     "SELECT uploaded_by FROM document_repository
                     WHERE File_Name=:name",
-                    array('name' => htmlspecialchars($record))
+                    array('name' => $record)
                 );
                 $file       = $path. "$uploadedBy/$record";
                 return (new \LORIS\Http\Response())
@@ -348,7 +348,7 @@ class Files extends \NDB_Page
         $uploadedFile = $uploadedFiles['file'];
         $fileSize     = $uploadedFile->getSize();
         $fileName     = $uploadedFile->getClientFileName();
-        $fileName     = str_replace("%22", "\"", $fileName);
+        $fileName     = urldecode($fileName);
         $fileType     = pathinfo($fileName, PATHINFO_EXTENSION);
         $uploadPath   = $path.$name."/";
         // $category is a string representation of an ID, and so should be at
@@ -378,7 +378,7 @@ class Files extends \NDB_Page
         ) {
                 $uploadedFile->moveTo($uploadPath.$fileName);
 
-                $DB->insert(
+                $DB->unsafeInsertOnDuplicateUpdate(
                     'document_repository',
                     array(
                         'File_category' => $category,

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -116,7 +116,7 @@ class Files extends \NDB_Page
                 $uploadedBy = $DB->pselectOne(
                     "SELECT uploaded_by FROM document_repository
                     WHERE File_Name=:name",
-                    array('name' => $record)
+                    array('name' => htmlspecialchars($record))
                 );
                 $file       = $path. "$uploadedBy/$record";
                 return (new \LORIS\Http\Response())
@@ -348,6 +348,7 @@ class Files extends \NDB_Page
         $uploadedFile = $uploadedFiles['file'];
         $fileSize     = $uploadedFile->getSize();
         $fileName     = $uploadedFile->getClientFileName();
+        $fileName     = str_replace("%22", "\"", $fileName);
         $fileType     = pathinfo($fileName, PATHINFO_EXTENSION);
         $uploadPath   = $path.$name."/";
         // $category is a string representation of an ID, and so should be at

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -350,9 +350,9 @@ class Files extends \NDB_Page
         $fileName     = $uploadedFile->getClientFileName();
         // urldecode() necessary to decode double quotes encoded automatically
         // by chrome browsers to avoid XSS attacks
-        $fileName     = urldecode($fileName);
-        $fileType     = pathinfo($fileName, PATHINFO_EXTENSION);
-        $uploadPath   = $path.$name."/";
+        $fileName   = urldecode($fileName);
+        $fileType   = pathinfo($fileName, PATHINFO_EXTENSION);
+        $uploadPath = $path.$name."/";
         // $category is a string representation of an ID, and so should be at
         // least equal to zero.
         if (intval($category) < 0) {

--- a/modules/document_repository/php/files.class.inc
+++ b/modules/document_repository/php/files.class.inc
@@ -348,6 +348,8 @@ class Files extends \NDB_Page
         $uploadedFile = $uploadedFiles['file'];
         $fileSize     = $uploadedFile->getSize();
         $fileName     = $uploadedFile->getClientFileName();
+        // urldecode() necessary to decode double quotes encoded automatically
+        // by chrome browsers to avoid XSS attacks
         $fileName     = urldecode($fileName);
         $fileType     = pathinfo($fileName, PATHINFO_EXTENSION);
         $uploadPath   = $path.$name."/";

--- a/tools/single_use/Cleanup_Special_Chars_Document_Repository.php
+++ b/tools/single_use/Cleanup_Special_Chars_Document_Repository.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This script is written to clean up the files with special characters from the document repository data table as well as clean up the
+ * quotes appearing as %22 in the file names in the file system
+ *
+ * To use the script: php Cleanup_Special_Chars_Document_Repository.php
+ *
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package Loris
+ * @author Pierre PAC SOO <pierre.pacsoo@mcin.ca>
+ * @license Loris license
+ * @link https://www.github.com/aces/Loris-Trunk/
+ */
+
+require_once __DIR__."/../generic_includes.php";
+$config = NDB_Config::singleton();
+
+$document_repository_path = $config->getSetting('documentRepositoryPath');
+
+$data = $DB->pselect(
+    "SELECT record_id, File_name
+        FROM document_repository",
+    []
+);
+
+foreach($data as $key => $file) {
+
+    // fileNameURLencoded is needed for the step line 48 as the file name got rid of '"' and replaced it with %22
+    // urldecode will get rid of %22 and replace it correctly for it to be inserted into the table
+    $fileNameURLencoded = htmlspecialchars_decode($file['File_name']);
+    $fileName = urldecode($fileNameURLencoded);
+
+    // update only if file name has been updated
+    if($fileName !== $file['File_name']) {
+
+        // change name in sql table media
+        $DB->unsafeupdate(
+            "document_repository",
+            [
+                "file_name" => $fileName
+            ],
+            [
+                "record_id" => $file['id']
+            ]
+        );
+
+        // update name in file system
+        shell_exec("mv " . escapeshellarg($document_repository_path . $fileNameURLencoded) . " " . escapeshellarg($document_repository_path . $fileName));
+        print("Old file name: " . $file['File_name'] . ". New file name: " . $fileName . "\n\n");
+    }
+}

--- a/tools/single_use/Cleanup_Special_Chars_Document_Repository.php
+++ b/tools/single_use/Cleanup_Special_Chars_Document_Repository.php
@@ -21,7 +21,7 @@ $config = NDB_Config::singleton();
 $document_repository_path = $config->getSetting('documentRepositoryPath');
 
 $data = $DB->pselect(
-    "SELECT record_id, File_name
+    "SELECT record_id, File_name, uploaded_by
         FROM document_repository",
     []
 );
@@ -40,7 +40,8 @@ foreach($data as $key => $file) {
         $DB->unsafeupdate(
             "document_repository",
             [
-                "file_name" => $fileName
+                "file_name" => $fileName,
+                "Data_dir"  => $fileName
             ],
             [
                 "record_id" => $file['id']
@@ -48,7 +49,7 @@ foreach($data as $key => $file) {
         );
 
         // update name in file system
-        shell_exec("mv " . escapeshellarg($document_repository_path . $fileNameURLencoded) . " " . escapeshellarg($document_repository_path . $fileName));
+        shell_exec("mv " . escapeshellarg($document_repository_path . $file['uploaded_by'] . "/" . $fileNameURLencoded) . " " . escapeshellarg($document_repository_path . $file['uploaded_by'] . "/" . $fileName));
         print("Old file name: " . $file['File_name'] . ". New file name: " . $fileName . "\n\n");
     }
 }

--- a/tools/single_use/Cleanup_Special_Chars_Document_Repository.php
+++ b/tools/single_use/Cleanup_Special_Chars_Document_Repository.php
@@ -44,7 +44,7 @@ foreach($data as $key => $file) {
                 "Data_dir"  => $fileName
             ],
             [
-                "record_id" => $file['id']
+                "record_id" => $file['record_id']
             ]
         );
 


### PR DESCRIPTION
## Brief summary of changes

Solves an issue when if using special characters (&, <, >, ") the file download fails and the name of the file appears incorrectly in the browse tab of the document repository

#### Testing instructions (if applicable)

1. Upload a file with special charcacters &, <, >, " into the document repository.
2. Look for the file in the file tree, check that the file name appears correctly
3. Try downloading the file and opening it.

