### PR TITLE
[Behavioural QC] Add subproject filter

### DIFF
--- a/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
+++ b/modules/behavioural_qc/jsx/tabs_content/behaviouralFeedback.js
@@ -196,6 +196,15 @@ class BehaviouralFeedback extends Component {
         },
       },
       {
+        label: 'Subproject',
+        show: false,
+        filter: {
+          name: 'Subproject',
+          type: 'select',
+          options: options.subprojects,
+        },
+      },
+      {
         label: 'Site',
         show: false,
         filter: {

--- a/modules/behavioural_qc/jsx/tabs_content/dataConflicts.js
+++ b/modules/behavioural_qc/jsx/tabs_content/dataConflicts.js
@@ -208,7 +208,15 @@ class DataConflicts extends Component {
           options: options.projects,
         },
       },
-
+      {
+        label: 'Subproject',
+        show: false,
+        filter: {
+          name: 'Subproject',
+          type: 'select',
+          options: options.subprojects,
+        },
+      },
       {
         label: 'Site',
         show: false,

--- a/modules/behavioural_qc/jsx/tabs_content/incompleteForms.js
+++ b/modules/behavioural_qc/jsx/tabs_content/incompleteForms.js
@@ -208,7 +208,15 @@ class IncompleteForms extends Component {
           options: options.projects,
         },
       },
-
+      {
+        label: 'Subproject',
+        show: false,
+        filter: {
+          name: 'Subproject',
+          type: 'select',
+          options: options.subprojects,
+        },
+      },
       {
         label: 'Site',
         show: false,

--- a/modules/behavioural_qc/php/behavioural.class.inc
+++ b/modules/behavioural_qc/php/behavioural.class.inc
@@ -89,6 +89,7 @@ class Behavioural extends \NDB_Page implements ETagCalculator
             $visit_array,
             \Utility::getAllInstruments(),
             \Utility::getProjectList(),
+            \Utility::getSubprojectList(),
             $list_of_sites
         ))->toArray();
     }

--- a/modules/behavioural_qc/php/conflicts.class.inc
+++ b/modules/behavioural_qc/php/conflicts.class.inc
@@ -91,6 +91,7 @@ class Conflicts extends \NDB_Page implements ETagCalculator
             $visit_array,
             \Utility::getAllInstruments(),
             \Utility::getProjectList(),
+            \Utility::getSubprojectList(),
             $list_of_sites
         ))->toArray();
     }

--- a/modules/behavioural_qc/php/incomplete.class.inc
+++ b/modules/behavioural_qc/php/incomplete.class.inc
@@ -92,7 +92,9 @@ class Incomplete extends \NDB_Page implements ETagCalculator
             $visit_array,
             \Utility::getAllInstruments(),
             $projects,
-            $list_of_sites
+            \Utility::getSubprojectList(),
+            $list_of_sites,
+            $subprojects
         ))->toArray();
     }
 

--- a/modules/behavioural_qc/php/incomplete.class.inc
+++ b/modules/behavioural_qc/php/incomplete.class.inc
@@ -93,8 +93,7 @@ class Incomplete extends \NDB_Page implements ETagCalculator
             \Utility::getAllInstruments(),
             $projects,
             \Utility::getSubprojectList(),
-            $list_of_sites,
-            $subprojects
+            $list_of_sites
         ))->toArray();
     }
 

