### PR TITLE
[LINST Instrument][Bugfix] Age at Death is displayed at top page when candidate is still alive

### DIFF
--- a/php/libraries/NDB_BVL_Instrument_LINST.class.inc
+++ b/php/libraries/NDB_BVL_Instrument_LINST.class.inc
@@ -77,7 +77,7 @@ class NDB_BVL_Instrument_LINST extends \NDB_BVL_Instrument
         $this->addBasicDate('Date_taken', 'Date of Administration', $dateOptions);
 
         if (strrpos($this->testName, '_proband') === false) {
-            if ($this->postMortem) {
+            if (!$this->postMortem) {
                 $this->addScoreColumn(
                     'Candidate_Age',
                     'Candidate Age (Months)'


### PR DESCRIPTION
## Brief summary of changes
Bugfix to ensure that age at death is only displayed if the candidate has passed away. 
This bug only appears in LINST instrument. Please refer to #7396

#### Testing instructions (if applicable)

1. Go to a random (LINST) instrument and fill out top page. Click `Save`.
2. Make sure that you see `Candidate Age (Months)` displayed if candidate is still alive. 
3. Navigate to `Candidate Parameters` and fill in `Date of Death` tab.
4. Go to instrument top page, you should now see `Candidate Age at Death (Months)`

#### Link(s) to related issue(s)

* Resolves #7396
