### PR TITLE
[raisinbread] Update RB with EEG chunks

### DIFF
--- a/raisinbread/RB_files/RB_parameter_type.sql
+++ b/raisinbread/RB_files/RB_parameter_type.sql
@@ -1,6 +1,4 @@
-SET FOREIGN_KEY_CHECKS=0;
-TRUNCATE TABLE `parameter_type`;
-LOCK TABLES `parameter_type` WRITE;
+SET FOREIGN_KEY_CHECKS=0;nTRUNCATE TABLE `parameter_type`;nLOCK TABLES `parameter_type` WRITE;
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (2,'Geometric_distortion','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,0,0);
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (3,'Intensity_artifact','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,0,0);
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (4,'Movement_artifacts_within_scan','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,0,0);
@@ -630,5 +628,6 @@ INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, 
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (1148,'electrode_file_blake2b_hash','text','electrode_file_blake2b_hash magically created by lib.physiological python class',NULL,NULL,NULL,'physiological_parameter_file',NULL,0,0);
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (1149,'channel_file_blake2b_hash','text','channel_file_blake2b_hash magically created by lib.physiological python class',NULL,NULL,NULL,'physiological_parameter_file',NULL,0,0);
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (1150,'event_file_blake2b_hash','text','event_file_blake2b_hash magically created by lib.physiological python class',NULL,NULL,NULL,'physiological_parameter_file',NULL,0,0);
+INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (1151,'electrophyiology_chunked_dataset_path','text','electrophyiology_chunked_dataset_path magically created by lib.physiological python class',NULL,NULL,NULL,'physiological_parameter_file',NULL,0,0);
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;

--- a/raisinbread/RB_files/RB_parameter_type.sql
+++ b/raisinbread/RB_files/RB_parameter_type.sql
@@ -1,4 +1,6 @@
-SET FOREIGN_KEY_CHECKS=0;nTRUNCATE TABLE `parameter_type`;nLOCK TABLES `parameter_type` WRITE;
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE `parameter_type`;
+LOCK TABLES `parameter_type` WRITE;
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (2,'Geometric_distortion','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,0,0);
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (3,'Intensity_artifact','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,0,0);
 INSERT INTO `parameter_type` (`ParameterTypeID`, `Name`, `Type`, `Description`, `RangeMin`, `RangeMax`, `SourceField`, `SourceFrom`, `SourceCondition`, `Queryable`, `IsFile`) VALUES (4,'Movement_artifacts_within_scan','text',NULL,NULL,NULL,NULL,'parameter_file',NULL,0,0);

--- a/raisinbread/RB_files/RB_physiological_parameter_file.sql
+++ b/raisinbread/RB_files/RB_physiological_parameter_file.sql
@@ -1,4 +1,6 @@
-SET FOREIGN_KEY_CHECKS=0;nTRUNCATE TABLE `physiological_parameter_file`;nLOCK TABLES `physiological_parameter_file` WRITE;
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE `physiological_parameter_file`;
+LOCK TABLES `physiological_parameter_file` WRITE;
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (1,1,1125,'2019-08-21 15:09:57','CMS');
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (2,1,1126,'2019-08-21 15:09:57','256');
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (3,1,1127,'2019-08-21 15:09:57','0');

--- a/raisinbread/RB_files/RB_physiological_parameter_file.sql
+++ b/raisinbread/RB_files/RB_physiological_parameter_file.sql
@@ -1,6 +1,4 @@
-SET FOREIGN_KEY_CHECKS=0;
-TRUNCATE TABLE `physiological_parameter_file`;
-LOCK TABLES `physiological_parameter_file` WRITE;
+SET FOREIGN_KEY_CHECKS=0;nTRUNCATE TABLE `physiological_parameter_file`;nLOCK TABLES `physiological_parameter_file` WRITE;
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (1,1,1125,'2019-08-21 15:09:57','CMS');
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (2,1,1126,'2019-08-21 15:09:57','256');
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (3,1,1127,'2019-08-21 15:09:57','0');
@@ -261,5 +259,15 @@ INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `Phy
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (258,10,1148,'2019-08-21 15:11:22','53870df80067539e8329f02c688cb881ca333a52e1c8eb650ab5b6f083e50a90c18ddf048945d3f227daa2baa1723fa267b454ba8d9c04065979fbab7a219738');
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (259,10,1149,'2019-08-21 15:11:22','62950466593dddb41b31cd4904871cddd672655750ea3f593181092ed509546f8495d81ab34f716add22daffdcb6a4d2842367f5dffb4f6c1363ece1cd2b0e75');
 INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (260,10,1150,'2019-08-21 15:11:22','417e38d863e0ca71953754c0a76ee808d6c77d289d6e1e8df504889b5eb1907e439d9be28938d69d655000dd8ffee4822c93555e72a56b1abfe38984a1737408');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (261,1,1151,'2021-03-23 12:50:21','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT167_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (262,2,1151,'2021-03-23 12:50:39','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT168_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (263,3,1151,'2021-03-23 12:50:54','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT174_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (264,4,1151,'2021-03-23 12:51:11','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT176_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (265,5,1151,'2021-03-23 12:51:29','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT175_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (266,6,1151,'2021-03-23 12:51:55','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT172_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (267,7,1151,'2021-03-23 12:52:12','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT170_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (268,8,1151,'2021-03-23 12:52:27','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT173_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (269,9,1151,'2021-03-23 12:52:49','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT171_ses-V1_task-faceO_eeg.chunks');
+INSERT INTO `physiological_parameter_file` (`PhysiologicalParameterFileID`, `PhysiologicalFileID`, `ParameterTypeID`, `InsertTime`, `Value`) VALUES (270,10,1151,'2021-03-23 12:53:19','bids_imports/Face13_BIDSVersion_1.1.0_chunks/sub-OTT166_ses-V1_task-faceO_eeg.chunks');
 UNLOCK TABLES;
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
## Brief summary of changes

This adds the necessary EEG chunks path to the raisin bread database in order to be able to view the signals.

Note: the signals will be rsynced to the /data directory of raisinbread today.

#### Link(s) to related issue(s)

* This is related to #7387 