### PR TITLE
[FilterableDataTable] Fix issue with GROUPCONCAT and multiselect

### DIFF
--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -317,7 +317,7 @@ class DataTable extends Component {
         searchKey = filterData[i].toLowerCase();
         searchString = data ? data.toString().toLowerCase() : '';
 
-        match = (searchString === searchKey);
+        match = (searchString.indexOf(searchKey) > -1);
         if (match) {
           result = true;
         }

--- a/jsx/DataTable.js
+++ b/jsx/DataTable.js
@@ -317,7 +317,8 @@ class DataTable extends Component {
         searchKey = filterData[i].toLowerCase();
         searchString = data ? data.toString().toLowerCase() : '';
 
-        match = (searchString.indexOf(searchKey) > -1);
+        let searchArray = searchString.split(',');
+        match = (searchArray.includes(searchKey));
         if (match) {
           result = true;
         }

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -38,7 +38,7 @@ function Filter(props) {
     const {fields} = JSON.parse(JSON.stringify(props));
     const type = fields
       .find((field) => (field.filter||{}).name == name).filter.type;
-    const exactMatch = (!(type === 'text' || type === 'date'));
+    const exactMatch = (!(type === 'text' || type === 'date' || type === 'multiselect'));
 
     if (value === null || value === '' ||
         (value.constructor === Array && value.length === 0)) {

--- a/jsx/Filter.js
+++ b/jsx/Filter.js
@@ -38,7 +38,7 @@ function Filter(props) {
     const {fields} = JSON.parse(JSON.stringify(props));
     const type = fields
       .find((field) => (field.filter||{}).name == name).filter.type;
-    const exactMatch = (!(type === 'text' || type === 'date' || type === 'multiselect'));
+    const exactMatch = (!(type === 'text' || type === 'date'));
 
     if (value === null || value === '' ||
         (value.constructor === Array && value.length === 0)) {


### PR DESCRIPTION
## Brief summary of changes

When using a multiselect on a group concat set of parameters, the filters gave only perfect matches. For example, if a candidate has 2 subproject AD and MCI, setting the filter to AD will not return the candidate although it should

Issue caught after release on CCNA of v23.0.3

Also thanks @HenriRabalais for the help
