### PR TITLE
[git actions] Phan can't run in php 7.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 checkstatic: phpdev
 	npm run lint:php
 	npm run lint:javascript
-	vendor/bin/phan
+	vendor/bin/phan --allow-polyfill-parser
 
 # The 'alex' tool scans documentation for condescending language.
 # Arguments:


### PR DESCRIPTION
## Brief summary of changes
23.0-release, php-ast can't install on the PHP 7.3 in the git action.
So, add "--allow-polyfill-parser" to ignore the  "php-ast" in 23.0-release


#### Link(s) to related issue(s)
ERROR: The php-ast extension must be loaded in order for Phan to work. 
https://github.com/aces/Loris/pull/7386/
