### PR TITLE
[TimePoint] Add TimepointData DTO class

### DIFF
--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -76,7 +76,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * A DTO for TimePoint related data
      */
-    protected TimePointData $data;
+    protected ?TimePointData $data;
 
     /**
      * Construct a TimePoint object seeded with the data
@@ -159,8 +159,12 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
         $this->data = new TimePointData(
             $sessionID,
-            new ProjectID($row['ProjectID']),
-            intval($row['CenterID']),
+            isset($row['ProjectID'])
+                ? new ProjectID($row['ProjectID'])
+                : null,
+            isset($row['CenterID'])
+                ? intval($row['CenterID'])
+                : null,
         );
 
         // store user data in object property

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -74,6 +74,19 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
 
 
     /**
+     * A DTO for TimePoint related data
+     */
+    protected TimePointData $data;
+
+    /**
+     * Construct a TimePoint object seeded with the data
+     * from the given DTO.
+     */
+    public function __construct(?TimePointData $data=null) {
+        $this->data = $data;
+    }
+
+    /**
      * Returns an object representing this Timepoint, and ensures that only
      * one is ever created per Session.
      *
@@ -141,6 +154,13 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
             ['SID' => $sessionID]
         );
 
+
+        $this->data = new TimePointData(
+            $sessionID,
+            new ProjectID($row['ProjectID']),
+            intval($row['CenterID']),
+        );
+
         // store user data in object property
         if (is_array($row) && count($row) > 0) {
             $this->_timePointInfo = $row;
@@ -149,12 +169,6 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
             );
             $title = $subprojectSettings['title'] ?? '';
             $this->_timePointInfo['SubprojectTitle'] = $title;
-
-            if ($this->_timePointInfo['ProjectID'] !== null) {
-                $this->_timePointInfo['ProjectID'] = new \ProjectID(
-                    $this->_timePointInfo['ProjectID']
-                );
-            }
         } else {
             // return error when 0 rows to prevent creation of an empty object
             throw new LorisException(
@@ -421,7 +435,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getSessionID(): SessionID
     {
-        return (new SessionID($this->_timePointInfo["SessionID"]));
+        return $this->data->getSessionID();
     }
 
     /**
@@ -441,7 +455,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     function getCenterID(): \CenterID
     {
-        return new \CenterID($this->_timePointInfo['CenterID']);
+        return $this->data->getCenterID();
     }
 
     /**
@@ -1200,7 +1214,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
      */
     public function getProjectID() : \ProjectID
     {
-        return $this->getData('ProjectID');
+        return $this->data->getProjectID();
     }
 
     /**

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -81,8 +81,11 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
     /**
      * Construct a TimePoint object seeded with the data
      * from the given DTO.
+     *
+     * @param ?TimePointData $data The Timepoint DTO
      */
-    public function __construct(?TimePointData $data=null) {
+    public function __construct(?TimePointData $data=null)
+    {
         $this->data = $data;
     }
 
@@ -153,7 +156,6 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
             $query,
             ['SID' => $sessionID]
         );
-
 
         $this->data = new TimePointData(
             $sessionID,

--- a/php/libraries/TimePoint.class.inc
+++ b/php/libraries/TimePoint.class.inc
@@ -163,7 +163,7 @@ class TimePoint implements \LORIS\StudyEntities\AccessibleResource,
                 ? new ProjectID($row['ProjectID'])
                 : null,
             isset($row['CenterID'])
-                ? intval($row['CenterID'])
+                ? new \CenterID($row['CenterID'])
                 : null,
         );
 

--- a/php/libraries/TimePointData.php
+++ b/php/libraries/TimePointData.php
@@ -34,7 +34,7 @@ class TimePointData
     /**
      * The TimePoint's CenterID
      *
-     * @var ?int
+     * @var ?\CenterID
      */
     protected $centerID;
 
@@ -50,12 +50,12 @@ class TimePointData
      *
      * @param ?SessionID $SessionID The SessionID for the TimePoint
      * @param ?ProjectID $ProjectID The ProjectID for the TimePoint
