### PR TITLE
[23.0][instrument] fix form freezing at first form opening

### DIFF
--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -2908,13 +2908,13 @@ abstract class NDB_BVL_Instrument extends NDB_Page
         $status->select($this->commentID);
 
         // freeze the form to prevent data entry
-        // IF (1) Instrument is NOT in progress
+        // IF (1) Instrument is set to complete
         // OR (2) The user does NOT have `data_entry` permission
         // OR (3) The user does NOT have access to the timepoint
         //        at which the instrument is instantiated
         // AND (4) The instrument is NOT in preview mode
         // AND (5) the instrument is NOT a direct entry
-        if ($status->getDataEntryStatus() != 'In Progress'
+        if (($status->getDataEntryStatus() == 'Complete')
             || !$user->hasPermission('data_entry')
             || (isset($timepoint) && !$user->hasCenter($timepoint->getCenterID()))
             && $this->preview !== true


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the issue reported in #7420 in which the form is frozen on first opening when the data entry is null.

#### Testing instructions (if applicable)

1. Make sure that form is only frozen when Data entry = 'Complete'. Try use case where Data entry is `null` (first opening) and when it is `In Progress`

#### Link(s) to related issue(s)

* Resolves #7420
