### PR TITLE
[Utility] Deprecate old getInstrument functions and replace with new ones

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2778,4 +2778,118 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     abstract public function getDataDictionary() : iterable;
 
+    /**
+     * Static function returning a full list of instruments defined in the database.
+     * Only instantiable instruments are returned in the format
+     * test_name => Instrument object.
+     *
+     * Note: An error_log entry is logged if an instrument is in the database but
+     * can not be instantiated. this check should eventually be replaced with an
+     * exception.
+     *
+     * @return array
+     * @throws DatabaseException
+     */
+    static function getInstrumentsList() : array
+    {
+        $Factory     = \NDB_Factory::singleton();
+        $DB          = $Factory->Database();
+        $instruments = $DB->pselectCol("SELECT Test_name FROM test_names", []);
+
+        $instrumentList = [];
+        foreach ($instruments as $inst) {
+            try {
+                $instrumentList[$inst] = NDB_BVL_Instrument::factory($inst, "", "");
+            } catch (Exception $e) {
+                error_log(
+                    "Instrument $inst does not seem to be a valid instrument."
+                );
+            }
+        }
+        return $instrumentList;
+    }
+
+    /**
+     * Static function returning list of all test_names available in the database as
+     * an associative array with format $testName => $fullName. Only Names of
+     * instruments which are instantiable are returned, invalid instruments will not
+     * appear in this list.
+     *
+     * @return array
+     * @throws DatabaseException
+     */
+    static function getInstrumentNamesList() : array
+    {
+        $instrumentsList = self::getInstrumentsList();
+
+        $instrumentNames = [];
+        foreach ($instrumentsList as $testName => $instrument) {
+            $fullName = $instrument->getFullName();
+            $instrumentNames[$testName] =$fullName;
+        }
+
+        return $instrumentNames;
+    }
+
+    /**
+     * Static function returning list of all test_names with Double Data Entry
+     * configuration enabled in the database. The list is returned as an associative
+     * array with format $testName => $fullName. Only Names of instruments which are
+     * instantiable are returned, invalid instruments will not appear in this list.
+     *
+     * @return array
+     * @throws DatabaseException
+     */
+    static function getDDEInstrumentNamesList() : array
+    {
+        $Factory = \NDB_Factory::singleton();
+        $config  = $Factory->config();
+
+        $instrumentNamesList = self::getInstrumentNamesList();
+
+        $doubleDataEntryInstruments = $config->getSetting(
+            'DoubleDataEntryInstruments'
+        );
+
+        $instrumentNames = [];
+        foreach ($instrumentNamesList as $testName => $fullName) {
+            if (in_array($testName, $doubleDataEntryInstruments, true)) {
+                $instrumentNames[$testName] = $fullName;
+            }
+        }
+
+        return $instrumentNames;
+    }
+
+    /**
+     * Static function returning list of all test_names with Direct Data Entry
+     * configuration enabled in the database. The list is returned as an associative
+     * array with format $testName => $fullName. Only Names of instruments which are
+     * instantiable are returned, invalid instruments will not appear in this list.
+     *
+     * @return array
+     * @throws DatabaseException
+     */
+    static function getDirectEntryInstrumentNamesList() : array
+    {
+        $Factory = \NDB_Factory::singleton();
+        $DB      = $Factory->Database();
+
+        $instrumentNamesList = self::getInstrumentNamesList();
+
+        $directEntryInstruments = $DB->pselectCol(
+            "SELECT Test_name FROM test_names WHERE IsDirectEntry=true",
+            []
+        );
+
+        $instrumentNames = [];
+        foreach ($instrumentNamesList as $testName => $instrument) {
+            $fullName = $instrument->getFullName();
+            if (in_array($testName, $directEntryInstruments, true)) {
+                $instrumentNames[$testName] = $fullName;
+            }
+        }
+
+        return $instrumentNames;
+    }
 }

--- a/php/libraries/Utility.class.inc
+++ b/php/libraries/Utility.class.inc
@@ -289,7 +289,7 @@ class Utility
         if (!is_null($projectID)) {
             $subprojects = $DB->pselect(
                 "SELECT * FROM subproject
-                JOIN project_subproject_rel USING (SubprojectID) 
+                JOIN project_subproject_rel USING (SubprojectID)
                 WHERE ProjectID=:pID",
                 ['pID' => $projectID]
             );
@@ -458,6 +458,12 @@ class Utility
      */
     static function getAllInstruments(): array
     {
+        error_log(
+            "LORIS Deprecation Warning: The getAllInstruments() function of
+            the Utility class has been deprecated. This function does not load the
+            most accurate Full_name value and should be replaced by
+            getInstrumentNamesList() of the NDB_BVL_Instrument class."
+        );
         $Factory       = \NDB_Factory::singleton();
         $DB            = $Factory->Database();
         $instruments_q = $DB->pselect(
@@ -481,6 +487,12 @@ class Utility
      */
     static function getAllDDEInstruments(): array
     {
+        error_log(
+            "LORIS Deprecation Warning: The getAllDDEInstruments() function of
+            the Utility class has been deprecated. This function does not load the
+            most accurate Full_name value and should be replaced by
+            getDDEInstrumentNamesList() of the NDB_BVL_Instrument class."
+        );
         $Factory       = \NDB_Factory::singleton();
         $DB            = $Factory->Database();
         $config        = $Factory->config();
@@ -513,12 +525,18 @@ class Utility
      */
     static function getDirectInstruments(): array
     {
+        error_log(
+            "LORIS Deprecation Warning: The getDirectInstruments() function of
+            the Utility class has been deprecated. This function does not load the
+            most accurate Full_name value and should be replaced by
+            getDirectEntryInstrumentNamesList() of the NDB_BVL_Instrument class."
+        );
         $factory = NDB_Factory::singleton();
         $DB      = $factory->database();
 
         $instruments   = [];
         $instruments_q = $DB->pselect(
-            "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true 
+            "SELECT Test_name,Full_name FROM test_names WHERE IsDirectEntry=true
              ORDER BY Full_name",
             []
         );
@@ -882,7 +900,7 @@ class Utility
     {
 
         $scan_types_DB = \NDB_Factory::singleton()->database()->pselect(
-            "SELECT ID, Scan_type 
+            "SELECT ID, Scan_type
              FROM mri_scan_type mri
                 JOIN files f ON (f.AcquisitionProtocolID=mri.ID)",
             []


### PR DESCRIPTION
Instrument Full names are no longer queried from the database `test_names` unless the instrument implements the LegacyTrait. that means that new "properly" implemented instruments should derive their full names directly from the instrument class.

The deprecated functions in this PR wrongly assume that the full name comes from the database table. the functions were deprecated to allow a sow transition to the newly created functions. The following 2 reasons explain why a deprecation was better than simply modifying the existing functions:

1. The old functions were in the Utility class which is a hodge-podge of function with no home. These functions belong more to the Instrument class in our libraries.
2. the is an added limitation to the new system of getting the instrument's full name. The instrument needs to be valid and instantiable, if the instrument can not be instantiated it's name will not be in the list of instruments
 