### PR TITLE
[publication] Lead investigator issue

### DIFF
--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -67,7 +67,6 @@ function uploadPublication() : void
         'FROM publication_collaborator '.
         'WHERE Email = :e',
         array(
-            'n' => $leadInvest,
             'e' => $leadInvestEmail,
         )
     );

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -65,7 +65,7 @@ function uploadPublication() : void
     $leadInvID = $db->pselectOne(
         'SELECT PublicationCollaboratorID '.
         'FROM publication_collaborator '.
-        'WHERE Name = :n OR Email = :e',
+        'WHERE Email = :e',
         array(
             'n' => $leadInvest,
             'e' => $leadInvestEmail,

--- a/modules/publication/ajax/FileUpload.php
+++ b/modules/publication/ajax/FileUpload.php
@@ -65,8 +65,9 @@ function uploadPublication() : void
     $leadInvID = $db->pselectOne(
         'SELECT PublicationCollaboratorID '.
         'FROM publication_collaborator '.
-        'WHERE Email = :e',
+        'WHERE Name = :n AND Email = :e',
         array(
+            'n' => $leadInvest,
             'e' => $leadInvestEmail,
         )
     );


### PR DESCRIPTION
## Brief summary of changes
As it currently stands, when a publication is proposed (tab: propose a project) the user is asked, amongst other things, for a lead investigator name and email if these values are not already in the database, they get inserted into the collaborator table, if they do already exist they get linked to the new project.

The issue here is when 2 or more users share a name and/or an email address (project address like cbigr@mcin.ca for example) Since the SQL query currently uses and `OR` operator, the query returns the first name that matches or the first email that matches without checking the other value causing in some instances to select the wrong investigator and displaying the incorrect name or email in the menu filter.


Solves issue from CCNA: https://github.com/aces/CCNA/issues/4555

#### Testing instructions (if applicable)

1. Create publication with your name as lead investigator and your email
2. Create another publication with someone else's name as lead investigator but with the same email
3. Check that the 2 publications lead investigators have saved properly


