### PR TITLE
[API] Add support for project names with space

### DIFF
--- a/modules/api/php/endpoints/projects.class.inc
+++ b/modules/api/php/endpoints/projects.class.inc
@@ -101,7 +101,7 @@ class Projects extends Endpoint implements \LORIS\Middleware\ETagCalculator
 
         // Delegate to project specific endpoint.
         try {
-            $project_name = $pathparts[1] ?? '';
+            $project_name = urldecode($pathparts[1] ?? '');
             $project      = \NDB_Factory::singleton()
                 ->project($project_name);
         } catch (\NotFound $e) {


### PR DESCRIPTION
Remark: Project names are not designed to be unique in the DB. In case of duplicates, the Project factory fails [here](https://github.com/aces/Loris/blob/main/php/libraries/Project.class.inc#L64) (pselectRow used on a query that returns more than one row). (reported in #7464)