### PR TITLE
[media] Special characters issue

### DIFF
--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -130,7 +130,7 @@ function uploadFile()
     checkDateTaken($dateTaken);
 
     $fileName  = preg_replace('/\s/', '_', $_FILES["file"]["name"]);
-    $fileName  = str_replace("%22", "\"", $fileName);
+    $fileName  = urldecode($fileName);
     $fileType  = $_FILES["file"]["type"];
     $extension = pathinfo($fileName)['extension'];
 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -116,7 +116,7 @@ function uploadFile()
     // If required fields are not set, show an error
     if (empty($_FILES)) {
         showMediaError(
-            "File could not be uploaded successfully. 
+            "File could not be uploaded successfully.
             Please contact the administrator.",
             400
         );
@@ -130,6 +130,7 @@ function uploadFile()
     checkDateTaken($dateTaken);
 
     $fileName  = preg_replace('/\s/', '_', $_FILES["file"]["name"]);
+    $fileName  = str_replace("%22", "\"", $fileName);
     $fileType  = $_FILES["file"]["type"];
     $extension = pathinfo($fileName)['extension'];
 

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -179,7 +179,7 @@ function uploadFile()
     if (move_uploaded_file($_FILES["file"]["tmp_name"], $mediaPath . $fileName)) {
         try {
             // Insert or override db record if file_name already exists
-            $db->insertOnDuplicateUpdate('media', $query);
+            $db->unsafeInsertOnDuplicateUpdate('media', $query);
             $uploadNotifier->notify(array("file" => $fileName));
         } catch (DatabaseException $e) {
             showMediaError("Could not upload the file. Please try again!", 500);

--- a/modules/media/ajax/FileUpload.php
+++ b/modules/media/ajax/FileUpload.php
@@ -129,7 +129,7 @@ function uploadFile()
 
     checkDateTaken($dateTaken);
 
-    $fileName  = preg_replace('/\s/', '_', $_FILES["file"]["name"]);
+    $fileName = preg_replace('/\s/', '_', $_FILES["file"]["name"]);
     $fileName  = urldecode($fileName);
     $fileType  = $_FILES["file"]["type"];
     $extension = pathinfo($fileName)['extension'];

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -64,18 +64,6 @@ class MediaIndex extends Component {
     }
   }
 
-  htmlSpecialCharsDecode(text) {
-    if (text != null) {
-      return text
-        .replace(/&amp;/g, '&')
-        .replace(/&quot;/g, '"')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>');
-    } else {
-      return text;
-    }
-  }
-
   /**
    * Modify behaviour of specified column cells in the Data Table component
    *
@@ -93,13 +81,11 @@ class MediaIndex extends Component {
     switch (column) {
     case 'File Name':
       if (this.props.hasPermission('media_write')) {
-        let fileName = this.htmlSpecialCharsDecode(row['File Name']);
-        cell = this.htmlSpecialCharsDecode(cell);
         const downloadURL = loris.BaseURL + '/media/ajax/FileDownload.php?File=' +
-          encodeURIComponent(fileName);
+          encodeURIComponent(row['File Name']);
         result = (
           <td className={style}>
-            <a href={downloadURL} target="_blank" download={fileName}>
+            <a href={downloadURL} target="_blank" download={row['File Name']}>
               {cell}
             </a>
           </td>

--- a/modules/media/jsx/mediaIndex.js
+++ b/modules/media/jsx/mediaIndex.js
@@ -64,6 +64,18 @@ class MediaIndex extends Component {
     }
   }
 
+  htmlSpecialCharsDecode(text) {
+    if (text != null) {
+      return text
+        .replace(/&amp;/g, '&')
+        .replace(/&quot;/g, '"')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>');
+    } else {
+      return text;
+    }
+  }
+
   /**
    * Modify behaviour of specified column cells in the Data Table component
    *
@@ -81,11 +93,13 @@ class MediaIndex extends Component {
     switch (column) {
     case 'File Name':
       if (this.props.hasPermission('media_write')) {
+        let fileName = this.htmlSpecialCharsDecode(row['File Name']);
+        cell = this.htmlSpecialCharsDecode(cell);
         const downloadURL = loris.BaseURL + '/media/ajax/FileDownload.php?File=' +
-          encodeURIComponent(row['File Name']);
+          encodeURIComponent(fileName);
         result = (
           <td className={style}>
-            <a href={downloadURL} target="_blank" download={row['File Name']}>
+            <a href={downloadURL} target="_blank" download={fileName}>
               {cell}
             </a>
           </td>

--- a/tools/single_use/Cleanup_Special_Chars_Media.php
+++ b/tools/single_use/Cleanup_Special_Chars_Media.php
@@ -48,7 +48,7 @@ foreach($data as $key => $file) {
         );
 
         // update name in file system
-        shell_exec("mv " . escapeshellarg($media_path . $fileNameURLencoded) . " " . escapeshellarg($media_path . $fileName));
+        rename(escapeshellarg($media_path . $fileNameURLencoded), escapeshellarg($media_path . $fileName));
         print("Old file name: " . $file['file_name'] . ". New file name: " . $fileName . "\n\n");
     }
 }

--- a/tools/single_use/Cleanup_Special_Chars_Media.php
+++ b/tools/single_use/Cleanup_Special_Chars_Media.php
@@ -16,6 +16,9 @@
  */
 
 require_once __DIR__."/../generic_includes.php";
+$config = NDB_Config::singleton();
+
+$media_path = $config->getSetting('mediaPath');
 
 $data = $DB->pselect(
     "SELECT id, file_name
@@ -45,8 +48,7 @@ foreach($data as $key => $file) {
         );
 
         // update name in file system
-        shell_exec("mv " . escapeshellarg("/data/uploads/$fileNameURLencoded") . " " . escapeshellarg("/data/uploads/$fileName"));
-        print("File name was: " . $file['file_name'] . "\n");
-        print("Now file name is: " . $fileName . "\n");
+        shell_exec("mv " . escapeshellarg($media_path . $fileNameURLencoded) . " " . escapeshellarg($media_path . $fileName));
+        print("Old file name: " . $file['file_name'] . ". New file name: " . $fileName . "\n\n");
     }
 }

--- a/tools/single_use/Cleanup_Special_Chars_Media.php
+++ b/tools/single_use/Cleanup_Special_Chars_Media.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This script is written to clean up the files with special characters from the media data table as well as clean up the
+ * quotes appearing as %22 in the file names in the file system
+ *
+ * To use the script: php Cleanup_Special_Chars_Media.php
+ *
+ *
+ * PHP Version 7
+ *
+ * @category Main
+ * @package Loris
+ * @author Pierre PAC SOO <pierre.pacsoo@mcin.ca>
+ * @license Loris license
+ * @link https://www.github.com/aces/Loris-Trunk/
+ */
+
+require_once __DIR__."/../generic_includes.php";
+
+$data = $DB->pselect(
+    "SELECT id, file_name
+        FROM media",
+    []
+);
+
+foreach($data as $key => $file) {
+
+    // decode special characters in the file name
+    // print("File name is: " . $file['file_name'] . "\n");
+    $fileNameURLencoded = htmlspecialchars_decode($file['file_name']);
+    $fileName = urldecode($fileNameURLencoded);
+    // print("Now file name is: " . $fileName . "\n");
+
+    // update only if file name has been updated
+    if($fileName !== $file['file_name']) {
+        print($fileNameURLencoded . "\n");
+//        $DB->unsafeupdate(
+//            "media",
+//            [
+//                "file_name" => $fileName
+//            ],
+//            [
+//                "id" => $file['id']
+//            ]
+//        );
+
+        // update name in file system
+        //shell_exec("mv /data/uploads/$fileNameURLencoded /data/uploads/" . addslashes($fileName));
+//        print("File name was: " . $file['file_name'] . "\n");
+//        print("Now file name is: " . $fileName . "\n");
+    }
+}

--- a/tools/single_use/Cleanup_Special_Chars_Media.php
+++ b/tools/single_use/Cleanup_Special_Chars_Media.php
@@ -48,7 +48,7 @@ foreach($data as $key => $file) {
         );
 
         // update name in file system
-        rename(escapeshellarg($media_path . $fileNameURLencoded), escapeshellarg($media_path . $fileName));
+        rename($media_path.$fileNameURLencoded, $media_path.$fileName);
         print("Old file name: " . $file['file_name'] . ". New file name: " . $fileName . "\n\n");
     }
 }

