### PR TITLE
[Utility/Instrument] Replace simple calls to getAllInstruments() by getInstrumentNamesList()

### DIFF
--- a/modules/api/php/views/project.class.inc
+++ b/modules/api/php/views/project.class.inc
@@ -54,7 +54,9 @@ class Project
         return [
             'Meta'        => $meta,
             'Candidates'  => $this->_project->getCandidateIds(),
-            'Instruments' => array_keys(\Utility::getAllInstruments()),
+            'Instruments' => array_keys(
+                \NDB_BVL_Instrument::getInstrumentNamesList()
+            ),
             'Visits'      => $this->_getVisits(),
         ];
     }

--- a/modules/battery_manager/php/testoptionsendpoint.class.inc
+++ b/modules/battery_manager/php/testoptionsendpoint.class.inc
@@ -59,7 +59,7 @@ class TestOptionsEndpoint extends \NDB_Page
     private function _getOptions() : array
     {
         return [
-            'instruments' => \Utility::getAllInstruments(),
+            'instruments' => \NDB_BVL_Instrument::getInstrumentNamesList(),
             'stages'      => $this->_getStageList(),
             'subprojects' => \Utility::getSubprojectList(null),
             'visits'      => \Utility::getVisitList(),

--- a/modules/behavioural_qc/php/behavioural.class.inc
+++ b/modules/behavioural_qc/php/behavioural.class.inc
@@ -87,7 +87,7 @@ class Behavioural extends \NDB_Page implements ETagCalculator
             : $user->getStudySites();
         return (new \LORIS\behavioural_qc\Views\Behavioral(
             $visit_array,
-            \Utility::getAllInstruments(),
+            \NDB_BVL_Instrument::getInstrumentNamesList(),
             \Utility::getProjectList(),
             $list_of_sites
         ))->toArray();

--- a/modules/behavioural_qc/php/conflicts.class.inc
+++ b/modules/behavioural_qc/php/conflicts.class.inc
@@ -89,7 +89,7 @@ class Conflicts extends \NDB_Page implements ETagCalculator
             : $user->getStudySites();
         return (new \LORIS\behavioural_qc\Views\Conflicts(
             $visit_array,
-            \Utility::getAllInstruments(),
+            \NDB_BVL_Instrument::getInstrumentNamesList(),
             \Utility::getProjectList(),
             $list_of_sites
         ))->toArray();

--- a/modules/behavioural_qc/php/incomplete.class.inc
+++ b/modules/behavioural_qc/php/incomplete.class.inc
@@ -90,7 +90,7 @@ class Incomplete extends \NDB_Page implements ETagCalculator
             : $user->getStudySites();
         return (new \LORIS\behavioural_qc\Views\Incomplete(
             $visit_array,
-            \Utility::getAllInstruments(),
+            \NDB_BVL_Instrument::getInstrumentNamesList(),
             $projects,
             $list_of_sites
         ))->toArray();

--- a/modules/configuration/php/configuration.class.inc
+++ b/modules/configuration/php/configuration.class.inc
@@ -67,7 +67,7 @@ class Configuration extends \NDB_Form
             'Ym'  => 'Ym (EX: 2015-12)'
         ];
 
-        $instruments     = \Utility::getAllInstruments();
+        $instruments     = \NDB_BVL_Instrument::getInstrumentNamesList();
         $instruments[''] = '';
 
         $this->tpl_data['parentMenuItems'] = $this->_getParentConfigLabels();
@@ -94,8 +94,8 @@ class Configuration extends \NDB_Form
         $DB = \Database::singleton();
 
         $parentConfigItems = $DB->pselect(
-            "SELECT Label, Name 
-             FROM ConfigSettings 
+            "SELECT Label, Name
+             FROM ConfigSettings
              WHERE Parent IS NULL AND Visible=1 ORDER BY OrderNumber",
             []
         );

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -258,7 +258,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
         $user = \NDB_Factory::singleton()->user();
 
         // Get instruments
-        $instruments = \Utility::getAllInstruments();
+        $instruments = \NDB_BVL_Instrument::getInstrumentNamesList();
 
         // Get visits
         $visits = \Utility::getVisitList();

--- a/modules/conflict_resolver/php/resolved_conflicts.class.inc
+++ b/modules/conflict_resolver/php/resolved_conflicts.class.inc
@@ -111,7 +111,7 @@ class Resolved_Conflicts extends \NDB_Menu_Filter
         $user = \NDB_Factory::singleton()->user();
 
         // Get instruments
-        $instruments = \Utility::getAllInstruments();
+        $instruments = \NDB_BVL_Instrument::getInstrumentNamesList();
 
         // Get visits
         $visits = \Utility::getVisitList();

--- a/modules/datadict/php/datadict.class.inc
+++ b/modules/datadict/php/datadict.class.inc
@@ -59,7 +59,7 @@ class Datadict extends \DataFrameworkMenu
     public function getFieldOptions() : array
     {
         return [
-            'sourceFrom' => \Utility::getAllInstruments(),
+            'sourceFrom' => \NDB_BVL_Instrument::getInstrumentNamesList(),
         ];
     }
 

--- a/modules/datadict/php/fields.class.inc
+++ b/modules/datadict/php/fields.class.inc
@@ -23,7 +23,7 @@ class Fields extends \NDB_Page
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         return new \LORIS\Http\Response\JSON\OK(
-            ['sourceFrom' => \Utility::getAllInstruments()]
+            ['sourceFrom' => \NDB_BVL_Instrument::getInstrumentNamesList()]
         );
     }
 }

