### PR TITLE
[Instruments] Fix Display of 0 scores with json data

### DIFF
--- a/smarty/templates/instrument_html.tpl
+++ b/smarty/templates/instrument_html.tpl
@@ -193,7 +193,7 @@
 				<div class="row form-group col-xs-12">
 					{$element.html}
 				</div>
-			{elseif $element.label eq $element.html}
+			{elseif $element.label === $element.html}
 				<label class="row form-group col-xs-12">
 					{$element.label}
 				</label>


### PR DESCRIPTION
When a JSON data instrument has a score column that's saved
as 0 (the int value, not the string), the LORIS front end
does not display it, and instead displays the field as a header.

This is caused by PHP's weak equality treating `"string" == 0` as
true. Forcing the template to use a strict equality comparison
fixes this without affecting the header columns that the comparison
in the template was intended to catch.

Fixes #7441.