### PR TITLE
[API] Project Subprojects

### DIFF
--- a/modules/api/php/endpoints/project/project.class.inc
+++ b/modules/api/php/endpoints/project/project.class.inc
@@ -133,18 +133,27 @@ class Project extends Endpoint implements \LORIS\Middleware\ETagCalculator
      * Generates a JSON representation of this project following the API
      * specification.
      *
+     * @param ServerRequestInterface $request The incoming PSR7 request
+     *
      * @return ResponseInterface
      */
-    private function _handleGET(): ResponseInterface
+    private function _handleGET(ServerRequestInterface $request): ResponseInterface
     {
         if (isset($this->_cache)) {
             return $this->_cache;
         }
 
-        $array = (new \LORIS\api\Views\Project($this->_project))
-            ->toArray();
-
-        $this->_cache = new \LORIS\Http\Response\JsonResponse($array);
+        $version = $request->getAttribute('LORIS-API-Version');
+        switch($version) {
+        case "v0.0.3":
+            $view = (new \LORIS\api\Views\Project($this->_project))
+                    ->toArray();
+            break;
+        default:
+            $view = (new \LORIS\api\Views\Project_0_0_4_Dev($this->_project))
+                    ->toArray();
+        }
+        $this->_cache = new \LORIS\Http\Response\JsonResponse($view);
 
         return $this->_cache;
     }

--- a/modules/api/php/views/project.class.inc
+++ b/modules/api/php/views/project.class.inc
@@ -29,7 +29,7 @@ class Project
      *
      * @var \Project
      */
-    private $_project;
+    protected $_project;
 
     /**
      * Constructor
@@ -55,7 +55,7 @@ class Project
             'Meta'        => $meta,
             'Candidates'  => $this->_project->getCandidateIds(),
             'Instruments' => array_keys(\Utility::getAllInstruments()),
-            'Visits'      => $this->_getVisits(),
+            'Visits'      => $this->getVisits(),
         ];
     }
 
@@ -87,7 +87,7 @@ class Project
 
         return [
             'Meta'   => $meta,
-            'Visits' => $this->_getVisits(),
+            'Visits' => $this->getVisits(),
         ];
     }
 
@@ -96,7 +96,7 @@ class Project
      *
      * @return array
      */
-    private function _getVisits(): array
+    protected function getVisits(): array
     {
         // TODO :: This should be replaced by $this->_project->getVisitLabels();
         return array_keys(

--- a/modules/api/php/views/project_0_0_4_dev.class.inc
+++ b/modules/api/php/views/project_0_0_4_dev.class.inc
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+/**
+ * PHP Version 7
+ *
+ * @category ApiViews
+ * @package  Loris
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+namespace LORIS\api\Views;
+
+/**
+ * This class formats a Project object into arrays following the API
+ * specifications.
+ *
+ * @category ApiViews
+ * @package  Loris
+ * @license  http://www.gnu.org/licenses/gpl-3.0.txt GPLv3
+ * @link     https://www.github.com/aces/Loris/
+ */
+
+class Project_0_0_4_Dev extends Project
+{
+    /**
+     * Produce an array representation of this project.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $meta = ['Project' => $this->_project->getName()];
+
+        return [
+            'Meta'        => $meta,
+            'Subprojects' => array_values(
+                \Utility::getSubprojectList(
+                    $this->_project->getId()
+                )
+            ),
+            'Candidates'  => $this->_project->getCandidateIds(),
+            'Instruments' => array_keys(\Utility::getAllInstruments()),
+            'Visits'      => $this->getVisits(),
+        ];
+    }
+}


### PR DESCRIPTION
**API 0.0.4 dev** 
Adds the list of project's subprojects to the response of a /projects/$ProjectName GET request.

--------------

2.1 Single project

GET /projects/$ProjectName

Returns a 200 OK response if the project exists, and 404 Not Found if it does not (the same is true of any portion of the API under /projects/$ProjectName.)

The body of the request to /projects/$ProjectName will be an entity of the form:

{
    "Meta" : {
        "Project" : "ProjectName"
    },
    "Visits" : ["V1", "V2", ... ],
    "Instruments" : ["InstrumentName", "InstrumentName2", ...],
    "Candidates" : ["123543", "523234", ...],
    "Subprojects": ["SubprojectName1", "SubProhjectName2"]
}

-------------------------------------
To do:

- [ ] CHANGELOG.md
- [ ] modules/api/docs/LorisRESTAPI_v0.0.4-dev.md 
- [ ] test suite

