### PR TITLE
[23.0][instrument] Fix _nullScores() inconsistencies

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2108,10 +2108,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
     function _nullScores(array $scoreCols): void
     {
         $record    = $this->loadInstanceData($this);
-        $scoreCols = array_combine($scoreCols, $scoreCols);
-        // order is important here because it keeps values of first array
-        // unsetting all columns which are not scores
-        $data = array_intersect_key($record, $scoreCols);
 
         // set the scoring cols to NULL
         foreach ($scoreCols as $key => $val) {
@@ -2120,8 +2116,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             // use a non-associative array. So if the key is numeric,
             // and we need to make sure we use the column name
             if (is_numeric($key)) {
+                $scoreCols = array_combine($scoreCols, $scoreCols);
+                // order is important here because it keeps values of first array
+                // unsetting all columns which are not scores
+                $data = array_intersect_key($record, $scoreCols);
                 $data[$val] = null; //null array
             } else {
+                $data = array_intersect_key($record, $scoreCols);
                 $data[$key] = null;
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2107,7 +2107,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _nullScores(array $scoreCols): void
     {
-        $record    = $this->loadInstanceData($this);
+        $record = $this->loadInstanceData($this);
 
         // set the scoring cols to NULL
         foreach ($scoreCols as $key => $val) {
@@ -2119,10 +2119,10 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 $scoreCols = array_combine($scoreCols, $scoreCols);
                 // order is important here because it keeps values of first array
                 // unsetting all columns which are not scores
-                $data = array_intersect_key($record, $scoreCols);
+                $data       = array_intersect_key($record, $scoreCols);
                 $data[$val] = null; //null array
             } else {
-                $data = array_intersect_key($record, $scoreCols);
+                $data       = array_intersect_key($record, $scoreCols);
                 $data[$key] = null;
             }
 

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2107,8 +2107,6 @@ abstract class NDB_BVL_Instrument extends NDB_Page
      */
     function _nullScores(array $scoreCols): void
     {
-        $record = $this->loadInstanceData($this);
-
         // set the scoring cols to NULL
         foreach ($scoreCols as $key => $val) {
             // Some Instruments use an associative array for
@@ -2116,19 +2114,14 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             // use a non-associative array. So if the key is numeric,
             // and we need to make sure we use the column name
             if (is_numeric($key)) {
-                $scoreCols = array_combine($scoreCols, $scoreCols);
-                // order is important here because it keeps values of first array
-                // unsetting all columns which are not scores
-                $data       = array_intersect_key($record, $scoreCols);
-                $data[$val] = null; //null array
+                $scores[$val] = null; //null array
             } else {
-                $data       = array_intersect_key($record, $scoreCols);
-                $data[$key] = null;
+                $scores[$key] = null;
             }
 
         }
 
-        $this->_save($data);
+        $this->_save($scores);
         return;
     }
 


### PR DESCRIPTION
## Brief summary of changes
See description in #7421 
This PR fixes logic so that both scoring formats are supported.

#### Testing instructions (if applicable)

1. Check which score array format your project / raisinbread is using
2. Run `php score_instrument.php all`
3. Try implementing the opposite score array format on any instrument, make sure scoring succeeds.

#### Link(s) to related issue(s)

* Resolves #7421 
