### PR TITLE
Add Nix shell for LORIS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  php = pkgs.php80.withExtensions ({ enabled, all }:
+    enabled ++ [ all.ast ]);
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [ php git nodejs php80Packages.composer ];
+}


### PR DESCRIPTION
This adds a configuration file for NixOS/the Nix package manager in LORIS.

The shell.nix allows you to drop into a reproducible nix shell where all the necessary
LORIS dependencies are installed. Using this I was able to run both `make checkstatic`
to run the static analysis test suite and `php -S localhost:8000 -t htdocs htdocs/router.php`
in order to run a development web server that connects to LORIS.

(Recreation of PR#7439 sent from the right fork.)