--- a/modules/behavioural_qc/php/models/behaviouraldto.class.inc
+++ b/modules/behavioural_qc/php/models/behaviouraldto.class.inc
@@ -55,6 +55,13 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance
     private $_project = '';
 
     /**
+     * The feedback_status
+     *
+     * @var string
+     */
+    private $_subproject = '';
+
+    /**
      * The site
      *
      * @var string
@@ -123,6 +130,7 @@ class BehaviouralDTO implements \LORIS\Data\DataInstance
             'pscID'           => $this->_pscID,
             'visit'           => $this->_visit,
             'project'         => $this->_project,
+            'subproject'      => $this->_subproject,
             'site'            => $this->_site,
             'feedbackID'      => $this->_feedbackID,
             'sessionID'       => $this->_sessionID,

--- a/modules/behavioural_qc/php/models/conflictsdto.class.inc
+++ b/modules/behavioural_qc/php/models/conflictsdto.class.inc
@@ -55,6 +55,13 @@ class ConflictsDTO implements \LORIS\Data\DataInstance
     private $_project = '';
 
     /**
+     * The feedback_status
+     *
+     * @var string
+     */
+    private $_subproject = '';
+
+    /**
      * The site
      *
      * @var string
@@ -109,6 +116,7 @@ class ConflictsDTO implements \LORIS\Data\DataInstance
             'pscID'             => $this->_pscID,
             'visit'             => $this->_visit,
             'project'           => $this->_project,
+            'subproject'        => $this->_subproject,
             'site'              => $this->_site,
             'fieldName'         => $this->_fieldName,
             'tableName'         => $this->_tableName,

--- a/modules/behavioural_qc/php/models/incompletedto.class.inc
+++ b/modules/behavioural_qc/php/models/incompletedto.class.inc
@@ -55,6 +55,13 @@ class IncompleteDTO implements \LORIS\Data\DataInstance
     private $_project = '';
 
     /**
+     * The feedback_status
+     *
+     * @var string
+     */
+    private $_subproject = '';
+
+    /**
      * The site
      *
      * @var string
@@ -109,6 +116,7 @@ class IncompleteDTO implements \LORIS\Data\DataInstance
             'pscID'      => $this->_pscID,
             'visit'      => $this->_visit,
             'project'    => $this->_project,
+            'subproject' => $this->_subproject,
             'site'       => $this->_site,
             'id'         => $this->_id,
             'sessionID'  => $this->_sessionID,

--- a/modules/behavioural_qc/php/provisioners/behaviouralprovisioner.class.inc
+++ b/modules/behavioural_qc/php/provisioners/behaviouralprovisioner.class.inc
@@ -30,6 +30,7 @@ class BehaviouralProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisione
                 ca.PSCID AS _pscID,
                 s.Visit_label AS _visit,
                 s.ProjectID AS _project,
+                s.SubprojectID AS _subproject,
                 psc.CenterID AS _site,
 	            fb.FeedbackID AS _feedbackID,
 	            fb.SessionID AS _sessionID,

--- a/modules/behavioural_qc/php/provisioners/conflictsprovisioner.class.inc
+++ b/modules/behavioural_qc/php/provisioners/conflictsprovisioner.class.inc
@@ -25,13 +25,14 @@ class ConflictsProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
         parent::__construct(
             "
             SELECT DISTINCT
-	          s.CandID AS _candID,
-	          ca.PSCID AS _pscID,
-	          c.FieldName AS _fieldName,
-	          c.TableName AS _tableName,
-	          t.full_name AS _test_name_display,
-	          s.visit_label AS _visit,
+  	          s.CandID AS _candID,
+  	          ca.PSCID AS _pscID,
+  	          c.FieldName AS _fieldName,
+  	          c.TableName AS _tableName,
+  	          t.full_name AS _test_name_display,
+  	          s.visit_label AS _visit,
               s.ProjectID AS _project,
+              s.SubprojectID AS _subproject,
               f.SessionID AS _sessionID,
               f.commentid AS _commentID,
               t.Full_name AS _instrument,

--- a/modules/behavioural_qc/php/provisioners/incompleteprovisioner.class.inc
+++ b/modules/behavioural_qc/php/provisioners/incompleteprovisioner.class.inc
@@ -45,6 +45,7 @@ class IncompleteProvisioner extends \LORIS\Data\Provisioners\DBObjectProvisioner
                 c.PSCID AS _pscID,
                 s.visit_label AS _visit,
                 s.ProjectID AS _project,
+                s.SubprojectID AS _subproject,
                 psc.CenterID AS _site,
                 s.ID AS _id,
                 f.SessionID as _sessionID,

--- a/modules/behavioural_qc/php/views/behavioral.class.inc
+++ b/modules/behavioural_qc/php/views/behavioral.class.inc
@@ -29,12 +29,13 @@ class Behavioral
      * @param array $projects    The projects for form element
      * @param array $sites       The sites for form element
      */
