### PR TITLE
[imaging_browser] Bugfix for Modality QC Status Display in Data Table

### DIFF
--- a/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
+++ b/modules/imaging_browser/php/imagingbrowserrowprovisioner.class.inc
@@ -110,7 +110,7 @@ class ImagingBrowserRowProvisioner extends \LORIS\Data\Provisioners\DBRowProvisi
         foreach ($scan_id_types as $id => $type) {
             $pass[$id]          = $DB->escape($type);
             $qc[$id]            = $DB->quote($type);
-            $coalesce_desc[$id] = $DB->quote($pass[$id] . '.' . $qc[$id]);
+            $coalesce_desc[$id] = $DB->escape($type);
             $case_desc[$id]     = "
                 CASE
                     COALESCE($coalesce_desc[$id], '')


### PR DESCRIPTION
## Brief summary of changes
This PR fixes the issue in which the modality QC status was not being displayed in the imaging browser's data table. 

The bug resulted in queries that look like this (which returned no results):
```
...
CASE
                    COALESCE('`3d_t1w`.\\'3d_t1w\\'', '')
                    WHEN '' THEN ''
                    WHEN 1 THEN 'Passed'
                    WHEN 2 THEN 'Failed'
                END as '3d_t1w_QC_Status',
...
```
Notice the parameter in the coalesce. This PR therefore fixes this issue.


#### Testing instructions (if applicable)

1. Go to 'Imaging Browser' 
2. Check that QC status is blank before checking out this PR
3. Check out this PR
4. Refresh 
5. Check that QC Status is now populated in the data table for scans that have Failed / Passed QC

#### Link(s) to related issue(s)

* Resolves #7468 
