### PR TITLE
[Data dictionary] Issue in builder script

### DIFF
--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -105,8 +105,8 @@ foreach ($instruments AS $instrument) {
         $paramId = "";
         $bits    = explode("{@}", trim($item));
         switch($bits[0]){
-	    case "testname":
-		break;
+	          case "testname":
+		          break;
             case "table":
                 $table = $bits[1];
                 print "Instrument: $table\n";
@@ -366,4 +366,3 @@ function enumizeOptions($options, $table, $name)
     $enum =implode(",", $enum);
     return "enum($enum)";
 }
-

--- a/tools/exporters/data_dictionary_builder.php
+++ b/tools/exporters/data_dictionary_builder.php
@@ -105,6 +105,8 @@ foreach ($instruments AS $instrument) {
         $paramId = "";
         $bits    = explode("{@}", trim($item));
         switch($bits[0]){
+	    case "testname":
+		break;
             case "table":
                 $table = $bits[1];
                 print "Instrument: $table\n";


### PR DESCRIPTION
## Brief summary of changes

- solves issue where testname was not recognized in the switch in the script. testname was introduced in this PR: #7153

#### Testing instructions (if applicable)

1. cd /var/www/loris/tools
2. find ../project/instruments/*.class.inc | php lorisformparser.php
3. cd exporters
4. php data_dictionary_builder.php