-    public function __construct($visits, $instruments, $projects, $sites)
+    public function __construct($visits, $instruments, $projects, $subprojects, $sites)
     {
         $this->_formElement = [
             'instruments' => $instruments,
             'visits'      => $visits,
             'projects'    => $projects,
+            'subprojects' => $subprojects,
             'sites'       => $sites,
         ];
     }

--- a/modules/behavioural_qc/php/views/behavioral.class.inc
+++ b/modules/behavioural_qc/php/views/behavioral.class.inc
@@ -31,10 +31,10 @@ class Behavioral
      * @param array $sites       The sites for form element
      */
     public function __construct(
-        $visits, 
-        $instruments, 
-        $projects, 
-        $subprojects, 
+        $visits,
+        $instruments,
+        $projects,
+        $subprojects,
         $sites
     ) {
         $this->_formElement = [

--- a/modules/behavioural_qc/php/views/behavioral.class.inc
+++ b/modules/behavioural_qc/php/views/behavioral.class.inc
@@ -30,8 +30,13 @@ class Behavioral
      * @param array $subprojects The subprojects for form element
      * @param array $sites       The sites for form element
      */
-    public function __construct($visits, $instruments, $projects, $subprojects, $sites)
-    {
+    public function __construct(
+        $visits, 
+        $instruments, 
+        $projects, 
+        $subprojects, 
+        $sites
+    ) {
         $this->_formElement = [
             'instruments' => $instruments,
             'visits'      => $visits,

--- a/modules/behavioural_qc/php/views/behavioral.class.inc
+++ b/modules/behavioural_qc/php/views/behavioral.class.inc
@@ -27,6 +27,7 @@ class Behavioral
      * @param array $visits      The visits for form element
      * @param array $instruments The instruments for form element
      * @param array $projects    The projects for form element
+     * @param array $subprojects The subprojects for form element
      * @param array $sites       The sites for form element
      */
     public function __construct($visits, $instruments, $projects, $subprojects, $sites)

--- a/modules/behavioural_qc/php/views/conflicts.class.inc
+++ b/modules/behavioural_qc/php/views/conflicts.class.inc
@@ -43,7 +43,6 @@ class Conflicts
             'projects'    => $projects,
             'subprojects' => $subprojects,
             'sites'       => $sites,
-            'subprojects' => $subprojects,
         ];
     }
 

--- a/modules/behavioural_qc/php/views/conflicts.class.inc
+++ b/modules/behavioural_qc/php/views/conflicts.class.inc
@@ -31,10 +31,10 @@ class Conflicts
      * @param array $sites       The sites for form element
      */
     public function __construct(
-        $visits, 
-        $instruments, 
-        $projects, 
-        $subprojects, 
+        $visits,
+        $instruments,
+        $projects,
+        $subprojects,
         $sites
     ) {
         $this->_formElement = [

--- a/modules/behavioural_qc/php/views/conflicts.class.inc
+++ b/modules/behavioural_qc/php/views/conflicts.class.inc
@@ -27,6 +27,7 @@ class Conflicts
      * @param array $visits      The visits for form element
      * @param array $instruments The instruments for form element
      * @param array $projects    The projects for form element
+     * @param array $subprojects The subprojects for form element
      * @param array $sites       The sites for form element
      */
     public function __construct($visits, $instruments, $projects, $subprojects, $sites)

--- a/modules/behavioural_qc/php/views/conflicts.class.inc
+++ b/modules/behavioural_qc/php/views/conflicts.class.inc
@@ -30,8 +30,13 @@ class Conflicts
      * @param array $subprojects The subprojects for form element
      * @param array $sites       The sites for form element
      */
-    public function __construct($visits, $instruments, $projects, $subprojects, $sites)
-    {
+    public function __construct(
+        $visits, 
+        $instruments, 
+        $projects, 
+        $subprojects, 
+        $sites
+    ) {
         $this->_formElement = [
             'instruments' => $instruments,
             'visits'      => $visits,

--- a/modules/behavioural_qc/php/views/conflicts.class.inc
+++ b/modules/behavioural_qc/php/views/conflicts.class.inc
@@ -29,13 +29,15 @@ class Conflicts
      * @param array $projects    The projects for form element
      * @param array $sites       The sites for form element
      */
-    public function __construct($visits, $instruments, $projects, $sites)
+    public function __construct($visits, $instruments, $projects, $subprojects, $sites)
     {
         $this->_formElement = [
             'instruments' => $instruments,
             'visits'      => $visits,
             'projects'    => $projects,
+            'subprojects' => $subprojects,
             'sites'       => $sites,
+            'subprojects' => $subprojects,
         ];
     }
 

--- a/modules/behavioural_qc/php/views/incomplete.class.inc
+++ b/modules/behavioural_qc/php/views/incomplete.class.inc
@@ -31,10 +31,10 @@ class Incomplete
      * @param array $sites       The sites for form element
      */
     public function __construct(
-        $visits, 
-        $instruments, 
-        $projects, 
-        $subprojects, 
+        $visits,
+        $instruments,
+        $projects,
+        $subprojects,
         $sites
     ) {
         $this->_formElement = [

--- a/modules/behavioural_qc/php/views/incomplete.class.inc
+++ b/modules/behavioural_qc/php/views/incomplete.class.inc
@@ -29,12 +29,13 @@ class Incomplete
      * @param array $projects    The projects for form element
      * @param array $sites       The sites for form element
      */
-    public function __construct($visits, $instruments, $projects, $sites)
+    public function __construct($visits, $instruments, $projects, $subprojects, $sites)
     {
         $this->_formElement = [
             'instruments' => $instruments,
             'visits'      => $visits,
             'projects'    => $projects,
+            'subprojects' => $subprojects,
             'sites'       => $sites,
         ];
     }

--- a/modules/behavioural_qc/php/views/incomplete.class.inc
+++ b/modules/behavioural_qc/php/views/incomplete.class.inc
@@ -30,8 +30,13 @@ class Incomplete
      * @param array $subprojects The subprojects for form element
      * @param array $sites       The sites for form element
      */
-    public function __construct($visits, $instruments, $projects, $subprojects, $sites)
-    {
+    public function __construct(
+        $visits, 
+        $instruments, 
+        $projects, 
+        $subprojects, 
+        $sites
+    ) {
         $this->_formElement = [
             'instruments' => $instruments,
             'visits'      => $visits,

--- a/modules/behavioural_qc/php/views/incomplete.class.inc
+++ b/modules/behavioural_qc/php/views/incomplete.class.inc
@@ -27,6 +27,7 @@ class Incomplete
      * @param array $visits      The visits for form element
      * @param array $instruments The instruments for form element
      * @param array $projects    The projects for form element
+     * @param array $subprojects The subprojects for form element
      * @param array $sites       The sites for form element
      */
     public function __construct($visits, $instruments, $projects, $subprojects, $sites)


### PR DESCRIPTION
## Brief summary of changes
This PR adds a subproject drop-down in the filters for Behavioural QC. This change was made on CCNA but should be relevant / useful to other projects as well.

#### Testing instructions (if applicable)

1. Make sure that module loads properly
2. Make sure that all drop downs in the filters are populated with the correct options
3. Test the filters and make sure that the results are updated accordingly 
4. Make sure you can clear the filters, and the results are reset

