### PR TITLE
[Core] Update NDB_Page constructor to include LorisInstance object

### DIFF
--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -54,6 +54,8 @@ class DirectDataEntryMainPage
     var $tpl_data;
     var $caller;
 
+    private $loris;
+
     /**
      * Initialize all of the class variables and things required from the
      * REQUEST.
@@ -78,6 +80,13 @@ class DirectDataEntryMainPage
         $this->key = $_REQUEST['key'];
 
         $DB = Database::singleton();
+
+
+        $this->loris = new \LORIS\LorisInstance(
+            $DB,
+            $config,
+            []
+        );
         $this->TestName  = $DB->pselectOne(
             "SELECT Test_name FROM participant_accounts
             WHERE OneTimePassword=:key AND Status <> 'Complete'",
@@ -346,6 +355,7 @@ class DirectDataEntryMainPage
         }
 
         $workspace = $this->caller->load(
+            $this->loris,
             $this->TestName,
             $this->Subtest ?? '',
             $this->CommentID,

--- a/htdocs/survey.php
+++ b/htdocs/survey.php
@@ -81,8 +81,7 @@ class DirectDataEntryMainPage
 
         $DB = Database::singleton();
 
-
-        $this->loris = new \LORIS\LorisInstance(
+        $this->loris     = new \LORIS\LorisInstance(
             $DB,
             $config,
             []

--- a/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instrument/flags.class.inc
@@ -152,7 +152,8 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
             );
         }
 
-        $this->_instrumentStatus = new \NDB_BVL_InstrumentStatus();
+        $loris = $request->getAttribute("loris");
+        $this->_instrumentStatus = new \NDB_BVL_InstrumentStatus($loris);
         $this->_instrumentStatus->select($this->_instrument->commentID);
 
         $data = json_decode((string) $request->getBody(), true);
@@ -213,7 +214,8 @@ class Flags extends Endpoint implements \LORIS\Middleware\ETagCalculator
             );
         }
 
-        $this->_instrumentStatus = new \NDB_BVL_InstrumentStatus();
+        $loris = $request->getAttribute("loris");
+        $this->_instrumentStatus = new \NDB_BVL_InstrumentStatus($loris);
         $this->_instrumentStatus->select($this->_instrument->commentID);
 
         if (!$this->_instrument->determineDataEntryAllowed()) {

--- a/modules/api/php/endpoints/candidate/visit/instruments.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instruments.class.inc
@@ -84,6 +84,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $pathparts = $request->getAttribute('pathparts');
+        $loris = $request->getAttribute("loris");
         if (count($pathparts) === 0) {
             switch ($request->getMethod()) {
             case 'GET':
@@ -124,6 +125,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         try {
             $instrument = \NDB_BVL_Instrument::factory(
+                $loris,
                 $instrumentname,
                 $commentid,
                 '',

--- a/modules/api/php/endpoints/candidate/visit/instruments.class.inc
+++ b/modules/api/php/endpoints/candidate/visit/instruments.class.inc
@@ -84,7 +84,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         $pathparts = $request->getAttribute('pathparts');
-        $loris = $request->getAttribute("loris");
+        $loris     = $request->getAttribute("loris");
         if (count($pathparts) === 0) {
             switch ($request->getMethod()) {
             case 'GET':

--- a/modules/api/php/endpoints/project/instruments.class.inc
+++ b/modules/api/php/endpoints/project/instruments.class.inc
@@ -100,7 +100,7 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
         // Delegate to instrument specific endpoint.
         $instrumentname = array_shift($pathparts);
         try {
-            $loris = $request->getAttribute("loris");
+            $loris      = $request->getAttribute("loris");
             $instrument = \NDB_BVL_Instrument::factory(
                 $loris,
                 $instrumentname,

--- a/modules/api/php/endpoints/project/instruments.class.inc
+++ b/modules/api/php/endpoints/project/instruments.class.inc
@@ -100,7 +100,9 @@ class Instruments extends Endpoint implements \LORIS\Middleware\ETagCalculator
         // Delegate to instrument specific endpoint.
         $instrumentname = array_shift($pathparts);
         try {
+            $loris = $request->getAttribute("loris");
             $instrument = \NDB_BVL_Instrument::factory(
+                $loris,
                 $instrumentname,
                 '',
                 '',

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -28,7 +28,9 @@ class Module extends \Module
             $candidate = \Candidate::singleton($candID);
 
             $request = $request->withAttribute('candidate', $candidate);
-            $page    = $this->loadPage("candidate_profile");
+            $loris   = $request->getAttribute("loris");
+            $page    = $this->loadPage($loris, "candidate_profile");
+
             return $page->process($request, $page);
         } catch (\DomainException | \LORISException $e) {
             // A LORISException means the \Candidate::singleton couldn't

--- a/modules/conflict_resolver/php/conflict_resolver.class.inc
+++ b/modules/conflict_resolver/php/conflict_resolver.class.inc
@@ -132,6 +132,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                     $TableName = $row['TableName'];
 
                     $Instrument = \NDB_BVL_Instrument::factory(
+                        $this->loris,
                         $TableName,
                         $row['CommentId1'],
                         '',
@@ -154,6 +155,7 @@ class Conflict_Resolver extends \NDB_Menu_Filter_Form
                     }
 
                     $Instrument = \NDB_BVL_Instrument::factory(
+                        $this->loris,
                         $TableName,
                         $row['CommentId2'],
                         '',

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -62,7 +62,7 @@ class Dashboard extends \NDB_Form
         string $page,
         string $identifier,
         string $commentID,
-        string $formname,
+        string $formname
     ) {
         parent::__construct(
             $loris,

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -53,13 +53,14 @@ class Dashboard extends \NDB_Form
      * @param string  $formname   The name to give this form
      */
     function __construct(
+        \LORIS\LorisInstance $loris,
         \Module $module,
         string $page,
         string $identifier,
         string $commentID,
-        string $formname
+        string $formname,
     ) {
-        parent::__construct($module, $page, $identifier, $commentID, $formname);
+        parent::__construct($loris, $module, $page, $identifier, $commentID, $formname);
 
         // This needs to be done before setup so that the widget specific CSS and
         // javascript are available for getCSSDependencies and getJSDependencies,

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -46,11 +46,15 @@ class Dashboard extends \NDB_Form
     /**
      * Page constructor for the dashboard main page.
      *
-     * @param \Module $module     The test name being accessed
-     * @param string  $page       The subtest being accessed (may be an empty string)
-     * @param string  $identifier The identifier for the data to load on this page
-     * @param string  $commentID  The CommentID to load the data for
-     * @param string  $formname   The name to give this form
+     * @param \LORIS\LorisInstance $loris      The LORIS instance the page is being
+     *                                         constructed for
+     * @param \Module              $module     The test name being accessed
+     * @param string               $page       The subtest being accessed
+     *                                         (may be an empty string)
+     * @param string               $identifier The identifier for the data to
+     *                                         load on this page
+     * @param string               $commentID  The CommentID to load the data for
+     * @param string               $formname   The name to give this form
      */
     function __construct(
         \LORIS\LorisInstance $loris,
@@ -60,7 +64,14 @@ class Dashboard extends \NDB_Form
         string $commentID,
         string $formname,
     ) {
-        parent::__construct($loris, $module, $page, $identifier, $commentID, $formname);
+        parent::__construct(
+            $loris,
+            $module,
+            $page,
+            $identifier,
+            $commentID,
+            $formname
+        );
 
         // This needs to be done before setup so that the widget specific CSS and
         // javascript are available for getCSSDependencies and getJSDependencies,

--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -23,7 +23,7 @@ class Files extends \NDB_Page
      *
      * @return bool
      */
-    function _hasAccess(\User $user) : bool
+    public function _hasAccess(\User $user) : bool
     {
         // check user permissions
         return $user->hasAnyPermission(

--- a/modules/data_release/php/files.class.inc
+++ b/modules/data_release/php/files.class.inc
@@ -23,7 +23,7 @@ class Files extends \NDB_Page
      *
      * @return bool
      */
-    public function _hasAccess(\User $user) : bool
+    function _hasAccess(\User $user) : bool
     {
         // check user permissions
         return $user->hasAnyPermission(

--- a/modules/data_release/php/permissions.class.inc
+++ b/modules/data_release/php/permissions.class.inc
@@ -59,6 +59,7 @@ class Permissions extends \NDB_Page
         $loris       = $request->getAttribute("loris");
         $DB          = $loris->getDatabaseConnection();
         $releasePage = $this->Module->loadPage(
+            $loris,
             'data_release',
         );
         assert($releasePage instanceof Data_Release);
@@ -206,7 +207,7 @@ class Permissions extends \NDB_Page
         $DB    = $loris->getDatabaseConnection();
 
         // Get current user version files and list of files for each version.
-        $dataRelease = $this->Module->loadPage('data_release');
+        $dataRelease = $this->Module->loadPage($loris, 'data_release');
         assert($dataRelease instanceof Data_Release);
         $userVersionFiles = $dataRelease->getUserVersionFiles($DB);
         $versionFiles     = $dataRelease->getVersionFiles($DB);

--- a/modules/dictionary/php/module.class.inc
+++ b/modules/dictionary/php/module.class.inc
@@ -126,15 +126,18 @@ class Module extends \Module
      * by the page, so we arbitrarily map "module" URLs to the "moduledict"
      * class name instead.
      *
-     * @param string $page the Page name being accessed.
+     * @param \LORIS\LorisInstance $loris The LORIS instance that the module
+     *                                    is serving.
+     * @param string               $page  The name of the page within the
+     *                                    module to load.
      *
      * @return \NDB_Page
      */
-    public function loadPage(string $page)
+    public function loadPage(\Loris\LORISInstance $loris, string $page)
     {
         if ($page === 'module') {
-            return $this->loadPage('moduledict');
+            return $this->loadPage($loris, 'moduledict');
         }
-        return parent::loadPage($page);
+        return parent::loadPage($loris, $page);
     }
 }

--- a/modules/instrument_list/php/instrument_list.class.inc
+++ b/modules/instrument_list/php/instrument_list.class.inc
@@ -164,6 +164,7 @@ class Instrument_List extends \NDB_Menu_Filter
     function getControlPanel()
     {
         $controlPanel = new Instrument_List_ControlPanel(
+            $this->loris,
             $this->timePoint->getSessionID()
         );
         // save possible changes from the control panel...
@@ -226,10 +227,10 @@ class Instrument_List extends \NDB_Menu_Filter
                 $prevSubgroup = $instrument['Sub_group'];
 
                 // make an instrument status object
-                $status = new \NDB_BVL_InstrumentStatus;
+                $status = new \NDB_BVL_InstrumentStatus($this->loris);
                 $status->select($instrument['CommentID']);
 
-                $ddeStatus = new \NDB_BVL_InstrumentStatus;
+                $ddeStatus = new \NDB_BVL_InstrumentStatus($this->loris);
                 $ddeStatus->select($instrument['DDECommentID']);
 
                 $Ins = "instruments";

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -34,15 +34,22 @@ class Instrument_List_ControlPanel extends \TimePoint
     protected array $tpl_data;
 
     /**
+     * @var \LORIS\LorisInstance $loris
+     */
+    protected $loris;
+
+    /**
      * Construct function
      *
      * @param \SessionID $sessionID the value of sessionID
      *
      * @return void
      */
-    function __construct($sessionID)
+    function __construct(\LORIS\LorisInstance $loris, $sessionID)
     {
         $this->tpl_data = [];
+        $this->loris = $loris;
+
         $this->select($sessionID);
     }
 
@@ -226,6 +233,7 @@ class Instrument_List_ControlPanel extends \TimePoint
                         $instrument['CommentID']
                     );
                     $diff =\ConflictDetector::detectConflictsForCommentIds(
+                        $this->loris,
                         $instrument['Test_name'],
                         $instrument['CommentID'],
                         $instrument['DDECommentID']
@@ -351,7 +359,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         $ddeConflictDetected = false;
         $dataEntry           = '';
         foreach ($batteryList as $instrument) {
-            $status = new \NDB_BVL_InstrumentStatus();
+            $status = new \NDB_BVL_InstrumentStatus($this->loris);
             $status->select($instrument['CommentID']);
             $dataEntry = $status->getDataEntryStatus();
             if ($dataEntry != 'Complete') {
@@ -361,7 +369,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             // If the instrument requires double data entry,
             //check that DDE is also done
             if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                $status = new \NDB_BVL_InstrumentStatus();
+                $status = new \NDB_BVL_InstrumentStatus($this->loris);
                 $status->select($instrument['DDECommentID']);
                 $dataEntry = $status->getDataEntryStatus();
                 if ($dataEntry != 'Complete') {
@@ -567,7 +575,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         $allDataEntryComplete =true;
         foreach ($batteryList as $instrument) {
 
-            $status = new \NDB_BVL_InstrumentStatus();
+            $status = new \NDB_BVL_InstrumentStatus($this->loris);
             $status->select($instrument['CommentID']);
             $dataEntry = $status->getDataEntryStatus();
             if ($dataEntry != 'Complete') {
@@ -578,7 +586,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             // If the instrument requires double data entry,
             // check that DDE is also done
             if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                $status = new \NDB_BVL_InstrumentStatus();
+                $status = new \NDB_BVL_InstrumentStatus($this->loris);
                 $status->select($instrument['DDECommentID']);
                 $dataEntry = $status->getDataEntryStatus();
                 if ($dataEntry != 'Complete') {
@@ -663,7 +671,7 @@ class Instrument_List_ControlPanel extends \TimePoint
         $allDataEntryComplete =true;
         foreach ($batteryList as $instrument) {
 
-            $status = new \NDB_BVL_InstrumentStatus();
+            $status = new \NDB_BVL_InstrumentStatus($this->loris);
             $status->select($instrument['CommentID']);
             $dataEntry = $status->getDataEntryStatus();
             if ($dataEntry != 'Complete') {
@@ -674,7 +682,7 @@ class Instrument_List_ControlPanel extends \TimePoint
             // If the instrument requires double data entry,
             // check that DDE is also done
             if (in_array($instrument['Test_name'], $ddeInstruments)) {
-                $status = new \NDB_BVL_InstrumentStatus();
+                $status = new \NDB_BVL_InstrumentStatus($this->loris);
                 $status->select($instrument['DDECommentID']);
                 $dataEntry = $status->getDataEntryStatus();
                 if ($dataEntry != 'Complete') {

--- a/modules/instrument_list/php/instrument_list_controlpanel.class.inc
+++ b/modules/instrument_list/php/instrument_list_controlpanel.class.inc
@@ -34,6 +34,8 @@ class Instrument_List_ControlPanel extends \TimePoint
     protected array $tpl_data;
 
     /**
+     * The LORIS Instance that this timepoint exists on
+     *
      * @var \LORIS\LorisInstance $loris
      */
     protected $loris;
@@ -41,14 +43,16 @@ class Instrument_List_ControlPanel extends \TimePoint
     /**
      * Construct function
      *
-     * @param \SessionID $sessionID the value of sessionID
+     * @param \LORIS\LorisInstance $loris     The LORIS Instance.
+     * @param \SessionID           $sessionID SessionID that this control
+     *                                        panel is controlling.
      *
      * @return void
      */
     function __construct(\LORIS\LorisInstance $loris, $sessionID)
     {
         $this->tpl_data = [];
-        $this->loris = $loris;
+        $this->loris    = $loris;
 
         $this->select($sessionID);
     }

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -61,7 +61,8 @@ class Module extends \Module
         // Falling back to instrument_list, ensure that the CandID
         // and SessionID are valid, and if so attach the models to
         // the request.
-        $page = $this->loadPage("instrument_list");
+        $loris = $request->getAttribute("loris");
+        $page = $this->loadPage($loris, "instrument_list");
         '@phan-var Instrument_List $page';
 
         $gets = $request->getQueryParams();

--- a/modules/instrument_list/php/module.class.inc
+++ b/modules/instrument_list/php/module.class.inc
@@ -62,7 +62,7 @@ class Module extends \Module
         // and SessionID are valid, and if so attach the models to
         // the request.
         $loris = $request->getAttribute("loris");
-        $page = $this->loadPage($loris, "instrument_list");
+        $page  = $this->loadPage($loris, "instrument_list");
         '@phan-var Instrument_List $page';
 
         $gets = $request->getQueryParams();

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -54,14 +54,20 @@ class Instrument_Manager extends \NDB_Menu_Filter
      * @param string $commentID The CommentID to load the data for
      * @param string $formname  The name to give this form
      */
-    public function __construct($module, $page, $id, $commentID, $formname)
-    {
+    public function __construct(
+        \LORIS\LorisInstance $loris,
+        $module,
+        $page,
+        $id,
+        $commentID,
+        $formname,
+    ) {
         $this->AjaxModule   = true;
         $this->skipTemplate = true;
         $this->_factory     = \NDB_Factory::singleton();
         $this->_path        = $this->_factory->config()->getSetting("base");
 
-        parent::__construct($module, $page, $id, $commentID);
+        parent::__construct($loris, $module, $page, $id, $commentID);
     }
 
     /**
@@ -184,7 +190,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         // messsage from MySQL. This will be stored in $result and
         // logged via LorisException.
         try {
-            $table_name = \NDB_BVL_Instrument::factory($instrument, '', '')->table;
+            $table_name = \NDB_BVL_Instrument::factory($this->loris, $instrument, '', '')->table;
         } catch (\NotFound $e) {
             return (new \LORIS\Http\Response\JSON\NotFound(
                 $e->getMessage()

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -64,7 +64,7 @@ class Instrument_Manager extends \NDB_Menu_Filter
         $page,
         $id,
         $commentID,
-        $formname,
+        $formname
     ) {
         $this->AjaxModule   = true;
         $this->skipTemplate = true;

--- a/modules/instrument_manager/php/instrument_manager.class.inc
+++ b/modules/instrument_manager/php/instrument_manager.class.inc
@@ -48,11 +48,15 @@ class Instrument_Manager extends \NDB_Menu_Filter
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param Module $module    The test name being accessed
-     * @param string $page      The subtest being accessed (may be an empty string)
-     * @param string $id        The identifier for the data to load on this page
-     * @param string $commentID The CommentID to load the data for
-     * @param string $formname  The name to give this form
+     * @param \LORIS\LorisInstance $loris     The LORIS Instance that is serving
+     *                                        the page
+     * @param Module               $module    The test name being accessed
+     * @param string               $page      The subtest being accessed (may be
+     *                                        an empty string)
+     * @param string               $id        The identifier for the data to load
+     *                                        on this page
+     * @param string               $commentID The CommentID to load the data for
+     * @param string               $formname  The name to give this form
      */
     public function __construct(
         \LORIS\LorisInstance $loris,
@@ -190,7 +194,12 @@ class Instrument_Manager extends \NDB_Menu_Filter
         // messsage from MySQL. This will be stored in $result and
         // logged via LorisException.
         try {
-            $table_name = \NDB_BVL_Instrument::factory($this->loris, $instrument, '', '')->table;
+            $table_name = \NDB_BVL_Instrument::factory(
+                $this->loris,
+                $instrument,
+                '',
+                '',
+            )->table;
         } catch (\NotFound $e) {
             return (new \LORIS\Http\Response\JSON\NotFound(
                 $e->getMessage()

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -74,7 +74,10 @@ class Module extends \Module
                 ->withStatus(400)
                 ->withBody(new \LORIS\Http\StringStream("Missing CommentID"));
         }
+
+        $loris = $request->getAttribute("loris");
         $instrument = \NDB_BVL_Instrument::factory(
+            $loris,
             $instrumentName,
             $commentID,
             $page

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -75,7 +75,7 @@ class Module extends \Module
                 ->withBody(new \LORIS\Http\StringStream("Missing CommentID"));
         }
 
-        $loris = $request->getAttribute("loris");
+        $loris      = $request->getAttribute("loris");
         $instrument = \NDB_BVL_Instrument::factory(
             $loris,
             $instrumentName,

--- a/modules/instruments/php/module.class.inc
+++ b/modules/instruments/php/module.class.inc
@@ -166,7 +166,7 @@ class Module extends \Module
         $dict = [];
         foreach ($tests as $testname) {
             try {
-                $inst   = \NDB_BVL_Instrument::factory($testname, "", "");
+                $inst   = \NDB_BVL_Instrument::factory($loris, $testname, "", "");
                 $cat    = new \LORIS\Data\Dictionary\Category(
                     $testname,
                     $inst->getFullName()

--- a/modules/instruments/php/visitsummary.class.inc
+++ b/modules/instruments/php/visitsummary.class.inc
@@ -105,6 +105,7 @@ class VisitSummary extends \NDB_Page
             $commentID = $row['CommentID'];
 
             $instrument = \NDB_BVL_Instrument::factory(
+                $this->loris,
                 $testName,
                 $commentID,
                 '',

--- a/modules/next_stage/php/next_stage.class.inc
+++ b/modules/next_stage/php/next_stage.class.inc
@@ -118,6 +118,7 @@ class Next_Stage extends \NDB_Form
 
         // add instruments to the time point (lower case stage)
         $battery->createBattery(
+            $this->loris,
             $timePoint->getSubprojectID(),
             $newStage,
             $timePoint->getVisitLabel(),

--- a/modules/survey_accounts/php/addsurvey.class.inc
+++ b/modules/survey_accounts/php/addsurvey.class.inc
@@ -152,6 +152,7 @@ class AddSurvey extends \NDB_Form
         foreach ($instrument_list as $instrument) {
             if ($values['Test_name'] == $instrument['Test_name']) {
                 $instrument_instance = \NDB_BVL_Instrument::factory(
+                    $this->loris,
                     $instrument['Test_name']
                 );
                 return [
@@ -210,12 +211,12 @@ class AddSurvey extends \NDB_Form
         if ($InstrumentExists == 'x') {
             return;
         }
-        $battery = new \NDB_BVL_Battery();
+        $battery = new \NDB_BVL_Battery($this->loris);
         $battery->selectBattery(
             new \SessionID($SessionID)
         );
 
-        $commentID = $battery->addInstrument($values['Test_name']);
+        $commentID = $battery->addInstrument($this->loris, $values['Test_name']);
 
         $key = $this->_generateSurveyKey();
 

--- a/modules/timepoint_list/php/module.class.inc
+++ b/modules/timepoint_list/php/module.class.inc
@@ -48,7 +48,8 @@ class Module extends \Module
             }
         } catch (\NotFound $e) {
         }
-        $page = $this->loadPage("timepoint_list");
+        $loris = $request->getAttribute("loris");
+        $page = $this->loadPage($loris, "timepoint_list");
         return $page->process($request, $page);
     }
 

--- a/modules/timepoint_list/php/module.class.inc
+++ b/modules/timepoint_list/php/module.class.inc
@@ -49,7 +49,7 @@ class Module extends \Module
         } catch (\NotFound $e) {
         }
         $loris = $request->getAttribute("loris");
-        $page = $this->loadPage($loris, "timepoint_list");
+        $page  = $this->loadPage($loris, "timepoint_list");
         return $page->process($request, $page);
     }
 

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -36,7 +36,7 @@ class Module extends \Module
     {
         if (strpos($request->getUri()->getPath(), "/edit_user/") === 0) {
             $loris = $request->getAttribute("loris");
-            $page = $this->loadPage($loris, "edit_user");
+            $page  = $this->loadPage($loris, "edit_user");
             return $page->process($request, $page);
         }
         return parent::handle($request);

--- a/modules/user_accounts/php/module.class.inc
+++ b/modules/user_accounts/php/module.class.inc
@@ -35,7 +35,8 @@ class Module extends \Module
     public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         if (strpos($request->getUri()->getPath(), "/edit_user/") === 0) {
-            $page = $this->loadPage("edit_user");
+            $loris = $request->getAttribute("loris");
+            $page = $this->loadPage($loris, "edit_user");
             return $page->process($request, $page);
         }
         return parent::handle($request);

--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -27,9 +27,11 @@ class ConflictDetector
     /**
      * Detects of there are any conflicts between 2 given CommentIDs
      *
-     * @param string $instrumentName The instrument being checked
-     * @param string $commentId1     The first data entry CommentID
-     * @param string $commentId2     The second data entry CommentID
+     * @param \LORIS\LorisInstance $loris          The LORIS instance with the
+     *                                             comment IDs being compared
+     * @param string               $instrumentName The instrument being checked
+     * @param string               $commentId1     The first data entry CommentID
+     * @param string               $commentId2     The second data entry CommentID
      *
      * @return array An array of differences between the 2 data entry
      *               points.

--- a/php/libraries/ConflictDetector.class.inc
+++ b/php/libraries/ConflictDetector.class.inc
@@ -35,6 +35,7 @@ class ConflictDetector
      *               points.
      */
     static function detectConflictsForCommentIds(
+        \LORIS\LorisInstance $loris,
         string $instrumentName,
         string $commentId1,
         string $commentId2
@@ -42,14 +43,14 @@ class ConflictDetector
         $diffResult = [];
 
         // Get data entry status for $commentId1
-        $status = new NDB_BVL_InstrumentStatus();
+        $status = new NDB_BVL_InstrumentStatus($loris);
         $status->select($commentId1);
         if ($status->getDataEntryStatus() != 'Complete') {
             return $diffResult;
         }
 
         // Get data entry status for $commentId2
-        $status = new NDB_BVL_InstrumentStatus();
+        $status = new NDB_BVL_InstrumentStatus($loris);
         $status->select($commentId2);
         if ($status->getDataEntryStatus() != 'Complete') {
             return $diffResult;
@@ -57,6 +58,7 @@ class ConflictDetector
 
         // Create the instrument instance for $commentId1
         $instance1 = NDB_BVL_Instrument::factory(
+            $loris,
             $instrumentName,
             $commentId1,
             ''
@@ -64,6 +66,7 @@ class ConflictDetector
 
         // Create the instrument instance for $commentId2
         $instance2 = NDB_BVL_Instrument::factory(
+            $loris,
             $instrumentName,
             $commentId2,
             ''

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -44,10 +44,13 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
      * Constructor for a DataFrameworkMenu class. This signature must match
      * the base NDB_Page type in order for LORIS to be able to load the page.
      *
-     * @param Module $module     The test name being accessed
-     * @param string $page       The subtest being accessed (may be an empty string)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
+     * @param \LORIS\LorisInstance $loris      The LORIS instance the page is serving
+     * @param Module               $module     The test name being accessed
+     * @param string               $page       The subtest being accessed (may be an
+     *                                         empty string)
+     * @param string               $identifier The identifier for the data to load
+     *                                         on this page
+     * @param string               $commentID  The CommentID to load the data for
      */
     public function __construct(
         \LORIS\LorisInstance $loris,

--- a/php/libraries/DataFrameworkMenu.class.inc
+++ b/php/libraries/DataFrameworkMenu.class.inc
@@ -50,12 +50,13 @@ abstract class DataFrameworkMenu extends NDB_Menu_Filter
      * @param string $commentID  The CommentID to load the data for
      */
     public function __construct(
+        \LORIS\LorisInstance $loris,
         \Module $module,
         string $page,
         string $identifier,
         string $commentID
     ) {
-        parent::__construct($module, $page, $identifier, $commentID);
+        parent::__construct($loris, $module, $page, $identifier, $commentID);
 
         $this->AjaxModule   = true;
         $this->skipTemplate = true;

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -254,15 +254,19 @@ abstract class Module extends \LORIS\Router\PrefixRouter
     /**
      * Loads a page within this module and calls all necessary setup.
      *
-     * @param string $page The name of the page within the module to load.
+     * @param \LORIS\LorisInstance $loris The LORIS instance that the module
+     *                                    is serving.
+     * @param string               $page  The name of the page within the
+     *                                    module to load.
      *
      * @return NDB_Page
      *         Returns NDB_Page (or subclass) representing this page.
      */
     public function loadPage(\Loris\LORISInstance $loris, string $page)
     {
-        // Some URLs are things like "/login/request-account", but `-` isn't valid
-        // in a class name, so remove it while loading the module.
+        // Some URLs are things like "/login/request-account", but
+        // `-` isn't valid in a class name, so remove it while loading
+        // the module.
         $page = str_replace("-", "", $page);
 
         $className = "\LORIS\\" . $this->name . "\\$page";
@@ -272,7 +276,14 @@ abstract class Module extends \LORIS\Router\PrefixRouter
 
         $identifier = $_REQUEST['identifier'] ?? '';
         $commentID  = $_REQUEST['commentID'] ?? '';
-        $cls        = new $className($loris, $this, $page, $identifier, $commentID, $page);
+        $cls        = new $className(
+            $loris,
+            $this,
+            $page,
+            $identifier,
+            $commentID,
+            $page,
+        );
 
         // Hacks so that existing display() functions load the right template
         // for different page types.
@@ -338,7 +349,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
             $pagename = explode("/", $path)[0];
         }
 
-        $user = $request->getAttribute("user") ?? new \LORIS\AnonymousUser();
+        $user  = $request->getAttribute("user") ?? new \LORIS\AnonymousUser();
         $loris = $request->getAttribute("loris");
         try {
             $page = $this->loadPage($loris, $pagename);

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -259,7 +259,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      * @return NDB_Page
      *         Returns NDB_Page (or subclass) representing this page.
      */
-    public function loadPage(string $page)
+    public function loadPage(\Loris\LORISInstance $loris, string $page)
     {
         // Some URLs are things like "/login/request-account", but `-` isn't valid
         // in a class name, so remove it while loading the module.
@@ -272,7 +272,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
 
         $identifier = $_REQUEST['identifier'] ?? '';
         $commentID  = $_REQUEST['commentID'] ?? '';
-        $cls        = new $className($this, $page, $identifier, $commentID, $page);
+        $cls        = new $className($loris, $this, $page, $identifier, $commentID, $page);
 
         // Hacks so that existing display() functions load the right template
         // for different page types.
@@ -339,8 +339,9 @@ abstract class Module extends \LORIS\Router\PrefixRouter
         }
 
         $user = $request->getAttribute("user") ?? new \LORIS\AnonymousUser();
+        $loris = $request->getAttribute("loris");
         try {
-            $page = $this->loadPage($pagename);
+            $page = $this->loadPage($loris, $pagename);
             // FIXME: Hack required for breadcrumbs. This should be removed,
             // but some tests depend on it.
             if ($this->getName() === $pagename) {

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -114,6 +114,7 @@ class NDB_BVL_Battery
      * @return void
      */
     function createBattery(
+        \LORIS\LorisInstance $loris,
         $SubprojectID,
         $stage=null,
         $visit_label=null,
@@ -154,7 +155,7 @@ class NDB_BVL_Battery
         // loop over the list of instruments
         foreach ($neededTests AS $testName) {
             // add the instrument
-            $this->addInstrument($testName);
+            $this->addInstrument($loris, $testName);
         } // end looping over the list of instruments
     } // end createBattery()
 
@@ -183,7 +184,7 @@ class NDB_BVL_Battery
      *
      * @return string The generated CommentID
      */
-    function addInstrument($testName)
+    function addInstrument($loris, $testName)
     {
         $DB = Database::singleton();
         // assert that a battery has already been selected
@@ -212,7 +213,7 @@ class NDB_BVL_Battery
         $ddeCommentID = 'DDE_'.$commentID;
 
         // instantiate instrument object to get table name attribute
-        $obj = NDB_BVL_Instrument::factory($testName, '', '');
+        $obj = NDB_BVL_Instrument::factory($loris, $testName, '', '');
 
         if ($obj->usesJSONdata() !== true) {
             // insert into the test table

--- a/php/libraries/NDB_BVL_Battery.class.inc
+++ b/php/libraries/NDB_BVL_Battery.class.inc
@@ -100,16 +100,20 @@ class NDB_BVL_Battery
      * on age AND SubprojectID, adds all appropriate instruments to the
      * battery
      *
-     * @param integer $SubprojectID The SubprojectID that we want the battery
-     *                              for
-     * @param string  $stage        Either 'visit' or 'screening'
-     * @param string  $visit_label  The visit label to create a battery for.
-     * @param integer $center_ID    The center of the candidate having a battery
-     *                              created
-     * @param boolean $firstVisit   Whether this is a first visit battery.
-     *                              true means ONLY first visit
-     *                              false means NOT first visit
-     *                              null can be any visit.
+     * @param \LORIS\LorisInstance $loris        The LORIS instance to add
+     *                                           instruments to
+     * @param integer              $SubprojectID The SubprojectID that we want
+     *                                           the battery for
+     * @param string               $stage        Either 'visit' or 'screening'
+     * @param string               $visit_label  The visit label to create a
+     *                                           battery for.
+     * @param integer              $center_ID    The center of the candidate
+     *                                           having a battery created
+     * @param boolean              $firstVisit   Whether this is a first visit
+     *                                           battery.  true means ONLY
+     *                                           first visit, false means NOT
+     *                                           first visit, null can be any
+     *                                           visit.
      *
      * @return void
      */
@@ -179,8 +183,10 @@ class NDB_BVL_Battery
      * Adds the specified instrument to the current battery, so long
      * as it is not already there (singleton model)
      *
-     * @param string $testName The test to be added to the currently
-     *                         selected battery.
+     * @param \LORIS\LorisInstance $loris    The LORIS instance to add the
+     *                                       instrument to
+     * @param string               $testName The test to be added to the
+     *                                       currently selected battery.
      *
      * @return string The generated CommentID
      */

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -203,6 +203,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * @throws Exception
      */
     public static function factory(
+        \LORIS\LORISInstance $loris,
         string $instrument,
         string $commentID = '',
         string $page = '',
@@ -232,10 +233,11 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 // The module directory we use for instruments is arbitrary,
                 // since it isn't a real module, but it's required for the page
                 // constructor.
+                $loris,
                 Module::factory("instruments"),
                 $page,
                 $commentID,
-                $commentID
+                $commentID,
             );
         } else {
             if (!class_exists($class)
@@ -250,6 +252,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
 
             // Now go ahead and instantiate it
             $obj = new $class(
+                $loris,
                 Module::factory("instruments"),
                 $page,
                 $commentID,
@@ -2464,6 +2467,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         if (!empty($_REQUEST['commentID'])) {
             // make the control panel object for the current instrument
             $controlPanel = new NDB_BVL_InstrumentStatus_ControlPanel(
+                $this->loris,
                 $this->testName,
                 $this->getCommentID() ?? '',
                 $candID,

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -188,14 +188,19 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      * $instrument, and runs the setup() method on that new
      * instrument.
      *
-     * @param string  $instrument       The name of the instrument to use
-     * @param string  $commentID        The CommentID identifying the data to load
-     *                                  load
-     * @param string  $page             If a multipage form, the page to show
-     * @param boolean $guarantee_exists If true the factory will throw an
-     *                                  error if the file does not exist, otherwise
-     *                                  will silently return if the instrument is
-     *                                  missing.
+     * @param \LORIS\LorisInstance $loris            The LORIS instance with the
+     *                                               instrument
+     * @param string               $instrument       The name of the instrument to
+     *                                               use
+     * @param string               $commentID        The CommentID identifying the
+     *                                               data to load
+     * @param string               $page             If a multipage form, the page to
+     *                                               show
+     * @param boolean              $guarantee_exists If true the factory will throw
+     *                                               an error if the file does not
+     *                                               exist, otherwise will silently
+     *                                               return if the instrument is
+     *                                               missing.
      *
      * @return object|null the new object of $instrument type
      * @access public
@@ -2986,7 +2991,12 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $instrumentList = [];
         foreach ($instruments as $inst) {
             try {
-                $instrumentList[$inst] = NDB_BVL_Instrument::factory($loris, $inst, "", "");
+                $instrumentList[$inst] = NDB_BVL_Instrument::factory(
+                    $loris,
+                    $inst,
+                    "",
+                    ""
+                );
             } catch (Exception $e) {
                 error_log(
                     "Instrument $inst does not seem to be a valid instrument."

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2937,7 +2937,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $timepoint = \Timepoint::singleton(new SessionID($sessionID));
 
         // create an instrument status object
-        $status = new \NDB_BVL_InstrumentStatus;
+        $status = new \NDB_BVL_InstrumentStatus($this->loris);
         $status->select($this->commentID);
 
         // freeze the form to prevent data entry

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2986,7 +2986,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $instrumentList = [];
         foreach ($instruments as $inst) {
             try {
-                $instrumentList[$inst] = NDB_BVL_Instrument::factory($inst, "", "");
+                $instrumentList[$inst] = NDB_BVL_Instrument::factory($loris, $inst, "", "");
             } catch (Exception $e) {
                 error_log(
                     "Instrument $inst does not seem to be a valid instrument."

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -73,6 +73,15 @@ class NDB_BVL_InstrumentStatus
         'Pass',
     ];
 
+
+    /**
+     * @var \LORIS\LorisInstance
+     */
+    protected $loris;
+
+    public function __construct(\LORIS\LorisInstance $loris) {
+        $this->loris = $loris;
+    }
     /**
      * Loads the object with the current status of the instrument
      *
@@ -213,6 +222,7 @@ class NDB_BVL_InstrumentStatus
 
                     ConflictDetector::clearConflictsForInstance($principalCommentId);
                     $diff = ConflictDetector::detectConflictsForCommentIds(
+                        $this->loris,
                         $instrumentName,
                         $principalCommentId,
                         $DDECommentId

--- a/php/libraries/NDB_BVL_InstrumentStatus.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus.class.inc
@@ -75,11 +75,21 @@ class NDB_BVL_InstrumentStatus
 
 
     /**
+     * The LORIS instance that the status comes from
+     *
      * @var \LORIS\LorisInstance
      */
     protected $loris;
 
-    public function __construct(\LORIS\LorisInstance $loris) {
+    /**
+     * Construct an NDB_BVL_InstrumentStatus object to manage
+     * instrument status flags.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance hosting
+     *                                    the instrument
+     */
+    public function __construct(\LORIS\LorisInstance $loris)
+    {
         $this->loris = $loris;
     }
     /**

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -37,6 +37,8 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
     protected string $testname;
     protected ?string $subtest;
 
+    protected $loris;
+
     /**
      * Construct a controller for the instrument status control panel
      *
@@ -47,12 +49,14 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
      * @param ?string   $subtest   The page of the instrument being accessed
      */
     function __construct(
+        \LORIS\LorisInstance $loris,
         string $testname,
         string $commentid,
         CandID $candid,
         SessionID $sessionid,
         ?string $subtest
     ) {
+        $this->loris      = $loris;
         $this->candID     = $candid;
         $this->testname   = $testname;
         $this->_commentID = $commentid;
@@ -98,6 +102,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             }
             // create an instance of the instrument
             $instrument = NDB_BVL_Instrument::factory(
+                $this->loris,
                 $this->testname,
                 $this->_commentID,
                 $this->subtest ?? ''
@@ -167,6 +172,7 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
             $user = User::singleton();
             if ($user->hasPermission('send_to_dcc')) {
                 $instrument = \NDB_BVL_Instrument::factory(
+                    $this->loris,
                     $this->testname,
                     $this->_commentID,
                     $this->subtest ?? ''

--- a/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
+++ b/php/libraries/NDB_BVL_InstrumentStatus_ControlPanel.class.inc
@@ -42,11 +42,16 @@ class NDB_BVL_InstrumentStatus_ControlPanel extends NDB_BVL_InstrumentStatus
     /**
      * Construct a controller for the instrument status control panel
      *
-     * @param string    $testname  The instrument name being managed
-     * @param string    $commentid The commentID being loaded
-     * @param CandID    $candid    The candidate who this instrument belongs to
-     * @param SessionID $sessionid The session at which the instrument took place
-     * @param ?string   $subtest   The page of the instrument being accessed
+     * @param \LORIS\LorisInstance $loris     The LORIS Instance containing this
+     *                                        instrument
+     * @param string               $testname  The instrument name being managed
+     * @param string               $commentid The commentID being loaded
+     * @param CandID               $candid    The candidate who this
+     *                                        instrument belongs to
+     * @param SessionID            $sessionid The session at which the
+     *                                        instrument took place
+     * @param ?string              $subtest   The page of the instrument
+     *                                        being accessed
      */
     function __construct(
         \LORIS\LorisInstance $loris,

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -78,6 +78,7 @@ class NDB_Caller
      * @return string rendered object, as html
      */
     function load(
+        \LORIS\LorisInstance $loris,
         $test_name,
         $subtest,
         $CommentID='',
@@ -94,6 +95,7 @@ class NDB_Caller
         $linstfile = $base."project/instruments/$test_name.linst";
         if ($this->existsAndRequire($phpfile)) {
             $html       = $this->loadInstrumentDirect(
+                $loris,
                 $test_name,
                 $subtest,
                 $CommentID,
@@ -103,6 +105,7 @@ class NDB_Caller
             return $html;
         } else if (file_exists($linstfile)) {
             $html       = $this->loadInstrumentDirect(
+                $loris,
                 $test_name,
                 $subtest,
                 $CommentID
@@ -126,6 +129,7 @@ class NDB_Caller
      * @return string HTML of the page to render.
      */
     function loadInstrumentDirect(
+        \LORIS\LorisInstance $loris,
         string $instrumentName,
         string $page,
         string $commentID,
@@ -133,6 +137,7 @@ class NDB_Caller
     ): string {
         if ($page === 'finalpage') {
             $instrument = NDB_BVL_Instrument::factory(
+                $loris,
                 $instrumentName,
                 $commentID,
                 $page
@@ -149,6 +154,7 @@ class NDB_Caller
 
         // make an instance of the instrument's object
         $instrument = NDB_BVL_Instrument::factory(
+            $loris,
             $instrumentName,
             $commentID,
             $page
@@ -161,7 +167,7 @@ class NDB_Caller
             return "";
         }
         // create an instrument status object
-        $status = new NDB_BVL_InstrumentStatus;
+        $status = new NDB_BVL_InstrumentStatus($loris);
         $status->select($commentID);
 
         $this->page = $instrument;

--- a/php/libraries/NDB_Caller.class.inc
+++ b/php/libraries/NDB_Caller.class.inc
@@ -68,12 +68,16 @@ class NDB_Caller
     /**
      * Renders the called menu, form or the instrument into html
      *
-     * @param string      $test_name The object type to load.  The test_name of the
-     *                               menu, form or instrument
-     * @param string      $subtest   The subpage of the module to load
-     * @param string      $CommentID The CommentID identifier to load the page with
-     * @param string|null $nextpage  The page to go to after submitting this
-     * @param bool        $anonymous True if the user has not logged in.
+     * @param \LORIS\LorisInstance $loris     The LORIS instance the call is being
+     *                                        handled for.
+     * @param string               $test_name The object type to load.  The test_name
+     *                                        of the menu, form or instrument
+     * @param string               $subtest   The subpage of the module to load
+     * @param string               $CommentID The CommentID identifier to load the
+     *                                        page with
+     * @param ?string              $nextpage  The page to go to after submitting
+     *                                        this
+     * @param bool                 $anonymous True if the user has not logged in
      *
      * @return string rendered object, as html
      */
@@ -120,11 +124,17 @@ class NDB_Caller
     /**
      * Renders html for a direct data entry Instrument
      *
-     * @param string      $instrumentName      Name of the instrument to load
-     * @param string      $page                Page (subtest) of the instrument
-     * @param string      $commentID           CommentID of the instrument to load
-     * @param string|null $redirectToOnSuccess URL to redirect to if the page is
-     *                                         loaded successfully.
+     * @param \LORIS\LorisInstance $loris               The LORIS instance the
+     *                                                  survey is being loaded
+     *                                                  for
+     * @param string               $instrumentName      Name of the instrument to
+     *                                                  load
+     * @param string               $page                Page (subtest) of the
+     *                                                  instrument
+     * @param string               $commentID           CommentID of the instrument
+     *                                                  to load
+     * @param string|null          $redirectToOnSuccess URL to redirect to if the
+     *                                                  page is loaded successfully.
      *
      * @return string HTML of the page to render.
      */

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -42,10 +42,14 @@ class NDB_Menu extends NDB_Page
     /**
      * Create a new NDB_Menu page
      *
-     * @param Module $module     The test name being accessed
-     * @param string $page       The subtest being accessed (may be null)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
+     * @param \LORIS\LorisInstance $loris      The LORIS Instance that the page is
+     *                                         serving serving
+     * @param Module               $module     The test name being accessed
+     * @param string               $page       The subtest being accessed (may be
+     *                                         null)
+     * @param string               $identifier The identifier for the data to load
+     *                                         on this page
+     * @param string               $commentID  The CommentID to load the data for
      */
     public function __construct(
         \LORIS\LorisInstance $loris,

--- a/php/libraries/NDB_Menu.class.inc
+++ b/php/libraries/NDB_Menu.class.inc
@@ -48,12 +48,13 @@ class NDB_Menu extends NDB_Page
      * @param string $commentID  The CommentID to load the data for
      */
     public function __construct(
+        \LORIS\LorisInstance $loris,
         \Module $module,
         string $page,
         string $identifier,
         string $commentID
     ) {
-        parent::__construct($module, $page, $identifier, $commentID);
+        parent::__construct($loris, $module, $page, $identifier, $commentID);
         $this->menu = $module->getName();
     }
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -128,7 +128,7 @@ class NDB_Page implements RequestHandlerInterface
         \Module $module,
         string $page,
         string $identifier,
-        string $commentID,
+        string $commentID
     ) {
         $this->loris  = $loris;
         $this->Module = $module;

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -75,6 +75,13 @@ class NDB_Page implements RequestHandlerInterface
     public $template;
 
     /**
+     * The LorisInstance that this page was created to serve.
+     *
+     * @var \LORIS\LorisInstance
+     */
+    protected $loris;
+
+    /**
      * The format that the page content should be returned in. This is generally
      * the value of the `?format=` GET parameter from the request, and is usually
      * either 'json' or empty (for the default return value of HTML format).
@@ -111,13 +118,17 @@ class NDB_Page implements RequestHandlerInterface
      * @param string $page       The subtest being accessed (may be an empty string)
      * @param string $identifier The identifier for the data to load on this page
      * @param string $commentID  The CommentID to load the data for
+     * @param \LORIS\LorisInstance $loris The LORIS instance that this page is being
+     *                                    constructed for
      */
     function __construct(
+        \LORIS\LorisInstance $loris,
         \Module $module,
         string $page,
         string $identifier,
-        string $commentID
+        string $commentID,
     ) {
+        $this->loris  = $loris;
         $this->Module = $module;
         $this->name   = $module->getName(); // for legacy purposes.
 

--- a/php/libraries/NDB_Page.class.inc
+++ b/php/libraries/NDB_Page.class.inc
@@ -114,12 +114,14 @@ class NDB_Page implements RequestHandlerInterface
      * that are common to every type of page. May be overridden by a specific
      * page or specific page type.
      *
-     * @param Module $module     The test name being accessed
-     * @param string $page       The subtest being accessed (may be an empty string)
-     * @param string $identifier The identifier for the data to load on this page
-     * @param string $commentID  The CommentID to load the data for
-     * @param \LORIS\LorisInstance $loris The LORIS instance that this page is being
-     *                                    constructed for
+     * @param \LORIS\LorisInstance $loris      The LORIS instance that the page is
+     *                                         serving
+     * @param Module               $module     The test name being accessed
+     * @param string               $page       The subtest being accessed (may be
+     *                                         an empty string)
+     * @param string               $identifier The identifier for the data to load
+     *                                         on this page
+     * @param string               $commentID  The CommentID to load the data for
      */
     function __construct(
         \LORIS\LorisInstance $loris,

--- a/src/Middleware/PageDecorationMiddleware.php
+++ b/src/Middleware/PageDecorationMiddleware.php
@@ -31,7 +31,8 @@ class PageDecorationMiddleware implements MiddlewareInterface
     {
         $baseURL = $request->getAttribute("baseurl");
         $config  = \NDB_Config::singleton();
-        $page    = $request->getAttribute("pageclass") ?? new \NDB_Page(new \NullModule(), "", "", "", "");
+        $loris   = $request->getAttribute("loris");
+        $page    = $request->getAttribute("pageclass") ?? new \NDB_Page($loris, new \NullModule(), "", "", "", "");
         if ($this->user instanceof \LORIS\AnonymousUser) {
             return (new \LORIS\Middleware\AnonymousPageDecorationMiddleware(
                 $baseURL ?? "",

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -46,8 +46,15 @@ class NDB_PageTest extends TestCase
     {
         parent::setUp();
 
+        $mockconfig = $this->getMockBuilder('NDB_Config')->getMock();
+        $mockdb = $this->getMockBuilder('Database')->getMock();
+
+        '@phan-var \Database $mockdb';
+        '@phan-var \NDB_Config $mockconfig';
+
         $this->_module = new NullModule("test_module");
         $this->_page   = new NDB_Page(
+            new \LORIS\LorisInstance($mockdb, $mockconfig, []),
             $this->_module,
             "test_page",
             "515",

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -47,7 +47,7 @@ class NDB_PageTest extends TestCase
         parent::setUp();
 
         $mockconfig = $this->getMockBuilder('NDB_Config')->getMock();
-        $mockdb = $this->getMockBuilder('Database')->getMock();
+        $mockdb     = $this->getMockBuilder('Database')->getMock();
 
         '@phan-var \Database $mockdb';
         '@phan-var \NDB_Config $mockconfig';


### PR DESCRIPTION
This updates the NDB_Page constructor to include a LorisInstance object. The LorisInstance object represents the properties of the LorisInstance itself (such as the database connection) and can replace many factory/singleton calls, but is seldom used in LORIS because it's difficult to get a copy of the object. (It needs to be indirectly accessed from a PSR7 request attribute). After moving it to the constructor, it can now be accessed directly from any NDB_Page class or subclass in a simple class property.

I was originally planning to clean up the NDB_Page constructor more by removing unnecessary parameters (why does every page get a CommentID parameter? Why is there both CommentID and identifier? Why does the class need to be told its own name? etc) but simply adding one argument and propagating it to all the places that needed to be updated was already a fairly large PR. This also makes some other cleanup possible, such as moving other statics like `\Module::factory` to `$loris->getModule()` but, once again, that would increase the size of this PR more than I'd like.