--- a/tools/single_use/Cleanup_Special_Chars_Media.php
+++ b/tools/single_use/Cleanup_Special_Chars_Media.php
@@ -25,28 +25,28 @@ $data = $DB->pselect(
 
 foreach($data as $key => $file) {
 
-    // decode special characters in the file name
-    // print("File name is: " . $file['file_name'] . "\n");
+    // fileNameURLencoded is needed for the step line 48 as the file name got rid of '"' and replaced it with %22
+    // urldecode will get rid of %22 and replace it correctly for it to be inserted into the table
     $fileNameURLencoded = htmlspecialchars_decode($file['file_name']);
     $fileName = urldecode($fileNameURLencoded);
-    // print("Now file name is: " . $fileName . "\n");
 
     // update only if file name has been updated
     if($fileName !== $file['file_name']) {
-        print($fileNameURLencoded . "\n");
-//        $DB->unsafeupdate(
-//            "media",
-//            [
-//                "file_name" => $fileName
-//            ],
-//            [
-//                "id" => $file['id']
-//            ]
-//        );
+
+        // change name in sql table media
+        $DB->unsafeupdate(
+            "media",
+            [
+                "file_name" => $fileName
+            ],
+            [
+                "id" => $file['id']
+            ]
+        );
 
         // update name in file system
-        //shell_exec("mv /data/uploads/$fileNameURLencoded /data/uploads/" . addslashes($fileName));
-//        print("File name was: " . $file['file_name'] . "\n");
-//        print("Now file name is: " . $fileName . "\n");
+        shell_exec("mv " . escapeshellarg("/data/uploads/$fileNameURLencoded") . " " . escapeshellarg("/data/uploads/$fileName"));
+        print("File name was: " . $file['file_name'] . "\n");
+        print("Now file name is: " . $fileName . "\n");
     }
 }


### PR DESCRIPTION
## Brief summary of changes

Solves an issue when if using special characters (&, <, >, ") the file download fails and the name of the file appears incorrectly in the browse tab of the media module.
The script removes the special characters from the sql data table media as well as from the file system.

#### Testing instructions (if applicable)

1. Before checking out this branch, on 23.0-release, upload a file with special characters &, <, >, " into media.
2. Check that the file name appears incorrectly in the media table
3. Check out this branch.
4. Upload a different file with special characters &, <, >, " into media.
5. Look for the file in the browse tab, check that the file name appears correctly
6. Try downloading the file and opening it.
7. run (need sudo to be able to change the name of the files under /data/media_uploads/): sudo php /var/www/loris/tools/single_use/Cleanup_Special_Chars_Media.php
8. Check that the first file now appears correctly in the data table and that when downloading you are able to read the file correctly.