-     * @param ?int       $CenterID  The CenterID for the TimePoint
+     * @param ?\CenterID $CenterID  The CenterID for the TimePoint
      */
     public function __construct(
         ?SessionID $SessionID,
         ?ProjectID $ProjectID,
-        ?int $CenterID
+        ?\CenterID $CenterID
     ) {
         $this->sessionID = $SessionID;
         $this->projectID = $ProjectID;
@@ -94,9 +94,9 @@ class TimePointData
      * Return the CenterID for this TimePoint, or throw
      * an exception if unknown.
      *
-     * @return int
+     * @return \CenterID
      */
-    public function getCenterID() : int
+    public function getCenterID() : \CenterID
     {
         if ($this->centerID === null) {
             throw new \LogicException("No CenterID loaded into data model");

--- a/php/libraries/TimePointData.php
+++ b/php/libraries/TimePointData.php
@@ -22,7 +22,8 @@
  *
  * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
  */
-class TimePointData {
+class TimePointData
+{
     protected $projectID;
     protected $centerID;
     protected $sessionID;
@@ -30,14 +31,18 @@ class TimePointData {
     /**
      * Construct a TimePointData DTO for a TimePoint object
      *
-     * @param ?SessionID $SessionID
-     * @param ?ProjectID $ProjectID
-     * @param ?int       $CenterID
+     * @param ?SessionID $SessionID The SessionID for the TimePoint
+     * @param ?ProjectID $ProjectID The ProjectID for the TimePoint
+     * @param ?int       $CenterID  The CenterID for the TimePoint
      */
-    public function __construct(?SessionID $SessionID, ?int $ProjectID, ?int $CenterID) {
+    public function __construct(
+        ?SessionID $SessionID,
+        ?ProjectID $ProjectID,
+        ?int $CenterID
+    ) {
         $this->sessionID = $SessionID;
         $this->projectID = $ProjectID;
-        $this->centerID = $CenterID;
+        $this->centerID  = $CenterID;
     }
 
     /**
@@ -46,8 +51,9 @@ class TimePointData {
      *
      * @return ?SessionID
      */
-    public function getSessionID() : SessionID {
-        if($this->sessionID === null) {
+    public function getSessionID() : SessionID
+    {
+        if ($this->sessionID === null) {
             throw new \Exception("No SessionID loaded into data model");
         }
         return $this->sessionID;
@@ -59,8 +65,9 @@ class TimePointData {
      *
      * @return ?ProjectID
      */
-    public function getProjectID () : ProjectID {
-        if($this->projectID === null) {
+    public function getProjectID() : ProjectID
+    {
+        if ($this->projectID === null) {
             throw new \Exception("No ProjectID loaded into data model");
         }
         return $this->projectID;
@@ -72,8 +79,9 @@ class TimePointData {
      *
      * @return ?int
      */
-    public function getCenterID () : int {
-        if($this->centerID === null) {
+    public function getCenterID() : int
+    {
+        if ($this->centerID === null) {
             throw new \Exception("No CenterID loaded into data model");
         }
         return $this->centerID;

--- a/php/libraries/TimePointData.php
+++ b/php/libraries/TimePointData.php
@@ -71,7 +71,7 @@ class TimePointData
     public function getSessionID() : SessionID
     {
         if ($this->sessionID === null) {
-            throw new \Exception("No SessionID loaded into data model");
+            throw new \LogicException("No SessionID loaded into data model");
         }
         return $this->sessionID;
     }
@@ -85,7 +85,7 @@ class TimePointData
     public function getProjectID() : ProjectID
     {
         if ($this->projectID === null) {
-            throw new \Exception("No ProjectID loaded into data model");
+            throw new \LogicException("No ProjectID loaded into data model");
         }
         return $this->projectID;
     }
@@ -99,7 +99,7 @@ class TimePointData
     public function getCenterID() : int
     {
         if ($this->centerID === null) {
-            throw new \Exception("No CenterID loaded into data model");
+            throw new \LogicException("No CenterID loaded into data model");
         }
         return $this->centerID;
     }

--- a/php/libraries/TimePointData.php
+++ b/php/libraries/TimePointData.php
@@ -24,8 +24,25 @@
  */
 class TimePointData
 {
+    /**
+     * The TimePoint's ProjectID
+     *
+     * @var ?ProjectID
+     */
     protected $projectID;
+
+    /**
+     * The TimePoint's CenterID
+     *
+     * @var ?int
+     */
     protected $centerID;
+
+    /**
+     * The TimePoint's SessionID
+     *
+     * @var ?SessionID
+     */
     protected $sessionID;
 
     /**
@@ -49,7 +66,7 @@ class TimePointData
      * Return the SessionID for this TimePoint, or throw
      * an exception if unknown.
      *
-     * @return ?SessionID
+     * @return SessionID
      */
     public function getSessionID() : SessionID
     {
@@ -63,7 +80,7 @@ class TimePointData
      * Return the ProjectID for this TimePoint, or throw
      * an exception if unknown.
      *
-     * @return ?ProjectID
+     * @return ProjectID
      */
     public function getProjectID() : ProjectID
     {
@@ -77,7 +94,7 @@ class TimePointData
      * Return the CenterID for this TimePoint, or throw
      * an exception if unknown.
      *
-     * @return ?int
+     * @return int
      */
     public function getCenterID() : int
     {

--- a/php/libraries/TimePointData.php
+++ b/php/libraries/TimePointData.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+/**
+ * A TimePointData object is a DTO (data transfer object) to
+ * store a representation of data associated with a TimePoint
+ * object in LORIS.
+ *
+ * The TimePointData may be partially loaded, in which case any
+ * getter trying to access an unknown will throw an exception.
+ * This allows modules to only load relevant data in a query,
+ * and avoid the overhead of the TimePoint::singleton() constructor.
+ *
+ * For instance, a query that selected CenterID and ProjectID on
+ * the database could instantiate a TimePoint as:
+ *    $visit = new TimePoint(new TimePointData(null, $projectid, $centerid));
+ *
+ * with data loaded from the query, and then call
+ * `$visit->isAccessibleBy($user)` without having to load all the
+ * over data that TimePoint::singleton() does. If an attempt is
+ * made to access a property not in the DTO (session in this example),
+ * an exception is thrown, rather than silently returning the incorrect
+ * value.
+ *
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ */
+class TimePointData {
+    protected $projectID;
+    protected $centerID;
+    protected $sessionID;
+
+    /**
+     * Construct a TimePointData DTO for a TimePoint object
+     *
+     * @param ?SessionID $SessionID
+     * @param ?ProjectID $ProjectID
+     * @param ?int       $CenterID
+     */
+    public function __construct(?SessionID $SessionID, ?int $ProjectID, ?int $CenterID) {
+        $this->sessionID = $SessionID;
+        $this->projectID = $ProjectID;
+        $this->centerID = $CenterID;
+    }
+
+    /**
+     * Return the SessionID for this TimePoint, or throw
+     * an exception if unknown.
+     *
+     * @return ?SessionID
+     */
+    public function getSessionID() : SessionID {
+        if($this->sessionID === null) {
+            throw new \Exception("No SessionID loaded into data model");
+        }
+        return $this->sessionID;
+    }
+
+    /**
+     * Return the ProjectID for this TimePoint, or throw
+     * an exception if unknown.
+     *
+     * @return ?ProjectID
+     */
+    public function getProjectID () : ProjectID {
+        if($this->projectID === null) {
+            throw new \Exception("No ProjectID loaded into data model");
+        }
+        return $this->projectID;
+    }
+
+    /**
+     * Return the CenterID for this TimePoint, or throw
+     * an exception if unknown.
+     *
+     * @return ?int
+     */
+    public function getCenterID () : int {
+        if($this->centerID === null) {
+            throw new \Exception("No CenterID loaded into data model");
+        }
+        return $this->centerID;
+    }
+}


### PR DESCRIPTION
Add a TimePointData class to act as a data transfer object for
data related to TimePoints.

 A TimePointData object is a DTO (data transfer object) to
 store a representation of data associated with a TimePoint
 object in LORIS.
 
The TimePointData may be partially loaded, in which case any
getter trying to access an unknown will throw an exception.
This allows modules to only load relevant data in a query,
and avoid the overhead of the TimePoint::singleton() constructor.

For instance, a query that selected CenterID and ProjectID on
the database could instantiate a TimePoint as:

```
$visit = new TimePoint(new TimePointData(null, $projectid, $centerid));
```

with data loaded from the query, and then call

`$visit->isAccessibleBy($user)` without having to load all the
over data that `TimePoint::select()` does. If an attempt is
made to access a property not in the DTO (session in this example),
an exception is thrown, rather than silently returning the incorrect
value. T