### PR TITLE
change parameter_file Value to longtext

### DIFF
--- a/SQL/New_patches/2021-03-15_change_parameter_file_Value_longtext.sql
+++ b/SQL/New_patches/2021-03-15_change_parameter_file_Value_longtext.sql
@@ -1,0 +1,2 @@
+ALTER TABLE parameter_file MODIFY Value LONGTEXT;
+

--- a/SQL/Release_patches/21.0_To_22.0_upgrade.sql
+++ b/SQL/Release_patches/21.0_To_22.0_upgrade.sql
@@ -35,7 +35,7 @@ SELECT 'Running: SQL/Archive/22.0/2019-07-04-remove_header_row_from_parameter_fi
 
 DELETE FROM parameter_file WHERE ParameterTypeID=(SELECT ParameterTypeID FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file');
 DELETE FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file';
-ALTER TABLE parameter_file MODIFY Value LONGTEXT;
+ALTER TABLE parameter_file MODIFY Value TEXT;
 
 SELECT 'Running: SQL/Archive/22.0/2019-07-10-subproject-session-FK.sql';
 

--- a/SQL/Release_patches/21.0_To_22.0_upgrade.sql
+++ b/SQL/Release_patches/21.0_To_22.0_upgrade.sql
@@ -35,7 +35,7 @@ SELECT 'Running: SQL/Archive/22.0/2019-07-04-remove_header_row_from_parameter_fi
 
 DELETE FROM parameter_file WHERE ParameterTypeID=(SELECT ParameterTypeID FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file');
 DELETE FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file';
-
+ALTER TABLE parameter_file MODIFY Value LONGTEXT;
 
 SELECT 'Running: SQL/Archive/22.0/2019-07-10-subproject-session-FK.sql';
 

--- a/SQL/Release_patches/21.0_To_22.0_upgrade.sql
+++ b/SQL/Release_patches/21.0_To_22.0_upgrade.sql
@@ -35,7 +35,7 @@ SELECT 'Running: SQL/Archive/22.0/2019-07-04-remove_header_row_from_parameter_fi
 
 DELETE FROM parameter_file WHERE ParameterTypeID=(SELECT ParameterTypeID FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file');
 DELETE FROM parameter_type WHERE Name='header' AND SourceFrom='parameter_file';
-ALTER TABLE parameter_file MODIFY Value TEXT;
+
 
 SELECT 'Running: SQL/Archive/22.0/2019-07-10-subproject-session-FK.sql';
 


### PR DESCRIPTION
## Brief summary of changes
Add a sql patch to change parameter_file Value to longtext for upgrade.

#### Testing instructions (if applicable)

1. On a upgrade instance (upgraded from v21), check parameter_file table Value is text datatype ([see also 21.0_to_22.0 upgrade](https://github.com/aces/Loris/blob/11e6780c0d0e2f4e33ee915f8258f9222c314892/SQL/Release_patches/21.0_To_22.0_upgrade.sql))
2. Source mysql file on a upgrade instance (upgraded from v21)
3. Verify parameter_file table Value is longtext datatype, and your existing data is OK.

#### Link(s) to related issue(s)

* Resolves  #7391
* Also resolves LORIS_MRI [issue# 589](https://github.com/aces/Loris-MRI/issues/589)

cc
@gdevenyi