### PR TITLE
[Module Manager][Bugfix] id undefined, not passed to callback

### DIFF
--- a/modules/module_manager/jsx/modulemanager.js
+++ b/modules/module_manager/jsx/modulemanager.js
@@ -58,9 +58,9 @@ class ModuleManagerIndex extends Component {
       }
   }
 
-  toggleActive(name, value, id) {
+  toggleActive(name, value) {
       fetch(
-          this.props.BaseURL + '/module_manager/modules/' + id,
+          this.props.BaseURL + '/module_manager/modules/' + name,
           {
               method: 'PATCH',
               body: JSON.stringify({
@@ -72,13 +72,13 @@ class ModuleManagerIndex extends Component {
           }
       ).then((response) => {
           if (response.status != 205) {
-              swal.fire('Error!', 'Could not update ' + id + '.', 'error');
+              swal.fire('Error!', 'Could not update ' + name + '.', 'error');
           } else {
-              const success = this.setModuleDisplayStatus(id, value);
+              const success = this.setModuleDisplayStatus(name, value);
               if (success === true) {
                 swal.fire({
                   title: 'Success!',
-                  text: 'Updated ' + id + ' status! ' +
+                  text: 'Updated ' + name + ' status! ' +
                     'To apply changes the interface must be reloaded. Proceed?',
                   type: 'success',
                   showCancelButton: true,
@@ -92,7 +92,7 @@ class ModuleManagerIndex extends Component {
               } else {
                   // If we get here something went very wrong, because somehow
                   // a module was toggled that isn't in the table.
-                  swal.fire('Error!', 'Could not find module ' + id + '.', 'error');
+                  swal.fire('Error!', 'Could not find module ' + name + '.', 'error');
               }
           }
       });
@@ -126,7 +126,7 @@ class ModuleManagerIndex extends Component {
   formatColumn(column, cell, row) {
     if (column == 'Active' && this.props.hasEditPermission) {
         return <td><SelectElement
-              name='active'
+              name={row.Name}
               id={row.Name}
               label=''
               emptyOption={false}


### PR DESCRIPTION
## Brief summary of changes
This PR resolves the following issue that was being thrown on CCNA when trying to change the status of a module:

<img width="873" alt="Screen Shot 2021-05-17 at 3 09 55 PM" src="https://user-images.githubusercontent.com/34260251/118543174-f361aa80-b721-11eb-9d78-792102973a8e.png">

The `id` was undefined since the callback only passes 2 arguments to `toggleActive` (see https://github.com/aces/Loris/blob/main/jsx/Form.js#L521)

#### Testing instructions (if applicable)

1. Make sure you can change the active status of a module successfully.