--- a/modules/statistics/php/statistics_dd_site.class.inc
+++ b/modules/statistics/php/statistics_dd_site.class.inc
@@ -51,7 +51,7 @@ class Statistics_DD_Site extends statistics_site
      */
     function _setInstrumentName()
     {
-        $this->instruments = \Utility::getAllInstruments();
+        $this->instruments = \NDB_BVL_Instrument::getInstrumentNamesList();
         foreach (array_keys($this->instruments) as $k) {
             $this->instruments[$k] = $k;
         }
@@ -85,13 +85,13 @@ class Statistics_DD_Site extends statistics_site
             "SELECT count(s.CandID)  FROM session s, candidate c,
                 flag f, $safe_instrument i
              WHERE
-                s.ID=f.SessionID AND f.CommentID=i.CommentID 
-                AND s.CandID=c.CandID  
-                AND s.Active='Y' 
+                s.ID=f.SessionID AND f.CommentID=i.CommentID
+                AND s.CandID=c.CandID
+                AND s.Active='Y'
                 AND s.CenterID <> '1'
                 AND s.Current_stage <> 'Recycling Bin'
                 $this->query_criteria
-                AND f.Data_entry='Complete' AND f.Administration='All' 
+                AND f.Data_entry='Complete' AND f.Administration='All'
                 AND i.CommentID LIKE 'DDE%' ORDER BY c.PSCID",
             $this->query_vars
         );
