### PR TITLE
[publication] Give publication creator edit permissions

### DIFF
--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -100,6 +100,15 @@ function uploadPublication() : void
     $db->insert('publication', $fields);
     $pubID = $db->getLastInsertId();
 
+    // give creator permission to edit
+    $db->insert(
+        'publication_users_edit_perm_rel',
+        [
+            'PublicationID' => $pubID,
+            'UserID'        => $uid,
+        ]
+    );
+
     try {
         // process files
         processFiles($pubID);


### PR DESCRIPTION
## Brief summary of changes
This PR ensures that the creator of a publication project is added to the `publication_users_edit_perm_rel` table and given edit access to their submission.

#### Testing instructions (if applicable)
1. Before checking out this PR, go to `Publication`
2. Create & submit a project proposal
3. Try accessing the created proposal and notice that you cannot edit the fields (other than status)
4. Checkout this PR
5. Repeat steps 1-3 and make sure that this time you can edit the fields

#### Link(s) to related issue(s)

* Resolves #7401
