### PR TITLE
[Core] Remove duplicated getActiveModules function

### DIFF
--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -89,7 +89,10 @@ if (is_dir($basePath . "project/modules/$Module")
 
 $public = false;
 try {
-    $m = Module::factory($Module);
+    // Anything that's still in an ajax directory isn't using the lorisinstance object,
+    // so for now just make a fake one to pass to the factory.
+    $loris = new \LORIS\LorisInstance(new \Database(), new \NDB_Config(), []);
+    $m = Module::factory($loris, $Module);
 
     $public = $m->isPublicModule();
 } catch (LorisModuleMissingException $e) {

--- a/htdocs/AjaxHelper.php
+++ b/htdocs/AjaxHelper.php
@@ -89,10 +89,14 @@ if (is_dir($basePath . "project/modules/$Module")
 
 $public = false;
 try {
-    // Anything that's still in an ajax directory isn't using the lorisinstance object,
-    // so for now just make a fake one to pass to the factory.
-    $loris = new \LORIS\LorisInstance(new \Database(), new \NDB_Config(), []);
-    $m = Module::factory($loris, $Module);
+    // Anything that's still in an ajax directory isn't using the lorisinstance
+    // object, so for now just make a fake one to pass to the factory.
+    $loris = new \LORIS\LorisInstance(
+        new \Database(),
+        new \NDB_Config(),
+        []
+    );
+    $m     = Module::factory($loris, $Module);
 
     $public = $m->isPublicModule();
 } catch (LorisModuleMissingException $e) {

--- a/modules/candidate_list/php/candidate_list.class.inc
+++ b/modules/candidate_list/php/candidate_list.class.inc
@@ -71,7 +71,7 @@ class Candidate_List extends \DataFrameworkMenu
     {
         // Relying on a side-effect of the the server process module to autoload
         // its namespace.
-        \Module::factory('candidate_parameters');
+        \Module::factory($this->lorisinstance, 'candidate_parameters');
 
         // create user object
         $factory = \NDB_Factory::singleton();

--- a/modules/candidate_parameters/ajax/getData.php
+++ b/modules/candidate_parameters/ajax/getData.php
@@ -302,7 +302,17 @@ function getFamilyInfoFields()
  */
 function getParticipantStatusFields()
 {
-    \Module::factory('candidate_parameters');
+    // All we care about is the namespace loading, so we just need to ensure
+    // that the directory path has this module in it
+    $loris = new \LORIS\LorisInstance(
+        new Database(),
+        new NDB_Config(),
+        [
+            __DIR__ . '../'
+        ]
+    );
+
+    \Module::factory($loris, 'candidate_parameters');
     $candID = new CandID($_GET['candID']);
 
     $db = \NDB_Factory::singleton()->database();

--- a/modules/candidate_profile/php/candidate_profile.class.inc
+++ b/modules/candidate_profile/php/candidate_profile.class.inc
@@ -72,10 +72,9 @@ class Candidate_Profile extends \NDB_Page
         }
 
         $factory = \NDB_Factory::singleton();
-        $DB      = $factory->database();
         $user    = $factory->user();
 
-        $modules = \Module::getActiveModules($DB);
+        $modules = $this->lorisinstance->getActiveModules();
 
         $widgets = [];
         foreach ($modules as $module) {

--- a/modules/candidate_profile/php/module.class.inc
+++ b/modules/candidate_profile/php/module.class.inc
@@ -70,9 +70,7 @@ class Module extends \Module
         case 'candidate':
             $factory = \NDB_Factory::singleton();
             $baseurl = $factory->settings()->getBaseURL();
-
-            $DB      = $factory->database();
-            $modules = \Module::getActiveModules($DB);
+            $modules = $this->lorisinstance->getActiveModules();
 
             $params = [];
             foreach ($modules as $module) {

--- a/modules/dashboard/php/dashboard.class.inc
+++ b/modules/dashboard/php/dashboard.class.inc
@@ -79,7 +79,6 @@ class Dashboard extends \NDB_Form
         // calculating the body.
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();
-
         $modules = $loris->getActiveModules();
 
         $this->_smallwidgets = [];

--- a/modules/dashboard/php/module.class.inc
+++ b/modules/dashboard/php/module.class.inc
@@ -136,8 +136,7 @@ class Module extends \Module
     private function _getTasksWidget()
     {
         $factory = \NDB_Factory::singleton();
-        $DB      = $factory->database();
-        $modules = \Module::getActiveModules($DB);
+        $modules = $this->lorisinstance->getActiveModules();
         $user    = $factory->user();
 
         $widgets = [];

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -14,13 +14,13 @@
 
 try {
     $factory = \NDB_Factory::singleton();
-    $loris = new \LORIS\LorisInstance(
-	    $factory->database(),
-	    $factory->config(),
-	    [
-		    __DIR__ . "/../../",
-		    __DIR__ . "/../../../project/modules"
-	    ],
+    $loris   = new \LORIS\LorisInstance(
+        $factory->database(),
+        $factory->config(),
+        [
+            __DIR__ . "/../../",
+            __DIR__ . "/../../../project/modules"
+        ],
     );
 
     $moduleName  = $_REQUEST['testName'] ?? null;
@@ -34,7 +34,9 @@ try {
         'format'  => 'markdown',
     ];
     print json_encode($help);
-    ob_end_flush();
+    if (ob_get_level() > 0) {
+        ob_end_flush();
+    }
     exit;
 } catch (Exception $e) {
 

--- a/modules/help_editor/ajax/help.php
+++ b/modules/help_editor/ajax/help.php
@@ -13,9 +13,19 @@
  */
 
 try {
+    $factory = \NDB_Factory::singleton();
+    $loris = new \LORIS\LorisInstance(
+	    $factory->database(),
+	    $factory->config(),
+	    [
+		    __DIR__ . "/../../",
+		    __DIR__ . "/../../../project/modules"
+	    ],
+    );
+
     $moduleName  = $_REQUEST['testName'] ?? null;
     $subpageName = $_REQUEST['subtest'] ?? null;
-    $m           = Module::factory($moduleName);
+    $m           = Module::factory($loris, $moduleName);
     // Load help data. Try to load subpage first as its more specific and
     // will only be present some of the time. Fallback to the module name if
     // no subpage present.

--- a/modules/issue_tracker/php/edit.class.inc
+++ b/modules/issue_tracker/php/edit.class.inc
@@ -162,7 +162,7 @@ class Edit extends \NDB_Page implements ETagCalculator
             }
         }
 
-        $allModules = \Module::getActiveModulesIndexed($db);
+        $allModules = \Module::getActiveModulesIndexed($this->loris);
 
         $modules = [];
         foreach ($allModules as $key => $m) {
@@ -306,7 +306,7 @@ class Edit extends \NDB_Page implements ETagCalculator
         );
 
         // looping by reference so can edit in place
-        $modules = \Module::getActiveModulesIndexed($db);
+        $modules = \Module::getActiveModulesIndexed($this->loris);
         foreach ($unformattedComments as &$comment) {
             if ($comment['fieldChanged'] === 'module') {
                 $mid = $comment['newValue'];

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -141,7 +141,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
         }
 
         $modules = array_reduce(
-            \Module::getActiveModules($db),
+            $this->lorisinstance->getActiveModules(),
             function (
                 $result,
                 $module

--- a/modules/issue_tracker/php/issue_tracker.class.inc
+++ b/modules/issue_tracker/php/issue_tracker.class.inc
@@ -54,7 +54,7 @@ class Issue_Tracker extends \NDB_Menu_Filter_Form
      */
     function getDataProvisioner() : \LORIS\Data\Provisioner
     {
-        $provisioner = new IssueRowProvisioner($this->loris);
+        $provisioner = new IssueRowProvisioner($this->lorisinstance);
 
         $factory = \NDB_Factory::singleton();
         $user    = $factory->user();

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -37,7 +37,7 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
     /**
      * Create a IssueRowProvisioner, which gets rows for the issues menu table.
      *
-     * @param \LORIS\LorisInstance $loris The LORIS instance with the issues
+     * @param \LORIS\LorisInstance $loris the LORIS instance with the issues
      */
     function __construct(\LORIS\LorisInstance $loris)
     {

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -31,6 +31,8 @@ namespace LORIS\issue_tracker;
 class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     private array $allCenterIDs;
+    private $_siteList;
+    private \LORIS\LorisInstance $lorisinstance;
 
     /**
      * Create a IssueRowProvisioner, which gets rows for the issues menu table.
@@ -39,15 +41,13 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     function __construct(\LORIS\LorisInstance $loris)
     {
-        $factory = \NDB_Factory::singleton();
-        $user    = $factory->user();
-        $this->allCenterIDs = array_map(
-            function ($center) {
-                return $center->getCenterID();
-            },
-            $loris->getAllSites()
-        );
-        $userID = $user->getUsername();
+        $factory         = \NDB_Factory::singleton();
+        $user            = $factory->user();
+        $this->_siteList = array_keys(\Utility::getSiteList(false));
+        $userID          = $user->getUsername();
+
+        $this->lorisinstance = $loris;
+
         //note that this needs to be in the same order as the headers array
         parent::__construct(
             "SELECT i.issueID,
@@ -99,10 +99,10 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
         static $modules = [];
 
         $mname  = $row['module'];
-        $module = new \NullModule();
+        $module = new \NullModule($this->lorisinstance);
         if (!empty($mname)) {
             if (!isset($modules[$mname])) {
-                $modules[$mname] = \Module::factory($mname);
+                $modules[$mname] = \Module::factory($this->lorisinstance, $mname);
             }
             $module = &$modules[$mname];
         }

--- a/modules/issue_tracker/php/issuerowprovisioner.class.inc
+++ b/modules/issue_tracker/php/issuerowprovisioner.class.inc
@@ -31,7 +31,6 @@ namespace LORIS\issue_tracker;
 class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
     private array $allCenterIDs;
-    private $_siteList;
     private \LORIS\LorisInstance $lorisinstance;
 
     /**
@@ -41,10 +40,15 @@ class IssueRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     function __construct(\LORIS\LorisInstance $loris)
     {
-        $factory         = \NDB_Factory::singleton();
-        $user            = $factory->user();
-        $this->_siteList = array_keys(\Utility::getSiteList(false));
-        $userID          = $user->getUsername();
+        $factory = \NDB_Factory::singleton();
+        $user    = $factory->user();
+        $this->allCenterIDs = array_map(
+            function ($center) {
+                return $center->getCenterID();
+            },
+            $loris->getAllSites()
+        );
+        $userID = $user->getUsername();
 
         $this->lorisinstance = $loris;
 

--- a/modules/module_manager/php/module_manager.class.inc
+++ b/modules/module_manager/php/module_manager.class.inc
@@ -64,7 +64,7 @@ class Module_Manager extends \DataFrameworkMenu
      */
     public function getBaseDataProvisioner(): \LORIS\Data\Provisioner
     {
-        return new ModuleManagerProvisioner();
+        return new ModuleManagerProvisioner($this->lorisinstance);
     }
 
     /**

--- a/modules/module_manager/php/modulemanagerprovisioner.class.inc
+++ b/modules/module_manager/php/modulemanagerprovisioner.class.inc
@@ -30,12 +30,17 @@ namespace LORIS\module_manager;
  */
 class ModuleManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
 {
+    protected \LORIS\LorisInstance $lorisinstance;
+
     /**
      * Create a ModuleManagerProvisioner, which gets modules for the
      * module manager menu table.
+     *
+     * @param \LORIS\LorisInstance $loris The LORIS instance
      */
-    function __construct()
+    function __construct(\LORIS\LorisInstance $loris)
     {
+        $this->lorisinstance = $loris;
         parent::__construct(
             "SELECT name, active FROM modules",
             []
@@ -51,6 +56,6 @@ class ModuleManagerProvisioner extends \LORIS\Data\Provisioners\DBRowProvisioner
      */
     public function getInstance($row) : \LORIS\Data\DataInstance
     {
-            return new ModuleRow($row);
+            return new ModuleRow($this->lorisinstance, $row);
     }
 }

--- a/modules/module_manager/php/modulerow.class.inc
+++ b/modules/module_manager/php/modulerow.class.inc
@@ -35,16 +35,19 @@ class ModuleRow implements \LORIS\Data\DataInstance
     protected $Module;
     protected $DBRow;
     protected $Active;
+    protected $lorisinstance;
 
     /**
      * Create a new ModuleRow Instance.
      *
-     * @param array $row The ModuleRow Instance
+     * @param \LORIS\LorisInstance $loris The LORIS instance with the module
+     * @param array                $row   The ModuleRow Instance
      */
-    public function __construct(array $row)
+    public function __construct(\LORIS\LorisInstance $loris, array $row)
     {
-        $this->Module = \Module::factory($row['name']);
-        $this->Active = $row['active'];
+        $this->lorisinstance = $loris;
+        $this->Module        = \Module::factory($loris, $row['name']);
+        $this->Active        = $row['active'];
     }
 
     /**

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -935,16 +935,7 @@ class Edit_User extends \NDB_Form
                 = self::canRejectAccount(\User::factory($this->identifier));
         }
 
-        // get the editor's permissions
-        if ($editor->hasPermission('superuser')) {
-            $query = "SELECT p.permID, p.code, p.description, pc.Description as type
-            FROM permissions p
-                LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
-                ORDER BY p.categoryID, p.description";
-            $perms = $factory->database()->pselect($query, []);
-        } else {
-            $perms = $editor->getPermissionsVerbose($this->lorisinstance);
-        }
+        $perms = $editor->getPermissionsVerbose($this->lorisinstance);
 
         $lastRole = '';
         $group    = [];

--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -936,7 +936,15 @@ class Edit_User extends \NDB_Form
         }
 
         // get the editor's permissions
-        $perms = $editor->getPermissionsVerbose();
+        if ($editor->hasPermission('superuser')) {
+            $query = "SELECT p.permID, p.code, p.description, pc.Description as type
+            FROM permissions p
+                LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
+                ORDER BY p.categoryID, p.description";
+            $perms = $factory->database()->pselect($query, []);
+        } else {
+            $perms = $editor->getPermissionsVerbose($this->lorisinstance);
+        }
 
         $lastRole = '';
         $group    = [];

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -47,13 +47,14 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      * Retrieve all active module descriptors from the given database, indexed
      * by their primary key in the database.
      *
-     * @param \Database $db an open connection to a database containing a 'modules'
-     *                      table
+     * @param \LORIS\LorisInstance $loris The LORIS instance with the modules
      *
      * @return \Module[]
      */
-    static public function getActiveModulesIndexed(\Database $db): array
-    {
+    static public function getActiveModulesIndexed(
+        \LORIS\LorisInstance $loris
+    ) : array {
+        $db     = $loris->getDatabaseConnection();
         $mnames = $db->pselect(
             "SELECT ID, Name FROM modules WHERE Active='Y'",
             []
@@ -61,7 +62,7 @@ abstract class Module extends \LORIS\Router\PrefixRouter
 
         $rv = [];
         foreach ($mnames as $row) {
-            $rv[$row['ID']] = self::factory($row['Name']);
+            $rv[$row['ID']] = self::factory($loris, $row['Name']);
         }
         return $rv;
     }
@@ -75,7 +76,8 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      * This also sets up PHP class autoloading for the module that is loaded,
      * such that files in the module/php directory can be autoloaded.
      *
-     * @param string $name The module name we'd like information about
+     * @param \Loris\LorisInstance $loris The LORIS instance containing the module
+     * @param string               $name  The module name we'd like information about
      *
      * @throws \LorisNoSuchModuleException
      * @throws \LorisModuleMissingException
@@ -83,8 +85,10 @@ abstract class Module extends \LORIS\Router\PrefixRouter
      *
      * @return \Module object
      */
-    static public function factory(string $name): \Module
-    {
+    static public function factory(
+        \Loris\LorisInstance $loris,
+        string $name
+    ) : \Module {
         $factory = NDB_Factory::singleton();
         $config  = $factory->config();
         $base    = $config->getSetting("base");
@@ -132,22 +136,23 @@ abstract class Module extends \LORIS\Router\PrefixRouter
         // namespacing
         //require_once $mpath . "/php/Module.class.inc";
         $className = "\LORIS\\$name\Module";
-        $cls       = new $className($name, $mpath);
+        $cls       = new $className($loris, $name, $mpath);
         return $cls;
     }
 
     /**
      * Creates a new module instance
      *
-     * @param string $name      The name of the module
-     * @param string $moduledir The directory on the filesystem containing the module
+     * @param \LORIS\LorisInstance $loris     The LORIS instance for the module
+     * @param string               $name      The name of the module
+     * @param string               $moduledir The directory on the filesystem
+     *                                        containing the module
      */
-    public function __construct(string $name, string $moduledir)
-    {
-        $config   = \NDB_Factory::singleton()->config();
-        $loglevel = $config->getLogSettings()->getRequestLogLevel();
-
-        $this->logger = new \LORIS\Log\ErrorLogLogger($loglevel);
+    public function __construct(
+        \LORIS\LorisInstance $loris,
+        string $name,
+        string $moduledir
+    ) {
         parent::__construct(
             new \ArrayIterator(
                 [
@@ -172,6 +177,9 @@ abstract class Module extends \LORIS\Router\PrefixRouter
                 ]
             )
         );
+
+        $this->lorisinstance = $loris;
+
         $this->name = $name;
         $this->dir  = $moduledir;
     }

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -40,33 +40,8 @@ abstract class Module extends \LORIS\Router\PrefixRouter
         . "your project administrator and/or verify your LORIS configuration.";
     protected $name;
     protected $dir;
-    protected $lorisinstance;
 
-    /**
-     * Retrieve all active module descriptors from the given database
-     *
-     * @param \Database $db an open connection to a database containing a 'modules'
-     *                      table
-     *
-     * @return \Module[]
-     */
-    static public function getActiveModules(\Database $db): array
-    {
-        $mnames = $db->pselectCol(
-            "SELECT Name FROM modules WHERE Active='Y'",
-            []
-        );
-
-        $modules = [];
-        foreach ($mnames as $name) {
-            try {
-                $modules[] = self::factory($name);
-            } catch (\LorisModuleMissingException $e) {
-                error_log($e->getMessage() . " " . $e->getTraceAsString());
-            }
-        }
-        return $modules;
-    }
+    protected \LORIS\LorisInstance $lorisinstance;
 
     /**
      * Retrieve all active module descriptors from the given database, indexed

--- a/php/libraries/Module.class.inc
+++ b/php/libraries/Module.class.inc
@@ -153,6 +153,12 @@ abstract class Module extends \LORIS\Router\PrefixRouter
         string $name,
         string $moduledir
     ) {
+        $loglevel = $loris->getConfiguration()
+            ->getLogSettings()
+            ->getRequestLogLevel();
+
+        $this->logger = new \LORIS\Log\ErrorLogLogger($loglevel);
+
         parent::__construct(
             new \ArrayIterator(
                 [

--- a/php/libraries/NDB_BVL_Instrument.class.inc
+++ b/php/libraries/NDB_BVL_Instrument.class.inc
@@ -253,7 +253,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
                 // since it isn't a real module, but it's required for the page
                 // constructor.
                 $loris,
-                Module::factory("instruments"),
+                Module::factory($loris, "instruments"),
                 $page,
                 $commentID,
                 $commentID,
@@ -272,7 +272,7 @@ abstract class NDB_BVL_Instrument extends NDB_Page
             // Now go ahead and instantiate it
             $obj = new $class(
                 $loris,
-                Module::factory("instruments"),
+                Module::factory($loris, "instruments"),
                 $page,
                 $commentID,
                 $commentID,

--- a/php/libraries/NullModule.class.inc
+++ b/php/libraries/NullModule.class.inc
@@ -32,12 +32,13 @@ class NullModule extends Module
      * directory to pass (such as unit tests) and as such
      * only takes an (optional) name as an argument.
      *
-     * @param string $name An optional name to use for this module.
+     * @param \LORIS\LorisInstance $loris The LORIS instance for this module.
+     * @param string               $name  An optional name to use for this module.
      */
-    public function __construct(string $name='')
+    public function __construct(\LORIS\LorisInstance $loris, string $name='')
     {
         $this->longname = $name;
-        parent::__construct($name, "");
+        parent::__construct($loris, $name, "");
     }
 
     /**

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -36,8 +36,6 @@ class UserPermissions
      */
     private $permissions = [];
 
-    private \LORIS\LorisInstance $lorisinstance;
-
     /**
      * Constructor
      *
@@ -282,13 +280,15 @@ class UserPermissions
     /**
      * Returns an array with all permissions information for the user
      *
+     * @param \LORIS\LorisInstance $loris The LORIS instance to get
+     *                                    permissions from.
+     *
      * @return array
-     * @access public
      */
-    function getPermissionsVerbose(): array
+    function getPermissionsVerbose(\LORIS\LorisInstance $loris): array
     {
         // create DB object
-        $DB = \NDB_Factory::singleton()->database();
+        $DB = $loris->getDatabaseConnection();
 
         $query = "SELECT
                 p.permID,
@@ -309,7 +309,7 @@ class UserPermissions
         }
 
         $results = $DB->pselect($query, ['UID' => $this->userID]);
-        $modules = \Module::getActiveModulesIndexed($this->lorisinstance);
+        $modules = \Module::getActiveModulesIndexed($loris);
         // Build new meaningful description from combination of columns
         // Module Long Name: action description
         foreach ($results as $key=>$perm) {

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -36,6 +36,7 @@ class UserPermissions
      */
     private $permissions = [];
 
+    private \LORIS\LorisInstance $lorisinstance;
 
     /**
      * Constructor
@@ -305,15 +306,10 @@ class UserPermissions
                 LEFT JOIN modules m ON p.moduleID=m.ID
             WHERE up.userID = :UID and m.Active='Y'
                 ORDER BY p.categoryID, m.Name, p.description";
-            $results = $DB->pselect($query, ['UID' => $this->userID]);
-        } else {
-            $query  .= "LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
-                LEFT JOIN modules m ON p.moduleID=m.ID WHERE m.Active='Y'
-                ORDER BY p.categoryID, m.Name, p.description";
-            $results = $DB->pselect($query, []);
-
         }
-        $modules = \Module::getActiveModulesIndexed($DB);
+
+        $results = $DB->pselect($query, ['UID' => $this->userID]);
+        $modules = \Module::getActiveModulesIndexed($this->lorisinstance);
         // Build new meaningful description from combination of columns
         // Module Long Name: action description
         foreach ($results as $key=>$perm) {

--- a/php/libraries/UserPermissions.class.inc
+++ b/php/libraries/UserPermissions.class.inc
@@ -306,9 +306,13 @@ class UserPermissions
                 LEFT JOIN modules m ON p.moduleID=m.ID
             WHERE up.userID = :UID and m.Active='Y'
                 ORDER BY p.categoryID, m.Name, p.description";
+            $results = $DB->pselect($query, ['UID' => $this->userID]);
+        } else {
+            $query  .= "LEFT JOIN permissions_category pc ON (pc.ID=p.categoryID)
+                LEFT JOIN modules m ON p.moduleID=m.ID WHERE m.Active='Y'
+                ORDER BY p.categoryID, m.Name, p.description";
+            $results = $DB->pselect($query, []);
         }
-
-        $results = $DB->pselect($query, ['UID' => $this->userID]);
         $modules = \Module::getActiveModulesIndexed($loris);
         // Build new meaningful description from combination of columns
         // Module Long Name: action description

--- a/src/LorisInstance.php
+++ b/src/LorisInstance.php
@@ -76,7 +76,7 @@ class LorisInstance
         $modules = [];
         foreach ($mnames as $name) {
             try {
-                $modules[] = \Module::factory($name);
+                $modules[] = \Module::factory($this, $name);
             } catch (\LorisModuleMissingException $e) {
                 error_log($e->getMessage() . " " . $e->getTraceAsString());
             }

--- a/src/Middleware/PageDecorationMiddleware.php
+++ b/src/Middleware/PageDecorationMiddleware.php
@@ -32,7 +32,8 @@ class PageDecorationMiddleware implements MiddlewareInterface
         $baseURL = $request->getAttribute("baseurl");
         $config  = \NDB_Config::singleton();
         $loris   = $request->getAttribute("loris");
-        $page    = $request->getAttribute("pageclass") ?? new \NDB_Page($loris, new \NullModule(), "", "", "", "");
+        $page    = $request->getAttribute("pageclass")
+        ?? new \NDB_Page($loris, new \NullModule($loris), "", "", "", "");
         if ($this->user instanceof \LORIS\AnonymousUser) {
             return (new \LORIS\Middleware\AnonymousPageDecorationMiddleware(
                 $baseURL ?? "",

--- a/src/Router/BaseRouter.php
+++ b/src/Router/BaseRouter.php
@@ -120,7 +120,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
 
             $factory->setBaseURL($baseurl);
 
-            $module  = \Module::factory($modulename);
+            $module  = \Module::factory($this->lorisinstance, $modulename);
             $mr      = new ModuleRouter($module);
             $request = $request->withURI($suburi);
             return $ehandler->process($request, $mr);
@@ -136,7 +136,7 @@ class BaseRouter extends PrefixRouter implements RequestHandlerInterface
                 $request = $request
                     ->withAttribute("baseurl", $baseurl->__toString())
                     ->withAttribute("CandID", $components[0]);
-                $module  = \Module::factory("timepoint_list");
+                $module  = \Module::factory($this->lorisinstance, "timepoint_list");
                 $mr      = new ModuleRouter($module);
                 return $ehandler->process($request, $mr);
             }

--- a/test/unittests/NDB_PageTest.php
+++ b/test/unittests/NDB_PageTest.php
@@ -52,13 +52,10 @@ class NDB_PageTest extends TestCase
         '@phan-var \Database $mockdb';
         '@phan-var \NDB_Config $mockconfig';
 
-        $factory = NDB_Factory::singleton();
-        $factory->setConfig($mockconfig);
-        $factory->setDatabase($mockdb);
-
-        $this->_module = new NullModule("test_module");
+        $loris         = new \LORIS\LorisInstance($mockdb, $mockconfig, []);
+        $this->_module = new NullModule($loris, "test_module");
         $this->_page   = new NDB_Page(
-            new \LORIS\LorisInstance($mockdb, $mockconfig, []),
+            $loris,
             $this->_module,
             "test_page",
             "515",

--- a/test/unittests/UserTest.php
+++ b/test/unittests/UserTest.php
@@ -1128,8 +1128,14 @@ class UserTest extends TestCase
             "modules",
             $this->_moduleInfo
         );
+
+        $loris = new \LORIS\LorisInstance(
+            $this->_dbMock,
+            new \NDB_Config(),
+            [],
+        );
         $this->assertEquals(
-            $this->_user->getPermissionsVerbose(),
+            $this->_user->getPermissionsVerbose($loris),
             [
                 0 => ['permID' => '2',
                     'code'        => "test_permission",


### PR DESCRIPTION
There was a static getActiveModules function in the module class
as well as a getActiveModules function in the LorisInstance class.

This removes the duplicate and unnecessary function, cleaning up the
references to the non-static version now that NDB_Page has a LorisInstance
object passed in the constructor and all references should be able to use
the non-static version.
