### PR TITLE
[user_accounts] Use userID to update examiners table

### DIFF
--- a/modules/user_accounts/php/edit_user.class.inc
+++ b/modules/user_accounts/php/edit_user.class.inc
@@ -327,9 +327,9 @@ class Edit_User extends \NDB_Form
             $examinerID = $DB->pselect(
                 "SELECT e.examinerID
              FROM examiners e
-             WHERE e.full_name=:fn",
+             WHERE e.userID=:uid",
                 array(
-                    "fn" => $values['Real_name'],
+                    "uid" => $uid,
                 )
             );
 
@@ -353,8 +353,8 @@ class Edit_User extends \NDB_Form
                 $examinerID = $DB->pselectOne(
                     "SELECT examinerID
                             FROM examiners
-                            WHERE full_name=:fullName",
-                    array('fullName' => $values['Real_name'])
+                            WHERE uid=:uid",
+                    array('uid' => $uid)
                 );
             } elseif (!empty($examinerID)
                 && ((!empty($ex_radiologist)
@@ -370,10 +370,10 @@ class Edit_User extends \NDB_Form
                     'examiners',
                     array(
                         'radiologist' => $ex_radiologist,
-                        'userID'      => $uid,
+                        'full_name'   => $values['Real_name']
                     ),
                     array(
-                        "full_name" => $values['Real_name'],
+                        'userID' => $uid
                     )
                 );
                 $examinerID = $examinerID[0]['examinerID'];


### PR DESCRIPTION
## Brief summary of changes
Currently when updating the examiners table in edit_user, it is assumed that a unique examiner exists based on their full name instead of their userID. This causes 2 problems:
- If an examiner with the same name as another examiner is edited, the older one will be replaced in the table and will no longer be considered an examiner. I.e. only one examiner can exist per full name.
- If a user's name is edited, then a new row will be created in the examiners table and there will be 2 rows for the same user.

This PR fixes this issue by assuming that examiners have a unique userID instead of assuming examiners have a unique full name.

#### Testing instructions (if applicable)

1.Request an account and select "Examiner role"
2. check that a row in the examiners table exists for this newly requested user
3. From user_accounts, edit this user to change the name.
4. Check that the full name is updated in the examiners table for that user, and that only one row exists for that userID
5. Create an account for a user with the same name as an already-existing examiner
6. Make sure that a new row with a different userID is created in the examiners table. Both the older user and the newer user should have rows in the examiner table.

#### Link(s) to related issue(s)
- #6973