@@ -112,10 +112,10 @@ class Statistics_DD_Site extends statistics_site
         $safe_instrument = $DB->escape($instrument);
         $result          = $DB->pselect(
             "SELECT s.CandID, f.SessionID, i.CommentID, c.PSCID,
-                lower(s.Visit_label) as Visit_label 
+                lower(s.Visit_label) as Visit_label
                 FROM session s, candidate c, flag f, $safe_instrument i
-                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID AND 
-                s.CandID=c.CandID  AND s.Active='Y' 
+                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID AND
+                s.CandID=c.CandID  AND s.Active='Y'
                 AND s.CenterID <> '1'
                 $this->query_criteria
                 AND s.Current_stage <> 'Recycling Bin'

--- a/modules/statistics/php/statistics_site.class.inc
+++ b/modules/statistics/php/statistics_site.class.inc
@@ -163,7 +163,7 @@ class Statistics_Site extends \NDB_Menu
      */
     function _setInstrumentName()
     {
-        $this->instruments = \Utility::getAllInstruments();
+        $this->instruments = \NDB_BVL_Instrument::getInstrumentNamesList();
     }
 
     /**
@@ -192,16 +192,16 @@ class Statistics_Site extends \NDB_Menu
         $this->_checkCriteria($centerID, $projectID);
         $DB    =& \Database::singleton();
         $count = $DB->pselectOne(
-            "SELECT count(s.CandID)  FROM session s, 
-                candidate c, flag f, {$instrument} i 
-                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID 
-                AND s.CandID=c.CandID  
-                AND s.Active='Y' 
-                AND s.CenterID <> '1' 
-                $this->query_criteria 
-                AND f.Data_entry='Complete' 
+            "SELECT count(s.CandID)  FROM session s,
+                candidate c, flag f, {$instrument} i
+                WHERE s.ID=f.SessionID AND f.CommentID=i.CommentID
+                AND s.CandID=c.CandID
+                AND s.Active='Y'
+                AND s.CenterID <> '1'
+                $this->query_criteria
+                AND f.Data_entry='Complete'
                 AND s.Current_stage <> 'Recycling Bin'
-                AND f.Administration='All' 
+                AND f.Administration='All'
                 AND i.CommentID NOT LIKE 'DDE%'",
             $this->query_vars
         );

--- a/modules/statistics/php/stats_demographic.class.inc
+++ b/modules/statistics/php/stats_demographic.class.inc
@@ -355,7 +355,7 @@ class Stats_Demographic extends \NDB_Form
                           count(DISTINCT(c.PSCID)) as val
                       FROM candidate as c
                           LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
-                          LEFT JOIN participant_status_options pso 
+                          LEFT JOIN participant_status_options pso
                                     ON (pso.ID=ps.participant_status)
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'
@@ -388,7 +388,7 @@ class Stats_Demographic extends \NDB_Form
                           count(DISTINCT(c.PSCID)) as val
                       FROM candidate as c
                           LEFT JOIN participant_status ps ON (ps.CandID=c.CandID)
-                          LEFT JOIN participant_status_options pso 
+                          LEFT JOIN participant_status_options pso
                                       ON (pso.ID=ps.participant_status)
                           LEFT JOIN session s ON (s.CandID=c.CandID)
                       WHERE c.RegistrationCenterID <> '1'
@@ -510,7 +510,7 @@ class Stats_Demographic extends \NDB_Form
         }
 
         //START BIG TABLE
-        $instrumentList = \Utility::getAllInstruments();
+        $instrumentList = \NDB_BVL_Instrument::getInstrumentNamesList();
         $instDropdown   = array_merge(
             [ '' => 'Recruit Breakdown by Sex'],
             $instrumentList

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2824,8 +2824,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $instrumentNames = [];
         foreach ($instrumentsList as $testName => $instrument) {
             $fullName = $instrument->getFullName();
-            $instrumentNames[$testName] =$fullName;
+            $instrumentNames[$testName] = $fullName;
         }
+
+        // sort array by instrument name for modules that rely on ordering
+        asort($instrumentNames, SORT_STRING | SORT_FLAG_CASE | SORT_NATURAL);
 
         return $instrumentNames;
     }
@@ -2856,6 +2859,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $instrumentNames[$testName] = $fullName;
             }
         }
+
+        // sort array by instrument name for modules that rely on ordering
+        asort($instrumentNames, SORT_STRING | SORT_FLAG_CASE | SORT_NATURAL);
 
         return $instrumentNames;
     }
@@ -2888,6 +2894,9 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $instrumentNames[$testName] = $fullName;
             }
         }
+
+        // sort array by instrument name for modules that rely on ordering
+        asort($instrumentNames, SORT_STRING | SORT_FLAG_CASE | SORT_NATURAL);
 
         return $instrumentNames;
     }

--- a/tools/CouchDB_Import_Instruments.php
+++ b/tools/CouchDB_Import_Instruments.php
@@ -269,7 +269,7 @@ class CouchDBInstrumentImporter
      */
     function getInstruments()
     {
-        return \Utility::getAllInstruments();
+        return \NDB_BVL_Instrument::getInstrumentNamesList();
     }
 
     /**

--- a/tools/detect_duplicated_commentids.php
+++ b/tools/detect_duplicated_commentids.php
@@ -81,7 +81,7 @@ $diff           = null;
 $commentids     = [];
 //Check to see if the variable instrument is set
 if (($instrument=='all') ||($instrument=='All')) {
-    $instruments = Utility::getAllInstruments();
+    $instruments = \NDB_BVL_Instrument::getInstrumentNamesList();
 } else {
     $instruments = [$instrument => $instrument];
 }

--- a/tools/populate_examiners_psc_rel.php
+++ b/tools/populate_examiners_psc_rel.php
@@ -29,7 +29,7 @@ $examinersRows = $db->pselect(
 );
 
 //get all instruments to update examiner fields
-$instruments = Utility::getAllInstruments();
+$instruments = \NDB_BVL_Instrument::getInstrumentNamesList();
 
 $examinersOrganized =[];
 
@@ -98,8 +98,8 @@ if (!empty($pendingNullCheck)) {
 }
 ///////// certification.examinerID NOT in examiners.examinerID
 $certCheck = $db->pselect(
-    "SELECT DISTINCT examinerID 
-     FROM certification 
+    "SELECT DISTINCT examinerID
+     FROM certification
      WHERE examinerID NOT IN (SELECT examinerID FROM examiners)",
     []
 );
@@ -128,8 +128,8 @@ foreach ($instruments as $table => $name) {
     }
 }
 $frrCheck = $db->pselect(
-    "SELECT * FROM final_radiological_review 
-      WHERE Final_Examiner2 NOT IN (SELECT examinerID FROM examiners) 
+    "SELECT * FROM final_radiological_review
+      WHERE Final_Examiner2 NOT IN (SELECT examinerID FROM examiners)
           OR Final_Examiner NOT IN (SELECT examinerID FROM examiners) ",
     []
 );
@@ -243,9 +243,9 @@ foreach ($examinersOrganized as $name => $data_array) {
 echo <<<'DONE'
 
 
-The script ran successfully, make sure to run the clean-up commands available 
+The script ran successfully, make sure to run the clean-up commands available
 in the SQL/Archive/18.0/clean-up directory.
-These commands will drop the now redundant fields and add new constraints to 
+These commands will drop the now redundant fields and add new constraints to
 the examiner tables.
 
 DONE;

--- a/tools/recreate_conflicts.php
+++ b/tools/recreate_conflicts.php
@@ -46,7 +46,7 @@ if (empty($argv[1]) || $argv[1] == 'help') {
 $action = $argv[1];
 
 if ($action=='all') {
-    $allInstruments = Utility::getAllInstruments();
+    $allInstruments = \NDB_BVL_Instrument::getInstrumentNamesList();
     $ddeInstruments = $config->getSetting('DoubleDataEntryInstruments');
 } else {
     $allInstruments = [$action => $action];


### PR DESCRIPTION
1. Replace calls to getAllInstruments() function (about to be deprecated) by getInstrumentNamesList as a followup to #7398.
2. added sorting to the Instrument class functions to reduce differences with old deprecated functions.

This PR is not exhaustive!! not all instances were replaced here, only the ones where instruments were queried only for their names. Other instances where instruments are queried to instantiate them and extract other data have not yet been included here.

 